### PR TITLE
G349: Add copilot-local host workflow guidance distinct from copilot cloud

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -39,15 +39,30 @@ internal static class GuidePromptMatrixCommand
     private const string AgentGeneric = "generic";
 
     /// <summary>
-    /// G345: GitHub Copilot is recognized as an assignment-oriented agent.
-    /// It does NOT participate in the local 5-minute heartbeat/loop model
-    /// that Claude / Codex / generic local agents use. Copilot is acceptable
-    /// for child-oneshot (assign an issue / mention on a PR / Copilot CLI
-    /// one-shot) but NOT for child-loop (returns structured unsupported
-    /// guidance) and NOT for host modes (host review/closeout/next-slice
-    /// remain with intent-cli host automation).
+    /// G345: GitHub Copilot cloud/assignment agent. Assignment-oriented:
+    /// triggered by GitHub issue assignment or PR mention. Does NOT
+    /// participate in the local 5-minute heartbeat loop, does NOT exec
+    /// host <c>intent-cli</c>, and does NOT touch host <c>.intent-cli/</c>
+    /// metadata. <c>"copilot"</c> is kept as the canonical spelling;
+    /// <c>"copilot-cloud"</c> is accepted as an alias (G349).
     /// </summary>
     private const string AgentCopilot = "copilot";
+
+    /// <summary>
+    /// G349: alias for the cloud/assignment Copilot path. Accepted on input;
+    /// normalised to <c>"copilot"</c> internally so existing downstream logic
+    /// is unchanged.
+    /// </summary>
+    private const string AgentCopilotCloud = "copilot-cloud";
+
+    /// <summary>
+    /// G349: local Copilot coding-agent running in a host cwd. Unlike the
+    /// cloud/assignment path, a local Copilot agent CAN exec <c>intent-cli</c>
+    /// in the host repo and perform host-owned intent/clarification/packet/
+    /// publish workflows. In a child implementation cwd it remains
+    /// host-state-free (same restrictions as cloud Copilot child work).
+    /// </summary>
+    private const string AgentCopilotLocal = "copilot-local";
 
     /// <summary>
     /// G279 follow-up (PR #662): the rendered prompts only contain meaningful
@@ -64,7 +79,7 @@ internal static class GuidePromptMatrixCommand
     private const string TopologySameRepo = "same-repo";
 
     private const string UsageLine =
-        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--topology same-repo] [--domain <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic|copilot] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--format markdown|json]";
+        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--topology same-repo] [--domain <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic|copilot|copilot-cloud|copilot-local] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--format markdown|json]";
 
     private static readonly string[] ForbiddenSources =
     [
@@ -147,21 +162,42 @@ internal static class GuidePromptMatrixCommand
 
         var isSameRepo = string.Equals(topology, TopologySameRepo, StringComparison.Ordinal);
 
+        // G349: normalise once for dispatch. copilot-cloud → copilot.
+        // copilot-local keeps its own string so the per-mode dispatch below
+        // can route to the new local-host builders.
         var resolvedAgentForDispatch = NormalizeAgent(agent);
+        var isCopilotLocal = string.Equals(resolvedAgentForDispatch, AgentCopilotLocal, StringComparison.Ordinal);
+        var isCopilotCloud = string.Equals(resolvedAgentForDispatch, AgentCopilot, StringComparison.Ordinal);
+
         var all = new[]
         {
-            string.Equals(resolvedAgentForDispatch, AgentCopilot, StringComparison.Ordinal)
+            // child-loop: copilot-local child cwd stays host-state-free.
+            isCopilotCloud
                 ? BuildCopilotChildLoop(resolvedPolicy)
-                : BuildChildLoop(domainPlaceholder, agent, frequency, resolvedPolicy, isSameRepo),
-            string.Equals(resolvedAgentForDispatch, AgentCopilot, StringComparison.Ordinal)
+                : isCopilotLocal
+                    ? BuildCopilotLocalChildLoop(resolvedPolicy, isSameRepo)
+                    : BuildChildLoop(domainPlaceholder, agent, frequency, resolvedPolicy, isSameRepo),
+
+            // host-loop: copilot-local CAN run intent-cli in host cwd.
+            isCopilotCloud
                 ? BuildCopilotUnsupportedHostMode(ModeHostLoop, KindLoop, TargetHost, resolvedPolicy)
-                : BuildHostLoop(domainPlaceholder, targetRepoPlaceholder, agent, frequency, resolvedPolicy),
-            string.Equals(resolvedAgentForDispatch, AgentCopilot, StringComparison.Ordinal)
+                : isCopilotLocal
+                    ? BuildCopilotLocalHostLoop(domainPlaceholder, targetRepoPlaceholder, resolvedPolicy)
+                    : BuildHostLoop(domainPlaceholder, targetRepoPlaceholder, agent, frequency, resolvedPolicy),
+
+            // child-oneshot: copilot-local child cwd stays host-state-free.
+            isCopilotCloud
                 ? BuildCopilotChildOneshot(resolvedPolicy)
-                : BuildChildOneshot(domainPlaceholder, resolvedPolicy, isSameRepo),
-            string.Equals(resolvedAgentForDispatch, AgentCopilot, StringComparison.Ordinal)
+                : isCopilotLocal
+                    ? BuildCopilotLocalChildOneshot(resolvedPolicy, isSameRepo)
+                    : BuildChildOneshot(domainPlaceholder, resolvedPolicy, isSameRepo),
+
+            // host-oneshot: copilot-local CAN run intent-cli host steps.
+            isCopilotCloud
                 ? BuildCopilotHostOneshot(targetRepoPlaceholder, resolvedPolicy)
-                : BuildHostOneshot(domainPlaceholder, targetRepoPlaceholder, resolvedPolicy)
+                : isCopilotLocal
+                    ? BuildCopilotLocalHostOneshot(domainPlaceholder, targetRepoPlaceholder, resolvedPolicy)
+                    : BuildHostOneshot(domainPlaceholder, targetRepoPlaceholder, resolvedPolicy)
         };
 
         if (mode is null)
@@ -260,7 +296,14 @@ $@"**Local scheduling contract (G314)**: this loop runs in the **agent's current
         {
             return AgentGeneric;
         }
-        return agent.Trim().ToLowerInvariant();
+        var normalized = agent.Trim().ToLowerInvariant();
+        // G349: copilot-cloud is an alias for copilot (cloud/assignment path).
+        // copilot-local retains its own identity for dispatch.
+        if (string.Equals(normalized, AgentCopilotCloud, StringComparison.Ordinal))
+        {
+            return AgentCopilot;
+        }
+        return normalized;
     }
 
     private static string ResolvedFrequencyGuidance(string? frequency) =>
@@ -639,6 +682,260 @@ Hard rules:
             Prompt = prompt,
             BaseBranchPolicy = baseBranchPolicy,
             ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
+        };
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // G349: local Copilot coding-agent guidance blocks.
+    //
+    // copilot-local differs from the cloud/assignment path (G345) in one
+    // key way: when running in a HOST cwd the local Copilot agent CAN exec
+    // `intent-cli` commands for host-owned metadata mutation — intent
+    // interview, clarification question generation/recording, packet draft,
+    // issue publish, and bug-to-intent repair. When running in a CHILD
+    // implementation cwd it remains host-state-free (same restrictions as
+    // cloud Copilot child work).
+    //
+    // The four rendered blocks are:
+    //   1. BuildCopilotLocalHostLoop   — host recurring loop with full host
+    //      intent-cli surfaces available.
+    //   2. BuildCopilotLocalHostOneshot — one-shot host action (same surfaces,
+    //      no recurring wake).
+    //   3. BuildCopilotLocalChildLoop   — child cwd stays host-state-free;
+    //      returns structured child guidance matching the cloud path.
+    //   4. BuildCopilotLocalChildOneshot — child cwd one-shot; host-state-free.
+    // ─────────────────────────────────────────────────────────────────────
+
+    private static GuidePromptMatrixEntry BuildCopilotLocalHostLoop(
+        string domainPlaceholder,
+        string targetRepoPlaceholder,
+        string baseBranchPolicy)
+    {
+        var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Closeout / merge expectation honors");
+        var prompt =
+$@"Local Copilot coding-agent host-loop guidance (G349). This is a local Copilot agent running in the HOST repo cwd. Unlike the cloud/assignment Copilot path, a local Copilot agent CAN exec `intent-cli` to perform host-owned intent/clarification/packet/issue-publish workflows. This is a RECURRING loop — the operator or scheduler drives subsequent wakes. Run the loop body exactly once per wake.
+
+{basePolicyBlock}
+
+If the installed CLI surface is stale or any required automation command is missing, abort the wake before any mutation: `intent-cli automation doctor --format json` (or `automation host-review-preflight` reporting `stale-host-cli`) is the canonical signal — refresh the installed CLI before continuing.
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — surface `primary` / `support` / `advanced` / `experimental` buckets.
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json` — canonical label-driven contract and capability JSON.
+5. `intent-cli intent status --domain {domainPlaceholder} --format json` — current baseline / WIP / queued / clarifications.
+
+Host-cwd workflow surfaces available to local Copilot (pick the relevant one per wake):
+
+**Intent interview / design**:
+- `intent-cli guide workflow task intent-interview --format json` — structured intent-interview guidance.
+- `intent-cli intent next-slice --dry-run --domain {domainPlaceholder} --target-repo {targetRepoPlaceholder} --format json` — verify WIP cap and clarification gates.
+
+**Clarification**:
+- `intent-cli clarification next --domain {domainPlaceholder} --format markdown` — fetch the next open structured clarification question.
+- `intent-cli clarification answer --domain {domainPlaceholder} --id <id> --choice <option-id> [--note ""<text>""] --write` — record clarification durably (G302).
+
+**Packet draft**:
+- `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --dry-run --format markdown` — preview packet.
+- `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --format json` — create packet artifacts.
+
+**Issue publish**:
+- `intent-cli issue publish-flow <id> --repo {targetRepoPlaceholder} --write --format json` — publish issue.
+- `intent-cli automation issue-publish --repo {targetRepoPlaceholder} --issue <n> --write --format json` — apply `intent-target` label after durable state is pushed.
+
+**Bug-to-intent repair**:
+- `intent-cli guide workflow task bug-to-intent-repair --format json` — structured bug-to-intent repair guidance.
+
+**Host review / closeout / next-slice** (full host loop surface):
+- `intent-cli automation host-review-preflight --repo {targetRepoPlaceholder} --format json`
+- `intent-cli review closeout-plan --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --format json`
+- `intent-cli guide review --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --format json`
+
+Hard rules:
+- Local Copilot MUST NOT launch AI providers from intent-cli (`never call intent-cli run`).
+- All host metadata mutations go through installed `intent-cli` command surfaces; never hand-edit queue-state, runs.jsonl, packet artifacts, or submodule pointers.
+- Do NOT read `intents/rules/**`, local skill files, or copied prompt files for routine work. Use `intent-cli guide ...` instead.
+- Process at most one action per wake. Do NOT create a new thread, remote scheduler, or external cron.";
+
+        return new GuidePromptMatrixEntry
+        {
+            Mode = ModeHostLoop,
+            Kind = KindLoop,
+            Target = TargetHost,
+            FrequencyGuidance = FrequencyGuidanceRecurring,
+            ForbiddenSources = ForbiddenSources,
+            FirstCalls =
+            [
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json",
+                $"intent-cli intent status --domain {domainPlaceholder} --format json"
+            ],
+            Prompt = prompt,
+            Agent = AgentCopilotLocal,
+            AgentClassification = "local_host_agent",
+            BaseBranchPolicy = baseBranchPolicy,
+            ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
+        };
+    }
+
+    private static GuidePromptMatrixEntry BuildCopilotLocalHostOneshot(
+        string domainPlaceholder,
+        string targetRepoPlaceholder,
+        string baseBranchPolicy)
+    {
+        var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Closeout / merge expectation honors");
+        var prompt =
+$@"Local Copilot coding-agent host one-shot guidance (G349). This is a local Copilot agent running in the HOST repo cwd, executing exactly ONE host-side action. Unlike the cloud/assignment Copilot path, a local Copilot agent CAN exec `intent-cli` for host-owned metadata mutation. Do not create or update any automation, loop, cron, monitor, reminder, or recurring wakeup.
+
+{basePolicyBlock}
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json`
+2. `intent-cli guide onboarding --format json`
+3. `intent-cli guide commands list --format json`
+4. `intent-cli automation summary --domain {domainPlaceholder} --format json`
+5. `intent-cli intent status --domain {domainPlaceholder} --format json`
+
+Pick exactly one host action per invocation:
+- Intent interview: `intent-cli guide workflow task intent-interview --format json`
+- Clarification next: `intent-cli clarification next --domain {domainPlaceholder} --format markdown`
+- Clarification answer: `intent-cli clarification answer --domain {domainPlaceholder} --id <id> --choice <option-id> --write`
+- Packet draft: `intent-cli packet draft --execution-unit <id> --target-repo {targetRepoPlaceholder} --format json`
+- Issue publish: `intent-cli issue publish-flow <id> --repo {targetRepoPlaceholder} --write --format json` then `intent-cli automation issue-publish --repo {targetRepoPlaceholder} --issue <n> --write --format json`
+- Bug-to-intent repair: `intent-cli guide workflow task bug-to-intent-repair --format json`
+- Review/closeout: `intent-cli review closeout-plan --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --format json` and `intent-cli guide review --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --format json`
+
+Hard rules:
+- Local Copilot MUST NOT launch AI providers from intent-cli.
+- All host metadata mutations go through installed `intent-cli` command surfaces.
+- Do NOT read `intents/rules/**`, local skill files, or copied prompt files. Use `intent-cli guide ...`.
+- Do not create a cron, monitor, scheduler, reminder, or new thread after completing this wake.";
+
+        return new GuidePromptMatrixEntry
+        {
+            Mode = ModeHostOneshot,
+            Kind = KindOneshot,
+            Target = TargetHost,
+            FrequencyGuidance = FrequencyGuidanceOneshot,
+            ForbiddenSources = ForbiddenSources,
+            FirstCalls =
+            [
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                $"intent-cli automation summary --domain {domainPlaceholder} --format json",
+                $"intent-cli intent status --domain {domainPlaceholder} --format json"
+            ],
+            Prompt = prompt,
+            Agent = AgentCopilotLocal,
+            AgentClassification = "local_host_agent",
+            BaseBranchPolicy = baseBranchPolicy,
+            ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
+        };
+    }
+
+    private static GuidePromptMatrixEntry BuildCopilotLocalChildLoop(string baseBranchPolicy, bool isSameRepo = false)
+    {
+        // G349: in a child implementation cwd, local Copilot is host-state-free —
+        // same restrictions as cloud Copilot child work (G345). The key difference
+        // from the cloud path is the agent tag so consumers can distinguish.
+        var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Honor");
+        var sameRepoBlock = isSameRepo ? $"\n{RenderSameRepoTopologyBlock()}" : string.Empty;
+        var prompt =
+$@"Local Copilot coding-agent child-loop guidance (G349). This is a local Copilot agent running in a CHILD implementation cwd. Even though this is a local agent, the child cwd is GitHub-contract-only — the agent must NOT read, write, or mutate host metadata (`.intent-cli/`, `intents/`) from the implementation side.
+
+{basePolicyBlock}{sameRepoBlock}
+
+{CopilotChildContractParagraph}
+
+{CopilotAllowedDoBullets}
+
+{CopilotForbiddenDoBullets}
+
+Note: if this local Copilot agent needs to perform HOST-side intent/clarification/packet/publish work, cd to the HOST repo cwd and use `intent-cli guide prompt-matrix --mode host-loop --agent copilot-local` (or `--mode host-oneshot --agent copilot-local`) instead. The host-cwd path allows full intent-cli access. This child-loop path is strictly GitHub-contract-only.
+
+Hard rules:
+- From a child implementation cwd, local Copilot has the same restrictions as cloud Copilot: no `.intent-cli/` mutation, no host queue-state, no workflow label edits from the implementation side.
+- The PR body MUST include a deterministic closing reference (`Closes #<issue>`, `Fixes #<issue>`, or `Resolves #<issue>`) (G311).
+- Create PRs as ready-for-review (non-draft) by default.
+- Process at most one assignment / PR-mention per wake. Do NOT create a recurring loop from a child cwd.";
+
+        var forbiddenSources = isSameRepo
+            ? [.. ForbiddenSources, .. SameRepoAdditionalForbiddenSources]
+            : (IReadOnlyList<string>)ForbiddenSources;
+
+        return new GuidePromptMatrixEntry
+        {
+            Mode = ModeChildLoop,
+            Kind = KindLoop,
+            Target = TargetChild,
+            FrequencyGuidance = "N/A — local Copilot in a child cwd is GitHub-contract-only; use host-loop / host-oneshot with copilot-local for recurring host design work (G349).",
+            ForbiddenSources = forbiddenSources,
+            FirstCalls =
+            [
+                "gh auth status",
+                "gh issue view <N> --repo <owner>/<repo> --json number,title,body,labels,assignees",
+                "gh pr view <PR> --repo <owner>/<repo> --json number,isDraft,body,reviews,comments"
+            ],
+            Prompt = prompt,
+            Agent = AgentCopilotLocal,
+            AgentClassification = "local_child_agent_host_state_free",
+            BaseBranchPolicy = baseBranchPolicy,
+            ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
+            Topology = isSameRepo ? TopologySameRepo : null,
+        };
+    }
+
+    private static GuidePromptMatrixEntry BuildCopilotLocalChildOneshot(string baseBranchPolicy, bool isSameRepo = false)
+    {
+        // G349: same child-cwd restrictions as cloud Copilot child-oneshot.
+        var basePolicyBlock = RenderBaseBranchPolicyBlock(baseBranchPolicy, "Honor");
+        var sameRepoBlock = isSameRepo ? $"\n{RenderSameRepoTopologyBlock()}" : string.Empty;
+        var prompt =
+$@"Local Copilot coding-agent child one-shot guidance (G349). Child implementation cwd — host-state-free. Even though this is a local agent, from a child cwd it must NOT touch host metadata.
+
+{basePolicyBlock}{sameRepoBlock}
+
+{CopilotChildContractParagraph}
+
+{CopilotAllowedDoBullets}
+
+{CopilotForbiddenDoBullets}
+
+If host-side intent/clarification/packet/publish work is needed, switch to the HOST cwd and use `--agent copilot-local --mode host-oneshot`.
+
+Hard rules:
+- No `.intent-cli/` mutation from child cwd. No host queue-state reads.
+- PR body MUST include a closing reference (`Closes #<issue>` etc.) (G311).
+- Create PRs as ready-for-review (non-draft) by default.
+- Do not create a cron, monitor, scheduler, or new thread.";
+
+        var forbiddenSources = isSameRepo
+            ? [.. ForbiddenSources, .. SameRepoAdditionalForbiddenSources]
+            : (IReadOnlyList<string>)ForbiddenSources;
+
+        return new GuidePromptMatrixEntry
+        {
+            Mode = ModeChildOneshot,
+            Kind = KindOneshot,
+            Target = TargetChild,
+            FrequencyGuidance = FrequencyGuidanceOneshot,
+            ForbiddenSources = forbiddenSources,
+            FirstCalls =
+            [
+                "gh auth status",
+                "gh issue view <N> --repo <owner>/<repo> --json number,title,body,labels,assignees",
+                "gh pr view <PR> --repo <owner>/<repo> --json number,isDraft,body,reviews,comments"
+            ],
+            Prompt = prompt,
+            Agent = AgentCopilotLocal,
+            AgentClassification = "local_child_agent_host_state_free",
+            BaseBranchPolicy = baseBranchPolicy,
+            ExpectedBaseBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy),
+            Topology = isSameRepo ? TopologySameRepo : null,
         };
     }
 
@@ -1047,16 +1344,18 @@ Hard rules:
                 case "--agent":
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
                     {
-                        error = "--agent requires a value (claude, codex, generic, or copilot).";
+                        error = "--agent requires a value (claude, codex, generic, copilot, copilot-cloud, or copilot-local).";
                         return false;
                     }
                     var requestedAgent = args[index + 1].Trim().ToLowerInvariant();
                     if (!string.Equals(requestedAgent, AgentClaude, StringComparison.Ordinal)
                         && !string.Equals(requestedAgent, AgentCodex, StringComparison.Ordinal)
                         && !string.Equals(requestedAgent, AgentGeneric, StringComparison.Ordinal)
-                        && !string.Equals(requestedAgent, AgentCopilot, StringComparison.Ordinal))
+                        && !string.Equals(requestedAgent, AgentCopilot, StringComparison.Ordinal)
+                        && !string.Equals(requestedAgent, AgentCopilotCloud, StringComparison.Ordinal)
+                        && !string.Equals(requestedAgent, AgentCopilotLocal, StringComparison.Ordinal))
                     {
-                        error = $"--agent must be 'claude', 'codex', 'generic', or 'copilot' (got '{requestedAgent}').";
+                        error = $"--agent must be 'claude', 'codex', 'generic', 'copilot', 'copilot-cloud', or 'copilot-local' (got '{requestedAgent}').";
                         return false;
                     }
                     agent = requestedAgent;
@@ -1135,7 +1434,7 @@ Hard rules:
         writer.WriteLine();
         writer.WriteLine("Omit --mode to get all four entries.");
         writer.WriteLine("--domain, --target-repo, --agent, --frequency, and --topology are optional; provide them to render a concrete paste-ready prompt instead of one with placeholders.");
-        writer.WriteLine("--agent values: claude (same-thread `/loop`), codex (current-thread heartbeat), generic, copilot (G345 — assignment-oriented; supported for child-oneshot, returns structured unsupported-loop guidance for child-loop, structured host-oneshot-human-driven guidance for host-oneshot, and structured unsupported-mode-agent-combination for host-loop).");
+        writer.WriteLine("--agent values: claude (same-thread `/loop`), codex (current-thread heartbeat), generic, copilot / copilot-cloud (G345 — cloud/assignment-oriented; supported for child-oneshot, returns structured unsupported-loop guidance for child-loop, structured host-oneshot-human-driven guidance for host-oneshot, and structured unsupported-mode-agent-combination for host-loop), copilot-local (G349 — local Copilot coding-agent in a host cwd; can exec intent-cli for host operations; child cwd usage remains host-state-free).");
         writer.WriteLine("--frequency examples: 5m, 20m, 1h. Omit to keep the rendered prompt's ask-the-operator instruction.");
         writer.WriteLine($"--base-branch-policy values: {CliRuntimeContracts.DirectMainBaseBranchPolicy} (default; child PRs target `{CliRuntimeContracts.DirectMainBaseBranch}`), {CliRuntimeContracts.MainAiBaseBranchPolicy} (child PRs target `{CliRuntimeContracts.MainAiIntegrationBaseBranch}`).");
         writer.WriteLine($"--topology values: {TopologySameRepo} (G348 — adds same-repo forbidden-path guidance to child prompts; host intent metadata paths `.intent-cli/**` and `intents/**` are visible but forbidden for implementation agents).");

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskInitHostCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskInitHostCommand.cs
@@ -26,7 +26,7 @@ internal static class GuideWorkflowTaskInitHostCommand
     private const string FormatMarkdown = "markdown";
 
     private const string UsageLine =
-        "Usage: intent-cli guide workflow task init-host [--role design|review-runtime|child-implementation] [--topology same-repo] [--force-host] [--format markdown|json]";
+        "Usage: intent-cli guide workflow task init-host [--role design|review-runtime|child-implementation] [--topology same-repo] [--agent copilot-local] [--force-host] [--format markdown|json]";
 
     /// <summary>
     /// G335: canonical role definitions for a new project. Mirrors the
@@ -134,6 +134,35 @@ internal static class GuideWorkflowTaskInitHostCommand
     };
 
     /// <summary>
+    /// G349: copilot-local agent guidance emitted when
+    /// <c>--agent copilot-local</c> is passed. Documents the host-cwd
+    /// permitted surfaces (intent-interview, packet-draft, issue-publish,
+    /// bug-to-intent-repair, and the underlying intent-cli commands) and
+    /// the child-cwd restriction (host-state-free, same as any child agent).
+    /// </summary>
+    internal static readonly CopilotLocalAgentGuidance CopilotLocalAgent = new()
+    {
+        HostCwdSummary = "A local Copilot coding agent running in a host cwd (design or review-runtime role) MAY run intent-cli host surfaces to organize intents, record clarifications, draft packets, and publish GitHub issues. It is NOT restricted to child-cwd / GitHub-contract-only mode when the cwd is a host — pass --agent copilot-local to confirm this runtime shape.",
+        PermittedWorkflowTaskSurfaces = new[]
+        {
+            "intent-cli guide workflow task intent-interview — ask for intent/clarification workflow guidance (interview new concepts, repair Hard Clarification blockers).",
+            "intent-cli guide workflow task packet-draft — ask for packet directory layout and contract completeness guidance.",
+            "intent-cli guide workflow task issue-publish — ask for issue draft/create/publish-flow boundary guidance.",
+            "intent-cli guide workflow task bug-to-intent-repair — ask for the guided bug-to-intent repair workflow (report → triage → plan → intent-repair → implementation-repair).",
+            "intent-cli interview next-question / record-answer / compile — host-owned interview workflow commands.",
+            "intent-cli clarification next / answer — host-owned clarification repair commands.",
+            "intent-cli packet draft / validate / issue publish-flow — host-owned packet and issue lifecycle."
+        },
+        ChildCwdRestriction = "When the local Copilot agent is in a child implementation cwd (no .intent-cli/ present), it follows the same host-state-free rules as any other child agent. It MUST NOT inspect or mutate parent host queue-state, intent tree, packet artifacts, or .intent-cli/** paths. Use `intent-cli guide prompt-matrix --mode child-loop --agent copilot-local` for child-cwd guidance.",
+        HostStateFreeSurfaces = new[]
+        {
+            "intent-cli worker next-action / claim / result-summary / complete — GitHub-label transitions only (child-cwd).",
+            "intent-cli guide prompt-matrix --mode child-loop --agent copilot-local — paste-ready child-loop guidance.",
+            "intent-cli automation base-branch-check — validate PR base branch from GitHub metadata only."
+        }
+    };
+
+    /// <summary>
     /// G335: explicit invariants the workflow guide must surface so
     /// external agents do not mis-initialize a project. Tests pin
     /// each invariant verbatim.
@@ -153,7 +182,7 @@ internal static class GuideWorkflowTaskInitHostCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (!TryParseArguments(args, out var focusRole, out var forceHost, out var topology, out var format, out var error))
+        if (!TryParseArguments(args, out var focusRole, out var forceHost, out var topology, out var agent, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -195,6 +224,10 @@ internal static class GuideWorkflowTaskInitHostCommand
             ? SameRepoTopology.Warning
             : null;
 
+        // G349: copilot-local agent guidance when --agent copilot-local is set.
+        var isCopilotLocal = string.Equals(agent, "copilot-local", StringComparison.Ordinal);
+        var copilotLocalGuidance = isCopilotLocal ? CopilotLocalAgent : null;
+
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
             var payload = new InitHostGuidance
@@ -204,18 +237,20 @@ internal static class GuideWorkflowTaskInitHostCommand
                 Invariants = Invariants,
                 FocusRole = string.IsNullOrEmpty(focusRole) ? null : focusRole,
                 Topology = string.IsNullOrEmpty(topology) ? null : topology,
+                Agent = string.IsNullOrEmpty(agent) ? null : agent,
                 CwdHasDotIntentCli = hasDotIntentCli,
                 ForceHost = forceHost,
                 Refusals = refusalReasons.Count == 0 ? null : refusalReasons,
                 SameRepoTopology = sameRepoGuidance,
-                SameRepoPolicyWarning = sameRepoPolicyWarning
+                SameRepoPolicyWarning = sameRepoPolicyWarning,
+                CopilotLocalAgent = copilotLocalGuidance
             };
             writer.Write(JsonSerializer.Serialize(payload, JsonOptions));
             writer.WriteLine();
         }
         else
         {
-            WriteMarkdown(visibleRoles, hasDotIntentCli, forceHost, refusalReasons, sameRepoGuidance, sameRepoPolicyWarning, writer);
+            WriteMarkdown(visibleRoles, hasDotIntentCli, forceHost, refusalReasons, sameRepoGuidance, sameRepoPolicyWarning, copilotLocalGuidance, writer);
         }
 
         return refusalReasons.Count == 0 ? 0 : 1;
@@ -248,6 +283,7 @@ internal static class GuideWorkflowTaskInitHostCommand
         IReadOnlyList<string> refusals,
         SameRepoTopologyGuidance? sameRepoGuidance,
         string? sameRepoPolicyWarning,
+        CopilotLocalAgentGuidance? copilotLocalGuidance,
         TextWriter writer)
     {
         writer.WriteLine("# intent-cli — init-host workflow guide");
@@ -331,6 +367,30 @@ internal static class GuideWorkflowTaskInitHostCommand
                 writer.WriteLine($"⚠ {sameRepoPolicyWarning}");
             }
         }
+
+        // G349: emit copilot-local agent section when --agent copilot-local is set.
+        if (copilotLocalGuidance is not null)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Copilot Local Agent (--agent copilot-local)");
+            writer.WriteLine();
+            writer.WriteLine(copilotLocalGuidance.HostCwdSummary);
+            writer.WriteLine();
+            writer.WriteLine("### Permitted workflow task surfaces (host cwd)");
+            foreach (var item in copilotLocalGuidance.PermittedWorkflowTaskSurfaces)
+            {
+                writer.WriteLine($"- {item}");
+            }
+            writer.WriteLine();
+            writer.WriteLine("### Child cwd restriction");
+            writer.WriteLine($"- {copilotLocalGuidance.ChildCwdRestriction}");
+            writer.WriteLine();
+            writer.WriteLine("### Host-state-free surfaces (child cwd)");
+            foreach (var item in copilotLocalGuidance.HostStateFreeSurfaces)
+            {
+                writer.WriteLine($"- {item}");
+            }
+        }
     }
 
     private static bool TryParseArguments(
@@ -338,12 +398,14 @@ internal static class GuideWorkflowTaskInitHostCommand
         out string focusRole,
         out bool forceHost,
         out string topology,
+        out string agent,
         out string format,
         out string error)
     {
         focusRole = string.Empty;
         forceHost = false;
         topology = string.Empty;
+        agent = string.Empty;
         format = FormatMarkdown;
         error = string.Empty;
 
@@ -389,6 +451,22 @@ internal static class GuideWorkflowTaskInitHostCommand
                         return false;
                     }
                     topology = requestedTopology;
+                    i++;
+                    break;
+                case "--agent":
+                    // G349: only 'copilot-local' is a recognized agent option.
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "--agent requires a value (copilot-local).";
+                        return false;
+                    }
+                    var requestedAgent = args[i + 1];
+                    if (!string.Equals(requestedAgent, "copilot-local", StringComparison.Ordinal))
+                    {
+                        error = $"--agent must be 'copilot-local' (got '{requestedAgent}').";
+                        return false;
+                    }
+                    agent = requestedAgent;
                     i++;
                     break;
                 case "--format":
@@ -509,6 +587,14 @@ internal sealed record InitHostGuidance
     /// <summary>G348: warning string when same-repo topology is active but no non-default base-branch policy is configured; null otherwise.</summary>
     [JsonPropertyName("same_repo_policy_warning")]
     public string? SameRepoPolicyWarning { get; init; }
+
+    /// <summary>G349: agent filter passed via <c>--agent</c>; null when not set.</summary>
+    [JsonPropertyName("agent")]
+    public string? Agent { get; init; }
+
+    /// <summary>G349: copilot-local agent guidance; null when <c>--agent copilot-local</c> is not set.</summary>
+    [JsonPropertyName("copilot_local_agent")]
+    public CopilotLocalAgentGuidance? CopilotLocalAgent { get; init; }
 }
 
 /// <summary>
@@ -531,4 +617,27 @@ internal sealed record SameRepoTopologyGuidance
 
     [JsonPropertyName("warning")]
     public required string Warning { get; init; }
+}
+
+/// <summary>
+/// G349: copilot-local agent guidance emitted when
+/// <c>--agent copilot-local</c> is passed to <c>guide workflow task init-host</c>.
+/// Documents what a local Copilot coding agent can do in a host cwd
+/// (design/review-runtime: full intent-cli host surfaces including
+/// intent-interview, packet-draft, issue-publish, bug-to-intent-repair)
+/// vs a child implementation cwd (host-state-free, same as any child agent).
+/// </summary>
+internal sealed record CopilotLocalAgentGuidance
+{
+    [JsonPropertyName("host_cwd_summary")]
+    public required string HostCwdSummary { get; init; }
+
+    [JsonPropertyName("permitted_workflow_task_surfaces")]
+    public required IReadOnlyList<string> PermittedWorkflowTaskSurfaces { get; init; }
+
+    [JsonPropertyName("child_cwd_restriction")]
+    public required string ChildCwdRestriction { get; init; }
+
+    [JsonPropertyName("host_state_free_surfaces")]
+    public required IReadOnlyList<string> HostStateFreeSurfaces { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -1360,7 +1360,7 @@ public sealed class GuidePromptMatrixCommandTests
             writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("--agent must be 'claude', 'codex', 'generic', or 'copilot'", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--agent must be 'claude', 'codex', 'generic', 'copilot', 'copilot-cloud', or 'copilot-local'", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1943,5 +1943,170 @@ public sealed class GuidePromptMatrixCommandTests
         Assert.Equal(0, exitCode);
         Assert.Contains("--topology", writer.ToString(), StringComparison.Ordinal);
         Assert.Contains("same-repo", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ----- G349: copilot-local vs copilot-cloud tests -----
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostLoop_ReturnsLocalHostAgentClassification()
+    {
+        // G349 AC: copilot-local host-loop must return agent_classification
+        // "local_host_agent", not "unsupported_mode_agent_combination".
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--agent", "copilot-local", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("local_host_agent", root.GetProperty("agent_classification").GetString());
+        Assert.Equal("host-loop", root.GetProperty("mode").GetString());
+        Assert.Equal("copilot-local", root.GetProperty("agent").GetString());
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostLoop_PromptMentionsIntentCliHostSurfaces()
+    {
+        // G349 AC: local Copilot host agent can ask intent-cli for
+        // intent/clarification/packet/issue-publish workflow guidance.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--agent", "copilot-local", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("intent-cli", prompt, StringComparison.Ordinal);
+        Assert.Contains("packet draft", prompt, StringComparison.Ordinal);
+        Assert.Contains("issue publish", prompt, StringComparison.Ordinal);
+        Assert.Contains("clarification", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-interview", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostOneshot_ReturnsLocalHostAgentClassification()
+    {
+        // G349 AC: host-oneshot with copilot-local returns local_host_agent.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-oneshot", "--agent", "copilot-local", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("local_host_agent", document.RootElement.GetProperty("agent_classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotLocalChildLoop_ReturnsLocalChildAgentHostStateFree()
+    {
+        // G349 AC: copilot-local in child-loop must return
+        // "local_child_agent_host_state_free" — NOT local_host_agent.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--agent", "copilot-local", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("local_child_agent_host_state_free", document.RootElement.GetProperty("agent_classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotLocalChildOneshot_ReturnsLocalChildAgentHostStateFree()
+    {
+        // G349 AC: copilot-local in child-oneshot is also host-state-free.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-oneshot", "--agent", "copilot-local", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("local_child_agent_host_state_free", document.RootElement.GetProperty("agent_classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotLocalChildLoop_PromptForbidsHostMetadataMutation()
+    {
+        // G349 AC: negative test — child cwd copilot-local guidance must
+        // explicitly state .intent-cli/ and host metadata are forbidden.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--agent", "copilot-local", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains(".intent-cli/", prompt, StringComparison.Ordinal);
+        Assert.Contains("host metadata", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("must NOT", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotCloud_BackwardCompatAlias_BehavesLikeCopilot()
+    {
+        // G349: copilot-cloud is an alias for copilot — produces
+        // "unsupported_local_loop" for child-loop (cloud/assignment path).
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--agent", "copilot-cloud", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        // copilot-cloud normalises to copilot → same cloud-assignment classification.
+        Assert.Equal("unsupported_local_loop", document.RootElement.GetProperty("agent_classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotCloud_HostLoop_UnsupportedModeAgentCombination()
+    {
+        // G349: copilot-cloud + host-loop still returns
+        // "unsupported_mode_agent_combination" (cloud Copilot never drives host loops).
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--agent", "copilot-cloud", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("unsupported_mode_agent_combination", document.RootElement.GetProperty("agent_classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_G349_Help_MentionsCopilotLocalAndCopilotCloud()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("copilot-local", output, StringComparison.Ordinal);
+        Assert.Contains("copilot-cloud", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostLoop_FirstCallsIncludeIntentCliSurfaces()
+    {
+        // G349: first_calls for local Copilot host mode must include
+        // intent-cli automation summary (same as claude/codex host loops).
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--agent", "copilot-local", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var firstCalls = document.RootElement.GetProperty("first_calls")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(firstCalls, c => c!.Contains("automation summary", StringComparison.Ordinal));
+        Assert.Contains(firstCalls, c => c!.Contains("intent status", StringComparison.Ordinal));
     }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskBugToIntentRepairCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskBugToIntentRepairCommandTests.cs
@@ -493,4 +493,53 @@ public sealed class GuideWorkflowTaskBugToIntentRepairCommandTests
             }
         };
     }
+
+    // ----- G349: copilot-local host agent can ask bug-to-intent-repair guide -----
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostCwd_CanAskBugToIntentRepairGuide_ExitZero()
+    {
+        // G349 Verification: a local Copilot host agent running in a host cwd
+        // can call `guide workflow task bug-to-intent-repair` and receive the
+        // full guided bug-to-intent repair workflow guidance (exit 0, all five
+        // stages: report → triage → plan → intent-repair → implementation-repair).
+        // This surface is accessible to any host-cwd agent including copilot-local.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // All five bug-to-intent repair stages must appear.
+        Assert.Contains("report", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("triage", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-repair", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("implementation-repair", output, StringComparison.OrdinalIgnoreCase);
+        // Gap classifications surface.
+        Assert.Contains("implementation-mismatch", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-gap", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostCwd_BugToIntentRepairJsonFormat_ExitZero()
+    {
+        // G349 Verification: local Copilot host agent can request JSON format from
+        // the bug-to-intent-repair guide and gets a parsable payload.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskBugToIntentRepairCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("stages", out _), "stages key must be present.");
+        Assert.True(root.TryGetProperty("classifications", out _), "classifications key must be present.");
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskInitHostCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskInitHostCommandTests.cs
@@ -504,4 +504,128 @@ public sealed class GuideWorkflowTaskInitHostCommandTests : IDisposable
             }
         };
     }
+
+    // ----- G349: copilot-local agent guidance -----
+
+    [Fact]
+    public void Execute_G349_AgentCopilotLocal_MarkdownIncludesCopilotLocalSection()
+    {
+        // G349 AC: `guide workflow task init-host --agent copilot-local` must
+        // emit a Copilot Local Agent section explaining host-cwd permissions.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--agent", "copilot-local" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Copilot Local Agent", output, StringComparison.Ordinal);
+        Assert.Contains("copilot-local", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G349_AgentCopilotLocal_JsonIncludesCopilotLocalAgentNode()
+    {
+        // G349 AC: JSON shape must include `copilot_local_agent` with
+        // `permitted_workflow_task_surfaces` and `child_cwd_restriction`.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--agent", "copilot-local", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("copilot_local_agent", out var agentNode),
+            "copilot_local_agent key must be present when --agent copilot-local is passed.");
+        Assert.True(agentNode.TryGetProperty("permitted_workflow_task_surfaces", out _),
+            "copilot_local_agent must include permitted_workflow_task_surfaces.");
+        Assert.True(agentNode.TryGetProperty("child_cwd_restriction", out _),
+            "copilot_local_agent must include child_cwd_restriction.");
+        Assert.True(agentNode.TryGetProperty("host_state_free_surfaces", out _),
+            "copilot_local_agent must include host_state_free_surfaces.");
+        // agent filter is echoed back in the top-level payload
+        Assert.True(root.TryGetProperty("agent", out var agentProp),
+            "agent key must be present at the root when --agent is passed.");
+        Assert.Equal("copilot-local", agentProp.GetString());
+    }
+
+    [Fact]
+    public void Execute_G349_AgentCopilotLocal_PermittedSurfacesIncludeAllFourWorkflowGuides()
+    {
+        // G349 Verification: permitted_workflow_task_surfaces must name all four
+        // workflow task guide commands that a local Copilot host agent can call.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--agent", "copilot-local" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+
+        // All four permitted workflow task surface commands must appear.
+        Assert.Contains("guide workflow task intent-interview", output, StringComparison.Ordinal);
+        Assert.Contains("guide workflow task packet-draft", output, StringComparison.Ordinal);
+        Assert.Contains("guide workflow task issue-publish", output, StringComparison.Ordinal);
+        Assert.Contains("guide workflow task bug-to-intent-repair", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G349_AgentCopilotLocal_ChildCwdRestrictionMentionsHostStateFree()
+    {
+        // G349 Verification: child-cwd restriction for copilot-local must mention
+        // host-state-free so the agent knows it follows the same rules as any
+        // other child agent when running from an implementation cwd.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--agent", "copilot-local" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("host-state-free", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G349_AgentCopilotLocal_NoAgentFlag_CopilotLocalSectionAbsent()
+    {
+        // G349: when --agent is not passed, copilot_local_agent must be absent.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        using var doc = JsonDocument.Parse(json);
+        Assert.False(doc.RootElement.TryGetProperty("copilot_local_agent", out _),
+            "copilot_local_agent must be absent when --agent is not set.");
+    }
+
+    [Fact]
+    public void Execute_G349_UnknownAgent_ExitsOneWithError()
+    {
+        // G349: an unrecognized --agent value must exit 1 with a clear error.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--agent", "unknown-agent" },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("--agent must be 'copilot-local'", output, StringComparison.Ordinal);
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIntentInterviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIntentInterviewCommandTests.cs
@@ -369,4 +369,59 @@ public sealed class GuideWorkflowTaskIntentInterviewCommandTests
             }
         };
     }
+
+    // ----- G349: copilot-local host agent can ask intent-interview guide -----
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostCwd_CanAskIntentInterviewGuide_ExitZero()
+    {
+        // G349 Verification: a local Copilot host agent running in a host cwd
+        // can call `guide workflow task intent-interview` and receive the full
+        // intent/clarification workflow guidance (exit 0, both modes, canonical
+        // commands). This surface is not restricted to non-Copilot agents.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIntentInterviewCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // Both modes available — copilot-local host agent can pick either.
+        Assert.Contains("Mode: interview", output, StringComparison.Ordinal);
+        Assert.Contains("Mode: clarification", output, StringComparison.Ordinal);
+        // Canonical intent-cli host surface commands are surfaced.
+        Assert.Contains("intent-cli interview next-question", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli interview record-answer", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli interview compile", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli clarification next", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli clarification answer", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostCwd_IntentInterviewJsonFormat_ExitZero()
+    {
+        // G349 Verification: local Copilot host agent can request JSON format from
+        // intent-interview guide and receives a parsable payload with both modes.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIntentInterviewCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("modes", out var modes), "modes key must be present.");
+        Assert.True(root.TryGetProperty("question_structure", out _), "question_structure must be present.");
+        // Both interview and clarification modes present.
+        var modeNames = modes.EnumerateArray()
+            .Select(m => m.GetProperty("mode").GetString())
+            .ToArray();
+        Assert.Contains(GuideWorkflowTaskIntentInterviewCommand.ModeInterview, modeNames);
+        Assert.Contains(GuideWorkflowTaskIntentInterviewCommand.ModeClarification, modeNames);
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIssuePublishCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskIssuePublishCommandTests.cs
@@ -307,4 +307,47 @@ public sealed class GuideWorkflowTaskIssuePublishCommandTests
             }
         };
     }
+
+    // ----- G349: copilot-local host agent can ask issue-publish guide -----
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostCwd_CanAskIssuePublishGuide_ExitZero()
+    {
+        // G349 Verification: a local Copilot host agent running in a host cwd
+        // can call `guide workflow task issue-publish` and receive the full
+        // draft/create/publish-flow boundary guidance (exit 0, four stages).
+        // This surface is accessible to any host-cwd agent including copilot-local.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIssuePublishCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // All four issue-publish stages must be surfaced.
+        Assert.Contains("draft", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("publish-flow", output, StringComparison.OrdinalIgnoreCase);
+        // The canonical issue-publish command is surfaced.
+        Assert.Contains("intent-cli issue publish-flow", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostCwd_IssuePublishJsonFormat_ExitZero()
+    {
+        // G349 Verification: local Copilot host agent can request JSON format from
+        // the issue-publish guide and gets a parsable payload.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskIssuePublishCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        using var doc = JsonDocument.Parse(json);
+        Assert.True(doc.RootElement.TryGetProperty("stages", out _), "stages key must be present.");
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
@@ -176,4 +176,50 @@ public sealed class GuideWorkflowTaskPacketDraftCommandTests
             }
         };
     }
+
+    // ----- G349: copilot-local host agent can ask packet-draft guide -----
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostCwd_CanAskPacketDraftGuide_ExitZero()
+    {
+        // G349 Verification: a local Copilot host agent running in a host cwd
+        // can call `guide workflow task packet-draft` and receive full packet
+        // directory layout and contract completeness guidance (exit 0).
+        // This surface is accessible to any host-cwd agent including copilot-local.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskPacketDraftCommand.Execute(
+            CreateContext(),
+            Array.Empty<string>(),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // All four packet files surfaced.
+        Assert.Contains("packet.yaml", output, StringComparison.Ordinal);
+        Assert.Contains("implementation.md", output, StringComparison.Ordinal);
+        Assert.Contains("review-context.md", output, StringComparison.Ordinal);
+        Assert.Contains("github-body.md", output, StringComparison.Ordinal);
+        // Canonical packet-draft command named.
+        Assert.Contains("intent-cli packet draft", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G349_CopilotLocalHostCwd_PacketDraftJsonFormat_ExitZero()
+    {
+        // G349 Verification: local Copilot host agent can request JSON format from
+        // the packet-draft guide and gets a parsable payload with packet files.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskPacketDraftCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("packet_files", out _), "packet_files key must be present.");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `copilot-local` agent type to `guide prompt-matrix`, distinct from `copilot-cloud` (which aliases the existing `copilot` cloud-assignment path)
- Provides 4 new builder methods: `BuildCopilotLocalHostLoop`, `BuildCopilotLocalHostOneshot`, `BuildCopilotLocalChildLoop`, `BuildCopilotLocalChildOneshot`
- Local host agents have `agent_classification: "local_host_agent"` and can call `intent-cli` host surfaces; local child agents have `agent_classification: "local_child_agent_host_state_free"` and remain host-state-free
- `copilot-cloud` is a backward-compatible alias for `copilot`
- 10 new tests + 1 existing test fixed for updated error message

## Test plan

- [x] All 2883 tests pass (1 pre-existing skip)
- [x] `copilot-local --mode host-loop` returns `local_host_agent` classification
- [x] `copilot-local --mode child-loop` returns `local_child_agent_host_state_free` classification
- [x] `copilot-cloud --mode host-loop` behaves like `copilot`
- [x] Help text mentions both `copilot-local` and `copilot-cloud`
- [x] Invalid agent value returns updated error message

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)