### PR TITLE
G350: Add same-repo metadata branch lane with direct-push host state

### DIFF
--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -36,6 +36,16 @@ internal static class CliRuntimeContracts
     public const string DefaultBaseBranchPolicy = DirectMainBaseBranchPolicy;
     public const string DirectMainBaseBranch = "main";
     public const string MainAiIntegrationBaseBranch = "main-ai";
+    /// <summary>G350: config key for the final stable branch in same-repo topology (e.g. "main").</summary>
+    public const string StableBranchKey = "stable_branch";
+    /// <summary>G350: config key for the branch implementation PRs target in same-repo topology.</summary>
+    public const string ImplementationBaseBranchKey = "implementation_base_branch";
+    /// <summary>G350: config key for the dedicated metadata direct-push branch in same-repo topology.</summary>
+    public const string MetadataBranchKey = "metadata_branch";
+    /// <summary>G350: conventional default for the stable branch.</summary>
+    public const string DefaultStableBranch = "main";
+    /// <summary>G350: conventional default for the metadata branch in same-repo topology.</summary>
+    public const string DefaultMetadataBranch = "main-metadata";
     public const string DefaultWorktreeRoot = ".intent-cli/worktrees";
     public const string DefaultSupervisionArtifactRoot = ".intent-cli/supervision";
     public const string DefaultDirectRunArtifactRoot = ".intent-cli/runs";

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskInitHostCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskInitHostCommand.cs
@@ -108,6 +108,8 @@ internal static class GuideWorkflowTaskInitHostCommand
     /// <c>--topology same-repo</c> is passed. Documents the branch
     /// strategy, the forbidden paths for implementation agents, and
     /// the warning when no base-branch policy is configured.
+    /// G350: extended with <see cref="SameRepoMetadataLaneGuidance"/> that
+    /// describes the three-branch lane model (stable / implementation / metadata).
     /// </summary>
     internal static readonly SameRepoTopologyGuidance SameRepoTopology = new()
     {
@@ -130,7 +132,23 @@ internal static class GuideWorkflowTaskInitHostCommand
             "Host metadata changes committed to the integration branch are automatically visible to the next implementation PR; no separate host repo checkout is required in same-repo topology.",
             "The design host and review-runtime roles BOTH run from the same local checkout of this one repository. The `.intent-cli/` directory is present and REQUIRED for host operations; it is FORBIDDEN for implementation agents working on feature branches."
         },
-        Warning = "SAME-REPO TOPOLOGY WARNING: when `base_branch_policy` is not configured (or is `direct-main`), child implementation agents will default to targeting `main` directly. In a same-repo project this is almost certainly wrong. Set `base_branch_policy: main-ai` in `.intent-cli/config.yaml` and ensure every published child issue includes a `Base Branch Policy` section pointing at the integration branch."
+        Warning = "SAME-REPO TOPOLOGY WARNING: when `base_branch_policy` is not configured (or is `direct-main`), child implementation agents will default to targeting `main` directly. In a same-repo project this is almost certainly wrong. Set `base_branch_policy: main-ai` in `.intent-cli/config.yaml` and ensure every published child issue includes a `Base Branch Policy` section pointing at the integration branch.",
+        // G350: metadata lane guidance for the three-branch model.
+        MetadataLane = new SameRepoMetadataLaneGuidance
+        {
+            StableBranchRole = "`stable_branch` (e.g. `main`): the final stable branch. Human-controlled merges only — host agents and implementation agents MUST NOT direct-push here. Declare in [project] stable_branch = \"main\".",
+            ImplementationBaseBranchRole = "`implementation_base_branch` (e.g. `main` or `main-ai`): the branch implementation PRs target. MUST NOT include `.intent-cli/**` or `intents/**` path changes. Declare in [project] implementation_base_branch = \"main-ai\".",
+            MetadataBranchRole = "`metadata_branch` (e.g. `main-metadata`): dedicated branch for host-owned metadata direct-push. `.intent-cli/**`, `intents/**`, queue-state, runs.jsonl, packet artifacts, clarifications, and closeout state are committed and pushed directly here by host agents via intent-cli commands. Implementation PRs MUST NOT target this branch and MUST NOT include metadata path changes. Declare in [project] metadata_branch = \"main-metadata\".",
+            Diagnostics = new[]
+            {
+                "Metadata mutation on wrong branch: before committing queue-state, runs.jsonl, or packet artifacts, verify `git rev-parse --abbrev-ref HEAD` returns the configured `metadata_branch`. If not, switch: `git checkout <metadata_branch>` (or create it if missing) before any mutation.",
+                "Implementation PR touches metadata paths: reject any PR diff that modifies `.intent-cli/**` or `intents/**` when targeting `implementation_base_branch`. These paths are metadata-lane-only and must not appear in implementation PR branches.",
+                "Missing metadata branch: if `metadata_branch` does not exist on origin, create it before first host commit: `git checkout -b <metadata_branch> <stable_branch> && git push -u origin <metadata_branch>`.",
+                "Stale metadata branch: if the local `metadata_branch` is behind `origin/<metadata_branch>`, run `git fetch --all --prune && git pull --ff-only origin <metadata_branch>` before any mutation to avoid divergence.",
+                "Single-lane fallback: if `metadata_branch` is not configured, host metadata is committed to the same branch as implementation work (the G348 integration-branch model). This is acceptable for simple projects but increases merge-conflict risk for high-churn metadata."
+            },
+            ConfigExample = "[project]\nstable_branch = \"main\"\nimplementation_base_branch = \"main-ai\"\nmetadata_branch = \"main-metadata\"\nbase_branch_policy = \"main-ai\""
+        }
     };
 
     /// <summary>
@@ -224,6 +242,28 @@ internal static class GuideWorkflowTaskInitHostCommand
             ? SameRepoTopology.Warning
             : null;
 
+        // G350: resolve effective same-repo branch lane values from config.
+        var effectiveMetadataBranch = isSameRepo
+            ? (string.IsNullOrWhiteSpace(context.Config.Project.MetadataBranch)
+                ? null
+                : context.Config.Project.MetadataBranch)
+            : null;
+        var effectiveImplementationBaseBranch = isSameRepo
+            ? (string.IsNullOrWhiteSpace(context.Config.Project.ImplementationBaseBranch)
+                ? null
+                : context.Config.Project.ImplementationBaseBranch)
+            : null;
+        var effectiveStableBranch = isSameRepo
+            ? (string.IsNullOrWhiteSpace(context.Config.Project.StableBranch)
+                ? null
+                : context.Config.Project.StableBranch)
+            : null;
+        // G350: when same-repo topology is active but metadata_branch is not configured,
+        // surface an advisory diagnostic (single-lane fallback — acceptable but noted).
+        var metadataLaneWarning = isSameRepo && string.IsNullOrWhiteSpace(context.Config.Project.MetadataBranch)
+            ? "METADATA LANE NOT CONFIGURED: `metadata_branch` is not set in `.intent-cli/config.toml`. Host metadata will be committed to the same branch as implementation work (single-lane fallback). Consider declaring `metadata_branch = \"main-metadata\"` to separate high-churn metadata from implementation history."
+            : null;
+
         // G349: copilot-local agent guidance when --agent copilot-local is set.
         var isCopilotLocal = string.Equals(agent, "copilot-local", StringComparison.Ordinal);
         var copilotLocalGuidance = isCopilotLocal ? CopilotLocalAgent : null;
@@ -243,6 +283,10 @@ internal static class GuideWorkflowTaskInitHostCommand
                 Refusals = refusalReasons.Count == 0 ? null : refusalReasons,
                 SameRepoTopology = sameRepoGuidance,
                 SameRepoPolicyWarning = sameRepoPolicyWarning,
+                EffectiveMetadataBranch = effectiveMetadataBranch,
+                EffectiveImplementationBaseBranch = effectiveImplementationBaseBranch,
+                EffectiveStableBranch = effectiveStableBranch,
+                MetadataLaneWarning = metadataLaneWarning,
                 CopilotLocalAgent = copilotLocalGuidance
             };
             writer.Write(JsonSerializer.Serialize(payload, JsonOptions));
@@ -250,7 +294,7 @@ internal static class GuideWorkflowTaskInitHostCommand
         }
         else
         {
-            WriteMarkdown(visibleRoles, hasDotIntentCli, forceHost, refusalReasons, sameRepoGuidance, sameRepoPolicyWarning, copilotLocalGuidance, writer);
+            WriteMarkdown(visibleRoles, hasDotIntentCli, forceHost, refusalReasons, sameRepoGuidance, sameRepoPolicyWarning, effectiveMetadataBranch, effectiveImplementationBaseBranch, effectiveStableBranch, metadataLaneWarning, copilotLocalGuidance, writer);
         }
 
         return refusalReasons.Count == 0 ? 0 : 1;
@@ -283,6 +327,10 @@ internal static class GuideWorkflowTaskInitHostCommand
         IReadOnlyList<string> refusals,
         SameRepoTopologyGuidance? sameRepoGuidance,
         string? sameRepoPolicyWarning,
+        string? effectiveMetadataBranch,
+        string? effectiveImplementationBaseBranch,
+        string? effectiveStableBranch,
+        string? metadataLaneWarning,
         CopilotLocalAgentGuidance? copilotLocalGuidance,
         TextWriter writer)
     {
@@ -365,6 +413,39 @@ internal static class GuideWorkflowTaskInitHostCommand
             {
                 writer.WriteLine();
                 writer.WriteLine($"⚠ {sameRepoPolicyWarning}");
+            }
+
+            // G350: emit metadata lane section.
+            if (sameRepoGuidance.MetadataLane is not null)
+            {
+                writer.WriteLine();
+                writer.WriteLine("### Metadata lane (three-branch model)");
+                writer.WriteLine();
+                writer.WriteLine($"- {sameRepoGuidance.MetadataLane.StableBranchRole}");
+                writer.WriteLine($"- {sameRepoGuidance.MetadataLane.ImplementationBaseBranchRole}");
+                writer.WriteLine($"- {sameRepoGuidance.MetadataLane.MetadataBranchRole}");
+                writer.WriteLine();
+                writer.WriteLine("#### Effective branch configuration (from context)");
+                writer.WriteLine($"- stable_branch: `{effectiveStableBranch ?? "(not configured)"}`");
+                writer.WriteLine($"- implementation_base_branch: `{effectiveImplementationBaseBranch ?? "(not configured — derive from base_branch_policy)"}`");
+                writer.WriteLine($"- metadata_branch: `{effectiveMetadataBranch ?? "(not configured — single-lane fallback)"}`");
+                writer.WriteLine();
+                writer.WriteLine("#### Diagnostics");
+                foreach (var diag in sameRepoGuidance.MetadataLane.Diagnostics)
+                {
+                    writer.WriteLine($"- {diag}");
+                }
+                writer.WriteLine();
+                writer.WriteLine("#### Config example (`.intent-cli/config.toml`)");
+                writer.WriteLine("```toml");
+                writer.WriteLine(sameRepoGuidance.MetadataLane.ConfigExample);
+                writer.WriteLine("```");
+
+                if (metadataLaneWarning is not null)
+                {
+                    writer.WriteLine();
+                    writer.WriteLine($"⚠ {metadataLaneWarning}");
+                }
             }
         }
 
@@ -595,11 +676,28 @@ internal sealed record InitHostGuidance
     /// <summary>G349: copilot-local agent guidance; null when <c>--agent copilot-local</c> is not set.</summary>
     [JsonPropertyName("copilot_local_agent")]
     public CopilotLocalAgentGuidance? CopilotLocalAgent { get; init; }
+
+    /// <summary>G350: effective metadata branch resolved from config; null when same-repo topology is not active or not configured.</summary>
+    [JsonPropertyName("effective_metadata_branch")]
+    public string? EffectiveMetadataBranch { get; init; }
+
+    /// <summary>G350: effective implementation base branch resolved from config; null when same-repo topology is not active or not configured.</summary>
+    [JsonPropertyName("effective_implementation_base_branch")]
+    public string? EffectiveImplementationBaseBranch { get; init; }
+
+    /// <summary>G350: effective stable branch resolved from config; null when same-repo topology is not active or not configured.</summary>
+    [JsonPropertyName("effective_stable_branch")]
+    public string? EffectiveStableBranch { get; init; }
+
+    /// <summary>G350: advisory warning when same-repo topology is active but metadata_branch is not configured (single-lane fallback).</summary>
+    [JsonPropertyName("metadata_lane_warning")]
+    public string? MetadataLaneWarning { get; init; }
 }
 
 /// <summary>
 /// G348: same-repo topology guidance emitted when
 /// <c>--topology same-repo</c> is passed to <c>guide workflow task init-host</c>.
+/// G350: extended with <see cref="MetadataLane"/> for the three-branch lane model.
 /// </summary>
 internal sealed record SameRepoTopologyGuidance
 {
@@ -617,6 +715,34 @@ internal sealed record SameRepoTopologyGuidance
 
     [JsonPropertyName("warning")]
     public required string Warning { get; init; }
+
+    /// <summary>G350: three-branch lane model guidance (stable / implementation / metadata).</summary>
+    [JsonPropertyName("metadata_lane")]
+    public SameRepoMetadataLaneGuidance? MetadataLane { get; init; }
+}
+
+/// <summary>
+/// G350: guidance for the same-repo three-branch lane model.
+/// Documents the roles of <c>stable_branch</c>, <c>implementation_base_branch</c>,
+/// and <c>metadata_branch</c> in a same-repo topology, plus diagnostic checks
+/// that agents must run before operating on each lane.
+/// </summary>
+internal sealed record SameRepoMetadataLaneGuidance
+{
+    [JsonPropertyName("stable_branch_role")]
+    public required string StableBranchRole { get; init; }
+
+    [JsonPropertyName("implementation_base_branch_role")]
+    public required string ImplementationBaseBranchRole { get; init; }
+
+    [JsonPropertyName("metadata_branch_role")]
+    public required string MetadataBranchRole { get; init; }
+
+    [JsonPropertyName("diagnostics")]
+    public required IReadOnlyList<string> Diagnostics { get; init; }
+
+    [JsonPropertyName("config_example")]
+    public required string ConfigExample { get; init; }
 }
 
 /// <summary>

--- a/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
+++ b/src/IntentSystem.Cli/Infrastructure/CliConfigLoader.cs
@@ -57,6 +57,12 @@ internal static class CliConfigLoader
         var parentIntentRepoRoot = TryGetOptionalString(rootTable, CliRuntimeContracts.ParentIntentRepoRootKey)
             ?? string.Empty;
         var baseBranchPolicy = ReadBaseBranchPolicy(rootTable, "CLI config root");
+        var stableBranch = TryGetOptionalString(rootTable, CliRuntimeContracts.StableBranchKey)
+            ?? string.Empty;
+        var implementationBaseBranch = TryGetOptionalString(rootTable, CliRuntimeContracts.ImplementationBaseBranchKey)
+            ?? string.Empty;
+        var metadataBranch = TryGetOptionalString(rootTable, CliRuntimeContracts.MetadataBranchKey)
+            ?? string.Empty;
         var roles = ReadRoles(rootTable);
         var supervision = ReadSupervision(rootTable);
         var run = ReadRun(rootTable);
@@ -69,6 +75,9 @@ internal static class CliConfigLoader
             workRepoPath,
             parentIntentRepoRoot,
             baseBranchPolicy,
+            stableBranch,
+            implementationBaseBranch,
+            metadataBranch,
             roles,
             supervision,
             run,
@@ -103,6 +112,12 @@ internal static class CliConfigLoader
         var parentIntentRepoRoot = TryGetOptionalString(projectTable, CliRuntimeContracts.ParentIntentRepoRootKey)
             ?? string.Empty;
         var baseBranchPolicy = ReadBaseBranchPolicy(projectTable, "CLI config [project] section");
+        var stableBranch = TryGetOptionalString(projectTable, CliRuntimeContracts.StableBranchKey)
+            ?? string.Empty;
+        var implementationBaseBranch = TryGetOptionalString(projectTable, CliRuntimeContracts.ImplementationBaseBranchKey)
+            ?? string.Empty;
+        var metadataBranch = TryGetOptionalString(projectTable, CliRuntimeContracts.MetadataBranchKey)
+            ?? string.Empty;
         var roles = ReadRoles(rootTable);
         var supervision = ReadSupervision(rootTable);
         var run = ReadRun(rootTable);
@@ -115,6 +130,9 @@ internal static class CliConfigLoader
             workRepoPath,
             parentIntentRepoRoot,
             baseBranchPolicy,
+            stableBranch,
+            implementationBaseBranch,
+            metadataBranch,
             roles,
             supervision,
             run,
@@ -129,6 +147,9 @@ internal static class CliConfigLoader
         string workRepoPath,
         string parentIntentRepoRoot,
         string baseBranchPolicy,
+        string stableBranch,
+        string implementationBaseBranch,
+        string metadataBranch,
         RoleMappings roles,
         SupervisionConfig supervision,
         RunConfig run,
@@ -143,7 +164,10 @@ internal static class CliConfigLoader
                 WorktreeRoot = worktreeRoot,
                 WorkRepoPath = workRepoPath,
                 ParentIntentRepoRoot = parentIntentRepoRoot,
-                BaseBranchPolicy = baseBranchPolicy
+                BaseBranchPolicy = baseBranchPolicy,
+                StableBranch = stableBranch,
+                ImplementationBaseBranch = implementationBaseBranch,
+                MetadataBranch = metadataBranch
             },
             Roles = roles,
             Supervision = supervision,

--- a/src/IntentSystem.Cli/Models/CliConfig.cs
+++ b/src/IntentSystem.Cli/Models/CliConfig.cs
@@ -26,6 +26,15 @@ internal sealed record ProjectConfig
     public string ParentIntentRepoRoot { get; init; } = string.Empty;
 
     public string BaseBranchPolicy { get; init; } = CliRuntimeContracts.DefaultBaseBranchPolicy;
+
+    /// <summary>G350: final stable branch in same-repo topology (e.g. "main"). Empty = not configured.</summary>
+    public string StableBranch { get; init; } = string.Empty;
+
+    /// <summary>G350: branch implementation PRs target in same-repo topology (e.g. "main" or "main-ai"). Empty = derive from BaseBranchPolicy.</summary>
+    public string ImplementationBaseBranch { get; init; } = string.Empty;
+
+    /// <summary>G350: dedicated metadata direct-push branch in same-repo topology (e.g. "main-metadata"). Empty = not configured.</summary>
+    public string MetadataBranch { get; init; } = string.Empty;
 }
 
 internal sealed record RoleMappings

--- a/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CliConfigLoaderTests.cs
@@ -307,6 +307,85 @@ public sealed class CliConfigLoaderTests
         Assert.Contains("trunk", exception.Message, StringComparison.Ordinal);
     }
 
+    // ----- G350: three branch-lane fields loaded from root-keys TOML -----
+
+    [Fact]
+    public void Load_G350_RootKeys_ParsesThreeBranchLaneFields()
+    {
+        // G350 loader AC: root-keys config with stable_branch, implementation_base_branch,
+        // and metadata_branch must populate ProjectConfig with the declared values.
+        var toml = """
+        default_domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        stable_branch = "main"
+        implementation_base_branch = "main-ai"
+        metadata_branch = "main-metadata"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+
+        Assert.Equal("main", config.Project.StableBranch);
+        Assert.Equal("main-ai", config.Project.ImplementationBaseBranch);
+        Assert.Equal("main-metadata", config.Project.MetadataBranch);
+    }
+
+    [Fact]
+    public void Load_G350_RootKeys_DefaultsThreeBranchLaneFieldsToEmpty()
+    {
+        // G350 loader AC: when the three branch-lane keys are absent from a root-keys
+        // config, all three fields default to empty string (not configured).
+        var toml = """
+        default_domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+
+        Assert.Equal(string.Empty, config.Project.StableBranch);
+        Assert.Equal(string.Empty, config.Project.ImplementationBaseBranch);
+        Assert.Equal(string.Empty, config.Project.MetadataBranch);
+    }
+
+    [Fact]
+    public void Load_G350_ProjectSection_ParsesThreeBranchLaneFields()
+    {
+        // G350 loader AC: [project]-section config with stable_branch,
+        // implementation_base_branch, and metadata_branch must populate ProjectConfig
+        // with the declared values.
+        var toml = """
+        [project]
+        domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        stable_branch = "main"
+        implementation_base_branch = "main-ai"
+        metadata_branch = "main-metadata"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+
+        Assert.Equal("main", config.Project.StableBranch);
+        Assert.Equal("main-ai", config.Project.ImplementationBaseBranch);
+        Assert.Equal("main-metadata", config.Project.MetadataBranch);
+    }
+
+    [Fact]
+    public void Load_G350_ProjectSection_DefaultsThreeBranchLaneFieldsToEmpty()
+    {
+        // G350 loader AC: when the three branch-lane keys are absent from a [project]
+        // section config, all three fields default to empty string (not configured).
+        var toml = """
+        [project]
+        domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+
+        Assert.Equal(string.Empty, config.Project.StableBranch);
+        Assert.Equal(string.Empty, config.Project.ImplementationBaseBranch);
+        Assert.Equal(string.Empty, config.Project.MetadataBranch);
+    }
+
     private sealed class TemporaryDirectory : IDisposable
     {
         private readonly string rootPath = Directory.CreateTempSubdirectory("intent-cli-tests-").FullName;

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskInitHostCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskInitHostCommandTests.cs
@@ -628,4 +628,242 @@ public sealed class GuideWorkflowTaskInitHostCommandTests : IDisposable
         var output = writer.ToString();
         Assert.Contains("--agent must be 'copilot-local'", output, StringComparison.Ordinal);
     }
+
+    // ----- G350: same-repo metadata branch lane guidance -----
+
+    [Fact]
+    public void Execute_G350_TopologySameRepo_MarkdownIncludesMetadataLaneSection()
+    {
+        // G350 AC: `guide workflow task init-host --topology same-repo` must
+        // emit a Metadata Lane section describing the three branch roles.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--topology", "same-repo" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Metadata lane", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("stable_branch", output, StringComparison.Ordinal);
+        Assert.Contains("implementation_base_branch", output, StringComparison.Ordinal);
+        Assert.Contains("metadata_branch", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G350_TopologySameRepo_JsonIncludesMetadataLaneNode()
+    {
+        // G350 AC: JSON shape must include `metadata_lane` under `same_repo_topology`
+        // with stable_branch_role, implementation_base_branch_role, metadata_branch_role,
+        // diagnostics, and config_example.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--topology", "same-repo", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("same_repo_topology", out var srt),
+            "same_repo_topology must be present.");
+        Assert.True(srt.TryGetProperty("metadata_lane", out var ml),
+            "metadata_lane must be present in same_repo_topology.");
+        Assert.True(ml.TryGetProperty("stable_branch_role", out _), "stable_branch_role must be present.");
+        Assert.True(ml.TryGetProperty("implementation_base_branch_role", out _), "implementation_base_branch_role must be present.");
+        Assert.True(ml.TryGetProperty("metadata_branch_role", out _), "metadata_branch_role must be present.");
+        Assert.True(ml.TryGetProperty("diagnostics", out var diags), "diagnostics must be present.");
+        Assert.True(diags.GetArrayLength() > 0, "diagnostics must be non-empty.");
+        Assert.True(ml.TryGetProperty("config_example", out _), "config_example must be present.");
+    }
+
+    [Fact]
+    public void Execute_G350_TopologySameRepo_NoMetadataBranch_EmitsMetadataLaneWarning()
+    {
+        // G350 AC: when same-repo topology is selected but metadata_branch is not
+        // configured, an advisory warning about single-lane fallback must appear.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--topology", "same-repo" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("METADATA LANE NOT CONFIGURED", output, StringComparison.Ordinal);
+        Assert.Contains("single-lane fallback", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_G350_TopologySameRepo_WithMetadataBranch_NoMetadataLaneWarning()
+    {
+        // G350 AC: when same-repo topology AND metadata_branch are configured,
+        // the metadata lane warning must NOT appear.
+        using var writer = new StringWriter();
+
+        var context = CreateContextWithBranchLane(emptyCwd, "main-metadata", "main-ai", "main");
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            context,
+            new[] { "--topology", "same-repo" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.DoesNotContain("METADATA LANE NOT CONFIGURED", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G350_TopologySameRepo_WithMetadataBranch_JsonIncludesEffectiveBranches()
+    {
+        // G350 AC: when metadata branch lane is configured, the JSON payload must
+        // surface effective_metadata_branch, effective_implementation_base_branch,
+        // and effective_stable_branch with the resolved values.
+        using var writer = new StringWriter();
+
+        var context = CreateContextWithBranchLane(emptyCwd, "main-metadata", "main-ai", "main");
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            context,
+            new[] { "--topology", "same-repo", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("effective_metadata_branch", out var emb),
+            "effective_metadata_branch must be present.");
+        Assert.Equal("main-metadata", emb.GetString());
+        Assert.True(root.TryGetProperty("effective_implementation_base_branch", out var eibb),
+            "effective_implementation_base_branch must be present.");
+        Assert.Equal("main-ai", eibb.GetString());
+        Assert.True(root.TryGetProperty("effective_stable_branch", out var esb),
+            "effective_stable_branch must be present.");
+        Assert.Equal("main", esb.GetString());
+    }
+
+    [Fact]
+    public void Execute_G350_NoTopology_MetadataLaneAbsent()
+    {
+        // G350: when --topology is not passed, metadata_lane must be absent.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.False(root.TryGetProperty("effective_metadata_branch", out _),
+            "effective_metadata_branch must be absent when --topology is not set.");
+        Assert.False(root.TryGetProperty("metadata_lane_warning", out _),
+            "metadata_lane_warning must be absent when --topology is not set.");
+    }
+
+    [Fact]
+    public void Execute_G350_TopologySameRepo_DiagnosticsIncludeWrongBranchCheck()
+    {
+        // G350 Verification: metadata lane diagnostics must include guidance about
+        // checking the current branch before metadata mutation.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--topology", "same-repo" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // Diagnostic for wrong-branch metadata mutation.
+        Assert.Contains("wrong branch", output, StringComparison.OrdinalIgnoreCase);
+        // Diagnostic for implementation PR touching metadata paths.
+        Assert.Contains(".intent-cli/**", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G350_TopologySameRepo_ConfigExampleMentionsAllThreeBranches()
+    {
+        // G350 Verification: the config_example must show all three branch keys
+        // so operators can copy-paste a working configuration.
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            CreateContext(emptyCwd),
+            new[] { "--topology", "same-repo" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // All three branch keys appear in the config example.
+        Assert.Contains("stable_branch", output, StringComparison.Ordinal);
+        Assert.Contains("implementation_base_branch", output, StringComparison.Ordinal);
+        Assert.Contains("metadata_branch", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G350_ProjectConfig_SupportsThreeBranchLaneFields()
+    {
+        // G350 AC: ProjectConfig must expose StableBranch, ImplementationBaseBranch,
+        // and MetadataBranch properties that default to empty (not configured).
+        var config = new ProjectConfig
+        {
+            Domain = "test",
+            ArtifactRoot = ".intent-cli"
+        };
+
+        Assert.Equal(string.Empty, config.MetadataBranch);
+        Assert.Equal(string.Empty, config.ImplementationBaseBranch);
+        Assert.Equal(string.Empty, config.StableBranch);
+    }
+
+    [Fact]
+    public void Execute_G350_ProjectConfig_CanSetThreeBranchLaneValues()
+    {
+        // G350 AC: ProjectConfig must accept explicit values for the three branch
+        // lane fields when declared in config.
+        var config = new ProjectConfig
+        {
+            Domain = "test",
+            ArtifactRoot = ".intent-cli",
+            StableBranch = "main",
+            ImplementationBaseBranch = "main-ai",
+            MetadataBranch = "main-metadata"
+        };
+
+        Assert.Equal("main", config.StableBranch);
+        Assert.Equal("main-ai", config.ImplementationBaseBranch);
+        Assert.Equal("main-metadata", config.MetadataBranch);
+    }
+
+    private static CliContext CreateContextWithBranchLane(
+        string repoRoot,
+        string metadataBranch,
+        string implementationBaseBranch,
+        string stableBranch)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                    MetadataBranch = metadataBranch,
+                    ImplementationBaseBranch = implementationBaseBranch,
+                    StableBranch = stableBranch
+                }
+            }
+        };
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskInitHostCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskInitHostCommandTests.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Infrastructure;
 using IntentSystem.Cli.Models;
 
 namespace IntentSystem.Cli.Tests;
@@ -841,6 +842,102 @@ public sealed class GuideWorkflowTaskInitHostCommandTests : IDisposable
         Assert.Equal("main", config.StableBranch);
         Assert.Equal("main-ai", config.ImplementationBaseBranch);
         Assert.Equal("main-metadata", config.MetadataBranch);
+    }
+
+    // ----- G350: end-to-end TOML loader → init-host command output -----
+
+    [Fact]
+    public void Execute_G350_LoaderToCommand_RootKeysTOML_EffectiveBranchesInJson()
+    {
+        // G350 loader AC: values declared in root-keys TOML config must flow through
+        // CliConfigLoader into guide workflow task init-host --topology same-repo
+        // JSON output as effective_metadata_branch / effective_implementation_base_branch
+        // / effective_stable_branch.
+        var toml = """
+        default_domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        stable_branch = "main"
+        implementation_base_branch = "main-ai"
+        metadata_branch = "main-metadata"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+        var context = new CliContext { RepoRoot = emptyCwd, Config = config };
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            context,
+            new[] { "--topology", "same-repo", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.True(root.TryGetProperty("effective_metadata_branch", out var emb));
+        Assert.Equal("main-metadata", emb.GetString());
+        Assert.True(root.TryGetProperty("effective_implementation_base_branch", out var eibb));
+        Assert.Equal("main-ai", eibb.GetString());
+        Assert.True(root.TryGetProperty("effective_stable_branch", out var esb));
+        Assert.Equal("main", esb.GetString());
+    }
+
+    [Fact]
+    public void Execute_G350_LoaderToCommand_ProjectSectionTOML_EffectiveBranchesInMarkdown()
+    {
+        // G350 loader AC: values declared in [project]-section TOML config must flow
+        // through CliConfigLoader into guide workflow task init-host --topology same-repo
+        // markdown output as effective branch references.
+        var toml = """
+        [project]
+        domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        stable_branch = "main"
+        implementation_base_branch = "main-ai"
+        metadata_branch = "main-metadata"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+        var context = new CliContext { RepoRoot = emptyCwd, Config = config };
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            context,
+            new[] { "--topology", "same-repo" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // Effective branch values from TOML must appear in the markdown output.
+        Assert.Contains("main-metadata", output, StringComparison.Ordinal);
+        Assert.Contains("main-ai", output, StringComparison.Ordinal);
+        // No advisory warning because metadata_branch is configured.
+        Assert.DoesNotContain("METADATA LANE NOT CONFIGURED", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G350_LoaderToCommand_NoMetadataBranchInTOML_EmitsAdvisory()
+    {
+        // G350 loader AC: when TOML config does not declare metadata_branch, the loaded
+        // config produces an empty MetadataBranch and the command must emit the advisory
+        // about single-lane fallback.
+        var toml = """
+        default_domain = "intent-cli"
+        artifact_root = ".intent-cli"
+        """;
+
+        var config = CliConfigLoader.Load(toml);
+        var context = new CliContext { RepoRoot = emptyCwd, Config = config };
+        using var writer = new StringWriter();
+
+        var exitCode = GuideWorkflowTaskInitHostCommand.Execute(
+            context,
+            new[] { "--topology", "same-repo" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("METADATA LANE NOT CONFIGURED", output, StringComparison.Ordinal);
     }
 
     private static CliContext CreateContextWithBranchLane(


### PR DESCRIPTION
## Summary

- Adds `StableBranch`, `ImplementationBaseBranch`, `MetadataBranch` to `ProjectConfig` (all default empty = not configured); 5 new constants in `CliRuntimeContracts`
- Extends `SameRepoTopologyGuidance` with a `MetadataLane` node (new `SameRepoMetadataLaneGuidance` record) describing the three-branch lane model: stable / implementation / metadata
- `guide workflow task init-host --topology same-repo` now emits a `### Metadata lane` section with effective branch values from config, 5 diagnostic checks (wrong-branch guard, metadata-path rejection, missing/stale branch, single-lane fallback), and a config example
- Advisory warning when `metadata_branch` is not configured (single-lane fallback)
- 10 new G350 tests

## Test plan

- [x] 10 G350 tests pass: markdown section, JSON shape, unconfigured advisory, configured suppresses advisory, effective branches in JSON, absent when no topology, diagnostics, config example, `ProjectConfig` defaults, `ProjectConfig` explicit values
- [x] Full suite: 2906 passed, 0 failed (1 pre-existing skip; 1 pre-existing flake isolated to parallel-run contention, passes solo)
- [x] `guide workflow task init-host --topology same-repo` markdown includes `Metadata lane`, `stable_branch`, `implementation_base_branch`, `metadata_branch`, diagnostics, config example
- [x] JSON `same_repo_topology.metadata_lane` includes all five fields

Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)