### PR TITLE
G351 scope selected-PR linked_pr recovery to closing issue before review lease stop

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
@@ -6,7 +6,7 @@ using IntentSystem.Supervisor.Serialization;
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G303: <c>intent-cli automation publish-recovery</c> — host-only safe
+/// G303 / G351: <c>intent-cli automation publish-recovery</c> — host-only safe
 /// recovery lane that consults
 /// <c>.intent-cli/issues/&lt;execution-unit&gt;/publish.yaml</c> together with the
 /// open PR list to repair queue-state items whose <c>linked_issue</c> AND
@@ -21,6 +21,13 @@ namespace IntentSystem.Cli.Commands;
 /// (which handles items that already have a <c>linked_issue</c>): G303
 /// covers the both-null variant that <c>reconcile</c> currently treats as
 /// advisory only.
+///
+/// G351: <c>--pr &lt;n&gt;</c> scopes the analysis to only the queue item
+/// that is relevant to the selected PR — the candidate whose
+/// <c>linked_issue</c> matches the closing-issue reference of PR #N.
+/// Without scoping the broad scan may flood the operator with unrelated
+/// unsafe stops. The scoped path returns at most one repair or one unsafe
+/// stop and never touches unrelated queue items.
 /// </summary>
 internal static class AutomationPublishRecoveryCommand
 {
@@ -44,7 +51,7 @@ internal static class AutomationPublishRecoveryCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (!TryParseArguments(args, out var repo, out var write, out var format, out var error))
+        if (!TryParseArguments(args, out var repo, out var selectedPr, out var write, out var format, out var error))
         {
             writer.WriteLine(error);
             return 1;
@@ -83,7 +90,18 @@ internal static class AutomationPublishRecoveryCommand
             return 1;
         }
 
-        var analysis = PublishRecoveryAnalyzer.Analyze(repo!, candidates, openPrs);
+        // G351: when --pr is given, scope the analysis to only the queue
+        // item relevant to the selected PR. This avoids flooding the
+        // operator with unrelated unsafe stops from a broad scan.
+        PublishRecoveryAnalysis analysis;
+        if (selectedPr is int prNumber)
+        {
+            analysis = PublishRecoveryAnalyzer.AnalyzeScopedToPr(repo!, candidates, openPrs, prNumber);
+        }
+        else
+        {
+            analysis = PublishRecoveryAnalyzer.Analyze(repo!, candidates, openPrs);
+        }
 
         var applied = new List<PublishRecoveryRepair>();
         var failures = new List<string>();
@@ -104,6 +122,7 @@ internal static class AutomationPublishRecoveryCommand
         {
             Repo = repo!,
             Mode = write ? ModeWrite : ModeDryRun,
+            SelectedPr = selectedPr,
             QueueStatePath = queueStatePath,
             SafeRepairs = analysis.SafeRepairs,
             UnsafeStops = analysis.UnsafeStops,
@@ -270,11 +289,13 @@ internal static class AutomationPublishRecoveryCommand
     private static bool TryParseArguments(
         string[] args,
         out string? repo,
+        out int? selectedPr,
         out bool write,
         out string format,
         out string error)
     {
         repo = null;
+        selectedPr = null;
         write = false;
         format = FormatMarkdown;
         error = string.Empty;
@@ -291,6 +312,23 @@ internal static class AutomationPublishRecoveryCommand
                         return false;
                     }
                     repo = args[++index].Trim();
+                    break;
+                case "--pr":
+                    // G351: optional PR scoping — scope analysis to the queue
+                    // item relevant to the selected PR's closing-issue reference.
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--pr requires a PR number.";
+                        return false;
+                    }
+                    var prRaw = args[++index].Trim().TrimStart('#');
+                    if (!int.TryParse(prRaw, System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture, out var prParsed) || prParsed <= 0)
+                    {
+                        error = $"--pr must be a positive integer PR number (got '{args[index]}').";
+                        return false;
+                    }
+                    selectedPr = prParsed;
                     break;
                 case "--write":
                     if (dryRun)
@@ -345,6 +383,10 @@ internal sealed record AutomationPublishRecoveryResult
 
     [JsonPropertyName("mode")]
     public required string Mode { get; init; }
+
+    /// <summary>G351: when --pr was supplied, the selected PR number. Null for a broad scan.</summary>
+    [JsonPropertyName("selected_pr")]
+    public int? SelectedPr { get; init; }
 
     [JsonPropertyName("queue_state_path")]
     public required string QueueStatePath { get; init; }

--- a/src/IntentSystem.Cli/Commands/PublishRecoveryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PublishRecoveryAnalyzer.cs
@@ -46,6 +46,79 @@ internal static class PublishRecoveryAnalyzer
         @"(?i)\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+(?:(?<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(?<number>\d+)\b",
         RegexOptions.Compiled);
 
+    /// <summary>
+    /// G351: PR-scoped analysis. Finds the selected PR from
+    /// <paramref name="openPrs"/>, extracts its closing-issue references, and
+    /// then runs the standard analysis only on the candidates whose
+    /// <c>linked_issue</c> number matches one of those closing issues. At most
+    /// one queue item is in scope, so the result contains at most one repair or
+    /// one unsafe stop — unrelated G* items are never included.
+    ///
+    /// If the selected PR is not found in <paramref name="openPrs"/>, or if
+    /// none of its closing issues match any candidate, the analysis returns
+    /// empty repairs and empty unsafe stops (no-op; the PR may already be
+    /// linked or closed).
+    /// </summary>
+    public static PublishRecoveryAnalysis AnalyzeScopedToPr(
+        string repo,
+        IReadOnlyList<PublishRecoveryCandidate> candidates,
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
+        int prNumber)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(candidates);
+        ArgumentNullException.ThrowIfNull(openPrs);
+
+        var selectedPr = openPrs.FirstOrDefault(pr => pr.Number == prNumber);
+        if (selectedPr is null)
+        {
+            // PR not found in the open list; nothing to scope to.
+            return new PublishRecoveryAnalysis { Repo = repo, SafeRepairs = [], UnsafeStops = [] };
+        }
+
+        var closingIssues = new HashSet<int>(ExtractLinkedIssueNumbers(repo, selectedPr));
+        if (closingIssues.Count == 0)
+        {
+            // PR has no closing-issue references — cannot determine which queue
+            // item to scope to. Surface as a single scoped unsafe stop so the
+            // operator knows the PR body needs a Closes/Fixes/Resolves reference.
+            return new PublishRecoveryAnalysis
+            {
+                Repo = repo,
+                SafeRepairs = [],
+                UnsafeStops = new[]
+                {
+                    new PublishRecoveryUnsafeStop
+                    {
+                        Kind = UnsafeNoClosingPrForLinkedIssue,
+                        ExecutionUnit = $"<selected-pr-{prNumber}>",
+                        Reason = $"PR #{prNumber} has no Closes/Fixes/Resolves reference. Cannot scope recovery to a queue item without a deterministic closing-issue link (G311).",
+                        PublishArtifactPath = string.Empty
+                    }
+                }
+            };
+        }
+
+        // Filter candidates to only those whose linked_issue matches a
+        // closing-issue reference of the selected PR.
+        var scopedCandidates = candidates
+            .Where(c => c.LinkedIssueNumber is int n && closingIssues.Contains(n))
+            .ToArray();
+
+        if (scopedCandidates.Length == 0)
+        {
+            // No queue item has a linked_issue that matches this PR's closing
+            // references. The PR may be for an untracked issue; no-op.
+            return new PublishRecoveryAnalysis { Repo = repo, SafeRepairs = [], UnsafeStops = [] };
+        }
+
+        // Run the standard analysis restricted to the scoped candidates. The
+        // normal ambiguity checks in AnalyzeLinkedIssueLane still apply within
+        // the scoped set (multiple queue items for the same linked_issue would
+        // produce an unsafe stop rather than a repair).
+        return Analyze(repo, scopedCandidates, openPrs);
+    }
+
     public static PublishRecoveryAnalysis Analyze(
         string repo,
         IReadOnlyList<PublishRecoveryCandidate> candidates,

--- a/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
@@ -358,8 +358,11 @@ internal static class ReviewCloseoutPlanCommand
             var missingLinkedPrGap = matchedItem is null
                 && gaps.Any(g => string.Equals(g.Classification, GapClassificationHostMetadata, StringComparison.Ordinal)
                     && g.Description.Contains("no queue item found with linked_pr", StringComparison.Ordinal));
+            // G351: include --pr <n> in the publish-recovery recommendation so
+            // the operator gets a scoped single-item recovery rather than a
+            // broad scan that floods with unrelated unsafe stops.
             recommendedRecoveryCommand = missingLinkedPrGap && PublishArtifactsExist(context.RepoRoot)
-                ? $"intent-cli automation publish-recovery --repo {repo} --format json"
+                ? $"intent-cli automation publish-recovery --repo {repo} --pr {pr} --format json"
                 : $"intent-cli automation reconcile --lane host-review --repo {repo} --format json";
         }
         else
@@ -393,6 +396,17 @@ internal static class ReviewCloseoutPlanCommand
             }
         }
 
+        // G351: when blockerClassification is host-metadata-blocked, surface
+        // explicit review-release guidance. If recovery cannot proceed (e.g.,
+        // no publish artifacts, no closing-issue reference, ambiguous match),
+        // the host loop must release the intent-pr-reviewing lease before
+        // stopping — otherwise the PR stays stuck in reviewing state.
+        string? reviewReleaseCommand = null;
+        if (string.Equals(blockerClassification, BlockerClassificationHostMetadataBlocked, StringComparison.Ordinal))
+        {
+            reviewReleaseCommand = $"intent-cli automation pr-transition --repo {repo} --pr {pr} --transition review-release --write";
+        }
+
         var result = new ReviewCloseoutPlanResult
         {
             Domain = domain,
@@ -412,6 +426,7 @@ internal static class ReviewCloseoutPlanCommand
             ClassifiedGaps = gaps,
             BlockerClassification = blockerClassification,
             RecommendedRecoveryCommand = recommendedRecoveryCommand,
+            ReviewReleaseCommand = reviewReleaseCommand,
             Ready = ready,
             RecoveredLinkage = recoveredLinkage,
             AmbiguousLinkage = ambiguousLinkage,
@@ -806,6 +821,12 @@ internal static class ReviewCloseoutPlanCommand
         {
             writer.WriteLine($"- recommended recovery command: {result.RecommendedRecoveryCommand}");
         }
+        // G351: surface review-release command when host-metadata-blocked so
+        // the host loop knows to release intent-pr-reviewing before stopping.
+        if (!string.IsNullOrWhiteSpace(result.ReviewReleaseCommand))
+        {
+            writer.WriteLine($"- review release required: {result.ReviewReleaseCommand}");
+        }
 
         writer.WriteLine();
 
@@ -1105,6 +1126,18 @@ internal sealed record ReviewCloseoutPlanResult
     /// </summary>
     [JsonPropertyName("recommended_recovery_command")]
     public required string? RecommendedRecoveryCommand { get; init; }
+
+    /// <summary>
+    /// G351: when <c>blocker_classification</c> is
+    /// <c>host-metadata-blocked</c>, this field surfaces the exact
+    /// <c>pr-transition --transition review-release</c> command the host
+    /// loop must run before stopping. Releasing <c>intent-pr-reviewing</c>
+    /// prevents the PR from staying stuck in the reviewing state when the
+    /// only blocker is a recoverable host-metadata gap.
+    /// Null for ready or implementation-review-finding wakes.
+    /// </summary>
+    [JsonPropertyName("review_release_command")]
+    public string? ReviewReleaseCommand { get; init; }
 
     [JsonPropertyName("ready")]
     public required bool Ready { get; init; }

--- a/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
@@ -254,6 +254,186 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         Assert.Contains("--repo", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // --- G351: --pr scoped recovery ----
+
+    [Fact]
+    public void Execute_G351_ScopedToPr_G346Fixture_ProducesSingleRepair_DryRun()
+    {
+        // G351 AC fixture: queue item G346 has linked_issue=#795, linked_pr=null.
+        // An unrelated G999 item also has missing linked_pr. --pr 796 scopes
+        // the result to only G346 — G999 must not appear.
+        using var workspace = new RecoveryWorkspace();
+        var li795 = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 795,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/795" };
+        var li888 = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 888,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/888" };
+        var qs = BuildQueueStateMulti(
+            ("G346", li795, null),
+            ("G999", li888, null));
+        workspace.WriteQueueState(qs);
+
+        // PR #796 closes #795; PR #900 closes #888.
+        AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
+            new[] { BuildPr(796, "Closes #795"), BuildPr(900, "Closes #888") });
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("dry-run", root.GetProperty("mode").GetString());
+        Assert.Equal(796, root.GetProperty("selected_pr").GetInt32());
+        Assert.Equal(1, root.GetProperty("safe_repairs").GetArrayLength());
+        Assert.Equal(0, root.GetProperty("unsafe_stops").GetArrayLength());
+        var repair = root.GetProperty("safe_repairs")[0];
+        Assert.Equal("G346", repair.GetProperty("execution_unit").GetString());
+        Assert.Equal(795, repair.GetProperty("linked_issue_number").GetInt32());
+        Assert.Equal(796, repair.GetProperty("linked_pr_number").GetInt32());
+    }
+
+    [Fact]
+    public void Execute_G351_ScopedToPr_Write_AppliesRepairForSelectedPrOnly()
+    {
+        // G351 AC: --pr --write applies the repair for the selected PR's
+        // linked queue item and does NOT mutate unrelated G999 item.
+        using var workspace = new RecoveryWorkspace();
+        var li795 = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 795,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/795" };
+        var li888 = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 888,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/888" };
+        workspace.WriteQueueState(BuildQueueStateMulti(("G346", li795, null), ("G999", li888, null)));
+
+        AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
+            new[] { BuildPr(796, "Closes #795"), BuildPr(900, "Closes #888") });
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(1, doc.RootElement.GetProperty("applied_count").GetInt32());
+
+        var queueAfter = QueueStateSerializer.Deserialize(
+            File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        var g346 = queueAfter.Items.First(i => i.ExecutionUnit == "G346");
+        var g999 = queueAfter.Items.First(i => i.ExecutionUnit == "G999");
+        // G346 got the repair.
+        Assert.Contains("/pull/796", g346.LinkedPr!, StringComparison.Ordinal);
+        // G999 was NOT mutated.
+        Assert.Null(g999.LinkedPr);
+    }
+
+    [Fact]
+    public void Execute_G351_ScopedToPr_InvalidPrNumber_ReturnsError()
+    {
+        using var workspace = new RecoveryWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G346", linkedIssue: null, linkedPr: null));
+        using var writer = new StringWriter();
+
+        var exitCode = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "not-a-number"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--pr", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G351_ScopedToPr_NoPrInOpenList_ReturnsEmptyNoOp()
+    {
+        // G351: when the selected PR is not in the open list (already merged),
+        // the scoped result is empty — no repairs and no unsafe stops.
+        using var workspace = new RecoveryWorkspace();
+        var li = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 795,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/795" };
+        workspace.WriteQueueState(BuildQueueState("G346", linkedIssue: li, linkedPr: null));
+
+        AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
+            new[] { BuildPr(900, "Closes #900") }); // PR #796 is NOT in the list
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("safe_repairs").GetArrayLength());
+        Assert.Equal(0, doc.RootElement.GetProperty("unsafe_stops").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_G351_ScopedToPr_PrHasNoClosingRef_ProducesConciseScopedUnsafeStop()
+    {
+        // G351 snapshot verification: with --pr, when the selected PR has no
+        // closing reference, the output contains exactly one unsafe stop (scoped)
+        // and does NOT include stops from unrelated queue items.
+        using var workspace = new RecoveryWorkspace();
+        var li795 = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 795,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/795" };
+        var li888 = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 888,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/888" };
+        workspace.WriteQueueState(BuildQueueStateMulti(("G346", li795, null), ("G999", li888, null)));
+
+        AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
+            new[] { BuildPr(796, "PR without closing reference") }); // no Closes #N
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        // Exactly one concise unsafe stop, not a flood of two stops.
+        Assert.Equal(0, doc.RootElement.GetProperty("safe_repairs").GetArrayLength());
+        Assert.Equal(1, doc.RootElement.GetProperty("unsafe_stops").GetArrayLength());
+        var stop = doc.RootElement.GetProperty("unsafe_stops")[0];
+        // The stop must mention the selected PR number.
+        Assert.Contains("796", stop.GetProperty("reason").GetString()!, StringComparison.Ordinal);
+    }
+
+    private static string BuildQueueStateMulti(params (string ExecutionUnit, LinkedIssue? LinkedIssue, string? LinkedPr)[] items)
+    {
+        var queueItems = items.Select(i => new QueueItem
+        {
+            ExecutionUnit = i.ExecutionUnit,
+            Title = $"{i.ExecutionUnit} title",
+            State = QueueItemState.Queued,
+            Dependencies = Array.Empty<string>(),
+            BlockedBy = Array.Empty<string>(),
+            ClarificationReturnPath = string.Empty,
+            PacketPaths = new PacketPaths
+            {
+                Yaml = $".intent-cli/issues/{i.ExecutionUnit}/packet.yaml",
+                Implementation = $".intent-cli/issues/{i.ExecutionUnit}/implementation.md",
+                ReviewContext = $".intent-cli/issues/{i.ExecutionUnit}/review-context.md"
+            },
+            LinkedIssue = i.LinkedIssue,
+            LinkedPr = i.LinkedPr,
+            WorkerRole = "Claude",
+            ReviewRole = "Codex",
+            Priority = "normal"
+        }).ToArray();
+        var state = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = new DateTimeOffset(2026, 5, 14, 0, 0, 0, TimeSpan.Zero),
+            Items = queueItems
+        };
+        return QueueStateSerializer.Serialize(state);
+    }
+
     private static string BuildQueueState(string executionUnit, LinkedIssue? linkedIssue, string? linkedPr)
     {
         var state = new QueueState

--- a/tests/IntentSystem.Cli.Tests/PublishRecoveryAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PublishRecoveryAnalyzerTests.cs
@@ -369,6 +369,136 @@ public sealed class PublishRecoveryAnalyzerTests
         Assert.Empty(result.UnsafeStops);
     }
 
+    // ----- G351: AnalyzeScopedToPr -----
+
+    [Fact]
+    public void AnalyzeScopedToPr_G351_G346Fixture_LinkedIssuePresent_ProducesSingleRepair()
+    {
+        // G351 AC fixture: queue item G346 has linked_issue=#795, linked_pr=null.
+        // PR #796 closes #795. Scoped recovery must return exactly one
+        // high-confidence repair and no unrelated unsafe stops.
+        var candidate = NewLinkedIssueCandidate("G346", "J-Tech-Japan/intent-system", 795,
+            "https://github.com/J-Tech-Japan/intent-system/issues/795");
+        var unrelated = NewLinkedIssueCandidate("G999", "J-Tech-Japan/intent-system", 888,
+            "https://github.com/J-Tech-Japan/intent-system/issues/888");
+        var pr796 = BuildPr(796, "G346 base branch", "Closes #795");
+        var pr900 = BuildPr(900, "G999 unrelated", "Closes #888");
+
+        var result = PublishRecoveryAnalyzer.AnalyzeScopedToPr(
+            "J-Tech-Japan/intent-system",
+            new[] { candidate, unrelated },
+            new[] { pr796, pr900 },
+            prNumber: 796);
+
+        Assert.Single(result.SafeRepairs);
+        Assert.Empty(result.UnsafeStops);
+        var repair = result.SafeRepairs[0];
+        Assert.Equal("G346", repair.ExecutionUnit);
+        Assert.Equal(795, repair.LinkedIssueNumber);
+        Assert.Equal(796, repair.LinkedPrNumber);
+        Assert.Equal(PublishRecoveryAnalyzer.RepairTypeLinkedIssueClosingPr, repair.Type);
+        Assert.Equal("high", repair.Confidence);
+    }
+
+    [Fact]
+    public void AnalyzeScopedToPr_G351_PrNotInOpenList_ReturnsEmpty()
+    {
+        // G351: when the selected PR is not in the open PR list (already
+        // merged/closed), the scoped analysis returns empty — no-op.
+        var candidate = NewLinkedIssueCandidate("G346", "J-Tech-Japan/intent-system", 795, null);
+        var pr797 = BuildPr(797, "other PR", "Closes #799");
+
+        var result = PublishRecoveryAnalyzer.AnalyzeScopedToPr(
+            "J-Tech-Japan/intent-system",
+            new[] { candidate },
+            new[] { pr797 },
+            prNumber: 796);
+
+        Assert.Empty(result.SafeRepairs);
+        Assert.Empty(result.UnsafeStops);
+    }
+
+    [Fact]
+    public void AnalyzeScopedToPr_G351_PrHasNoClosingReference_ProducesScopedUnsafeStop()
+    {
+        // G351: when the selected PR has no Closes/Fixes/Resolves reference,
+        // the scoped analysis produces a single concise unsafe stop — not a
+        // flood of unrelated stops.
+        var candidate = NewLinkedIssueCandidate("G346", "J-Tech-Japan/intent-system", 795, null);
+        var pr796 = BuildPr(796, "G346 PR", "no closing reference here");
+
+        var result = PublishRecoveryAnalyzer.AnalyzeScopedToPr(
+            "J-Tech-Japan/intent-system",
+            new[] { candidate },
+            new[] { pr796 },
+            prNumber: 796);
+
+        Assert.Empty(result.SafeRepairs);
+        Assert.Single(result.UnsafeStops);
+        Assert.Equal(PublishRecoveryAnalyzer.UnsafeNoClosingPrForLinkedIssue, result.UnsafeStops[0].Kind);
+        Assert.Contains("796", result.UnsafeStops[0].Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnalyzeScopedToPr_G351_NoCandidateMatchesClosingIssue_ReturnsEmpty()
+    {
+        // G351: when the selected PR closes an issue that no queue candidate
+        // has as its linked_issue, the scoped analysis returns empty — the PR
+        // may be for an untracked issue.
+        var candidate = NewLinkedIssueCandidate("G346", "J-Tech-Japan/intent-system", 795, null);
+        var pr796 = BuildPr(796, "untracked issue PR", "Closes #999");
+
+        var result = PublishRecoveryAnalyzer.AnalyzeScopedToPr(
+            "J-Tech-Japan/intent-system",
+            new[] { candidate },
+            new[] { pr796 },
+            prNumber: 796);
+
+        Assert.Empty(result.SafeRepairs);
+        Assert.Empty(result.UnsafeStops);
+    }
+
+    [Fact]
+    public void AnalyzeScopedToPr_G351_UnrelatedQueueItemsNotIncluded()
+    {
+        // G351 verification: when multiple queue items have missing linked_pr,
+        // a scoped call for PR #796 / issue #795 only surfaces that one item —
+        // G999/888 is untouched even though it also has missing linked_pr.
+        var g346 = NewLinkedIssueCandidate("G346", "J-Tech-Japan/intent-system", 795, null);
+        var g999 = NewLinkedIssueCandidate("G999", "J-Tech-Japan/intent-system", 888, null);
+        var pr796 = BuildPr(796, "G346", "Closes #795");
+        var pr900 = BuildPr(900, "G999", "Closes #888");
+
+        var result = PublishRecoveryAnalyzer.AnalyzeScopedToPr(
+            "J-Tech-Japan/intent-system",
+            new[] { g346, g999 },
+            new[] { pr796, pr900 },
+            prNumber: 796);
+
+        // Only G346 is in scope; G999 must not appear in repairs or stops.
+        Assert.All(result.SafeRepairs, r => Assert.Equal("G346", r.ExecutionUnit));
+        Assert.All(result.UnsafeStops, s => Assert.NotEqual("G999", s.ExecutionUnit));
+    }
+
+    [Fact]
+    public void AnalyzeScopedToPr_G351_IssueMismatch_DoesNotRepair()
+    {
+        // G351 negative test: queue item G346 has linked_issue=#795 but
+        // PR #796 closes #888 (wrong issue). No candidate matches, result is empty.
+        var candidate = NewLinkedIssueCandidate("G346", "J-Tech-Japan/intent-system", 795, null);
+        var pr796 = BuildPr(796, "mismatch", "Closes #888");
+
+        var result = PublishRecoveryAnalyzer.AnalyzeScopedToPr(
+            "J-Tech-Japan/intent-system",
+            new[] { candidate },
+            new[] { pr796 },
+            prNumber: 796);
+
+        Assert.Empty(result.SafeRepairs);
+        // No stop either — the PR just doesn't match any in-scope candidate.
+        Assert.Empty(result.UnsafeStops);
+    }
+
     private static PublishRecoveryCandidate NewLinkedIssueCandidate(
         string executionUnit,
         string linkedIssueRepo,

--- a/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
@@ -1198,6 +1198,127 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             """;
     }
 
+    // ----- G351: review-release guidance and --pr scoped publish-recovery -----
+
+    [Fact]
+    public void Execute_G351_HostMetadataBlocked_EmitsReviewReleaseCommand()
+    {
+        // G351 AC: when blocker_classification is host-metadata-blocked, the
+        // result must include a review_release_command surfacing the exact
+        // pr-transition --transition review-release command so the host loop
+        // can release intent-pr-reviewing before stopping.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G346", "review", linkedPr: "999", linkedIssue: null));
+
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("host-metadata-blocked", root.GetProperty("blocker_classification").GetString());
+        Assert.True(root.TryGetProperty("review_release_command", out var rrCmd),
+            "review_release_command must be present when host-metadata-blocked.");
+        var rrCmdStr = rrCmd.GetString()!;
+        Assert.Contains("pr-transition", rrCmdStr, StringComparison.Ordinal);
+        Assert.Contains("review-release", rrCmdStr, StringComparison.Ordinal);
+        Assert.Contains("796", rrCmdStr, StringComparison.Ordinal);
+        Assert.Contains("J-Tech-Japan/intent-system", rrCmdStr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G351_Ready_ReviewReleaseCommandIsNull()
+    {
+        // G351: when the closeout plan is ready, review_release_command must
+        // be null — no lease release is needed for a clean wake.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review",
+            linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/796",
+            linkedIssue: ("J-Tech-Japan/intent-system", 795, "https://github.com/J-Tech-Japan/intent-system/issues/795")));
+        WriteCompliantPacketFiles(workspace, "G247");
+
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("ready").GetBoolean());
+        if (root.TryGetProperty("review_release_command", out var rrCmd))
+        {
+            // Must be null when ready.
+            Assert.Equal(JsonValueKind.Null, rrCmd.ValueKind);
+        }
+    }
+
+    [Fact]
+    public void Execute_G351_HostMetadataBlocked_PublishRecoveryRecommendationIncludesPrFlag()
+    {
+        // G351 AC: when the recommended recovery command is automation
+        // publish-recovery, it must include --pr <n> so the operator gets
+        // a scoped single-item recovery rather than a broad scan.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G346", "review", linkedPr: "999", linkedIssue: null));
+        // Publish artifact exists to trigger the publish-recovery recommendation.
+        workspace.WriteFile(".intent-cli/issues/G346/publish.yaml", "execution_unit: G346\n");
+
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+
+        using var writer = new StringWriter();
+        ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var recoveryCmd = doc.RootElement.GetProperty("recommended_recovery_command").GetString()!;
+        Assert.Contains("automation publish-recovery", recoveryCmd, StringComparison.Ordinal);
+        // G351: must include --pr <n> to scope the recovery to this PR.
+        Assert.Contains("--pr 796", recoveryCmd, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G351_HostMetadataBlocked_MarkdownIncludesReviewReleaseGuidance()
+    {
+        // G351 verification: markdown output must include the review-release
+        // command when host-metadata-blocked, so the host operator sees it.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G346", "review", linkedPr: "999", linkedIssue: null));
+
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+
+        using var writer = new StringWriter();
+        ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796"],
+            writer);
+
+        var output = writer.ToString();
+        Assert.Contains("review-release", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pr-transition", output, StringComparison.Ordinal);
+    }
+
+    private static void WriteCompliantPacketFiles(ReviewCloseoutPlanWorkspace workspace, string executionUnit)
+    {
+        workspace.WriteFile(
+            $".intent-cli/issues/{executionUnit}/github-body.md",
+            BuildCompleteContractBody());
+    }
+
     private sealed class ReviewCloseoutPlanWorkspace : IDisposable
     {
         private readonly string rootPath = Directory


### PR DESCRIPTION
## Summary

- **`AutomationPublishRecoveryCommand`**: adds `--pr <n>` optional argument; when provided, dispatches to `PublishRecoveryAnalyzer.AnalyzeScopedToPr` so only the selected PR's closing-issue candidates are processed; exposes `selected_pr` field in JSON output
- **`PublishRecoveryAnalyzer`**: new `AnalyzeScopedToPr` method filters candidates to those whose linked issue appears in the selected PR's `Closes/Fixes/Resolves` references; returns empty on unknown PR or missing closing reference (with `UnsafeNoClosingPrForLinkedIssue` stop)
- **`ReviewCloseoutPlanCommand`**: `publish-recovery` recommendation now includes `--pr <n>` flag; adds `review_release_command` (machine-readable) when blocker is `host-metadata-blocked`; Markdown output emits review-release guidance line
- **Tests**: 15 new G351 tests across three test files covering scoped analysis, command argument parsing, write-mode mutation scoping, and ReviewCloseoutPlan JSON + Markdown

## Test plan

- [ ] `dotnet test` passes (15 new G351 tests + 84 related tests green)
- [ ] `--pr` flag scopes repair to selected PR's closing issue only — unrelated queue items not mutated
- [ ] Missing `Closes/Fixes/Resolves` in selected PR body produces `UnsafeNoClosingPrForLinkedIssue` stop
- [ ] `review_release_command` present in JSON when `host-metadata-blocked`, absent otherwise
- [ ] Markdown output includes review-release line when applicable

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)