### PR TITLE
G353: Add host-artifact-repair-required classification to pr-comment-preflight

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationWorkspaceGuardCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationWorkspaceGuardCommand.cs
@@ -215,9 +215,10 @@ internal static class AutomationWorkspaceGuardCommand
 
         // --- Write mode ---
 
-        // G352: checkout lane — preserve each gitlink-only submodule.
+        // G352: Step 1 — collect original submodule HEADs (read-only, no mutations yet).
+        // Separating this from the checkout loop makes the preliminary state write below safe.
         var gitlinkRestoreEntries = new List<GitlinkRestoreEntry>();
-        foreach (var (entry, parentCommit) in gitlinkOnly)
+        foreach (var (entry, _) in gitlinkOnly)
         {
             var originalHead = GetCurrentSubmoduleHead(runner, entry.Path);
             if (originalHead is null)
@@ -238,10 +239,39 @@ internal static class AutomationWorkspaceGuardCommand
                 EmitResult(writer, format, failure);
                 return 1;
             }
+            gitlinkRestoreEntries.Add(new GitlinkRestoreEntry { Path = entry.Path, OriginalHead = originalHead });
+        }
 
+        // G352: Step 2 — for mixed lanes (gitlink + stash), write a preliminary state file
+        // with the gitlink restore entries BEFORE any repo mutation. If the stash lane fails
+        // after gitlinks are checked out, this guarantees the operator has a durable restore
+        // instruction and can run `workspace-guard --mode end --write` to recover.
+        bool hasMixedLanes = gitlinkOnly.Count > 0 && regularStash.Count > 0;
+        if (hasMixedLanes)
+        {
+            var prelimState = new WorkspaceGuardState
+            {
+                StashRef = null,
+                StashMessage = null,
+                CreatedAt = ResolveNow(),
+                StashedPaths = Array.Empty<string>(),
+                GitlinkRestorePaths = gitlinkRestoreEntries
+            };
+            Directory.CreateDirectory(Path.GetDirectoryName(statePath)!);
+            File.WriteAllText(statePath, JsonSerializer.Serialize(prelimState, JsonOptions));
+        }
+
+        // G352: Step 3 — checkout each gitlink to the parent-recorded commit.
+        // The preliminary state file (step 2) ensures any failure here is recoverable via `end`.
+        for (var i = 0; i < gitlinkOnly.Count; i++)
+        {
+            var (entry, parentCommit) = gitlinkOnly[i];
             var checkoutResult = runner.Run(new[] { "-C", entry.Path, "checkout", parentCommit });
             if (checkoutResult.ExitCode != 0)
             {
+                var recoverySuffix = hasMixedLanes
+                    ? $" Gitlink restore state is at `{statePath}`; run `automation workspace-guard --mode end --write` to restore already-checked-out gitlinks."
+                    : $" Original submodule HEAD: {gitlinkRestoreEntries[i].OriginalHead}. No state file was written; retry after resolving the submodule.";
                 var failure = new WorkspaceGuardResult
                 {
                     Mode = ModeBegin,
@@ -253,16 +283,14 @@ internal static class AutomationWorkspaceGuardCommand
                     StashRef = null,
                     ConflictPaths = Array.Empty<string>(),
                     StateFilePath = statePath,
-                    Summary = $"workspace-guard begin failed: `git -C {entry.Path} checkout {parentCommit}` exited {checkoutResult.ExitCode}: {checkoutResult.StandardError.Trim()}. Original submodule HEAD: {originalHead}."
+                    Summary = $"workspace-guard begin failed: `git -C {entry.Path} checkout {parentCommit}` exited {checkoutResult.ExitCode}: {checkoutResult.StandardError.Trim()}.{recoverySuffix}"
                 };
                 EmitResult(writer, format, failure);
                 return 1;
             }
-
-            gitlinkRestoreEntries.Add(new GitlinkRestoreEntry { Path = entry.Path, OriginalHead = originalHead });
         }
 
-        // Stash lane — handle regular dirty files.
+        // Step 4 — stash regular dirty files.
         string? stashRef = null;
         if (regularStash.Count > 0)
         {
@@ -271,6 +299,9 @@ internal static class AutomationWorkspaceGuardCommand
             var pushResult = runner.Run(pushArgs);
             if (pushResult.ExitCode != 0)
             {
+                var recoverySuffix = hasMixedLanes
+                    ? $" Gitlink restore state is at `{statePath}`; run `automation workspace-guard --mode end --write` to restore the checked-out gitlinks."
+                    : string.Empty;
                 var failure = new WorkspaceGuardResult
                 {
                     Mode = ModeBegin,
@@ -282,7 +313,7 @@ internal static class AutomationWorkspaceGuardCommand
                     StashRef = null,
                     ConflictPaths = Array.Empty<string>(),
                     StateFilePath = statePath,
-                    Summary = $"workspace-guard begin failed: `git stash push` exited {pushResult.ExitCode}: {pushResult.StandardError.Trim()}"
+                    Summary = $"workspace-guard begin failed: `git stash push` exited {pushResult.ExitCode}: {pushResult.StandardError.Trim()}.{recoverySuffix}"
                 };
                 EmitResult(writer, format, failure);
                 return 1;
@@ -293,6 +324,9 @@ internal static class AutomationWorkspaceGuardCommand
             stashRef = ParseStashRef(listResult.StandardOutput, message!);
             if (listResult.ExitCode != 0 || stashRef is null)
             {
+                var recoverySuffix = hasMixedLanes
+                    ? $" Gitlink restore state is at `{statePath}`; run `automation workspace-guard --mode end --write` to restore gitlinks."
+                    : string.Empty;
                 var failure = new WorkspaceGuardResult
                 {
                     Mode = ModeBegin,
@@ -304,15 +338,16 @@ internal static class AutomationWorkspaceGuardCommand
                     StashRef = null,
                     ConflictPaths = Array.Empty<string>(),
                     StateFilePath = statePath,
-                    Summary = listResult.ExitCode != 0
+                    Summary = (listResult.ExitCode != 0
                         ? $"workspace-guard begin failed after stash push: `git stash list` exited {listResult.ExitCode}: {listResult.StandardError.Trim()}. Inspect `git stash list` and restore the stash with message '{message}' before continuing."
-                        : $"workspace-guard begin failed after stash push: could not identify a stash entry with message '{message}'. Inspect `git stash list` and restore that stash before continuing."
+                        : $"workspace-guard begin failed after stash push: could not identify a stash entry with message '{message}'. Inspect `git stash list` and restore that stash before continuing.") + recoverySuffix
                 };
                 EmitResult(writer, format, failure);
                 return 1;
             }
         }
 
+        // Step 5 — write final state file (overwrites preliminary if hasMixedLanes).
         var state = new WorkspaceGuardState
         {
             StashRef = stashRef,

--- a/src/IntentSystem.Cli/Commands/AutomationWorkspaceGuardCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationWorkspaceGuardCommand.cs
@@ -84,35 +84,52 @@ internal static class AutomationWorkspaceGuardCommand
     private static int ExecutePlan(IGitRunner runner, CliContext context, string format, TextWriter writer)
     {
         var entries = ScanWorkingTree(runner);
-        var safeStash = entries.Where(e => !IsDurableStatePath(e.Path)).ToArray();
+        var nonDurable = entries.Where(e => !IsDurableStatePath(e.Path)).ToArray();
         var durable = entries.Where(e => IsDurableStatePath(e.Path)).ToArray();
-        var stashMessage = BuildStashMessage();
+
+        // G352: classify non-durable entries to surface gitlink vs regular paths in the plan.
+        var (gitlinkOnly, submoduleInternalDirty, regular) = ClassifyNonDurableEntries(runner, nonDurable);
+
+        var stashMessage = regular.Count > 0 ? BuildStashMessage() : null;
+        var totalNonDurable = nonDurable.Length;
+
+        var proceedAllowed = durable.Length == 0 && submoduleInternalDirty.Count == 0;
+        string summary;
+        if (durable.Length > 0)
+            summary = $"workspace-guard plan: {durable.Length} dirty durable-state path(s) present; safe-stash refused. Reconcile durable host-state through the G304 fail-closed path before re-running.";
+        else if (submoduleInternalDirty.Count > 0)
+            summary = $"workspace-guard plan: {submoduleInternalDirty.Count} submodule(s) have internal uncommitted changes ({string.Join(", ", submoduleInternalDirty.Select(e => e.Path))}); checkout-lane refused. Manually reconcile submodule internal changes before re-running.";
+        else if (gitlinkOnly.Count > 0 && regular.Count > 0)
+            summary = $"workspace-guard plan: {gitlinkOnly.Count} gitlink-only path(s) (checkout lane) + {regular.Count} regular path(s) (stash lane) on `--mode begin --write`.";
+        else if (gitlinkOnly.Count > 0)
+            summary = $"workspace-guard plan: {gitlinkOnly.Count} gitlink-only path(s) would be preserved via checkout lane on `--mode begin --write`.";
+        else if (regular.Count > 0)
+            summary = $"workspace-guard plan: {regular.Count} unrelated dirty path(s) would be stashed under message '{stashMessage}' on `--mode begin --write`.";
+        else
+            summary = "workspace-guard plan: working tree is clean; no stash required.";
 
         var result = new WorkspaceGuardResult
         {
             Mode = ModePlan,
-            ProceedAllowed = durable.Length == 0,
-            SafeStashPaths = safeStash,
+            ProceedAllowed = proceedAllowed,
+            SafeStashPaths = regular.ToArray(),
+            GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
             DirtyDurableStatePaths = durable,
             StashMessage = stashMessage,
             StashRef = null,
             ConflictPaths = Array.Empty<string>(),
             StateFilePath = Path.Combine(context.RepoRoot, StateFileRelativePath.Replace('/', Path.DirectorySeparatorChar)),
-            Summary = durable.Length > 0
-                ? $"workspace-guard plan: {durable.Length} dirty durable-state path(s) present; safe-stash refused. Reconcile durable host-state through the G304 fail-closed path before re-running."
-                : safeStash.Length > 0
-                    ? $"workspace-guard plan: {safeStash.Length} unrelated dirty path(s) would be stashed under message '{stashMessage}' on `--mode begin --write`."
-                    : "workspace-guard plan: working tree is clean; no stash required."
+            Summary = summary
         };
 
         EmitResult(writer, format, result);
-        return durable.Length > 0 ? 1 : 0;
+        return (durable.Length > 0 || submoduleInternalDirty.Count > 0) ? 1 : 0;
     }
 
     private static int ExecuteBegin(IGitRunner runner, CliContext context, string statePath, bool write, string format, TextWriter writer)
     {
         var entries = ScanWorkingTree(runner);
-        var safeStash = entries.Where(e => !IsDurableStatePath(e.Path)).ToArray();
+        var nonDurable = entries.Where(e => !IsDurableStatePath(e.Path)).ToArray();
         var durable = entries.Where(e => IsDurableStatePath(e.Path)).ToArray();
 
         if (durable.Length > 0)
@@ -121,7 +138,7 @@ internal static class AutomationWorkspaceGuardCommand
             {
                 Mode = ModeBegin,
                 ProceedAllowed = false,
-                SafeStashPaths = safeStash,
+                SafeStashPaths = nonDurable,
                 DirtyDurableStatePaths = durable,
                 StashMessage = null,
                 StashRef = null,
@@ -133,7 +150,32 @@ internal static class AutomationWorkspaceGuardCommand
             return 1;
         }
 
-        if (safeStash.Length == 0)
+        // G352: classify non-durable entries: gitlink-only, submodule-internal-dirty, regular.
+        var (gitlinkOnly, submoduleInternalDirty, regularStash) = ClassifyNonDurableEntries(runner, nonDurable);
+
+        // G352: refuse if any submodule has internal uncommitted changes — we cannot safely auto-reset those.
+        if (submoduleInternalDirty.Count > 0)
+        {
+            var paths = string.Join(", ", submoduleInternalDirty.Select(e => e.Path));
+            var refusal = new WorkspaceGuardResult
+            {
+                Mode = ModeBegin,
+                ProceedAllowed = false,
+                SafeStashPaths = regularStash.ToArray(),
+                GitlinkPaths = submoduleInternalDirty.ToArray(),
+                DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
+                StashMessage = null,
+                StashRef = null,
+                ConflictPaths = Array.Empty<string>(),
+                StateFilePath = statePath,
+                Summary = $"workspace-guard begin refused: {submoduleInternalDirty.Count} submodule(s) have internal uncommitted changes ({paths}). " +
+                          "Cannot auto-handle; commit or stash the changes inside each submodule manually before re-running. Do NOT claim the wake can continue."
+            };
+            EmitResult(writer, format, refusal);
+            return 1;
+        }
+
+        if (gitlinkOnly.Count == 0 && regularStash.Count == 0)
         {
             var noop = new WorkspaceGuardResult
             {
@@ -151,67 +193,124 @@ internal static class AutomationWorkspaceGuardCommand
             return 0;
         }
 
-        var message = BuildStashMessage();
+        var message = regularStash.Count > 0 ? BuildStashMessage() : null;
         if (!write)
         {
             var dryRun = new WorkspaceGuardResult
             {
                 Mode = ModeBegin,
                 ProceedAllowed = true,
-                SafeStashPaths = safeStash,
+                SafeStashPaths = regularStash.ToArray(),
+                GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
                 DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
                 StashMessage = message,
                 StashRef = null,
                 ConflictPaths = Array.Empty<string>(),
                 StateFilePath = statePath,
-                Summary = $"workspace-guard begin (dry-run): would stash {safeStash.Length} path(s) under '{message}'. Re-run with --write to apply."
+                Summary = BuildBeginDryRunSummary(gitlinkOnly.Count, regularStash.Count, message)
             };
             EmitResult(writer, format, dryRun);
             return 0;
         }
 
-        var pushArgs = new List<string> { "stash", "push", "--include-untracked", "-m", message, "--" };
-        pushArgs.AddRange(safeStash.Select(e => e.Path));
-        var pushResult = runner.Run(pushArgs);
-        if (pushResult.ExitCode != 0)
+        // --- Write mode ---
+
+        // G352: checkout lane — preserve each gitlink-only submodule.
+        var gitlinkRestoreEntries = new List<GitlinkRestoreEntry>();
+        foreach (var (entry, parentCommit) in gitlinkOnly)
         {
-            var failure = new WorkspaceGuardResult
+            var originalHead = GetCurrentSubmoduleHead(runner, entry.Path);
+            if (originalHead is null)
             {
-                Mode = ModeBegin,
-                ProceedAllowed = false,
-                SafeStashPaths = safeStash,
-                DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
-                StashMessage = message,
-                StashRef = null,
-                ConflictPaths = Array.Empty<string>(),
-                StateFilePath = statePath,
-                Summary = $"workspace-guard begin failed: `git stash push` exited {pushResult.ExitCode}: {pushResult.StandardError.Trim()}"
-            };
-            EmitResult(writer, format, failure);
-            return 1;
+                var failure = new WorkspaceGuardResult
+                {
+                    Mode = ModeBegin,
+                    ProceedAllowed = false,
+                    SafeStashPaths = regularStash.ToArray(),
+                    GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
+                    DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
+                    StashMessage = message,
+                    StashRef = null,
+                    ConflictPaths = Array.Empty<string>(),
+                    StateFilePath = statePath,
+                    Summary = $"workspace-guard begin failed: could not read HEAD of submodule `{entry.Path}`. Inspect the submodule and retry."
+                };
+                EmitResult(writer, format, failure);
+                return 1;
+            }
+
+            var checkoutResult = runner.Run(new[] { "-C", entry.Path, "checkout", parentCommit });
+            if (checkoutResult.ExitCode != 0)
+            {
+                var failure = new WorkspaceGuardResult
+                {
+                    Mode = ModeBegin,
+                    ProceedAllowed = false,
+                    SafeStashPaths = regularStash.ToArray(),
+                    GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
+                    DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
+                    StashMessage = message,
+                    StashRef = null,
+                    ConflictPaths = Array.Empty<string>(),
+                    StateFilePath = statePath,
+                    Summary = $"workspace-guard begin failed: `git -C {entry.Path} checkout {parentCommit}` exited {checkoutResult.ExitCode}: {checkoutResult.StandardError.Trim()}. Original submodule HEAD: {originalHead}."
+                };
+                EmitResult(writer, format, failure);
+                return 1;
+            }
+
+            gitlinkRestoreEntries.Add(new GitlinkRestoreEntry { Path = entry.Path, OriginalHead = originalHead });
         }
 
-        // Stash list lookup: find the most recent stash matching our message.
-        var listResult = runner.Run(new[] { "stash", "list", "--format=%gd %s" });
-        var stashRef = ParseStashRef(listResult.StandardOutput, message);
-        if (listResult.ExitCode != 0 || stashRef is null)
+        // Stash lane — handle regular dirty files.
+        string? stashRef = null;
+        if (regularStash.Count > 0)
         {
-            var failure = new WorkspaceGuardResult
+            var pushArgs = new List<string> { "stash", "push", "--include-untracked", "-m", message!, "--" };
+            pushArgs.AddRange(regularStash.Select(e => e.Path));
+            var pushResult = runner.Run(pushArgs);
+            if (pushResult.ExitCode != 0)
             {
-                Mode = ModeBegin,
-                ProceedAllowed = false,
-                SafeStashPaths = safeStash,
-                DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
-                StashMessage = message,
-                StashRef = null,
-                ConflictPaths = Array.Empty<string>(),
-                StateFilePath = statePath,
-                Summary = listResult.ExitCode != 0
-                    ? $"workspace-guard begin failed after stash push: `git stash list` exited {listResult.ExitCode}: {listResult.StandardError.Trim()}. Inspect `git stash list` and restore the stash with message '{message}' before continuing."
-                    : $"workspace-guard begin failed after stash push: could not identify a stash entry with message '{message}'. Inspect `git stash list` and restore that stash before continuing."
-            };
-            EmitResult(writer, format, failure);
-            return 1;
+                var failure = new WorkspaceGuardResult
+                {
+                    Mode = ModeBegin,
+                    ProceedAllowed = false,
+                    SafeStashPaths = regularStash.ToArray(),
+                    GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
+                    DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
+                    StashMessage = message,
+                    StashRef = null,
+                    ConflictPaths = Array.Empty<string>(),
+                    StateFilePath = statePath,
+                    Summary = $"workspace-guard begin failed: `git stash push` exited {pushResult.ExitCode}: {pushResult.StandardError.Trim()}"
+                };
+                EmitResult(writer, format, failure);
+                return 1;
+            }
+
+            // Stash list lookup: find the most recent stash matching our message.
+            var listResult = runner.Run(new[] { "stash", "list", "--format=%gd %s" });
+            stashRef = ParseStashRef(listResult.StandardOutput, message!);
+            if (listResult.ExitCode != 0 || stashRef is null)
+            {
+                var failure = new WorkspaceGuardResult
+                {
+                    Mode = ModeBegin,
+                    ProceedAllowed = false,
+                    SafeStashPaths = regularStash.ToArray(),
+                    GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
+                    DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
+                    StashMessage = message,
+                    StashRef = null,
+                    ConflictPaths = Array.Empty<string>(),
+                    StateFilePath = statePath,
+                    Summary = listResult.ExitCode != 0
+                        ? $"workspace-guard begin failed after stash push: `git stash list` exited {listResult.ExitCode}: {listResult.StandardError.Trim()}. Inspect `git stash list` and restore the stash with message '{message}' before continuing."
+                        : $"workspace-guard begin failed after stash push: could not identify a stash entry with message '{message}'. Inspect `git stash list` and restore that stash before continuing."
+                };
+                EmitResult(writer, format, failure);
+                return 1;
+            }
         }
 
         var state = new WorkspaceGuardState
@@ -219,25 +318,45 @@ internal static class AutomationWorkspaceGuardCommand
             StashRef = stashRef,
             StashMessage = message,
             CreatedAt = ResolveNow(),
-            StashedPaths = safeStash.Select(e => e.Path).ToArray()
+            StashedPaths = regularStash.Select(e => e.Path).ToArray(),
+            GitlinkRestorePaths = gitlinkRestoreEntries
         };
         Directory.CreateDirectory(Path.GetDirectoryName(statePath)!);
         File.WriteAllText(statePath, JsonSerializer.Serialize(state, JsonOptions));
 
-        var result = new WorkspaceGuardResult
+        var successResult = new WorkspaceGuardResult
         {
             Mode = ModeBegin,
             ProceedAllowed = true,
-            SafeStashPaths = safeStash,
+            SafeStashPaths = regularStash.ToArray(),
+            GitlinkPaths = gitlinkOnly.Select(t => t.Entry).ToArray(),
             DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
             StashMessage = message,
             StashRef = stashRef,
             ConflictPaths = Array.Empty<string>(),
             StateFilePath = statePath,
-            Summary = $"workspace-guard begin: stashed {safeStash.Length} path(s) at `{stashRef}` (state file: `{statePath}`). Run `automation workspace-guard --mode end --write` after the wake commits/pushes durable host-state."
+            Summary = BuildBeginSuccessSummary(gitlinkRestoreEntries.Count, regularStash.Count, stashRef, statePath)
         };
-        EmitResult(writer, format, result);
+        EmitResult(writer, format, successResult);
         return 0;
+    }
+
+    private static string BuildBeginDryRunSummary(int gitlinkCount, int regularCount, string? message)
+    {
+        if (gitlinkCount > 0 && regularCount > 0)
+            return $"workspace-guard begin (dry-run): would preserve {gitlinkCount} gitlink path(s) via checkout lane and stash {regularCount} regular path(s) under '{message}'. Re-run with --write to apply.";
+        if (gitlinkCount > 0)
+            return $"workspace-guard begin (dry-run): would preserve {gitlinkCount} gitlink-only path(s) via checkout lane. Re-run with --write to apply.";
+        return $"workspace-guard begin (dry-run): would stash {regularCount} path(s) under '{message}'. Re-run with --write to apply.";
+    }
+
+    private static string BuildBeginSuccessSummary(int gitlinkCount, int regularCount, string? stashRef, string statePath)
+    {
+        if (gitlinkCount > 0 && regularCount > 0)
+            return $"workspace-guard begin: preserved {gitlinkCount} gitlink path(s) via checkout lane and stashed {regularCount} regular path(s) at `{stashRef}` (state file: `{statePath}`). Run `automation workspace-guard --mode end --write` after the wake commits/pushes durable host-state.";
+        if (gitlinkCount > 0)
+            return $"workspace-guard begin: preserved {gitlinkCount} gitlink-only path(s) via checkout lane (state file: `{statePath}`). Run `automation workspace-guard --mode end --write` after the wake commits/pushes durable host-state.";
+        return $"workspace-guard begin: stashed {regularCount} path(s) at `{stashRef}` (state file: `{statePath}`). Run `automation workspace-guard --mode end --write` after the wake commits/pushes durable host-state.";
     }
 
     private static int ExecuteEnd(IGitRunner runner, string statePath, bool write, string format, TextWriter writer)
@@ -274,39 +393,72 @@ internal static class AutomationWorkspaceGuardCommand
 
         if (!write)
         {
+            var dryRunSummary = BuildEndDryRunSummary(state);
             var dryRun = new WorkspaceGuardResult
             {
                 Mode = ModeEnd,
                 ProceedAllowed = true,
                 SafeStashPaths = state.StashedPaths.Select(p => new HostSyncWorkingTreeEntry { Path = p, Status = "  " }).ToArray(),
+                GitlinkPaths = state.GitlinkRestorePaths.Select(e => new HostSyncWorkingTreeEntry { Path = e.Path, Status = "  " }).ToArray(),
                 DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
                 StashMessage = state.StashMessage,
                 StashRef = state.StashRef,
                 ConflictPaths = Array.Empty<string>(),
                 StateFilePath = statePath,
-                Summary = $"workspace-guard end (dry-run): would restore stash `{state.StashRef}` ({state.StashedPaths.Count} path(s)). Re-run with --write to apply."
+                Summary = dryRunSummary
             };
             EmitResult(writer, format, dryRun);
             return 0;
         }
 
-        var popResult = runner.Run(new[] { "stash", "pop", state.StashRef });
-        if (popResult.ExitCode != 0)
+        // --- Write mode ---
+
+        // Stash lane: pop the stash if one was created.
+        if (state.StashRef is not null)
         {
-            var conflict = new WorkspaceGuardResult
+            var popResult = runner.Run(new[] { "stash", "pop", state.StashRef });
+            if (popResult.ExitCode != 0)
             {
-                Mode = ModeEnd,
-                ProceedAllowed = false,
-                SafeStashPaths = state.StashedPaths.Select(p => new HostSyncWorkingTreeEntry { Path = p, Status = "  " }).ToArray(),
-                DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
-                StashMessage = state.StashMessage,
-                StashRef = state.StashRef,
-                ConflictPaths = ParseConflictPaths(popResult.StandardOutput + "\n" + popResult.StandardError),
-                StateFilePath = statePath,
-                Summary = $"workspace-guard end CONFLICT: `git stash pop {state.StashRef}` exited {popResult.ExitCode}. Resolve conflicts manually then `git stash drop {state.StashRef}`. State file preserved at `{statePath}`. Do NOT claim the wake completed cleanly."
-            };
-            EmitResult(writer, format, conflict);
-            return 1;
+                var conflict = new WorkspaceGuardResult
+                {
+                    Mode = ModeEnd,
+                    ProceedAllowed = false,
+                    SafeStashPaths = state.StashedPaths.Select(p => new HostSyncWorkingTreeEntry { Path = p, Status = "  " }).ToArray(),
+                    GitlinkPaths = state.GitlinkRestorePaths.Select(e => new HostSyncWorkingTreeEntry { Path = e.Path, Status = "  " }).ToArray(),
+                    DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
+                    StashMessage = state.StashMessage,
+                    StashRef = state.StashRef,
+                    ConflictPaths = ParseConflictPaths(popResult.StandardOutput + "\n" + popResult.StandardError),
+                    StateFilePath = statePath,
+                    Summary = $"workspace-guard end CONFLICT: `git stash pop {state.StashRef}` exited {popResult.ExitCode}. Resolve conflicts manually then `git stash drop {state.StashRef}`. State file preserved at `{statePath}`. Do NOT claim the wake completed cleanly."
+                };
+                EmitResult(writer, format, conflict);
+                return 1;
+            }
+        }
+
+        // G352: gitlink restore lane — return each submodule to its original HEAD.
+        foreach (var gitlinkEntry in state.GitlinkRestorePaths)
+        {
+            var restoreResult = runner.Run(new[] { "-C", gitlinkEntry.Path, "checkout", gitlinkEntry.OriginalHead });
+            if (restoreResult.ExitCode != 0)
+            {
+                var failure = new WorkspaceGuardResult
+                {
+                    Mode = ModeEnd,
+                    ProceedAllowed = false,
+                    SafeStashPaths = state.StashedPaths.Select(p => new HostSyncWorkingTreeEntry { Path = p, Status = "  " }).ToArray(),
+                    GitlinkPaths = state.GitlinkRestorePaths.Select(e => new HostSyncWorkingTreeEntry { Path = e.Path, Status = "  " }).ToArray(),
+                    DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
+                    StashMessage = state.StashMessage,
+                    StashRef = state.StashRef,
+                    ConflictPaths = new[] { $"git -C {gitlinkEntry.Path} checkout {gitlinkEntry.OriginalHead}: exit {restoreResult.ExitCode}" },
+                    StateFilePath = statePath,
+                    Summary = $"workspace-guard end CONFLICT: `git -C {gitlinkEntry.Path} checkout {gitlinkEntry.OriginalHead}` exited {restoreResult.ExitCode}. Restore the submodule manually to commit `{gitlinkEntry.OriginalHead}`. State file preserved at `{statePath}`. Do NOT claim the wake completed cleanly."
+                };
+                EmitResult(writer, format, failure);
+                return 1;
+            }
         }
 
         File.Delete(statePath);
@@ -315,15 +467,39 @@ internal static class AutomationWorkspaceGuardCommand
             Mode = ModeEnd,
             ProceedAllowed = true,
             SafeStashPaths = state.StashedPaths.Select(p => new HostSyncWorkingTreeEntry { Path = p, Status = "  " }).ToArray(),
+            GitlinkPaths = state.GitlinkRestorePaths.Select(e => new HostSyncWorkingTreeEntry { Path = e.Path, Status = "  " }).ToArray(),
             DirtyDurableStatePaths = Array.Empty<HostSyncWorkingTreeEntry>(),
             StashMessage = state.StashMessage,
             StashRef = state.StashRef,
             ConflictPaths = Array.Empty<string>(),
             StateFilePath = statePath,
-            Summary = $"workspace-guard end: restored {state.StashedPaths.Count} path(s) from `{state.StashRef}` and removed the state file."
+            Summary = BuildEndSuccessSummary(state)
         };
         EmitResult(writer, format, result);
         return 0;
+    }
+
+    private static string BuildEndDryRunSummary(WorkspaceGuardState state)
+    {
+        var parts = new List<string>();
+        if (state.StashRef is not null)
+            parts.Add($"restore stash `{state.StashRef}` ({state.StashedPaths.Count} path(s))");
+        if (state.GitlinkRestorePaths.Count > 0)
+            parts.Add($"restore {state.GitlinkRestorePaths.Count} gitlink path(s) to original HEAD(s)");
+        return parts.Count == 0
+            ? "workspace-guard end (dry-run): state file present but nothing recorded to restore. Re-run with --write to apply."
+            : $"workspace-guard end (dry-run): would {string.Join(" and ", parts)}. Re-run with --write to apply.";
+    }
+
+    private static string BuildEndSuccessSummary(WorkspaceGuardState state)
+    {
+        var parts = new List<string>();
+        if (state.StashedPaths.Count > 0)
+            parts.Add($"restored {state.StashedPaths.Count} path(s) from `{state.StashRef}`");
+        if (state.GitlinkRestorePaths.Count > 0)
+            parts.Add($"restored {state.GitlinkRestorePaths.Count} gitlink path(s) to original HEAD(s)");
+        var body = parts.Count > 0 ? string.Join(" and ", parts) : "nothing to restore";
+        return $"workspace-guard end: {body} and removed the state file.";
     }
 
     private static IReadOnlyList<HostSyncWorkingTreeEntry> ScanWorkingTree(IGitRunner runner)
@@ -422,6 +598,7 @@ internal static class AutomationWorkspaceGuardCommand
             writer.WriteLine($"- stash_message: `{result.StashMessage}`");
         }
         writer.WriteLine($"- safe_stash_paths: {result.SafeStashPaths.Count}");
+        writer.WriteLine($"- gitlink_paths: {result.GitlinkPaths.Count}");
         writer.WriteLine($"- dirty_durable_state_paths: {result.DirtyDurableStatePaths.Count}");
         if (result.ConflictPaths.Count > 0)
         {
@@ -434,6 +611,15 @@ internal static class AutomationWorkspaceGuardCommand
             writer.WriteLine();
             writer.WriteLine("## Safe-stash paths");
             foreach (var entry in result.SafeStashPaths)
+            {
+                writer.WriteLine($"- `{entry.Status}` `{entry.Path}`");
+            }
+        }
+        if (result.GitlinkPaths.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Gitlink paths (checkout lane)");
+            foreach (var entry in result.GitlinkPaths)
             {
                 writer.WriteLine($"- `{entry.Status}` `{entry.Path}`");
             }
@@ -457,6 +643,82 @@ internal static class AutomationWorkspaceGuardCommand
             }
         }
     }
+
+    // ------------------------------------------------------------------ G352 helpers
+
+    /// <summary>
+    /// G352: checks whether <paramref name="path"/> is a submodule gitlink (mode 160000)
+    /// in the git index, and returns the parent-recorded commit sha.
+    /// </summary>
+    private static bool TryGetGitlinkCommit(IGitRunner runner, string path, out string parentCommit)
+    {
+        var result = runner.Run(new[] { "ls-files", "--stage", "--", path });
+        if (result.ExitCode != 0 || string.IsNullOrWhiteSpace(result.StandardOutput))
+        {
+            parentCommit = string.Empty;
+            return false;
+        }
+        // Format: "<mode> <sha> <stage>\t<path>"
+        var firstLine = result.StandardOutput.Replace("\r\n", "\n").Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+        var parts = firstLine.Split(' ', 3);
+        if (parts.Length < 2 || !string.Equals(parts[0], "160000", StringComparison.Ordinal))
+        {
+            parentCommit = string.Empty;
+            return false;
+        }
+        parentCommit = parts[1].Trim();
+        return true;
+    }
+
+    /// <summary>
+    /// G352: returns true when the submodule at <paramref name="submodulePath"/>
+    /// has no internal uncommitted changes (clean working tree inside the submodule).
+    /// </summary>
+    private static bool IsSubmoduleInternallyClean(IGitRunner runner, string submodulePath)
+    {
+        var result = runner.Run(new[] { "-C", submodulePath, "status", "--short" });
+        return result.ExitCode == 0 && string.IsNullOrWhiteSpace(result.StandardOutput);
+    }
+
+    /// <summary>G352: returns the current HEAD sha of the submodule, or null on failure.</summary>
+    private static string? GetCurrentSubmoduleHead(IGitRunner runner, string submodulePath)
+    {
+        var result = runner.Run(new[] { "-C", submodulePath, "rev-parse", "HEAD" });
+        return result.ExitCode == 0 ? result.StandardOutput.Trim() : null;
+    }
+
+    /// <summary>
+    /// G352: classifies non-durable dirty entries into gitlink-only,
+    /// submodule-internal-dirty, and regular buckets.
+    /// </summary>
+    private static (
+        IReadOnlyList<(HostSyncWorkingTreeEntry Entry, string ParentCommit)> GitlinkOnly,
+        IReadOnlyList<HostSyncWorkingTreeEntry> SubmoduleInternalDirty,
+        IReadOnlyList<HostSyncWorkingTreeEntry> Regular)
+    ClassifyNonDurableEntries(IGitRunner runner, IReadOnlyList<HostSyncWorkingTreeEntry> nonDurableEntries)
+    {
+        var gitlinkOnly = new List<(HostSyncWorkingTreeEntry, string)>();
+        var submoduleInternalDirty = new List<HostSyncWorkingTreeEntry>();
+        var regular = new List<HostSyncWorkingTreeEntry>();
+
+        foreach (var entry in nonDurableEntries)
+        {
+            if (TryGetGitlinkCommit(runner, entry.Path, out var parentCommit))
+            {
+                if (IsSubmoduleInternallyClean(runner, entry.Path))
+                    gitlinkOnly.Add((entry, parentCommit));
+                else
+                    submoduleInternalDirty.Add(entry);
+            }
+            else
+            {
+                regular.Add(entry);
+            }
+        }
+        return (gitlinkOnly, submoduleInternalDirty, regular);
+    }
+
+    // ------------------------------------------------------------------ arg parse
 
     private static bool TryParseArguments(string[] args, out string mode, out bool write, out string format, out string error)
     {
@@ -572,12 +834,33 @@ internal sealed record WorkspaceGuardResult
     [JsonPropertyName("conflict_paths")] public required IReadOnlyList<string> ConflictPaths { get; init; }
     [JsonPropertyName("state_file_path")] public required string StateFilePath { get; init; }
     [JsonPropertyName("summary")] public required string Summary { get; init; }
+
+    /// <summary>
+    /// G352: gitlink-only submodule paths that the workspace-guard handles
+    /// via the checkout-based preservation lane (not git stash).
+    /// </summary>
+    [JsonPropertyName("gitlink_paths")]
+    public IReadOnlyList<HostSyncWorkingTreeEntry> GitlinkPaths { get; init; } = Array.Empty<HostSyncWorkingTreeEntry>();
+}
+
+/// <summary>G352: gitlink restore entry recording the original submodule HEAD so
+/// <c>workspace-guard end</c> can return the submodule to the operator's commit.</summary>
+internal sealed record GitlinkRestoreEntry
+{
+    [JsonPropertyName("path")] public required string Path { get; init; }
+    [JsonPropertyName("original_head")] public required string OriginalHead { get; init; }
 }
 
 internal sealed record WorkspaceGuardState
 {
-    [JsonPropertyName("stash_ref")] public required string StashRef { get; init; }
-    [JsonPropertyName("stash_message")] public required string StashMessage { get; init; }
+    /// <summary>Stash ref created by <c>git stash push</c>; null when only gitlink paths were preserved.</summary>
+    [JsonPropertyName("stash_ref")] public string? StashRef { get; init; }
+    /// <summary>Stash message used during <c>git stash push</c>; null when only gitlink paths were preserved.</summary>
+    [JsonPropertyName("stash_message")] public string? StashMessage { get; init; }
     [JsonPropertyName("created_at")] public required DateTimeOffset CreatedAt { get; init; }
-    [JsonPropertyName("stashed_paths")] public required IReadOnlyList<string> StashedPaths { get; init; }
+    /// <summary>Paths that were placed into the git stash (regular files / untracked).</summary>
+    [JsonPropertyName("stashed_paths")] public IReadOnlyList<string> StashedPaths { get; init; } = Array.Empty<string>();
+    /// <summary>G352: submodule gitlink paths preserved via checkout lane; restored on <c>end</c>.</summary>
+    [JsonPropertyName("gitlink_restore_paths")]
+    public IReadOnlyList<GitlinkRestoreEntry> GitlinkRestorePaths { get; init; } = Array.Empty<GitlinkRestoreEntry>();
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
@@ -74,7 +74,9 @@ First-call sequence (read-only; required before any code work):
 
 Comment triage (required before checkout or code changes):
 Read review comments with `gh pr view <n> --repo <OWNER>/<REPO> --comments` and `gh api repos/<OWNER>/<REPO>/pulls/<n>/reviews`. Identify all unresolved, actionable review comments.
+Alternatively, run `intent-cli worker pr-comment-preflight --repo <OWNER>/<REPO> --pr <n> --format json` and check the `classification` field — it performs the full ten-step triage and surfaces the stop condition automatically.
 - If there are no unresolved actionable comments, stop. Set outcome to `no-actionable-comments`.
+- If ALL actionable comments target host metadata paths (`.intent-cli/**` or `intents/**`), stop. Set outcome to `host-artifact-repair-required`. These paths are host-owned durable artifacts that child implementation workers must not edit; the host repair agent must handle them. (The `pr-comment-preflight` result will show `classification: host-artifact-repair-required` in this case.)
 - If a comment is ambiguous and cannot be resolved without guessing, stop. Set outcome to `clarification-required`. Report which comment and why.
 - If the requested change is already applied in the existing branch, stop. Set outcome to `already-resolved`.
 
@@ -91,6 +93,7 @@ Outcome classification:
 - `no-actionable-comments` — no unresolved actionable review comments; nothing to fix.
 - `already-resolved` — the requested change is already applied in the branch.
 - `clarification-required` — ambiguous comment or blocker found; cannot proceed without operator input.
+- `host-artifact-repair-required` — all actionable comments target host metadata paths (`.intent-cli/**` or `intents/**`); child worker must not attempt to repair them.
 - `failed` — fix failed (build/test failure, unresolvable conflict).
 - `label-cleanup-required` — stale labels prevent clean claim/complete flow.
 
@@ -106,6 +109,7 @@ Hard rules:
 - Do not add `intent-target` to the PR; it is host-owned.
 - Do not add `intent-pr-created` to the PR; it is an issue-side completion marker.
 - Do not edit `queue-state.json`, `linked_issue`, or `linked_pr`; those are host-owned durable bookkeeping and must not be touched during a PR comment fix turn.
+- Do not edit `.intent-cli/**` or `intents/**` paths. These are host-owned metadata artifacts (packet files, publish artifacts, clarifications, queue state, runs). If a comment requests such changes, stop with outcome `host-artifact-repair-required` — the host repair agent must handle them, not the child implementation worker.
 - Do not run `intent-cli automation issue-publish`; that command is for publishing child issues, not for resolving PR comment repairs.";
 
         return new GuideWorkerPrCommentFixResult
@@ -127,6 +131,7 @@ Hard rules:
                 ["no-actionable-comments"] = "No unresolved actionable review comments; nothing to fix.",
                 ["already-resolved"] = "The requested change is already applied in the branch.",
                 ["clarification-required"] = "Ambiguous comment or blocker found; cannot proceed without operator input.",
+                ["host-artifact-repair-required"] = "All actionable comments target host metadata paths (.intent-cli/** or intents/**); child worker must not attempt to repair them.",
                 ["failed"] = "Fix failed (build/test failure, unresolvable conflict).",
                 ["label-cleanup-required"] = "Stale labels prevent clean claim/complete flow."
             },

--- a/src/IntentSystem.Cli/Commands/HostSyncPreflightAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/HostSyncPreflightAnalyzer.cs
@@ -166,10 +166,12 @@ internal static class HostSyncPreflightAnalyzer
             ClassificationDirtyDurableState => BuildDirtyDurableSteps(dirtyDurable),
             ClassificationDirtyUnrelatedSubmodule => new[]
             {
-                "Run `intent-cli automation workspace-guard --mode begin --write` to stash the unrelated paths into a recoverable safe-stash ref (G306). Stashed paths: " + string.Join(", ", dirtyOther.Select(e => "`" + e.Path + "`")),
+                "Run `intent-cli automation workspace-guard --mode begin --write` to preserve the unrelated path(s) (G306). " +
+                "Regular files are placed into a git stash; submodule gitlink-only changes are preserved via the checkout lane (records the current submodule HEAD and checks out the parent-recorded commit). Unrelated paths: " + string.Join(", ", dirtyOther.Select(e => "`" + e.Path + "`")),
                 "Run the host wake (review/closeout/next-slice). Durable host-state stays untouched throughout.",
-                "After durable host-state is committed/pushed, run `intent-cli automation workspace-guard --mode end --write` to restore the unrelated changes.",
-                "If `--mode end` reports a stash-pop conflict, do NOT claim the wake completed; surface the structured recovery instruction to the operator."
+                "After durable host-state is committed/pushed, run `intent-cli automation workspace-guard --mode end --write` to restore the unrelated changes (stash pop for regular files, submodule HEAD restore for gitlinks).",
+                "If `--mode end` reports a conflict, do NOT claim the wake completed; surface the structured recovery instruction to the operator.",
+                "If workspace-guard begin returns `proceed_allowed: false` (e.g. submodule has internal uncommitted changes), follow the manual recovery instructions in the output before re-running."
             },
             ClassificationDirtyMixed => BuildDirtyDurableSteps(dirtyDurable).Concat(new[]
             {

--- a/src/IntentSystem.Cli/Commands/WorkerPrCommentPreflightAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerPrCommentPreflightAnalyzer.cs
@@ -310,6 +310,37 @@ internal static class WorkerPrCommentPreflightAnalyzer
             }
         }
 
+        // Step 8.5 (G353): host-artifact-repair-required — when EVERY
+        // actionable comment targets a host metadata path (.intent-cli/**
+        // or intents/**), the child worker must not attempt to repair them.
+        // The host agent must commit/push the artifact fix and re-run review
+        // readiness. If even one comment targets implementation code the
+        // standard repair-required path takes over so the child can still
+        // address it.
+        if (actionableComments.Count > 0
+            && actionableComments.All(c => CommentTargetsHostMetadata(c.Excerpt)))
+        {
+            var reasons = new List<string>
+            {
+                $"all {actionableComments.Count} actionable comment(s) target host metadata paths " +
+                "(.intent-cli/** or intents/**); child worker must not edit host artifacts"
+            };
+            return Build(
+                pr,
+                repo,
+                prNumber,
+                title,
+                displayState,
+                labels,
+                sourceIssueCandidate?.Number,
+                sourceIssueLabels,
+                actionableComments,
+                WorkerPrCommentPreflightConstants.Classifications.HostArtifactRepairRequired,
+                reasons,
+                actionable: false,
+                WorkerPrCommentPreflightConstants.RecommendedActions.EscalateToHostRepair);
+        }
+
         // Step 9: repair-required.
         if (actionableComments.Count > 0)
         {
@@ -459,6 +490,24 @@ internal static class WorkerPrCommentPreflightAnalyzer
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// G353: Returns true when a comment excerpt explicitly references a host
+    /// metadata path (<c>.intent-cli/</c> or <c>intents/</c>), indicating the
+    /// reviewer is asking to repair a host artifact rather than an
+    /// implementation file. The check is ordinal because path separators are
+    /// case-sensitive on Linux file systems and these path prefixes are always
+    /// lowercase in the intent-system layout.
+    /// </summary>
+    private static bool CommentTargetsHostMetadata(string excerpt)
+    {
+        if (string.IsNullOrEmpty(excerpt))
+        {
+            return false;
+        }
+        return excerpt.Contains(".intent-cli/", StringComparison.Ordinal)
+            || excerpt.Contains("intents/", StringComparison.Ordinal);
     }
 
     private static string TruncateExcerpt(string? body)

--- a/src/IntentSystem.Cli/Commands/WorkerPrCommentPreflightResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerPrCommentPreflightResult.cs
@@ -110,6 +110,14 @@ internal static class WorkerPrCommentPreflightConstants
     {
         public const string RepairRequired = "repair-required";
         public const string NoActionableComments = "no-actionable-comments";
+
+        /// <summary>
+        /// G353: All actionable comments target host metadata paths
+        /// (<c>.intent-cli/**</c> or <c>intents/**</c>). The child worker
+        /// must not attempt to repair these; the host agent must commit/push
+        /// the artifact fix and re-run review readiness.
+        /// </summary>
+        public const string HostArtifactRepairRequired = "host-artifact-repair-required";
         public const string RequestUpdatePending = "request-update-pending";
         public const string UpdateInProgress = "update-in-progress";
         public const string MissingTargetLabel = "missing-target-label";
@@ -128,6 +136,12 @@ internal static class WorkerPrCommentPreflightConstants
         public const string DeclineWithSummary = "decline-with-summary";
         public const string LabelCleanupRequired = "label-cleanup-required";
         public const string SwitchRepo = "switch-repo";
+
+        /// <summary>
+        /// G353: Escalate to the host repair agent; the child worker must not
+        /// edit host metadata paths (<c>.intent-cli/**</c>, <c>intents/**</c>).
+        /// </summary>
+        public const string EscalateToHostRepair = "escalate-to-host-repair";
     }
 
     public static class Labels

--- a/tests/IntentSystem.Cli.Tests/AutomationWorkspaceGuardCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationWorkspaceGuardCommandTests.cs
@@ -255,6 +255,280 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         Assert.Contains("must be 'plan', 'begin', or 'end'", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // ======================================================================
+    // G352 — gitlink-only submodule safe lane
+    // ======================================================================
+
+    [Fact]
+    public void Plan_G352_GitlinkOnly_ExposesGitlinkPaths_NotSafeStashPaths()
+    {
+        // A submodule with a gitlink-only dirty state (no internal changes)
+        // should appear in gitlink_paths, not safe_stash_paths.
+        using var workspace = new GuardWorkspace();
+        var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
+        // ls-files returns mode 160000 → gitlink
+        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
+            stdout: "160000 abc1234567890abcdef 0\tsubmodules/SekibanAsAService\n");
+        // Internal status → empty (clean)
+        fake.QueueResponse("-C submodules/SekibanAsAService status --short", stdout: "");
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "plan", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Equal(0, root.GetProperty("safe_stash_paths").GetArrayLength());
+        Assert.Equal(1, root.GetProperty("gitlink_paths").GetArrayLength());
+        Assert.Equal("submodules/SekibanAsAService",
+            root.GetProperty("gitlink_paths")[0].GetProperty("path").GetString());
+        Assert.Contains("checkout lane", root.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Plan_G352_SubmoduleInternalDirty_RefusesAndExitsOne()
+    {
+        // A submodule that has internal uncommitted changes must be refused.
+        using var workspace = new GuardWorkspace();
+        var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
+        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
+            stdout: "160000 abc1234567890abcdef 0\tsubmodules/SekibanAsAService\n");
+        // Internal status → non-empty (dirty inside submodule)
+        fake.QueueResponse("-C submodules/SekibanAsAService status --short",
+            stdout: " M src/SomeFile.cs\n");
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "plan", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Contains("internal uncommitted changes", doc.RootElement.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Begin_G352_GitlinkOnly_Write_RecordsOriginalHeadAndCheckoutsParentCommit()
+    {
+        // begin --write for a gitlink-only dirty submodule should:
+        // 1. Read the original submodule HEAD.
+        // 2. Checkout the parent-recorded commit in the submodule.
+        // 3. Write a state file with gitlink_restore_paths (no stash).
+        using var workspace = new GuardWorkspace();
+        AutomationWorkspaceGuardCommand.UtcNowFactory = () => new DateTimeOffset(2026, 5, 13, 0, 0, 0, TimeSpan.Zero);
+
+        var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
+        // Classification: ls-files → 160000 (gitlink), internal status → clean
+        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
+            stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
+        fake.QueueResponse("-C submodules/SekibanAsAService status --short", stdout: "");
+        // Begin write: get current submodule HEAD
+        fake.QueueResponse("-C submodules/SekibanAsAService rev-parse HEAD",
+            stdout: "originalhead5678\n");
+        // Checkout to parent commit
+        fake.QueueResponse("-C submodules/SekibanAsAService checkout parentcommit1234", stdout: "");
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "begin", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("stash_ref").ValueKind);
+        Assert.Equal(1, root.GetProperty("gitlink_paths").GetArrayLength());
+        Assert.Contains("checkout lane", root.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+
+        // State file should have gitlink_restore_paths with original HEAD.
+        var statePath = Path.Combine(workspace.RepoRoot, ".intent-cli", "workspace-guard.json");
+        Assert.True(File.Exists(statePath));
+        using var stateDoc = JsonDocument.Parse(File.ReadAllText(statePath));
+        var restorePaths = stateDoc.RootElement.GetProperty("gitlink_restore_paths");
+        Assert.Equal(1, restorePaths.GetArrayLength());
+        Assert.Equal("submodules/SekibanAsAService", restorePaths[0].GetProperty("path").GetString());
+        Assert.Equal("originalhead5678", restorePaths[0].GetProperty("original_head").GetString());
+        // No stash ref in state file.
+        Assert.True(
+            stateDoc.RootElement.GetProperty("stash_ref").ValueKind == JsonValueKind.Null ||
+            !stateDoc.RootElement.TryGetProperty("stash_ref", out _) ||
+            string.IsNullOrEmpty(stateDoc.RootElement.GetProperty("stash_ref").GetString()));
+
+        // Verify checkout command was invoked.
+        Assert.Contains(fake.Invocations, args =>
+            args.Contains("-C") &&
+            args.Contains("submodules/SekibanAsAService") &&
+            args.Contains("checkout") &&
+            args.Contains("parentcommit1234"));
+    }
+
+    [Fact]
+    public void Begin_G352_SubmoduleInternalDirty_RefusesProceedAllowed()
+    {
+        // A submodule with internal uncommitted changes must refuse begin.
+        using var workspace = new GuardWorkspace();
+        var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n");
+        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
+            stdout: "160000 abc1234567890 0\tsubmodules/SekibanAsAService\n");
+        fake.QueueResponse("-C submodules/SekibanAsAService status --short",
+            stdout: " M src/SomeFile.cs\n");
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "begin", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Contains("internal uncommitted changes", doc.RootElement.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("manually", doc.RootElement.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(workspace.RepoRoot, ".intent-cli", "workspace-guard.json")));
+    }
+
+    [Fact]
+    public void End_G352_GitlinkOnly_RestoresOriginalSubmoduleHead()
+    {
+        // end --write for a gitlink-only state should restore the submodule HEAD.
+        using var workspace = new GuardWorkspace();
+        var stateFile = Path.Combine(workspace.RepoRoot, ".intent-cli", "workspace-guard.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(stateFile)!);
+        File.WriteAllText(stateFile, """
+        {
+          "stash_ref": null,
+          "stash_message": null,
+          "created_at": "2026-05-13T00:00:00+00:00",
+          "stashed_paths": [],
+          "gitlink_restore_paths": [
+            { "path": "submodules/SekibanAsAService", "original_head": "originalhead5678" }
+          ]
+        }
+        """);
+
+        var fake = new FakeGitRunner(porcelain: string.Empty);
+        // Restore: checkout the original HEAD inside the submodule
+        fake.QueueResponse("-C submodules/SekibanAsAService checkout originalhead5678", stdout: "HEAD is now at originalhead5678\n");
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "end", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(File.Exists(stateFile));
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.True(doc.RootElement.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Contains("restored 1 gitlink", doc.RootElement.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+        Assert.Equal(1, doc.RootElement.GetProperty("gitlink_paths").GetArrayLength());
+
+        // Verify the checkout restoration call was made.
+        Assert.Contains(fake.Invocations, args =>
+            args.Contains("-C") &&
+            args.Contains("submodules/SekibanAsAService") &&
+            args.Contains("checkout") &&
+            args.Contains("originalhead5678"));
+    }
+
+    [Fact]
+    public void End_G352_GitlinkRestoreFailure_PreservesStateFile_AndReportsFail()
+    {
+        using var workspace = new GuardWorkspace();
+        var stateFile = Path.Combine(workspace.RepoRoot, ".intent-cli", "workspace-guard.json");
+        Directory.CreateDirectory(Path.GetDirectoryName(stateFile)!);
+        File.WriteAllText(stateFile, """
+        {
+          "stash_ref": null,
+          "stash_message": null,
+          "created_at": "2026-05-13T00:00:00+00:00",
+          "stashed_paths": [],
+          "gitlink_restore_paths": [
+            { "path": "submodules/SekibanAsAService", "original_head": "originalhead5678" }
+          ]
+        }
+        """);
+
+        var fake = new FakeGitRunner(porcelain: string.Empty);
+        fake.QueueResponse("-C submodules/SekibanAsAService checkout originalhead5678",
+            stdout: "error: something bad\n",
+            exitCode: 1);
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "end", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Contains("CONFLICT", doc.RootElement.GetProperty("summary").GetString()!, StringComparison.Ordinal);
+        // State file preserved for operator recovery.
+        Assert.True(File.Exists(stateFile));
+    }
+
+    [Fact]
+    public void Begin_G352_MixedGitlinkAndRegular_HandlesBothLanes()
+    {
+        // When both a gitlink-only path and a regular dirty file are present,
+        // begin --write should handle them independently: checkout for gitlink,
+        // stash for regular files.
+        using var workspace = new GuardWorkspace();
+        AutomationWorkspaceGuardCommand.UtcNowFactory = () => new DateTimeOffset(2026, 5, 13, 0, 0, 0, TimeSpan.Zero);
+
+        var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n M scratch.txt\n");
+        // For submodules/SekibanAsAService: ls-files → gitlink, internal → clean
+        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
+            stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
+        fake.QueueResponse("-C submodules/SekibanAsAService status --short", stdout: "");
+        // For scratch.txt: ls-files → regular file (not 160000)
+        fake.QueueResponse("ls-files --stage -- scratch.txt",
+            stdout: "100644 abc123 0\tscratch.txt\n");
+        // Gitlink begin: rev-parse HEAD and checkout
+        fake.QueueResponse("-C submodules/SekibanAsAService rev-parse HEAD",
+            stdout: "originalhead5678\n");
+        fake.QueueResponse("-C submodules/SekibanAsAService checkout parentcommit1234", stdout: "");
+        // Stash lane for scratch.txt
+        fake.QueueResponse("stash list --format=%gd %s",
+            stdout: "stash@{0} On main: intent-cli/G306 workspace-guard 2026-05-13T00:00:00Z\n");
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "begin", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.True(doc.RootElement.GetProperty("proceed_allowed").GetBoolean());
+        Assert.Equal(1, doc.RootElement.GetProperty("safe_stash_paths").GetArrayLength());
+        Assert.Equal(1, doc.RootElement.GetProperty("gitlink_paths").GetArrayLength());
+        Assert.Equal("stash@{0}", doc.RootElement.GetProperty("stash_ref").GetString());
+
+        // State file should have both stashed_paths and gitlink_restore_paths.
+        var statePath = Path.Combine(workspace.RepoRoot, ".intent-cli", "workspace-guard.json");
+        Assert.True(File.Exists(statePath));
+        using var stateDoc = JsonDocument.Parse(File.ReadAllText(statePath));
+        Assert.Equal(1, stateDoc.RootElement.GetProperty("stashed_paths").GetArrayLength());
+        Assert.Equal(1, stateDoc.RootElement.GetProperty("gitlink_restore_paths").GetArrayLength());
+    }
+
     private sealed class FakeGitRunner : IGitRunner
     {
         private readonly string defaultStatusOutput;

--- a/tests/IntentSystem.Cli.Tests/AutomationWorkspaceGuardCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationWorkspaceGuardCommandTests.cs
@@ -529,6 +529,104 @@ public sealed class AutomationWorkspaceGuardCommandTests : IDisposable
         Assert.Equal(1, stateDoc.RootElement.GetProperty("gitlink_restore_paths").GetArrayLength());
     }
 
+    // ======================================================================
+    // G352 pr-comment-fix — transactional begin for mixed gitlink+regular lanes
+    // ======================================================================
+
+    [Fact]
+    public void Begin_G352_MixedLanes_StashPushFails_StateFilePreservesGitlinkRestoreEntries()
+    {
+        // Regression test: when stash push fails AFTER gitlinks are checked out,
+        // the preliminary state file must have been written so the operator can
+        // run `workspace-guard end --write` to restore the gitlinks.
+        using var workspace = new GuardWorkspace();
+        AutomationWorkspaceGuardCommand.UtcNowFactory = () => new DateTimeOffset(2026, 5, 13, 12, 0, 0, TimeSpan.Zero);
+
+        var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n M scratch.txt\n");
+        // Classification: gitlink + internal clean
+        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
+            stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
+        fake.QueueResponse("-C submodules/SekibanAsAService status --short", stdout: "");
+        // scratch.txt is regular
+        fake.QueueResponse("ls-files --stage -- scratch.txt",
+            stdout: "100644 abc456 0\tscratch.txt\n");
+        // Collect original HEAD (read-only, before any mutation)
+        fake.QueueResponse("-C submodules/SekibanAsAService rev-parse HEAD",
+            stdout: "originalhead5678\n");
+        // Gitlink checkout succeeds
+        fake.QueueResponse("-C submodules/SekibanAsAService checkout parentcommit1234", stdout: "");
+        // Stash push FAILS (simulates transient git error)
+        fake.QueueResponse("stash push", stdout: "", stderr: "error: cannot stash\n", exitCode: 1);
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "begin", "--write", "--format", "json"],
+            writer);
+
+        // Begin must fail (stash push failed)
+        Assert.Equal(1, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("proceed_allowed").GetBoolean());
+
+        // State file MUST exist with the gitlink restore entry so `end` can restore it.
+        var statePath = Path.Combine(workspace.RepoRoot, ".intent-cli", "workspace-guard.json");
+        Assert.True(File.Exists(statePath),
+            "Preliminary state file must be written before any checkout mutation.");
+        using var stateDoc = JsonDocument.Parse(File.ReadAllText(statePath));
+        var restorePaths = stateDoc.RootElement.GetProperty("gitlink_restore_paths");
+        Assert.Equal(1, restorePaths.GetArrayLength());
+        Assert.Equal("submodules/SekibanAsAService", restorePaths[0].GetProperty("path").GetString());
+        Assert.Equal("originalhead5678", restorePaths[0].GetProperty("original_head").GetString());
+
+        // Summary must reference the state file so operator knows recovery path.
+        var summary = doc.RootElement.GetProperty("summary").GetString()!;
+        Assert.Contains(statePath, summary, StringComparison.Ordinal);
+        Assert.Contains("end --write", summary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Begin_G352_MixedLanes_StashListFails_StateFilePreservesGitlinkRestoreEntries()
+    {
+        // Regression test: stash push succeeded but stash list cannot find the ref.
+        // Gitlinks are already checked out; preliminary state file must survive.
+        using var workspace = new GuardWorkspace();
+        AutomationWorkspaceGuardCommand.UtcNowFactory = () => new DateTimeOffset(2026, 5, 13, 12, 0, 0, TimeSpan.Zero);
+
+        var fake = new FakeGitRunner(porcelain: " m submodules/SekibanAsAService\n M scratch.txt\n");
+        fake.QueueResponse("ls-files --stage -- submodules/SekibanAsAService",
+            stdout: "160000 parentcommit1234 0\tsubmodules/SekibanAsAService\n");
+        fake.QueueResponse("-C submodules/SekibanAsAService status --short", stdout: "");
+        fake.QueueResponse("ls-files --stage -- scratch.txt",
+            stdout: "100644 abc456 0\tscratch.txt\n");
+        fake.QueueResponse("-C submodules/SekibanAsAService rev-parse HEAD",
+            stdout: "originalhead5678\n");
+        fake.QueueResponse("-C submodules/SekibanAsAService checkout parentcommit1234", stdout: "");
+        // Stash push succeeds, but stash list returns unrelated entry (ref not found)
+        fake.QueueResponse("stash list --format=%gd %s",
+            stdout: "stash@{0} On main: operator-personal-stash\n");
+        AutomationWorkspaceGuardCommand.GitRunnerFactory = _ => fake;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationWorkspaceGuardCommand.Execute(
+            workspace.Context,
+            ["--mode", "begin", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("proceed_allowed").GetBoolean());
+
+        // Preliminary state file must persist for gitlink recovery.
+        var statePath = Path.Combine(workspace.RepoRoot, ".intent-cli", "workspace-guard.json");
+        Assert.True(File.Exists(statePath));
+        using var stateDoc = JsonDocument.Parse(File.ReadAllText(statePath));
+        Assert.Equal(1, stateDoc.RootElement.GetProperty("gitlink_restore_paths").GetArrayLength());
+        Assert.Equal("originalhead5678",
+            stateDoc.RootElement.GetProperty("gitlink_restore_paths")[0].GetProperty("original_head").GetString());
+    }
+
     private sealed class FakeGitRunner : IGitRunner
     {
         private readonly string defaultStatusOutput;

--- a/tests/IntentSystem.Cli.Tests/GuideWorkerPrCommentFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkerPrCommentFixCommandTests.cs
@@ -313,6 +313,94 @@ public sealed class GuideWorkerPrCommentFixCommandTests
         Assert.Contains("worker next-action", prompt, StringComparison.Ordinal);
     }
 
+    // ── G353: host-artifact-repair-required stop condition ───────────
+
+    [Fact]
+    public void Execute_Json_G353_PromptStopsOnHostMetadataCommentPaths()
+    {
+        // G353 AC: "Child worker guidance refuses to edit .intent-cli/**
+        // or intents/** during pr-comment-fix and reports
+        // host-artifact-repair-required."
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+
+        // The prompt must name the forbidden host metadata path patterns.
+        Assert.Contains(".intent-cli/**", prompt, StringComparison.Ordinal);
+        Assert.Contains("intents/**", prompt, StringComparison.Ordinal);
+
+        // The prompt must surface the stop outcome name.
+        Assert.Contains("host-artifact-repair-required", prompt, StringComparison.Ordinal);
+
+        // The prompt must explicitly instruct the worker to stop (not repair) on host paths.
+        Assert.Contains("host metadata", prompt, StringComparison.OrdinalIgnoreCase);
+
+        // The outcome_classification map must include the new outcome.
+        var outcomes = document.RootElement.GetProperty("outcome_classification")
+            .EnumerateObject().Select(p => p.Name).ToArray();
+        Assert.Contains("host-artifact-repair-required", outcomes, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_G353_PromptMentionsPrCommentPreflightAsHostMetadataDetector()
+    {
+        // G353: the guide prompt should direct the worker to use
+        // pr-comment-preflight to detect host-artifact-repair-required
+        // automatically, rather than parsing comment bodies manually.
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+
+        // The prompt should mention pr-comment-preflight as a triage helper.
+        Assert.Contains("pr-comment-preflight", prompt, StringComparison.Ordinal);
+        // And link the classification field to the stop condition.
+        Assert.Contains("classification", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Json_G353_HardRulesForbidHostMetadataEdits()
+    {
+        // The "Hard rules" section of the prompt must explicitly prohibit
+        // editing .intent-cli/** or intents/** paths during a pr-comment-fix.
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+
+        // Hard-rules prohibition must reference both path families.
+        Assert.Contains("Do not edit `.intent-cli/**`", prompt, StringComparison.Ordinal);
+        Assert.Contains("intents/**`", prompt, StringComparison.Ordinal);
+        // And name the stop outcome.
+        // (The outcome name appears in both the triage section and the hard rules.)
+        var occurrences = 0;
+        var search = "host-artifact-repair-required";
+        var idx = 0;
+        while ((idx = prompt.IndexOf(search, idx, StringComparison.Ordinal)) >= 0)
+        {
+            occurrences++;
+            idx += search.Length;
+        }
+        // Must appear at least twice: once in comment-triage, once in hard-rules.
+        Assert.True(occurrences >= 2, $"Expected ≥2 occurrences of '{search}' in prompt, found {occurrences}.");
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/HostSyncPreflightAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/HostSyncPreflightAnalyzerTests.cs
@@ -72,7 +72,8 @@ public sealed class HostSyncPreflightAnalyzerTests
         Assert.Single(result.DirtyUnrelatedPaths);
         Assert.Contains(result.NextSteps, s => s.Contains("automation workspace-guard --mode begin --write", StringComparison.Ordinal));
         Assert.Contains(result.NextSteps, s => s.Contains("--mode end --write", StringComparison.Ordinal));
-        Assert.Contains(result.NextSteps, s => s.Contains("stash-pop conflict", StringComparison.Ordinal));
+        // G352: updated wording covers both stash-pop and gitlink restore conflicts.
+        Assert.Contains(result.NextSteps, s => s.Contains("conflict", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -122,6 +123,28 @@ public sealed class HostSyncPreflightAnalyzerTests
     {
         Assert.Throws<ArgumentOutOfRangeException>(() =>
             HostSyncPreflightAnalyzer.Analyze("main", -1, Array.Empty<HostSyncWorkingTreeEntry>()));
+    }
+
+    // G352: next-steps guidance alignment with updated workspace-guard capabilities.
+
+    [Fact]
+    public void Analyze_G352_DirtyUnrelatedSubmodule_NextSteps_MentionCheckoutLaneAndManualFallback()
+    {
+        // host-sync-preflight should surface guidance that workspace-guard now
+        // handles gitlink-only submodule paths via the checkout lane (G352),
+        // and that a proceed_allowed:false result means manual intervention is needed.
+        var result = HostSyncPreflightAnalyzer.Analyze(
+            "main",
+            behindOriginCommits: 0,
+            workingTreeEntries: new[] { Entry("submodules/SekibanAsAService", " m") });
+
+        Assert.Equal("dirty-unrelated-submodule", result.Classification);
+        Assert.True(result.ProceedAllowed);
+        // Guidance must mention checkout lane (G352) and the stash lane.
+        Assert.Contains(result.NextSteps, s => s.Contains("checkout lane", StringComparison.Ordinal));
+        // Guidance must mention the fallback for submodule internal changes.
+        Assert.Contains(result.NextSteps, s => s.Contains("proceed_allowed: false", StringComparison.Ordinal));
+        Assert.Contains(result.NextSteps, s => s.Contains("manual recovery", StringComparison.OrdinalIgnoreCase));
     }
 
     private static HostSyncWorkingTreeEntry Entry(string path, string status) =>

--- a/tests/IntentSystem.Cli.Tests/WorkerPrCommentPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerPrCommentPreflightCommandTests.cs
@@ -1070,6 +1070,174 @@ public sealed class WorkerPrCommentPreflightCommandTests : IDisposable
         Assert.Contains("actionable=false", output, StringComparison.Ordinal);
     }
 
+    // -----------------------------------------------------------------------
+    // G353: host-artifact-repair-required classification
+    // Comments that reference .intent-cli/** or intents/** must be escalated
+    // to the host repair agent; the child worker must not attempt to fix them.
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void Execute_G353_AllCommentsTargetHostMetadata_ClassifiesAsHostArtifactRepairRequired()
+    {
+        // G353 regression: a comment asking to fix
+        // `.intent-cli/issues/G347/github-body.md` (the host packet artifact)
+        // must not be classified as `repair-required` for the child worker.
+        using var workspace = new WorkerPrCommentPreflightWorkspace();
+        SetTargetedPrAndIssue(prNumber: 630);
+        WorkerPrCommentPreflightCommand.CommentsLookupFactory = () => new FakeCommentsLookup(BuildComments(
+            reviewThreads: new[]
+            {
+                BuildThread(id: "t1", isResolved: false, comments: new[]
+                {
+                    BuildThreadComment(id: "c1", author: "tomohisa",
+                        body: "The Related Links section is missing from `.intent-cli/issues/G347/github-body.md`. Please add it.")
+                })
+            }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrCommentPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "630", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrCommentPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrCommentPreflightConstants.Classifications.HostArtifactRepairRequired, result.Classification);
+        Assert.False(result.Actionable, "host artifact repair must not be forwarded to child worker");
+        Assert.Equal(WorkerPrCommentPreflightConstants.RecommendedActions.EscalateToHostRepair, result.RecommendedAction);
+        // The comment appears in actionable_comments so the host agent knows what to repair.
+        Assert.Single(result.ActionableComments);
+        Assert.Contains(result.Reasons, r => r.Contains(".intent-cli/**", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_G353_CommentsTargetIntentsPath_ClassifiesAsHostArtifactRepairRequired()
+    {
+        // intents/** paths (clarifications, intent bodies) are also host metadata.
+        using var workspace = new WorkerPrCommentPreflightWorkspace();
+        SetTargetedPrAndIssue(prNumber: 631);
+        WorkerPrCommentPreflightCommand.CommentsLookupFactory = () => new FakeCommentsLookup(BuildComments(
+            comments: new[]
+            {
+                BuildIssueComment(id: "ic1", author: "alice",
+                    body: "Please update intents/intent-cli/clarifications/open.md with the resolution.")
+            }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrCommentPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "631", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrCommentPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrCommentPreflightConstants.Classifications.HostArtifactRepairRequired, result.Classification);
+        Assert.False(result.Actionable);
+        Assert.Equal(WorkerPrCommentPreflightConstants.RecommendedActions.EscalateToHostRepair, result.RecommendedAction);
+    }
+
+    [Fact]
+    public void Execute_G353_MixedComments_HostAndImpl_StillRepairRequired()
+    {
+        // When SOME comments target host metadata and SOME target implementation
+        // code, the standard repair-required path applies — the child must still
+        // address the implementation comments.
+        using var workspace = new WorkerPrCommentPreflightWorkspace();
+        SetTargetedPrAndIssue(prNumber: 632);
+        WorkerPrCommentPreflightCommand.CommentsLookupFactory = () => new FakeCommentsLookup(BuildComments(
+            reviewThreads: new[]
+            {
+                BuildThread(id: "t1", isResolved: false, comments: new[]
+                {
+                    BuildThreadComment(id: "c1", author: "alice",
+                        body: "The test coverage for the adapter is missing. Please add a unit test.")
+                }),
+                BuildThread(id: "t2", isResolved: false, comments: new[]
+                {
+                    BuildThreadComment(id: "c2", author: "alice",
+                        body: "Also update .intent-cli/issues/G347/github-body.md with the Related Links section.")
+                })
+            }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrCommentPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "632", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrCommentPreflightResult>(writer.ToString())!;
+        // Mixed: some impl, some host → repair-required so child handles impl comments.
+        Assert.Equal(WorkerPrCommentPreflightConstants.Classifications.RepairRequired, result.Classification);
+        Assert.True(result.Actionable);
+        Assert.Equal(WorkerPrCommentPreflightConstants.RecommendedActions.RepairPr, result.RecommendedAction);
+        Assert.Equal(2, result.ActionableComments.Count);
+    }
+
+    [Fact]
+    public void Execute_G353_PureImplComment_NotAffectedByG353()
+    {
+        // A comment about implementation code must still route to repair-required.
+        using var workspace = new WorkerPrCommentPreflightWorkspace();
+        SetTargetedPrAndIssue(prNumber: 633);
+        WorkerPrCommentPreflightCommand.CommentsLookupFactory = () => new FakeCommentsLookup(BuildComments(
+            reviewThreads: new[]
+            {
+                BuildThread(id: "t1", isResolved: false, comments: new[]
+                {
+                    BuildThreadComment(id: "c1", author: "alice",
+                        body: "The adapter factory is not disposed in the test. Please add a using statement.")
+                })
+            }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrCommentPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "633", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrCommentPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrCommentPreflightConstants.Classifications.RepairRequired, result.Classification);
+        Assert.True(result.Actionable);
+        Assert.NotEqual(
+            WorkerPrCommentPreflightConstants.Classifications.HostArtifactRepairRequired,
+            result.Classification);
+    }
+
+    [Fact]
+    public void Execute_G353_HostArtifactRepairRequired_PrecedenceAfterStep8_BeforeStep9()
+    {
+        // G353 step is inserted between step 8 (source-issue-not-target) and
+        // step 9 (repair-required). A PR that passes all guards 1–8 with ONLY
+        // host metadata comments must land on host-artifact-repair-required,
+        // not repair-required.
+        using var workspace = new WorkerPrCommentPreflightWorkspace();
+        SetTargetedPrAndIssue(prNumber: 634);
+        WorkerPrCommentPreflightCommand.CommentsLookupFactory = () => new FakeCommentsLookup(BuildComments(
+            comments: new[]
+            {
+                BuildIssueComment(id: "ic1", author: "alice",
+                    body: "Fix the publish artifact at .intent-cli/issues/G353/publish.yaml.")
+            }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrCommentPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "634", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrCommentPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrCommentPreflightConstants.Classifications.HostArtifactRepairRequired, result.Classification);
+        Assert.False(result.Actionable);
+        // Step-8 guards (closed, approved, update-in-progress, missing-target, etc.)
+        // must still dominate over step 8.5.
+        Assert.NotEqual(
+            WorkerPrCommentPreflightConstants.Classifications.NonActionable,
+            result.Classification);
+    }
+
     private static void SetTargetedPrAndIssue(int prNumber)
     {
         WorkerPrCommentPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(


### PR DESCRIPTION
## Summary

- Adds `host-artifact-repair-required` classification (and `escalate-to-host-repair` recommended action) to `WorkerPrCommentPreflightConstants`
- Inserts new step 8.5 in `WorkerPrCommentPreflightAnalyzer.Analyze()`: when ALL actionable comments reference host metadata paths (`.intent-cli/**` or `intents/**`), returns `host-artifact-repair-required` / `actionable: false` instead of `repair-required`; mixed comments (some host, some impl) still route to `repair-required` so the child can address implementation comments
- Adds `CommentTargetsHostMetadata(excerpt)` pure helper that checks for `.intent-cli/` or `intents/` path prefixes in comment text (ordinal, case-sensitive per Linux filesystem convention)
- 5 new tests covering: pure host-metadata comment → `host-artifact-repair-required`, `intents/` path → same, mixed comments → `repair-required`, pure impl comment unaffected, and precedence ordering

## Test plan

- [x] `Execute_G353_AllCommentsTargetHostMetadata_ClassifiesAsHostArtifactRepairRequired` — G347-like missing Related Links case
- [x] `Execute_G353_CommentsTargetIntentsPath_ClassifiesAsHostArtifactRepairRequired` — `intents/` paths
- [x] `Execute_G353_MixedComments_HostAndImpl_StillRepairRequired` — mixed comments stay child-routable
- [x] `Execute_G353_PureImplComment_NotAffectedByG353` — regression guard
- [x] `Execute_G353_HostArtifactRepairRequired_PrecedenceAfterStep8_BeforeStep9` — precedence ordering
- [x] All 69 WorkerPrComment tests pass; full suite clean

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)