### PR TITLE
G354: Add packet contract gap classifier for mechanical vs product sections

### DIFF
--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -33,6 +33,16 @@ internal static class IntentNextSliceCommand
     /// </summary>
     internal const string OutcomeDesignNeeded = "design-needed";
 
+    /// <summary>
+    /// G354: emitted when the packet candidate has missing contract sections
+    /// but ALL of them are <c>mechanical-repairable</c> (e.g.
+    /// <c>Verification</c>, <c>Related Links</c>). The result carries
+    /// per-section repair guidance so the host agent can append the
+    /// missing boilerplate without operator input and immediately
+    /// re-run to reach <c>issue-cut-ready</c>.
+    /// </summary>
+    internal const string OutcomePacketGapMechanicalRepairable = "packet-gap-mechanical-repairable";
+
     // G285: surfaced in `warnings` when the clarification file has stale
     // front-matter (`intent_state: open`) but the body explicitly records no
     // current blockers / open questions. The candidate may still publish.
@@ -348,12 +358,21 @@ internal static class IntentNextSliceCommand
         // `default-design` per `NextSlicePacketProvenanceReader`.
         var provenance = NextSlicePacketProvenanceReader.Read(directory);
 
+        // G354: classify missing sections as mechanical-repairable vs
+        // product-clarification-required so the host agent knows whether
+        // it can apply boilerplate templates autonomously or must wait
+        // for an operator/product decision.
+        var gapAnalysis = missing.Count > 0
+            ? PacketContractGapAnalyzer.Analyze(missing, directory)
+            : null;
+
         return new IntentNextSliceCandidate
         {
             ExecutionUnit = executionUnit,
             PacketDirectory = directory,
             GithubBodyPresent = githubBodyPresent,
             MissingContractSections = missing,
+            GapAnalysis = gapAnalysis,
             Provenance = provenance
         };
     }
@@ -413,6 +432,17 @@ internal static class IntentNextSliceCommand
 
         if (candidate.MissingContractSections.Count > 0)
         {
+            // G354: when every missing section is mechanical-repairable
+            // (Verification, Related Links), surface the specific repair
+            // outcome so the host agent can apply the boilerplate templates
+            // autonomously — no operator clarification needed.
+            if (candidate.GapAnalysis is not null
+                && candidate.GapAnalysis.OverallClassification ==
+                    PacketContractGapAnalyzer.ClassificationMechanicalRepairable)
+            {
+                return OutcomePacketGapMechanicalRepairable;
+            }
+
             return OutcomeClarificationRequired;
         }
 
@@ -827,6 +857,16 @@ internal sealed record IntentNextSliceCandidate
 
     [JsonPropertyName("missing_contract_sections")]
     public required IReadOnlyList<string> MissingContractSections { get; init; }
+
+    /// <summary>
+    /// G354: per-section gap classification and repair guidance.
+    /// Non-null only when <see cref="MissingContractSections"/> is non-empty.
+    /// When <see cref="PacketContractGapAnalysisResult.OverallClassification"/>
+    /// is <c>mechanical-repairable</c>, <see cref="PacketContractGapAnalysisResult.RepairGuidance"/>
+    /// contains actionable instructions the host agent can apply immediately.
+    /// </summary>
+    [JsonPropertyName("gap_analysis")]
+    public PacketContractGapAnalysisResult? GapAnalysis { get; init; }
 
     /// <summary>
     /// G328: packet provenance — which role authored the packet

--- a/src/IntentSystem.Cli/Commands/PacketContractGapAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PacketContractGapAnalyzer.cs
@@ -1,0 +1,213 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G354: Pure analyzer that classifies missing Child Issue Contract sections
+/// in a drafted packet's <c>github-body.md</c> as either
+/// <c>mechanical-repairable</c> (boilerplate that can be derived without
+/// product knowledge) or <c>product-clarification-required</c> (sections
+/// that require a product decision before the packet can be published).
+///
+/// <para>Mechanical sections: <c>Verification</c> and <c>Related Links</c>.
+/// These can be appended with standard templates; no operator input is needed.
+/// For each mechanical gap the analyzer emits a repair guidance string that
+/// the host agent can execute directly.</para>
+///
+/// <para>Product sections: all other required contract sections
+/// (<c>Goal</c>, <c>Why This Slice Exists Now</c>, <c>Current Observed
+/// State</c>, etc.). Missing product sections remain hard-stop
+/// clarification-required gaps.</para>
+///
+/// <para>Never reads from or writes to the filesystem. Pure over the
+/// supplied <paramref name="missingSections"/> list so that
+/// <c>IntentNextSliceCommand</c> can re-use the same pre-computed missing
+/// list without a second file read. The optional
+/// <paramref name="packetDirectory"/> is used only to produce actionable
+/// file paths in the repair guidance strings.</para>
+/// </summary>
+internal static class PacketContractGapAnalyzer
+{
+    public const string ClassificationMechanicalRepairable = "mechanical-repairable";
+    public const string ClassificationProductClarificationRequired = "product-clarification-required";
+    public const string ClassificationMixed = "mixed";
+    public const string ClassificationNone = "none";
+
+    /// <summary>
+    /// Sections whose content can be derived mechanically from standard
+    /// project conventions, without any product-specific decision. When
+    /// ALL missing sections belong to this set, the packet is classified
+    /// as <c>mechanical-repairable</c> and the host agent receives exact
+    /// repair guidance to append.
+    /// </summary>
+    private static readonly HashSet<string> MechanicalSections =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "Verification",
+            "Related Links"
+        };
+
+    /// <summary>
+    /// Classify <paramref name="missingSections"/> and, for mechanical
+    /// gaps, emit a repair guidance string that the host agent can
+    /// apply directly (appending the missing heading to
+    /// <c>github-body.md</c>).
+    /// </summary>
+    /// <param name="missingSections">
+    /// The list of section headings absent from the packet's
+    /// <c>github-body.md</c> (as produced by
+    /// <c>IntentNextSliceCommand.BuildCandidate</c>).
+    /// </param>
+    /// <param name="packetDirectory">
+    /// Optional absolute path to the packet directory. When supplied,
+    /// repair guidance embeds the full path to <c>github-body.md</c>
+    /// so the host agent can run the command without further lookup.
+    /// When <c>null</c>, a relative placeholder is used instead.
+    /// </param>
+    public static PacketContractGapAnalysisResult Analyze(
+        IReadOnlyList<string> missingSections,
+        string? packetDirectory = null)
+    {
+        ArgumentNullException.ThrowIfNull(missingSections);
+
+        if (missingSections.Count == 0)
+        {
+            return new PacketContractGapAnalysisResult
+            {
+                Gaps = Array.Empty<PacketContractGapItem>(),
+                HasMechanicalGaps = false,
+                HasProductGaps = false,
+                OverallClassification = ClassificationNone,
+                RepairGuidance = Array.Empty<string>()
+            };
+        }
+
+        var gaps = new List<PacketContractGapItem>(missingSections.Count);
+        var repairGuidance = new List<string>();
+        var hasMechanical = false;
+        var hasProduct = false;
+
+        foreach (var section in missingSections)
+        {
+            if (MechanicalSections.Contains(section))
+            {
+                hasMechanical = true;
+                var guidance = BuildRepairGuidance(section, packetDirectory);
+                gaps.Add(new PacketContractGapItem
+                {
+                    Section = section,
+                    Classification = ClassificationMechanicalRepairable,
+                    RepairGuidance = guidance
+                });
+                repairGuidance.Add(guidance);
+            }
+            else
+            {
+                hasProduct = true;
+                gaps.Add(new PacketContractGapItem
+                {
+                    Section = section,
+                    Classification = ClassificationProductClarificationRequired,
+                    RepairGuidance = null
+                });
+            }
+        }
+
+        var overall = (hasMechanical, hasProduct) switch
+        {
+            (true, false) => ClassificationMechanicalRepairable,
+            (false, true) => ClassificationProductClarificationRequired,
+            (true, true) => ClassificationMixed,
+            _ => ClassificationNone
+        };
+
+        return new PacketContractGapAnalysisResult
+        {
+            Gaps = gaps,
+            HasMechanicalGaps = hasMechanical,
+            HasProductGaps = hasProduct,
+            OverallClassification = overall,
+            RepairGuidance = repairGuidance
+        };
+    }
+
+    private static string BuildRepairGuidance(string section, string? packetDirectory)
+    {
+        var bodyPath = packetDirectory is not null
+            ? Path.Combine(packetDirectory, "github-body.md")
+            : "github-body.md";
+
+        return section switch
+        {
+            "Verification" =>
+                $"Append the following section to `{bodyPath}`:\n" +
+                "```markdown\n" +
+                "## Verification\n\n" +
+                "- Run `dotnet test` and confirm all tests pass.\n" +
+                "- Run `intent-cli automation doctor --format json` to confirm CLI version.\n" +
+                "```",
+
+            "Related Links" =>
+                $"Append the following section to `{bodyPath}`:\n" +
+                "```markdown\n" +
+                "## Related Links\n\n" +
+                "- (none)\n" +
+                "```",
+
+            _ =>
+                $"Add a `## {section}` heading with content to `{bodyPath}`."
+        };
+    }
+}
+
+/// <summary>
+/// G354: Result of <c>PacketContractGapAnalyzer.Analyze</c>. Embedded in
+/// <c>IntentNextSliceCandidate</c> so callers can inspect per-section
+/// classifications without re-scanning the file.
+/// </summary>
+internal sealed record PacketContractGapAnalysisResult
+{
+    [JsonPropertyName("gaps")]
+    public required IReadOnlyList<PacketContractGapItem> Gaps { get; init; }
+
+    [JsonPropertyName("has_mechanical_gaps")]
+    public required bool HasMechanicalGaps { get; init; }
+
+    [JsonPropertyName("has_product_gaps")]
+    public required bool HasProductGaps { get; init; }
+
+    /// <summary>
+    /// Overall classification: <c>mechanical-repairable</c>,
+    /// <c>product-clarification-required</c>, <c>mixed</c>, or <c>none</c>.
+    /// </summary>
+    [JsonPropertyName("overall_classification")]
+    public required string OverallClassification { get; init; }
+
+    /// <summary>
+    /// Human-readable repair instructions for each mechanical gap.
+    /// Empty when <see cref="HasMechanicalGaps"/> is false.
+    /// </summary>
+    [JsonPropertyName("repair_guidance")]
+    public required IReadOnlyList<string> RepairGuidance { get; init; }
+}
+
+/// <summary>
+/// G354: One classified gap entry in <see cref="PacketContractGapAnalysisResult"/>.
+/// </summary>
+internal sealed record PacketContractGapItem
+{
+    [JsonPropertyName("section")]
+    public required string Section { get; init; }
+
+    /// <summary>
+    /// <c>mechanical-repairable</c> or <c>product-clarification-required</c>.
+    /// </summary>
+    [JsonPropertyName("classification")]
+    public required string Classification { get; init; }
+
+    /// <summary>
+    /// Non-null for mechanical sections; null for product sections.
+    /// </summary>
+    [JsonPropertyName("repair_guidance")]
+    public string? RepairGuidance { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -1350,6 +1350,410 @@ public sealed class IntentNextSliceCommandTests
         Assert.Equal(0, root.GetProperty("warnings").GetArrayLength());
     }
 
+    // ─── G354: packet contract gap classification ──────────────────────────────
+
+    [Fact]
+    public void Execute_G354_OnlyMechanicalSectionsMissing_RecommendsPacketGapMechanicalRepairable()
+    {
+        // G348-like regression: a packet missing only Verification and
+        // Related Links must return packet-gap-mechanical-repairable (not
+        // clarification-required). The host agent can append the sections
+        // from the supplied repair_guidance without operator input.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G348/github-body.md",
+            """
+            ## Goal
+            x
+
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            x
+
+            ## Out Of Scope
+            x
+
+            ## Acceptance Criteria
+            x
+            """);
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-13T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G348",
+                  "title": "G348 test",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("packet-gap-mechanical-repairable", root.GetProperty("recommended_outcome").GetString());
+
+        var candidate = root.GetProperty("candidate");
+        Assert.Equal("G348", candidate.GetProperty("execution_unit").GetString());
+
+        // missing_contract_sections must still list the gaps
+        var missing = candidate.GetProperty("missing_contract_sections")
+            .EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains("Verification", missing);
+        Assert.Contains("Related Links", missing);
+
+        // gap_analysis must be present
+        var gapAnalysis = candidate.GetProperty("gap_analysis");
+        Assert.Equal("mechanical-repairable", gapAnalysis.GetProperty("overall_classification").GetString());
+        Assert.True(gapAnalysis.GetProperty("has_mechanical_gaps").GetBoolean());
+        Assert.False(gapAnalysis.GetProperty("has_product_gaps").GetBoolean());
+
+        // repair_guidance must have entries for each mechanical gap
+        var repairGuidance = gapAnalysis.GetProperty("repair_guidance");
+        Assert.Equal(2, repairGuidance.GetArrayLength());
+
+        // gaps array must classify each section
+        var gaps = gapAnalysis.GetProperty("gaps").EnumerateArray().ToArray();
+        Assert.Contains(gaps, g => g.GetProperty("section").GetString() == "Verification"
+            && g.GetProperty("classification").GetString() == "mechanical-repairable");
+        Assert.Contains(gaps, g => g.GetProperty("section").GetString() == "Related Links"
+            && g.GetProperty("classification").GetString() == "mechanical-repairable");
+    }
+
+    [Fact]
+    public void Execute_G354_ApplyingMechanicalRepairMakesPacketIssueCutReady()
+    {
+        // After appending Verification and Related Links, re-running
+        // intent next-slice --dry-run must return issue-cut-ready.
+        using var workspace = new IntentNextSliceWorkspace();
+        var githubBodyRelPath = ".intent-cli/issues/G348b/github-body.md";
+        workspace.WriteFile(
+            githubBodyRelPath,
+            """
+            ## Goal
+            x
+
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            x
+
+            ## Out Of Scope
+            x
+
+            ## Acceptance Criteria
+            x
+            """);
+
+        // First pass: confirm mechanical-repairable
+        using var firstWriter = new StringWriter();
+        IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], firstWriter);
+        using var firstDoc = JsonDocument.Parse(firstWriter.ToString());
+        Assert.Equal("packet-gap-mechanical-repairable",
+            firstDoc.RootElement.GetProperty("recommended_outcome").GetString());
+
+        // Apply the repair: add Verification and Related Links
+        workspace.WriteFile(
+            githubBodyRelPath,
+            """
+            ## Goal
+            x
+
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            x
+
+            ## Out Of Scope
+            x
+
+            ## Acceptance Criteria
+            x
+
+            ## Verification
+
+            - Run `dotnet test` and confirm all tests pass.
+
+            ## Related Links
+
+            - (none)
+            """);
+
+        // Second pass: must return issue-cut-ready
+        using var secondWriter = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            secondWriter);
+
+        Assert.Equal(0, exitCode);
+        using var secondDoc = JsonDocument.Parse(secondWriter.ToString());
+        Assert.Equal("issue-cut-ready",
+            secondDoc.RootElement.GetProperty("recommended_outcome").GetString());
+    }
+
+    [Fact]
+    public void Execute_G354_ProductSectionMissing_StillReturnsClarificationRequired()
+    {
+        // A packet missing Goal (product section) must still return
+        // clarification-required, not mechanical-repairable.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G354a/github-body.md",
+            """
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            x
+
+            ## Out Of Scope
+            x
+
+            ## Acceptance Criteria
+            x
+
+            ## Verification
+
+            - Run `dotnet test`.
+
+            ## Related Links
+
+            - (none)
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("clarification-required", root.GetProperty("recommended_outcome").GetString());
+
+        // gap_analysis must classify Goal as product-clarification-required
+        var gapAnalysis = root.GetProperty("candidate").GetProperty("gap_analysis");
+        Assert.Equal("product-clarification-required", gapAnalysis.GetProperty("overall_classification").GetString());
+        Assert.False(gapAnalysis.GetProperty("has_mechanical_gaps").GetBoolean());
+        Assert.True(gapAnalysis.GetProperty("has_product_gaps").GetBoolean());
+        var goalGap = gapAnalysis.GetProperty("gaps").EnumerateArray()
+            .First(g => g.GetProperty("section").GetString() == "Goal");
+        Assert.Equal("product-clarification-required", goalGap.GetProperty("classification").GetString());
+        Assert.False(goalGap.TryGetProperty("repair_guidance", out _));
+    }
+
+    [Fact]
+    public void Execute_G354_MixedGaps_ReturnsClarificationRequired()
+    {
+        // A packet missing both a product section (Goal) AND a
+        // mechanical section (Verification) must return
+        // clarification-required (not packet-gap-mechanical-repairable)
+        // because the product gap still requires operator input.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G354b/github-body.md",
+            """
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            x
+
+            ## Out Of Scope
+            x
+
+            ## Acceptance Criteria
+            x
+
+            ## Related Links
+
+            - (none)
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // Product gap (Goal) dominates — must remain clarification-required
+        Assert.Equal("clarification-required", root.GetProperty("recommended_outcome").GetString());
+
+        var gapAnalysis = root.GetProperty("candidate").GetProperty("gap_analysis");
+        Assert.Equal("mixed", gapAnalysis.GetProperty("overall_classification").GetString());
+        Assert.True(gapAnalysis.GetProperty("has_mechanical_gaps").GetBoolean());
+        Assert.True(gapAnalysis.GetProperty("has_product_gaps").GetBoolean());
+    }
+
+    [Fact]
+    public void Execute_G354_CompletePacket_HasNoGapAnalysis()
+    {
+        // A complete packet must NOT expose a gap_analysis field
+        // (null → omitted by JsonSerializer).
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G354c/github-body.md",
+            BuildCompleteContractBody());
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var candidate = document.RootElement.GetProperty("candidate");
+        Assert.Equal("issue-cut-ready", document.RootElement.GetProperty("recommended_outcome").GetString());
+        // gap_analysis must be absent (null serialized as omitted)
+        Assert.False(candidate.TryGetProperty("gap_analysis", out _));
+    }
+
+    // ─── G354 pure unit tests for PacketContractGapAnalyzer ───────────────────
+
+    [Fact]
+    public void PacketContractGapAnalyzer_EmptyMissing_ReturnsNone()
+    {
+        var result = PacketContractGapAnalyzer.Analyze(Array.Empty<string>());
+
+        Assert.Equal(PacketContractGapAnalyzer.ClassificationNone, result.OverallClassification);
+        Assert.False(result.HasMechanicalGaps);
+        Assert.False(result.HasProductGaps);
+        Assert.Empty(result.Gaps);
+        Assert.Empty(result.RepairGuidance);
+    }
+
+    [Fact]
+    public void PacketContractGapAnalyzer_VerificationMissing_IsMechanicalRepairable()
+    {
+        var result = PacketContractGapAnalyzer.Analyze(new[] { "Verification" });
+
+        Assert.Equal(PacketContractGapAnalyzer.ClassificationMechanicalRepairable, result.OverallClassification);
+        Assert.True(result.HasMechanicalGaps);
+        Assert.False(result.HasProductGaps);
+        Assert.Single(result.Gaps);
+        Assert.Equal(PacketContractGapAnalyzer.ClassificationMechanicalRepairable, result.Gaps[0].Classification);
+        Assert.NotNull(result.Gaps[0].RepairGuidance);
+        Assert.Contains("## Verification", result.Gaps[0].RepairGuidance!, StringComparison.Ordinal);
+        Assert.Single(result.RepairGuidance);
+    }
+
+    [Fact]
+    public void PacketContractGapAnalyzer_RelatedLinksMissing_IsMechanicalRepairable()
+    {
+        var result = PacketContractGapAnalyzer.Analyze(new[] { "Related Links" });
+
+        Assert.Equal(PacketContractGapAnalyzer.ClassificationMechanicalRepairable, result.OverallClassification);
+        Assert.True(result.HasMechanicalGaps);
+        Assert.NotNull(result.Gaps[0].RepairGuidance);
+        Assert.Contains("## Related Links", result.Gaps[0].RepairGuidance!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PacketContractGapAnalyzer_GoalMissing_IsProductClarificationRequired()
+    {
+        var result = PacketContractGapAnalyzer.Analyze(new[] { "Goal" });
+
+        Assert.Equal(PacketContractGapAnalyzer.ClassificationProductClarificationRequired, result.OverallClassification);
+        Assert.False(result.HasMechanicalGaps);
+        Assert.True(result.HasProductGaps);
+        Assert.Null(result.Gaps[0].RepairGuidance);
+        Assert.Empty(result.RepairGuidance);
+    }
+
+    [Fact]
+    public void PacketContractGapAnalyzer_MixedGaps_ClassifiesMixed()
+    {
+        var result = PacketContractGapAnalyzer.Analyze(new[] { "Goal", "Verification", "Related Links" });
+
+        Assert.Equal(PacketContractGapAnalyzer.ClassificationMixed, result.OverallClassification);
+        Assert.True(result.HasMechanicalGaps);
+        Assert.True(result.HasProductGaps);
+        // 2 repair guidance entries (Verification + Related Links)
+        Assert.Equal(2, result.RepairGuidance.Count);
+        Assert.Equal(3, result.Gaps.Count);
+    }
+
+    [Fact]
+    public void PacketContractGapAnalyzer_WithPacketDirectory_EmbedsFull_PathInGuidance()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "G354-test-" + Guid.NewGuid().ToString("N")[..8]);
+        var result = PacketContractGapAnalyzer.Analyze(new[] { "Verification" }, packetDirectory: dir);
+
+        var expectedPath = Path.Combine(dir, "github-body.md");
+        Assert.Contains(expectedPath, result.Gaps[0].RepairGuidance!, StringComparison.Ordinal);
+    }
+
     private sealed class IntentNextSliceWorkspace : IDisposable
     {
         private readonly string rootPath = Directory


### PR DESCRIPTION
## Summary
- New `PacketContractGapAnalyzer` pure classifier: categorises missing `github-body.md` sections as `mechanical-repairable` (`Verification`, `Related Links`) or `product-clarification-required` (all other required sections)
- `IntentNextSliceCommand` now emits `packet-gap-mechanical-repairable` outcome when only mechanical sections are missing, enabling the host agent to auto-repair boilerplate without operator input
- Repair guidance strings embedded in `PacketContractGapAnalysisResult` so the host agent can apply them directly without re-reading the file

## Test plan
- [x] 6 unit tests for `PacketContractGapAnalyzer` (empty / Verification / Related Links / Goal / mixed / with packetDirectory)
- [x] 5 integration tests via `IntentNextSliceCommand.Execute` (mechanical-only → `packet-gap-mechanical-repairable`, repair→re-run→`issue-cut-ready`, product-missing, mixed, complete packet)
- [x] All 45 `IntentNextSlice|PacketContractGap` tests pass
- [x] Full suite: 2957 passed, 1 skipped (pre-existing intermittent G311 test unrelated to this change)

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)