### PR TITLE
G358: Recover closeout drift from GitHub closing-PR facts before true-idle

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationCloseoutDriftCheckCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationCloseoutDriftCheckCommand.cs
@@ -41,8 +41,25 @@ internal static class AutomationCloseoutDriftCheckCommand
     internal const string ReasonMissingClosingIssueLinkage = "missing-closing-issue-linkage";
     internal const string ReasonClosingIssueMismatch = "closing-issue-mismatch";
 
+    // ── G358: reason codes for the linked_issue-only second pass ─────────────
+
+    /// <summary>G358: linked_issue found exactly one merged closing PR in the target repo; linked_pr inferred — safe repair available.</summary>
+    internal const string ReasonLinkedIssuePrInferred = "linked-issue-pr-inferred";
+
+    /// <summary>G358: linked_issue found more than one merged closing PR in the target repo; ambiguous — unsafe stop.</summary>
+    internal const string ReasonLinkedIssueAmbiguousClosingPrs = "linked-issue-ambiguous-closing-prs";
+
+    /// <summary>G358: linked_issue found no merged closing PRs in the target repo yet; skipped (issue may not be closed or PR not yet merged).</summary>
+    internal const string ReasonLinkedIssueNoMergedClosingPr = "linked-issue-no-merged-closing-pr";
+
+    /// <summary>G358: gh api graphql lookup for the linked_issue's closing PRs failed; skipped with warning.</summary>
+    internal const string ReasonLinkedIssueLookupFailed = "linked-issue-lookup-failed";
+
     /// <summary>Test seam — replaces the gh-backed PR lookup.</summary>
     public static Func<IGitHubPrLookup>? PrLookupFactory { get; set; }
+
+    /// <summary>G358: test seam — replaces the gh api graphql closing-PR lookup for linked_issue-only items.</summary>
+    public static Func<IGitHubIssueClosingPrLookup>? IssueLookupFactory { get; set; }
 
     /// <summary>Test seam — replaces the UTC timestamp source for run events.</summary>
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
@@ -113,13 +130,20 @@ internal static class AutomationCloseoutDriftCheckCommand
             return 0;
         }
 
-        // Collect non-Completed items that have a linked_pr.
-        var candidates = queueState.Items
+        // ── Pass 1 (G356): non-Completed items that have a linked_pr ───────
+        var pass1Candidates = queueState.Items
             .Where(item => item.State != QueueItemState.Completed
                 && !string.IsNullOrWhiteSpace(item.LinkedPr))
             .ToList();
 
-        if (candidates.Count == 0)
+        // ── Pass 2 (G358): non-Completed items with linked_issue but no linked_pr ──
+        var pass2Candidates = queueState.Items
+            .Where(item => item.State != QueueItemState.Completed
+                && item.LinkedIssue?.Number is { } n and > 0
+                && string.IsNullOrWhiteSpace(item.LinkedPr))
+            .ToList();
+
+        if (pass1Candidates.Count == 0 && pass2Candidates.Count == 0)
         {
             var empty = new CloseoutDriftCheckResult
             {
@@ -130,7 +154,7 @@ internal static class AutomationCloseoutDriftCheckCommand
                 AppliedCount = 0,
                 Records = Array.Empty<CloseoutDriftRecord>(),
                 Warnings = Array.Empty<string>(),
-                Summary = "closeout-drift-check: no candidate queue items with linked_pr; nothing to repair.",
+                Summary = "closeout-drift-check: no candidate queue items with linked_pr or linked_issue-only; nothing to repair.",
             };
             Emit(writer, empty, format);
             return 0;
@@ -141,7 +165,7 @@ internal static class AutomationCloseoutDriftCheckCommand
         var prToItems = new Dictionary<int, List<QueueItem>>();
         var itemsWithoutPrNumber = new List<QueueItem>();
 
-        foreach (var item in candidates)
+        foreach (var item in pass1Candidates)
         {
             var prNumber = TryParsePrNumberFromUrl(item.LinkedPr);
             if (prNumber is null)
@@ -159,6 +183,7 @@ internal static class AutomationCloseoutDriftCheckCommand
         }
 
         var prLookup = PrLookupFactory?.Invoke() ?? new GhCliGitHubPrLookup();
+        var issueLookup = IssueLookupFactory?.Invoke() ?? new GhCliGitHubIssueClosingPrLookup();
         var records = new List<CloseoutDriftRecord>();
         var warnings = new List<string>();
 
@@ -294,6 +319,87 @@ internal static class AutomationCloseoutDriftCheckCommand
             });
         }
 
+        // ── Pass 2 (G358): items with linked_issue but no linked_pr ─────────
+        // Parse repo owner/name for same-repo PR filtering.
+        var repoSlashIdx = repo!.IndexOf('/', StringComparison.Ordinal);
+        var repoOwnerPart = repoSlashIdx >= 0 ? repo[..repoSlashIdx] : repo;
+        var repoNamePart = repoSlashIdx >= 0 && repoSlashIdx + 1 < repo.Length
+            ? repo[(repoSlashIdx + 1)..]
+            : string.Empty;
+
+        foreach (var item in pass2Candidates)
+        {
+            var issueNumber = item.LinkedIssue!.Number!.Value;
+
+            GitHubIssueClosingPrLookupResult issueView;
+            try
+            {
+                issueView = issueLookup.Lookup(repo, issueNumber);
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                records.Add(new CloseoutDriftRecord
+                {
+                    ExecutionUnit = item.ExecutionUnit,
+                    Result = ResultSkipped,
+                    ReasonCode = ReasonLinkedIssueLookupFailed,
+                    Explanation = $"issue #{issueNumber} lookup failed: {exception.Message}; skipped.",
+                    LinkedPrNumber = null,
+                    LinkedIssueNumber = issueNumber,
+                });
+                warnings.Add($"issue #{issueNumber} lookup failed for '{item.ExecutionUnit}': {exception.Message}");
+                continue;
+            }
+
+            // G358: filter closing PRs to only merged same-repo PRs.
+            var mergedSameRepoPrs = issueView.ClosingPullRequests
+                .Where(pr => pr.Merged && IsSameRepoAsTarget(pr, repoOwnerPart, repoNamePart))
+                .ToList();
+
+            if (mergedSameRepoPrs.Count == 0)
+            {
+                records.Add(new CloseoutDriftRecord
+                {
+                    ExecutionUnit = item.ExecutionUnit,
+                    Result = ResultSkipped,
+                    ReasonCode = ReasonLinkedIssueNoMergedClosingPr,
+                    Explanation = $"issue #{issueNumber} has no merged closing PR in {repo} yet; skipped (issue state: {issueView.State}).",
+                    LinkedPrNumber = null,
+                    LinkedIssueNumber = issueNumber,
+                });
+                continue;
+            }
+
+            if (mergedSameRepoPrs.Count > 1)
+            {
+                var prNums = string.Join(", ", mergedSameRepoPrs.Select(p => $"#{p.Number}"));
+                records.Add(new CloseoutDriftRecord
+                {
+                    ExecutionUnit = item.ExecutionUnit,
+                    Result = ResultUnsafeStop,
+                    ReasonCode = ReasonLinkedIssueAmbiguousClosingPrs,
+                    Explanation = $"issue #{issueNumber} was closed by {mergedSameRepoPrs.Count} merged PRs in {repo} ({prNums}); ambiguous — cannot infer linked_pr deterministically.",
+                    LinkedPrNumber = null,
+                    LinkedIssueNumber = issueNumber,
+                });
+                continue;
+            }
+
+            // Exactly one merged same-repo closing PR — safe repair: infer linked_pr.
+            var inferredPr = mergedSameRepoPrs[0];
+            var inferredPrUrl = $"https://github.com/{repo}/pull/{inferredPr.Number}";
+            records.Add(new CloseoutDriftRecord
+            {
+                ExecutionUnit = item.ExecutionUnit,
+                Result = ResultSafeRepair,
+                ReasonCode = ReasonLinkedIssuePrInferred,
+                Explanation = $"issue #{issueNumber} was closed by exactly one merged PR in {repo}: #{inferredPr.Number}; queue item '{item.ExecutionUnit}' has no linked_pr — inferring '{inferredPrUrl}' and repair available (G358).",
+                LinkedPrNumber = inferredPr.Number,
+                LinkedIssueNumber = issueNumber,
+                InferredLinkedPrUrl = inferredPrUrl,
+            });
+        }
+
         var safeRepairCount = records.Count(r => string.Equals(r.Result, ResultSafeRepair, StringComparison.Ordinal));
         var unsafeStopCount = records.Count(r => string.Equals(r.Result, ResultUnsafeStop, StringComparison.Ordinal));
 
@@ -316,10 +422,28 @@ internal static class AutomationCloseoutDriftCheckCommand
                 .Where(r => r.LinkedPrNumber.HasValue)
                 .ToDictionary(r => r.ExecutionUnit, r => r.LinkedPrNumber!.Value);
 
+            // G358: map executionUnit → inferred PR URL for items where linked_pr
+            // was absent and must be written into queue-state during the repair.
+            var inferredPrUrls = repairRecords
+                .Where(r => r.InferredLinkedPrUrl is not null)
+                .ToDictionary(r => r.ExecutionUnit, r => r.InferredLinkedPrUrl!,
+                    StringComparer.Ordinal);
+
             var updatedItems = queueState.Items
-                .Select(item => unitsToComplete.Contains(item.ExecutionUnit)
-                    ? item with { State = QueueItemState.Completed }
-                    : item)
+                .Select(item =>
+                {
+                    if (!unitsToComplete.Contains(item.ExecutionUnit))
+                    {
+                        return item;
+                    }
+                    var completed = item with { State = QueueItemState.Completed };
+                    // G358: also populate linked_pr when it was inferred from the issue's closing PR.
+                    if (inferredPrUrls.TryGetValue(item.ExecutionUnit, out var inferredUrl))
+                    {
+                        completed = completed with { LinkedPr = inferredUrl };
+                    }
+                    return completed;
+                })
                 .ToArray();
 
             var updatedState = new QueueState
@@ -379,6 +503,21 @@ internal static class AutomationCloseoutDriftCheckCommand
             return 1;
         }
         return 0;
+    }
+
+    /// <summary>
+    /// G358: returns true when the PR's owner/name matches the target repo.
+    /// Empty owner/name fields (edge-case from the GraphQL response) are
+    /// treated as same-repo (safe fallback).
+    /// </summary>
+    private static bool IsSameRepoAsTarget(GitHubIssueClosingPrRef pr, string repoOwner, string repoName)
+    {
+        if (string.IsNullOrEmpty(pr.RepoOwner) || string.IsNullOrEmpty(pr.RepoName))
+        {
+            return true; // assume same-repo if the GraphQL response omits the field
+        }
+        return string.Equals(pr.RepoOwner, repoOwner, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(pr.RepoName, repoName, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string BuildSummary(int safeRepairs, int unsafeStops, int applied, bool write)
@@ -610,4 +749,13 @@ internal sealed record CloseoutDriftRecord
 
     [JsonPropertyName("linked_issue_number")]
     public int? LinkedIssueNumber { get; init; }
+
+    /// <summary>
+    /// G358: for records where <c>linked_pr</c> was absent in queue-state and
+    /// is inferred from the issue's closing PR facts, this is the URL written
+    /// (or to be written) into queue-state during the repair pass. Null for
+    /// Pass 1 records where <c>linked_pr</c> was already present.
+    /// </summary>
+    [JsonPropertyName("inferred_linked_pr_url")]
+    public string? InferredLinkedPrUrl { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -203,13 +203,18 @@ internal static class AutomationHostLoopNextActionCommand
         // this probe the lane would only fire when the operator typed
         // the count, and recoverable `linked_pr` blockers would fall
         // through to true-idle.
+        // The unsafe_stop_count gate is critical: publish-recovery --write
+        // refuses all mutations when any unsafe stop is present, so
+        // recommending it in a mixed (safe+unsafe) state would be a no-op
+        // and confuse the operator. Gate on UnsafeStopCount == 0 to ensure
+        // the lane is only surfaced when the repair is actually writeable.
         var publishRecoveryRepairsAvailable = parsed.PublishRecoveryRepairsAvailable;
         if (publishRecoveryRepairsAvailable == 0)
         {
             var recoveryProbe = PublishRecoveryProbeFactory?.Invoke(context)
                 ?? new IntentCliPublishRecoveryProbe(context);
             var recoveryProbed = recoveryProbe.Probe(parsed.Repo);
-            if (recoveryProbed != null && recoveryProbed.SafeRepairCount > 0)
+            if (recoveryProbed != null && recoveryProbed.SafeRepairCount > 0 && recoveryProbed.UnsafeStopCount == 0)
             {
                 publishRecoveryRepairsAvailable = recoveryProbed.SafeRepairCount;
             }

--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -243,16 +243,20 @@ internal static class AutomationHostLoopNextActionCommand
 
         // G358: auto-probe `automation closeout-drift-check --dry-run` to detect
         // items with linked_issue but no linked_pr where GitHub confirms a single
-        // merged closing PR. When safe_repair_count > 0 the analyzer surfaces
-        // `repair-host-metadata` with the `closeout-drift-check --write`
-        // recommendation, so the host loop never falls through to true-idle while
-        // an infer-linked_pr repair is available.
+        // merged closing PR. When safe_repair_count > 0 AND unsafe_stop_count == 0
+        // the analyzer surfaces `repair-host-metadata` with the
+        // `closeout-drift-check --write` recommendation, so the host loop never
+        // falls through to true-idle while an infer-linked_pr repair is available.
+        // The unsafe_stop_count gate is critical: closeout-drift-check --write
+        // refuses all mutations when any unsafe stop is present (ambiguous closing
+        // PRs), so recommending it in that mixed state would be a no-op and confuse
+        // the operator.
         var closeoutDriftRepairsAvailable = 0;
         {
             var driftProbe = CloseoutDriftCheckProbeFactory?.Invoke(context)
                 ?? new IntentCliCloseoutDriftCheckProbe(context);
             var driftProbed = driftProbe.Probe(parsed.Repo);
-            if (driftProbed != null && driftProbed.SafeRepairCount > 0)
+            if (driftProbed != null && driftProbed.SafeRepairCount > 0 && driftProbed.UnsafeStopCount == 0)
             {
                 closeoutDriftRepairsAvailable = driftProbed.SafeRepairCount;
             }

--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -54,6 +54,15 @@ internal static class AutomationHostLoopNextActionCommand
     /// </summary>
     public static Func<CliContext, IHostSyncPreflightProbe>? HostSyncPreflightProbeFactory { get; set; }
 
+    /// <summary>
+    /// G358: testability seam for the closeout-drift-check auto-probe.
+    /// Production uses <see cref="IntentCliCloseoutDriftCheckProbe"/> which
+    /// runs closeout-drift-check in dry-run mode; tests inject a fake to
+    /// model repairable / no-repairs outcomes without touching live
+    /// queue-state or network.
+    /// </summary>
+    public static Func<CliContext, ICloseoutDriftCheckProbe>? CloseoutDriftCheckProbeFactory { get; set; }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -232,6 +241,23 @@ internal static class AutomationHostLoopNextActionCommand
             }
         }
 
+        // G358: auto-probe `automation closeout-drift-check --dry-run` to detect
+        // items with linked_issue but no linked_pr where GitHub confirms a single
+        // merged closing PR. When safe_repair_count > 0 the analyzer surfaces
+        // `repair-host-metadata` with the `closeout-drift-check --write`
+        // recommendation, so the host loop never falls through to true-idle while
+        // an infer-linked_pr repair is available.
+        var closeoutDriftRepairsAvailable = 0;
+        {
+            var driftProbe = CloseoutDriftCheckProbeFactory?.Invoke(context)
+                ?? new IntentCliCloseoutDriftCheckProbe(context);
+            var driftProbed = driftProbe.Probe(parsed.Repo);
+            if (driftProbed != null && driftProbed.SafeRepairCount > 0)
+            {
+                closeoutDriftRepairsAvailable = driftProbed.SafeRepairCount;
+            }
+        }
+
         var input = new HostLoopNextActionInput
         {
             Repo = parsed.Repo,
@@ -243,6 +269,7 @@ internal static class AutomationHostLoopNextActionCommand
             ApprovedPrPendingMergeCloseout = approvedPr,
             PublishRecoveryRepairsAvailable = publishRecoveryRepairsAvailable,
             PublishLifecycleDriftCount = parsed.PublishLifecycleDriftCount,
+            CloseoutDriftRepairsAvailable = closeoutDriftRepairsAvailable,
             NextSliceIssueCutReady = nextSliceIssueCutReady,
             PublishNextSliceExecutionUnit = publishNextSliceExecutionUnit,
             OpenIntentTargetPrOrIssueExists = openIntentTargetExistsResolved,

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsAnalyzer.cs
@@ -312,6 +312,33 @@ internal static class AutomationHostReviewDiagnosticsAnalyzer
                 warnings);
         }
 
+        // G358: when closeout-drift-check reports unapplied repairs, surface
+        // `closeout-drift-repair` BEFORE the WIP-cap / wait-for-child returns so
+        // the host loop can record the missing closeout even when an open
+        // intent-target issue or PR occupies the WIP slot. A merged-PR closeout
+        // is a deterministic state repair that does not publish new work, so it
+        // must not be hidden behind the WIP gate.
+        if (closeoutDriftRepairsAvailable > 0)
+        {
+            details.Add(new AutomationHostReviewDiagnosticsDetail
+            {
+                Kind = AutomationHostReviewDiagnosticsClassifications.CloseoutDriftRepair,
+                TargetKind = null,
+                TargetNumber = null,
+                TargetUrl = null,
+                Description = $"closeout-drift-check reports {closeoutDriftRepairsAvailable} queue item(s) whose linked PR is merged but whose state is not Completed.",
+            });
+            return Build(
+                repo,
+                AutomationHostReviewDiagnosticsClassifications.CloseoutDriftRepair,
+                $"Closeout drift detected: {closeoutDriftRepairsAvailable} queue item(s) are not Completed despite their linked PR being merged. Apply the repair with `automation closeout-drift-check --write`, commit/push durable state, then retry the wake.",
+                recommendedNextCommand: $"intent-cli automation closeout-drift-check --repo {repo} --write --format json",
+                clarification: null,
+                details,
+                warnings,
+                safeRepairCategory: SafeRepairCategories.CloseoutDriftRepair);
+        }
+
         if (inFlightPrs.Length > 0 || inFlightIssues.Length > 0)
         {
             // G288: when the operator explicitly opts in (--allow-wip-cap-override)
@@ -451,31 +478,6 @@ internal static class AutomationHostReviewDiagnosticsAnalyzer
                 details,
                 warnings,
                 safeRepairCategory: SafeRepairCategories.HostArtifactRepair);
-        }
-
-        // G356: when closeout-drift-check reports unapplied repairs, surface
-        // `closeout-drift-repair` before `true-idle` so the host loop records
-        // the missing closeout deterministically rather than declaring idle
-        // while a queue item remains un-completed for an already-merged PR.
-        if (closeoutDriftRepairsAvailable > 0)
-        {
-            details.Add(new AutomationHostReviewDiagnosticsDetail
-            {
-                Kind = AutomationHostReviewDiagnosticsClassifications.CloseoutDriftRepair,
-                TargetKind = null,
-                TargetNumber = null,
-                TargetUrl = null,
-                Description = $"closeout-drift-check reports {closeoutDriftRepairsAvailable} queue item(s) whose linked PR is merged but whose state is not Completed.",
-            });
-            return Build(
-                repo,
-                AutomationHostReviewDiagnosticsClassifications.CloseoutDriftRepair,
-                $"Closeout drift detected: {closeoutDriftRepairsAvailable} queue item(s) are not Completed despite their linked PR being merged. Apply the repair with `automation closeout-drift-check --write`, commit/push durable state, then retry the wake.",
-                recommendedNextCommand: $"intent-cli automation closeout-drift-check --repo {repo} --write --format json",
-                clarification: null,
-                details,
-                warnings,
-                safeRepairCategory: SafeRepairCategories.CloseoutDriftRepair);
         }
 
         return Build(

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
@@ -186,7 +186,7 @@ internal static class AutomationHostReviewDiagnosticsCommand
             var recoveryProbe = PublishRecoveryProbeFactory?.Invoke(context)
                 ?? new IntentCliPublishRecoveryProbe(context);
             var recoveryProbed = recoveryProbe.Probe(repo!);
-            if (recoveryProbed != null && recoveryProbed.SafeRepairCount > 0)
+            if (recoveryProbed != null && recoveryProbed.SafeRepairCount > 0 && recoveryProbed.UnsafeStopCount == 0)
             {
                 publishRecoveryRepairsAvailable = recoveryProbed.SafeRepairCount;
             }

--- a/src/IntentSystem.Cli/Commands/HostLoopNextActionAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/HostLoopNextActionAnalyzer.cs
@@ -214,6 +214,18 @@ internal static class HostLoopNextActionAnalyzer
                 },
                 "Publish artifact lifecycle drift — run G307 publish-lifecycle-repair.");
         }
+        if (input.CloseoutDriftRepairsAvailable > 0)
+        {
+            return Result(ClassificationRepairHostMetadata, mutationAllowed: true,
+                $"intent-cli automation closeout-drift-check --repo {input.Repo} --write --format json",
+                new[]
+                {
+                    $"closeout-drift-check detected {input.CloseoutDriftRepairsAvailable} queue item(s) with linked_issue but no linked_pr where GitHub confirms exactly one merged closing PR (G358).",
+                    "Run closeout-drift-check --write to infer and persist the linked_pr, mark the item Completed, and append pr-merged / closeout-recorded events.",
+                    "Re-run the host loop after the repair to confirm the item is resolved and no further drift remains."
+                },
+                "Closeout drift (G358): linked_issue-only items have an inferred closing PR — run closeout-drift-check --write.");
+        }
 
         // 6. publish next issue
         if (input.NextSliceIssueCutReady && input.PublishNextSliceExecutionUnit is { } unit && !input.OpenIntentTargetPrOrIssueExists)
@@ -342,6 +354,15 @@ internal sealed record HostLoopNextActionInput
 
     /// <summary>G307: count of stale lifecycle drift entries available for safe upgrade.</summary>
     public int PublishLifecycleDriftCount { get; init; }
+
+    /// <summary>
+    /// G358: count of queue items where <c>linked_issue</c> is present but
+    /// <c>linked_pr</c> is absent, and GitHub confirms exactly one merged
+    /// closing PR in the target repo — deterministic closeout-drift repairs.
+    /// When &gt; 0 the analyzer surfaces <c>repair-host-metadata</c> (priority 5)
+    /// recommending <c>closeout-drift-check --write</c>.
+    /// </summary>
+    public int CloseoutDriftRepairsAvailable { get; init; }
 
     /// <summary>True when intent next-slice --dry-run reports `issue-cut-ready`.</summary>
     public bool NextSliceIssueCutReady { get; init; }

--- a/src/IntentSystem.Cli/Commands/IGitHubIssueClosingPrLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubIssueClosingPrLookup.cs
@@ -1,0 +1,256 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G358: Testability seam for querying which PRs closed a GitHub issue.
+/// The production implementation shells out to <c>gh api graphql</c> using
+/// the <c>closedByPullRequestsReferences</c> field on the GraphQL
+/// <c>Issue</c> type; tests inject a fake to avoid GitHub network access.
+/// </summary>
+internal interface IGitHubIssueClosingPrLookup
+{
+    GitHubIssueClosingPrLookupResult Lookup(string repo, int issueNumber);
+}
+
+/// <summary>
+/// G358: Default <see cref="IGitHubIssueClosingPrLookup"/> that shells out to
+/// <c>gh api graphql</c> with the GitHub GraphQL
+/// <c>closedByPullRequestsReferences</c> field on the <c>Issue</c> type to
+/// discover merged PRs that closed a given issue. This is the only place
+/// permitted to call <c>Process.Start</c> for issue-closing-PR lookups —
+/// command and analyzer layers remain pure.
+/// </summary>
+internal sealed class GhCliGitHubIssueClosingPrLookup : IGitHubIssueClosingPrLookup
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    // Compact single-line query to avoid shell quoting issues. Fetches up to
+    // 10 closing PRs — in practice there is at most one per issue.
+    private const string GraphQlQuery =
+        "query($owner:String!,$name:String!,$number:Int!)" +
+        "{repository(owner:$owner,name:$name)" +
+        "{issue(number:$number)" +
+        "{state closedByPullRequestsReferences(includeClosedPrs:true first:10)" +
+        "{nodes{number state merged mergedAt baseRefName repository{name owner{login}}}}}}}";
+
+    public GitHubIssueClosingPrLookupResult Lookup(string repo, int issueNumber)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var slashIdx = repo.IndexOf('/', StringComparison.Ordinal);
+        if (slashIdx < 0 || slashIdx + 1 >= repo.Length)
+        {
+            throw new InvalidOperationException(
+                $"repo must be in 'owner/name' format (got '{repo}').");
+        }
+        var owner = repo[..slashIdx];
+        var name = repo[(slashIdx + 1)..];
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        startInfo.ArgumentList.Add("api");
+        startInfo.ArgumentList.Add("graphql");
+        startInfo.ArgumentList.Add("-F");
+        startInfo.ArgumentList.Add($"owner={owner}");
+        startInfo.ArgumentList.Add("-F");
+        startInfo.ArgumentList.Add($"name={name}");
+        startInfo.ArgumentList.Add("-F");
+        startInfo.ArgumentList.Add($"number={issueNumber}");
+        startInfo.ArgumentList.Add("-f");
+        startInfo.ArgumentList.Add($"query={GraphQlQuery}");
+
+        string stdout;
+        string stderr;
+        int exitCode;
+
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException(
+                    "failed to start `gh` process for issue closing-PR lookup");
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            exitCode = process.ExitCode;
+        }
+        catch (Exception exception) when (
+            exception is System.ComponentModel.Win32Exception
+            or InvalidOperationException
+            or IOException)
+        {
+            throw new InvalidOperationException(
+                $"could not invoke `gh api graphql` for issue #{issueNumber} in {repo}: {exception.Message}",
+                exception);
+        }
+
+        if (exitCode != 0)
+        {
+            var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+            throw new InvalidOperationException(
+                $"`gh api graphql` failed (exit {exitCode}) for issue #{issueNumber} in {repo}: {errorBody.Trim()}");
+        }
+
+        try
+        {
+            var response = JsonSerializer.Deserialize<GraphQlResponse>(stdout, JsonOptions);
+            var issue = response?.Data?.Repository?.Issue;
+            if (issue is null)
+            {
+                throw new InvalidOperationException(
+                    $"`gh api graphql` returned an empty payload for issue #{issueNumber} in {repo}");
+            }
+
+            var closingPrs = (issue.ClosedByPullRequestsReferences?.Nodes
+                ?? Array.Empty<ClosingPrNode>())
+                .Select(n => new GitHubIssueClosingPrRef
+                {
+                    Number = n.Number,
+                    State = n.State ?? string.Empty,
+                    Merged = n.Merged,
+                    MergedAt = n.MergedAt,
+                    BaseRefName = n.BaseRefName ?? string.Empty,
+                    RepoOwner = n.Repository?.Owner?.Login ?? string.Empty,
+                    RepoName = n.Repository?.Name ?? string.Empty,
+                })
+                .ToArray();
+
+            return new GitHubIssueClosingPrLookupResult
+            {
+                IssueNumber = issueNumber,
+                State = issue.State ?? string.Empty,
+                ClosingPullRequests = closingPrs,
+            };
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException(
+                $"could not parse `gh api graphql` JSON for issue #{issueNumber} in {repo}: {exception.Message}",
+                exception);
+        }
+    }
+
+    // ── Internal deserialization types (private to this file) ───────────────
+
+    private sealed class GraphQlResponse
+    {
+        [JsonPropertyName("data")]
+        public GraphQlData? Data { get; init; }
+    }
+
+    private sealed class GraphQlData
+    {
+        [JsonPropertyName("repository")]
+        public GraphQlRepository? Repository { get; init; }
+    }
+
+    private sealed class GraphQlRepository
+    {
+        [JsonPropertyName("issue")]
+        public GraphQlIssue? Issue { get; init; }
+    }
+
+    private sealed class GraphQlIssue
+    {
+        [JsonPropertyName("state")]
+        public string? State { get; init; }
+
+        [JsonPropertyName("closedByPullRequestsReferences")]
+        public ClosingPrConnection? ClosedByPullRequestsReferences { get; init; }
+    }
+
+    private sealed class ClosingPrConnection
+    {
+        [JsonPropertyName("nodes")]
+        public IReadOnlyList<ClosingPrNode>? Nodes { get; init; }
+    }
+
+    private sealed class ClosingPrNode
+    {
+        [JsonPropertyName("number")]
+        public int Number { get; init; }
+
+        [JsonPropertyName("state")]
+        public string? State { get; init; }
+
+        [JsonPropertyName("merged")]
+        public bool Merged { get; init; }
+
+        [JsonPropertyName("mergedAt")]
+        public string? MergedAt { get; init; }
+
+        [JsonPropertyName("baseRefName")]
+        public string? BaseRefName { get; init; }
+
+        [JsonPropertyName("repository")]
+        public ClosingPrRepository? Repository { get; init; }
+    }
+
+    private sealed class ClosingPrRepository
+    {
+        [JsonPropertyName("name")]
+        public string? Name { get; init; }
+
+        [JsonPropertyName("owner")]
+        public ClosingPrOwner? Owner { get; init; }
+    }
+
+    private sealed class ClosingPrOwner
+    {
+        [JsonPropertyName("login")]
+        public string? Login { get; init; }
+    }
+}
+
+/// <summary>
+/// G358: Result of querying which PRs closed a GitHub issue, via
+/// <c>gh api graphql</c> <c>closedByPullRequestsReferences</c>.
+/// </summary>
+internal sealed record GitHubIssueClosingPrLookupResult
+{
+    /// <summary>The queried issue number.</summary>
+    public required int IssueNumber { get; init; }
+
+    /// <summary>GitHub issue state (e.g. <c>OPEN</c>, <c>CLOSED</c>).</summary>
+    public required string State { get; init; }
+
+    /// <summary>
+    /// PRs that closed (or reference-closed) this issue, as reported by
+    /// GitHub's <c>closedByPullRequestsReferences</c> field.
+    /// Empty when no closing PRs exist or the issue is still open.
+    /// </summary>
+    public required IReadOnlyList<GitHubIssueClosingPrRef> ClosingPullRequests { get; init; }
+}
+
+/// <summary>
+/// G358: A single PR that closed a GitHub issue, returned by the
+/// <c>closedByPullRequestsReferences</c> GraphQL field.
+/// </summary>
+internal sealed record GitHubIssueClosingPrRef
+{
+    public required int Number { get; init; }
+    public required string State { get; init; }
+    public required bool Merged { get; init; }
+    public string? MergedAt { get; init; }
+    public required string BaseRefName { get; init; }
+
+    /// <summary>Owner login of the repo where the PR lives. Empty for same-repo PRs
+    /// when the GraphQL response omits the field.</summary>
+    public required string RepoOwner { get; init; }
+
+    /// <summary>Repository name (not full path) where the PR lives. Empty for
+    /// same-repo PRs when the GraphQL response omits the field.</summary>
+    public required string RepoName { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ISafeRepairProbes.cs
+++ b/src/IntentSystem.Cli/Commands/ISafeRepairProbes.cs
@@ -215,13 +215,22 @@ internal interface ICloseoutDriftCheckProbe
 
 /// <summary>
 /// G358: minimal projection of the closeout-drift-check dry-run output.
-/// Only the safe-repair count the host-loop analyzer needs surfaces here;
-/// richer per-repair detail stays in the full command output for operators
-/// who run it directly.
+/// Both <see cref="SafeRepairCount"/> and <see cref="UnsafeStopCount"/> are
+/// surfaced because the host-loop analyzer must suppress the
+/// <c>repair-host-metadata</c> lane whenever unsafe stops are present —
+/// <c>closeout-drift-check --write</c> refuses to apply any mutations when
+/// <c>unsafe_stop_count &gt; 0</c>, so recommending it would be a no-op.
 /// </summary>
 internal sealed record CloseoutDriftCheckProbeResult
 {
     public required int SafeRepairCount { get; init; }
+
+    /// <summary>
+    /// Count of items where closing-PR lookup found multiple merged PRs for
+    /// the same issue (ambiguous). When &gt; 0 the write path is blocked and
+    /// the host-loop analyzer must not surface the repair lane.
+    /// </summary>
+    public required int UnsafeStopCount { get; init; }
 }
 
 /// <summary>
@@ -296,9 +305,17 @@ internal sealed class IntentCliCloseoutDriftCheckProbe : ICloseoutDriftCheckProb
                 safeRepairCount = safeRepairCountElement.GetInt32();
             }
 
+            var unsafeStopCount = 0;
+            if (root.TryGetProperty("unsafe_stop_count", out var unsafeStopCountElement)
+                && unsafeStopCountElement.ValueKind == JsonValueKind.Number)
+            {
+                unsafeStopCount = unsafeStopCountElement.GetInt32();
+            }
+
             return new CloseoutDriftCheckProbeResult
             {
-                SafeRepairCount = safeRepairCount
+                SafeRepairCount = safeRepairCount,
+                UnsafeStopCount = unsafeStopCount
             };
         }
         catch (JsonException)

--- a/src/IntentSystem.Cli/Commands/ISafeRepairProbes.cs
+++ b/src/IntentSystem.Cli/Commands/ISafeRepairProbes.cs
@@ -198,3 +198,112 @@ internal sealed class IntentCliHostSyncPreflightProbe : IHostSyncPreflightProbe
         return null;
     }
 }
+
+// ── G358: closeout-drift-check probe ────────────────────────────────────────
+
+/// <summary>
+/// G358: testability seam for the auto-probe of
+/// <c>intent-cli automation closeout-drift-check --dry-run --format json</c>.
+/// Production uses <see cref="IntentCliCloseoutDriftCheckProbe"/>; tests
+/// inject a fake to model repairable / no-repairs outcomes without touching
+/// live queue-state or network.
+/// </summary>
+internal interface ICloseoutDriftCheckProbe
+{
+    CloseoutDriftCheckProbeResult? Probe(string repo);
+}
+
+/// <summary>
+/// G358: minimal projection of the closeout-drift-check dry-run output.
+/// Only the safe-repair count the host-loop analyzer needs surfaces here;
+/// richer per-repair detail stays in the full command output for operators
+/// who run it directly.
+/// </summary>
+internal sealed record CloseoutDriftCheckProbeResult
+{
+    public required int SafeRepairCount { get; init; }
+}
+
+/// <summary>
+/// G358: in-process invoker of <see cref="AutomationCloseoutDriftCheckCommand"/>
+/// in dry-run mode. Reuses the host's existing <see cref="CliContext"/> so
+/// queue-state resolves from the parent host root, not a child worktree.
+/// Fail-soft: returns <see langword="null"/> on any error so the host loop
+/// never crashes when closeout-drift-check itself is unhealthy.
+/// </summary>
+internal sealed class IntentCliCloseoutDriftCheckProbe : ICloseoutDriftCheckProbe
+{
+    private readonly CliContext _context;
+
+    public IntentCliCloseoutDriftCheckProbe(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    public CloseoutDriftCheckProbeResult? Probe(string repo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var args = new[]
+        {
+            "--repo", repo,
+            "--dry-run",
+            "--format", "json"
+        };
+
+        using var buffer = new StringWriter();
+        int exitCode;
+        try
+        {
+            exitCode = AutomationCloseoutDriftCheckCommand.Execute(_context, args, buffer);
+        }
+        catch (Exception exception) when (
+            exception is IOException or InvalidOperationException or JsonException
+            or ArgumentException or ArgumentNullException)
+        {
+            // ArgumentException / ArgumentNullException can occur when the host
+            // context has an empty domain (e.g., tests using CreateContextWithoutDomain).
+            // Always fail-soft so the host loop never crashes on probe errors.
+            return null;
+        }
+
+        if (exitCode != 0)
+        {
+            // Non-zero may indicate unsafe stops; still parse the JSON to get
+            // the safe-repair count (the host loop only cares about safe repairs).
+        }
+
+        var stdout = buffer.ToString();
+        if (string.IsNullOrWhiteSpace(stdout))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(stdout);
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            var safeRepairCount = 0;
+            if (root.TryGetProperty("safe_repair_count", out var safeRepairCountElement)
+                && safeRepairCountElement.ValueKind == JsonValueKind.Number)
+            {
+                safeRepairCount = safeRepairCountElement.GetInt32();
+            }
+
+            return new CloseoutDriftCheckProbeResult
+            {
+                SafeRepairCount = safeRepairCount
+            };
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationCloseoutDriftCheckCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationCloseoutDriftCheckCommandTests.cs
@@ -7,12 +7,17 @@ using IntentSystem.Supervisor.Serialization;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G356: Tests for <c>intent-cli automation closeout-drift-check</c>. Covers:
+/// G356 / G358: Tests for <c>intent-cli automation closeout-drift-check</c>. Covers:
 /// - Merged PR with non-Completed queue item → safe-repair.
 /// - Unmerged PR → skipped (no drift).
 /// - Multiple queue items sharing the same PR number → unsafe-stop.
 /// - No queue-state present → empty result.
 /// - --write: marks item Completed and appends pr-merged/closeout-recorded events.
+/// - G358: linked_issue-only item + single merged closing PR → safe-repair, infer linked_pr.
+/// - G358: linked_issue-only item + multiple closing PRs → unsafe-stop (ambiguous).
+/// - G358: linked_issue-only item + no closing PRs → skipped.
+/// - G358: linked_issue-only item + lookup failure → skipped with warning.
+/// - G358: host-loop-next-action surfaces repair-host-metadata when drift repairs available.
 /// - Diagnostics returns closeout-drift-repair instead of true-idle when count > 0.
 /// </summary>
 public sealed class AutomationCloseoutDriftCheckCommandTests : IDisposable
@@ -20,6 +25,7 @@ public sealed class AutomationCloseoutDriftCheckCommandTests : IDisposable
     public AutomationCloseoutDriftCheckCommandTests()
     {
         AutomationCloseoutDriftCheckCommand.PrLookupFactory = null;
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = null;
         AutomationCloseoutDriftCheckCommand.UtcNowFactory =
             () => new DateTimeOffset(2026, 5, 15, 10, 0, 0, TimeSpan.Zero);
         // Reset all diagnostics-command static seams so tests that exercise the
@@ -34,6 +40,7 @@ public sealed class AutomationCloseoutDriftCheckCommandTests : IDisposable
     public void Dispose()
     {
         AutomationCloseoutDriftCheckCommand.PrLookupFactory = null;
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = null;
         AutomationCloseoutDriftCheckCommand.UtcNowFactory = null;
         // Restore diagnostics-command static seams after each test.
         AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = null;
@@ -622,8 +629,355 @@ public sealed class AutomationCloseoutDriftCheckCommandTests : IDisposable
     }
 
     // ──────────────────────────────────────────────────────────────────────────
+    // G358: linked_issue-only pass (no linked_pr in queue-state)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_G358_LinkedIssueOnly_SingleMergedClosingPr_ReturnsSafeRepair()
+    {
+        // G358: queue item has linked_issue but no linked_pr; GitHub reports exactly
+        // one merged PR that closed the issue → safe-repair with inferred linked_pr.
+        using var workspace = new DriftWorkspace();
+        workspace.WriteQueueState(BuildQueueStateLinkedIssueOnly("G819", "review", linkedIssueNumber: 819));
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = () =>
+            new FakeIssueLookup(819, closingPrs: [(820, true, "J-Tech-Japan", "intent-system")]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCloseoutDriftCheckCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutDriftCheckResult>(writer.ToString())!;
+        Assert.Equal(1, result.SafeRepairCount);
+        Assert.Equal(0, result.UnsafeStopCount);
+        var record = Assert.Single(result.Records);
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ResultSafeRepair, record.Result);
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ReasonLinkedIssuePrInferred, record.ReasonCode);
+        Assert.Equal(820, record.LinkedPrNumber);
+        Assert.Equal(819, record.LinkedIssueNumber);
+        Assert.NotNull(record.InferredLinkedPrUrl);
+        Assert.Contains("820", record.InferredLinkedPrUrl!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G358_LinkedIssueOnly_NoClosingPr_ReturnsSkipped()
+    {
+        // G358: queue item has linked_issue but no linked_pr; GitHub reports no
+        // merged closing PR → skipped (issue may not be closed yet).
+        using var workspace = new DriftWorkspace();
+        workspace.WriteQueueState(BuildQueueStateLinkedIssueOnly("G819", "review", linkedIssueNumber: 819));
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = () =>
+            new FakeIssueLookup(819, closingPrs: []);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCloseoutDriftCheckCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutDriftCheckResult>(writer.ToString())!;
+        Assert.Equal(0, result.SafeRepairCount);
+        Assert.Equal(0, result.UnsafeStopCount);
+        var record = Assert.Single(result.Records);
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ResultSkipped, record.Result);
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ReasonLinkedIssueNoMergedClosingPr, record.ReasonCode);
+    }
+
+    [Fact]
+    public void Execute_G358_LinkedIssueOnly_MultipleClosingPrs_ReturnsUnsafeStop()
+    {
+        // G358: queue item has linked_issue but no linked_pr; GitHub reports two
+        // merged PRs that closed the issue → unsafe-stop (ambiguous mapping).
+        using var workspace = new DriftWorkspace();
+        workspace.WriteQueueState(BuildQueueStateLinkedIssueOnly("G819", "review", linkedIssueNumber: 819));
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = () =>
+            new FakeIssueLookup(819, closingPrs:
+            [
+                (820, true, "J-Tech-Japan", "intent-system"),
+                (821, true, "J-Tech-Japan", "intent-system"),
+            ]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCloseoutDriftCheckCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutDriftCheckResult>(writer.ToString())!;
+        Assert.Equal(0, result.SafeRepairCount);
+        Assert.Equal(1, result.UnsafeStopCount);
+        var record = Assert.Single(result.Records);
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ResultUnsafeStop, record.Result);
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ReasonLinkedIssueAmbiguousClosingPrs, record.ReasonCode);
+    }
+
+    [Fact]
+    public void Execute_G358_LinkedIssueOnly_LookupFailed_ReturnsSkippedWithWarning()
+    {
+        // G358: issue lookup throws → skipped with a warning.
+        using var workspace = new DriftWorkspace();
+        workspace.WriteQueueState(BuildQueueStateLinkedIssueOnly("G819", "review", linkedIssueNumber: 819));
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = () =>
+            new FakeFailingIssueLookup("gh api graphql returned error 403");
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCloseoutDriftCheckCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode); // warnings cause non-zero exit
+        var result = JsonSerializer.Deserialize<CloseoutDriftCheckResult>(writer.ToString())!;
+        Assert.Equal(0, result.SafeRepairCount);
+        Assert.Equal(0, result.UnsafeStopCount);
+        var record = Assert.Single(result.Records);
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ResultSkipped, record.Result);
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ReasonLinkedIssueLookupFailed, record.ReasonCode);
+        Assert.NotEmpty(result.Warnings);
+    }
+
+    [Fact]
+    public void Execute_G358_CrossRepoPrFiltered_NoSameRepoMergedPr_Skipped()
+    {
+        // G358: closing PR belongs to a different repo → filtered out; result is skipped.
+        using var workspace = new DriftWorkspace();
+        workspace.WriteQueueState(BuildQueueStateLinkedIssueOnly("G819", "review", linkedIssueNumber: 819));
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = () =>
+            new FakeIssueLookup(819, closingPrs:
+            [
+                (820, true, "OtherOwner", "other-repo"), // cross-repo — must be filtered out
+            ]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCloseoutDriftCheckCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutDriftCheckResult>(writer.ToString())!;
+        Assert.Equal(0, result.SafeRepairCount);
+        Assert.Equal(0, result.UnsafeStopCount);
+        var record = Assert.Single(result.Records);
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ResultSkipped, record.Result);
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ReasonLinkedIssueNoMergedClosingPr, record.ReasonCode);
+    }
+
+    [Fact]
+    public void Execute_G358_WriteWithInferredPr_PopulatesLinkedPrAndMarksCompleted()
+    {
+        // G358 write path: linked_pr is inferred and written into queue-state
+        // alongside the state=Completed transition.
+        using var workspace = new DriftWorkspace();
+        workspace.WriteQueueState(BuildQueueStateLinkedIssueOnly("G819", "review", linkedIssueNumber: 819));
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = () =>
+            new FakeIssueLookup(819, closingPrs: [(820, true, "J-Tech-Japan", "intent-system")]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCloseoutDriftCheckCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutDriftCheckResult>(writer.ToString())!;
+        Assert.Equal(1, result.SafeRepairCount);
+        Assert.Equal(1, result.AppliedCount);
+
+        // Queue-state must have linked_pr set to inferred URL and state=completed.
+        var queueOnDisk = workspace.QueueStateOnDisk();
+        Assert.Contains("pull/820", queueOnDisk, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("\"state\": \"completed\"", queueOnDisk, StringComparison.OrdinalIgnoreCase);
+
+        // Run events must be appended.
+        var runsLines = workspace.RunsLines();
+        Assert.Equal(2, runsLines.Length);
+        var event0 = RunLogSerializer.DeserializeLine(runsLines[0]);
+        var event1 = RunLogSerializer.DeserializeLine(runsLines[1]);
+        Assert.Equal("pr-merged", event0.Event);
+        Assert.Equal("closeout-recorded", event1.Event);
+        Assert.Equal("G819", event0.ExecutionUnit);
+        Assert.Equal(820, event0.Pr);
+    }
+
+    [Fact]
+    public void Execute_G358_CompletedItemExcluded_NoRepair()
+    {
+        // G358: item in state=completed is excluded from the second pass.
+        using var workspace = new DriftWorkspace();
+        workspace.WriteQueueState(BuildQueueStateLinkedIssueOnly("G819", "completed", linkedIssueNumber: 819));
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = () =>
+            new FakeIssueLookup(819, closingPrs: [(820, true, "J-Tech-Japan", "intent-system")]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCloseoutDriftCheckCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutDriftCheckResult>(writer.ToString())!;
+        Assert.Equal(0, result.SafeRepairCount);
+        Assert.Empty(result.Records);
+    }
+
+    [Fact]
+    public void Analyzer_G358_CloseoutDriftRepairsAvailable_SurfacesRepairHostMetadata()
+    {
+        // G358: HostLoopNextActionAnalyzer emits repair-host-metadata with the
+        // closeout-drift-check --write recommendation when CloseoutDriftRepairsAvailable > 0.
+        var result = HostLoopNextActionAnalyzer.Analyze(new HostLoopNextActionInput
+        {
+            Repo = "J-Tech-Japan/intent-system",
+            CloseoutDriftRepairsAvailable = 1,
+        });
+
+        Assert.Equal(HostLoopNextActionAnalyzer.ClassificationRepairHostMetadata, result.Classification);
+        Assert.True(result.MutationAllowed);
+        Assert.NotNull(result.RecommendedCommand);
+        Assert.Contains("closeout-drift-check", result.RecommendedCommand!, StringComparison.Ordinal);
+        Assert.Contains("--write", result.RecommendedCommand!, StringComparison.Ordinal);
+        Assert.Contains(result.Evidence, e => e.Contains("G358", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Analyzer_G358_CloseoutDriftRepairsAvailable_PrecedesTrueIdle()
+    {
+        // G358: with zero drift repairs → true-idle; with one → repair-host-metadata.
+        var idleResult = HostLoopNextActionAnalyzer.Analyze(new HostLoopNextActionInput
+        {
+            Repo = "J-Tech-Japan/intent-system",
+            CloseoutDriftRepairsAvailable = 0,
+        });
+        Assert.Equal(HostLoopNextActionAnalyzer.ClassificationTrueIdle, idleResult.Classification);
+
+        var repairResult = HostLoopNextActionAnalyzer.Analyze(new HostLoopNextActionInput
+        {
+            Repo = "J-Tech-Japan/intent-system",
+            CloseoutDriftRepairsAvailable = 1,
+        });
+        Assert.Equal(HostLoopNextActionAnalyzer.ClassificationRepairHostMetadata, repairResult.Classification);
+    }
+
+    [Fact]
+    public void Execute_G358_BothPass1AndPass2_BothRepairsDetected()
+    {
+        // G358: a queue with one pass-1 item (has linked_pr) and one pass-2 item
+        // (has linked_issue only) → both safe-repair records are emitted.
+        using var workspace = new DriftWorkspace();
+        workspace.WriteQueueState(BuildQueueStateMixed(
+            unit1: "G330", state1: "review",
+            linkedPr1: "https://github.com/J-Tech-Japan/intent-system/pull/780", linkedIssue1: 815,
+            unit2: "G819", state2: "review",
+            linkedIssue2: 819));
+        AutomationCloseoutDriftCheckCommand.PrLookupFactory = () =>
+            new FakePrLookup(780, merged: true, closingIssueNumbers: [815]);
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = () =>
+            new FakeIssueLookup(819, closingPrs: [(820, true, "J-Tech-Japan", "intent-system")]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationCloseoutDriftCheckCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutDriftCheckResult>(writer.ToString())!;
+        Assert.Equal(2, result.SafeRepairCount);
+        Assert.Equal(0, result.UnsafeStopCount);
+        Assert.Equal(2, result.Records.Count);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
     // Helper types
     // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// G358: build a queue-state JSON where the item has <c>linked_issue</c>
+    /// but NO <c>linked_pr</c> (the canonical G358 candidate shape).
+    /// </summary>
+    private static string BuildQueueStateLinkedIssueOnly(
+        string executionUnit,
+        string state,
+        int linkedIssueNumber)
+    {
+        return $$"""
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-15T10:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "{{executionUnit}}",
+                  "title": "title",
+                  "state": "{{state}}",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_pr": null,
+                  "linked_issue": {"repo": "J-Tech-Japan/intent-system", "number": {{linkedIssueNumber}}, "url": "https://github.com/J-Tech-Japan/intent-system/issues/{{linkedIssueNumber}}"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """;
+    }
+
+    /// <summary>
+    /// G358: build a queue-state JSON with two items — one pass-1 item (has
+    /// <c>linked_pr</c>) and one pass-2 item (has <c>linked_issue</c> only,
+    /// no <c>linked_pr</c>).
+    /// </summary>
+    private static string BuildQueueStateMixed(
+        string unit1, string state1, string linkedPr1, int? linkedIssue1,
+        string unit2, string state2, int linkedIssue2)
+    {
+        var linkedIssueBlock1 = linkedIssue1.HasValue
+            ? $"\"linked_issue\": {{\"repo\": \"J-Tech-Japan/intent-system\", \"number\": {linkedIssue1.Value}}},"
+            : "\"linked_issue\": null,";
+        return $$"""
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-15T10:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "{{unit1}}",
+                  "title": "pass1 item",
+                  "state": "{{state1}}",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_pr": "{{linkedPr1}}",
+                  {{linkedIssueBlock1}}
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "{{unit2}}",
+                  "title": "pass2 item",
+                  "state": "{{state2}}",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_pr": null,
+                  "linked_issue": {"repo": "J-Tech-Japan/intent-system", "number": {{linkedIssue2}}, "url": "https://github.com/J-Tech-Japan/intent-system/issues/{{linkedIssue2}}"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """;
+    }
 
     private static string BuildQueueState(
         string executionUnit,
@@ -792,6 +1146,59 @@ public sealed class AutomationCloseoutDriftCheckCommandTests : IDisposable
         public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
             string repo, IReadOnlyCollection<string> requiredLabels)
             => Array.Empty<GitHubAutomationIssueCandidate>();
+    }
+
+    /// <summary>
+    /// G358: fake <see cref="IGitHubIssueClosingPrLookup"/> for tests. Returns a
+    /// canned list of closing PR refs. Each entry is (prNumber, merged, repoOwner, repoName).
+    /// </summary>
+    private sealed class FakeIssueLookup : IGitHubIssueClosingPrLookup
+    {
+        private readonly int issueNumber;
+        private readonly IReadOnlyList<(int Pr, bool Merged, string Owner, string Repo)> closingPrs;
+
+        public FakeIssueLookup(
+            int issueNumber,
+            IReadOnlyList<(int Pr, bool Merged, string Owner, string Repo)> closingPrs)
+        {
+            this.issueNumber = issueNumber;
+            this.closingPrs = closingPrs;
+        }
+
+        public GitHubIssueClosingPrLookupResult Lookup(string repo, int number)
+        {
+            if (number != issueNumber)
+            {
+                throw new InvalidOperationException(
+                    $"FakeIssueLookup: unexpected issue number {number} (expected {issueNumber})");
+            }
+            return new GitHubIssueClosingPrLookupResult
+            {
+                IssueNumber = number,
+                State = closingPrs.Any(p => p.Merged) ? "CLOSED" : "OPEN",
+                ClosingPullRequests = closingPrs
+                    .Select(p => new GitHubIssueClosingPrRef
+                    {
+                        Number = p.Pr,
+                        State = p.Merged ? "MERGED" : "OPEN",
+                        Merged = p.Merged,
+                        BaseRefName = "main",
+                        RepoOwner = p.Owner,
+                        RepoName = p.Repo,
+                    })
+                    .ToArray()
+            };
+        }
+    }
+
+    /// <summary>G358: fake that always throws, simulating a gh lookup failure.</summary>
+    private sealed class FakeFailingIssueLookup : IGitHubIssueClosingPrLookup
+    {
+        private readonly string message;
+        public FakeFailingIssueLookup(string message) { this.message = message; }
+
+        public GitHubIssueClosingPrLookupResult Lookup(string repo, int issueNumber) =>
+            throw new InvalidOperationException(message);
     }
 
     private sealed class DriftWorkspace : IDisposable

--- a/tests/IntentSystem.Cli.Tests/AutomationCloseoutDriftCheckCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationCloseoutDriftCheckCommandTests.cs
@@ -20,6 +20,11 @@ namespace IntentSystem.Cli.Tests;
 /// - G358: host-loop-next-action surfaces repair-host-metadata when drift repairs available.
 /// - Diagnostics returns closeout-drift-repair instead of true-idle when count > 0.
 /// </summary>
+// G358: serialise with AutomationHostReviewDiagnosticsCommandTests so that
+// CandidateListerFactory resets in that class's ctor/Dispose cannot race
+// with the FakeEmptyLister set in
+// DiagnosticsCommand_WithCloseoutDriftRepairsAvailableFlag_ClassifiesCloseoutDriftRepair.
+[Collection("HostReviewDiagnostics")]
 public sealed class AutomationCloseoutDriftCheckCommandTests : IDisposable
 {
     public AutomationCloseoutDriftCheckCommandTests()
@@ -28,9 +33,13 @@ public sealed class AutomationCloseoutDriftCheckCommandTests : IDisposable
         AutomationCloseoutDriftCheckCommand.IssueLookupFactory = null;
         AutomationCloseoutDriftCheckCommand.UtcNowFactory =
             () => new DateTimeOffset(2026, 5, 15, 10, 0, 0, TimeSpan.Zero);
-        // Reset all diagnostics-command static seams so tests that exercise the
+        // Reset diagnostics-command probe seams so tests that exercise the
         // full diagnostics command do not leak state into other test classes.
-        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = null;
+        // CandidateListerFactory is intentionally NOT reset here: resetting a
+        // shared static in the constructor (which runs on a parallel thread) can
+        // race with tests in other classes that have already captured their fake
+        // lister. Each test that exercises the diagnostics command manages
+        // CandidateListerFactory within its own try/finally instead.
         AutomationHostReviewDiagnosticsCommand.NestedProviderLauncher = null;
         AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
         AutomationHostReviewDiagnosticsCommand.PublishRecoveryProbeFactory = null;
@@ -42,8 +51,10 @@ public sealed class AutomationCloseoutDriftCheckCommandTests : IDisposable
         AutomationCloseoutDriftCheckCommand.PrLookupFactory = null;
         AutomationCloseoutDriftCheckCommand.IssueLookupFactory = null;
         AutomationCloseoutDriftCheckCommand.UtcNowFactory = null;
-        // Restore diagnostics-command static seams after each test.
-        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = null;
+        // Restore diagnostics-command probe seams after each test.
+        // CandidateListerFactory is intentionally NOT reset here — see the
+        // constructor comment. The specific test that uses it resets it in its
+        // own try/finally block.
         AutomationHostReviewDiagnosticsCommand.NestedProviderLauncher = null;
         AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
         AutomationHostReviewDiagnosticsCommand.PublishRecoveryProbeFactory = null;
@@ -487,11 +498,61 @@ public sealed class AutomationCloseoutDriftCheckCommandTests : IDisposable
     }
 
     [Fact]
+    public void Analyzer_CloseoutDriftRepair_SurfacesBeforeWipCapBlocked_WhenOpenIntentTargetPrExists()
+    {
+        // G358: the closeout-drift-repair lane must fire BEFORE the wip-cap-blocked
+        // return so that a merged-PR closeout can be recorded even while another
+        // intent-target issue or PR occupies the WIP slot. Previously the
+        // closeout-drift check was positioned after the wip-cap check so this
+        // scenario incorrectly returned wip-cap-blocked.
+        // PR with intent-target + intent-pr-update-in-progress simulates a PR
+        // currently held by a child worker — it is in-flight (triggers wip-cap)
+        // but is NOT classified as actionable-review-pr (which requires no
+        // blocking label). This is the real regression scenario: the child is
+        // holding the lease while a separate merged PR needs its closeout
+        // recorded.
+        var openIntentTargetPr = new GitHubAutomationPrCandidate
+        {
+            Number = 99,
+            Title = "In-flight work (child worker holds lease)",
+            Url = "https://github.com/J-Tech-Japan/intent-system/pull/99",
+            Body = "",
+            CreatedAt = "2026-05-15T00:00:00Z",
+            UpdatedAt = "2026-05-15T00:00:00Z",
+            State = "OPEN",
+            Labels =
+            [
+                new GitHubAutomationLabel { Name = "intent-target" },
+                new GitHubAutomationLabel { Name = "intent-pr-update-in-progress" },
+            ],
+        };
+
+        var result = AutomationHostReviewDiagnosticsAnalyzer.Analyze(
+            repo: "J-Tech-Japan/intent-system",
+            openPrs: [openIntentTargetPr],
+            publishedIntentTargetIssues: Array.Empty<GitHubAutomationIssueCandidate>(),
+            clarificationRequired: false,
+            candidateExecutionUnit: null,
+            closeoutDriftRepairsAvailable: 1);
+
+        Assert.Equal(
+            AutomationHostReviewDiagnosticsClassifications.CloseoutDriftRepair,
+            result.Classification);
+        Assert.True(result.SafeRepairAvailable);
+        Assert.Equal(SafeRepairCategories.CloseoutDriftRepair, result.SafeRepairCategory);
+    }
+
+    [Fact]
     public void DiagnosticsCommand_WithCloseoutDriftRepairsAvailableFlag_ClassifiesCloseoutDriftRepair()
     {
         using var workspace = new DriftWorkspace();
         workspace.WriteInstalledCliScript();
         AutomationInstalledCliSurfaceProbe.ProbeRunner = null; // use real check or stub
+        // Set CandidateListerFactory without resetting it to null afterwards.
+        // Resetting to null after the test can race with a concurrent test in
+        // another class that has already set its own fake lister, causing it to
+        // fall through to the real GhCli lister and return unexpected live data.
+        // Any subsequent test that needs the factory will set its own value.
         AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeEmptyLister();
 
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -493,6 +493,48 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_PublishRecoveryProbe_LaneSuppressed_WhenUnsafeStopsPresent()
+    {
+        // G342 review fix: when the probe returns safe_repair_count > 0 but
+        // unsafe_stop_count > 0, publish-recovery --write refuses all mutations,
+        // so the repair-host-metadata lane must be suppressed and the host loop
+        // must fall through to true-idle (or the next applicable lane).
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        // Mixed: 1 safe repair available BUT 1 unsafe stop also present →
+        // publish-recovery --write would refuse to run → lane suppressed.
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            new PublishRecoveryProbeResult { SafeRepairCount = 1, UnsafeStopCount = 1 });
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ => new FakeHostSyncPreflightProbe(
+            new HostSyncPreflightProbeResult { Classification = HostSyncPreflightAnalyzer.ClassificationClean });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            var classification = JsonDocument.Parse(writer.ToString()).RootElement
+                .GetProperty("classification").GetString();
+            // Must NOT recommend repair-host-metadata — the write would be a no-op.
+            Assert.NotEqual("repair-host-metadata", classification);
+            // With no other signals, falls through to true-idle.
+            Assert.Equal("true-idle", classification);
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+            AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        }
+    }
+
+    [Fact]
     public void Execute_HostSyncPreflightProbe_SurfacesSafeStash_WhenDirtyUnrelatedSubmodule()
     {
         // G342: when host-sync-preflight reports

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -18,12 +18,18 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
     {
         AutomationHostLoopNextActionCommand.CandidateListerFactory = null;
         AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = null;
     }
 
     public void Dispose()
     {
         AutomationHostLoopNextActionCommand.CandidateListerFactory = null;
         AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = null;
     }
 
     [Fact]
@@ -640,6 +646,93 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
         }
     }
 
+    [Fact]
+    public void Execute_G358_CloseoutDriftCheckProbe_SurfacesRepairHostMetadata_WhenSafeRepairsAvailable()
+    {
+        // G358: when `automation closeout-drift-check --dry-run` reports
+        // safe_repair_count > 0 (items with linked_issue but no linked_pr where
+        // GitHub confirms a single merged closing PR), the host loop must surface
+        // `repair-host-metadata` with the closeout-drift-check --write recommendation
+        // instead of falling through to `true-idle`.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            new PublishRecoveryProbeResult { SafeRepairCount = 0, UnsafeStopCount = 0 });
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ => new FakeHostSyncPreflightProbe(
+            new HostSyncPreflightProbeResult { Classification = HostSyncPreflightAnalyzer.ClassificationClean });
+        AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = _ => new FakeCloseoutDriftCheckProbe(
+            new CloseoutDriftCheckProbeResult { SafeRepairCount = 1 });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            var root = JsonDocument.Parse(writer.ToString()).RootElement;
+            Assert.Equal("repair-host-metadata", root.GetProperty("classification").GetString());
+            Assert.True(root.GetProperty("mutation_allowed").GetBoolean());
+            Assert.Contains(
+                "closeout-drift-check",
+                root.GetProperty("recommended_command").GetString() ?? string.Empty,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "--write",
+                root.GetProperty("recommended_command").GetString() ?? string.Empty,
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = null;
+            AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+            AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G358_CloseoutDriftCheckProbe_TrueIdleWhenNoRepairs()
+    {
+        // G358: closeout-drift-check probe returning 0 repairs must not prevent
+        // the host loop from reaching true-idle (regression guard).
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            new PublishRecoveryProbeResult { SafeRepairCount = 0, UnsafeStopCount = 0 });
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ => new FakeHostSyncPreflightProbe(
+            new HostSyncPreflightProbeResult { Classification = HostSyncPreflightAnalyzer.ClassificationClean });
+        AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = _ => new FakeCloseoutDriftCheckProbe(
+            new CloseoutDriftCheckProbeResult { SafeRepairCount = 0 });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            Assert.Equal(
+                "true-idle",
+                JsonDocument.Parse(writer.ToString()).RootElement.GetProperty("classification").GetString());
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = null;
+            AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+            AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        }
+    }
+
     private static CliContext CreateContextWithoutDomain() =>
         new()
         {
@@ -696,6 +789,18 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
             _onProbe?.Invoke();
             return _canned;
         }
+    }
+
+    /// <summary>
+    /// G358: deterministic stand-in for the closeout-drift-check probe.
+    /// Returns a canned safe-repair count so the host-loop tests can drive
+    /// the `repair-host-metadata` lane without touching live queue-state or network.
+    /// </summary>
+    private sealed class FakeCloseoutDriftCheckProbe : ICloseoutDriftCheckProbe
+    {
+        private readonly CloseoutDriftCheckProbeResult? _canned;
+        public FakeCloseoutDriftCheckProbe(CloseoutDriftCheckProbeResult? canned) { _canned = canned; }
+        public CloseoutDriftCheckProbeResult? Probe(string repo) => _canned;
     }
 
     private sealed class FakeLister : IGitHubAutomationCandidateLister

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -664,7 +664,7 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
         AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ => new FakeHostSyncPreflightProbe(
             new HostSyncPreflightProbeResult { Classification = HostSyncPreflightAnalyzer.ClassificationClean });
         AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = _ => new FakeCloseoutDriftCheckProbe(
-            new CloseoutDriftCheckProbeResult { SafeRepairCount = 1 });
+            new CloseoutDriftCheckProbeResult { SafeRepairCount = 1, UnsafeStopCount = 0 });
 
         try
         {
@@ -710,7 +710,7 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
         AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ => new FakeHostSyncPreflightProbe(
             new HostSyncPreflightProbeResult { Classification = HostSyncPreflightAnalyzer.ClassificationClean });
         AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = _ => new FakeCloseoutDriftCheckProbe(
-            new CloseoutDriftCheckProbeResult { SafeRepairCount = 0 });
+            new CloseoutDriftCheckProbeResult { SafeRepairCount = 0, UnsafeStopCount = 0 });
 
         try
         {
@@ -724,6 +724,51 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
             Assert.Equal(
                 "true-idle",
                 JsonDocument.Parse(writer.ToString()).RootElement.GetProperty("classification").GetString());
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = null;
+            AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = null;
+            AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G358_CloseoutDriftCheckProbe_LaneSuppressed_WhenUnsafeStopsPresent()
+    {
+        // G358 review fix: when the probe returns safe_repair_count > 0 but
+        // unsafe_stop_count > 0, closeout-drift-check --write will refuse all
+        // mutations, so the repair-host-metadata lane must be suppressed and the
+        // host loop must fall through to true-idle (or the next applicable lane).
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        AutomationHostLoopNextActionCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            new PublishRecoveryProbeResult { SafeRepairCount = 0, UnsafeStopCount = 0 });
+        AutomationHostLoopNextActionCommand.HostSyncPreflightProbeFactory = _ => new FakeHostSyncPreflightProbe(
+            new HostSyncPreflightProbeResult { Classification = HostSyncPreflightAnalyzer.ClassificationClean });
+        // Mixed: 1 safe repair available BUT 1 unsafe stop also present →
+        // closeout-drift-check --write would refuse to run → lane suppressed.
+        AutomationHostLoopNextActionCommand.CloseoutDriftCheckProbeFactory = _ => new FakeCloseoutDriftCheckProbe(
+            new CloseoutDriftCheckProbeResult { SafeRepairCount = 1, UnsafeStopCount = 1 });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            var classification = JsonDocument.Parse(writer.ToString()).RootElement
+                .GetProperty("classification").GetString();
+            // Must NOT recommend repair-host-metadata — the write would be a no-op.
+            Assert.NotEqual("repair-host-metadata", classification);
+            // With no other signals, falls through to true-idle.
+            Assert.Equal("true-idle", classification);
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
@@ -5,6 +5,11 @@ using IntentSystem.Cli.Models;
 
 namespace IntentSystem.Cli.Tests;
 
+// G358: serialise with AutomationCloseoutDriftCheckCommandTests so that
+// CandidateListerFactory resets in this class's ctor/Dispose cannot race
+// with the FakeEmptyLister assignment in
+// DiagnosticsCommand_WithCloseoutDriftRepairsAvailableFlag_ClassifiesCloseoutDriftRepair.
+[Collection("HostReviewDiagnostics")]
 public sealed class AutomationHostReviewDiagnosticsCommandTests : IDisposable
 {
     public AutomationHostReviewDiagnosticsCommandTests()

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
@@ -905,6 +905,40 @@ public sealed class AutomationHostReviewDiagnosticsCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_PublishRecoveryProbe_LaneSuppressed_WhenUnsafeStopsPresent()
+    {
+        // G358: when the publish-recovery probe reports safe_repairs > 0 but
+        // also unsafe_stop_count > 0, the diagnostics must NOT surface
+        // `publish-recovery-ready` because the --write path refuses all
+        // mutations when unsafe stops are present. The result must fall
+        // through to `true-idle` (no work to do safely).
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+        AutomationHostReviewDiagnosticsCommand.PublishRecoveryProbeFactory = _ => new FakePublishRecoveryProbe(
+            new PublishRecoveryProbeResult { SafeRepairCount = 1, UnsafeStopCount = 1 });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+            Assert.NotEqual("publish-recovery-ready", result.Classification);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+            AutomationHostReviewDiagnosticsCommand.PublishRecoveryProbeFactory = null;
+        }
+    }
+
+    [Fact]
     public void Execute_OperatorSupplied_PublishRecoveryRepairs_BypassesProbe_InDiagnostics()
     {
         // G342: when the operator pre-supplies


### PR DESCRIPTION
## Summary

- Adds `IGitHubIssueClosingPrLookup` interface + `GhCliGitHubIssueClosingPrLookup` production implementation using `gh api graphql` with the `closedByPullRequestsReferences` field to find merged PRs that closed a given issue
- Extends `AutomationCloseoutDriftCheckCommand` with a G358 second pass: detects non-Completed queue items with `linked_issue` but no `linked_pr`; when exactly one merged same-repo PR closed the issue, classifies as `safe-repair` and infers the PR URL; with `--write` populates `linked_pr` and marks Completed; multiple closing PRs → unsafe-stop (ambiguous); lookup failure → skipped-with-warning
- Adds `CloseoutDriftRepairsAvailable` to `HostLoopNextActionInput` and wires it at priority-5 in `HostLoopNextActionAnalyzer` to surface `repair-host-metadata` (with `closeout-drift-check --write` recommendation) instead of `true-idle`
- Adds `ICloseoutDriftCheckProbe` + `IntentCliCloseoutDriftCheckProbe` to `ISafeRepairProbes.cs` and wires it into `AutomationHostLoopNextActionCommand` as a fail-soft auto-probe

## Test plan

- [x] 13 new G358 tests added covering: single merged closing PR → safe-repair, no closing PR → skipped, multiple → unsafe-stop, lookup failure → skipped-with-warning, cross-repo PR filtered, write path populates linked_pr + marks Completed + appends run events, completed item excluded, pass-1+pass-2 combined, analyzer priority-5 lane, host-loop command probe wiring
- [x] `Execute_NextSliceProbe_IsNotInvoked_WhenDomainMissingAndConfigEmpty` fixed (probe now catches `ArgumentException` for empty-domain contexts)
- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — 3015 passed; 2 pre-existing flaky failures unchanged

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)