### PR TITLE
G359: Filter next-slice candidates by domain bindings and target repo

### DIFF
--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -240,6 +241,15 @@ internal static class IntentNextSliceCommand
             // `clarification status` surface returns the structured error
             // when the operator audits it directly.
         }
+        // G359: load the domain's execution_unit_regex from
+        // intents/<domain>/automation/bindings.md so candidates from a
+        // shared `.intent-cli/issues` root (multiple domains sharing
+        // one host workspace) are filtered to the requested domain's
+        // namespace. A missing bindings file, missing field, or
+        // invalid regex degrades to "no name filter" so pre-G359 hosts
+        // continue to behave byte-identically.
+        var executionUnitRegex = NextSliceDomainBindingsExecutionUnitRegex.TryLoad(context, domain);
+
         IntentNextSliceCandidate? candidate = null;
         if (Directory.Exists(packetRoot))
         {
@@ -252,10 +262,20 @@ internal static class IntentNextSliceCommand
             // filtered by those values. Domain is derived from the queue item's
             // clarification_return_path (shape: intents/<domain>/clarifications/open.md).
             // Target-repo is read from the packet.yaml file inside the packet directory.
+            // G359: Additionally, when the domain's bindings.md declares an
+            // execution_unit_regex, only packet directory names matching that
+            // regex are considered. This stops a shared packet root from
+            // surfacing a wrong-namespace candidate (e.g. SKS-G365 leaking
+            // into --domain intent-cli).
             foreach (var executionUnit in queued)
             {
                 var directory = Path.Combine(packetRoot, executionUnit);
                 if (!Directory.Exists(directory))
+                {
+                    continue;
+                }
+
+                if (!MatchesExecutionUnitRegex(executionUnitRegex, executionUnit))
                 {
                     continue;
                 }
@@ -277,6 +297,11 @@ internal static class IntentNextSliceCommand
                 {
                     var executionUnit = Path.GetFileName(directory)!;
                     if (completed.Contains(executionUnit))
+                    {
+                        continue;
+                    }
+
+                    if (!MatchesExecutionUnitRegex(executionUnitRegex, executionUnit))
                     {
                         continue;
                     }
@@ -447,6 +472,38 @@ internal static class IntentNextSliceCommand
         }
 
         return OutcomeIssueCutReady;
+    }
+
+    /// <summary>
+    /// G359: Returns true when the given <paramref name="executionUnit"/>
+    /// matches the domain's bindings.md <c>execution_unit_regex</c>. When
+    /// <paramref name="regex"/> is null (bindings file missing, field
+    /// missing, or invalid pattern) the filter is treated as "open" —
+    /// every unit passes so pre-G359 hosts and misconfigured bindings
+    /// never silently block all candidates.
+    /// </summary>
+    private static bool MatchesExecutionUnitRegex(Regex? regex, string executionUnit)
+    {
+        if (regex is null)
+        {
+            return true;
+        }
+
+        if (string.IsNullOrEmpty(executionUnit))
+        {
+            return false;
+        }
+
+        try
+        {
+            return regex.IsMatch(executionUnit);
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            // Treat catastrophic regex evaluation as no-match so a
+            // pathological binding cannot keep a stale candidate alive.
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -182,6 +182,16 @@ internal static class IntentNextSliceCommand
 
         var packetRoot = Path.Combine(context.RepoRoot, ".intent-cli", "issues");
 
+        // G359 (PR #822 review repair): load the domain's
+        // execution_unit_regex BEFORE the WIP pass so the same scope
+        // check applied to packet directories also applies to queue
+        // items. Without this, a misnamed `SKS-G…` queue item could
+        // still appear in WIP under `--domain intent-cli` and block
+        // the lane with `skip-next-slice-due-to-wip`, defeating the
+        // shared-root scoping rule. Missing bindings file / missing
+        // field / invalid regex still degrades to "no name filter".
+        var executionUnitRegex = NextSliceDomainBindingsExecutionUnitRegex.TryLoad(context, domain);
+
         var wip = new List<string>();
         var queued = new List<string>();
         var completed = new HashSet<string>(StringComparer.Ordinal);
@@ -196,7 +206,12 @@ internal static class IntentNextSliceCommand
                     case QueueItemState.Fixing:
                         // G275: filter WIP by the same domain/repo predicates as candidate selection
                         // so cross-domain in-flight items do not block the requested lane.
-                        if (MatchesDomainAndRepoFilter(domain, targetRepo, queueState, item.ExecutionUnit, Path.Combine(packetRoot, item.ExecutionUnit)))
+                        // G359 (PR #822 review repair): also enforce the
+                        // domain bindings execution_unit_regex on queue
+                        // items so a misnamed cross-namespace WIP item
+                        // cannot block the requested domain lane.
+                        if (MatchesDomainAndRepoFilter(domain, targetRepo, queueState, item.ExecutionUnit, Path.Combine(packetRoot, item.ExecutionUnit))
+                            && MatchesExecutionUnitRegex(executionUnitRegex, item.ExecutionUnit))
                         {
                             wip.Add(item.ExecutionUnit);
                         }
@@ -241,14 +256,12 @@ internal static class IntentNextSliceCommand
             // `clarification status` surface returns the structured error
             // when the operator audits it directly.
         }
-        // G359: load the domain's execution_unit_regex from
-        // intents/<domain>/automation/bindings.md so candidates from a
-        // shared `.intent-cli/issues` root (multiple domains sharing
-        // one host workspace) are filtered to the requested domain's
-        // namespace. A missing bindings file, missing field, or
-        // invalid regex degrades to "no name filter" so pre-G359 hosts
-        // continue to behave byte-identically.
-        var executionUnitRegex = NextSliceDomainBindingsExecutionUnitRegex.TryLoad(context, domain);
+        // G359: `executionUnitRegex` is loaded above (before the WIP
+        // pass) so both queue items and packet directories are scoped
+        // to the requested domain's namespace via the same regex.
+        // Missing bindings file / missing field / invalid regex still
+        // degrades to "no name filter" so pre-G359 hosts continue to
+        // behave byte-identically.
 
         IntentNextSliceCandidate? candidate = null;
         if (Directory.Exists(packetRoot))

--- a/src/IntentSystem.Cli/Commands/NextSliceDomainBindingsExecutionUnitRegex.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceDomainBindingsExecutionUnitRegex.cs
@@ -1,0 +1,169 @@
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G359: Loads the <c>execution_unit_regex</c> declared in
+/// <c>intents/&lt;domain&gt;/automation/bindings.md</c> so the
+/// <see cref="IntentNextSliceCommand"/> can filter packet candidates
+/// from a shared <c>.intent-cli/issues</c> root by the requested
+/// domain's namespace.
+///
+/// Resolution order matches the rest of the parent-aware analyzers
+/// (<see cref="AutomationSummaryAnalyzer"/>,
+/// <see cref="NextSliceClassifyAnalyzer"/>):
+/// the parent intent repo root takes precedence over the child
+/// <see cref="CliContext.RepoRoot"/> when configured, falling back to
+/// the child root when no parent root is set. Missing bindings file,
+/// missing <c>execution_unit_regex</c> field, and invalid regex
+/// patterns all degrade to "no filter" so pre-G359 hosts and
+/// misconfigured bindings never block next-slice planning.
+/// </summary>
+internal static class NextSliceDomainBindingsExecutionUnitRegex
+{
+    /// <summary>
+    /// Tries to load and compile the <c>execution_unit_regex</c> for
+    /// <paramref name="domain"/>. Returns <c>null</c> when the bindings
+    /// file is missing, the field is absent, or the pattern fails to
+    /// compile (degrades open so misconfiguration cannot block the
+    /// host loop entirely).
+    /// </summary>
+    public static Regex? TryLoad(CliContext context, string? domain)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            return null;
+        }
+
+        var bindingsPath = ResolveBindingsAbsolutePath(context, domain);
+        if (string.IsNullOrWhiteSpace(bindingsPath) || !File.Exists(bindingsPath))
+        {
+            return null;
+        }
+
+        string content;
+        try
+        {
+            content = File.ReadAllText(bindingsPath);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+
+        var pattern = ExtractExecutionUnitRegex(content);
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            return null;
+        }
+
+        try
+        {
+            return new Regex(pattern, RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(200));
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+    }
+
+    private static string? ResolveBindingsAbsolutePath(CliContext context, string domain)
+    {
+        // Prefer the child RepoRoot when the bindings.md is colocated
+        // (host workspace layout); fall back to a configured parent
+        // intent repo root. This mirrors the lookup logic in
+        // AutomationSummaryAnalyzer / NextSliceClassifyAnalyzer but
+        // checks the child root first so test workspaces that drop
+        // bindings under RepoRoot/intents/<domain>/... behave the
+        // same as production hosts with a colocated intents tree.
+        var childPath = string.IsNullOrWhiteSpace(context.RepoRoot)
+            ? null
+            : Path.Combine(context.RepoRoot, "intents", domain, "automation", "bindings.md");
+        if (!string.IsNullOrWhiteSpace(childPath) && File.Exists(childPath))
+        {
+            return childPath;
+        }
+
+        var parentRoot = context.ResolveParentIntentRepoRootPath();
+        if (string.IsNullOrWhiteSpace(parentRoot))
+        {
+            return childPath;
+        }
+
+        return Path.Combine(parentRoot, "intents", domain, "automation", "bindings.md");
+    }
+
+    /// <summary>
+    /// Minimal deterministic parser for the <c>execution_unit_regex</c>
+    /// scalar. Tolerates YAML frontmatter delimited by <c>---</c>, and
+    /// also accepts the same key written as a top-level inline field
+    /// outside frontmatter (mirroring
+    /// <see cref="AutomationSummaryAnalyzer"/>'s tolerant scan).
+    /// </summary>
+    internal static string? ExtractExecutionUnitRegex(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            return null;
+        }
+
+        var normalized = content.Replace("\r\n", "\n", StringComparison.Ordinal);
+        var lines = normalized.Split('\n');
+
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            // Skip indented (nested) lines; only top-level keys are
+            // recognized.
+            if (line[0] == ' ' || line[0] == '\t')
+            {
+                continue;
+            }
+
+            // Skip markdown headings, list markers, frontmatter
+            // delimiters, comments.
+            if (line.StartsWith('#')
+                || line.StartsWith("- ", StringComparison.Ordinal)
+                || string.Equals(line.Trim(), "---", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var colonIndex = line.IndexOf(':', StringComparison.Ordinal);
+            if (colonIndex <= 0)
+            {
+                continue;
+            }
+
+            var key = line[..colonIndex].Trim();
+            if (!string.Equals(key, "execution_unit_regex", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var value = line[(colonIndex + 1)..].Trim();
+
+            // Strip surrounding quotes if present.
+            if (value.Length >= 2
+                && ((value[0] == '\'' && value[^1] == '\'')
+                    || (value[0] == '"' && value[^1] == '"')))
+            {
+                value = value[1..^1];
+            }
+
+            return string.IsNullOrWhiteSpace(value) ? null : value;
+        }
+
+        return null;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/NextSliceDomainBindingsExecutionUnitRegex.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceDomainBindingsExecutionUnitRegex.cs
@@ -74,28 +74,28 @@ internal static class NextSliceDomainBindingsExecutionUnitRegex
 
     private static string? ResolveBindingsAbsolutePath(CliContext context, string domain)
     {
-        // Prefer the child RepoRoot when the bindings.md is colocated
-        // (host workspace layout); fall back to a configured parent
-        // intent repo root. This mirrors the lookup logic in
-        // AutomationSummaryAnalyzer / NextSliceClassifyAnalyzer but
-        // checks the child root first so test workspaces that drop
-        // bindings under RepoRoot/intents/<domain>/... behave the
-        // same as production hosts with a colocated intents tree.
-        var childPath = string.IsNullOrWhiteSpace(context.RepoRoot)
-            ? null
-            : Path.Combine(context.RepoRoot, "intents", domain, "automation", "bindings.md");
-        if (!string.IsNullOrWhiteSpace(childPath) && File.Exists(childPath))
-        {
-            return childPath;
-        }
-
+        // PR #822 review fix: when a parent intent repo root is
+        // configured, the PARENT bindings.md is authoritative. The
+        // previous order (child first, parent fallback) let a stale or
+        // partial child workspace bindings.md override the host's
+        // authoritative bindings and drop `execution_unit_regex`,
+        // letting the wrong namespace leak back into
+        // `intent next-slice --dry-run`. This now mirrors the parent-
+        // aware lookup contract used by AutomationSummaryAnalyzer and
+        // NextSliceClassifyAnalyzer: parent root takes precedence when
+        // set, child root is the fallback for host-colocated workspace
+        // layouts (and the in-memory test fixtures).
         var parentRoot = context.ResolveParentIntentRepoRootPath();
-        if (string.IsNullOrWhiteSpace(parentRoot))
+        if (!string.IsNullOrWhiteSpace(parentRoot))
         {
-            return childPath;
+            return Path.Combine(parentRoot, "intents", domain, "automation", "bindings.md");
         }
 
-        return Path.Combine(parentRoot, "intents", domain, "automation", "bindings.md");
+        if (string.IsNullOrWhiteSpace(context.RepoRoot))
+        {
+            return null;
+        }
+        return Path.Combine(context.RepoRoot, "intents", domain, "automation", "bindings.md");
     }
 
     /// <summary>

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -1754,6 +1754,312 @@ public sealed class IntentNextSliceCommandTests
         Assert.Contains(expectedPath, result.Gaps[0].RepairGuidance!, StringComparison.Ordinal);
     }
 
+    // ─── G359 tests ───────────────────────────────────────────────────────────
+    // execution_unit_regex from intents/<domain>/automation/bindings.md must
+    // filter packet candidates from a shared `.intent-cli/issues` root so a
+    // wrong-namespace packet (e.g. SKS-G365) cannot be selected when
+    // --domain intent-cli is requested.
+
+    [Fact]
+    public void Execute_G359_SharedPacketRoot_DomainBindingsRegex_SelectsMatchingNamespace()
+    {
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteAutomationBindings(
+            "intent-cli",
+            """
+            ---
+            execution_unit_regex: '^G[0-9]+$'
+            ---
+            """);
+        workspace.WriteFile(
+            ".intent-cli/issues/G359/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/SKS-G365/github-body.md",
+            BuildCompleteContractBody());
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        var candidate = root.GetProperty("candidate");
+        Assert.Equal("G359", candidate.GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_G359_OnlySksPacketAvailable_IntentCliDomain_RecommendsDesignNeeded()
+    {
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteAutomationBindings(
+            "intent-cli",
+            """
+            ---
+            execution_unit_regex: '^G[0-9]+$'
+            ---
+            """);
+        workspace.WriteFile(
+            ".intent-cli/issues/SKS-G365/github-body.md",
+            BuildCompleteContractBody());
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // No matching candidate AND runtime creation NOT allowed → design-needed (G328).
+        Assert.Equal("design-needed", root.GetProperty("recommended_outcome").GetString());
+        Assert.False(root.TryGetProperty("candidate", out _));
+    }
+
+    [Fact]
+    public void Execute_G359_SekibanDomain_BindingsRegex_SelectsSksPacket()
+    {
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteAutomationBindings(
+            "intent-cli",
+            """
+            ---
+            execution_unit_regex: '^G[0-9]+$'
+            ---
+            """);
+        workspace.WriteAutomationBindings(
+            "sekiban-as-a-service",
+            """
+            ---
+            execution_unit_regex: '^SKS-G[0-9]+$'
+            ---
+            """);
+        // Clarification dir for sekiban domain to silence the missing-file note;
+        // not strictly required for the assertion but mirrors realistic state.
+        workspace.WriteClarificationOpen("", "sekiban-as-a-service");
+        workspace.WriteFile(
+            ".intent-cli/issues/G359/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/SKS-G365/github-body.md",
+            BuildCompleteContractBody());
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "sekiban-as-a-service", "--target-repo", "J-Tech-Japan/SekibanAsAService"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        var candidate = root.GetProperty("candidate");
+        Assert.Equal("SKS-G365", candidate.GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_G359_MismatchedTargetRepoWithinDomain_DoesNotReachIssueCutReady()
+    {
+        // Packet matches the domain bindings regex but its packet.yaml
+        // declares a different target_repo — must NOT reach issue-cut-ready.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteAutomationBindings(
+            "intent-cli",
+            """
+            ---
+            execution_unit_regex: '^G[0-9]+$'
+            ---
+            """);
+        workspace.WriteFile(
+            ".intent-cli/issues/G359/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G359/packet.yaml",
+            """
+            implementation_issue_packet:
+              source_execution_unit: G359
+              target_repo: J-Tech-Japan/other-repo
+              issue_title: G359 wrong repo
+              issue_kind: feature
+              goal: x
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.NotEqual("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        // With runtime creation NOT allowed, no candidate maps to design-needed.
+        Assert.Equal("design-needed", root.GetProperty("recommended_outcome").GetString());
+    }
+
+    [Fact]
+    public void Execute_G359_NoBindingsFile_FallsBackToOpenFilter()
+    {
+        // Pre-G359 hosts (no bindings.md) must continue to behave
+        // byte-identically: with no regex configured, every candidate
+        // passes the name filter.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G359/github-body.md",
+            BuildCompleteContractBody());
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal(
+            "G359",
+            root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_G359_InvalidBindingsRegex_FallsBackToOpenFilter()
+    {
+        // Misconfigured bindings (invalid regex pattern) must not
+        // silently block ALL candidates; the filter degrades open.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteAutomationBindings(
+            "intent-cli",
+            """
+            ---
+            execution_unit_regex: '[unterminated'
+            ---
+            """);
+        workspace.WriteFile(
+            ".intent-cli/issues/G359/github-body.md",
+            BuildCompleteContractBody());
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+    }
+
+    [Fact]
+    public void Execute_G359_QueuedSksPacket_NotSelectedUnderIntentCliDomain()
+    {
+        // Queued path (the preferred selection branch) must also honor
+        // the bindings regex — SKS-G365 queued but intent-cli requested
+        // should fall through to design-needed.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteAutomationBindings(
+            "intent-cli",
+            """
+            ---
+            execution_unit_regex: '^G[0-9]+$'
+            ---
+            """);
+        workspace.WriteFile(
+            ".intent-cli/issues/SKS-G365/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-15T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SKS-G365",
+                  "title": "sks queued packet",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/sekiban-as-a-service/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("design-needed", root.GetProperty("recommended_outcome").GetString());
+        Assert.False(root.TryGetProperty("candidate", out _));
+    }
+
+    // ─── G359 pure unit tests for NextSliceDomainBindingsExecutionUnitRegex ───
+
+    [Fact]
+    public void NextSliceDomainBindingsExecutionUnitRegex_ExtractsFromFrontmatter()
+    {
+        var content = """
+            ---
+            repo: J-Tech-Japan/intent-system
+            execution_unit_regex: '^G[0-9]+$'
+            ---
+            """;
+
+        var pattern = NextSliceDomainBindingsExecutionUnitRegex.ExtractExecutionUnitRegex(content);
+
+        Assert.Equal("^G[0-9]+$", pattern);
+    }
+
+    [Fact]
+    public void NextSliceDomainBindingsExecutionUnitRegex_ExtractsDoubleQuotedValue()
+    {
+        var content = """
+            execution_unit_regex: "^SKS-G[0-9]+$"
+            """;
+
+        var pattern = NextSliceDomainBindingsExecutionUnitRegex.ExtractExecutionUnitRegex(content);
+
+        Assert.Equal("^SKS-G[0-9]+$", pattern);
+    }
+
+    [Fact]
+    public void NextSliceDomainBindingsExecutionUnitRegex_AbsentField_ReturnsNull()
+    {
+        var content = """
+            ---
+            repo: J-Tech-Japan/intent-system
+            ---
+            """;
+
+        var pattern = NextSliceDomainBindingsExecutionUnitRegex.ExtractExecutionUnitRegex(content);
+
+        Assert.Null(pattern);
+    }
+
+    [Fact]
+    public void NextSliceDomainBindingsExecutionUnitRegex_EmptyContent_ReturnsNull()
+    {
+        Assert.Null(NextSliceDomainBindingsExecutionUnitRegex.ExtractExecutionUnitRegex(string.Empty));
+    }
+
     private sealed class IntentNextSliceWorkspace : IDisposable
     {
         private readonly string rootPath = Directory
@@ -1790,6 +2096,13 @@ public sealed class IntentNextSliceCommandTests
             var path = Path.Combine(rootPath, "intents", domain, "clarifications");
             Directory.CreateDirectory(path);
             File.WriteAllText(Path.Combine(path, "open.md"), content);
+        }
+
+        public void WriteAutomationBindings(string domain, string content)
+        {
+            var path = Path.Combine(rootPath, "intents", domain, "automation");
+            Directory.CreateDirectory(path);
+            File.WriteAllText(Path.Combine(path, "bindings.md"), content);
         }
 
         public void WriteFile(string relativePath, string content)

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -2060,6 +2060,102 @@ public sealed class IntentNextSliceCommandTests
         Assert.Null(NextSliceDomainBindingsExecutionUnitRegex.ExtractExecutionUnitRegex(string.Empty));
     }
 
+    [Fact]
+    public void NextSliceDomainBindingsExecutionUnitRegex_ParentRootAuthoritative_OverridesChildBindings()
+    {
+        // PR #822 review fix: when a parent intent repo root is
+        // configured, the PARENT bindings.md is the authoritative
+        // source of `execution_unit_regex` — a stale or partial child
+        // workspace bindings.md must NOT override it. This locks the
+        // parent-aware lookup contract used by the other
+        // parent-aware analyzers (AutomationSummaryAnalyzer /
+        // NextSliceClassifyAnalyzer).
+        var parentRoot = Directory.CreateTempSubdirectory("g359-parent-root-").FullName;
+        var childRoot = Directory.CreateTempSubdirectory("g359-child-root-").FullName;
+        try
+        {
+            // Parent has the authoritative regex.
+            var parentBindings = Path.Combine(parentRoot, "intents", "intent-cli", "automation");
+            Directory.CreateDirectory(parentBindings);
+            File.WriteAllText(Path.Combine(parentBindings, "bindings.md"),
+                "---\nexecution_unit_regex: '^G[0-9]+$'\n---\n");
+
+            // Child has a STALE / DIFFERENT regex that must NOT win.
+            var childBindings = Path.Combine(childRoot, "intents", "intent-cli", "automation");
+            Directory.CreateDirectory(childBindings);
+            File.WriteAllText(Path.Combine(childBindings, "bindings.md"),
+                "---\nexecution_unit_regex: '^SKS-G[0-9]+$'\n---\n");
+
+            var context = new CliContext
+            {
+                RepoRoot = childRoot,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                        ParentIntentRepoRoot = parentRoot,
+                    },
+                },
+            };
+
+            var regex = NextSliceDomainBindingsExecutionUnitRegex.TryLoad(context, "intent-cli");
+
+            Assert.NotNull(regex);
+            // Parent regex matches `G42`; child's `^SKS-G[0-9]+$` would NOT.
+            Assert.True(regex!.IsMatch("G42"));
+            Assert.False(regex.IsMatch("SKS-G42"));
+        }
+        finally
+        {
+            if (Directory.Exists(parentRoot)) Directory.Delete(parentRoot, recursive: true);
+            if (Directory.Exists(childRoot)) Directory.Delete(childRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void NextSliceDomainBindingsExecutionUnitRegex_NoParentRoot_FallsBackToChildBindings()
+    {
+        // PR #822 review fix: without a parent root configured, the
+        // child workspace bindings.md remains the source of truth so
+        // host-colocated layouts (and the in-memory test fixtures)
+        // keep working.
+        var childRoot = Directory.CreateTempSubdirectory("g359-child-only-").FullName;
+        try
+        {
+            var childBindings = Path.Combine(childRoot, "intents", "intent-cli", "automation");
+            Directory.CreateDirectory(childBindings);
+            File.WriteAllText(Path.Combine(childBindings, "bindings.md"),
+                "---\nexecution_unit_regex: '^SKS-G[0-9]+$'\n---\n");
+
+            var context = new CliContext
+            {
+                RepoRoot = childRoot,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                        // No ParentIntentRepoRoot configured.
+                    },
+                },
+            };
+
+            var regex = NextSliceDomainBindingsExecutionUnitRegex.TryLoad(context, "intent-cli");
+
+            Assert.NotNull(regex);
+            Assert.True(regex!.IsMatch("SKS-G42"));
+        }
+        finally
+        {
+            if (Directory.Exists(childRoot)) Directory.Delete(childRoot, recursive: true);
+        }
+    }
+
     private sealed class IntentNextSliceWorkspace : IDisposable
     {
         private readonly string rootPath = Directory

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -1793,6 +1793,83 @@ public sealed class IntentNextSliceCommandTests
     }
 
     [Fact]
+    public void Execute_G359_WipPass_AppliesExecutionUnitRegex_IgnoresMisnamedQueueItem()
+    {
+        // PR #822 review repair: the WIP pass must also enforce
+        // `execution_unit_regex` so a misnamed SKS-G… queue item in
+        // Active/Review/Fixing state cannot block `--domain intent-cli`
+        // with `skip-next-slice-due-to-wip`. Before the fix, the WIP
+        // filter used clarification_return_path alone, so a queue item
+        // whose path pointed at intent-cli but whose execution_unit
+        // was SKS-G… would slip into WIP under the requested lane.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteAutomationBindings(
+            "intent-cli",
+            """
+            ---
+            execution_unit_regex: '^G[0-9]+$'
+            ---
+            """);
+        workspace.WriteFile(
+            ".intent-cli/issues/G280/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-16T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SKS-G99",
+                  "title": "misnamed wip item pointing at intent-cli clarifications",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_issue": {
+                    "repo": "J-Tech-Japan/intent-system",
+                    "number": 999,
+                    "url": "https://github.com/J-Tech-Japan/intent-system/issues/999"
+                  },
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "G280",
+                  "title": "intent-cli queued slice",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // SKS-G99 misnamed item fails the intent-cli regex, so WIP is
+        // empty and G280 is selected — NOT skip-next-slice-due-to-wip.
+        Assert.NotEqual("skip-next-slice-due-to-wip", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal(0, root.GetProperty("wip").GetArrayLength());
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G280", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
     public void Execute_G359_OnlySksPacketAvailable_IntentCliDomain_RecommendsDesignNeeded()
     {
         using var workspace = new IntentNextSliceWorkspace();


### PR DESCRIPTION
## Summary

- Add `NextSliceDomainBindingsExecutionUnitRegex` to load `execution_unit_regex` from `intents/<domain>/automation/bindings.md`.
- Wire `IntentNextSliceCommand` to filter packet candidates by the requested domain's namespace and by `--target-repo`.
- Prevents a shared `.intent-cli/issues` root from surfacing wrong-namespace packets (e.g. `SKS-G365` selected when `--domain intent-cli --target-repo J-Tech-Japan/intent-system` was requested).
- Fail-open: missing bindings.md / absent regex / invalid pattern degrades to "no filter" so pre-G359 hosts and misconfigured bindings never block next-slice planning.

## Acceptance coverage

All four G359 acceptance criteria covered by new tests in `IntentNextSliceCommandTests`:

1. `G359 + SKS-G365` mix with `--domain intent-cli --target-repo J-Tech-Japan/intent-system` → selects `G359`.
2. Inverse with `--domain sekiban-as-a-service --target-repo J-Tech-Japan/SekibanAsAService` → selects `SKS-G365`.
3. Only `SKS-G365` available with `--domain intent-cli` → `design-needed` / structured non-ready (not `issue-cut-ready`).
4. Mismatched packet `target_repo` within the same domain → cannot reach `issue-cut-ready`.

## Test plan

- [x] `dotnet build tests/IntentSystem.Cli.Tests/` — 0 errors
- [x] `dotnet test --filter "IntentNextSlice"` — 56/56 pass
- [x] `dotnet test tests/IntentSystem.Cli.Tests/` (full) — 3032 passed / 1 known skip
- [x] Frontmatter parser unit test covers quoted scalar form

Closes #821

🤖 Generated with [Claude Code](https://claude.com/claude-code)