### PR TITLE
G360: Make --version and --help host-state-free process options

### DIFF
--- a/src/IntentSystem.Cli/Commands/VersionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/VersionCommand.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G360: process-level <c>--version</c> / <c>-v</c> handler that
+/// emits the installed binary's identifier without touching host
+/// state. Reads the assembly's
+/// <see cref="AssemblyInformationalVersionAttribute"/> (baked at
+/// pack/build time by IntentSystem.Cli.csproj). The full shape is
+/// <c>intent-cli &lt;package-version&gt;[-&lt;short-sha&gt;]-&lt;latest-execution-unit&gt;</c>,
+/// e.g. <c>intent-cli 0.2.0-f6cbf65-G357</c>. When the build did not
+/// embed a git short SHA the SHA segment is omitted, but the latest
+/// execution-unit segment is always present.
+///
+/// CRITICAL: this command must NEVER read <c>.intent-cli/</c>,
+/// queue-state, packet directories, GitHub, or anything else that
+/// makes <c>intent-cli --version</c> dependent on the current
+/// working directory. Operators rely on it to verify the installed
+/// binary from any cwd (home directory, child implementation repo,
+/// fresh CI machine).
+/// </summary>
+internal static class VersionCommand
+{
+    /// <summary>Test seam: override the version string for tests.</summary>
+    public static string? OverrideVersionString { get; set; }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="args"/> request the
+    /// version output (the recognized shapes are <c>--version</c>,
+    /// <c>-v</c>, or <c>version</c> as the first or only token).
+    /// </summary>
+    public static bool IsVersionRequest(string[] args)
+    {
+        if (args is null || args.Length == 0)
+        {
+            return false;
+        }
+        var first = args[0];
+        return string.Equals(first, "--version", StringComparison.Ordinal)
+            || string.Equals(first, "-v", StringComparison.Ordinal)
+            || string.Equals(first, "version", StringComparison.Ordinal);
+    }
+
+    public static int Execute(TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        var versionString = OverrideVersionString
+            ?? BuildVersionString(typeof(VersionCommand).Assembly);
+        writer.WriteLine(versionString);
+        return 0;
+    }
+
+    /// <summary>
+    /// Test seam exposing the pure builder so tests can verify the
+    /// shape independently of the executing assembly's actual
+    /// InformationalVersion.
+    /// </summary>
+    internal static string BuildVersionString(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+        if (string.IsNullOrWhiteSpace(informational))
+        {
+            // Defensive: the .csproj always sets InformationalVersion,
+            // so this fallback only fires for an assembly the build
+            // contract did not produce.
+            informational = assembly.GetName().Version?.ToString()
+                ?? "0.0.0";
+        }
+        else
+        {
+            // Strip the `+<commit-sha>` SourceLink suffix the SDK appends
+            // by default (e.g. "0.2.0-G360+abcdef..."). The canonical
+            // G360 form embeds the short SHA in the dash-segment via the
+            // build target; the `+` suffix is duplicate noise.
+            var plusIndex = informational.IndexOf('+', StringComparison.Ordinal);
+            if (plusIndex >= 0)
+            {
+                informational = informational[..plusIndex];
+            }
+        }
+        return $"intent-cli {informational}";
+    }
+}

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -14,7 +14,47 @@
     <PackageTags>intent-cli;dotnet-tool</PackageTags>
     <RepositoryUrl>https://github.com/J-Tech-Japan/intent-system</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+
+    <!--
+      G360: build-time metadata baked into the assembly's
+      AssemblyInformationalVersion so the version flag handler can
+      identify the installed binary without reading host state at
+      runtime.
+
+      IntentSystemLatestExecutionUnit is the latest implemented
+      intent-system G-number at pack/build time. Bump it as new
+      slices land. CI may override via the MSBuild property of the
+      same name.
+
+      The git short SHA is captured from SourceRevisionId
+      (set by Microsoft.SourceLink.GitHub or any CI that exports
+      SourceRevisionId). When neither is available the SHA segment
+      is omitted gracefully.
+    -->
+    <IntentSystemLatestExecutionUnit Condition="'$(IntentSystemLatestExecutionUnit)' == ''">G360</IntentSystemLatestExecutionUnit>
+    <SourceRevisionShortId Condition="'$(SourceRevisionId)' != ''">$(SourceRevisionId.Substring(0, 7))</SourceRevisionShortId>
+    <InformationalVersion Condition="'$(SourceRevisionShortId)' != ''">$(Version)-$(SourceRevisionShortId)-$(IntentSystemLatestExecutionUnit)</InformationalVersion>
+    <InformationalVersion Condition="'$(SourceRevisionShortId)' == ''">$(Version)-$(IntentSystemLatestExecutionUnit)</InformationalVersion>
   </PropertyGroup>
+
+  <!--
+    G360: capture the current git short SHA at build time so the
+    InformationalVersion can include it even when SourceLink is
+    not wired up. Best-effort: ignored when git is not available
+    or the project is built outside a git worktree. The git
+    command resolves the seven-character short SHA so the value
+    matches the form specified by the issue body (e.g. f6cbf65).
+  -->
+  <Target Name="ResolveIntentCliSourceRevision" BeforeTargets="GetAssemblyAttributes;CoreCompile" Condition="'$(SourceRevisionShortId)' == ''">
+    <Exec Command="git rev-parse --short=7 HEAD" WorkingDirectory="$(MSBuildProjectDirectory)" ConsoleToMSBuild="true" IgnoreExitCode="true" StandardOutputImportance="low" ContinueOnError="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="SourceRevisionShortIdFromGit" />
+      <Output TaskParameter="ExitCode" PropertyName="SourceRevisionShortIdGitExitCode" />
+    </Exec>
+    <PropertyGroup Condition="'$(SourceRevisionShortIdGitExitCode)' == '0' AND '$(SourceRevisionShortIdFromGit)' != ''">
+      <SourceRevisionShortId>$(SourceRevisionShortIdFromGit.Trim())</SourceRevisionShortId>
+      <InformationalVersion>$(Version)-$(SourceRevisionShortId)-$(IntentSystemLatestExecutionUnit)</InformationalVersion>
+    </PropertyGroup>
+  </Target>
 
   <ItemGroup>
     <ProjectReference Include="..\IntentSystem.Clarify\IntentSystem.Clarify.csproj" />

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -10,6 +10,19 @@ internal static class Program
     {
         try
         {
+            // G360: process-level `--version` / `-v` MUST exit before
+            // any host-state resolution. Operators rely on
+            // `intent-cli --version` to verify the installed binary
+            // from any cwd (home directory, child implementation
+            // repo, fresh CI machine). Routing it through the
+            // bootstrap path would still emit the G299 missing-host-
+            // state guidance because the command router doesn't
+            // recognize it; handle it inline here instead.
+            if (VersionCommand.IsVersionRequest(args))
+            {
+                return VersionCommand.Execute(Console.Out);
+            }
+
             if (DirectRunDetachedCaptureCommand.TryExecute(args, out var directRunDetachedCaptureExitCode))
             {
                 return directRunDetachedCaptureExitCode;

--- a/tests/IntentSystem.Cli.Tests/VersionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionCommandTests.cs
@@ -1,0 +1,222 @@
+using System.Diagnostics;
+using System.Reflection;
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class VersionCommandTests : IDisposable
+{
+    public VersionCommandTests()
+    {
+        VersionCommand.OverrideVersionString = null;
+    }
+
+    public void Dispose()
+    {
+        VersionCommand.OverrideVersionString = null;
+    }
+
+    [Theory]
+    [InlineData("--version")]
+    [InlineData("-v")]
+    [InlineData("version")]
+    public void IsVersionRequest_RecognizesCanonicalShapes(string token)
+    {
+        Assert.True(VersionCommand.IsVersionRequest(new[] { token }));
+    }
+
+    [Theory]
+    [InlineData("worker", "next-action")]
+    [InlineData("--help")]
+    [InlineData("intent", "status")]
+    public void IsVersionRequest_RejectsNonVersionTokens(params string[] args)
+    {
+        Assert.False(VersionCommand.IsVersionRequest(args));
+    }
+
+    [Fact]
+    public void IsVersionRequest_EmptyArgs_ReturnsFalse()
+    {
+        Assert.False(VersionCommand.IsVersionRequest(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void Execute_WithOverride_WritesExactVersionString_AndReturnsZero()
+    {
+        VersionCommand.OverrideVersionString = "intent-cli 0.2.0-f6cbf65-G357";
+        using var writer = new StringWriter();
+
+        var exitCode = VersionCommand.Execute(writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("intent-cli 0.2.0-f6cbf65-G357" + Environment.NewLine, writer.ToString());
+    }
+
+    [Fact]
+    public void BuildVersionString_FromAssemblyWithInformationalVersion_IncludesPackageVersionShaAndExecutionUnit()
+    {
+        // G360 acceptance: the cli assembly's
+        // AssemblyInformationalVersionAttribute is baked at pack/build
+        // time with the canonical format. This test pins the shape
+        // produced by BuildVersionString against the executing
+        // IntentSystem.Cli assembly so the build-time wiring keeps
+        // producing the expected string.
+        var assembly = typeof(VersionCommand).Assembly;
+        var result = VersionCommand.BuildVersionString(assembly);
+
+        Assert.StartsWith("intent-cli ", result, StringComparison.Ordinal);
+        // Package version segment must be present.
+        Assert.Matches(@"intent-cli \d+\.\d+\.\d+", result);
+        // Latest implemented execution unit segment must be present;
+        // the csproj sets G360 by default, but allow any G-number to
+        // future-proof against bumps.
+        Assert.Matches(@"-G\d+$", result);
+        // The `+commit` SourceLink suffix must be stripped — the
+        // canonical form uses dash-separated segments only.
+        Assert.DoesNotContain('+', result);
+    }
+
+    [Fact]
+    public void Execute_VersionFromNonHostCwd_DoesNotResolveHostState()
+    {
+        // G360 acceptance: running `intent-cli --version` from a
+        // directory that has no `.intent-cli/` must NOT emit the
+        // G299 missing-host-state guidance. Exercises the real
+        // Program.Main entry by launching the built binary against
+        // a temp cwd with no `.intent-cli/`.
+        var binaryPath = LocateBuiltCliBinary();
+        Assert.True(File.Exists(binaryPath), $"built CLI binary not found at {binaryPath}");
+
+        var nonHostDir = Directory.CreateTempSubdirectory("g360-non-host-").FullName;
+        try
+        {
+            using var process = new Process();
+            process.StartInfo.FileName = binaryPath;
+            process.StartInfo.Arguments = "--version";
+            process.StartInfo.WorkingDirectory = nonHostDir;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.UseShellExecute = false;
+            process.Start();
+            var stdout = process.StandardOutput.ReadToEnd();
+            var stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            Assert.True(process.ExitCode == 0,
+                $"exit={process.ExitCode}\nstdout={stdout}\nstderr={stderr}");
+            Assert.StartsWith("intent-cli ", stdout, StringComparison.Ordinal);
+            // Must NOT contain the G299 fail-closed missing-host-state guidance.
+            Assert.DoesNotContain("missing host state", stdout, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("G299", stdout, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(nonHostDir))
+            {
+                Directory.Delete(nonHostDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void Execute_DashVFromNonHostCwd_PrintsVersionAndExitsZero()
+    {
+        var binaryPath = LocateBuiltCliBinary();
+        var nonHostDir = Directory.CreateTempSubdirectory("g360-non-host-").FullName;
+        try
+        {
+            using var process = new Process();
+            process.StartInfo.FileName = binaryPath;
+            process.StartInfo.Arguments = "-v";
+            process.StartInfo.WorkingDirectory = nonHostDir;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.UseShellExecute = false;
+            process.Start();
+            var stdout = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+
+            Assert.Equal(0, process.ExitCode);
+            Assert.StartsWith("intent-cli ", stdout, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(nonHostDir))
+            {
+                Directory.Delete(nonHostDir, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void Execute_HostDependentCommandFromNonHostCwd_StillReturnsMissingHostStateGuidance()
+    {
+        // G360 negative test: confirm the existing G299 fail-closed
+        // posture is preserved for commands that genuinely require
+        // host state. Running e.g. `intent-cli intent status` from a
+        // non-host cwd must NOT silently succeed.
+        var binaryPath = LocateBuiltCliBinary();
+        var nonHostDir = Directory.CreateTempSubdirectory("g360-non-host-").FullName;
+        try
+        {
+            using var process = new Process();
+            process.StartInfo.FileName = binaryPath;
+            process.StartInfo.Arguments = "intent status";
+            process.StartInfo.WorkingDirectory = nonHostDir;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.UseShellExecute = false;
+            process.Start();
+            var stdout = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+
+            Assert.NotEqual(0, process.ExitCode);
+            // The G299 guidance text mentions "host state" so this is a
+            // reliable smoke check that the fail-closed lane still
+            // fires for host-dependent commands.
+            Assert.Contains("host", stdout, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(nonHostDir))
+            {
+                Directory.Delete(nonHostDir, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolve the locally-built IntentSystem.Cli executable path.
+    /// Uses the test assembly's adjacency to the project tree to
+    /// find the dll the build just produced.
+    /// </summary>
+    private static string LocateBuiltCliBinary()
+    {
+        // tests/IntentSystem.Cli.Tests/bin/Debug/net10.0/IntentSystem.Cli.Tests.dll
+        // → src/IntentSystem.Cli/bin/Debug/net10.0/IntentSystem.Cli(.dll)
+        var testDir = Path.GetDirectoryName(typeof(VersionCommandTests).Assembly.Location)!;
+        var repoRoot = testDir;
+        while (repoRoot is not null
+            && !File.Exists(Path.Combine(repoRoot, "IntentSystem.sln")))
+        {
+            var parent = Directory.GetParent(repoRoot);
+            if (parent is null) break;
+            repoRoot = parent.FullName;
+        }
+        if (repoRoot is null)
+        {
+            return string.Empty;
+        }
+        var cliDir = Path.Combine(repoRoot, "src", "IntentSystem.Cli", "bin", "Debug", "net10.0");
+        // dotnet SDK produces a native host launcher `IntentSystem.Cli`
+        // (the project's AssemblyName, not the `ToolCommandName`).
+        // Prefer that native exec when present.
+        var execPath = Path.Combine(cliDir, "IntentSystem.Cli");
+        if (File.Exists(execPath))
+        {
+            return execPath;
+        }
+        // Fall back to `dotnet IntentSystem.Cli.dll` via the runtime.
+        return Path.Combine(cliDir, "IntentSystem.Cli.dll");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `VersionCommand` (early-exit in `Program.Main` before host-state resolution) so `intent-cli --version` / `-v` / `version` work from any cwd and emit the canonical identifier `intent-cli 0.2.0-<short-sha>-<latest-execution-unit>` (matches the issue body example).
- Wires build-time metadata in `IntentSystem.Cli.csproj`: `IntentSystemLatestExecutionUnit` MSBuild property (default `G360`, CI override via `-p:`) plus a `ResolveIntentCliSourceRevision` target that runs `git rev-parse --short=7 HEAD` from the project directory to capture the SHA when SourceLink isn't already wired. Gracefully omits the SHA segment when git is unavailable.
- Top-level `--help` already routes through the existing `IsHelpCommand` bootstrap allow-list (G334) and is host-state-free.

## Acceptance coverage

- `--version` / `-v` exit 0 from a non-host cwd: `Execute_VersionFromNonHostCwd_DoesNotResolveHostState`, `Execute_DashVFromNonHostCwd_PrintsVersionAndExitsZero`.
- Version string shape (package version + optional SHA + latest execution unit): `BuildVersionString_FromAssemblyWithInformationalVersion_IncludesPackageVersionShaAndExecutionUnit`.
- Recognized request shapes: `IsVersionRequest_RecognizesCanonicalShapes`, `IsVersionRequest_RejectsNonVersionTokens`.
- G299 fail-closed preserved for host-dependent commands from non-host cwd: `Execute_HostDependentCommandFromNonHostCwd_StillReturnsMissingHostStateGuidance`.

## Test plan

- [x] `dotnet test --filter VersionCommand` (12/12 pass)
- [x] Local smoke: `cd /tmp && IntentSystem.Cli --version` → `intent-cli 0.2.0-6fd6691-G360`
- [x] Local smoke: `cd /tmp && IntentSystem.Cli -v` → same output
- [ ] Full Cli suite (running in background — verified clean before push)

Closes #825

🤖 Generated with [Claude Code](https://claude.com/claude-code)