### PR TITLE
G364: route next-slice clarification + expose candidate execution unit

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -290,6 +290,29 @@ internal static class AutomationHostLoopNextActionCommand
         };
 
         var result = HostLoopNextActionAnalyzer.Analyze(input);
+
+        // G364: surface the next-slice candidate execution unit as a
+        // top-level structured field whenever it is relevant to the
+        // emitted action. Today the unit appears inside the recommended
+        // command and the evidence; promoting it to its own field lets
+        // downstream consumers (host loop wake scripts, dashboards) read
+        // it without parsing the recommended_command string.
+        //
+        // The field is populated for two analyzer lanes:
+        //   * publish-next-issue (G275/G318): next-slice surfaced an
+        //     `issue-cut-ready` candidate ready to publish.
+        //   * prepared-packet-commit-ready (G361): durable-state preflight
+        //     surfaced a prepared packet directory whose execution unit
+        //     should be committed before the next host action.
+        // For all other lanes the field is null so consumers can detect
+        // "no specific candidate selected" deterministically.
+        var candidateExecutionUnit =
+            string.Equals(result.Classification, HostLoopNextActionAnalyzer.ClassificationPublishNextIssue, StringComparison.Ordinal)
+                ? input.PublishNextSliceExecutionUnit
+                : string.Equals(result.Classification, HostLoopNextActionAnalyzer.ClassificationPreparedPacketCommitReady, StringComparison.Ordinal)
+                    ? input.PreparedPacketExecutionUnit
+                    : null;
+
         var emitted = new HostLoopNextActionEmittedResult
         {
             Repo = parsed.Repo,
@@ -297,6 +320,7 @@ internal static class AutomationHostLoopNextActionCommand
             Classification = result.Classification,
             MutationAllowed = result.MutationAllowed,
             RecommendedCommand = result.RecommendedCommand,
+            CandidateExecutionUnit = candidateExecutionUnit,
             Evidence = result.Evidence,
             Summary = result.Summary
         };
@@ -630,6 +654,17 @@ internal sealed record HostLoopNextActionEmittedResult
     [JsonPropertyName("classification")] public required string Classification { get; init; }
     [JsonPropertyName("mutation_allowed")] public required bool MutationAllowed { get; init; }
     [JsonPropertyName("recommended_command")] public required string? RecommendedCommand { get; init; }
+
+    /// <summary>
+    /// G364: when the analyzer chose the <c>publish-next-issue</c> or
+    /// <c>prepared-packet-commit-ready</c> lane, the next-slice / prepared
+    /// packet execution unit is also surfaced here as a top-level structured
+    /// field so consumers can read it directly rather than parsing it out of
+    /// <see cref="RecommendedCommand"/>. <c>null</c> for all other
+    /// classifications.
+    /// </summary>
+    [JsonPropertyName("candidate_execution_unit")] public string? CandidateExecutionUnit { get; init; }
+
     [JsonPropertyName("evidence")] public required IReadOnlyList<string> Evidence { get; init; }
     [JsonPropertyName("summary")] public required string Summary { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
@@ -162,16 +162,45 @@ internal static class AutomationHostReviewDiagnosticsCommand
         // Fail-soft: a probe error (queue-state missing, packet root
         // unreadable) falls through to the existing
         // candidate-not-supplied path so the host loop never crashes.
+        //
+        // G364: extend the switch so `clarification-required` from the
+        // next-slice probe routes to the `clarification-required`
+        // diagnostics lane instead of falling through to `true-idle`.
+        // This keeps diagnostics in lockstep with the host-loop-next-action
+        // probe (which already handles all next-slice outcomes) and is
+        // what the observed SekibanAsAService SKS-G403 case requires.
         if (string.IsNullOrWhiteSpace(candidate) && !string.IsNullOrWhiteSpace(domain))
         {
             var probe = NextSliceDryRunProbeFactory?.Invoke(context)
                 ?? new IntentCliNextSliceDryRunProbe(context);
             var probed = probe.Probe(repo!, domain!);
-            if (probed != null
-                && string.Equals(probed.RecommendedOutcome, "issue-cut-ready", StringComparison.Ordinal)
-                && !string.IsNullOrWhiteSpace(probed.ExecutionUnit))
+            if (probed != null)
             {
-                candidate = probed.ExecutionUnit;
+                switch (probed.RecommendedOutcome)
+                {
+                    case "issue-cut-ready":
+                        if (!string.IsNullOrWhiteSpace(probed.ExecutionUnit))
+                        {
+                            candidate = probed.ExecutionUnit;
+                        }
+                        break;
+
+                    case "clarification-required":
+                        // G364: next-slice authoritatively reports a
+                        // clarification gate. Forward to the analyzer's
+                        // existing `clarification-required` lane so the
+                        // host loop surfaces the blocker rather than
+                        // falling through to `true-idle`.
+                        clarificationRequired = true;
+                        break;
+
+                    // Other outcomes (design-needed, skip-next-slice-due-to-wip,
+                    // no-actionable-item) intentionally not handled here:
+                    // diagnostics has no design-needed lane (host-loop-next-action
+                    // owns that lane via its analyzer), and skip-due-to-wip /
+                    // no-actionable-item correctly flow through the existing
+                    // wip-cap / true-idle logic based on GitHub label state.
+                }
             }
         }
 

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -455,6 +455,74 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_G364_PublishNextIssue_SurfacesCandidateExecutionUnitField()
+    {
+        // G364 AC: when the analyzer selects the `publish-next-issue`
+        // lane, the JSON output must expose the chosen execution unit
+        // as a top-level `candidate_execution_unit` field — not only
+        // inside `recommended_command` / `evidence`. This lets host
+        // loop wake scripts and dashboards read the next-slice target
+        // deterministically without parsing the command string.
+        // Captures the observed SekibanAsAService SKS-G403 shape.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "SKS-G403" });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            var root = JsonDocument.Parse(writer.ToString()).RootElement;
+            Assert.Equal("publish-next-issue", root.GetProperty("classification").GetString());
+            Assert.Equal("SKS-G403", root.GetProperty("candidate_execution_unit").GetString());
+            Assert.Contains("SKS-G403", root.GetProperty("recommended_command").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G364_NonPublishLane_CandidateExecutionUnitFieldIsNull()
+    {
+        // G364: `candidate_execution_unit` is only meaningful for lanes
+        // where a specific next-slice / prepared-packet unit was chosen.
+        // For all other classifications (e.g. true-idle, wip-cap-blocked)
+        // the field must be null so consumers can deterministically
+        // detect "no specific candidate selected".
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(),
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            var root = JsonDocument.Parse(writer.ToString()).RootElement;
+            Assert.Equal(JsonValueKind.Null, root.GetProperty("candidate_execution_unit").ValueKind);
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
     public void Execute_PublishRecoveryProbe_SurfacesRepairHostMetadata_WhenSafeRepairsAvailable()
     {
         // G342: when `automation publish-recovery --dry-run` reports

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
@@ -874,6 +874,132 @@ public sealed class AutomationHostReviewDiagnosticsCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_G364_NextSliceProbe_ClarificationRequired_RoutesToClarificationLane()
+    {
+        // G364 AC: when `intent next-slice --dry-run` reports
+        // `clarification-required`, the diagnostics must surface
+        // `clarification-required` instead of falling through to
+        // `true-idle`. This mirrors the host-loop-next-action probe
+        // (which already maps the same outcome to hardClarificationOpen)
+        // so both surfaces agree on the same next-slice signal. The
+        // observed SekibanAsAService SKS-G403 case showed that without
+        // this mapping the host loop sees `true-idle` on the diagnostics
+        // surface while the explicit `intent next-slice` command reports
+        // a real blocker — the two must not disagree.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "clarification-required", ExecutionUnit = null });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+            Assert.Equal("clarification-required", result.Classification);
+            Assert.NotEqual("true-idle", result.Classification);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G364_NextSliceProbe_IssueCutReady_AndExplicitCandidate_Agree()
+    {
+        // G364 AC: diagnostics with `--candidate SKS-G403` and diagnostics
+        // without `--candidate` (where the auto-probe returns
+        // `issue-cut-ready` for SKS-G403) must agree on classification.
+        // Captures the observed SKS-G403 regression shape: explicit
+        // candidate path returns `issue-publish-ready`; the implicit
+        // path must do the same.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+
+        try
+        {
+            // 1. Implicit candidate path: probe returns issue-cut-ready
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+                new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "SKS-G403" });
+            using var implicitWriter = new StringWriter();
+            var implicitExit = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                implicitWriter);
+            Assert.Equal(0, implicitExit);
+            var implicitResult = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(implicitWriter.ToString())!;
+
+            // 2. Explicit candidate path: operator passes --candidate
+            // SKS-G403 directly (probe is skipped by design)
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+                new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "SKS-G403" });
+            using var explicitWriter = new StringWriter();
+            var explicitExit = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--candidate", "SKS-G403", "--format", "json"],
+                explicitWriter);
+            Assert.Equal(0, explicitExit);
+            var explicitResult = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(explicitWriter.ToString())!;
+
+            // Both paths must agree on classification (issue-publish-ready)
+            // and surface SKS-G403 in the recommended next command.
+            Assert.Equal("issue-publish-ready", implicitResult.Classification);
+            Assert.Equal("issue-publish-ready", explicitResult.Classification);
+            Assert.Equal(implicitResult.Classification, explicitResult.Classification);
+            Assert.Contains("SKS-G403", implicitResult.RecommendedNextCommand!, StringComparison.Ordinal);
+            Assert.Contains("SKS-G403", explicitResult.RecommendedNextCommand!, StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G364_NextSliceProbe_DesignNeeded_LeavesAnalyzerToClassify()
+    {
+        // G364 AC (negative): diagnostics does not own the
+        // `design-needed` lane — that lane lives in the host-loop-next-action
+        // analyzer. When next-slice reports `design-needed`, the
+        // diagnostics probe must NOT promote it to a different
+        // classification or clarification gate. The analyzer is allowed
+        // to fall through to `true-idle` (its current behavior) because
+        // diagnostics has no lane vocabulary for design-needed; the
+        // host-loop-next-action surface is responsible for surfacing
+        // design-needed to the operator. This test pins the contract so
+        // a future "promote design-needed to clarification" change is
+        // intentional.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "design-needed", ExecutionUnit = null });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+            Assert.NotEqual("clarification-required", result.Classification);
+            Assert.NotEqual("issue-publish-ready", result.Classification);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
     public void Execute_PublishRecoveryProbe_SurfacesPublishRecoveryReady_WhenSafeRepairsAvailable()
     {
         // G342: when `automation publish-recovery --dry-run` reports


### PR DESCRIPTION
Closes #831

## Summary

Two related fixes so the implicit host-loop surfaces stay in lockstep with the explicit `intent next-slice --dry-run` command. Captured by the observed SekibanAsAService SKS-G403 regression where:

- `intent next-slice --dry-run` returned `issue-cut-ready` for SKS-G403
- `automation host-review-diagnostics` (no `--candidate`) returned `true-idle`
- `automation host-loop-next-action` returned `design-needed`

Even with G341's existing implicit-candidate auto-probe, non-`issue-cut-ready` next-slice outcomes silently dropped at the diagnostics surface and host-loop-next-action's chosen execution unit was only visible inside `recommended_command` / `evidence` strings.

## Changes

1. **`AutomationHostReviewDiagnosticsCommand`**: extend the G341 next-slice auto-probe switch so a `clarification-required` outcome routes to the analyzer's `clarification-required` lane instead of falling through to `true-idle`. Other outcomes (`design-needed`, `skip-next-slice-due-to-wip`, `no-actionable-item`) intentionally remain unhandled here — diagnostics has no lane vocabulary for them, and `host-loop-next-action`'s analyzer owns those lanes.

2. **`AutomationHostLoopNextActionCommand` / `HostLoopNextActionEmittedResult`**: surface the chosen next-slice (or prepared-packet) execution unit as a top-level `candidate_execution_unit` JSON field. Populated for the `publish-next-issue` (G275/G318) and `prepared-packet-commit-ready` (G361) lanes; `null` elsewhere so consumers can detect "no specific candidate selected" deterministically.

## Test plan

- [x] `Execute_G364_NextSliceProbe_ClarificationRequired_RoutesToClarificationLane`: probe returns `clarification-required` → diagnostics returns `clarification-required`, not `true-idle`.
- [x] `Execute_G364_NextSliceProbe_IssueCutReady_AndExplicitCandidate_Agree`: implicit auto-probe and explicit `--candidate SKS-G403` produce the same `issue-publish-ready` classification (SKS-G403 regression shape).
- [x] `Execute_G364_NextSliceProbe_DesignNeeded_LeavesAnalyzerToClassify`: diagnostics does NOT promote `design-needed` to clarification or `issue-publish-ready` (host-loop-next-action owns that lane).
- [x] `Execute_G364_PublishNextIssue_SurfacesCandidateExecutionUnitField`: host-loop-next-action JSON surfaces `candidate_execution_unit: "SKS-G403"` for the `publish-next-issue` lane.
- [x] `Execute_G364_NonPublishLane_CandidateExecutionUnitFieldIsNull`: field is `null` for lanes without a chosen candidate.
- [x] Full suite: **3119 passed, 0 failed** (1 pre-existing skip).
- [x] `git diff --check` clean.

## Acceptance criteria cross-check

- ✅ Given no open review PR, no WIP, and next-slice returns `issue-cut-ready` for `SKS-G403`, `automation host-review-diagnostics --repo ...` returns `issue-publish-ready` without `--candidate` (already worked via G341; pinned by new regression test).
- ✅ Given the same state, `automation host-loop-next-action --repo ...` returns a publish action with `candidate_execution_unit: SKS-G403` and the deterministic publish chain in `recommended_command` / `evidence`.
- ✅ `automation host-review-diagnostics --candidate SKS-G403` and diagnostics without `--candidate` agree on classification + summary.
- ✅ If next-slice returns `design-needed`, `host-loop-next-action` may return `design-needed` (existing G328 behavior preserved).
- ✅ If next-slice returns `clarification-required`, diagnostics and next-action return a clarification/blocker classification, not `true-idle`.
- ✅ Tests cover the observed SKS-G403 regression shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)