### PR TITLE
G365: derive next-slice domain from host-binding for candidate-less diagnostics

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -63,6 +63,27 @@ internal static class AutomationHostLoopNextActionCommand
     /// </summary>
     public static Func<CliContext, ICloseoutDriftCheckProbe>? CloseoutDriftCheckProbeFactory { get; set; }
 
+    /// <summary>
+    /// G365: testability seam for the host-binding domain resolver.
+    /// Production uses <see cref="HostBindingDomainResolver.Resolve"/>;
+    /// tests inject a fake to model Match / Mismatch / Missing
+    /// outcomes deterministically without writing a real
+    /// <c>.intent-cli/host-binding.toml</c> to the workspace.
+    /// </summary>
+    public static Func<CliContext, string, HostBindingDomainResolution>? HostBindingDomainResolverDelegate { get; set; }
+
+    /// <summary>
+    /// G365: classification emitted when the operator did not supply
+    /// <c>--domain</c> and the host-binding lookup for the requested
+    /// <c>--repo</c> records a different <c>target_repo</c> (no safe
+    /// domain inference is possible). Surfacing this classification
+    /// instead of silently falling back to the host's configured
+    /// domain prevents the next-slice probe from probing the wrong
+    /// domain and reporting a misleading <c>design-needed</c> /
+    /// <c>true-idle</c> outcome.
+    /// </summary>
+    public const string ClassificationMissingDomainBinding = "missing-domain-binding";
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -82,20 +103,53 @@ internal static class AutomationHostLoopNextActionCommand
             return 1;
         }
 
-        // G341: when the operator omits `--domain`, fall back to the
-        // host's configured domain (`context.Config.Project.Domain`).
-        // Without this fallback, the next-slice probe at line ~98 is
-        // skipped and a real `issue-cut-ready` candidate falls through
-        // to `true-idle`, contradicting G318's "host loop must never
-        // report true-idle when a candidate is ready to publish"
-        // contract.
+        // G341 / G365: domain resolution priority when --domain is
+        // omitted:
+        //
+        //   1. `.intent-cli/host-binding.toml` (G365) — the canonical
+        //      domain-for-this-target-repo mapping. The host's binding
+        //      records (host_repo, target_repo, domain); when the
+        //      caller's `--repo` matches the binding's `target_repo`
+        //      the binding's `domain` is authoritative. This stops a
+        //      host whose own config records domain X from probing
+        //      next-slice against target_repo Y with domain X.
+        //   2. `context.Config.Project.Domain` (G341 legacy) — used
+        //      when no binding file is present.
+        //
+        // The Mismatch outcome (binding present but its `target_repo`
+        // names a different repo) short-circuits to a structured
+        // `missing-domain-binding` emission below the lister, so the
+        // host loop surfaces the gap instead of silently using the
+        // wrong domain.
+        var domainBinding = HostBindingDomainResolution.Missing(null);
         if (string.IsNullOrWhiteSpace(parsed.Domain))
         {
-            var configuredDomain = context.Config?.Project?.Domain;
-            if (!string.IsNullOrWhiteSpace(configuredDomain))
+            var resolver = HostBindingDomainResolverDelegate
+                ?? HostBindingDomainResolver.Resolve;
+            domainBinding = resolver(context, parsed.Repo);
+            if (domainBinding.Kind == HostBindingDomainResolutionKind.Match
+                && !string.IsNullOrWhiteSpace(domainBinding.Domain))
             {
-                parsed = parsed with { Domain = configuredDomain.Trim() };
+                parsed = parsed with { Domain = domainBinding.Domain };
             }
+            else if (domainBinding.Kind == HostBindingDomainResolutionKind.Missing)
+            {
+                var configuredDomain = context.Config?.Project?.Domain;
+                if (!string.IsNullOrWhiteSpace(configuredDomain))
+                {
+                    parsed = parsed with { Domain = configuredDomain.Trim() };
+                }
+            }
+            // Mismatch: deliberately do NOT fall through to the
+            // configured domain. The structured missing-domain-binding
+            // emission below explains why.
+        }
+
+        if (domainBinding.Kind == HostBindingDomainResolutionKind.Mismatch
+            && string.IsNullOrWhiteSpace(parsed.Domain))
+        {
+            EmitMissingDomainBinding(writer, parsed.Repo, domainBinding, parsed.Format);
+            return 0;
         }
 
         IReadOnlyList<GitHubAutomationPrCandidate> openPrs;
@@ -335,6 +389,57 @@ internal static class AutomationHostLoopNextActionCommand
             WriteMarkdown(writer, emitted);
         }
         return 0;
+    }
+
+    /// <summary>
+    /// G365: structured emission for the
+    /// <see cref="ClassificationMissingDomainBinding"/> lane. Fires when
+    /// the operator omitted <c>--domain</c> and the host-binding
+    /// resolution returned <see cref="HostBindingDomainResolutionKind.Mismatch"/>:
+    /// a binding exists but its <c>target_repo</c> records a different
+    /// repo than the <c>--repo</c> argument, so neither the binding's
+    /// nor the configured domain can be safely used for the next-slice
+    /// probe. The recommended command points the operator at the
+    /// canonical fix: pass <c>--domain</c> explicitly or align the
+    /// host-binding's <c>target_repo</c>.
+    /// </summary>
+    private static void EmitMissingDomainBinding(
+        TextWriter writer,
+        string repo,
+        HostBindingDomainResolution binding,
+        string format)
+    {
+        var bindingPath = binding.BindingPath ?? "(unresolved)";
+        var boundRepo = binding.BoundTargetRepo ?? "(none)";
+        var boundDomain = binding.Domain ?? "(none)";
+        var emitted = new HostLoopNextActionEmittedResult
+        {
+            Repo = repo,
+            Domain = null,
+            Classification = ClassificationMissingDomainBinding,
+            MutationAllowed = false,
+            RecommendedCommand =
+                $"intent-cli automation host-loop-next-action --repo {repo} --domain <DOMAIN> --format json",
+            CandidateExecutionUnit = null,
+            Evidence = new[]
+            {
+                $"`{bindingPath}` records target_repo=`{boundRepo}` / domain=`{boundDomain}`, "
+                + $"which does not match --repo=`{repo}`. Cannot infer the active domain safely.",
+                "Either pass --domain explicitly or update host-binding.toml's `target_repo` to match this repo."
+            },
+            Summary =
+                $"Missing domain binding for `{repo}` — host-binding.toml maps a different target_repo; "
+                + "pass --domain or fix the binding before re-running the host loop."
+        };
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(emitted, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, emitted);
+        }
     }
 
     private static ActionableReviewPr? FindActionableReviewPr(IReadOnlyList<GitHubAutomationPrCandidate> openPrs)

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
@@ -63,25 +63,57 @@ internal static class AutomationHostReviewDiagnosticsCommand
             return 1;
         }
 
-        // G341: when the operator omits `--domain`, fall back to the
-        // host's configured domain. Needed so the next-slice probe
-        // below can run without requiring the operator to type the
-        // domain every time.
-        if (string.IsNullOrWhiteSpace(domain))
-        {
-            var configuredDomain = context.Config?.Project?.Domain;
-            if (!string.IsNullOrWhiteSpace(configuredDomain))
-            {
-                domain = configuredDomain.Trim();
-            }
-        }
-
         var resolvedWorkdir = ResolveWorkdir(context, workdir);
         if (string.IsNullOrWhiteSpace(repo)
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
         {
             writer.WriteLine(error);
             return 1;
+        }
+
+        // G341 / G365: domain resolution priority when --domain is
+        // omitted:
+        //
+        //   1. `.intent-cli/host-binding.toml` (G365) — the canonical
+        //      domain-for-this-target-repo mapping. When the requested
+        //      `--repo` matches the binding's `target_repo` the
+        //      binding's `domain` is authoritative.
+        //   2. `context.Config.Project.Domain` (G341 legacy) — used
+        //      when no binding file is present.
+        //
+        // Mismatch outcome (binding records a different target_repo)
+        // short-circuits to a `missing-domain-binding` emission so the
+        // host loop surfaces the gap rather than silently using the
+        // wrong domain.
+        var domainBinding = HostBindingDomainResolution.Missing(null);
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            var resolver = HostBindingDomainResolverDelegate
+                ?? HostBindingDomainResolver.Resolve;
+            domainBinding = resolver(context, repo!);
+            if (domainBinding.Kind == HostBindingDomainResolutionKind.Match
+                && !string.IsNullOrWhiteSpace(domainBinding.Domain))
+            {
+                domain = domainBinding.Domain;
+            }
+            else if (domainBinding.Kind == HostBindingDomainResolutionKind.Missing)
+            {
+                var configuredDomain = context.Config?.Project?.Domain;
+                if (!string.IsNullOrWhiteSpace(configuredDomain))
+                {
+                    domain = configuredDomain.Trim();
+                }
+            }
+            // Mismatch: deliberately do NOT fall through to the
+            // configured domain; the structured emission below names
+            // the inconsistency.
+        }
+
+        if (domainBinding.Kind == HostBindingDomainResolutionKind.Mismatch
+            && string.IsNullOrWhiteSpace(domain))
+        {
+            EmitMissingDomainBinding(writer, repo!, domainBinding, format);
+            return 0;
         }
 
         var surfaceReport = AutomationInstalledCliSurfaceProbe.Check(context);
@@ -256,6 +288,52 @@ internal static class AutomationHostReviewDiagnosticsCommand
     /// signal.
     /// </summary>
     public static Func<CliContext, IPublishRecoveryProbe>? PublishRecoveryProbeFactory { get; set; }
+
+    /// <summary>
+    /// G365: testability seam for the host-binding domain resolver.
+    /// Mirrors the seam in <see cref="AutomationHostLoopNextActionCommand"/>
+    /// so both surfaces agree on the same per-repo domain mapping.
+    /// </summary>
+    public static Func<CliContext, string, HostBindingDomainResolution>? HostBindingDomainResolverDelegate { get; set; }
+
+    private static void EmitMissingDomainBinding(
+        TextWriter writer,
+        string repo,
+        HostBindingDomainResolution binding,
+        string format)
+    {
+        var bindingPath = binding.BindingPath ?? "(unresolved)";
+        var boundRepo = binding.BoundTargetRepo ?? "(none)";
+        var boundDomain = binding.Domain ?? "(none)";
+        var emitted = new AutomationHostReviewDiagnosticsResult
+        {
+            Repo = repo,
+            Classification = AutomationHostReviewDiagnosticsClassifications.MissingDomainBinding,
+            Summary =
+                $"Missing domain binding for `{repo}` — host-binding.toml maps a different target_repo (`{boundRepo}` / domain `{boundDomain}`); "
+                + "pass --domain explicitly or align the host-binding so candidate-less diagnostics can probe the right domain.",
+            ReadOnly = true,
+            RecommendedNextCommand =
+                $"intent-cli automation host-review-diagnostics --repo {repo} --domain <DOMAIN> --format json",
+            StructuredClarification = null,
+            Details =
+            [
+                new AutomationHostReviewDiagnosticsDetail
+                {
+                    Kind = AutomationHostReviewDiagnosticsClassifications.MissingDomainBinding,
+                    TargetKind = null,
+                    TargetNumber = null,
+                    TargetUrl = null,
+                    Description =
+                        $"binding_path: {bindingPath}; bound_target_repo: {boundRepo}; bound_domain: {boundDomain}; requested_repo: {repo}",
+                }
+            ],
+            Warnings = Array.Empty<string>(),
+            SafeRepairAvailable = false,
+            SafeRepairCategory = null,
+        };
+        Emit(writer, emitted, format);
+    }
 
     private static bool TryParseArguments(
         string[] args,

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsResult.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsResult.cs
@@ -183,6 +183,20 @@ internal static class AutomationHostReviewDiagnosticsClassifications
     /// reporting a misleading <c>true-idle</c>.
     /// </summary>
     public const string CloseoutDriftRepair = "closeout-drift-repair";
+
+    /// <summary>
+    /// G365: terminal class returned when the operator did not supply
+    /// <c>--domain</c> and the host-binding lookup returns
+    /// <see cref="HostBindingDomainResolutionKind.Mismatch"/> — the
+    /// host's <c>.intent-cli/host-binding.toml</c> records a different
+    /// <c>target_repo</c> than the <c>--repo</c> argument. The host
+    /// loop must NOT silently fall back to the configured domain in
+    /// this case because the next-slice probe would run against the
+    /// wrong domain and report a misleading <c>true-idle</c> /
+    /// <c>design-needed</c> outcome. The recommended fix is to either
+    /// pass <c>--domain</c> explicitly or update the binding.
+    /// </summary>
+    public const string MissingDomainBinding = "missing-domain-binding";
 }
 
 /// <summary>

--- a/src/IntentSystem.Cli/Commands/HostBindingDomainResolver.cs
+++ b/src/IntentSystem.Cli/Commands/HostBindingDomainResolver.cs
@@ -1,0 +1,236 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G365: domain-aware lookup that derives the active domain for a
+/// requested target repo from the host's
+/// <c>.intent-cli/host-binding.toml</c>. The host-loop-next-action and
+/// host-review-diagnostics commands consult this resolver BEFORE
+/// falling back to the host's configured
+/// <see cref="CliConfig.Project"/>.<see cref="ProjectConfig.Domain"/>
+/// so a host that operates against a different target repo than the
+/// one its config records does not silently probe
+/// <see cref="IntentNextSliceCommand"/> with the wrong domain.
+///
+/// Resolution order:
+/// <list type="number">
+///   <item>Parent intent repo root (when configured) — the canonical
+///   binding for cross-repo hosts.</item>
+///   <item>Child <see cref="CliContext.RepoRoot"/> — single-repo
+///   hosts and in-memory test fixtures.</item>
+/// </list>
+///
+/// Outcomes:
+/// <list type="bullet">
+///   <item><c>Match</c>: binding's <c>target_repo</c> matches the
+///   requested repo (case-insensitive). The binding's <c>domain</c>
+///   is returned and should be used as if the operator had typed
+///   <c>--domain</c>.</item>
+///   <item><c>Mismatch</c>: a binding exists but its
+///   <c>target_repo</c> records a DIFFERENT repo. Returning this
+///   distinct outcome lets the caller surface a structured
+///   <c>missing-domain-binding</c> diagnostic instead of silently
+///   probing with the wrong domain.</item>
+///   <item><c>Missing</c>: no binding file present, the file does not
+///   declare a <c>[host]</c> section, or the <c>target_repo</c> field
+///   is blank. The caller may fall back to other domain sources
+///   (e.g. <c>--domain</c>, config) without raising a missing-binding
+///   diagnostic.</item>
+/// </list>
+///
+/// The parser is intentionally minimal (no external TOML dependency
+/// pulled in here) and mirrors the tolerance contract of
+/// <see cref="IntentHostCheckCommand.ParseHostBinding"/>: a malformed
+/// or unparseable file degrades to <c>Missing</c> so misconfiguration
+/// never blocks the host loop entirely.
+/// </summary>
+internal static class HostBindingDomainResolver
+{
+    public static HostBindingDomainResolution Resolve(CliContext context, string repo)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var bindingPath = ResolveBindingPath(context);
+        if (string.IsNullOrWhiteSpace(bindingPath) || !File.Exists(bindingPath))
+        {
+            return HostBindingDomainResolution.Missing(bindingPath);
+        }
+
+        string content;
+        try
+        {
+            content = File.ReadAllText(bindingPath);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return HostBindingDomainResolution.Missing(bindingPath);
+        }
+
+        (string? domain, string? targetRepo) parsed;
+        try
+        {
+            parsed = ParseHostBinding(content);
+        }
+        catch (Exception)
+        {
+            return HostBindingDomainResolution.Missing(bindingPath);
+        }
+
+        if (string.IsNullOrWhiteSpace(parsed.domain) || string.IsNullOrWhiteSpace(parsed.targetRepo))
+        {
+            return HostBindingDomainResolution.Missing(bindingPath);
+        }
+
+        if (string.Equals(parsed.targetRepo, repo, StringComparison.OrdinalIgnoreCase))
+        {
+            return HostBindingDomainResolution.Match(parsed.domain!, bindingPath);
+        }
+
+        return HostBindingDomainResolution.Mismatch(parsed.domain!, parsed.targetRepo!, bindingPath);
+    }
+
+    private static string? ResolveBindingPath(CliContext context)
+    {
+        var parentRoot = context.ResolveParentIntentRepoRootPath();
+        if (!string.IsNullOrWhiteSpace(parentRoot))
+        {
+            return Path.Combine(parentRoot, ".intent-cli", "host-binding.toml");
+        }
+        if (string.IsNullOrWhiteSpace(context.RepoRoot))
+        {
+            return null;
+        }
+        return Path.Combine(context.RepoRoot, ".intent-cli", "host-binding.toml");
+    }
+
+    /// <summary>
+    /// Minimal manual TOML parse for the <c>[host]</c> section so this
+    /// resolver does not pull a TOML dependency into the
+    /// <c>Commands</c> namespace. Recognizes only the two fields the
+    /// resolver needs (<c>domain</c>, <c>target_repo</c>); other
+    /// fields are ignored. Quoted and unquoted scalar values are both
+    /// accepted. Mirrors the tolerance contract of
+    /// <see cref="IntentHostCheckCommand.ParseHostBinding"/> so a
+    /// malformed file degrades to <c>Missing</c> in
+    /// <see cref="Resolve"/> rather than throwing.
+    /// </summary>
+    internal static (string? Domain, string? TargetRepo) ParseHostBinding(string toml)
+    {
+        if (string.IsNullOrWhiteSpace(toml))
+        {
+            return (null, null);
+        }
+
+        string? domain = null;
+        string? targetRepo = null;
+        var inHost = false;
+
+        var normalized = toml.Replace("\r\n", "\n", StringComparison.Ordinal);
+        foreach (var rawLine in normalized.Split('\n'))
+        {
+            var trimmed = rawLine.Trim();
+            if (trimmed.Length == 0 || trimmed.StartsWith('#'))
+            {
+                continue;
+            }
+
+            if (trimmed.StartsWith('[') && trimmed.EndsWith(']'))
+            {
+                var section = trimmed[1..^1].Trim();
+                inHost = string.Equals(section, "host", StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+
+            if (!inHost)
+            {
+                continue;
+            }
+
+            var equalsIndex = trimmed.IndexOf('=', StringComparison.Ordinal);
+            if (equalsIndex <= 0)
+            {
+                continue;
+            }
+
+            var key = trimmed[..equalsIndex].Trim();
+            var value = trimmed[(equalsIndex + 1)..].Trim();
+
+            // Strip an optional trailing inline comment ` # ...`.
+            var commentIndex = value.IndexOf(" #", StringComparison.Ordinal);
+            if (commentIndex >= 0)
+            {
+                value = value[..commentIndex].Trim();
+            }
+
+            // Strip surrounding quotes if present.
+            if (value.Length >= 2
+                && ((value[0] == '"' && value[^1] == '"')
+                    || (value[0] == '\'' && value[^1] == '\'')))
+            {
+                value = value[1..^1];
+            }
+
+            if (string.Equals(key, "domain", StringComparison.OrdinalIgnoreCase))
+            {
+                domain = string.IsNullOrWhiteSpace(value) ? null : value;
+            }
+            else if (string.Equals(key, "target_repo", StringComparison.OrdinalIgnoreCase))
+            {
+                targetRepo = string.IsNullOrWhiteSpace(value) ? null : value;
+            }
+        }
+
+        return (domain, targetRepo);
+    }
+}
+
+/// <summary>
+/// G365: outcome of a <see cref="HostBindingDomainResolver.Resolve"/>
+/// call. See <see cref="HostBindingDomainResolver"/> docs for the
+/// semantics of each value.
+/// </summary>
+internal enum HostBindingDomainResolutionKind
+{
+    /// <summary>No usable binding file present.</summary>
+    Missing,
+    /// <summary>Binding's <c>target_repo</c> matches the requested repo.</summary>
+    Match,
+    /// <summary>Binding present but its <c>target_repo</c> records a different repo.</summary>
+    Mismatch,
+}
+
+/// <summary>
+/// G365: structured outcome of
+/// <see cref="HostBindingDomainResolver.Resolve"/>. Callers branch on
+/// <see cref="Kind"/>; <see cref="Domain"/> and
+/// <see cref="BoundTargetRepo"/> are populated only for the Match /
+/// Mismatch outcomes.
+/// </summary>
+internal sealed record HostBindingDomainResolution
+{
+    public required HostBindingDomainResolutionKind Kind { get; init; }
+    public string? Domain { get; init; }
+    public string? BoundTargetRepo { get; init; }
+    public string? BindingPath { get; init; }
+
+    public static HostBindingDomainResolution Match(string domain, string bindingPath) => new()
+    {
+        Kind = HostBindingDomainResolutionKind.Match,
+        Domain = domain,
+        BindingPath = bindingPath,
+    };
+
+    public static HostBindingDomainResolution Mismatch(string domain, string boundTargetRepo, string bindingPath) => new()
+    {
+        Kind = HostBindingDomainResolutionKind.Mismatch,
+        Domain = domain,
+        BoundTargetRepo = boundTargetRepo,
+        BindingPath = bindingPath,
+    };
+
+    public static HostBindingDomainResolution Missing(string? bindingPath) => new()
+    {
+        Kind = HostBindingDomainResolutionKind.Missing,
+        BindingPath = bindingPath,
+    };
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -888,6 +888,195 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
         }
     }
 
+    [Fact]
+    public void Execute_G365_HostBinding_Match_DerivesDomainAndPublishesNextIssue()
+    {
+        // G365: when --domain is omitted but --repo matches the host's
+        // host-binding.toml target_repo, the binding's domain is used
+        // for the next-slice probe so a real `issue-cut-ready` candidate
+        // surfaces as `publish-next-issue` instead of `design-needed`.
+        // Mirrors the observed SekibanAsAService SKS-G406 case where the
+        // operator runs the host loop without typing the domain.
+        string? probedDomain = null;
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.HostBindingDomainResolverDelegate = (_, repo) =>
+            HostBindingDomainResolution.Match("sekiban-as-a-service", "/host/.intent-cli/host-binding.toml");
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeProbeRecorder(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "SKS-G406" },
+            (_, d) => probedDomain = d);
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContextWithoutDomain(),
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            Assert.Equal("sekiban-as-a-service", probedDomain);
+            using var doc = JsonDocument.Parse(writer.ToString());
+            var root = doc.RootElement;
+            Assert.Equal("publish-next-issue", root.GetProperty("classification").GetString());
+            Assert.Equal("SKS-G406", root.GetProperty("candidate_execution_unit").GetString());
+            var recommended = root.GetProperty("recommended_command").GetString()!;
+            Assert.Contains("--execution-unit SKS-G406", recommended, StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.HostBindingDomainResolverDelegate = null;
+            AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G365_HostBinding_Mismatch_EmitsMissingDomainBindingClassification()
+    {
+        // G365: when --domain is omitted and the host-binding records a
+        // different target_repo than --repo, the command MUST surface
+        // `missing-domain-binding` rather than silently fall back to the
+        // configured domain. The probe MUST NOT be invoked (it would
+        // run against the wrong domain).
+        var probeWasInvoked = false;
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.HostBindingDomainResolverDelegate = (_, _) =>
+            HostBindingDomainResolution.Mismatch(
+                domain: "intent-cli",
+                boundTargetRepo: "J-Tech-Japan/intent-system",
+                bindingPath: "/host/.intent-cli/host-binding.toml");
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "WRONG-DOMAIN" },
+            onProbe: () => probeWasInvoked = true);
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContextWithoutDomain(),
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            Assert.False(probeWasInvoked, "next-slice probe must not run when host-binding records a different target_repo");
+            using var doc = JsonDocument.Parse(writer.ToString());
+            var root = doc.RootElement;
+            Assert.Equal("missing-domain-binding", root.GetProperty("classification").GetString());
+            Assert.False(root.GetProperty("mutation_allowed").GetBoolean());
+            var recommended = root.GetProperty("recommended_command").GetString()!;
+            Assert.Contains("--domain <DOMAIN>", recommended, StringComparison.Ordinal);
+            var evidence = string.Join(' ',
+                root.GetProperty("evidence").EnumerateArray().Select(e => e.GetString()));
+            Assert.Contains("J-Tech-Japan/intent-system", evidence, StringComparison.Ordinal);
+            Assert.Contains("J-Tech-Japan/SekibanAsAService", evidence, StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.HostBindingDomainResolverDelegate = null;
+            AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G365_HostBinding_Missing_FallsBackToConfiguredDomain()
+    {
+        // G365: when no host-binding is present, the existing G341
+        // fallback to `context.Config.Project.Domain` MUST remain
+        // byte-identical. Pre-G365 hosts (no binding file) keep
+        // working exactly as they did under G341.
+        string? probedDomain = null;
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.HostBindingDomainResolverDelegate = (_, _) =>
+            HostBindingDomainResolution.Missing("(no binding file)");
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeProbeRecorder(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null },
+            (_, d) => probedDomain = d);
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContext(), // configured domain = "intent-cli"
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            Assert.Equal("intent-cli", probedDomain);
+            using var doc = JsonDocument.Parse(writer.ToString());
+            Assert.Equal("true-idle", doc.RootElement.GetProperty("classification").GetString());
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.HostBindingDomainResolverDelegate = null;
+            AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G365_ExplicitDomainFlag_BypassesHostBindingLookup()
+    {
+        // G365: an operator-supplied `--domain` is authoritative; the
+        // host-binding resolver MUST NOT be invoked. This preserves the
+        // pre-G365 contract that an explicit domain flag wins.
+        var resolverInvoked = false;
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: Array.Empty<GitHubAutomationIssueCandidate>());
+        AutomationHostLoopNextActionCommand.HostBindingDomainResolverDelegate = (_, _) =>
+        {
+            resolverInvoked = true;
+            return HostBindingDomainResolution.Mismatch(
+                "wrong-domain", "wrong-repo", "/host/.intent-cli/host-binding.toml");
+        };
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationHostLoopNextActionCommand.Execute(
+                CreateContextWithoutDomain(),
+                ["--repo", "owner/repo",
+                 "--domain", "operator-supplied",
+                 "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            Assert.False(resolverInvoked, "host-binding resolver must not run when --domain is supplied");
+        }
+        finally
+        {
+            AutomationHostLoopNextActionCommand.HostBindingDomainResolverDelegate = null;
+            AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    /// <summary>
+    /// G365: stand-in for the next-slice probe that records the
+    /// (repo, domain) pair the command supplied. Used by tests that
+    /// assert the derived domain reaches the probe.
+    /// </summary>
+    private sealed class FakeProbeRecorder : INextSliceDryRunProbe
+    {
+        private readonly NextSliceProbeResult? _canned;
+        private readonly Action<string, string> _onProbeArgs;
+        public FakeProbeRecorder(NextSliceProbeResult? canned, Action<string, string> onProbeArgs)
+        {
+            _canned = canned;
+            _onProbeArgs = onProbeArgs;
+        }
+        public NextSliceProbeResult? Probe(string repo, string domain)
+        {
+            _onProbeArgs(repo, domain);
+            return _canned;
+        }
+    }
+
     private static CliContext CreateContextWithoutDomain() =>
         new()
         {

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
@@ -1253,6 +1253,161 @@ public sealed class AutomationHostReviewDiagnosticsCommandTests : IDisposable
         Assert.Contains("workspace-guard", result.RecommendedNextCommand!, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_G365_HostBinding_Match_DerivesDomainAndProbesAndReturnsIssuePublishReady()
+    {
+        // G365: when neither --candidate nor --domain is supplied and
+        // the host-binding records target_repo matching --repo, the
+        // resolver-supplied domain reaches the next-slice probe and a
+        // returned `issue-cut-ready` candidate flips diagnostics from
+        // `true-idle` to `issue-publish-ready`.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        string? probedDomain = null;
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationHostReviewDiagnosticsCommand.HostBindingDomainResolverDelegate = (_, repo) =>
+            HostBindingDomainResolution.Match("sekiban-as-a-service", "/host/.intent-cli/host-binding.toml");
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "SKS-G406" },
+            onProbeArgs: (_, d) => probedDomain = d);
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context, // configured domain = "intent-cli"
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("sekiban-as-a-service", probedDomain);
+            var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+            Assert.Equal("issue-publish-ready", result.Classification);
+            Assert.Contains("SKS-G406", result.RecommendedNextCommand!, StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.HostBindingDomainResolverDelegate = null;
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G365_HostBinding_Mismatch_EmitsMissingDomainBindingClassification()
+    {
+        // G365: when no --domain is supplied and the host-binding records
+        // a target_repo that does not match --repo, diagnostics must
+        // return `missing-domain-binding` with read_only true and a
+        // recommendation to pass --domain explicitly. The next-slice
+        // probe must NOT run.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        var probeWasInvoked = false;
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationHostReviewDiagnosticsCommand.HostBindingDomainResolverDelegate = (_, _) =>
+            HostBindingDomainResolution.Mismatch(
+                domain: "intent-cli",
+                boundTargetRepo: "J-Tech-Japan/intent-system",
+                bindingPath: "/host/.intent-cli/host-binding.toml");
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "WRONG-DOMAIN" },
+            onProbe: () => probeWasInvoked = true);
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "J-Tech-Japan/SekibanAsAService", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(probeWasInvoked, "next-slice probe must not run on host-binding mismatch");
+            var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+            Assert.Equal("missing-domain-binding", result.Classification);
+            Assert.True(result.ReadOnly);
+            Assert.False(result.SafeRepairAvailable);
+            Assert.Null(result.SafeRepairCategory);
+            Assert.NotNull(result.RecommendedNextCommand);
+            Assert.Contains("--domain <DOMAIN>", result.RecommendedNextCommand!, StringComparison.Ordinal);
+            Assert.Single(result.Details);
+            Assert.Contains("J-Tech-Japan/intent-system", result.Details[0].Description, StringComparison.Ordinal);
+            Assert.Contains("J-Tech-Japan/SekibanAsAService", result.Details[0].Description, StringComparison.Ordinal);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.HostBindingDomainResolverDelegate = null;
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G365_HostBinding_Missing_FallsBackToConfiguredDomain()
+    {
+        // G365 backward-compat: when no host-binding is present the
+        // existing G341 fallback to context.Config.Project.Domain
+        // continues to work unchanged.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        string? probedDomain = null;
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationHostReviewDiagnosticsCommand.HostBindingDomainResolverDelegate = (_, _) =>
+            HostBindingDomainResolution.Missing("(no binding file)");
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null },
+            onProbeArgs: (_, d) => probedDomain = d);
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context, // configured domain = "intent-cli"
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.Equal("intent-cli", probedDomain);
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.HostBindingDomainResolverDelegate = null;
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_G365_ExplicitDomainFlag_BypassesHostBindingLookup()
+    {
+        // G365: when --domain is supplied, the host-binding resolver
+        // must not be invoked. This preserves the pre-G365 contract
+        // that an explicit domain flag wins.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        var resolverInvoked = false;
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationHostReviewDiagnosticsCommand.HostBindingDomainResolverDelegate = (_, _) =>
+        {
+            resolverInvoked = true;
+            return HostBindingDomainResolution.Mismatch(
+                "wrong-domain", "wrong-repo", "/host/.intent-cli/host-binding.toml");
+        };
+        AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "no-actionable-item", ExecutionUnit = null });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+                workspace.Context,
+                ["--repo", "owner/repo", "--domain", "operator-supplied", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            Assert.False(resolverInvoked, "host-binding resolver must not run when --domain is supplied");
+        }
+        finally
+        {
+            AutomationHostReviewDiagnosticsCommand.HostBindingDomainResolverDelegate = null;
+            AutomationHostReviewDiagnosticsCommand.NextSliceDryRunProbeFactory = null;
+        }
+    }
+
     /// <summary>
     /// G342: deterministic stand-in for the publish-recovery probe.
     /// </summary>

--- a/tests/IntentSystem.Cli.Tests/HostBindingDomainResolverTests.cs
+++ b/tests/IntentSystem.Cli.Tests/HostBindingDomainResolverTests.cs
@@ -1,0 +1,176 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G365: covers <see cref="HostBindingDomainResolver"/>'s on-disk
+/// resolution behavior (parent-root vs child-root precedence, parse
+/// tolerance, case-insensitive target_repo matching) so the
+/// host-loop-next-action and host-review-diagnostics commands can
+/// trust the lookup. Each test owns a temp workspace and deletes it
+/// on dispose.
+/// </summary>
+public sealed class HostBindingDomainResolverTests : IDisposable
+{
+    private readonly string _root;
+
+    public HostBindingDomainResolverTests()
+    {
+        _root = Directory.CreateTempSubdirectory("host-binding-domain-resolver-tests-").FullName;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_ReturnsMissing_WhenBindingFileAbsent()
+    {
+        var context = CreateContext(_root, parentRoot: null);
+
+        var result = HostBindingDomainResolver.Resolve(context, "owner/repo");
+
+        Assert.Equal(HostBindingDomainResolutionKind.Missing, result.Kind);
+        Assert.Null(result.Domain);
+        Assert.Null(result.BoundTargetRepo);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsMatch_WhenTargetRepoMatchesCaseInsensitive()
+    {
+        WriteBinding(_root, """
+        [host]
+        domain = "sekiban-as-a-service"
+        host_repo = "J-Tech-Japan/intent-system"
+        target_repo = "J-Tech-Japan/SekibanAsAService"
+        """);
+
+        var context = CreateContext(_root, parentRoot: null);
+        var result = HostBindingDomainResolver.Resolve(context, "j-tech-japan/sekibanasaservice");
+
+        Assert.Equal(HostBindingDomainResolutionKind.Match, result.Kind);
+        Assert.Equal("sekiban-as-a-service", result.Domain);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsMismatch_WhenTargetRepoDoesNotMatch()
+    {
+        WriteBinding(_root, """
+        [host]
+        domain = "intent-cli"
+        host_repo = "J-Tech-Japan/intent-system"
+        target_repo = "J-Tech-Japan/intent-system"
+        """);
+
+        var context = CreateContext(_root, parentRoot: null);
+        var result = HostBindingDomainResolver.Resolve(context, "J-Tech-Japan/OtherRepo");
+
+        Assert.Equal(HostBindingDomainResolutionKind.Mismatch, result.Kind);
+        Assert.Equal("intent-cli", result.Domain);
+        Assert.Equal("J-Tech-Japan/intent-system", result.BoundTargetRepo);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsMissing_WhenBindingHasEmptyTargetRepo()
+    {
+        WriteBinding(_root, """
+        [host]
+        domain = "intent-cli"
+        host_repo = "J-Tech-Japan/intent-system"
+        target_repo = ""
+        """);
+
+        var context = CreateContext(_root, parentRoot: null);
+        var result = HostBindingDomainResolver.Resolve(context, "owner/repo");
+
+        Assert.Equal(HostBindingDomainResolutionKind.Missing, result.Kind);
+    }
+
+    [Fact]
+    public void Resolve_PrefersParentBindingOverChildBinding()
+    {
+        // G365: when a parent intent repo root is configured, the
+        // parent's host-binding wins so a stale child workspace
+        // binding cannot override the host's authoritative mapping.
+        var parentRoot = Directory.CreateDirectory(Path.Combine(_root, "parent-host")).FullName;
+        var childRoot = Directory.CreateDirectory(Path.Combine(_root, "child-workspace")).FullName;
+        WriteBinding(parentRoot, """
+        [host]
+        domain = "parent-domain"
+        host_repo = "owner/parent"
+        target_repo = "owner/target"
+        """);
+        WriteBinding(childRoot, """
+        [host]
+        domain = "child-domain"
+        host_repo = "owner/child"
+        target_repo = "owner/target"
+        """);
+
+        var context = CreateContext(childRoot, parentRoot: parentRoot);
+        var result = HostBindingDomainResolver.Resolve(context, "owner/target");
+
+        Assert.Equal(HostBindingDomainResolutionKind.Match, result.Kind);
+        Assert.Equal("parent-domain", result.Domain);
+    }
+
+    [Fact]
+    public void ParseHostBinding_TolerantOfCommentsAndQuotes()
+    {
+        var content = """
+        # leading comment
+        [host]
+          # nested comment is ignored
+        domain = 'single-quoted-domain' # trailing inline comment
+        host_repo = "owner/repo"
+        target_repo = unquoted/value
+        """;
+
+        var (domain, targetRepo) = HostBindingDomainResolver.ParseHostBinding(content);
+
+        Assert.Equal("single-quoted-domain", domain);
+        Assert.Equal("unquoted/value", targetRepo);
+    }
+
+    [Fact]
+    public void ParseHostBinding_ReturnsBlankWhenNoHostSection()
+    {
+        var content = "[other]\ndomain = \"x\"\ntarget_repo = \"y\"\n";
+
+        var (domain, targetRepo) = HostBindingDomainResolver.ParseHostBinding(content);
+
+        Assert.Null(domain);
+        Assert.Null(targetRepo);
+    }
+
+    private static void WriteBinding(string repoRoot, string content)
+    {
+        var dir = Path.Combine(repoRoot, ".intent-cli");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "host-binding.toml"), content);
+    }
+
+    private static CliContext CreateContext(string repoRoot, string? parentRoot)
+    {
+        return new CliContext
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = string.Empty,
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                    ParentIntentRepoRoot = parentRoot ?? string.Empty,
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Closes #833.

- New `HostBindingDomainResolver` reads `.intent-cli/host-binding.toml` (parent root preferred, child root fallback) and reports Match / Mismatch / Missing for a requested `--repo`.
- `automation host-loop-next-action` and `automation host-review-diagnostics` consult the resolver BEFORE the G341 `context.Config.Project.Domain` fallback so the next-slice probe runs against the right domain whenever a binding maps the requested repo.
- Binding `Mismatch` now short-circuits to a new `missing-domain-binding` classification (both surfaces) rather than silently probing the wrong domain and reporting `design-needed` / `true-idle`.
- An explicit `--domain` flag still wins; pre-G365 hosts (no binding file) keep the byte-identical G341 fallback path.

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — 3134 passed, 1 pre-existing skip, 0 failed.
- [x] 15 new tests: 7 in `HostBindingDomainResolverTests` (Missing / Match / Mismatch / case-insensitive / parent-precedence / parse tolerance), 4 in `AutomationHostLoopNextActionCommandTests` (Match → publish-next-issue, Mismatch → missing-domain-binding, Missing → config fallback, explicit `--domain` bypass), 4 in `AutomationHostReviewDiagnosticsCommandTests` (Match → issue-publish-ready, Mismatch → missing-domain-binding, Missing → config fallback, explicit `--domain` bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)