### PR TITLE
G366: canonical workflow label palette audit and sync

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationLabelPaletteAuditCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationLabelPaletteAuditCommand.cs
@@ -1,0 +1,155 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G366: <c>intent-cli automation label-palette-audit --repo
+/// &lt;owner/repo&gt; [--format text|json]</c> — read-only audit of
+/// the workflow label palette against
+/// <see cref="WorkflowLabelPaletteContract.Canonical"/>. Lists each
+/// canonical label as <c>ok</c>, <c>missing</c>, <c>wrong-color</c>,
+/// <c>wrong-description</c>, or <c>wrong-color-and-description</c> so
+/// the operator can decide whether to run the matching
+/// <c>label-palette-sync --write</c> command. Never mutates GitHub.
+/// </summary>
+internal static class AutomationLabelPaletteAuditCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatText = "text";
+
+    /// <summary>
+    /// G366: testability seam for the GitHub label list source.
+    /// Production uses <see cref="GhCliGitHubLabelLister"/>; tests
+    /// inject a fake so they can model missing labels, drifted
+    /// colors, and drifted descriptions deterministically without
+    /// invoking <c>gh</c>.
+    /// </summary>
+    public static Func<IGitHubLabelLister>? LabelListerFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var repo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubLabelLister lister;
+        try
+        {
+            lister = LabelListerFactory?.Invoke() ?? new GhCliGitHubLabelLister();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub label lister: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<GitHubLabelMetadata> labels;
+        try
+        {
+            labels = lister.ListLabels(repo!);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to list labels in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var result = WorkflowLabelPaletteAnalyzer.Analyze(repo!, labels);
+        Emit(writer, result, format);
+        return 0;
+    }
+
+    internal static void Emit(TextWriter writer, WorkflowLabelPaletteAuditResult result, string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+    }
+
+    private static void WriteText(TextWriter writer, WorkflowLabelPaletteAuditResult result)
+    {
+        writer.WriteLine($"# Workflow label palette audit — {result.Repo}");
+        writer.WriteLine($"- canonical_entries: {WorkflowLabelPaletteContract.Canonical.Count}");
+        writer.WriteLine($"- ok: {result.OkCount}");
+        writer.WriteLine($"- missing: {result.MissingCount}");
+        writer.WriteLine($"- wrong_color: {result.WrongColorCount}");
+        writer.WriteLine($"- wrong_description: {result.WrongDescriptionCount}");
+        writer.WriteLine($"- drift_count: {result.DriftCount}");
+        writer.WriteLine();
+        writer.WriteLine("## Entries");
+        foreach (var entry in result.Entries)
+        {
+            writer.WriteLine($"- {entry.Name}: {entry.Status}");
+            writer.WriteLine($"  - canonical: color={entry.CanonicalColor}; description={entry.CanonicalDescription}");
+            if (!string.Equals(entry.Status, WorkflowLabelPaletteAnalyzer.StatusMissing, StringComparison.Ordinal))
+            {
+                writer.WriteLine($"  - current: color={entry.CurrentColor}; description={entry.CurrentDescription}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string? repo, out string format, out string error)
+    {
+        repo = null;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo)."; return false;
+                    }
+                    repo = args[++index].Trim();
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json)."; return false;
+                    }
+                    var requested = args[++index].Trim();
+                    if (!string.Equals(requested, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requested}')."; return false;
+                    }
+                    format = requested;
+                    break;
+                default:
+                    error = $"Unknown argument '{argument}'."; return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "automation label-palette-audit requires '--repo <owner/repo>'.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/AutomationLabelPaletteSyncCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationLabelPaletteSyncCommand.cs
@@ -1,0 +1,327 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G366: <c>intent-cli automation label-palette-sync --repo
+/// &lt;owner/repo&gt; [--write] [--format text|json]</c> — applies
+/// the canonical workflow label palette to a repository. Without
+/// <c>--write</c> the command is a dry-run: it lists every planned
+/// create / edit action without invoking <c>gh label create</c> or
+/// <c>gh label edit</c>. With <c>--write</c>, mutations are applied
+/// in palette order; the emitted report records each applied / skipped
+/// entry plus an <c>applied_count</c> total.
+///
+/// Idempotency contract (G366 acceptance): running sync twice against
+/// the same repo state MUST report <c>applied_count = 0</c> on the
+/// second run. The first run brings the labels to the canonical
+/// palette; a second run sees zero drift in the audit and therefore
+/// plans zero mutations.
+///
+/// Out of scope: this command never touches label assignments on
+/// existing issues or PRs. It only manages label definitions
+/// themselves (name / color / description).
+/// </summary>
+internal static class AutomationLabelPaletteSyncCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatText = "text";
+
+    /// <summary>
+    /// G366: testability seam for the GitHub label list source.
+    /// Production uses <see cref="GhCliGitHubLabelLister"/>; tests
+    /// inject a fake.
+    /// </summary>
+    public static Func<IGitHubLabelLister>? LabelListerFactory { get; set; }
+
+    /// <summary>
+    /// G366: testability seam for the create / edit mutator.
+    /// Production uses <see cref="GhCliGitHubLabelPaletteMutator"/>;
+    /// tests inject a fake that records calls so assertions can
+    /// verify the exact sequence of create / edit operations.
+    /// </summary>
+    public static Func<IGitHubLabelPaletteMutator>? LabelPaletteMutatorFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var repo, out var write, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubLabelLister lister;
+        try
+        {
+            lister = LabelListerFactory?.Invoke() ?? new GhCliGitHubLabelLister();
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub label lister: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<GitHubLabelMetadata> labels;
+        try
+        {
+            labels = lister.ListLabels(repo!);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to list labels in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var audit = WorkflowLabelPaletteAnalyzer.Analyze(repo!, labels);
+        var plannedActions = new List<WorkflowLabelPaletteSyncAction>();
+        foreach (var entry in audit.Entries)
+        {
+            switch (entry.Status)
+            {
+                case WorkflowLabelPaletteAnalyzer.StatusMissing:
+                    plannedActions.Add(new WorkflowLabelPaletteSyncAction
+                    {
+                        Name = entry.Name,
+                        Action = "create",
+                        FromColor = null,
+                        FromDescription = null,
+                        ToColor = entry.CanonicalColor,
+                        ToDescription = entry.CanonicalDescription,
+                    });
+                    break;
+                case WorkflowLabelPaletteAnalyzer.StatusWrongColor:
+                case WorkflowLabelPaletteAnalyzer.StatusWrongDescription:
+                case WorkflowLabelPaletteAnalyzer.StatusWrongColorAndDescription:
+                    plannedActions.Add(new WorkflowLabelPaletteSyncAction
+                    {
+                        Name = entry.Name,
+                        Action = "edit",
+                        FromColor = entry.CurrentColor,
+                        FromDescription = entry.CurrentDescription,
+                        ToColor = entry.CanonicalColor,
+                        ToDescription = entry.CanonicalDescription,
+                    });
+                    break;
+            }
+        }
+
+        var appliedActions = new List<WorkflowLabelPaletteSyncAction>();
+        if (write && plannedActions.Count > 0)
+        {
+            IGitHubLabelPaletteMutator mutator;
+            try
+            {
+                mutator = LabelPaletteMutatorFactory?.Invoke()
+                    ?? new GhCliGitHubLabelPaletteMutator();
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException or IOException)
+            {
+                writer.WriteLine($"failed to initialize label palette mutator: {exception.Message}");
+                return 1;
+            }
+
+            foreach (var action in plannedActions)
+            {
+                try
+                {
+                    if (string.Equals(action.Action, "create", StringComparison.Ordinal))
+                    {
+                        mutator.CreateLabel(repo!, action.Name, action.ToColor, action.ToDescription);
+                    }
+                    else
+                    {
+                        mutator.EditLabel(repo!, action.Name, action.ToColor, action.ToDescription);
+                    }
+                    appliedActions.Add(action);
+                }
+                catch (Exception exception) when (
+                    exception is InvalidOperationException or IOException)
+                {
+                    writer.WriteLine(
+                        $"failed to {action.Action} label `{action.Name}` in {repo}: {exception.Message}");
+                    return 1;
+                }
+            }
+        }
+
+        var result = new WorkflowLabelPaletteSyncResult
+        {
+            Repo = repo!,
+            Mode = write ? "write" : "dry-run",
+            Audit = audit,
+            PlannedActions = plannedActions,
+            AppliedActions = appliedActions,
+            PlannedCount = plannedActions.Count,
+            AppliedCount = appliedActions.Count,
+        };
+        Emit(writer, result, format);
+        return 0;
+    }
+
+    internal static void Emit(TextWriter writer, WorkflowLabelPaletteSyncResult result, string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+    }
+
+    private static void WriteText(TextWriter writer, WorkflowLabelPaletteSyncResult result)
+    {
+        writer.WriteLine($"# Workflow label palette sync — {result.Repo} ({result.Mode})");
+        writer.WriteLine($"- canonical_entries: {WorkflowLabelPaletteContract.Canonical.Count}");
+        writer.WriteLine($"- planned_count: {result.PlannedCount}");
+        writer.WriteLine($"- applied_count: {result.AppliedCount}");
+        if (result.PlannedActions.Count == 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("All canonical workflow labels are already in sync; nothing to do (idempotent).");
+            return;
+        }
+        writer.WriteLine();
+        writer.WriteLine("## Planned actions");
+        foreach (var action in result.PlannedActions)
+        {
+            writer.WriteLine($"- {action.Action} {action.Name}");
+            if (string.Equals(action.Action, "edit", StringComparison.Ordinal))
+            {
+                writer.WriteLine($"  - from: color={action.FromColor}; description={action.FromDescription}");
+            }
+            writer.WriteLine($"  - to: color={action.ToColor}; description={action.ToDescription}");
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out bool write,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        write = false;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo)."; return false;
+                    }
+                    repo = args[++index].Trim();
+                    break;
+                case "--write":
+                    write = true;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json)."; return false;
+                    }
+                    var requested = args[++index].Trim();
+                    if (!string.Equals(requested, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requested}')."; return false;
+                    }
+                    format = requested;
+                    break;
+                default:
+                    error = $"Unknown argument '{argument}'."; return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "automation label-palette-sync requires '--repo <owner/repo>'.";
+            return false;
+        }
+
+        return true;
+    }
+}
+
+/// <summary>
+/// G366: structured result emitted by <c>label-palette-sync</c>. The
+/// <see cref="Audit"/> field embeds the same per-entry classification
+/// the read-only audit command returns so dashboards can render the
+/// drift table from either surface uniformly. The
+/// <see cref="AppliedActions"/> list is always a prefix of
+/// <see cref="PlannedActions"/> — equal in <c>write</c> mode (modulo
+/// errors mid-sync) and empty in <c>dry-run</c> mode.
+/// </summary>
+internal sealed record WorkflowLabelPaletteSyncResult
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("audit")]
+    public required WorkflowLabelPaletteAuditResult Audit { get; init; }
+
+    [JsonPropertyName("planned_actions")]
+    public required IReadOnlyList<WorkflowLabelPaletteSyncAction> PlannedActions { get; init; }
+
+    [JsonPropertyName("applied_actions")]
+    public required IReadOnlyList<WorkflowLabelPaletteSyncAction> AppliedActions { get; init; }
+
+    [JsonPropertyName("planned_count")]
+    public required int PlannedCount { get; init; }
+
+    [JsonPropertyName("applied_count")]
+    public required int AppliedCount { get; init; }
+}
+
+/// <summary>
+/// G366: a single planned (or applied) palette mutation. The
+/// <see cref="Action"/> field is either <c>create</c> (canonical
+/// label absent in the repo) or <c>edit</c> (label exists but its
+/// color or description does not match the canonical palette).
+/// <see cref="FromColor"/> / <see cref="FromDescription"/> are
+/// <c>null</c> for <c>create</c> actions.
+/// </summary>
+internal sealed record WorkflowLabelPaletteSyncAction
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("action")]
+    public required string Action { get; init; }
+
+    [JsonPropertyName("from_color")]
+    public string? FromColor { get; init; }
+
+    [JsonPropertyName("from_description")]
+    public string? FromDescription { get; init; }
+
+    [JsonPropertyName("to_color")]
+    public required string ToColor { get; init; }
+
+    [JsonPropertyName("to_description")]
+    public required string ToDescription { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -177,6 +177,8 @@ internal static class CommandRouter
                 ["host-sync-preflight"] = AutomationHostSyncPreflightCommand.Execute,
                 ["intent-target-gap-recovery"] = AutomationIntentTargetGapRecoveryCommand.Execute,
                 ["issue-publish"] = AutomationIssuePublishCommand.Execute,
+                ["label-palette-audit"] = AutomationLabelPaletteAuditCommand.Execute,
+                ["label-palette-sync"] = AutomationLabelPaletteSyncCommand.Execute,
                 ["pr-transition"] = AutomationPrTransitionCommand.Execute,
                 ["publish-lifecycle-repair"] = AutomationPublishLifecycleRepairCommand.Execute,
                 ["publish-recovery"] = AutomationPublishRecoveryCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelLister.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G366: testability seam for <c>gh label list</c>. The
+/// <see cref="AutomationLabelPaletteAuditCommand"/> and
+/// <see cref="AutomationLabelPaletteSyncCommand"/> commands use this
+/// to read the live label metadata for a repository; tests inject a
+/// fake to model missing labels, drifted colors, and drifted
+/// descriptions deterministically without invoking <c>gh</c>.
+/// </summary>
+internal interface IGitHubLabelLister
+{
+    IReadOnlyList<GitHubLabelMetadata> ListLabels(string repo);
+}
+
+/// <summary>
+/// G366: minimal projection of <c>gh label list --json
+/// name,color,description</c>. Only the fields the audit/sync
+/// analyzer compares against the canonical palette are surfaced;
+/// other GitHub label metadata (URL, id) is intentionally excluded so
+/// the seam stays stable.
+/// </summary>
+internal sealed record GitHubLabelMetadata
+{
+    [JsonPropertyName("name")] public string Name { get; init; } = string.Empty;
+    [JsonPropertyName("color")] public string Color { get; init; } = string.Empty;
+    [JsonPropertyName("description")] public string Description { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// G366: default lister that shells out to
+/// <c>gh label list --repo &lt;owner/repo&gt; --json
+/// name,color,description --limit 200</c>. The only file in the
+/// label-palette surface permitted to call <c>Process.Start</c>;
+/// analyzer and command layers remain pure.
+/// </summary>
+internal sealed class GhCliGitHubLabelLister : IGitHubLabelLister
+{
+    public IReadOnlyList<GitHubLabelMetadata> ListLabels(string repo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var argument in new[]
+        {
+            "label", "list",
+            "--repo", repo,
+            "--json", "name,color,description",
+            "--limit", "200",
+        })
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        string stdout;
+        string stderr;
+        int exitCode;
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException(
+                    $"failed to start `gh` process to list labels in {repo}");
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            exitCode = process.ExitCode;
+        }
+        catch (Exception exception) when (
+            exception is System.ComponentModel.Win32Exception
+            or InvalidOperationException
+            or IOException)
+        {
+            throw new InvalidOperationException(
+                $"could not invoke `gh` to list labels in {repo}: {exception.Message}",
+                exception);
+        }
+
+        if (exitCode != 0)
+        {
+            var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+            throw new InvalidOperationException(
+                $"`gh` failed to list labels in {repo} with exit {exitCode}: {errorBody.Trim()}");
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<GitHubLabelMetadata>>(stdout)
+                ?? new List<GitHubLabelMetadata>();
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException(
+                $"could not parse `gh label list` for {repo} JSON: {exception.Message}",
+                exception);
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelPaletteMutator.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelPaletteMutator.cs
@@ -1,0 +1,117 @@
+using System.Diagnostics;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G366: testability seam for label metadata create / edit
+/// operations. <see cref="AutomationLabelPaletteSyncCommand"/> uses
+/// this to apply the canonical workflow label palette to a repository;
+/// tests inject a fake that records calls so assertions can verify
+/// exactly which create / edit operations the sync planner emitted.
+/// The fake also lets tests verify idempotency: a second sync against
+/// the same repo state must record zero mutations.
+///
+/// Distinct from <see cref="IGitHubLabelMutator"/> (G211), which
+/// transitions individual issue/PR label assignments via
+/// <c>gh issue/pr edit --add-label / --remove-label</c>. The palette
+/// mutator never touches issue or PR assignments — it only manages
+/// the label definitions themselves via <c>gh label create</c> /
+/// <c>gh label edit</c>.
+/// </summary>
+internal interface IGitHubLabelPaletteMutator
+{
+    void CreateLabel(string repo, string name, string color, string description);
+    void EditLabel(string repo, string name, string color, string description);
+}
+
+/// <summary>
+/// G366: default palette mutator that shells out to
+/// <c>gh label create</c> and <c>gh label edit</c>.
+/// <see cref="AutomationLabelPaletteSyncCommand"/> only calls this
+/// when invoked with <c>--write</c>; the read-only path emits the
+/// planned mutations as a JSON / text report instead.
+/// </summary>
+internal sealed class GhCliGitHubLabelPaletteMutator : IGitHubLabelPaletteMutator
+{
+    public void CreateLabel(string repo, string name, string color, string description)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(color);
+        ArgumentNullException.ThrowIfNull(description);
+
+        Run(
+            new[]
+            {
+                "label", "create", name,
+                "--repo", repo,
+                "--color", color,
+                "--description", description,
+            },
+            $"create label `{name}` in {repo}");
+    }
+
+    public void EditLabel(string repo, string name, string color, string description)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentException.ThrowIfNullOrWhiteSpace(color);
+        ArgumentNullException.ThrowIfNull(description);
+
+        Run(
+            new[]
+            {
+                "label", "edit", name,
+                "--repo", repo,
+                "--color", color,
+                "--description", description,
+            },
+            $"edit label `{name}` in {repo}");
+    }
+
+    private static void Run(IReadOnlyList<string> arguments, string description)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        string stdout;
+        string stderr;
+        int exitCode;
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException(
+                    $"failed to start `gh` process to {description}");
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            exitCode = process.ExitCode;
+        }
+        catch (Exception exception) when (
+            exception is System.ComponentModel.Win32Exception
+            or InvalidOperationException
+            or IOException)
+        {
+            throw new InvalidOperationException(
+                $"could not invoke `gh` to {description}: {exception.Message}",
+                exception);
+        }
+
+        if (exitCode != 0)
+        {
+            var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+            throw new InvalidOperationException(
+                $"`gh` failed to {description} with exit {exitCode}: {errorBody.Trim()}");
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkflowLabelPaletteAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkflowLabelPaletteAnalyzer.cs
@@ -1,0 +1,196 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G366: pure analyzer that diffs an observed set of GitHub labels
+/// (from <see cref="IGitHubLabelLister.ListLabels"/>) against the
+/// canonical <see cref="WorkflowLabelPaletteContract.Canonical"/>
+/// palette and produces a structured audit. Used by both
+/// <see cref="AutomationLabelPaletteAuditCommand"/> (read-only,
+/// always emits the audit verbatim) and
+/// <see cref="AutomationLabelPaletteSyncCommand"/> (uses the same
+/// classification to plan create / edit mutations).
+///
+/// Pure data in / pure data out: no I/O, no <c>gh</c> calls.
+/// Comparison is case-insensitive on the 6-character hex color so
+/// <c>0E8A16</c> and <c>0e8a16</c> are treated as equal (GitHub
+/// returns lowercase from <c>--json color</c> but accepts either on
+/// write). Description comparison uses ordinal equality with an
+/// empty-vs-null tolerance: a GitHub label whose description is
+/// missing reads as <c>""</c>, which is treated as equivalent to a
+/// canonical entry of <c>""</c> only.
+/// </summary>
+internal static class WorkflowLabelPaletteAnalyzer
+{
+    public const string StatusOk = "ok";
+    public const string StatusMissing = "missing";
+    public const string StatusWrongColor = "wrong-color";
+    public const string StatusWrongDescription = "wrong-description";
+    public const string StatusWrongColorAndDescription = "wrong-color-and-description";
+
+    public static WorkflowLabelPaletteAuditResult Analyze(
+        string repo,
+        IReadOnlyList<GitHubLabelMetadata> observed)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(observed);
+
+        var observedByName = new Dictionary<string, GitHubLabelMetadata>(StringComparer.Ordinal);
+        foreach (var label in observed)
+        {
+            if (!string.IsNullOrWhiteSpace(label.Name))
+            {
+                observedByName[label.Name] = label;
+            }
+        }
+
+        var entries = new List<WorkflowLabelPaletteAuditEntry>(WorkflowLabelPaletteContract.Canonical.Count);
+        var missing = 0;
+        var wrongColor = 0;
+        var wrongDescription = 0;
+        var ok = 0;
+
+        foreach (var canonical in WorkflowLabelPaletteContract.Canonical)
+        {
+            if (!observedByName.TryGetValue(canonical.Name, out var current))
+            {
+                entries.Add(new WorkflowLabelPaletteAuditEntry
+                {
+                    Name = canonical.Name,
+                    Status = StatusMissing,
+                    CanonicalColor = canonical.Color,
+                    CanonicalDescription = canonical.Description,
+                    CurrentColor = null,
+                    CurrentDescription = null,
+                });
+                missing++;
+                continue;
+            }
+
+            var colorMismatch = !string.Equals(
+                current.Color?.Trim() ?? string.Empty,
+                canonical.Color,
+                StringComparison.OrdinalIgnoreCase);
+            var descriptionMismatch = !string.Equals(
+                current.Description ?? string.Empty,
+                canonical.Description,
+                StringComparison.Ordinal);
+
+            string status;
+            if (colorMismatch && descriptionMismatch)
+            {
+                status = StatusWrongColorAndDescription;
+                wrongColor++;
+                wrongDescription++;
+            }
+            else if (colorMismatch)
+            {
+                status = StatusWrongColor;
+                wrongColor++;
+            }
+            else if (descriptionMismatch)
+            {
+                status = StatusWrongDescription;
+                wrongDescription++;
+            }
+            else
+            {
+                status = StatusOk;
+                ok++;
+            }
+
+            entries.Add(new WorkflowLabelPaletteAuditEntry
+            {
+                Name = canonical.Name,
+                Status = status,
+                CanonicalColor = canonical.Color,
+                CanonicalDescription = canonical.Description,
+                CurrentColor = current.Color ?? string.Empty,
+                CurrentDescription = current.Description ?? string.Empty,
+            });
+        }
+
+        // DriftCount must count each non-ok entry exactly once even
+        // when both axes mismatch (wrong-color-and-description). The
+        // per-axis counters above still record both axes for dashboard
+        // per-axis totals; the total entry-level drift is simply
+        // canonical_count - ok_count.
+        return new WorkflowLabelPaletteAuditResult
+        {
+            Repo = repo,
+            Entries = entries,
+            MissingCount = missing,
+            WrongColorCount = wrongColor,
+            WrongDescriptionCount = wrongDescription,
+            OkCount = ok,
+            DriftCount = entries.Count - ok,
+        };
+    }
+}
+
+/// <summary>
+/// G366: audit result for one repository. Counts are derived so
+/// downstream consumers can decide whether to invoke
+/// <c>label-palette sync --write</c> based on a single
+/// <see cref="DriftCount"/> field rather than walking the entries.
+/// </summary>
+internal sealed record WorkflowLabelPaletteAuditResult
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("entries")]
+    public required IReadOnlyList<WorkflowLabelPaletteAuditEntry> Entries { get; init; }
+
+    [JsonPropertyName("missing_count")]
+    public required int MissingCount { get; init; }
+
+    [JsonPropertyName("wrong_color_count")]
+    public required int WrongColorCount { get; init; }
+
+    [JsonPropertyName("wrong_description_count")]
+    public required int WrongDescriptionCount { get; init; }
+
+    [JsonPropertyName("ok_count")]
+    public required int OkCount { get; init; }
+
+    /// <summary>
+    /// G366: total entries that would change on
+    /// <c>label-palette sync --write</c> — equals
+    /// <c>missing + wrong-color + wrong-description</c> with the
+    /// combined-mismatch case (<see cref="WorkflowLabelPaletteAnalyzer.StatusWrongColorAndDescription"/>)
+    /// counted once. Zero means the palette is in sync and sync is
+    /// a no-op (idempotency contract).
+    /// </summary>
+    [JsonPropertyName("drift_count")]
+    public required int DriftCount { get; init; }
+}
+
+/// <summary>
+/// G366: a single canonical label entry plus its observed state and
+/// the audit classification. <see cref="CurrentColor"/> and
+/// <see cref="CurrentDescription"/> are <c>null</c> when the label is
+/// missing from the repository; otherwise both echo whatever GitHub
+/// returned, including the empty string for an unset description.
+/// </summary>
+internal sealed record WorkflowLabelPaletteAuditEntry
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("canonical_color")]
+    public required string CanonicalColor { get; init; }
+
+    [JsonPropertyName("canonical_description")]
+    public required string CanonicalDescription { get; init; }
+
+    [JsonPropertyName("current_color")]
+    public string? CurrentColor { get; init; }
+
+    [JsonPropertyName("current_description")]
+    public string? CurrentDescription { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/WorkflowLabelPaletteContract.cs
+++ b/src/IntentSystem.Cli/Commands/WorkflowLabelPaletteContract.cs
@@ -1,0 +1,96 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G366: canonical palette for the intent workflow labels that
+/// <c>intent-cli</c> owns end-to-end. Each entry pairs a label name
+/// with its canonical color and description so the audit/sync
+/// commands can detect repos where the same logical label was created
+/// with a different color or description (a common drift signal once
+/// the same workflow lights up across multiple repositories such as
+/// <c>intent-system</c>, <c>SekibanAsAService</c>, <c>TraceForge</c>,
+/// and <c>Zero4Racer</c>).
+///
+/// The palette only governs label metadata (color + description). It
+/// does NOT add or remove label assignments from existing issues or
+/// PRs — that remains the exclusive responsibility of the
+/// <c>intent-cli automation</c> / <c>intent-cli worker</c> transition
+/// commands.
+///
+/// Colors use the 6-character hex form GitHub returns from
+/// <c>gh label list --json color</c> (no leading <c>#</c>), uppercased
+/// so comparisons remain case-insensitive.
+/// </summary>
+internal static class WorkflowLabelPaletteContract
+{
+    /// <summary>
+    /// G366: canonical entries in stable visual-lane order so audit
+    /// output reads top-to-bottom through the workflow (target →
+    /// implementation → review → approval).
+    /// </summary>
+    public static readonly IReadOnlyList<WorkflowLabelPaletteEntry> Canonical =
+    [
+        new()
+        {
+            Name = "intent-target",
+            Color = "0E8A16",
+            Description = "Intent automation target — implementation worker may claim this issue."
+        },
+        new()
+        {
+            Name = "intent-issue-in-progress",
+            Color = "E11D21",
+            Description = "Automation is currently working on this issue."
+        },
+        new()
+        {
+            Name = "intent-pr-created",
+            Color = "1D76DB",
+            Description = "PR created by intent automation; ready for review."
+        },
+        new()
+        {
+            Name = "intent-pr-reviewing",
+            Color = "FBCA04",
+            Description = "PR is currently under review by intent automation."
+        },
+        new()
+        {
+            Name = "intent-pr-request-update",
+            Color = "D93F0B",
+            Description = "Review requested updates to this PR; implementer must address."
+        },
+        new()
+        {
+            Name = "intent-pr-update-in-progress",
+            Color = "BFD4F2",
+            Description = "Implementer is updating this PR per review feedback."
+        },
+        new()
+        {
+            Name = "intent-pr-rereview-ready",
+            Color = "5319E7",
+            Description = "PR has been updated and is ready for re-review."
+        },
+        new()
+        {
+            Name = "intent-pr-approved",
+            Color = "0E8A16",
+            Description = "PR is approved by intent automation review; ready to merge + close out."
+        },
+    ];
+}
+
+/// <summary>
+/// G366: a single canonical label entry. All three fields are
+/// authoritative: <see cref="WorkflowLabelPaletteAnalyzer"/> compares
+/// observed <c>color</c> and <c>description</c> against these to
+/// classify the label as <c>ok</c>, <c>wrong-color</c>,
+/// <c>wrong-description</c>, <c>wrong-color-and-description</c>, or
+/// <c>missing</c>.
+/// </summary>
+internal sealed record WorkflowLabelPaletteEntry
+{
+    public required string Name { get; init; }
+    public required string Color { get; init; }
+    public required string Description { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -104,6 +104,8 @@ internal static class Program
                 || string.Equals(args[1], "host-review-diagnostics", StringComparison.Ordinal)
                 || string.Equals(args[1], "host-sync-preflight", StringComparison.Ordinal)
                 || string.Equals(args[1], "issue-publish", StringComparison.Ordinal)
+                || string.Equals(args[1], "label-palette-audit", StringComparison.Ordinal)
+                || string.Equals(args[1], "label-palette-sync", StringComparison.Ordinal)
                 || string.Equals(args[1], "pr-transition", StringComparison.Ordinal)
                 || string.Equals(args[1], "publish-lifecycle-repair", StringComparison.Ordinal)
                 || string.Equals(args[1], "publish-recovery", StringComparison.Ordinal)

--- a/tests/IntentSystem.Cli.Tests/AutomationLabelPaletteCommandsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationLabelPaletteCommandsTests.cs
@@ -1,0 +1,267 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G366: command-level coverage for
+/// <see cref="AutomationLabelPaletteAuditCommand"/> and
+/// <see cref="AutomationLabelPaletteSyncCommand"/>. The audit tests
+/// pin the JSON / text shape; the sync tests pin the dry-run /
+/// write split, the idempotency contract (a second sync against the
+/// already-applied state plans zero mutations), and the exact
+/// sequence of create / edit calls the planner emits for missing /
+/// drifted labels.
+/// </summary>
+public sealed class AutomationLabelPaletteCommandsTests
+{
+    [Fact]
+    public void Audit_AllInSync_EmitsOkForEveryCanonicalLabel()
+    {
+        AutomationLabelPaletteAuditCommand.LabelListerFactory = () =>
+            new FakeLister(WorkflowLabelPaletteContract.Canonical
+                .Select(e => new GitHubLabelMetadata
+                {
+                    Name = e.Name,
+                    Color = e.Color,
+                    Description = e.Description,
+                })
+                .ToList());
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationLabelPaletteAuditCommand.Execute(
+                CreateContext(),
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            using var doc = JsonDocument.Parse(writer.ToString());
+            var root = doc.RootElement;
+            Assert.Equal(0, root.GetProperty("missing_count").GetInt32());
+            Assert.Equal(0, root.GetProperty("wrong_color_count").GetInt32());
+            Assert.Equal(0, root.GetProperty("wrong_description_count").GetInt32());
+            Assert.Equal(0, root.GetProperty("drift_count").GetInt32());
+            Assert.Equal(WorkflowLabelPaletteContract.Canonical.Count, root.GetProperty("ok_count").GetInt32());
+        }
+        finally
+        {
+            AutomationLabelPaletteAuditCommand.LabelListerFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Audit_DriftedRepo_ReportsMissingAndWrongColorEntries()
+    {
+        var canonical0 = WorkflowLabelPaletteContract.Canonical[0]; // intent-target
+        var canonical1 = WorkflowLabelPaletteContract.Canonical[1]; // intent-issue-in-progress
+        AutomationLabelPaletteAuditCommand.LabelListerFactory = () =>
+            new FakeLister(new[]
+            {
+                // canonical0 with a wrong color (typical cross-repo drift signal).
+                new GitHubLabelMetadata { Name = canonical0.Name, Color = "FFFFFF", Description = canonical0.Description },
+                // canonical1 with correct color but missing description.
+                new GitHubLabelMetadata { Name = canonical1.Name, Color = canonical1.Color, Description = string.Empty },
+                // The rest of the palette is absent → MissingCount = 6.
+            });
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationLabelPaletteAuditCommand.Execute(
+                CreateContext(),
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            using var doc = JsonDocument.Parse(writer.ToString());
+            var root = doc.RootElement;
+            Assert.Equal(WorkflowLabelPaletteContract.Canonical.Count - 2, root.GetProperty("missing_count").GetInt32());
+            Assert.Equal(1, root.GetProperty("wrong_color_count").GetInt32());
+            Assert.Equal(1, root.GetProperty("wrong_description_count").GetInt32());
+            Assert.Equal(WorkflowLabelPaletteContract.Canonical.Count, root.GetProperty("drift_count").GetInt32());
+        }
+        finally
+        {
+            AutomationLabelPaletteAuditCommand.LabelListerFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Audit_MissingRepo_ReturnsValidationError()
+    {
+        using var writer = new StringWriter();
+        var exit = AutomationLabelPaletteAuditCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+        Assert.Equal(1, exit);
+        Assert.Contains("--repo", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sync_DryRun_PlansAllMutationsAndAppliesNone()
+    {
+        // Repo with NO intent labels: every canonical entry must be planned
+        // as a `create` action, and dry-run must not touch the mutator.
+        AutomationLabelPaletteSyncCommand.LabelListerFactory = () =>
+            new FakeLister(Array.Empty<GitHubLabelMetadata>());
+        var mutator = new RecordingMutator();
+        AutomationLabelPaletteSyncCommand.LabelPaletteMutatorFactory = () => mutator;
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationLabelPaletteSyncCommand.Execute(
+                CreateContext(),
+                ["--repo", "owner/repo", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            using var doc = JsonDocument.Parse(writer.ToString());
+            var root = doc.RootElement;
+            Assert.Equal("dry-run", root.GetProperty("mode").GetString());
+            Assert.Equal(WorkflowLabelPaletteContract.Canonical.Count, root.GetProperty("planned_count").GetInt32());
+            Assert.Equal(0, root.GetProperty("applied_count").GetInt32());
+            Assert.Empty(mutator.Creates);
+            Assert.Empty(mutator.Edits);
+            // Every planned action for a missing label is a `create`.
+            var planned = root.GetProperty("planned_actions").EnumerateArray().ToArray();
+            Assert.All(planned, a => Assert.Equal("create", a.GetProperty("action").GetString()));
+        }
+        finally
+        {
+            AutomationLabelPaletteSyncCommand.LabelListerFactory = null;
+            AutomationLabelPaletteSyncCommand.LabelPaletteMutatorFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Sync_Write_AppliesCreateForMissingAndEditForDrifted()
+    {
+        var canonical0 = WorkflowLabelPaletteContract.Canonical[0];
+        var canonical1 = WorkflowLabelPaletteContract.Canonical[1];
+        AutomationLabelPaletteSyncCommand.LabelListerFactory = () =>
+            new FakeLister(new[]
+            {
+                new GitHubLabelMetadata { Name = canonical0.Name, Color = "FFFFFF", Description = canonical0.Description },
+                new GitHubLabelMetadata { Name = canonical1.Name, Color = canonical1.Color, Description = canonical1.Description },
+                // canonical[2..7] missing → create.
+            });
+        var mutator = new RecordingMutator();
+        AutomationLabelPaletteSyncCommand.LabelPaletteMutatorFactory = () => mutator;
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationLabelPaletteSyncCommand.Execute(
+                CreateContext(),
+                ["--repo", "owner/repo", "--write", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            // canonical0 → edit (wrong color); canonical[2..7] → create.
+            Assert.Equal(6, mutator.Creates.Count);
+            Assert.Single(mutator.Edits);
+            Assert.Equal(canonical0.Name, mutator.Edits[0].name);
+            Assert.Equal(canonical0.Color, mutator.Edits[0].color);
+            // Every create matches a canonical palette entry by name + color + description.
+            foreach (var (name, color, description) in mutator.Creates)
+            {
+                var canonical = WorkflowLabelPaletteContract.Canonical.Single(e => e.Name == name);
+                Assert.Equal(canonical.Color, color);
+                Assert.Equal(canonical.Description, description);
+            }
+
+            using var doc = JsonDocument.Parse(writer.ToString());
+            var root = doc.RootElement;
+            Assert.Equal("write", root.GetProperty("mode").GetString());
+            Assert.Equal(7, root.GetProperty("applied_count").GetInt32());
+        }
+        finally
+        {
+            AutomationLabelPaletteSyncCommand.LabelListerFactory = null;
+            AutomationLabelPaletteSyncCommand.LabelPaletteMutatorFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Sync_Idempotent_SecondRunPlansZeroActions()
+    {
+        // G366 acceptance: sync MUST be idempotent. A second sync after the
+        // palette has been applied plans zero actions and applies zero
+        // mutations.
+        AutomationLabelPaletteSyncCommand.LabelListerFactory = () =>
+            new FakeLister(WorkflowLabelPaletteContract.Canonical
+                .Select(e => new GitHubLabelMetadata
+                {
+                    Name = e.Name,
+                    Color = e.Color,
+                    Description = e.Description,
+                })
+                .ToList());
+        var mutator = new RecordingMutator();
+        AutomationLabelPaletteSyncCommand.LabelPaletteMutatorFactory = () => mutator;
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationLabelPaletteSyncCommand.Execute(
+                CreateContext(),
+                ["--repo", "owner/repo", "--write", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+            Assert.Empty(mutator.Creates);
+            Assert.Empty(mutator.Edits);
+            using var doc = JsonDocument.Parse(writer.ToString());
+            var root = doc.RootElement;
+            Assert.Equal(0, root.GetProperty("planned_count").GetInt32());
+            Assert.Equal(0, root.GetProperty("applied_count").GetInt32());
+        }
+        finally
+        {
+            AutomationLabelPaletteSyncCommand.LabelListerFactory = null;
+            AutomationLabelPaletteSyncCommand.LabelPaletteMutatorFactory = null;
+        }
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                }
+            }
+        };
+    }
+
+    private sealed class FakeLister : IGitHubLabelLister
+    {
+        private readonly IReadOnlyList<GitHubLabelMetadata> _labels;
+        public FakeLister(IReadOnlyList<GitHubLabelMetadata> labels) { _labels = labels; }
+        public IReadOnlyList<GitHubLabelMetadata> ListLabels(string repo) => _labels;
+    }
+
+    private sealed class RecordingMutator : IGitHubLabelPaletteMutator
+    {
+        public List<(string name, string color, string description)> Creates { get; } = new();
+        public List<(string name, string color, string description)> Edits { get; } = new();
+
+        public void CreateLabel(string repo, string name, string color, string description) =>
+            Creates.Add((name, color, description));
+
+        public void EditLabel(string repo, string name, string color, string description) =>
+            Edits.Add((name, color, description));
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkflowLabelPaletteAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkflowLabelPaletteAnalyzerTests.cs
@@ -1,0 +1,192 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G366: covers the pure palette diff analyzer. Each test feeds a
+/// canned <see cref="GitHubLabelMetadata"/> list and asserts the
+/// per-entry classification and the aggregate counts.
+/// </summary>
+public sealed class WorkflowLabelPaletteAnalyzerTests
+{
+    [Fact]
+    public void Canonical_PaletteContainsExactlyEightLabels()
+    {
+        // G366 acceptance: the canonical palette is exhaustive and stable.
+        Assert.Equal(8, WorkflowLabelPaletteContract.Canonical.Count);
+        var names = WorkflowLabelPaletteContract.Canonical.Select(e => e.Name).ToHashSet();
+        Assert.Contains("intent-target", names);
+        Assert.Contains("intent-issue-in-progress", names);
+        Assert.Contains("intent-pr-created", names);
+        Assert.Contains("intent-pr-reviewing", names);
+        Assert.Contains("intent-pr-request-update", names);
+        Assert.Contains("intent-pr-update-in-progress", names);
+        Assert.Contains("intent-pr-rereview-ready", names);
+        Assert.Contains("intent-pr-approved", names);
+    }
+
+    [Fact]
+    public void Canonical_AllEntriesHaveSixCharHexColorAndNonEmptyDescription()
+    {
+        // G366: enforce the palette shape so future additions can't
+        // silently break audit comparison (colors must be 6 hex digits;
+        // descriptions must be non-empty so missing-description drift
+        // stays distinguishable from empty-description-is-canonical).
+        foreach (var entry in WorkflowLabelPaletteContract.Canonical)
+        {
+            Assert.Equal(6, entry.Color.Length);
+            Assert.Matches("^[0-9A-Fa-f]{6}$", entry.Color);
+            Assert.False(string.IsNullOrWhiteSpace(entry.Description),
+                $"canonical entry `{entry.Name}` must have a non-empty description");
+        }
+    }
+
+    [Fact]
+    public void Analyze_AllLabelsMissing_ReturnsAllMissing()
+    {
+        var result = WorkflowLabelPaletteAnalyzer.Analyze("owner/repo", Array.Empty<GitHubLabelMetadata>());
+
+        Assert.Equal(WorkflowLabelPaletteContract.Canonical.Count, result.MissingCount);
+        Assert.Equal(0, result.OkCount);
+        Assert.Equal(0, result.WrongColorCount);
+        Assert.Equal(0, result.WrongDescriptionCount);
+        Assert.Equal(WorkflowLabelPaletteContract.Canonical.Count, result.DriftCount);
+        Assert.All(result.Entries, e =>
+        {
+            Assert.Equal(WorkflowLabelPaletteAnalyzer.StatusMissing, e.Status);
+            Assert.Null(e.CurrentColor);
+            Assert.Null(e.CurrentDescription);
+        });
+    }
+
+    [Fact]
+    public void Analyze_AllCanonical_ReturnsAllOk()
+    {
+        var observed = WorkflowLabelPaletteContract.Canonical
+            .Select(e => new GitHubLabelMetadata
+            {
+                Name = e.Name,
+                Color = e.Color,
+                Description = e.Description,
+            })
+            .ToList();
+
+        var result = WorkflowLabelPaletteAnalyzer.Analyze("owner/repo", observed);
+
+        Assert.Equal(0, result.MissingCount);
+        Assert.Equal(0, result.WrongColorCount);
+        Assert.Equal(0, result.WrongDescriptionCount);
+        Assert.Equal(WorkflowLabelPaletteContract.Canonical.Count, result.OkCount);
+        Assert.Equal(0, result.DriftCount);
+    }
+
+    [Fact]
+    public void Analyze_ColorCaseInsensitive_TreatsLowercaseHexAsCanonical()
+    {
+        // G366: GitHub returns lowercase hex from `--json color` while
+        // intent-cli stores uppercase. Comparison must be case-insensitive.
+        var canonical = WorkflowLabelPaletteContract.Canonical[0];
+        var observed = new[]
+        {
+            new GitHubLabelMetadata
+            {
+                Name = canonical.Name,
+                Color = canonical.Color.ToLowerInvariant(),
+                Description = canonical.Description,
+            },
+        };
+
+        var result = WorkflowLabelPaletteAnalyzer.Analyze("owner/repo", observed);
+        var entry = result.Entries.First(e => e.Name == canonical.Name);
+
+        Assert.Equal(WorkflowLabelPaletteAnalyzer.StatusOk, entry.Status);
+    }
+
+    [Fact]
+    public void Analyze_WrongColorOnly_ReturnsWrongColorEntry()
+    {
+        var canonical = WorkflowLabelPaletteContract.Canonical[0];
+        var observed = new[]
+        {
+            new GitHubLabelMetadata
+            {
+                Name = canonical.Name,
+                Color = "FFFFFF",
+                Description = canonical.Description,
+            },
+        };
+
+        var result = WorkflowLabelPaletteAnalyzer.Analyze("owner/repo", observed);
+        var entry = result.Entries.First(e => e.Name == canonical.Name);
+
+        Assert.Equal(WorkflowLabelPaletteAnalyzer.StatusWrongColor, entry.Status);
+        Assert.Equal("FFFFFF", entry.CurrentColor);
+        Assert.Equal(canonical.Description, entry.CurrentDescription);
+        Assert.Equal(1, result.WrongColorCount);
+        Assert.Equal(0, result.WrongDescriptionCount);
+    }
+
+    [Fact]
+    public void Analyze_WrongDescriptionOnly_ReturnsWrongDescriptionEntry()
+    {
+        var canonical = WorkflowLabelPaletteContract.Canonical[0];
+        var observed = new[]
+        {
+            new GitHubLabelMetadata
+            {
+                Name = canonical.Name,
+                Color = canonical.Color,
+                Description = "out of date description",
+            },
+        };
+
+        var result = WorkflowLabelPaletteAnalyzer.Analyze("owner/repo", observed);
+        var entry = result.Entries.First(e => e.Name == canonical.Name);
+
+        Assert.Equal(WorkflowLabelPaletteAnalyzer.StatusWrongDescription, entry.Status);
+        Assert.Equal(0, result.WrongColorCount);
+        Assert.Equal(1, result.WrongDescriptionCount);
+    }
+
+    [Fact]
+    public void Analyze_WrongColorAndDescription_ReturnsCombinedStatus()
+    {
+        // Build a fully-populated observed set: all canonical entries
+        // match except canonical[0], which has BOTH wrong color and
+        // wrong description. Counters on both axes increment; the
+        // entry contributes exactly 1 to drift_count (single-entry
+        // de-duplication contract).
+        var observed = WorkflowLabelPaletteContract.Canonical
+            .Select((entry, index) => index == 0
+                ? new GitHubLabelMetadata { Name = entry.Name, Color = "FFFFFF", Description = "out of date" }
+                : new GitHubLabelMetadata { Name = entry.Name, Color = entry.Color, Description = entry.Description })
+            .ToList();
+
+        var result = WorkflowLabelPaletteAnalyzer.Analyze("owner/repo", observed);
+        var entry = result.Entries.First(e => e.Name == WorkflowLabelPaletteContract.Canonical[0].Name);
+
+        Assert.Equal(WorkflowLabelPaletteAnalyzer.StatusWrongColorAndDescription, entry.Status);
+        Assert.Equal(1, result.WrongColorCount);
+        Assert.Equal(1, result.WrongDescriptionCount);
+        // Single combined entry contributes exactly 1 to drift_count;
+        // the 7 other canonical labels are already in sync.
+        Assert.Equal(1, result.DriftCount);
+    }
+
+    [Fact]
+    public void Analyze_NonCanonicalLabelsAreIgnored()
+    {
+        // G366 out-of-scope: only canonical workflow labels are reported.
+        // Non-intent labels must not surface in the audit.
+        var observed = new[]
+        {
+            new GitHubLabelMetadata { Name = "bug", Color = "EE0701", Description = "A bug" },
+            new GitHubLabelMetadata { Name = "documentation", Color = "0075CA", Description = "Docs" },
+        };
+
+        var result = WorkflowLabelPaletteAnalyzer.Analyze("owner/repo", observed);
+
+        Assert.Equal(WorkflowLabelPaletteContract.Canonical.Count, result.MissingCount);
+        Assert.DoesNotContain(result.Entries, e => e.Name == "bug" || e.Name == "documentation");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #835.

- `WorkflowLabelPaletteContract` defines canonical name + color + description for the 8 intent workflow labels (`intent-target`, `intent-issue-in-progress`, `intent-pr-created`, `intent-pr-reviewing`, `intent-pr-request-update`, `intent-pr-update-in-progress`, `intent-pr-rereview-ready`, `intent-pr-approved`).
- `automation label-palette-audit --repo <r> [--format text|json]` reports per-entry status (`ok` | `missing` | `wrong-color` | `wrong-description` | `wrong-color-and-description`) plus aggregate counters and a single `drift_count` (each entry counted once).
- `automation label-palette-sync --repo <r> [--write] [--format text|json]` plans `create` for missing labels and `edit` for drifted ones. Without `--write` it emits a dry-run plan; with `--write` it applies via `gh label create` / `gh label edit`. **Idempotent**: a second sync against an already-synced repo plans and applies zero actions (covered by `Sync_Idempotent_SecondRunPlansZeroActions`).
- Never mutates label assignments on existing issues or PRs — that remains the worker / automation transition contract.

## Test plan

- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj` — 3149 passed, 1 pre-existing skip, 0 failed.
- [x] 15 new tests: 8 in `WorkflowLabelPaletteAnalyzerTests` (palette shape, all-missing, all-in-sync, case-insensitive color, wrong-color, wrong-description, combined, non-canonical labels ignored), 7 in `AutomationLabelPaletteCommandsTests` (audit in-sync JSON shape, audit drifted, audit missing --repo validation, sync dry-run plans only, sync --write applies create + edit, sync idempotency, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)