### PR TITLE
G367: Build private-preview NuGet artifacts on every main merge

### DIFF
--- a/.github/workflows/private-preview-pack.yml
+++ b/.github/workflows/private-preview-pack.yml
@@ -1,8 +1,8 @@
 # G367: build a private-preview intent-cli .nupkg on every merge to
 # main and upload it as a workflow artifact. Private testers download
 # the artifact and install the tool from a local folder source rather
-# than from public NuGet — see README.md "Private-preview install" for
-# the consumption steps. Two key properties of this workflow:
+# than from public NuGet -- see README.md "Private-preview install" for
+# the consumption steps. Three key properties of this workflow:
 #
 #   1. The package version changes on every run so a tester can tell
 #      which CI build they installed. The patch component is derived
@@ -13,10 +13,18 @@
 #   2. The CI build embeds machine-readable preview metadata
 #      (channel / build timestamp / expires-at / source commit) into
 #      the produced assembly via MSBuild properties consumed by
-#      `src/IntentSystem.Cli/IntentSystem.Cli.csproj`. Local source
-#      builds that do not set these properties produce a package with
-#      no expiry contract — matching the issue acceptance that
-#      contributor builds remain unrestricted.
+#      `src/IntentSystem.Cli/IntentSystem.Cli.csproj`. The pack step
+#      compiles the CLI fresh with those properties active (no
+#      `--no-build`) so the conditional `AssemblyMetadata` ItemGroup is
+#      actually materialized into the packaged DLL.
+#
+#   3. A deterministic verifier (`tools/PreviewArtifactVerify`) opens
+#      the produced .nupkg, walks the embedded IntentSystem.Cli.dll's
+#      AssemblyMetadata custom attributes, and fails the workflow if
+#      the preview pack is missing any `PrivatePreview*` entry OR if a
+#      source-only pack (same source tree, no preview properties)
+#      accidentally carries them. This makes the build-time wiring
+#      regression-proof without depending on a real GitHub Actions run.
 name: private-preview-pack
 
 on:
@@ -35,7 +43,7 @@ concurrency:
 jobs:
   pack:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,23 +77,39 @@ jobs:
       - name: Restore
         run: dotnet restore IntentSystem.sln
 
-      - name: Build
+      - name: Build (source contract, no preview properties)
         run: dotnet build IntentSystem.sln --configuration Release --no-restore
 
-      - name: Test
+      - name: Test (source contract)
         run: dotnet test IntentSystem.sln --configuration Release --no-build --logger "trx;LogFileName=test-results.trx"
 
-      - name: Pack private-preview .nupkg
+      - name: Pack private-preview .nupkg (recompiles with preview properties active)
         run: |
           dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
             --configuration Release \
-            --no-build \
             -o .artifacts/private-preview \
             -p:Version=${{ steps.meta.outputs.package_version }} \
             -p:PrivatePreviewChannel=private-preview \
             -p:PrivatePreviewBuildTimestamp=${{ steps.meta.outputs.build_timestamp }} \
             -p:PrivatePreviewExpiresAt=${{ steps.meta.outputs.expires_at }} \
             -p:PrivatePreviewSourceCommit=${{ github.sha }}
+
+      - name: Pack source baseline (no preview properties)
+        run: |
+          dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
+            --configuration Release \
+            -o .artifacts/source-baseline
+
+      - name: Verify preview pack embeds AssemblyMetadata
+        run: |
+          PREVIEW_NUPKG="$(ls .artifacts/private-preview/intent-cli.*.nupkg | head -n 1)"
+          SOURCE_NUPKG="$(ls .artifacts/source-baseline/intent-cli.*.nupkg | head -n 1)"
+          echo "preview-nupkg=${PREVIEW_NUPKG}"
+          echo "source-nupkg=${SOURCE_NUPKG}"
+          dotnet run --project tools/PreviewArtifactVerify --configuration Release -- \
+            "${PREVIEW_NUPKG}" --expect-preview
+          dotnet run --project tools/PreviewArtifactVerify --configuration Release -- \
+            "${SOURCE_NUPKG}" --expect-no-preview
 
       - name: Write artifact metadata
         run: |

--- a/.github/workflows/private-preview-pack.yml
+++ b/.github/workflows/private-preview-pack.yml
@@ -1,0 +1,112 @@
+# G367: build a private-preview intent-cli .nupkg on every merge to
+# main and upload it as a workflow artifact. Private testers download
+# the artifact and install the tool from a local folder source rather
+# than from public NuGet — see README.md "Private-preview install" for
+# the consumption steps. Two key properties of this workflow:
+#
+#   1. The package version changes on every run so a tester can tell
+#      which CI build they installed. The patch component is derived
+#      from `github.run_number` plus `github.run_attempt` so two
+#      different workflow runs of the same commit also produce
+#      distinct versions.
+#
+#   2. The CI build embeds machine-readable preview metadata
+#      (channel / build timestamp / expires-at / source commit) into
+#      the produced assembly via MSBuild properties consumed by
+#      `src/IntentSystem.Cli/IntentSystem.Cli.csproj`. Local source
+#      builds that do not set these properties produce a package with
+#      no expiry contract — matching the issue acceptance that
+#      contributor builds remain unrestricted.
+name: private-preview-pack
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: private-preview-pack-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  pack:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          dotnet-quality: preview
+
+      - name: Compute private-preview metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          BASE_VERSION="0.2.0"
+          BUILD_NUMBER="${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          PACKAGE_VERSION="${BASE_VERSION}-preview.${BUILD_NUMBER}"
+          BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          EXPIRES_AT="$(date -u -d '+14 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || python3 -c 'import datetime; print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(days=14)).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
+          SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+          {
+            echo "package_version=${PACKAGE_VERSION}"
+            echo "build_timestamp=${BUILD_TIMESTAMP}"
+            echo "expires_at=${EXPIRES_AT}"
+            echo "short_sha=${SHORT_SHA}"
+          } | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Restore
+        run: dotnet restore IntentSystem.sln
+
+      - name: Build
+        run: dotnet build IntentSystem.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test IntentSystem.sln --configuration Release --no-build --logger "trx;LogFileName=test-results.trx"
+
+      - name: Pack private-preview .nupkg
+        run: |
+          dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
+            --configuration Release \
+            --no-build \
+            -o .artifacts/private-preview \
+            -p:Version=${{ steps.meta.outputs.package_version }} \
+            -p:PrivatePreviewChannel=private-preview \
+            -p:PrivatePreviewBuildTimestamp=${{ steps.meta.outputs.build_timestamp }} \
+            -p:PrivatePreviewExpiresAt=${{ steps.meta.outputs.expires_at }} \
+            -p:PrivatePreviewSourceCommit=${{ github.sha }}
+
+      - name: Write artifact metadata
+        run: |
+          mkdir -p .artifacts/private-preview
+          cat > .artifacts/private-preview/preview-metadata.json <<EOF
+          {
+            "channel": "private-preview",
+            "package_version": "${{ steps.meta.outputs.package_version }}",
+            "build_timestamp": "${{ steps.meta.outputs.build_timestamp }}",
+            "expires_at": "${{ steps.meta.outputs.expires_at }}",
+            "source_commit": "${{ github.sha }}",
+            "source_short_sha": "${{ steps.meta.outputs.short_sha }}",
+            "run_number": "${{ github.run_number }}",
+            "run_attempt": "${{ github.run_attempt }}"
+          }
+          EOF
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: intent-cli-private-preview-${{ steps.meta.outputs.package_version }}
+          path: .artifacts/private-preview/**
+          retention-days: 14
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -43,6 +43,41 @@ Equivalent `dnx` path:
 (cd .artifacts/smoke-repo && dnx --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" intent-cli project status)
 ```
 
+## Private-preview install (G367)
+
+The `private-preview-pack` GitHub Actions workflow runs on every merge to
+`main` and uploads an `intent-cli` `.nupkg` plus a `preview-metadata.json`
+descriptor as a workflow artifact named
+`intent-cli-private-preview-<version>`. The package version pattern is
+`0.2.0-preview.<run_number>.<run_attempt>`, so every CI run produces a
+distinct version.
+
+Install or update from a downloaded artifact:
+
+```bash
+# 1. Download and unzip the workflow artifact from the GitHub Actions
+#    run page, e.g. into ./private-preview-package.
+# 2. Install (or update) the .NET tool from that local folder:
+dotnet tool install --global --add-source ./private-preview-package \
+  --version 0.2.0-preview.<run_number>.<run_attempt> intent-cli
+# Or for an upgrade-in-place:
+dotnet tool update --global --add-source ./private-preview-package \
+  --version 0.2.0-preview.<run_number>.<run_attempt> intent-cli
+```
+
+The installed binary exposes the preview metadata via `intent-cli --version`:
+
+```text
+intent-cli 0.2.0-preview.<run_number>.<run_attempt>-<short-sha>-G<unit>
+channel=private-preview built=<iso-utc> expires=<iso-utc> commit=<full-sha>
+```
+
+CI-built private-preview packages expire 14 days after their build
+timestamp; refresh the install from a newer workflow run when the
+`expires=` line moves into the past. Local source builds
+(`dotnet pack` without the CI properties) carry no expiry trailer and
+remain unrestricted.
+
 ## CLI command roles
 
 The accepted production automation boundary lives in the parent host-side

--- a/src/IntentSystem.Cli/Commands/VersionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/VersionCommand.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using IntentSystem.Cli.Infrastructure;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -26,6 +27,25 @@ internal static class VersionCommand
     public static string? OverrideVersionString { get; set; }
 
     /// <summary>
+    /// G367 test seam: override the resolved
+    /// <see cref="PrivatePreviewMetadata"/> for tests so they can
+    /// assert the version output contains (or omits) the optional
+    /// private-preview trailer without rebuilding the assembly.
+    /// Setting this to <c>null</c> falls back to reading the running
+    /// assembly's <see cref="AssemblyMetadataAttribute"/> entries.
+    /// </summary>
+    public static PrivatePreviewMetadata? OverridePrivatePreviewMetadata { get; set; }
+
+    /// <summary>
+    /// G367 test seam: when <c>true</c>, <see cref="Execute"/> skips
+    /// reading <see cref="PrivatePreviewMetadata.Read"/> against the
+    /// real assembly so existing tests that pinned the single-line
+    /// output stay deterministic regardless of whether the build
+    /// embedded preview metadata.
+    /// </summary>
+    public static bool SuppressPrivatePreviewTrailer { get; set; }
+
+    /// <summary>
     /// Returns <c>true</c> when <paramref name="args"/> request the
     /// version output (the recognized shapes are <c>--version</c>,
     /// <c>-v</c>, or <c>version</c> as the first or only token).
@@ -49,6 +69,27 @@ internal static class VersionCommand
         var versionString = OverrideVersionString
             ?? BuildVersionString(typeof(VersionCommand).Assembly);
         writer.WriteLine(versionString);
+
+        // G367: when the CI workflow built this assembly with the
+        // private-preview metadata properties, append a single
+        // additional line so operators can tell a CI preview artifact
+        // from a source build without scraping the package itself.
+        // Local builds (no AssemblyMetadata("PrivatePreviewChannel"))
+        // are silent here, matching the issue acceptance that source
+        // builds carry no expiry contract. The
+        // <see cref="SuppressPrivatePreviewTrailer"/> seam keeps
+        // existing single-line `--version` tests deterministic across
+        // CI/source environments.
+        if (OverrideVersionString is null && !SuppressPrivatePreviewTrailer)
+        {
+            var preview = OverridePrivatePreviewMetadata
+                ?? PrivatePreviewMetadata.Read(typeof(VersionCommand).Assembly);
+            if (preview is not null)
+            {
+                writer.WriteLine(preview.ToVersionTrailer());
+            }
+        }
+
         return 0;
     }
 

--- a/src/IntentSystem.Cli/Infrastructure/PrivatePreviewMetadata.cs
+++ b/src/IntentSystem.Cli/Infrastructure/PrivatePreviewMetadata.cs
@@ -1,0 +1,158 @@
+using System.Globalization;
+using System.Reflection;
+
+namespace IntentSystem.Cli.Infrastructure;
+
+/// <summary>
+/// G367: machine-readable private-preview metadata baked into a
+/// CI-built <c>intent-cli</c> package. The CI workflow that runs on
+/// every merge to <c>main</c> passes MSBuild properties
+/// (<c>PrivatePreviewChannel</c>, <c>PrivatePreviewBuildTimestamp</c>,
+/// <c>PrivatePreviewExpiresAt</c>, <c>PrivatePreviewSourceCommit</c>)
+/// which the csproj copies into <see cref="AssemblyMetadataAttribute"/>
+/// entries. Local source builds that do not set
+/// <c>PrivatePreviewChannel</c> leave the assembly free of these
+/// attributes, so <see cref="Read"/> returns <c>null</c> and the
+/// binary has no expiry restriction — matching the issue acceptance
+/// "Local source build without CI preview properties has no expiry
+/// restriction."
+///
+/// Why a separate record: keeping this small, allocation-light, and
+/// dependency-free lets <c>--version</c> append a single non-host
+/// line without touching <c>.intent-cli/</c>, GitHub, or queue
+/// state. The expiry calculation lives in
+/// <see cref="ComputeExpiresAt"/> so unit tests can exercise the
+/// 14-day window without spinning up a real GitHub Actions run.
+/// </summary>
+internal sealed record PrivatePreviewMetadata
+{
+    /// <summary>
+    /// Standard private-preview window. Embedded preview artifacts
+    /// expire 14 days after their CI build timestamp, after which
+    /// the operator must download a fresh artifact from a later
+    /// main-merge run.
+    /// </summary>
+    public static readonly TimeSpan PreviewWindow = TimeSpan.FromDays(14);
+
+    public const string ChannelAttributeName = "PrivatePreviewChannel";
+    public const string BuildTimestampAttributeName = "PrivatePreviewBuildTimestamp";
+    public const string ExpiresAtAttributeName = "PrivatePreviewExpiresAt";
+    public const string SourceCommitAttributeName = "PrivatePreviewSourceCommit";
+
+    public const string ChannelPrivatePreview = "private-preview";
+
+    public required string Channel { get; init; }
+    public required DateTimeOffset BuildTimestamp { get; init; }
+    public required DateTimeOffset ExpiresAt { get; init; }
+    public required string SourceCommit { get; init; }
+
+    /// <summary>
+    /// Pure helper: returns <paramref name="buildTimestamp"/> +
+    /// <see cref="PreviewWindow"/>. Centralising the calculation
+    /// keeps the workflow and the test surface honest: a unit test
+    /// can assert the 14-day window without invoking
+    /// <c>dotnet pack</c> or a GitHub Actions runner.
+    /// </summary>
+    public static DateTimeOffset ComputeExpiresAt(DateTimeOffset buildTimestamp)
+    {
+        return buildTimestamp + PreviewWindow;
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="now"/> falls strictly
+    /// after the recorded <see cref="ExpiresAt"/>. The boundary
+    /// minute itself is still considered "in-window" so a clock skew
+    /// of a few seconds does not flip an artifact to expired right
+    /// at the cutoff.
+    /// </summary>
+    public bool IsExpired(DateTimeOffset now)
+    {
+        return now > ExpiresAt;
+    }
+
+    /// <summary>
+    /// Build a metadata record from a dictionary of attribute values
+    /// (typically pulled from
+    /// <see cref="AssemblyMetadataAttribute"/> entries on the
+    /// running assembly). Returns <c>null</c> when the required
+    /// channel marker is absent, missing, or blank — that case
+    /// signals "this is a plain source build, no expiry contract."
+    /// </summary>
+    public static PrivatePreviewMetadata? TryParse(IReadOnlyDictionary<string, string?> attributes)
+    {
+        ArgumentNullException.ThrowIfNull(attributes);
+
+        if (!attributes.TryGetValue(ChannelAttributeName, out var channel)
+            || string.IsNullOrWhiteSpace(channel))
+        {
+            return null;
+        }
+
+        attributes.TryGetValue(BuildTimestampAttributeName, out var builtAtRaw);
+        attributes.TryGetValue(ExpiresAtAttributeName, out var expiresAtRaw);
+        attributes.TryGetValue(SourceCommitAttributeName, out var sourceCommit);
+
+        if (!TryParseTimestamp(builtAtRaw, out var builtAt))
+        {
+            return null;
+        }
+        if (!TryParseTimestamp(expiresAtRaw, out var expiresAt))
+        {
+            // Defensive: if CI forgot to pass an explicit expiry,
+            // recompute it from the build timestamp so callers can
+            // still tell when this artifact ages out.
+            expiresAt = ComputeExpiresAt(builtAt);
+        }
+
+        return new PrivatePreviewMetadata
+        {
+            Channel = channel.Trim(),
+            BuildTimestamp = builtAt,
+            ExpiresAt = expiresAt,
+            SourceCommit = string.IsNullOrWhiteSpace(sourceCommit) ? string.Empty : sourceCommit.Trim(),
+        };
+    }
+
+    /// <summary>
+    /// Read CI-baked metadata from the supplied assembly's
+    /// <see cref="AssemblyMetadataAttribute"/> entries. Returns
+    /// <c>null</c> for ordinary source builds.
+    /// </summary>
+    public static PrivatePreviewMetadata? Read(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+        var attrs = assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .ToDictionary(a => a.Key, a => (string?)a.Value, StringComparer.Ordinal);
+        return TryParse(attrs);
+    }
+
+    /// <summary>
+    /// Format the metadata as a single-line, key=value summary
+    /// suitable for appending to <c>intent-cli --version</c> output.
+    /// Operators can grep this line to distinguish a CI private-
+    /// preview artifact from a source build:
+    /// <c>channel=private-preview built=2026-05-19T12:34:56Z expires=2026-06-02T12:34:56Z commit=f6cbf65</c>.
+    /// </summary>
+    public string ToVersionTrailer()
+    {
+        var builtAtIso = BuildTimestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+        var expiresAtIso = ExpiresAt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+        var commitSegment = string.IsNullOrEmpty(SourceCommit) ? string.Empty : $" commit={SourceCommit}";
+        return $"channel={Channel} built={builtAtIso} expires={expiresAtIso}{commitSegment}";
+    }
+
+    private static bool TryParseTimestamp(string? raw, out DateTimeOffset parsed)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            parsed = default;
+            return false;
+        }
+        return DateTimeOffset.TryParse(
+            raw,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out parsed);
+    }
+}

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -56,6 +56,31 @@
     </PropertyGroup>
   </Target>
 
+  <!--
+    G367: when the CI private-preview pack workflow runs on a merge to
+    main it sets four MSBuild properties so the produced .nupkg
+    embeds machine-readable preview metadata as
+    AssemblyMetadata("PrivatePreview...") attributes. A normal local
+    `dotnet build` / `dotnet pack` leaves the properties blank, which
+    skips this ItemGroup entirely and produces a source build with no
+    expiry contract, matching the issue acceptance that source builds
+    remain unrestricted. CI passes:
+      PrivatePreviewChannel=private-preview
+      PrivatePreviewBuildTimestamp=ISO-8601 UTC build timestamp
+      PrivatePreviewExpiresAt=ISO-8601 UTC build timestamp plus 14 days
+      PrivatePreviewSourceCommit=full git SHA
+    The runtime side reads the resulting attributes in
+    IntentSystem.Cli.Infrastructure.PrivatePreviewMetadata so
+    `intent-cli version` can surface the channel and expiry to the
+    private tester without depending on host state.
+  -->
+  <ItemGroup Condition="'$(PrivatePreviewChannel)' != ''">
+    <AssemblyMetadata Include="PrivatePreviewChannel" Value="$(PrivatePreviewChannel)" />
+    <AssemblyMetadata Include="PrivatePreviewBuildTimestamp" Value="$(PrivatePreviewBuildTimestamp)" />
+    <AssemblyMetadata Include="PrivatePreviewExpiresAt" Value="$(PrivatePreviewExpiresAt)" />
+    <AssemblyMetadata Include="PrivatePreviewSourceCommit" Value="$(PrivatePreviewSourceCommit)" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\IntentSystem.Clarify\IntentSystem.Clarify.csproj" />
     <ProjectReference Include="..\IntentSystem.ConceptIntake\IntentSystem.ConceptIntake.csproj" />

--- a/tests/IntentSystem.Cli.Tests/PrivatePreviewMetadataTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PrivatePreviewMetadataTests.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G367: covers the pure helpers behind the CI private-preview pack
+/// workflow so the 14-day expiry contract and metadata parsing can be
+/// asserted without spinning up a real GitHub Actions run.
+/// </summary>
+public sealed class PrivatePreviewMetadataTests
+{
+    [Fact]
+    public void ComputeExpiresAt_AddsFourteenDayWindow()
+    {
+        var built = new DateTimeOffset(2026, 5, 19, 12, 34, 56, TimeSpan.Zero);
+        var expires = PrivatePreviewMetadata.ComputeExpiresAt(built);
+        Assert.Equal(TimeSpan.FromDays(14), expires - built);
+        Assert.Equal(new DateTimeOffset(2026, 6, 2, 12, 34, 56, TimeSpan.Zero), expires);
+    }
+
+    [Fact]
+    public void PreviewWindow_Is14Days()
+    {
+        // Guard the published constant so the workflow and runtime
+        // never drift out of sync silently.
+        Assert.Equal(TimeSpan.FromDays(14), PrivatePreviewMetadata.PreviewWindow);
+    }
+
+    [Fact]
+    public void TryParse_ReadsAllAttributes()
+    {
+        var attrs = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [PrivatePreviewMetadata.ChannelAttributeName] = "private-preview",
+            [PrivatePreviewMetadata.BuildTimestampAttributeName] = "2026-05-19T12:34:56Z",
+            [PrivatePreviewMetadata.ExpiresAtAttributeName] = "2026-06-02T12:34:56Z",
+            [PrivatePreviewMetadata.SourceCommitAttributeName] = "f6cbf65b1234567890",
+        };
+
+        var meta = PrivatePreviewMetadata.TryParse(attrs);
+
+        Assert.NotNull(meta);
+        Assert.Equal("private-preview", meta!.Channel);
+        Assert.Equal(new DateTimeOffset(2026, 5, 19, 12, 34, 56, TimeSpan.Zero), meta.BuildTimestamp);
+        Assert.Equal(new DateTimeOffset(2026, 6, 2, 12, 34, 56, TimeSpan.Zero), meta.ExpiresAt);
+        Assert.Equal("f6cbf65b1234567890", meta.SourceCommit);
+    }
+
+    [Fact]
+    public void TryParse_WithoutChannel_ReturnsNull()
+    {
+        var attrs = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [PrivatePreviewMetadata.BuildTimestampAttributeName] = "2026-05-19T12:34:56Z",
+        };
+
+        Assert.Null(PrivatePreviewMetadata.TryParse(attrs));
+    }
+
+    [Fact]
+    public void TryParse_WithBlankChannel_ReturnsNull()
+    {
+        var attrs = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [PrivatePreviewMetadata.ChannelAttributeName] = "   ",
+            [PrivatePreviewMetadata.BuildTimestampAttributeName] = "2026-05-19T12:34:56Z",
+        };
+
+        Assert.Null(PrivatePreviewMetadata.TryParse(attrs));
+    }
+
+    [Fact]
+    public void TryParse_WithMissingExpiry_RecomputesFromBuildTimestamp()
+    {
+        // Defensive lane: if CI ever forgets to pass the explicit
+        // expiry property, the runtime still reports a sane 14-day
+        // window relative to the embedded build timestamp.
+        var attrs = new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            [PrivatePreviewMetadata.ChannelAttributeName] = "private-preview",
+            [PrivatePreviewMetadata.BuildTimestampAttributeName] = "2026-05-19T00:00:00Z",
+            [PrivatePreviewMetadata.SourceCommitAttributeName] = "abc1234",
+        };
+
+        var meta = PrivatePreviewMetadata.TryParse(attrs);
+
+        Assert.NotNull(meta);
+        Assert.Equal(new DateTimeOffset(2026, 6, 2, 0, 0, 0, TimeSpan.Zero), meta!.ExpiresAt);
+    }
+
+    [Fact]
+    public void IsExpired_ComparesAgainstUtcExpiry()
+    {
+        var meta = new PrivatePreviewMetadata
+        {
+            Channel = "private-preview",
+            BuildTimestamp = new DateTimeOffset(2026, 5, 19, 0, 0, 0, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2026, 6, 2, 0, 0, 0, TimeSpan.Zero),
+            SourceCommit = "abc1234",
+        };
+
+        Assert.False(meta.IsExpired(new DateTimeOffset(2026, 6, 2, 0, 0, 0, TimeSpan.Zero)));
+        Assert.False(meta.IsExpired(new DateTimeOffset(2026, 5, 20, 12, 0, 0, TimeSpan.Zero)));
+        Assert.True(meta.IsExpired(new DateTimeOffset(2026, 6, 2, 0, 0, 1, TimeSpan.Zero)));
+        Assert.True(meta.IsExpired(new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero)));
+    }
+
+    [Fact]
+    public void ToVersionTrailer_FormatsAsIsoUtcWithCommit()
+    {
+        var meta = new PrivatePreviewMetadata
+        {
+            Channel = "private-preview",
+            BuildTimestamp = new DateTimeOffset(2026, 5, 19, 12, 34, 56, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2026, 6, 2, 12, 34, 56, TimeSpan.Zero),
+            SourceCommit = "f6cbf65",
+        };
+
+        Assert.Equal(
+            "channel=private-preview built=2026-05-19T12:34:56Z expires=2026-06-02T12:34:56Z commit=f6cbf65",
+            meta.ToVersionTrailer());
+    }
+
+    [Fact]
+    public void ToVersionTrailer_BlankCommit_OmitsCommitSegment()
+    {
+        var meta = new PrivatePreviewMetadata
+        {
+            Channel = "private-preview",
+            BuildTimestamp = new DateTimeOffset(2026, 5, 19, 12, 34, 56, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2026, 6, 2, 12, 34, 56, TimeSpan.Zero),
+            SourceCommit = "",
+        };
+
+        Assert.Equal(
+            "channel=private-preview built=2026-05-19T12:34:56Z expires=2026-06-02T12:34:56Z",
+            meta.ToVersionTrailer());
+    }
+
+    [Fact]
+    public void Read_FromAssemblyWithoutMetadata_ReturnsNull()
+    {
+        // The test assembly is an ordinary source build with no
+        // private-preview MSBuild properties, so reading its
+        // AssemblyMetadata returns null — matching the contract that
+        // local source builds carry no expiry restriction.
+        var meta = PrivatePreviewMetadata.Read(typeof(PrivatePreviewMetadataTests).Assembly);
+        Assert.Null(meta);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/VersionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionCommandTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Reflection;
 using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Infrastructure;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -9,11 +10,20 @@ public sealed class VersionCommandTests : IDisposable
     public VersionCommandTests()
     {
         VersionCommand.OverrideVersionString = null;
+        VersionCommand.OverridePrivatePreviewMetadata = null;
+        // G367: the binary embedded into this test process might carry
+        // AssemblyMetadata("PrivatePreviewChannel") when the CI pack
+        // workflow built it. Tests that pin the single-line `--version`
+        // contract must opt out so a CI run does not accidentally trip
+        // them by appending the metadata trailer.
+        VersionCommand.SuppressPrivatePreviewTrailer = true;
     }
 
     public void Dispose()
     {
         VersionCommand.OverrideVersionString = null;
+        VersionCommand.OverridePrivatePreviewMetadata = null;
+        VersionCommand.SuppressPrivatePreviewTrailer = false;
     }
 
     [Theory]
@@ -183,6 +193,58 @@ public sealed class VersionCommandTests : IDisposable
                 Directory.Delete(nonHostDir, recursive: true);
             }
         }
+    }
+
+    [Fact]
+    public void Execute_WithPrivatePreviewMetadataOverride_AppendsTrailerLineAfterVersion()
+    {
+        // G367: a CI-built private-preview package surfaces an extra
+        // single-line trailer below the version banner so operators
+        // can grep `channel=private-preview` and `expires=` without
+        // unpacking the .nupkg or touching host state.
+        VersionCommand.SuppressPrivatePreviewTrailer = false;
+        VersionCommand.OverridePrivatePreviewMetadata = new PrivatePreviewMetadata
+        {
+            Channel = PrivatePreviewMetadata.ChannelPrivatePreview,
+            BuildTimestamp = new DateTimeOffset(2026, 5, 19, 12, 34, 56, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2026, 6, 2, 12, 34, 56, TimeSpan.Zero),
+            SourceCommit = "f6cbf65",
+        };
+        using var writer = new StringWriter();
+
+        var exitCode = VersionCommand.Execute(writer);
+
+        Assert.Equal(0, exitCode);
+        var lines = writer.ToString()
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        Assert.Equal(2, lines.Length);
+        Assert.StartsWith("intent-cli ", lines[0], StringComparison.Ordinal);
+        Assert.Equal(
+            "channel=private-preview built=2026-05-19T12:34:56Z expires=2026-06-02T12:34:56Z commit=f6cbf65",
+            lines[1]);
+    }
+
+    [Fact]
+    public void Execute_WithoutPrivatePreviewMetadata_OmitsTrailer()
+    {
+        // G367: source builds (no AssemblyMetadata("PrivatePreviewChannel"))
+        // must NOT emit the trailer so the `--version` contract stays
+        // single-line for ordinary contributors.
+        VersionCommand.SuppressPrivatePreviewTrailer = false;
+        VersionCommand.OverridePrivatePreviewMetadata = null;
+        using var writer = new StringWriter();
+
+        var exitCode = VersionCommand.Execute(writer);
+
+        Assert.Equal(0, exitCode);
+        var lines = writer.ToString()
+            .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+        // The running test assembly has no private-preview metadata
+        // baked in unless the CI workflow set the MSBuild properties,
+        // which the suppression seam above accounts for. Without the
+        // override the trailer must be absent.
+        Assert.Single(lines);
+        Assert.StartsWith("intent-cli ", lines[0], StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tools/PreviewArtifactVerify/PreviewArtifactVerify.csproj
+++ b/tools/PreviewArtifactVerify/PreviewArtifactVerify.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    G367: deterministic verifier the private-preview-pack workflow runs
+    after packing to prove the produced .nupkg compiled DLL carries (or
+    omits) the four PrivatePreview AssemblyMetadata entries. Lives
+    outside the main solution so adding or removing the verifier never
+    touches the shipping product surface. See Program.cs for the CLI
+    contract.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>IntentSystem.Tools.PreviewArtifactVerify</RootNamespace>
+    <AssemblyName>PreviewArtifactVerify</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/tools/PreviewArtifactVerify/Program.cs
+++ b/tools/PreviewArtifactVerify/Program.cs
@@ -1,0 +1,198 @@
+using System.IO.Compression;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+// G367: post-pack verifier that opens the .nupkg, locates the
+// IntentSystem.Cli.dll inside its tools folder, and walks the assembly's
+// AssemblyMetadata entries to confirm the four `PrivatePreview*` keys
+// are present (preview pack) or absent (source pack). Using
+// System.Reflection.Metadata lets the verifier inspect a packaged .NET
+// 10 assembly without resolving its project references, so a .NET 10
+// runtime is the only host requirement.
+//
+// Usage:
+//   PreviewArtifactVerify <nupkg-path> --expect-preview
+//   PreviewArtifactVerify <nupkg-path> --expect-no-preview
+//
+// Exit codes:
+//   0 -- expectation matched (and printed key/value summary)
+//   1 -- usage error
+//   2 -- expectation mismatch (preview metadata present when not
+//        expected, or absent/incomplete when expected)
+//
+// The verifier intentionally avoids `Assembly.LoadFrom` so a future
+// CLI dependency change cannot accidentally fail this gate via a
+// missing transitive dependency. Only the `IntentSystem.Cli` PE file's
+// AssemblyMetadata custom attributes are inspected.
+
+const int ExitOk = 0;
+const int ExitUsage = 1;
+const int ExitMismatch = 2;
+
+if (args.Length != 2)
+{
+    Console.Error.WriteLine("usage: PreviewArtifactVerify <nupkg-path> --expect-preview|--expect-no-preview");
+    return ExitUsage;
+}
+
+var nupkgPath = args[0];
+var mode = args[1];
+if (!File.Exists(nupkgPath))
+{
+    Console.Error.WriteLine($"nupkg not found: {nupkgPath}");
+    return ExitUsage;
+}
+
+bool expectPreview = mode switch
+{
+    "--expect-preview" => true,
+    "--expect-no-preview" => false,
+    _ => throw new ArgumentException($"unknown expectation: {mode}"),
+};
+
+using var archive = ZipFile.OpenRead(nupkgPath);
+var dllEntry = archive.Entries
+    .FirstOrDefault(e =>
+        e.FullName.StartsWith("tools/", StringComparison.OrdinalIgnoreCase)
+        && e.FullName.EndsWith("/IntentSystem.Cli.dll", StringComparison.OrdinalIgnoreCase));
+
+if (dllEntry is null)
+{
+    Console.Error.WriteLine($"could not locate tools/<tfm>/<rid>/IntentSystem.Cli.dll in {nupkgPath}");
+    return ExitMismatch;
+}
+
+using var dllStream = dllEntry.Open();
+using var memory = new MemoryStream();
+dllStream.CopyTo(memory);
+memory.Position = 0;
+
+using var peReader = new PEReader(memory);
+var metadataReader = peReader.GetMetadataReader();
+var entries = ReadAssemblyMetadata(metadataReader);
+
+var previewKeys = new[]
+{
+    "PrivatePreviewChannel",
+    "PrivatePreviewBuildTimestamp",
+    "PrivatePreviewExpiresAt",
+    "PrivatePreviewSourceCommit",
+};
+
+var present = entries
+    .Where(e => previewKeys.Contains(e.Key, StringComparer.Ordinal))
+    .ToDictionary(e => e.Key, e => e.Value, StringComparer.Ordinal);
+
+Console.WriteLine($"nupkg: {nupkgPath}");
+Console.WriteLine($"assembly entry: {dllEntry.FullName}");
+foreach (var key in previewKeys)
+{
+    Console.WriteLine(present.TryGetValue(key, out var value)
+        ? $"  {key} = {value}"
+        : $"  {key} = <absent>");
+}
+
+if (expectPreview)
+{
+    if (present.Count != previewKeys.Length
+        || present.Values.Any(string.IsNullOrWhiteSpace))
+    {
+        Console.Error.WriteLine("FAIL: expected all four PrivatePreview* AssemblyMetadata entries to be present and non-empty.");
+        return ExitMismatch;
+    }
+    if (!string.Equals(present["PrivatePreviewChannel"], "private-preview", StringComparison.Ordinal))
+    {
+        Console.Error.WriteLine($"FAIL: PrivatePreviewChannel must equal 'private-preview', got '{present["PrivatePreviewChannel"]}'.");
+        return ExitMismatch;
+    }
+    Console.WriteLine("OK: preview pack carries all required PrivatePreview* AssemblyMetadata entries.");
+    return ExitOk;
+}
+else
+{
+    if (present.Count != 0)
+    {
+        Console.Error.WriteLine($"FAIL: source pack must NOT carry PrivatePreview* AssemblyMetadata entries, but found {present.Count}.");
+        return ExitMismatch;
+    }
+    Console.WriteLine("OK: source pack carries no PrivatePreview* AssemblyMetadata entries.");
+    return ExitOk;
+}
+
+static IEnumerable<(string Key, string Value)> ReadAssemblyMetadata(MetadataReader reader)
+{
+    foreach (var handle in reader.CustomAttributes)
+    {
+        var attr = reader.GetCustomAttribute(handle);
+
+        // Only assembly-level attributes count.
+        if (attr.Parent.Kind != HandleKind.AssemblyDefinition)
+        {
+            continue;
+        }
+
+        var (typeNamespace, typeName) = ResolveAttributeType(reader, attr);
+        if (typeNamespace != "System.Reflection" || typeName != "AssemblyMetadataAttribute")
+        {
+            continue;
+        }
+
+        if (TryDecodeAssemblyMetadata(reader, attr, out var key, out var value))
+        {
+            yield return (key, value);
+        }
+    }
+}
+
+static (string Namespace, string Name) ResolveAttributeType(MetadataReader reader, CustomAttribute attr)
+{
+    return attr.Constructor.Kind switch
+    {
+        HandleKind.MemberReference => ResolveMemberReference(reader, (MemberReferenceHandle)attr.Constructor),
+        HandleKind.MethodDefinition => ResolveMethodDefinition(reader, (MethodDefinitionHandle)attr.Constructor),
+        _ => (string.Empty, string.Empty),
+    };
+}
+
+static (string Namespace, string Name) ResolveMemberReference(MetadataReader reader, MemberReferenceHandle handle)
+{
+    var member = reader.GetMemberReference(handle);
+    return member.Parent.Kind switch
+    {
+        HandleKind.TypeReference => GetTypeReferenceName(reader, (TypeReferenceHandle)member.Parent),
+        _ => (string.Empty, string.Empty),
+    };
+}
+
+static (string Namespace, string Name) ResolveMethodDefinition(MetadataReader reader, MethodDefinitionHandle handle)
+{
+    var method = reader.GetMethodDefinition(handle);
+    var type = reader.GetTypeDefinition(method.GetDeclaringType());
+    return (reader.GetString(type.Namespace), reader.GetString(type.Name));
+}
+
+static (string Namespace, string Name) GetTypeReferenceName(MetadataReader reader, TypeReferenceHandle handle)
+{
+    var type = reader.GetTypeReference(handle);
+    return (reader.GetString(type.Namespace), reader.GetString(type.Name));
+}
+
+static bool TryDecodeAssemblyMetadata(MetadataReader reader, CustomAttribute attr, out string key, out string value)
+{
+    key = string.Empty;
+    value = string.Empty;
+    var blob = reader.GetBlobReader(attr.Value);
+    // CustomAttribute blob prolog: 0x0001
+    if (blob.RemainingBytes < 2)
+    {
+        return false;
+    }
+    if (blob.ReadUInt16() != 0x0001)
+    {
+        return false;
+    }
+    key = blob.ReadSerializedString() ?? string.Empty;
+    value = blob.ReadSerializedString() ?? string.Empty;
+    return true;
+}


### PR DESCRIPTION
## Summary
- Add `.github/workflows/private-preview-pack.yml` that packs `intent-cli` as a `.nupkg` on every push to `main`, uses `0.2.0-preview.<run_number>.<run_attempt>` so two runs always produce distinct versions, and uploads the package plus a `preview-metadata.json` descriptor as a workflow artifact.
- Extend `IntentSystem.Cli.csproj` with a conditional `AssemblyMetadata` ItemGroup that embeds CI-supplied private-preview properties (channel / build timestamp / expires-at / source commit) into the produced assembly. Local source builds without the properties remain unrestricted (no expiry contract).
- Add `Infrastructure/PrivatePreviewMetadata.cs` with the pure 14-day expiry calculator (`ComputeExpiresAt`), the assembly-metadata reader (`Read` / `TryParse`), and a `ToVersionTrailer()` formatter. `VersionCommand` appends the trailer below the existing `intent-cli ...` line when CI metadata is present.
- Add unit tests for the expiry calculator, attribute parser, and `--version` trailer behaviour; extend existing `VersionCommandTests` with a suppression seam so the single-line contract stays deterministic in CI builds.
- Document the private-preview install/update flow in `README.md`.

Closes #837

## Test plan
- [x] `dotnet build IntentSystem.sln` (0 warnings, 0 errors).
- [x] `dotnet test IntentSystem.sln` — full suite green (3 161 passing, 1 pre-existing skip).
- [x] Smoke pack with CI properties: `dotnet pack ... -p:Version=0.2.0-preview.999.1 -p:PrivatePreviewChannel=private-preview -p:PrivatePreviewBuildTimestamp=... -p:PrivatePreviewExpiresAt=... -p:PrivatePreviewSourceCommit=...` produces `intent-cli.0.2.0-preview.999.1.nupkg`, and a tiny reflection probe confirmed the assembly carries the four `AssemblyMetadata` entries.
- [x] Smoke pack without preview properties produces `intent-cli.0.2.0.nupkg` with no `PrivatePreview*` `AssemblyMetadata` entries.
- [x] New `PrivatePreviewMetadataTests` cover the 14-day window, missing-channel rejection, missing-expiry fallback, IsExpired boundary, and trailer formatting; new `VersionCommandTests` cases pin the optional trailer on/off contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)