### PR TITLE
G368: Enforce private-preview expiry only for CI-packaged builds

### DIFF
--- a/src/IntentSystem.Cli/Infrastructure/PrivatePreviewExpiryGate.cs
+++ b/src/IntentSystem.Cli/Infrastructure/PrivatePreviewExpiryGate.cs
@@ -1,0 +1,142 @@
+using System.Globalization;
+using System.Reflection;
+
+namespace IntentSystem.Cli.Infrastructure;
+
+/// <summary>
+/// G368: process-level runtime gate that fails-closed when the running
+/// binary is a CI-packed private-preview artifact whose embedded
+/// <c>expires_at</c> has passed. The gate has three properties that
+/// keep it compatible with the rest of the entry-point contract:
+///
+///   1. Source builds (no <c>AssemblyMetadata("PrivatePreviewChannel")</c>)
+///      always pass through. This preserves the G367 acceptance that
+///      contributor builds carry no expiry contract.
+///   2. The check reads only the running assembly's
+///      <see cref="AssemblyMetadataAttribute"/> entries via
+///      <see cref="PrivatePreviewMetadata.Read"/>. It never touches
+///      <c>.intent-cli/</c>, queue-state, GitHub, or the filesystem
+///      beyond the assembly's own image, so the gate works from any
+///      cwd (home directory, fresh container, child implementation
+///      repo) just like G360 <c>--version</c>.
+///   3. <c>--version</c> / <c>-v</c> / <c>version</c> must still
+///      succeed even on an expired build so operators have a stable
+///      diagnosis surface; <see cref="Program"/> calls
+///      <see cref="VersionCommand"/> before this gate runs.
+///
+/// On a passed check the gate emits no output and returns
+/// <see cref="PrivatePreviewExpiryDecision.Ok"/>. On a failed check
+/// the gate writes a structured operator message to the supplied
+/// <see cref="TextWriter"/> and returns
+/// <see cref="PrivatePreviewExpiryDecision.Expired"/>. The caller maps
+/// <c>Expired</c> to a non-zero process exit code.
+/// </summary>
+internal static class PrivatePreviewExpiryGate
+{
+    /// <summary>
+    /// Process exit code used by <see cref="Program"/> when the gate
+    /// fails closed. Kept distinct from the "1" exit returned by
+    /// command-level error lanes so operators can filter expired-
+    /// preview exits without inspecting the message text.
+    /// </summary>
+    public const int ExpiredExitCode = 78;
+
+    /// <summary>
+    /// Test seam: override the assembly the gate reads metadata from.
+    /// When set to <c>null</c> the gate inspects the running
+    /// <c>IntentSystem.Cli</c> assembly.
+    /// </summary>
+    public static Assembly? OverrideAssembly { get; set; }
+
+    /// <summary>
+    /// Test seam: bypass the assembly-attribute read entirely and
+    /// supply preview metadata directly. Returning non-null here wins
+    /// over <see cref="OverrideAssembly"/>.
+    /// </summary>
+    public static PrivatePreviewMetadata? OverrideMetadata { get; set; }
+
+    /// <summary>
+    /// Test seam: pin the wall-clock "now" used for expiry
+    /// comparisons. Production callers leave this <c>null</c> and the
+    /// gate reads <see cref="DateTimeOffset.UtcNow"/>.
+    /// </summary>
+    public static DateTimeOffset? OverrideNow { get; set; }
+
+    /// <summary>
+    /// Inspect the running binary's embedded preview metadata against
+    /// the current wall clock. See class docs for the three
+    /// pass/fail contracts. The caller's <paramref name="writer"/>
+    /// receives the structured operator message only on
+    /// <see cref="PrivatePreviewExpiryDecision.Expired"/>.
+    /// </summary>
+    public static PrivatePreviewExpiryDecision Check(TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(writer);
+
+        var metadata = OverrideMetadata
+            ?? PrivatePreviewMetadata.Read(OverrideAssembly ?? typeof(PrivatePreviewExpiryGate).Assembly);
+        if (metadata is null)
+        {
+            // Source build: no preview contract, no expiry.
+            return PrivatePreviewExpiryDecision.Ok;
+        }
+
+        var now = OverrideNow ?? DateTimeOffset.UtcNow;
+        if (!metadata.IsExpired(now))
+        {
+            return PrivatePreviewExpiryDecision.Ok;
+        }
+
+        EmitExpiredMessage(writer, metadata, now);
+        return PrivatePreviewExpiryDecision.Expired;
+    }
+
+    /// <summary>
+    /// Pure-text formatter for the expired-preview operator message.
+    /// Exposed so tests can pin the exact wording without going
+    /// through <see cref="Check"/>.
+    /// </summary>
+    public static string BuildExpiredMessage(PrivatePreviewMetadata metadata, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(metadata);
+
+        var builtAtIso = metadata.BuildTimestamp.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+        var expiresAtIso = metadata.ExpiresAt.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+        var nowIso = now.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+
+        return string.Join(Environment.NewLine, new[]
+        {
+            $"intent-cli: private-preview artifact expired on {expiresAtIso} (now {nowIso}).",
+            $"  channel: {metadata.Channel}",
+            $"  built: {builtAtIso}",
+            $"  expired_at: {expiresAtIso}",
+            string.IsNullOrEmpty(metadata.SourceCommit)
+                ? "  commit: <unknown>"
+                : $"  commit: {metadata.SourceCommit}",
+            string.Empty,
+            "Download a newer artifact from a more recent `private-preview-pack` workflow run on `main` and reinstall:",
+            "  dotnet tool update --global --add-source <downloaded-folder> --version <newer-version> intent-cli",
+            string.Empty,
+            "Source-only builds (no preview metadata) are unaffected; see README.md \"Private-preview install\" for the full flow.",
+        });
+    }
+
+    private static void EmitExpiredMessage(TextWriter writer, PrivatePreviewMetadata metadata, DateTimeOffset now)
+    {
+        writer.WriteLine(BuildExpiredMessage(metadata, now));
+    }
+}
+
+/// <summary>
+/// G368: outcome of <see cref="PrivatePreviewExpiryGate.Check"/>.
+/// Distinct from <see cref="bool"/> so future variants
+/// (e.g. <c>WarnOnly</c> for soft-expiry warnings) can extend the
+/// surface without changing call-site shape.
+/// </summary>
+internal enum PrivatePreviewExpiryDecision
+{
+    /// <summary>Source build, no preview metadata, OR an unexpired preview build.</summary>
+    Ok,
+    /// <summary>Preview build past its embedded <c>expires_at</c>; caller must fail closed.</summary>
+    Expired,
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -23,6 +23,20 @@ internal static class Program
                 return VersionCommand.Execute(Console.Out);
             }
 
+            // G368: CI-packed private-preview artifacts expire 14 days
+            // after their build timestamp (G367 metadata). Once the
+            // expiry passes, fail closed BEFORE any workflow command or
+            // host-state lookup so operators see a single, clear
+            // "download a newer artifact" message regardless of the
+            // current working directory. `--version` is intentionally
+            // exempt (handled above) so the operator can still inspect
+            // the embedded build/expiry trailer. Source builds
+            // (no PrivatePreview AssemblyMetadata) pass through.
+            if (PrivatePreviewExpiryGate.Check(Console.Out) == PrivatePreviewExpiryDecision.Expired)
+            {
+                return PrivatePreviewExpiryGate.ExpiredExitCode;
+            }
+
             if (DirectRunDetachedCaptureCommand.TryExecute(args, out var directRunDetachedCaptureExitCode))
             {
                 return directRunDetachedCaptureExitCode;

--- a/tests/IntentSystem.Cli.Tests/PrivatePreviewExpiryGateTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PrivatePreviewExpiryGateTests.cs
@@ -1,0 +1,177 @@
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G368: covers the runtime expiry gate that fails closed when the
+/// running binary is a CI-packed private-preview artifact whose
+/// embedded <c>expires_at</c> has passed. All tests reset the static
+/// override seams in <see cref="Dispose"/> so the gate is back to its
+/// production read-from-running-assembly contract for subsequent
+/// tests.
+/// </summary>
+public sealed class PrivatePreviewExpiryGateTests : IDisposable
+{
+    public PrivatePreviewExpiryGateTests()
+    {
+        PrivatePreviewExpiryGate.OverrideAssembly = null;
+        PrivatePreviewExpiryGate.OverrideMetadata = null;
+        PrivatePreviewExpiryGate.OverrideNow = null;
+    }
+
+    public void Dispose()
+    {
+        PrivatePreviewExpiryGate.OverrideAssembly = null;
+        PrivatePreviewExpiryGate.OverrideMetadata = null;
+        PrivatePreviewExpiryGate.OverrideNow = null;
+    }
+
+    [Fact]
+    public void Check_NoMetadata_ReturnsOkAndEmitsNothing()
+    {
+        // Source-build path: the running test assembly has no
+        // PrivatePreview AssemblyMetadata entries unless the CI pack
+        // workflow built it, so leaving the overrides null exercises
+        // the source-build pass-through.
+        using var writer = new StringWriter();
+
+        var result = PrivatePreviewExpiryGate.Check(writer);
+
+        Assert.Equal(PrivatePreviewExpiryDecision.Ok, result);
+        Assert.Empty(writer.ToString());
+    }
+
+    [Fact]
+    public void Check_PreviewBuildWithFutureExpiry_ReturnsOkAndEmitsNothing()
+    {
+        PrivatePreviewExpiryGate.OverrideMetadata = new PrivatePreviewMetadata
+        {
+            Channel = PrivatePreviewMetadata.ChannelPrivatePreview,
+            BuildTimestamp = new DateTimeOffset(2026, 5, 19, 12, 0, 0, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2026, 6, 2, 12, 0, 0, TimeSpan.Zero),
+            SourceCommit = "abc1234",
+        };
+        PrivatePreviewExpiryGate.OverrideNow = new DateTimeOffset(2026, 5, 25, 0, 0, 0, TimeSpan.Zero);
+        using var writer = new StringWriter();
+
+        var result = PrivatePreviewExpiryGate.Check(writer);
+
+        Assert.Equal(PrivatePreviewExpiryDecision.Ok, result);
+        Assert.Empty(writer.ToString());
+    }
+
+    [Fact]
+    public void Check_PreviewBuildAtBoundaryDate_ReturnsOk()
+    {
+        // The boundary minute itself is still considered "in-window"
+        // (consistent with PrivatePreviewMetadata.IsExpired). A small
+        // clock skew between CI and the operator's host must not flip
+        // a fresh artifact to expired right at the cutoff.
+        PrivatePreviewExpiryGate.OverrideMetadata = new PrivatePreviewMetadata
+        {
+            Channel = PrivatePreviewMetadata.ChannelPrivatePreview,
+            BuildTimestamp = new DateTimeOffset(2026, 5, 19, 12, 0, 0, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2026, 6, 2, 12, 0, 0, TimeSpan.Zero),
+            SourceCommit = "abc1234",
+        };
+        PrivatePreviewExpiryGate.OverrideNow = new DateTimeOffset(2026, 6, 2, 12, 0, 0, TimeSpan.Zero);
+        using var writer = new StringWriter();
+
+        var result = PrivatePreviewExpiryGate.Check(writer);
+
+        Assert.Equal(PrivatePreviewExpiryDecision.Ok, result);
+        Assert.Empty(writer.ToString());
+    }
+
+    [Fact]
+    public void Check_PreviewBuildPastExpiry_ReturnsExpiredAndEmitsStructuredMessage()
+    {
+        PrivatePreviewExpiryGate.OverrideMetadata = new PrivatePreviewMetadata
+        {
+            Channel = PrivatePreviewMetadata.ChannelPrivatePreview,
+            BuildTimestamp = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2026, 5, 15, 12, 0, 0, TimeSpan.Zero),
+            SourceCommit = "f6cbf65",
+        };
+        PrivatePreviewExpiryGate.OverrideNow = new DateTimeOffset(2026, 5, 19, 12, 0, 0, TimeSpan.Zero);
+        using var writer = new StringWriter();
+
+        var result = PrivatePreviewExpiryGate.Check(writer);
+
+        Assert.Equal(PrivatePreviewExpiryDecision.Expired, result);
+        var emitted = writer.ToString();
+        Assert.Contains("private-preview artifact expired", emitted, StringComparison.Ordinal);
+        Assert.Contains("expired_at: 2026-05-15T12:00:00Z", emitted, StringComparison.Ordinal);
+        Assert.Contains("built: 2026-05-01T12:00:00Z", emitted, StringComparison.Ordinal);
+        Assert.Contains("commit: f6cbf65", emitted, StringComparison.Ordinal);
+        Assert.Contains("dotnet tool update --global --add-source", emitted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Check_PreviewBuildOneSecondAfterExpiry_ReturnsExpired()
+    {
+        // Deterministic boundary: one second after expires_at must
+        // flip to Expired so a stale build cannot linger by virtue of
+        // sub-minute rounding.
+        PrivatePreviewExpiryGate.OverrideMetadata = new PrivatePreviewMetadata
+        {
+            Channel = PrivatePreviewMetadata.ChannelPrivatePreview,
+            BuildTimestamp = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2026, 5, 15, 12, 0, 0, TimeSpan.Zero),
+            SourceCommit = "abc1234",
+        };
+        PrivatePreviewExpiryGate.OverrideNow = new DateTimeOffset(2026, 5, 15, 12, 0, 1, TimeSpan.Zero);
+        using var writer = new StringWriter();
+
+        var result = PrivatePreviewExpiryGate.Check(writer);
+
+        Assert.Equal(PrivatePreviewExpiryDecision.Expired, result);
+    }
+
+    [Fact]
+    public void BuildExpiredMessage_FormatsAllFields()
+    {
+        var meta = new PrivatePreviewMetadata
+        {
+            Channel = "private-preview",
+            BuildTimestamp = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2026, 5, 15, 12, 0, 0, TimeSpan.Zero),
+            SourceCommit = "f6cbf65",
+        };
+        var now = new DateTimeOffset(2026, 5, 19, 6, 30, 0, TimeSpan.Zero);
+
+        var message = PrivatePreviewExpiryGate.BuildExpiredMessage(meta, now);
+
+        Assert.Contains("intent-cli: private-preview artifact expired on 2026-05-15T12:00:00Z (now 2026-05-19T06:30:00Z).", message, StringComparison.Ordinal);
+        Assert.Contains("channel: private-preview", message, StringComparison.Ordinal);
+        Assert.Contains("built: 2026-05-01T12:00:00Z", message, StringComparison.Ordinal);
+        Assert.Contains("expired_at: 2026-05-15T12:00:00Z", message, StringComparison.Ordinal);
+        Assert.Contains("commit: f6cbf65", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildExpiredMessage_BlankCommit_RendersUnknownPlaceholder()
+    {
+        var meta = new PrivatePreviewMetadata
+        {
+            Channel = "private-preview",
+            BuildTimestamp = new DateTimeOffset(2026, 5, 1, 0, 0, 0, TimeSpan.Zero),
+            ExpiresAt = new DateTimeOffset(2026, 5, 15, 0, 0, 0, TimeSpan.Zero),
+            SourceCommit = "",
+        };
+
+        var message = PrivatePreviewExpiryGate.BuildExpiredMessage(meta, new DateTimeOffset(2026, 5, 20, 0, 0, 0, TimeSpan.Zero));
+
+        Assert.Contains("commit: <unknown>", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExpiredExitCode_IsDistinctFromGenericError()
+    {
+        // The reserved 78 exit code lets operators filter
+        // expired-preview exits without inspecting message text.
+        Assert.NotEqual(0, PrivatePreviewExpiryGate.ExpiredExitCode);
+        Assert.NotEqual(1, PrivatePreviewExpiryGate.ExpiredExitCode);
+        Assert.Equal(78, PrivatePreviewExpiryGate.ExpiredExitCode);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `Infrastructure/PrivatePreviewExpiryGate.cs`, a host-state-free runtime gate that reads the four `PrivatePreview*` `AssemblyMetadata` entries baked by the G367 CI pack workflow and fails closed when `now > expires_at`. Source builds (no preview metadata) pass through with no expiry contract.
- Wire the gate into `Program.Main` between the `--version` exit and every other lane (direct-run helpers, bootstrap commands, host-state resolution). `--version` / `-v` / `version` remain exempt so the operator can still inspect the embedded build/expiry trailer on an expired binary. The gate uses a reserved exit code (`78`) so operators can filter expired-preview exits without parsing stdout.
- Emit a structured operator message that names channel, build/expiry timestamps, current time, source commit, and the `dotnet tool update` install instruction.
- Add `PrivatePreviewExpiryGateTests` covering: source-build pass-through, future-expiry pass-through, boundary date (in-window), one-second-after-expiry fail, message formatter shape (with and without commit SHA), and the reserved exit code constant.

Closes #839

## Test plan
- [x] `dotnet build IntentSystem.sln` (0 errors).
- [x] `dotnet test IntentSystem.sln` full suite stays green: 3 169 passing (8 new), 1 pre-existing skip, 0 failed.
- [x] Manual review: gate is invoked in `Program.Main` *before* `DirectRunDetachedCaptureCommand`, `DirectRunExitMonitorCommand`, `RepoRootResolver.Resolve`, and the bootstrap/help routing, so an expired build cannot reach a host-state-dependent surface.
- [x] `--version` short-circuit remains the only command above the gate so operators retain their diagnosis surface on an expired binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)