### PR TITLE
G370: Make source contract tests hermetic for Linux CI preview packaging

### DIFF
--- a/src/IntentSystem.Cli/Commands/WorkerPrCommentPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerPrCommentPreflightCommand.cs
@@ -100,37 +100,55 @@ internal static class WorkerPrCommentPreflightCommand
             return 1;
         }
 
-        IGitHubPrCommentsLookup commentsLookup;
-        try
-        {
-            commentsLookup = CommentsLookupFactory?.Invoke() ?? new GhCliGitHubPrCommentsLookup();
-        }
-        catch (Exception exception) when (
-            exception is InvalidOperationException
-            or IOException)
-        {
-            writer.WriteLine(
-                $"failed to initialize GitHub PR comments lookup: {exception.Message}");
-            return 1;
-        }
+        // G370: compute the state-level non-actionable verdict BEFORE
+        // any further GitHub lookup. The analyzer's step-1 fast path
+        // for closed-not-merged / fresh-draft PRs is purely a function
+        // of the PR payload, so the command must short-circuit here to
+        // avoid letting a transient `gh pr view --comments` transport
+        // failure (rate limit, permission shortfall, network blip)
+        // flip a deterministic non-actionable PR to exit 1. The
+        // analyzer accepts an empty comments payload for that path; we
+        // build one inline instead of hitting GitHub again.
+        var preLookupNonActionable = IsStateLevelNonActionable(prPayload);
 
         GitHubPrCommentsLookupResult commentsPayload;
-        try
+        if (preLookupNonActionable)
         {
-            commentsPayload = commentsLookup.Lookup(repo!, prNumber);
+            commentsPayload = new GitHubPrCommentsLookupResult();
         }
-        catch (Exception exception)
+        else
         {
-            writer.WriteLine(
-                $"failed to look up GitHub PR comments for {repo}#{prNumber}: {exception.Message}");
-            return 1;
-        }
+            IGitHubPrCommentsLookup commentsLookup;
+            try
+            {
+                commentsLookup = CommentsLookupFactory?.Invoke() ?? new GhCliGitHubPrCommentsLookup();
+            }
+            catch (Exception exception) when (
+                exception is InvalidOperationException
+                or IOException)
+            {
+                writer.WriteLine(
+                    $"failed to initialize GitHub PR comments lookup: {exception.Message}");
+                return 1;
+            }
 
-        if (commentsPayload is null)
-        {
-            writer.WriteLine(
-                $"GitHub PR comments lookup returned no payload for {repo}#{prNumber}.");
-            return 1;
+            try
+            {
+                commentsPayload = commentsLookup.Lookup(repo!, prNumber);
+            }
+            catch (Exception exception)
+            {
+                writer.WriteLine(
+                    $"failed to look up GitHub PR comments for {repo}#{prNumber}: {exception.Message}");
+                return 1;
+            }
+
+            if (commentsPayload is null)
+            {
+                writer.WriteLine(
+                    $"GitHub PR comments lookup returned no payload for {repo}#{prNumber}.");
+                return 1;
+            }
         }
 
         SourceIssueCandidate? candidate;
@@ -148,24 +166,12 @@ internal static class WorkerPrCommentPreflightCommand
             return 1;
         }
 
-        // G370: split the source-issue lookup failure mode into two
-        // contracts so the non-actionable exit-code is stable across
-        // CI environments without weakening the fail-closed posture for
-        // genuinely OPEN actionable PRs:
-        //
-        //   * Closed / fresh-draft PRs are already non-actionable from
-        //     the PR payload alone. Skip the source-issue lookup
-        //     entirely; the analyzer accepts a null `sourceIssuePayload`
-        //     for those paths. This way a `gh` permission shortfall
-        //     (token without `issues: read`), rate limit, or network
-        //     blip cannot flip a deterministic non-actionable PR to
-        //     exit 1 on a fresh runner.
-        //
-        //   * For any other PR we still attempt the lookup and
-        //     fail-closed on transport failures; the existing
-        //     "transport-failure" test pins that lane.
+        // G370: same state-level short-circuit applies to the source-
+        // issue lookup. The analyzer can classify a closed/draft PR as
+        // non-actionable with `sourceIssuePayload = null`; skipping the
+        // lookup here ensures a transient `gh issue view` failure
+        // cannot flip the exit code either.
         GitHubIssueLookupResult? sourceIssuePayload = null;
-        var preLookupNonActionable = IsStateLevelNonActionable(prPayload);
         if (candidate is { } traced && !preLookupNonActionable)
         {
             IGitHubIssueLookup issueLookup;

--- a/src/IntentSystem.Cli/Commands/WorkerPrCommentPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerPrCommentPreflightCommand.cs
@@ -256,16 +256,23 @@ internal static class WorkerPrCommentPreflightCommand
 
     private static bool HasReviewCycleLabel(GitHubPrLookupResult pr)
     {
+        // Match the analyzer's `HasAnyReviewLabel` set exactly so the
+        // command-layer short-circuit cannot diverge from the
+        // classifier's draft gate. `intent-target` is the host-side
+        // selector marker and must NOT count: an `intent-target`-only
+        // draft PR is still non-actionable from the analyzer's
+        // perspective, so we want to skip the source-issue lookup.
         foreach (var label in pr.Labels)
         {
-            if (label.Name is { Length: > 0 } name
-                && (name.StartsWith("intent-pr-", StringComparison.Ordinal)
-                    || string.Equals(name, "intent-target", StringComparison.Ordinal)))
+            if (label.Name is not { Length: > 0 } name)
             {
-                if (name.StartsWith("intent-pr-", StringComparison.Ordinal))
-                {
-                    return true;
-                }
+                continue;
+            }
+            if (string.Equals(name, WorkerPrCommentPreflightConstants.Labels.IntentPrRequestUpdate, StringComparison.Ordinal)
+                || string.Equals(name, WorkerPrCommentPreflightConstants.Labels.IntentPrUpdateInProgress, StringComparison.Ordinal)
+                || string.Equals(name, WorkerPrCommentPreflightConstants.Labels.IntentPrApproved, StringComparison.Ordinal))
+            {
+                return true;
             }
         }
         return false;

--- a/src/IntentSystem.Cli/Commands/WorkerPrCommentPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerPrCommentPreflightCommand.cs
@@ -148,8 +148,25 @@ internal static class WorkerPrCommentPreflightCommand
             return 1;
         }
 
+        // G370: split the source-issue lookup failure mode into two
+        // contracts so the non-actionable exit-code is stable across
+        // CI environments without weakening the fail-closed posture for
+        // genuinely OPEN actionable PRs:
+        //
+        //   * Closed / fresh-draft PRs are already non-actionable from
+        //     the PR payload alone. Skip the source-issue lookup
+        //     entirely; the analyzer accepts a null `sourceIssuePayload`
+        //     for those paths. This way a `gh` permission shortfall
+        //     (token without `issues: read`), rate limit, or network
+        //     blip cannot flip a deterministic non-actionable PR to
+        //     exit 1 on a fresh runner.
+        //
+        //   * For any other PR we still attempt the lookup and
+        //     fail-closed on transport failures; the existing
+        //     "transport-failure" test pins that lane.
         GitHubIssueLookupResult? sourceIssuePayload = null;
-        if (candidate is { } traced)
+        var preLookupNonActionable = IsStateLevelNonActionable(prPayload);
+        if (candidate is { } traced && !preLookupNonActionable)
         {
             IGitHubIssueLookup issueLookup;
             try
@@ -209,6 +226,49 @@ internal static class WorkerPrCommentPreflightCommand
         }
 
         return 0;
+    }
+
+    /// <summary>
+    /// G370: returns <c>true</c> when the PR payload alone already
+    /// determines non-actionability (closed, merged, or a fresh draft
+    /// without any review-cycle label). In those cases the source-issue
+    /// lookup is unnecessary -- the analyzer can classify the PR as
+    /// non-actionable from the PR payload -- so we skip the lookup
+    /// rather than letting a transient `gh` failure flip the exit code.
+    /// </summary>
+    private static bool IsStateLevelNonActionable(GitHubPrLookupResult pr)
+    {
+        if (pr.Closed || pr.Merged)
+        {
+            return true;
+        }
+        if (string.Equals(pr.State, "CLOSED", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(pr.State, "MERGED", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        if (pr.IsDraft && !HasReviewCycleLabel(pr))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private static bool HasReviewCycleLabel(GitHubPrLookupResult pr)
+    {
+        foreach (var label in pr.Labels)
+        {
+            if (label.Name is { Length: > 0 } name
+                && (name.StartsWith("intent-pr-", StringComparison.Ordinal)
+                    || string.Equals(name, "intent-target", StringComparison.Ordinal)))
+            {
+                if (name.StartsWith("intent-pr-", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static void WriteText(TextWriter writer, WorkerPrCommentPreflightResult result)

--- a/src/IntentSystem.Cli/Commands/WorkerPrReviewPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerPrReviewPreflightCommand.cs
@@ -107,8 +107,14 @@ internal static class WorkerPrReviewPreflightCommand
             return 1;
         }
 
+        // G370: split the source-issue lookup failure mode into two
+        // contracts so the non-actionable exit-code is stable across
+        // CI environments without weakening the fail-closed posture for
+        // genuinely OPEN actionable PRs. See
+        // <see cref="IsStateLevelNonActionable"/>.
         GitHubIssueLookupResult? sourceIssuePayload = null;
-        if (candidate is { } traced)
+        var preLookupNonActionable = IsStateLevelNonActionable(prPayload);
+        if (candidate is { } traced && !preLookupNonActionable)
         {
             IGitHubIssueLookup issueLookup;
             try
@@ -167,6 +173,45 @@ internal static class WorkerPrReviewPreflightCommand
         }
 
         return 0;
+    }
+
+    /// <summary>
+    /// G370: returns <c>true</c> when the PR payload alone already
+    /// determines non-actionability (closed, merged, or a fresh draft
+    /// without any review-cycle label). In those cases the source-issue
+    /// lookup is unnecessary -- the analyzer can classify the PR as
+    /// non-actionable from the PR payload -- so we skip the lookup
+    /// rather than letting a transient `gh` failure flip the exit code.
+    /// </summary>
+    private static bool IsStateLevelNonActionable(GitHubPrLookupResult pr)
+    {
+        if (pr.Closed || pr.Merged)
+        {
+            return true;
+        }
+        if (string.Equals(pr.State, "CLOSED", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(pr.State, "MERGED", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        if (pr.IsDraft && !HasReviewCycleLabel(pr))
+        {
+            return true;
+        }
+        return false;
+    }
+
+    private static bool HasReviewCycleLabel(GitHubPrLookupResult pr)
+    {
+        foreach (var label in pr.Labels)
+        {
+            if (label.Name is { Length: > 0 } name
+                && name.StartsWith("intent-pr-", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static void WriteText(TextWriter writer, WorkerPrReviewPreflightResult result)

--- a/src/IntentSystem.Cli/Commands/WorkerPrReviewPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerPrReviewPreflightCommand.cs
@@ -203,10 +203,21 @@ internal static class WorkerPrReviewPreflightCommand
 
     private static bool HasReviewCycleLabel(GitHubPrLookupResult pr)
     {
+        // Match the analyzer's `HasAnyReviewLabel` set exactly so the
+        // command-layer short-circuit cannot diverge from the
+        // classifier's draft gate. Includes `intent-pr-reviewing`
+        // because the review-side analyzer treats it as an active
+        // review-cycle marker; the comment-side analyzer omits it.
         foreach (var label in pr.Labels)
         {
-            if (label.Name is { Length: > 0 } name
-                && name.StartsWith("intent-pr-", StringComparison.Ordinal))
+            if (label.Name is not { Length: > 0 } name)
+            {
+                continue;
+            }
+            if (string.Equals(name, WorkerPrReviewPreflightConstants.Labels.IntentPrReviewing, StringComparison.Ordinal)
+                || string.Equals(name, WorkerPrReviewPreflightConstants.Labels.IntentPrRequestUpdate, StringComparison.Ordinal)
+                || string.Equals(name, WorkerPrReviewPreflightConstants.Labels.IntentPrUpdateInProgress, StringComparison.Ordinal)
+                || string.Equals(name, WorkerPrReviewPreflightConstants.Labels.IntentPrApproved, StringComparison.Ordinal))
             {
                 return true;
             }

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -172,9 +172,12 @@ public sealed class PackagedInvocationSmokeTests
 
     private static ProcessResult RunShellCommand(string script, string workingDirectory)
     {
+        // G370: resolve the host shell at runtime so the packaged-
+        // invocation smoke can run on GitHub-hosted Ubuntu (no zsh)
+        // without losing the macOS dev-loop behavior.
         var startInfo = new ProcessStartInfo
         {
-            FileName = "/bin/zsh",
+            FileName = IntentSystem.Cli.Tests.TestSupport.PortableShellResolver.Resolve(),
             WorkingDirectory = workingDirectory,
             UseShellExecute = false
         };

--- a/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewRunCommandTests.cs
@@ -1447,9 +1447,13 @@ public sealed class ReviewRunCommandTests
 
     private static Process StartCliProcess(string workingDirectory, string arguments)
     {
+        // G370: resolve the wrapper shell at runtime so GitHub-hosted
+        // Ubuntu runners (no `/bin/zsh`) can host the same fixture.
+        // Production behavior is unchanged: macOS dev loops still pick
+        // `/bin/zsh` first, Linux CI falls through to bash.
         var startInfo = new ProcessStartInfo
         {
-            FileName = "/bin/zsh",
+            FileName = IntentSystem.Cli.Tests.TestSupport.PortableShellResolver.Resolve(),
             WorkingDirectory = workingDirectory,
             UseShellExecute = false,
             RedirectStandardOutput = true,

--- a/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/RunFixCommandTests.cs
@@ -843,7 +843,7 @@ public sealed class RunFixCommandTests
         var wrapperPath = tempDirectory.CreateExecutableFile(
             "bin/codex-isolated",
             $$"""
-            #!/bin/zsh
+            #!/bin/bash
             export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
             exec {{providerBinaryPath}} "$@"
             """);
@@ -963,7 +963,7 @@ public sealed class RunFixCommandTests
         var wrapperPath = tempDirectory.CreateExecutableFile(
             "bin/codex-isolated",
             $$"""
-            #!/bin/zsh
+            #!/bin/bash
             export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
             exec {{providerBinaryPath}} "$@"
             """);
@@ -1125,7 +1125,7 @@ public sealed class RunFixCommandTests
         var wrapperPath = tempDirectory.CreateExecutableFile(
             "bin/codex-isolated",
             $$"""
-            #!/bin/zsh
+            #!/bin/bash
             export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
             exec {{providerBinaryPath}} "$@"
             """);
@@ -1253,7 +1253,7 @@ public sealed class RunFixCommandTests
         var wrapperPath = tempDirectory.CreateExecutableFile(
             "bin/codex-isolated",
             $$"""
-            #!/bin/zsh
+            #!/bin/bash
             export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
             exec {{providerBinaryPath}} "$@"
             """);
@@ -1392,7 +1392,7 @@ public sealed class RunFixCommandTests
         var wrapperPath = tempDirectory.CreateExecutableFile(
             "bin/codex-isolated",
             $$"""
-            #!/bin/zsh
+            #!/bin/bash
             export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
             exec {{providerBinaryPath}} "$@"
             """);
@@ -1507,7 +1507,7 @@ public sealed class RunFixCommandTests
         var wrapperPath = tempDirectory.CreateExecutableFile(
             "bin/codex-isolated",
             $$"""
-            #!/bin/zsh
+            #!/bin/bash
             export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
             exec {{providerBinaryPath}} "$@"
             """);
@@ -1640,7 +1640,7 @@ public sealed class RunFixCommandTests
         var wrapperPath = tempDirectory.CreateExecutableFile(
             "bin/codex-isolated",
             $$"""
-            #!/bin/zsh
+            #!/bin/bash
             export CODEX_HOME={{tempDirectory.GetPath(".codex-direct-backend")}}
             exec {{providerBinaryPath}} "$@"
             """);

--- a/tests/IntentSystem.Cli.Tests/TestSupport/PortableShellResolver.cs
+++ b/tests/IntentSystem.Cli.Tests/TestSupport/PortableShellResolver.cs
@@ -1,0 +1,55 @@
+namespace IntentSystem.Cli.Tests.TestSupport;
+
+/// <summary>
+/// G370: portable shell discovery for test fixtures that launch child
+/// processes through a login-shell wrapper. The historical hard-coded
+/// path was <c>/bin/zsh</c>, which works on macOS dev machines but
+/// breaks on GitHub-hosted Ubuntu runners (no <c>/bin/zsh</c>) and any
+/// container that ships with bash only. This helper inspects the
+/// runtime environment and returns the first existing absolute path
+/// from a small priority list, falling back to <c>/bin/sh</c> which is
+/// guaranteed on any POSIX-compliant runner.
+///
+/// The helper intentionally avoids <see cref="System.Environment.GetEnvironmentVariable"/>
+/// lookups on <c>SHELL</c> -- CI containers often run with <c>SHELL</c>
+/// unset, and we want a deterministic, byte-identical resolution
+/// regardless of operator profile.
+/// </summary>
+internal static class PortableShellResolver
+{
+    /// <summary>
+    /// Ordered candidates: zsh first to preserve the macOS dev-loop
+    /// fixture behavior (zsh-only features such as <c>-lc</c> with
+    /// glob expansion match the original tests bit-for-bit), then
+    /// bash variants for Linux CI, then POSIX <c>sh</c> as the
+    /// universal fallback.
+    /// </summary>
+    private static readonly string[] Candidates =
+    {
+        "/bin/zsh",
+        "/bin/bash",
+        "/usr/bin/bash",
+        "/usr/local/bin/bash",
+        "/bin/sh",
+    };
+
+    /// <summary>
+    /// Resolve the first available shell on the runner. Throws
+    /// <see cref="InvalidOperationException"/> if none of the
+    /// candidates exist -- which would only happen on a runner so
+    /// minimal it cannot host these integration fixtures at all.
+    /// </summary>
+    public static string Resolve()
+    {
+        foreach (var candidate in Candidates)
+        {
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"PortableShellResolver: no candidate shell found in [{string.Join(", ", Candidates)}].");
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/VersionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionCommandTests.cs
@@ -254,9 +254,20 @@ public sealed class VersionCommandTests : IDisposable
     /// </summary>
     private static string LocateBuiltCliBinary()
     {
-        // tests/IntentSystem.Cli.Tests/bin/Debug/net10.0/IntentSystem.Cli.Tests.dll
-        // → src/IntentSystem.Cli/bin/Debug/net10.0/IntentSystem.Cli(.dll)
+        // G370: the CI workflow builds Release while the local dev
+        // loop builds Debug. Detect the configuration from the test
+        // assembly's own bin path so the same lookup works in both
+        // (and any future configuration name that lands here).
+        // Layout under `tests/IntentSystem.Cli.Tests/bin/<Config>/<TFM>/`:
+        //   tests/.../IntentSystem.Cli.Tests.dll
+        //   → src/IntentSystem.Cli/bin/<Config>/<TFM>/IntentSystem.Cli(.dll)
         var testDir = Path.GetDirectoryName(typeof(VersionCommandTests).Assembly.Location)!;
+        var configurationDir = Directory.GetParent(testDir);
+        var configurationName = configurationDir?.Parent?.Name == "bin"
+            ? configurationDir!.Name
+            : "Debug";
+        var targetFramework = Path.GetFileName(testDir);
+
         var repoRoot = testDir;
         while (repoRoot is not null
             && !File.Exists(Path.Combine(repoRoot, "IntentSystem.sln")))
@@ -269,7 +280,7 @@ public sealed class VersionCommandTests : IDisposable
         {
             return string.Empty;
         }
-        var cliDir = Path.Combine(repoRoot, "src", "IntentSystem.Cli", "bin", "Debug", "net10.0");
+        var cliDir = Path.Combine(repoRoot, "src", "IntentSystem.Cli", "bin", configurationName, targetFramework);
         // dotnet SDK produces a native host launcher `IntentSystem.Cli`
         // (the project's AssemblyName, not the `ToolCommandName`).
         // Prefer that native exec when present.

--- a/tests/IntentSystem.Cli.Tests/WorkerPrCommentPreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerPrCommentPreflightCommandTests.cs
@@ -542,6 +542,65 @@ public sealed class WorkerPrCommentPreflightCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenClosedPrAndCommentsLookupThrows_StillClassifiesAsNonActionable()
+    {
+        // G370 regression: closed/draft PRs are state-level
+        // non-actionable from the PR payload alone, so a transient
+        // failure on `gh pr view --comments` (rate limit, permission
+        // shortfall, network blip) MUST NOT flip the exit code. The
+        // command must short-circuit before invoking the comments
+        // lookup.
+        using var workspace = new WorkerPrCommentPreflightWorkspace();
+        WorkerPrCommentPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 6151, state: "CLOSED", title: "closed",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            closed: true,
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrCommentPreflightCommand.CommentsLookupFactory = () =>
+            new ThrowingCommentsLookup("simulated comments-lookup failure: gh pr view --comments exited 1");
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrCommentPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "6151", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrCommentPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrCommentPreflightConstants.Classifications.NonActionable, result.Classification);
+        Assert.Contains(result.Reasons, r => r.Contains("closed", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenFreshDraftPrAndCommentsLookupThrows_StillClassifiesAsNonActionable()
+    {
+        // G370 regression: a fresh draft (no `intent-pr-*` review-cycle
+        // label) is state-level non-actionable. Comments lookup must
+        // be skipped so a transport failure cannot flip exit 0 -> 1.
+        using var workspace = new WorkerPrCommentPreflightWorkspace();
+        WorkerPrCommentPreflightCommand.PrLookupFactory = () => new FakePrLookup(BuildPr(
+            number: 6152, state: "OPEN", title: "fresh draft",
+            body: "Closes #100",
+            labelNames: new[] { "intent-target" },
+            isDraft: true,
+            closingIssueNumbers: new[] { 100 }));
+        WorkerPrCommentPreflightCommand.CommentsLookupFactory = () =>
+            new ThrowingCommentsLookup("simulated comments-lookup failure: rate limit");
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerPrCommentPreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "6152", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerPrCommentPreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerPrCommentPreflightConstants.Classifications.NonActionable, result.Classification);
+        Assert.Contains(result.Reasons, r => r.Contains("draft", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Execute_GivenJsonFormat_RoundTripsStably()
     {
         using var workspace = new WorkerPrCommentPreflightWorkspace();


### PR DESCRIPTION
## Summary
- Add `tests/IntentSystem.Cli.Tests/TestSupport/PortableShellResolver` that picks the first available shell from `/bin/zsh`, `/bin/bash`, `/usr/bin/bash`, `/usr/local/bin/bash`, `/bin/sh`. Replace the two real `/bin/zsh` `Process.Start` calls (`ReviewRunCommandTests.StartCliProcess`, `PackagedInvocationSmokeTests.RunShellCommand`) with the resolver so the macOS dev loop keeps zsh while Ubuntu CI falls through to bash.
- Rewrite the 7 `#!/bin/zsh` shebangs in `RunFixCommandTests`-generated wrapper scripts to `#!/bin/bash`. The shebang is the only zsh dependency; the scripts only use shell builtins (`exec`, `export`, `printf`) that bash supports identically.
- `VersionCommandTests.LocateBuiltCliBinary` now derives the configuration name and target framework from the test assembly's bin path so the integration smoke finds `bin/Release/net10.0/IntentSystem.Cli` when CI built in Release, and `bin/Debug/net10.0/...` for local dev.
- Split the source-issue lookup failure contract in `WorkerPrCommentPreflightCommand` and `WorkerPrReviewPreflightCommand`: PRs whose state alone determines non-actionability (closed / merged / fresh draft without an `intent-pr-*` label) skip the lookup entirely. OPEN PRs still fail-closed on transport failures, preserving `Execute_GivenIssueLookupTransportFailure_ReturnsNonZero_*`.

Closes #841

## Test plan
- [x] `dotnet build IntentSystem.sln -c Debug` (0 errors).
- [x] `dotnet test tests/IntentSystem.Cli.Tests` full suite stays green on local macOS: 3 161 passing, 1 pre-existing skip, 0 failed.
- [x] `dotnet test --filter "FullyQualifiedName~WorkerPrCommentPreflightCommandTests|FullyQualifiedName~WorkerPrReviewPreflightCommandTests"` — 87/87 green; both closed/draft non-actionable tests and the transport-failure tests pass.
- [x] Manual check of the rewritten shebangs and the resolver — the shell selection order keeps the macOS dev-loop bit-identical and falls through to bash on Ubuntu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)