### PR TITLE
G369: bundle SHA256 checksum and per-build INSTALL.md with the preview .nupkg

### DIFF
--- a/.github/workflows/private-preview-pack.yml
+++ b/.github/workflows/private-preview-pack.yml
@@ -127,6 +127,138 @@ jobs:
           }
           EOF
 
+      # G369: generate a SHA256 checksum sidecar so testers can verify
+      # the bundle they received matches what CI produced before
+      # `dotnet tool install` consumes it. The `<nupkg-filename>` form
+      # (relative path) keeps `shasum -a 256 -c` / `sha256sum -c` happy
+      # when the tester runs the check from inside the unzipped bundle
+      # directory.
+      - name: Generate SHA256 checksum for .nupkg
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd .artifacts/private-preview
+          NUPKG_FILE="$(basename "$(ls intent-cli.*.nupkg | head -n 1)")"
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${NUPKG_FILE}" > "${NUPKG_FILE}.sha256"
+          else
+            shasum -a 256 "${NUPKG_FILE}" > "${NUPKG_FILE}.sha256"
+          fi
+          echo "wrote ${NUPKG_FILE}.sha256:"
+          cat "${NUPKG_FILE}.sha256"
+
+      # G369: generate an in-bundle INSTALL.md so a tester who received
+      # the zip via private email / file share has self-contained
+      # install / update / verify / uninstall steps without needing
+      # access to this repo's README. The template fills in this
+      # build's exact version, expiry, and commit so the commands a
+      # tester copy-pastes are correct as-is (no `<run_number>`
+      # placeholders to substitute).
+      - name: Generate install bundle README (INSTALL.md)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd .artifacts/private-preview
+          NUPKG_FILE="$(basename "$(ls intent-cli.*.nupkg | head -n 1)")"
+          PACKAGE_VERSION="${{ steps.meta.outputs.package_version }}"
+          BUILD_TIMESTAMP="${{ steps.meta.outputs.build_timestamp }}"
+          EXPIRES_AT="${{ steps.meta.outputs.expires_at }}"
+          SOURCE_COMMIT="${{ github.sha }}"
+          SHORT_SHA="${{ steps.meta.outputs.short_sha }}"
+          cat > INSTALL.md <<EOF
+          # intent-cli private-preview bundle
+
+          - **Package version**: \`${PACKAGE_VERSION}\`
+          - **Built (UTC)**: \`${BUILD_TIMESTAMP}\`
+          - **Expires (UTC)**: \`${EXPIRES_AT}\` (14 days after build; refresh
+            from a newer workflow run when this passes)
+          - **Source commit**: \`${SOURCE_COMMIT}\` (short: \`${SHORT_SHA}\`)
+          - **Channel**: \`private-preview\`
+
+          This bundle is a self-contained private-preview drop of the
+          \`intent-cli\` .NET global tool. No PAT, source checkout, or
+          public NuGet feed is required to install it -- only a
+          compatible .NET SDK / runtime and the files in this folder.
+
+          ## Bundle contents
+
+          | File | Purpose |
+          | --- | --- |
+          | \`${NUPKG_FILE}\` | The signed-into-place NuGet package consumed by \`dotnet tool install\`. |
+          | \`${NUPKG_FILE}.sha256\` | SHA-256 checksum; verify before installing. |
+          | \`preview-metadata.json\` | Machine-readable build provenance (channel, version, build/expiry timestamps, commit, CI run identifiers). |
+          | \`INSTALL.md\` | This file. |
+
+          ## 1. Verify the download
+
+          From inside the unzipped bundle folder:
+
+          \`\`\`bash
+          # macOS:
+          shasum -a 256 -c "${NUPKG_FILE}.sha256"
+          # Linux:
+          sha256sum -c "${NUPKG_FILE}.sha256"
+          \`\`\`
+
+          Both forms print \`${NUPKG_FILE}: OK\` on success. Do not
+          install if verification fails.
+
+          ## 2. Install (fresh)
+
+          \`\`\`bash
+          dotnet tool install --global --add-source . \\
+            --version ${PACKAGE_VERSION} intent-cli
+          \`\`\`
+
+          \`--add-source .\` tells \`dotnet tool install\` to look for
+          \`intent-cli\` in the current folder instead of a NuGet feed.
+
+          ## 3. Update (replace a previous preview)
+
+          Drop the new bundle in a folder, then:
+
+          \`\`\`bash
+          dotnet tool update --global --add-source . \\
+            --version ${PACKAGE_VERSION} intent-cli
+          \`\`\`
+
+          \`update\` is the right command even when moving forward by a
+          single CI run.
+
+          ## 4. Verify the install
+
+          \`\`\`bash
+          intent-cli --version
+          \`\`\`
+
+          Expected (two lines):
+
+          \`\`\`text
+          intent-cli ${PACKAGE_VERSION}-${SHORT_SHA}-G<unit>
+          channel=private-preview built=${BUILD_TIMESTAMP} expires=${EXPIRES_AT} commit=${SHORT_SHA}
+          \`\`\`
+
+          The \`channel=private-preview\` trailer is your confirmation
+          that the embedded preview metadata loaded successfully. If
+          the trailer is missing, the wrong package was installed.
+
+          ## 5. Uninstall
+
+          \`\`\`bash
+          dotnet tool uninstall --global intent-cli
+          \`\`\`
+
+          ## Expiry behaviour
+
+          When the wall clock passes \`expires=${EXPIRES_AT}\`, the
+          installed tool refuses to run and exits with code \`78\`
+          (G368 private-preview expiry gate). Refresh by installing a
+          newer bundle following step 3 above. Local source builds
+          (\`dotnet pack\` without the CI properties) carry no expiry
+          trailer and are not affected.
+          EOF
+          echo "wrote INSTALL.md (${PACKAGE_VERSION})"
+
       - name: Upload preview artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/private-preview-pack.yml
+++ b/.github/workflows/private-preview-pack.yml
@@ -235,7 +235,7 @@ jobs:
 
           \`\`\`text
           intent-cli ${PACKAGE_VERSION}-${SHORT_SHA}-G<unit>
-          channel=private-preview built=${BUILD_TIMESTAMP} expires=${EXPIRES_AT} commit=${SHORT_SHA}
+          channel=private-preview built=${BUILD_TIMESTAMP} expires=${EXPIRES_AT} commit=${SOURCE_COMMIT}
           \`\`\`
 
           The \`channel=private-preview\` trailer is your confirmation

--- a/README.md
+++ b/README.md
@@ -43,26 +43,48 @@ Equivalent `dnx` path:
 (cd .artifacts/smoke-repo && dnx --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" intent-cli project status)
 ```
 
-## Private-preview install (G367)
+## Private-preview install (G367 / G369)
 
 The `private-preview-pack` GitHub Actions workflow runs on every merge to
-`main` and uploads an `intent-cli` `.nupkg` plus a `preview-metadata.json`
-descriptor as a workflow artifact named
-`intent-cli-private-preview-<version>`. The package version pattern is
-`0.2.0-preview.<run_number>.<run_attempt>`, so every CI run produces a
-distinct version.
+`main` and uploads a self-contained install bundle as a workflow artifact
+named `intent-cli-private-preview-<version>`. The bundle contains:
+
+| File | Purpose |
+| --- | --- |
+| `intent-cli.<version>.nupkg` | The NuGet package consumed by `dotnet tool install`. |
+| `intent-cli.<version>.nupkg.sha256` | SHA-256 checksum sidecar; verify before installing (G369). |
+| `preview-metadata.json` | Machine-readable build provenance (channel, version, build/expiry timestamps, commit, CI run identifiers). |
+| `INSTALL.md` | Per-build install / update / verify / uninstall guide with this build's exact version, expiry, and commit pre-filled (G369). |
+
+The package version pattern is `0.2.0-preview.<run_number>.<run_attempt>`,
+so every CI run produces a distinct version. No PAT, source checkout, or
+public NuGet feed is required to install -- only a compatible .NET SDK /
+runtime and the unzipped bundle.
 
 Install or update from a downloaded artifact:
 
 ```bash
 # 1. Download and unzip the workflow artifact from the GitHub Actions
-#    run page, e.g. into ./private-preview-package.
-# 2. Install (or update) the .NET tool from that local folder:
-dotnet tool install --global --add-source ./private-preview-package \
+#    run page, e.g. into ./private-preview-package. Then `cd` into it.
+cd ./private-preview-package
+
+# 2. Verify the checksum (macOS: shasum; Linux: sha256sum). Prints
+#    `intent-cli.<version>.nupkg: OK` on success. Do not install if
+#    verification fails.
+shasum -a 256 -c intent-cli.*.nupkg.sha256
+
+# 3. Install (or update) the .NET tool from this local folder:
+dotnet tool install --global --add-source . \
   --version 0.2.0-preview.<run_number>.<run_attempt> intent-cli
 # Or for an upgrade-in-place:
-dotnet tool update --global --add-source ./private-preview-package \
+dotnet tool update --global --add-source . \
   --version 0.2.0-preview.<run_number>.<run_attempt> intent-cli
+```
+
+To uninstall:
+
+```bash
+dotnet tool uninstall --global intent-cli
 ```
 
 The installed binary exposes the preview metadata via `intent-cli --version`:
@@ -72,11 +94,19 @@ intent-cli 0.2.0-preview.<run_number>.<run_attempt>-<short-sha>-G<unit>
 channel=private-preview built=<iso-utc> expires=<iso-utc> commit=<full-sha>
 ```
 
+The `channel=private-preview` trailer is the confirmation that the
+embedded preview metadata loaded successfully; missing trailer means the
+wrong package was installed.
+
 CI-built private-preview packages expire 14 days after their build
 timestamp; refresh the install from a newer workflow run when the
-`expires=` line moves into the past. Local source builds
-(`dotnet pack` without the CI properties) carry no expiry trailer and
-remain unrestricted.
+`expires=` line moves into the past. After expiry the installed tool
+exits with code `78` (G368 private-preview expiry gate). Local source
+builds (`dotnet pack` without the CI properties) carry no expiry trailer
+and remain unrestricted. Each bundle's `INSTALL.md` contains the full
+copy-pasteable step list with this build's exact version, expiry, and
+commit pre-filled, so a tester who only received the zip via a private
+share can install without referring back to this README.
 
 ## CLI command roles
 


### PR DESCRIPTION
## Summary

Closes #843

Extends the G367 `private-preview-pack` workflow so the uploaded artifact is a self-contained install bundle a tester can consume from a private file-share without referring back to this repo. Two new steps run after the `.nupkg` is packed:

- **SHA-256 checksum sidecar** — writes `<nupkg>.sha256` next to the `.nupkg` using `sha256sum` on Linux and falling back to `shasum -a 256` so the same step works locally on macOS. The sidecar uses the basename of the `.nupkg` so testers can run `shasum -a 256 -c intent-cli.*.nupkg.sha256` (or `sha256sum -c ...`) from inside the unzipped bundle and get `intent-cli.<version>.nupkg: OK`.
- **Per-build `INSTALL.md`** — generated with this build's exact package version, build timestamp, expiry, source commit, and short SHA pre-filled. Covers verify → install → update → verify → uninstall, plus a section on the G368 expiry behaviour (exit code 78 after expiry, only affects CI-built bundles). Lives next to the `.nupkg` so the existing `path: .artifacts/private-preview/**` upload picks it up.

Repo `README.md` "Private-preview install" section also updated to:
- Advertise the new bundle contents in a table (`.nupkg`, `.sha256`, `preview-metadata.json`, `INSTALL.md`).
- Document the checksum verification step before `dotnet tool install`.
- Add the `dotnet tool uninstall --global intent-cli` step.
- Cross-reference the in-bundle `INSTALL.md` so testers know offline copy-pasteable instructions ship in every bundle.

## Test plan

- [x] `dotnet build IntentSystem.sln -c Debug` — 0 errors.
- [x] Local smoke: `dotnet pack` produced `intent-cli.0.2.0-preview.999.1.nupkg`; ran the workflow's new checksum block locally and confirmed `shasum -a 256 -c <nupkg>.sha256` prints `intent-cli.0.2.0-preview.999.1.nupkg: OK`.
- [x] Local smoke of the `INSTALL.md` heredoc with the same env vars the workflow exports; output renders cleanly with the version / timestamp / commit substituted in code spans and code fences.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/private-preview-pack.yml'))"` — YAML parses.
- [x] `git diff --check` — clean (no whitespace errors).

Once merged, the next `main` push will run the workflow end-to-end and produce a bundle including the new sidecar + INSTALL.md for the next downloader to consume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)