### PR TITLE
G372: converge already-resolved PR-comment-fix completion to rereview-ready

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
@@ -78,7 +78,7 @@ Alternatively, run `intent-cli worker pr-comment-preflight --repo <OWNER>/<REPO>
 - If there are no unresolved actionable comments, stop. Set outcome to `no-actionable-comments`.
 - If ALL actionable comments target host metadata paths (`.intent-cli/**` or `intents/**`), stop. Set outcome to `host-artifact-repair-required`. These paths are host-owned durable artifacts that child implementation workers must not edit; the host repair agent must handle them. (The `pr-comment-preflight` result will show `classification: host-artifact-repair-required` in this case.)
 - If a comment is ambiguous and cannot be resolved without guessing, stop. Set outcome to `clarification-required`. Report which comment and why.
-- If the requested change is already applied in the existing branch, stop. Set outcome to `already-resolved`.
+- If the requested change is already applied in the existing branch (no new commit needed), stop. Set outcome to `already-resolved`. Like `repair-pushed`, this converges the PR to `intent-pr-rereview-ready` and clears `intent-pr-request-update`, so the host re-reviews it and `worker next-action` will NOT re-select it (G372). Do NOT use `no-actionable-comments` for this case — that outcome leaves `intent-pr-request-update` in place and the selector would re-pick the PR on the next wake.
 
 Repair steps:
 1. Claim the PR: `intent-cli worker claim --kind pr --number <n> --repo <OWNER>/<REPO> --write --format json`.
@@ -89,9 +89,9 @@ Repair steps:
 6. From the parent host root, run `intent-cli worker result-summary --kind pr-comment-fix --pr <n> --repo <OWNER>/<REPO> --format json`, then `intent-cli worker complete --kind pr --number <n> --repo <OWNER>/<REPO> --outcome repair-pushed --write --format json`.
 
 Outcome classification:
-- `repair-pushed` — narrow fix pushed to the existing PR branch.
-- `no-actionable-comments` — no unresolved actionable review comments; nothing to fix.
-- `already-resolved` — the requested change is already applied in the branch.
+- `repair-pushed` — a NEW narrow fix commit was pushed to the existing PR branch. Converges the PR to `intent-pr-rereview-ready` (removes `intent-pr-request-update` / `intent-pr-update-in-progress`).
+- `already-resolved` — the requested change is ALREADY on the branch, so no new commit is needed. Converges identically to `repair-pushed` (rereview-ready), so the host re-reviews and the selector will not re-pick the PR (G372). Use this — not `no-actionable-comments` — whenever the PR carries `intent-pr-request-update` but the branch already satisfies it.
+- `no-actionable-comments` — there were never any unresolved actionable review comments to act on (e.g. the request-update label was applied but no concrete change was requested, or all comments were already addressed and acknowledged). This releases the claim but does NOT add `intent-pr-rereview-ready`; only use it when there is genuinely nothing for the host to re-review on the basis of a code change.
 - `clarification-required` — ambiguous comment or blocker found; cannot proceed without operator input.
 - `host-artifact-repair-required` — all actionable comments target host metadata paths (`.intent-cli/**` or `intents/**`); child worker must not attempt to repair them.
 - `failed` — fix failed (build/test failure, unresolvable conflict).
@@ -127,9 +127,9 @@ Hard rules:
             },
             OutcomeClassification = new Dictionary<string, string>(StringComparer.Ordinal)
             {
-                ["repair-pushed"] = "Narrow fix pushed to the existing PR branch.",
-                ["no-actionable-comments"] = "No unresolved actionable review comments; nothing to fix.",
-                ["already-resolved"] = "The requested change is already applied in the branch.",
+                ["repair-pushed"] = "A new narrow fix commit was pushed to the existing PR branch; converges to intent-pr-rereview-ready.",
+                ["no-actionable-comments"] = "No unresolved actionable review comments to act on; releases the claim but does NOT add intent-pr-rereview-ready.",
+                ["already-resolved"] = "The requested change is already on the branch (no new commit); converges to intent-pr-rereview-ready like repair-pushed so the selector will not re-pick the PR (G372). Prefer this over no-actionable-comments when intent-pr-request-update is present but already satisfied.",
                 ["clarification-required"] = "Ambiguous comment or blocker found; cannot proceed without operator input.",
                 ["host-artifact-repair-required"] = "All actionable comments target host metadata paths (.intent-cli/** or intents/**); child worker must not attempt to repair them.",
                 ["failed"] = "Fix failed (build/test failure, unresolvable conflict).",

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteAnalyzer.cs
@@ -140,10 +140,9 @@ internal static class WorkerCompleteAnalyzer
         }
 
         // Stale: rereview-ready already present means the PR's repair
-        // was already completed; refuse to re-add for a successful
-        // repair-pushed completion.
-        if (hasRereviewReady
-            && string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.RepairPushed, StringComparison.Ordinal))
+        // was already completed; refuse to re-add for any convergent
+        // rereview outcome (repair-pushed or, per G372, already-resolved).
+        if (hasRereviewReady && IsConvergentRereviewOutcome(outcome))
         {
             errors.Add(
                 $"{WorkerClaimCompleteConstants.ErrorCodes.CompleteAlreadyCompleted}: PR already carries '{WorkerNextActionConstants.Labels.IntentPrRereviewReady}'.");
@@ -160,9 +159,17 @@ internal static class WorkerCompleteAnalyzer
             // All terminal pr-comment-fix outcomes release the in-progress claim.
             removeLabels.Add(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress);
 
-            // repair-pushed success path clears the old request-update state
-            // and marks the PR as ready for re-review.
-            if (string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.RepairPushed, StringComparison.Ordinal))
+            // G372: convergent rereview outcomes (repair-pushed and
+            // already-resolved) clear the old request-update state and mark
+            // the PR ready for re-review. Without this, `already-resolved`
+            // used to remove only intent-pr-update-in-progress, leaving
+            // intent-pr-request-update behind so `worker next-action`
+            // re-selected the same PR on every wake — a 5-minute
+            // oscillation even though the requested fix was already on the
+            // branch. Treating "fix already present" as a host-reviewable
+            // terminal state (like repair-pushed, but without a new commit)
+            // breaks that loop.
+            if (IsConvergentRereviewOutcome(outcome))
             {
                 removeLabels.Add(WorkerNextActionConstants.Labels.IntentPrRequestUpdate);
                 addLabels.Add(WorkerNextActionConstants.Labels.IntentPrRereviewReady);
@@ -182,6 +189,21 @@ internal static class WorkerCompleteAnalyzer
                 : "Refusing to complete PR: stale or already-completed target.",
         };
     }
+
+    /// <summary>
+    /// G372: pr-comment-fix completion outcomes that converge a PR to the
+    /// host-reviewable <c>intent-pr-rereview-ready</c> state by clearing the
+    /// child-actionable <c>intent-pr-request-update</c> /
+    /// <c>intent-pr-update-in-progress</c> labels. Both <c>repair-pushed</c>
+    /// (a new commit was pushed) and <c>already-resolved</c> (the requested
+    /// fix was already on the branch, no new commit) are terminal review
+    /// hand-offs; the only difference is whether a commit landed. Keeping
+    /// them in one set guarantees the selector cannot re-pick the PR after
+    /// either outcome.
+    /// </summary>
+    private static bool IsConvergentRereviewOutcome(string outcome) =>
+        string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.RepairPushed, StringComparison.Ordinal)
+        || string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.AlreadyResolved, StringComparison.Ordinal);
 
     private static CompleteDecision Refuse(string errorMessage, string summary)
     {

--- a/src/IntentSystem.Cli/Commands/WorkerResultSummaryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerResultSummaryAnalyzer.cs
@@ -144,9 +144,12 @@ internal static class WorkerResultSummaryAnalyzer
 
         // Common cleanup: when PR-comment-fix work ended on a non-cleanup
         // terminal outcome, the worker's claim label on the PR
-        // (intent-pr-update-in-progress) should be released.
+        // (intent-pr-update-in-progress) should be released. The convergent
+        // rereview outcomes (repair-pushed, already-resolved) handle that
+        // release via the explicit swap below, so they are excluded here to
+        // avoid a duplicate remove action (G372).
         if (kind == WorkerResultSummaryConstants.Kinds.PrCommentFix
-            && outcome != WorkerResultSummaryConstants.Outcomes.RepairPushed)
+            && !IsConvergentRereviewOutcome(outcome))
         {
             actions.Add(MakeAction(
                 WorkerResultSummaryConstants.LabelActionVerbs.Remove,
@@ -167,6 +170,12 @@ internal static class WorkerResultSummaryAnalyzer
                 break;
 
             case WorkerResultSummaryConstants.Outcomes.RepairPushed:
+            // G372: already-resolved converges identically to repair-pushed
+            // — the requested fix is on the branch, so the PR is handed back
+            // to host re-review. Sharing this branch keeps the recommended
+            // label actions aligned with the worker-complete transition.
+            case WorkerResultSummaryConstants.Outcomes.AlreadyResolved
+                when kind == WorkerResultSummaryConstants.Kinds.PrCommentFix:
                 // The PR claim label and the old request-update state both
                 // clear as the PR becomes rereview-ready. Keep the primary
                 // in-progress -> rereview-ready transition as a swap, and
@@ -224,9 +233,14 @@ internal static class WorkerResultSummaryAnalyzer
         // explicitly so the host loop can ready-for-review or stop the
         // closeout. Repaired-via-pr-comment-fix on a still-draft PR is also
         // host-merge-blocked; surface the same warning for that path.
+        // G372: already-resolved on a pr-comment-fix now converges to
+        // rereview-ready (like repair-pushed), so a still-draft PR carries
+        // the same host-merge-blocking risk and must surface the warning.
         if (prDraft == true
             && (outcome == WorkerResultSummaryConstants.Outcomes.PrCreated
-                || outcome == WorkerResultSummaryConstants.Outcomes.RepairPushed))
+                || outcome == WorkerResultSummaryConstants.Outcomes.RepairPushed
+                || (outcome == WorkerResultSummaryConstants.Outcomes.AlreadyResolved
+                    && kind == WorkerResultSummaryConstants.Kinds.PrCommentFix)))
         {
             warnings.Add(
                 "draft PR: automation-created PRs default to ready-for-review (G296). A draft PR will block host merge — ready it for review or document why draft is intentional.");
@@ -279,7 +293,9 @@ internal static class WorkerResultSummaryAnalyzer
                 $"Clarification required — worker stopped without changing scope ({Identifier(repo, issue ?? pr, "#")}).",
 
             WorkerResultSummaryConstants.Outcomes.AlreadyResolved =>
-                $"Already resolved on origin/main — no further action needed ({Identifier(repo, issue ?? pr, "#")}).",
+                kind == WorkerResultSummaryConstants.Kinds.PrCommentFix
+                    ? $"Requested fix already present on the PR branch — marked ready for re-review{draftSuffix} ({Identifier(repo, pr, "#")})."
+                    : $"Already resolved — no further action needed ({Identifier(repo, issue ?? pr, "#")}).",
 
             WorkerResultSummaryConstants.Outcomes.NoActionableComments =>
                 $"No actionable review comments remain on PR ({Identifier(repo, pr, "#")}).",
@@ -304,4 +320,16 @@ internal static class WorkerResultSummaryAnalyzer
             Target = target,
             Label = label,
         };
+
+    /// <summary>
+    /// G372: pr-comment-fix outcomes that converge a PR to the
+    /// host-reviewable <c>intent-pr-rereview-ready</c> state. Both
+    /// <c>repair-pushed</c> and <c>already-resolved</c> hand the PR back to
+    /// the host review loop and clear the child-actionable update labels;
+    /// keeping them in one set keeps the recommended label actions aligned
+    /// with <see cref="WorkerCompleteAnalyzer"/>.
+    /// </summary>
+    private static bool IsConvergentRereviewOutcome(string outcome) =>
+        string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.RepairPushed, StringComparison.Ordinal)
+        || string.Equals(outcome, WorkerResultSummaryConstants.Outcomes.AlreadyResolved, StringComparison.Ordinal);
 }

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -625,6 +625,96 @@ public sealed class WorkerCompleteCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_PrAlreadyResolvedOutcome_WriteConvergesToRereviewReadyAndClearsRequestUpdate()
+    {
+        // G372: completing a PR-comment-fix with `already-resolved` (the
+        // requested change is already on the branch) must converge the PR
+        // exactly like repair-pushed — remove intent-pr-update-in-progress
+        // AND intent-pr-request-update, add intent-pr-rereview-ready — so
+        // the selector cannot re-pick the PR on the next wake. This pins the
+        // fix for the observed PR #842 5-minute oscillation.
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-request-update", "intent-pr-update-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "pr",
+                "--number", "842",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.AlreadyResolved,
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.True(result.Proceed);
+        Assert.True(result.Applied);
+        Assert.Contains("intent-pr-rereview-ready", result.AddLabels);
+        Assert.Contains("intent-pr-update-in-progress", result.RemoveLabels);
+        Assert.Contains("intent-pr-request-update", result.RemoveLabels);
+        // intent-pr-created MUST NOT be added to a PR.
+        Assert.DoesNotContain("intent-pr-created", result.AddLabels);
+
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Contains("intent-pr-rereview-ready", transition.AddLabels);
+        Assert.Contains("intent-pr-update-in-progress", transition.RemoveLabels);
+        Assert.Contains("intent-pr-request-update", transition.RemoveLabels);
+
+        // The resulting PR must carry NO child-actionable update label, so
+        // `worker next-action` returns `none` for it until the host opens a
+        // new review request.
+        var finalLabels = mutator.Labels
+            .Except(transition.RemoveLabels, StringComparer.Ordinal)
+            .Concat(transition.AddLabels)
+            .ToArray();
+        Assert.Contains("intent-pr-rereview-ready", finalLabels);
+        Assert.DoesNotContain("intent-pr-request-update", finalLabels);
+        Assert.DoesNotContain("intent-pr-update-in-progress", finalLabels);
+    }
+
+    [Fact]
+    public void Execute_PrAlreadyResolvedOnConvergedPr_RefusesAlreadyCompleted()
+    {
+        // G372: once a PR has converged to intent-pr-rereview-ready, a
+        // repeat already-resolved completion must refuse rather than
+        // re-add the label — mirroring the existing repair-pushed guard.
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-update-in-progress", "intent-pr-rereview-ready" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "pr",
+                "--number", "842",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.AlreadyResolved,
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, e => e.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.CompleteAlreadyCompleted, StringComparison.Ordinal));
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
     public void Execute_PrFailedOutcome_RemovesUpdateInProgressOnly()
     {
         using var workspace = new WorkerCompleteWorkspace();

--- a/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
@@ -63,6 +63,42 @@ public sealed class WorkerNextActionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenPrConvergedToRereviewReadyAfterAlreadyResolved_ReturnsNone()
+    {
+        // G372 selector regression: after a pr-comment-fix completes with
+        // `already-resolved`, the PR carries intent-pr-rereview-ready and no
+        // longer carries intent-pr-request-update / intent-pr-update-in-progress
+        // (see WorkerCompleteAnalyzer). The selector MUST NOT re-pick such a
+        // PR — this is the exact state PR #842 was stuck oscillating on
+        // before the convergence fix. With no other candidates the action
+        // must be `none`, not pr-comment-fix.
+        using var workspace = new WorkerNextActionWorkspace();
+        var lister = new FakeLister
+        {
+            Prs = new[]
+            {
+                BuildPr(842, "Converged PR (fix already present)",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/842",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-rereview-ready" }),
+            },
+            Issues = Array.Empty<GitHubAutomationIssueCandidate>(),
+        };
+        WorkerNextActionCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--github-only", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerNextActionResult>(writer.ToString())!;
+        Assert.Equal(WorkerNextActionConstants.Actions.None, result.Action);
+        Assert.Null(result.Number);
+    }
+
+    [Fact]
     public void Execute_GivenPrInUpdateInProgress_SurfacesWaitLease()
     {
         // G325 replaces the previous "fall through to issue-to-pr"

--- a/tests/IntentSystem.Cli.Tests/WorkerResultSummaryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerResultSummaryCommandTests.cs
@@ -109,6 +109,51 @@ public sealed class WorkerResultSummaryCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenPrCommentFixAlreadyResolved_EmitsSwapActionToRereviewReady()
+    {
+        // G372: already-resolved on a pr-comment-fix now recommends the
+        // SAME convergent label actions as repair-pushed (swap
+        // update-in-progress -> rereview-ready, remove request-update) so
+        // an agent that reports "fix already present" hands the PR back to
+        // host re-review instead of leaving request-update behind for the
+        // selector to re-pick.
+        using var workspace = new WorkerResultSummaryWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = WorkerResultSummaryCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--kind", "pr-comment-fix",
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "842",
+                "--outcome", "already-resolved",
+                "--format", "json"
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerResultSummaryResult>(writer.ToString())!;
+        Assert.Equal(WorkerResultSummaryConstants.Statuses.Completed, result.Status);
+        Assert.Contains("ready for re-review", result.Summary, StringComparison.Ordinal);
+
+        Assert.Contains(result.RecommendedLabelActions, a =>
+            a.Action == "swap"
+            && a.Target == "pr"
+            && a.Label.Contains(WorkerResultSummaryConstants.Labels.IntentPrUpdateInProgress, StringComparison.Ordinal)
+            && a.Label.Contains(WorkerResultSummaryConstants.Labels.IntentPrRereviewReady, StringComparison.Ordinal));
+        Assert.Contains(result.RecommendedLabelActions, a =>
+            a.Action == "remove"
+            && a.Target == "pr"
+            && a.Label == WorkerResultSummaryConstants.Labels.IntentPrRequestUpdate);
+
+        // No spurious standalone "remove in-progress" action — the swap covers it.
+        Assert.DoesNotContain(result.RecommendedLabelActions, a =>
+            a.Action == "remove"
+            && a.Label == WorkerResultSummaryConstants.Labels.IntentPrUpdateInProgress);
+    }
+
+    [Fact]
     public void Execute_GivenIssueToPrDeclinedContractIncomplete_EmitsDeclinedStatus()
     {
         using var workspace = new WorkerResultSummaryWorkspace();


### PR DESCRIPTION
## Summary

Closes #847

Fixes the 5-minute oscillation where a child loop repeatedly reselected a PR (observed on #842) after the implementer reported the requested fix was already on the branch. `worker complete --outcome already-resolved` removed only `intent-pr-update-in-progress`, leaving `intent-pr-request-update` so `worker next-action` re-picked the same PR every wake. The loop converged only when the operator switched to `repair-pushed`.

This makes `already-resolved` (for the `pr-comment-fix` kind) a **convergent rereview outcome** — like `repair-pushed` but without a new commit, since the fix is already present:

- **`WorkerCompleteAnalyzer`** — `already-resolved` now removes `intent-pr-request-update` + `intent-pr-update-in-progress` and adds `intent-pr-rereview-ready` (shared `IsConvergentRereviewOutcome` set). The "already completed" stale guard also covers `already-resolved`, so a repeat completion on a converged PR refuses instead of re-adding the label.
- **`WorkerResultSummaryAnalyzer`** — `already-resolved` (pr-comment-fix) recommends the same swap (`update-in-progress -> rereview-ready`) + `request-update` removal as `repair-pushed`, emits a kind-aware summary ("marked ready for re-review"), and is included in the G296 draft-PR warning. `issue-to-pr` `already-resolved` is unchanged.
- **`GuideWorkerPrCommentFixCommand`** — outcome classification now explains when to use `repair-pushed` (new commit) vs `already-resolved` (fix present; converges — do NOT use `no-actionable-comments`) vs `no-actionable-comments` (nothing to act on; does not add `rereview-ready`).

## Acceptance criteria mapping

- ✅ Completing with the fix-present outcome leaves the PR with no child-actionable update label (`WorkerCompleteAnalyzer` removes both update labels).
- ✅ The PR becomes host-reviewable with `intent-pr-rereview-ready`.
- ✅ A subsequent `worker next-action --github-only` returns `none` for that PR (selector regression test).
- ✅ Tests assert the old `already-resolved` oscillation cannot recur.
- ✅ Guidance explains `repair-pushed` / `already-resolved` / `no-actionable-comments`.

## Tests

- `WorkerCompleteCommandTests`: already-resolved write converges (removes both update labels, adds rereview-ready, final labels carry no child-actionable update label); repeat already-resolved on a converged PR refuses with `complete.already-completed`.
- `WorkerNextActionCommandTests`: a PR converged to `rereview-ready` is NOT reselected — action is `none` (the exact PR #842 stuck state).
- `WorkerResultSummaryCommandTests`: already-resolved pr-comment-fix emits the swap + request-update removal and the rereview summary.

Full suite: **3175 passed, 1 skipped, 0 failed**. `git diff --check` clean.

## Note on the spec target path

The issue lists `intents/intent-cli/specs/05-intent-cli-surface.md` as a target, but that host-owned spec is not present in the child GitHub-contract-only worktree (G300/G333), so it is left to the host. The code + guide + tests fully satisfy the acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)