### PR TITLE
G374: add GitHub-label-backed structured worker signal protocol

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -88,7 +88,10 @@ internal static class CommandRouter
                 ["run"] = ReviewRunCommand.Execute,
                 ["comment"] = ReviewCommentCommand.Execute,
                 ["accept"] = ReviewAcceptCommand.Execute,
-                ["closeout-plan"] = ReviewCloseoutPlanCommand.Execute
+                ["closeout-plan"] = ReviewCloseoutPlanCommand.Execute,
+                // G374: host-side structured worker-signal collection / convergence.
+                ["collect-signals"] = ReviewCollectSignalsCommand.Execute,
+                ["signal-handled"] = ReviewSignalHandledCommand.Execute
             },
             ["interview"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
@@ -200,7 +203,9 @@ internal static class CommandRouter
                 ["result-summary"] = WorkerResultSummaryCommand.Execute,
                 ["next-action"] = WorkerNextActionCommand.Execute,
                 ["claim"] = WorkerClaimCommand.Execute,
-                ["complete"] = WorkerCompleteCommand.Execute
+                ["complete"] = WorkerCompleteCommand.Execute,
+                // G374: child-side structured worker-signal raising.
+                ["signal"] = WorkerSignalCommand.Execute
             },
             ["metadata"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GuideWorkerCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerCommand.cs
@@ -9,7 +9,7 @@ namespace IntentSystem.Cli.Commands;
 internal static class GuideWorkerCommand
 {
     private const string UsageLine =
-        "Usage: intent-cli guide worker <issue-to-pr|pr-comment-fix> [--repo <owner/repo>] [--domain <name>] [--format markdown|json]";
+        "Usage: intent-cli guide worker <issue-to-pr|pr-comment-fix|signal> [--repo <owner/repo>] [--domain <name>] [--format markdown|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -33,6 +33,11 @@ internal static class GuideWorkerCommand
             return GuideWorkerPrCommentFixCommand.Execute(context, args[1..], writer);
         }
 
+        if (args.Length >= 1 && string.Equals(args[0], "signal", StringComparison.Ordinal))
+        {
+            return GuideWorkerSignalCommand.Execute(context, args[1..], writer);
+        }
+
         writer.WriteLine("A subcommand is required for 'guide worker'.");
         writer.WriteLine(UsageLine);
         return 1;
@@ -42,6 +47,6 @@ internal static class GuideWorkerCommand
     {
         writer.WriteLine("guide worker");
         writer.WriteLine(UsageLine);
-        writer.WriteLine("Subcommands: issue-to-pr, pr-comment-fix");
+        writer.WriteLine("Subcommands: issue-to-pr, pr-comment-fix, signal");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkerSignalCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerSignalCommand.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G374: read-only <c>intent-cli guide worker signal</c>. Emits
+/// paste-ready comment templates and the exact <c>intent-cli</c> commands
+/// for the structured worker-signal protocol so a child implementation
+/// agent can hand a blocker / follow-up / scope-warning back to host
+/// review/design automation without reading host metadata or guessing
+/// the label transitions. Never mutates state; never launches a provider.
+/// </summary>
+internal static class GuideWorkerSignalCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide worker signal [--repo <owner/repo>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var repo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = Build(repo);
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static GuideWorkerSignalResult Build(string? repo)
+    {
+        var repoArg = string.IsNullOrWhiteSpace(repo) ? "<OWNER>/<REPO>" : repo;
+
+        var templates = new[]
+        {
+            new GuideWorkerSignalTemplate
+            {
+                Kind = WorkerSignalContract.Kinds.Blocker,
+                Target = WorkerSignalContract.Targets.Issue,
+                When = "The assigned issue cannot be safely implemented and should be declined before any code is written (missing contract, unbuildable premise, conflicting parent intent).",
+                Command = $"intent-cli worker signal blocker --repo {repoArg} --issue <n> --from-file signal.md --write --github-only --format json",
+                Body = "Summary: <one line — why this issue cannot be implemented as written>.\n\nEvidence:\n- <file/path or command output that demonstrates the blocker>\n\nWhat host design should decide:\n- <the clarification, packet change, or parent-intent reconciliation needed before this is implementable>",
+            },
+            new GuideWorkerSignalTemplate
+            {
+                Kind = WorkerSignalContract.Kinds.FollowUp,
+                Target = WorkerSignalContract.Targets.Pr,
+                When = "Implementation can proceed and the PR is open, but you found a follow-up defect or design gap that is out of scope for this PR.",
+                Command = $"intent-cli worker signal follow-up --repo {repoArg} --pr <n> --from-file signal.md --write --github-only --format json",
+                Body = "Summary: <one line — the follow-up defect/gap, distinct from this PR's scope>.\n\nEvidence:\n- <where it surfaces; why it is out of scope for the current PR>\n\nSuggested follow-up:\n- <a candidate next slice / issue the host could cut>",
+            },
+            new GuideWorkerSignalTemplate
+            {
+                Kind = WorkerSignalContract.Kinds.ScopeWarning,
+                Target = "issue|pr",
+                When = "The finding belongs to host intent/packet metadata (paths under intents/** or .intent-cli/**) or would widen scope beyond the assigned slice. Child workers must not edit those paths.",
+                Command = $"intent-cli worker signal scope-warning --repo {repoArg} (--issue <n> | --pr <n>) --from-file signal.md --write --github-only --format json",
+                Body = "Summary: <one line — the host-owned metadata or scope concern>.\n\nWhy it is host-owned / out of scope:\n- <the path or contract that a child worker must not touch>\n\nRequested host action:\n- <packet edit, rule update, or metadata repair for the host loop to perform>",
+            },
+        };
+
+        var prompt =
+$@"Raise a structured worker signal for {repoArg} when you find something outside the assigned slice. A signal is a GitHub issue/PR comment carrying a hidden marker plus the `intent-signal-sent` label; host review/design automation collects it with `intent-cli review collect-signals` and clears it with `intent-cli review signal-handled`.
+
+Pick the kind:
+- blocker (issue): decline-before-implementation — the issue cannot be safely implemented as written.
+- follow-up (PR): a follow-up defect / design gap found while the PR is open, out of scope for this PR.
+- scope-warning (issue or PR): the finding is host-owned metadata (intents/** or .intent-cli/**) or widens scope.
+
+Send a signal:
+1. Write the signal body to a file (e.g. signal.md) using the matching template below.
+2. Run the `intent-cli worker signal <kind>` command for the target. It posts the marker-wrapped comment and adds `intent-signal-sent` in one step. Default is dry-run; add --write to actually post.
+3. Do NOT hand-edit labels with `gh ... edit --add-label`; the worker signal command owns the transition.
+
+Hard rules:
+- Do not read or edit host metadata (intents/**, .intent-cli/**); a scope-warning signal is how you hand those findings back.
+- Do not raise a signal for ordinary PR review comments — those go through the normal pr-comment-fix flow.
+- One signal per finding; if you already sent one and nothing changed, do not duplicate it.";
+
+        return new GuideWorkerSignalResult
+        {
+            Kind = "worker-signal",
+            Repo = string.IsNullOrWhiteSpace(repo) ? null : repo,
+            Prompt = prompt,
+            Labels = new GuideWorkerSignalLabels
+            {
+                Sent = WorkerSignalContract.Labels.SignalSent,
+                Handled = WorkerSignalContract.Labels.SignalHandled,
+            },
+            MarkerExample = $"{WorkerSignalContract.MarkerPrefix} v={WorkerSignalContract.MarkerVersion} kind=blocker target=issue#<n> -->",
+            Templates = templates,
+            HostCommands = new[]
+            {
+                $"intent-cli review collect-signals --repo {repoArg} --format json",
+                $"intent-cli review signal-handled --repo {repoArg} (--issue <n> | --pr <n>) --write --format json",
+            },
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideWorkerSignalResult result)
+    {
+        writer.WriteLine("# Guide worker — structured signal protocol");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Repo))
+        {
+            writer.WriteLine($"- repo: {result.Repo}");
+        }
+        writer.WriteLine($"- pending label: {result.Labels.Sent}");
+        writer.WriteLine($"- handled label: {result.Labels.Handled}");
+        writer.WriteLine($"- marker shape: `{result.MarkerExample}`");
+        writer.WriteLine();
+
+        writer.WriteLine("## Templates");
+        foreach (var template in result.Templates)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"### {template.Kind} ({template.Target})");
+            writer.WriteLine();
+            writer.WriteLine($"When: {template.When}");
+            writer.WriteLine();
+            writer.WriteLine($"Command: `{template.Command}`");
+            writer.WriteLine();
+            writer.WriteLine("Body (write to --from-file):");
+            writer.WriteLine();
+            writer.WriteLine("```text");
+            writer.WriteLine(template.Body);
+            writer.WriteLine("```");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Host collection commands");
+        foreach (var command in result.HostCommands)
+        {
+            writer.WriteLine($"- `{command}`");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Prompt");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+    }
+
+    private static bool TryParseArguments(string[] args, out string? repo, out string format, out string error)
+    {
+        repo = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide worker signal");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only paste-ready structured worker-signal templates (blocker / follow-up / scope-warning).");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}
+
+internal sealed record GuideWorkerSignalResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("repo")]
+    public string? Repo { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("labels")]
+    public required GuideWorkerSignalLabels Labels { get; init; }
+
+    [JsonPropertyName("marker_example")]
+    public required string MarkerExample { get; init; }
+
+    [JsonPropertyName("templates")]
+    public required IReadOnlyList<GuideWorkerSignalTemplate> Templates { get; init; }
+
+    [JsonPropertyName("host_commands")]
+    public required IReadOnlyList<string> HostCommands { get; init; }
+}
+
+internal sealed record GuideWorkerSignalLabels
+{
+    [JsonPropertyName("sent")]
+    public required string Sent { get; init; }
+
+    [JsonPropertyName("handled")]
+    public required string Handled { get; init; }
+}
+
+internal sealed record GuideWorkerSignalTemplate
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("target")]
+    public required string Target { get; init; }
+
+    [JsonPropertyName("when")]
+    public required string When { get; init; }
+
+    [JsonPropertyName("command")]
+    public required string Command { get; init; }
+
+    [JsonPropertyName("body")]
+    public required string Body { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IGitHubSignalGateway.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubSignalGateway.cs
@@ -1,0 +1,213 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G374: testability seam for posting and reading GitHub issue/PR
+/// comments in the structured worker-signal protocol. The production
+/// implementation shells out to <c>gh issue/pr comment</c> (write) and
+/// <c>gh issue/pr view --json comments</c> (read); tests inject a fake
+/// to avoid any GitHub network access and to verify the dry-run / write
+/// split. Label transitions stay on the existing
+/// <see cref="IGitHubLabelMutator"/> seam — this seam only touches
+/// comments.
+/// </summary>
+internal interface IGitHubSignalGateway
+{
+    /// <summary>
+    /// Post <paramref name="body"/> as a new comment on the issue/PR and
+    /// return the created comment reference (the URL <c>gh</c> prints).
+    /// </summary>
+    string PostComment(string repo, string kind, int number, string body);
+
+    /// <summary>
+    /// Read the existing comments on the issue/PR. Read-only — never
+    /// mutates GitHub.
+    /// </summary>
+    IReadOnlyList<GitHubSignalComment> ListComments(string repo, string kind, int number);
+}
+
+/// <summary>G374: a single GitHub issue/PR comment row.</summary>
+internal sealed record GitHubSignalComment
+{
+    [JsonPropertyName("body")]
+    public string Body { get; init; } = string.Empty;
+
+    [JsonPropertyName("createdAt")]
+    public string CreatedAt { get; init; } = string.Empty;
+
+    [JsonPropertyName("url")]
+    public string Url { get; init; } = string.Empty;
+
+    [JsonPropertyName("author")]
+    public GitHubSignalCommentAuthor Author { get; init; } = new();
+}
+
+internal sealed record GitHubSignalCommentAuthor
+{
+    [JsonPropertyName("login")]
+    public string Login { get; init; } = string.Empty;
+}
+
+/// <summary>
+/// G374: default gateway that shells out to <c>gh</c>. The only file in
+/// the signal surface permitted to call <c>Process.Start</c> — the
+/// contract, analyzer, and command layers stay pure. Comment bodies are
+/// passed via stdin (<c>--body-file -</c>) so multi-line / special
+/// characters never hit shell quoting.
+/// </summary>
+internal sealed class GhCliGitHubSignalGateway : IGitHubSignalGateway
+{
+    public static class Kinds
+    {
+        public const string Issue = "issue";
+        public const string Pr = "pr";
+    }
+
+    /// <summary>G374: <c>gh ... view --json comments</c> field name.</summary>
+    internal const string ViewCommentsJsonFields = "comments";
+
+    /// <summary>G374: build the <c>gh issue/pr comment</c> argument list (body via stdin).</summary>
+    internal static IReadOnlyList<string> BuildCommentArguments(string repo, string kind, int number)
+    {
+        ValidateKindAndNumber(repo, kind, number);
+        return new List<string>
+        {
+            kind,
+            "comment",
+            number.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "--repo", repo,
+            "--body-file", "-",
+        };
+    }
+
+    /// <summary>G374: build the <c>gh issue/pr view --json comments</c> argument list.</summary>
+    internal static IReadOnlyList<string> BuildViewCommentsArguments(string repo, string kind, int number)
+    {
+        ValidateKindAndNumber(repo, kind, number);
+        return new List<string>
+        {
+            kind,
+            "view",
+            number.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            "--repo", repo,
+            "--json", ViewCommentsJsonFields,
+        };
+    }
+
+    public string PostComment(string repo, string kind, int number, string body)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(body);
+        var args = BuildCommentArguments(repo, kind, number);
+        var stdout = RunGh(args, $"post comment on {kind} #{number} in {repo}", body);
+        return stdout.Trim();
+    }
+
+    public IReadOnlyList<GitHubSignalComment> ListComments(string repo, string kind, int number)
+    {
+        var args = BuildViewCommentsArguments(repo, kind, number);
+        var stdout = RunGh(args, $"read comments on {kind} #{number} in {repo}", standardInput: null);
+        return DeserializeComments(stdout, $"`gh {kind} view #{number} --json comments` for {repo}");
+    }
+
+    private static void ValidateKindAndNumber(string repo, string kind, int number)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        if (number <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(number), "issue/PR number must be positive.");
+        }
+        if (!string.Equals(kind, Kinds.Issue, StringComparison.Ordinal)
+            && !string.Equals(kind, Kinds.Pr, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"unrecognized kind '{kind}'. Supported: '{Kinds.Issue}', '{Kinds.Pr}'.",
+                nameof(kind));
+        }
+    }
+
+    private static string RunGh(IReadOnlyList<string> arguments, string description, string? standardInput)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = standardInput is not null,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        string stdout;
+        string stderr;
+        int exitCode;
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException(
+                    $"failed to start `gh` process to {description}");
+
+            if (standardInput is not null)
+            {
+                using (var stdin = process.StandardInput)
+                {
+                    stdin.Write(standardInput);
+                }
+            }
+
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            exitCode = process.ExitCode;
+        }
+        catch (Exception exception) when (
+            exception is System.ComponentModel.Win32Exception
+            or InvalidOperationException
+            or IOException)
+        {
+            throw new InvalidOperationException(
+                $"could not invoke `gh` to {description}: {exception.Message}",
+                exception);
+        }
+
+        if (exitCode != 0)
+        {
+            var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+            throw new InvalidOperationException(
+                $"`gh` failed to {description} with exit {exitCode}: {errorBody.Trim()}");
+        }
+
+        return stdout;
+    }
+
+    private static IReadOnlyList<GitHubSignalComment> DeserializeComments(
+        string stdout,
+        string callDescription)
+    {
+        try
+        {
+            var view = JsonSerializer.Deserialize<CommentsView>(stdout);
+            return view?.Comments ?? (IReadOnlyList<GitHubSignalComment>)Array.Empty<GitHubSignalComment>();
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException(
+                $"could not parse {callDescription} JSON: {exception.Message}",
+                exception);
+        }
+    }
+
+    private sealed record CommentsView
+    {
+        [JsonPropertyName("comments")]
+        public IReadOnlyList<GitHubSignalComment> Comments { get; init; }
+            = Array.Empty<GitHubSignalComment>();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ReviewCollectSignalsAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCollectSignalsAnalyzer.cs
@@ -1,0 +1,143 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G374: pure classifier for <c>intent-cli review collect-signals</c>.
+/// Given the normalized issue/PR candidates (each already filtered to
+/// carry <c>intent-signal-sent</c> by the gh label query, but tolerant
+/// of any label set so it stays unit-testable), it parses the latest
+/// structured marker comment per item and partitions them into:
+/// - pending  : has intent-signal-sent + a parseable marker, not handled
+/// - skipped  : intent-signal-handled present (already processed)
+/// - unmarked : labelled intent-signal-sent but no marker comment found
+/// No GitHub or filesystem I/O — the command layer feeds it data read
+/// through the lister + gateway seams.
+/// </summary>
+internal static class ReviewCollectSignalsAnalyzer
+{
+    public static ReviewCollectSignalsResult Analyze(
+        string repo,
+        IReadOnlyList<SignalCandidateInput> candidates)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(candidates);
+
+        var pending = new List<PendingSignal>();
+        var warnings = new List<string>();
+        var handledSkipped = 0;
+        var unmarked = 0;
+
+        foreach (var candidate in candidates)
+        {
+            var hasSent = candidate.Labels.Contains(WorkerSignalContract.Labels.SignalSent, StringComparer.Ordinal);
+            var hasHandled = candidate.Labels.Contains(WorkerSignalContract.Labels.SignalHandled, StringComparer.Ordinal);
+
+            // Already-processed items: handled marker present and the pending
+            // marker cleared. These must never be reprocessed.
+            if (hasHandled && !hasSent)
+            {
+                handledSkipped++;
+                continue;
+            }
+
+            // Not actually a pending signal (defensive — production filters
+            // on the label, but a fed candidate may not carry it).
+            if (!hasSent)
+            {
+                continue;
+            }
+
+            if (hasHandled)
+            {
+                warnings.Add(
+                    $"{candidate.Target} #{candidate.Number} carries both '{WorkerSignalContract.Labels.SignalSent}' and '{WorkerSignalContract.Labels.SignalHandled}'; treating as pending — run `intent-cli review signal-handled` to converge.");
+            }
+
+            if (!TryResolveLatestSignalComment(candidate.Comments, out var signalKind, out var commentRef, out var createdAt))
+            {
+                unmarked++;
+                warnings.Add(
+                    $"{candidate.Target} #{candidate.Number} is labelled '{WorkerSignalContract.Labels.SignalSent}' but has no parseable structured signal marker comment.");
+                continue;
+            }
+
+            pending.Add(new PendingSignal
+            {
+                Target = candidate.Target,
+                Number = candidate.Number,
+                SignalKind = signalKind,
+                Title = candidate.Title,
+                Url = candidate.Url,
+                CommentRef = commentRef,
+                CommentCreatedAt = createdAt,
+            });
+        }
+
+        return new ReviewCollectSignalsResult
+        {
+            Repo = repo,
+            PendingSignals = pending,
+            HandledSkippedCount = handledSkipped,
+            UnmarkedCount = unmarked,
+            Warnings = warnings,
+        };
+    }
+
+    /// <summary>
+    /// G374: among an item's comments, pick the most recent one that is a
+    /// structured signal marker (ISO-8601 UTC timestamps sort
+    /// lexicographically; comments with no timestamp fall back to source
+    /// order). Returns its kind, url, and created-at.
+    /// </summary>
+    private static bool TryResolveLatestSignalComment(
+        IReadOnlyList<GitHubSignalComment> comments,
+        out string signalKind,
+        out string commentRef,
+        out string createdAt)
+    {
+        signalKind = string.Empty;
+        commentRef = string.Empty;
+        createdAt = string.Empty;
+
+        GitHubSignalComment? latest = null;
+        var latestKind = string.Empty;
+        foreach (var comment in comments)
+        {
+            if (!WorkerSignalContract.TryParseSignalKind(comment.Body, out var kind))
+            {
+                continue;
+            }
+
+            if (latest is null
+                || string.Compare(comment.CreatedAt, latest.CreatedAt, StringComparison.Ordinal) >= 0)
+            {
+                latest = comment;
+                latestKind = kind;
+            }
+        }
+
+        if (latest is null)
+        {
+            return false;
+        }
+
+        signalKind = latestKind;
+        commentRef = latest.Url;
+        createdAt = latest.CreatedAt;
+        return true;
+    }
+}
+
+/// <summary>
+/// G374: normalized input row for <see cref="ReviewCollectSignalsAnalyzer"/>.
+/// The command builds these from the candidate lister (labels/title/url)
+/// and the comment gateway (comments).
+/// </summary>
+internal sealed record SignalCandidateInput
+{
+    public required string Target { get; init; }
+    public required int Number { get; init; }
+    public string Title { get; init; } = string.Empty;
+    public string Url { get; init; } = string.Empty;
+    public required IReadOnlyList<string> Labels { get; init; }
+    public required IReadOnlyList<GitHubSignalComment> Comments { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/ReviewCollectSignalsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCollectSignalsCommand.cs
@@ -1,0 +1,220 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G374: <c>intent-cli review collect-signals --repo &lt;r&gt;</c>. Host
+/// review/design side scan: lists issues and PRs carrying
+/// <c>intent-signal-sent</c>, reads their comments to find the latest
+/// structured signal marker, and reports the pending set so a host loop
+/// can convert each into clarification / packet / metadata-repair work.
+/// Items already carrying <c>intent-signal-handled</c> (with the pending
+/// marker cleared) drop out of the label query, so they are never
+/// reprocessed. Read-only — never mutates GitHub.
+/// </summary>
+internal static class ReviewCollectSignalsCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>Test seam: inject a fake candidate lister.</summary>
+    public static Func<IGitHubAutomationCandidateLister>? ListerFactory { get; set; }
+
+    /// <summary>Test seam: inject a fake comment gateway.</summary>
+    public static Func<IGitHubSignalGateway>? GatewayFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var repo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubAutomationCandidateLister lister;
+        IGitHubSignalGateway gateway;
+        try
+        {
+            lister = ListerFactory?.Invoke() ?? new GhCliGitHubAutomationCandidateLister();
+            gateway = GatewayFactory?.Invoke() ?? new GhCliGitHubSignalGateway();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub adapters: {exception.Message}");
+            return 1;
+        }
+
+        var requiredLabels = new[] { WorkerSignalContract.Labels.SignalSent };
+        List<SignalCandidateInput> candidates = new();
+        try
+        {
+            foreach (var issue in lister.ListIssues(repo!, requiredLabels))
+            {
+                candidates.Add(BuildCandidate(
+                    gateway,
+                    repo!,
+                    GhCliGitHubSignalGateway.Kinds.Issue,
+                    issue.Number,
+                    issue.Title,
+                    issue.Url,
+                    issue.Labels));
+            }
+
+            foreach (var pr in lister.ListPullRequests(repo!, requiredLabels))
+            {
+                candidates.Add(BuildCandidate(
+                    gateway,
+                    repo!,
+                    GhCliGitHubSignalGateway.Kinds.Pr,
+                    pr.Number,
+                    pr.Title,
+                    pr.Url,
+                    pr.Labels));
+            }
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to collect signals from {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var result = ReviewCollectSignalsAnalyzer.Analyze(repo!, candidates);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static SignalCandidateInput BuildCandidate(
+        IGitHubSignalGateway gateway,
+        string repo,
+        string target,
+        int number,
+        string title,
+        string url,
+        IReadOnlyList<GitHubAutomationLabel> labels)
+    {
+        var comments = gateway.ListComments(repo, target, number);
+        return new SignalCandidateInput
+        {
+            Target = target,
+            Number = number,
+            Title = title,
+            Url = url,
+            Labels = labels.Select(l => l.Name).Where(n => !string.IsNullOrEmpty(n)).ToArray(),
+            Comments = comments,
+        };
+    }
+
+    private static void WriteText(TextWriter writer, ReviewCollectSignalsResult result)
+    {
+        writer.WriteLine($"# Worker signals pending in {result.Repo}");
+        writer.WriteLine();
+        writer.WriteLine($"- pending: {result.PendingCount}");
+        writer.WriteLine($"- handled (skipped): {result.HandledSkippedCount}");
+        writer.WriteLine($"- unmarked (labelled, no marker): {result.UnmarkedCount}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Pending signals");
+        if (result.PendingSignals.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var signal in result.PendingSignals)
+            {
+                writer.WriteLine(
+                    $"- {signal.SignalKind} on {signal.Target} #{signal.Number}: {signal.Title} ({signal.CommentRef})");
+            }
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Warnings");
+        if (result.Warnings.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var warning in result.Warnings)
+            {
+                writer.WriteLine($"- {warning}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --repo <owner/repo> [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required (e.g. --repo owner/repo).";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ReviewCollectSignalsResult.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCollectSignalsResult.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G374: result of <c>intent-cli review collect-signals</c>. Lists the
+/// pending structured worker signals a host review/design loop should
+/// triage, and reports how many label-matched items were skipped because
+/// they were already handled or carried no parseable marker.
+/// </summary>
+internal sealed record ReviewCollectSignalsResult
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("pending_signals")]
+    public required IReadOnlyList<PendingSignal> PendingSignals { get; init; }
+
+    [JsonPropertyName("pending_count")]
+    public int PendingCount => PendingSignals.Count;
+
+    /// <summary>Items carrying intent-signal-handled (already processed) that were skipped.</summary>
+    [JsonPropertyName("handled_skipped_count")]
+    public required int HandledSkippedCount { get; init; }
+
+    /// <summary>Items labelled intent-signal-sent but with no parseable marker comment.</summary>
+    [JsonPropertyName("unmarked_count")]
+    public required int UnmarkedCount { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>G374: one pending structured signal awaiting host triage.</summary>
+internal sealed record PendingSignal
+{
+    [JsonPropertyName("target")]
+    public required string Target { get; init; }
+
+    [JsonPropertyName("number")]
+    public required int Number { get; init; }
+
+    [JsonPropertyName("signal_kind")]
+    public required string SignalKind { get; init; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; init; } = string.Empty;
+
+    [JsonPropertyName("url")]
+    public string Url { get; init; } = string.Empty;
+
+    [JsonPropertyName("comment_ref")]
+    public string CommentRef { get; init; } = string.Empty;
+
+    [JsonPropertyName("comment_created_at")]
+    public string CommentCreatedAt { get; init; } = string.Empty;
+}

--- a/src/IntentSystem.Cli/Commands/ReviewSignalHandledCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewSignalHandledCommand.cs
@@ -1,0 +1,287 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G374: <c>intent-cli review signal-handled (--issue &lt;n&gt; | --pr &lt;n&gt;) --repo &lt;r&gt;</c>.
+/// Host review/design side convergence: once a structured worker signal
+/// has been triaged into clarification / packet / metadata-repair work,
+/// this adds <c>intent-signal-handled</c> and removes
+/// <c>intent-signal-sent</c> so <c>review collect-signals</c> will not
+/// re-surface it. GitHub-only by data flow (label mutator seam; no
+/// queue-state / packet / intent metadata touched). Dry-run by default.
+/// </summary>
+internal static class ReviewSignalHandledCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>Test seam: inject a fake label mutator.</summary>
+    public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var repo, out var target, out var number, out var mode, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubLabelMutator mutator;
+        try
+        {
+            mutator = MutatorFactory?.Invoke() ?? new GhCliGitHubLabelMutator();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub mutator: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<GitHubAutomationLabel> currentLabels;
+        try
+        {
+            currentLabels = mutator.ReadLabels(repo!, target!, number);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine(
+                $"failed to read current labels for {target} #{number} in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var currentNames = LabelNames(currentLabels);
+        var plan = WorkerSignalContract.PlanHandledTransition(currentNames);
+        var hadSent = currentNames.Contains(WorkerSignalContract.Labels.SignalSent, StringComparer.Ordinal);
+        var alreadyHandled = currentNames.Contains(WorkerSignalContract.Labels.SignalHandled, StringComparer.Ordinal);
+
+        var warnings = new List<string>();
+        if (!hadSent)
+        {
+            warnings.Add(
+                $"{target} #{number} does not carry '{WorkerSignalContract.Labels.SignalSent}'; there is no pending signal to converge.");
+        }
+
+        var proceed = plan.HasChanges;
+        var applied = false;
+        if (proceed && string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal))
+        {
+            try
+            {
+                mutator.ApplyLabelTransitions(repo!, target!, number, plan.AddLabels, plan.RemoveLabels);
+                applied = true;
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or IOException)
+            {
+                writer.WriteLine(
+                    $"failed to apply signal-handled transition on {target} #{number} in {repo}: {exception.Message}");
+                return 1;
+            }
+        }
+
+        var summary = !proceed
+            ? (alreadyHandled
+                ? $"{target} #{number} is already marked '{WorkerSignalContract.Labels.SignalHandled}'; nothing to do."
+                : $"{target} #{number} has no pending signal labels; nothing to do.")
+            : (string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal)
+                ? $"Marked {target} #{number} '{WorkerSignalContract.Labels.SignalHandled}' and cleared '{WorkerSignalContract.Labels.SignalSent}'."
+                : $"Dry run: would mark {target} #{number} '{WorkerSignalContract.Labels.SignalHandled}' and clear '{WorkerSignalContract.Labels.SignalSent}'.");
+
+        var result = new ReviewSignalHandledResult
+        {
+            Repo = repo!,
+            Target = target!,
+            Number = number,
+            Mode = mode,
+            Proceed = proceed,
+            Applied = applied,
+            AddLabels = plan.AddLabels,
+            RemoveLabels = plan.RemoveLabels,
+            CurrentLabels = currentNames,
+            Summary = summary,
+            Warnings = warnings,
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static IReadOnlyList<string> LabelNames(IReadOnlyList<GitHubAutomationLabel>? labels)
+    {
+        if (labels is null || labels.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var names = new List<string>(labels.Count);
+        foreach (var label in labels)
+        {
+            if (!string.IsNullOrEmpty(label.Name))
+            {
+                names.Add(label.Name);
+            }
+        }
+        return names;
+    }
+
+    private static void WriteText(TextWriter writer, ReviewSignalHandledResult result)
+    {
+        writer.WriteLine($"# Signal handled: {result.Target} #{result.Number} ({result.Repo})");
+        writer.WriteLine();
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- proceed: {result.Proceed}");
+        writer.WriteLine($"- applied: {result.Applied}");
+        writer.WriteLine($"- add: {(result.AddLabels.Count == 0 ? "(none)" : string.Join(", ", result.AddLabels))}");
+        writer.WriteLine($"- remove: {(result.RemoveLabels.Count == 0 ? "(none)" : string.Join(", ", result.RemoveLabels))}");
+        writer.WriteLine($"- summary: {result.Summary}");
+        writer.WriteLine();
+        writer.WriteLine("## Warnings");
+        if (result.Warnings.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var warning in result.Warnings)
+            {
+                writer.WriteLine($"- {warning}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? target,
+        out int number,
+        out string mode,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        target = null;
+        number = 0;
+        mode = WorkerClaimCompleteConstants.Modes.DryRun;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--issue":
+                    if (!TryParseTarget(args, ref index, WorkerSignalContract.Targets.Issue, ref target, ref number, out error))
+                    {
+                        return false;
+                    }
+                    break;
+
+                case "--pr":
+                    if (!TryParseTarget(args, ref index, WorkerSignalContract.Targets.Pr, ref target, ref number, out error))
+                    {
+                        return false;
+                    }
+                    break;
+
+                case "--write":
+                    mode = WorkerClaimCompleteConstants.Modes.Write;
+                    break;
+
+                case "--dry-run":
+                    mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error =
+                        $"Unknown argument '{argument}'. Supported: --repo <owner/repo> (--issue <n> | --pr <n>) [--write] [--dry-run] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required (e.g. --repo owner/repo).";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(target) || number <= 0)
+        {
+            error = "exactly one of --issue <n> or --pr <n> is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryParseTarget(
+        string[] args,
+        ref int index,
+        string targetKind,
+        ref string? target,
+        ref int number,
+        out string error)
+    {
+        error = string.Empty;
+        if (target is not null)
+        {
+            error = "specify exactly one of --issue or --pr, not both.";
+            return false;
+        }
+        if (index + 1 >= args.Length
+            || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out number)
+            || number <= 0)
+        {
+            error = $"--{targetKind} requires a positive integer.";
+            return false;
+        }
+        target = targetKind;
+        index++;
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ReviewSignalHandledResult.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewSignalHandledResult.cs
@@ -1,0 +1,47 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G374: result of <c>intent-cli review signal-handled</c>. Records the
+/// planned (dry-run) or executed (write) label convergence that marks a
+/// structured worker signal processed: add <c>intent-signal-handled</c>,
+/// remove <c>intent-signal-sent</c>.
+/// </summary>
+internal sealed record ReviewSignalHandledResult
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("target")]
+    public required string Target { get; init; }
+
+    [JsonPropertyName("number")]
+    public required int Number { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    /// <summary>Whether there was a pending signal to converge (false ⇒ nothing to do).</summary>
+    [JsonPropertyName("proceed")]
+    public required bool Proceed { get; init; }
+
+    /// <summary>Whether the label transition was actually applied (write mode only).</summary>
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("add_labels")]
+    public required IReadOnlyList<string> AddLabels { get; init; }
+
+    [JsonPropertyName("remove_labels")]
+    public required IReadOnlyList<string> RemoveLabels { get; init; }
+
+    [JsonPropertyName("current_labels")]
+    public required IReadOnlyList<string> CurrentLabels { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
+}

--- a/src/IntentSystem.Cli/Commands/WorkerSignalCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerSignalCommand.cs
@@ -1,0 +1,438 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G374: <c>intent-cli worker signal &lt;blocker|follow-up|scope-warning&gt;</c>.
+/// A child implementation worker raises a structured signal back to host
+/// review/design automation by posting a marker-wrapped comment on the
+/// assigned Issue/PR and adding <c>intent-signal-sent</c>. GitHub-only by
+/// data flow — it uses the comment gateway + label mutator seams and
+/// never reads or writes host queue-state / packet / intent metadata.
+///
+/// Targets by kind:
+/// - <c>blocker</c>     → <c>--issue &lt;n&gt;</c> (decline before implementation)
+/// - <c>follow-up</c>   → <c>--pr &lt;n&gt;</c> (defect/design gap found mid-PR)
+/// - <c>scope-warning</c> → <c>--issue &lt;n&gt;</c> or <c>--pr &lt;n&gt;</c>
+///
+/// Dry-run by default: no comment is posted and no label is applied
+/// unless <c>--write</c> is passed.
+/// </summary>
+internal static class WorkerSignalCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    /// <summary>Test seam: inject a fake comment gateway so no GitHub call is made.</summary>
+    public static Func<IGitHubSignalGateway>? GatewayFactory { get; set; }
+
+    /// <summary>Test seam: inject a fake label mutator so no GitHub call is made.</summary>
+    public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
+
+    /// <summary>
+    /// Test sentinel: must NEVER be invoked. Locks the "no nested
+    /// provider launch" guarantee for the signal surface.
+    /// </summary>
+    public static Func<bool>? NestedProviderLauncher { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 0
+            || string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return args.Length == 0 ? 1 : 0;
+        }
+
+        var signalKind = args[0];
+        if (!WorkerSignalContract.IsKnownKind(signalKind))
+        {
+            writer.WriteLine(
+                $"Unknown signal kind '{signalKind}'. Supported: {string.Join(", ", WorkerSignalContract.AllKinds)}.");
+            return 1;
+        }
+
+        if (!TryParseArguments(
+                args[1..],
+                out var repo,
+                out var target,
+                out var number,
+                out var bodyPathArg,
+                out var mode,
+                out var githubOnly,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        if (!WorkerSignalContract.IsTargetAllowed(signalKind!, target!))
+        {
+            writer.WriteLine(
+                $"Signal kind '{signalKind}' cannot target a {target}. Allowed: {string.Join(", ", WorkerSignalContract.AllowedTargets(signalKind!))}.");
+            return 1;
+        }
+
+        string body;
+        try
+        {
+            var bodyPath = ResolveBodyPath(context.RepoRoot, bodyPathArg!);
+            if (!File.Exists(bodyPath))
+            {
+                writer.WriteLine($"Signal body file was not found at {bodyPath}");
+                return 1;
+            }
+            body = File.ReadAllText(bodyPath);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            writer.WriteLine($"failed to read signal body file: {exception.Message}");
+            return 1;
+        }
+
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            writer.WriteLine("Signal body file must not be empty.");
+            return 1;
+        }
+
+        IGitHubLabelMutator mutator;
+        try
+        {
+            mutator = MutatorFactory?.Invoke() ?? new GhCliGitHubLabelMutator();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub mutator: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<GitHubAutomationLabel> currentLabels;
+        try
+        {
+            currentLabels = mutator.ReadLabels(repo!, target!, number);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine(
+                $"failed to read current labels for {target} #{number} in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var currentNames = LabelNames(currentLabels);
+        var plan = WorkerSignalContract.PlanSentTransition(currentNames);
+        var marker = WorkerSignalContract.BuildMarker(signalKind!, target!, number);
+        var commentBody = WorkerSignalContract.BuildCommentBody(signalKind!, target!, number, body);
+
+        var isWrite = string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal);
+        var posted = false;
+        var applied = false;
+        string? commentRef = null;
+        var warnings = new List<string>();
+
+        if (currentNames.Contains(WorkerSignalContract.Labels.SignalSent, StringComparer.Ordinal))
+        {
+            warnings.Add(
+                $"{target} #{number} already carries '{WorkerSignalContract.Labels.SignalSent}'; this posts an additional signal comment without a duplicate label add.");
+        }
+
+        if (isWrite)
+        {
+            IGitHubSignalGateway gateway;
+            try
+            {
+                gateway = GatewayFactory?.Invoke() ?? new GhCliGitHubSignalGateway();
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or IOException)
+            {
+                writer.WriteLine($"failed to initialize GitHub signal gateway: {exception.Message}");
+                return 1;
+            }
+
+            try
+            {
+                commentRef = gateway.PostComment(repo!, target!, number, commentBody);
+                posted = true;
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or IOException)
+            {
+                writer.WriteLine(
+                    $"failed to post signal comment on {target} #{number} in {repo}: {exception.Message}");
+                return 1;
+            }
+
+            if (plan.HasChanges)
+            {
+                try
+                {
+                    mutator.ApplyLabelTransitions(repo!, target!, number, plan.AddLabels, plan.RemoveLabels);
+                    applied = true;
+                }
+                catch (Exception exception) when (exception is InvalidOperationException or IOException)
+                {
+                    writer.WriteLine(
+                        $"posted signal comment {commentRef} but failed to apply '{WorkerSignalContract.Labels.SignalSent}' on {target} #{number} in {repo}: {exception.Message}");
+                    return 1;
+                }
+            }
+        }
+
+        var summary = isWrite
+            ? $"Posted {signalKind} signal on {target} #{number} and marked it {WorkerSignalContract.Labels.SignalSent}."
+            : $"Dry run: would post {signalKind} signal on {target} #{number} and add {WorkerSignalContract.Labels.SignalSent}.";
+
+        var result = new WorkerSignalResult
+        {
+            SignalKind = signalKind!,
+            Repo = repo!,
+            Target = target!,
+            Number = number,
+            Mode = mode,
+            Proceed = true,
+            Posted = posted,
+            Applied = applied,
+            CommentRef = commentRef,
+            Marker = marker,
+            AddLabels = plan.AddLabels,
+            RemoveLabels = plan.RemoveLabels,
+            CurrentLabels = currentNames,
+            Summary = summary,
+            Warnings = warnings,
+            GithubOnly = githubOnly ? true : null,
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static IReadOnlyList<string> LabelNames(IReadOnlyList<GitHubAutomationLabel>? labels)
+    {
+        if (labels is null || labels.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var names = new List<string>(labels.Count);
+        foreach (var label in labels)
+        {
+            if (!string.IsNullOrEmpty(label.Name))
+            {
+                names.Add(label.Name);
+            }
+        }
+        return names;
+    }
+
+    private static string ResolveBodyPath(string repoRoot, string rawPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(rawPath);
+        if (Path.IsPathRooted(rawPath))
+        {
+            return Path.GetFullPath(rawPath);
+        }
+        var baseDir = string.IsNullOrWhiteSpace(repoRoot) ? Directory.GetCurrentDirectory() : repoRoot;
+        return Path.GetFullPath(Path.Combine(baseDir, rawPath));
+    }
+
+    private static void WriteText(TextWriter writer, WorkerSignalResult result)
+    {
+        writer.WriteLine($"# Worker signal: {result.SignalKind} on {result.Target} #{result.Number} ({result.Repo})");
+        writer.WriteLine();
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- posted: {result.Posted}");
+        writer.WriteLine($"- applied: {result.Applied}");
+        if (!string.IsNullOrWhiteSpace(result.CommentRef))
+        {
+            writer.WriteLine($"- comment: {result.CommentRef}");
+        }
+        writer.WriteLine($"- add: {(result.AddLabels.Count == 0 ? "(none)" : string.Join(", ", result.AddLabels))}");
+        writer.WriteLine($"- remove: {(result.RemoveLabels.Count == 0 ? "(none)" : string.Join(", ", result.RemoveLabels))}");
+        writer.WriteLine($"- summary: {result.Summary}");
+        writer.WriteLine();
+        writer.WriteLine("## Warnings");
+        if (result.Warnings.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var item in result.Warnings)
+            {
+                writer.WriteLine($"- {item}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? target,
+        out int number,
+        out string? bodyPath,
+        out string mode,
+        out bool githubOnly,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        target = null;
+        number = 0;
+        bodyPath = null;
+        mode = WorkerClaimCompleteConstants.Modes.DryRun;
+        githubOnly = false;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--issue":
+                    if (!TryParseTarget(args, ref index, WorkerSignalContract.Targets.Issue, ref target, ref number, out error))
+                    {
+                        return false;
+                    }
+                    break;
+
+                case "--pr":
+                    if (!TryParseTarget(args, ref index, WorkerSignalContract.Targets.Pr, ref target, ref number, out error))
+                    {
+                        return false;
+                    }
+                    break;
+
+                case "--from-file":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--from-file requires a path.";
+                        return false;
+                    }
+                    bodyPath = args[index + 1];
+                    index++;
+                    break;
+
+                case "--write":
+                    mode = WorkerClaimCompleteConstants.Modes.Write;
+                    break;
+
+                case "--dry-run":
+                    mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    break;
+
+                case "--github-only":
+                    githubOnly = true;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                default:
+                    error =
+                        $"Unknown argument '{argument}'. Supported: --repo <owner/repo> (--issue <n> | --pr <n>) --from-file <path> [--write] [--dry-run] [--github-only] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required (e.g. --repo owner/repo).";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(target) || number <= 0)
+        {
+            error = "exactly one of --issue <n> or --pr <n> is required.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(bodyPath))
+        {
+            error = "--from-file <path> is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryParseTarget(
+        string[] args,
+        ref int index,
+        string targetKind,
+        ref string? target,
+        ref int number,
+        out string error)
+    {
+        error = string.Empty;
+        if (target is not null)
+        {
+            error = "specify exactly one of --issue or --pr, not both.";
+            return false;
+        }
+        if (index + 1 >= args.Length
+            || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out number)
+            || number <= 0)
+        {
+            error = $"--{targetKind} requires a positive integer.";
+            return false;
+        }
+        target = targetKind;
+        index++;
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("intent-cli worker signal <blocker|follow-up|scope-warning>");
+        writer.WriteLine(
+            "Usage: intent-cli worker signal <kind> --repo <owner/repo> (--issue <n> | --pr <n>) --from-file <path> [--write] [--github-only] [--format text|json]");
+        writer.WriteLine("Kinds:");
+        writer.WriteLine("- blocker      (--issue <n>): decline before implementation.");
+        writer.WriteLine("- follow-up    (--pr <n>): follow-up defect / design gap found while a PR is open.");
+        writer.WriteLine("- scope-warning (--issue <n> | --pr <n>): finding belongs to host metadata or widens scope.");
+        writer.WriteLine("Default is dry-run; pass --write to post the comment and add intent-signal-sent.");
+        writer.WriteLine("See `intent-cli guide worker signal` for paste-ready comment templates.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerSignalContract.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerSignalContract.cs
@@ -1,0 +1,250 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G374: pure contract for the GitHub-label-backed structured worker
+/// signal protocol. A child implementation worker uses it to hand a
+/// blocker / follow-up / scope-warning finding back to host
+/// review/design automation using only GitHub issue/PR comments plus
+/// <c>intent-cli</c> label transitions — never by reading or mutating
+/// host <c>.intent-cli</c> / <c>intents/**</c> metadata.
+///
+/// The protocol has two halves:
+/// - <b>send</b> (child): post a marker-wrapped structured comment on
+///   the assigned Issue/PR and add <see cref="Labels.SignalSent"/>.
+/// - <b>collect / handled</b> (host): scan items carrying
+///   <see cref="Labels.SignalSent"/>, parse the latest marker comment,
+///   and once processed add <see cref="Labels.SignalHandled"/> while
+///   removing <see cref="Labels.SignalSent"/> so later scans skip it.
+///
+/// This file is intentionally pure (no <c>Process.Start</c>, no
+/// filesystem, no GitHub I/O) so the marker format and label-transition
+/// planning are unit-testable in isolation.
+/// </summary>
+internal static class WorkerSignalContract
+{
+    /// <summary>G374: canonical signal labels (also in the workflow palette).</summary>
+    public static class Labels
+    {
+        public const string SignalSent = "intent-signal-sent";
+        public const string SignalHandled = "intent-signal-handled";
+    }
+
+    /// <summary>G374: the structured-signal kinds a worker may raise.</summary>
+    public static class Kinds
+    {
+        /// <summary>Issue cannot be safely implemented; decline before implementation.</summary>
+        public const string Blocker = "blocker";
+
+        /// <summary>Implementation can proceed, but a follow-up defect/design gap was found.</summary>
+        public const string FollowUp = "follow-up";
+
+        /// <summary>Finding belongs to host intent/packet metadata or widens scope.</summary>
+        public const string ScopeWarning = "scope-warning";
+    }
+
+    /// <summary>G374: GitHub target kinds a signal can be attached to.</summary>
+    public static class Targets
+    {
+        public const string Issue = "issue";
+        public const string Pr = "pr";
+    }
+
+    /// <summary>G374: marker schema version (bumped if the marker grammar changes).</summary>
+    public const int MarkerVersion = 1;
+
+    /// <summary>
+    /// G374: HTML-comment marker prefix that identifies a structured
+    /// worker-signal comment. Hidden from rendered Markdown so the
+    /// comment reads cleanly while still being machine-detectable.
+    /// </summary>
+    public const string MarkerPrefix = "<!-- intent-signal";
+
+    /// <summary>G374: canonical kind order for help/template/audit output.</summary>
+    public static readonly IReadOnlyList<string> AllKinds =
+    [
+        Kinds.Blocker,
+        Kinds.FollowUp,
+        Kinds.ScopeWarning,
+    ];
+
+    public static bool IsKnownKind(string? kind) =>
+        !string.IsNullOrWhiteSpace(kind)
+        && (string.Equals(kind, Kinds.Blocker, StringComparison.Ordinal)
+            || string.Equals(kind, Kinds.FollowUp, StringComparison.Ordinal)
+            || string.Equals(kind, Kinds.ScopeWarning, StringComparison.Ordinal));
+
+    public static bool IsKnownTarget(string? target) =>
+        !string.IsNullOrWhiteSpace(target)
+        && (string.Equals(target, Targets.Issue, StringComparison.Ordinal)
+            || string.Equals(target, Targets.Pr, StringComparison.Ordinal));
+
+    /// <summary>
+    /// G374: which GitHub target kinds a given signal kind may be posted
+    /// on. blocker is issue-only (decline before implementation),
+    /// follow-up is pr-only (a defect found while a PR is open), and
+    /// scope-warning can attach to either.
+    /// </summary>
+    public static IReadOnlyList<string> AllowedTargets(string kind) => kind switch
+    {
+        Kinds.Blocker => [Targets.Issue],
+        Kinds.FollowUp => [Targets.Pr],
+        Kinds.ScopeWarning => [Targets.Issue, Targets.Pr],
+        _ => Array.Empty<string>(),
+    };
+
+    public static bool IsTargetAllowed(string kind, string target) =>
+        AllowedTargets(kind).Contains(target, StringComparer.Ordinal);
+
+    /// <summary>
+    /// G374: build the single-line machine marker embedded as the first
+    /// line of a structured-signal comment, e.g.
+    /// <c>&lt;!-- intent-signal v=1 kind=blocker target=issue#851 --&gt;</c>.
+    /// </summary>
+    public static string BuildMarker(string kind, string target, int number)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(target);
+        if (number <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(number), "target number must be positive.");
+        }
+
+        return $"{MarkerPrefix} v={MarkerVersion} kind={kind} target={target}#{number} -->";
+    }
+
+    /// <summary>
+    /// G374: wrap an operator-authored signal body in the canonical
+    /// comment shape: the hidden marker line, a human-readable heading,
+    /// then the body. The result is what gets posted to GitHub.
+    /// </summary>
+    public static string BuildCommentBody(string kind, string target, int number, string body)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(body);
+
+        var marker = BuildMarker(kind, target, number);
+        var heading = kind switch
+        {
+            Kinds.Blocker => "Worker signal — blocker (decline before implementation)",
+            Kinds.FollowUp => "Worker signal — follow-up finding",
+            Kinds.ScopeWarning => "Worker signal — scope warning",
+            _ => "Worker signal",
+        };
+
+        return string.Join(
+            "\n",
+            marker,
+            string.Empty,
+            $"### {heading}",
+            string.Empty,
+            body.TrimEnd(),
+            string.Empty,
+            "_Raised by `intent-cli worker signal`. Host review/design automation collects this via "
+                + "`intent-cli review collect-signals` and marks it handled with `intent-cli review signal-handled`._");
+    }
+
+    /// <summary>
+    /// G374: detect whether a comment body is a structured worker signal
+    /// and, if so, extract its <c>kind</c>. Tolerant of leading
+    /// whitespace and additional marker tokens.
+    /// </summary>
+    public static bool TryParseSignalKind(string? commentBody, out string kind)
+    {
+        kind = string.Empty;
+        if (string.IsNullOrWhiteSpace(commentBody))
+        {
+            return false;
+        }
+
+        using var reader = new StringReader(commentBody);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            var trimmed = line.Trim();
+            if (!trimmed.StartsWith(MarkerPrefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (var token in trimmed.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (!token.StartsWith("kind=", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var value = token["kind=".Length..].TrimEnd('-', '>').Trim();
+                if (IsKnownKind(value))
+                {
+                    kind = value;
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public static bool IsSignalComment(string? commentBody) =>
+        TryParseSignalKind(commentBody, out _);
+
+    /// <summary>
+    /// G374: plan the label transition for SENDING a signal. The fresh
+    /// signal becomes pending, so add <see cref="Labels.SignalSent"/>
+    /// (when absent) and clear a stale <see cref="Labels.SignalHandled"/>
+    /// — a previously-handled item with a new signal is pending again.
+    /// </summary>
+    public static SignalLabelPlan PlanSentTransition(IReadOnlyCollection<string> currentLabels)
+    {
+        ArgumentNullException.ThrowIfNull(currentLabels);
+
+        var add = new List<string>();
+        var remove = new List<string>();
+
+        if (!currentLabels.Contains(Labels.SignalSent, StringComparer.Ordinal))
+        {
+            add.Add(Labels.SignalSent);
+        }
+        if (currentLabels.Contains(Labels.SignalHandled, StringComparer.Ordinal))
+        {
+            remove.Add(Labels.SignalHandled);
+        }
+
+        return new SignalLabelPlan { AddLabels = add, RemoveLabels = remove };
+    }
+
+    /// <summary>
+    /// G374: plan the label transition for MARKING a signal handled. Add
+    /// <see cref="Labels.SignalHandled"/> (when absent) and remove
+    /// <see cref="Labels.SignalSent"/> (when present) so later
+    /// collection scans skip the already-processed item.
+    /// </summary>
+    public static SignalLabelPlan PlanHandledTransition(IReadOnlyCollection<string> currentLabels)
+    {
+        ArgumentNullException.ThrowIfNull(currentLabels);
+
+        var add = new List<string>();
+        var remove = new List<string>();
+
+        if (!currentLabels.Contains(Labels.SignalHandled, StringComparer.Ordinal))
+        {
+            add.Add(Labels.SignalHandled);
+        }
+        if (currentLabels.Contains(Labels.SignalSent, StringComparer.Ordinal))
+        {
+            remove.Add(Labels.SignalSent);
+        }
+
+        return new SignalLabelPlan { AddLabels = add, RemoveLabels = remove };
+    }
+}
+
+/// <summary>
+/// G374: a planned add/remove label transition for a signal operation.
+/// </summary>
+internal sealed record SignalLabelPlan
+{
+    public required IReadOnlyList<string> AddLabels { get; init; }
+    public required IReadOnlyList<string> RemoveLabels { get; init; }
+
+    public bool HasChanges => AddLabels.Count > 0 || RemoveLabels.Count > 0;
+}

--- a/src/IntentSystem.Cli/Commands/WorkerSignalResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerSignalResult.cs
@@ -1,0 +1,64 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G374: result of <c>intent-cli worker signal &lt;kind&gt;</c>. Records
+/// the planned (dry-run) or executed (write) comment post + label
+/// transition for sending a structured worker signal.
+/// </summary>
+internal sealed record WorkerSignalResult
+{
+    [JsonPropertyName("signal_kind")]
+    public required string SignalKind { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("target")]
+    public required string Target { get; init; }
+
+    [JsonPropertyName("number")]
+    public required int Number { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    /// <summary>Whether the signal is valid to send (kind/target legal, body present).</summary>
+    [JsonPropertyName("proceed")]
+    public required bool Proceed { get; init; }
+
+    /// <summary>Whether a comment was actually posted (write mode only).</summary>
+    [JsonPropertyName("posted")]
+    public required bool Posted { get; init; }
+
+    /// <summary>Whether the label transition was actually applied (write mode only).</summary>
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    /// <summary>The created comment reference (URL) when posted; null in dry-run.</summary>
+    [JsonPropertyName("comment_ref")]
+    public string? CommentRef { get; init; }
+
+    /// <summary>The machine marker line embedded (or that would be embedded) in the comment.</summary>
+    [JsonPropertyName("marker")]
+    public required string Marker { get; init; }
+
+    [JsonPropertyName("add_labels")]
+    public required IReadOnlyList<string> AddLabels { get; init; }
+
+    [JsonPropertyName("remove_labels")]
+    public required IReadOnlyList<string> RemoveLabels { get; init; }
+
+    [JsonPropertyName("current_labels")]
+    public required IReadOnlyList<string> CurrentLabels { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public IReadOnlyList<string> Warnings { get; init; } = Array.Empty<string>();
+
+    [JsonPropertyName("github_only")]
+    public bool? GithubOnly { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/WorkflowLabelPaletteContract.cs
+++ b/src/IntentSystem.Cli/Commands/WorkflowLabelPaletteContract.cs
@@ -77,6 +77,24 @@ internal static class WorkflowLabelPaletteContract
             Color = "0E8A16",
             Description = "PR is approved by intent automation review; ready to merge + close out."
         },
+        // G374: structured worker-signal protocol. These two labels are
+        // the durable pending/handled markers a child implementation
+        // worker uses to hand a blocker / follow-up / scope-warning back
+        // to host review/design automation without touching host intent
+        // metadata. They sit outside the linear target→review→approval
+        // lane, so they appear last in the canonical palette.
+        new()
+        {
+            Name = "intent-signal-sent",
+            Color = "B60205",
+            Description = "Item has an unhandled structured worker signal comment awaiting host review."
+        },
+        new()
+        {
+            Name = "intent-signal-handled",
+            Color = "C2E0C6",
+            Description = "Host/review side processed the current worker signal set."
+        },
     ];
 }
 

--- a/tests/IntentSystem.Cli.Tests/AutomationLabelPaletteCommandsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationLabelPaletteCommandsTests.cs
@@ -149,7 +149,7 @@ public sealed class AutomationLabelPaletteCommandsTests
             {
                 new GitHubLabelMetadata { Name = canonical0.Name, Color = "FFFFFF", Description = canonical0.Description },
                 new GitHubLabelMetadata { Name = canonical1.Name, Color = canonical1.Color, Description = canonical1.Description },
-                // canonical[2..7] missing → create.
+                // Every canonical entry after the first two is missing → create.
             });
         var mutator = new RecordingMutator();
         AutomationLabelPaletteSyncCommand.LabelPaletteMutatorFactory = () => mutator;
@@ -163,8 +163,8 @@ public sealed class AutomationLabelPaletteCommandsTests
                 writer);
 
             Assert.Equal(0, exit);
-            // canonical0 → edit (wrong color); canonical[2..7] → create.
-            Assert.Equal(6, mutator.Creates.Count);
+            // canonical0 → edit (wrong color); all entries after canonical1 → create.
+            Assert.Equal(WorkflowLabelPaletteContract.Canonical.Count - 2, mutator.Creates.Count);
             Assert.Single(mutator.Edits);
             Assert.Equal(canonical0.Name, mutator.Edits[0].name);
             Assert.Equal(canonical0.Color, mutator.Edits[0].color);
@@ -179,7 +179,7 @@ public sealed class AutomationLabelPaletteCommandsTests
             using var doc = JsonDocument.Parse(writer.ToString());
             var root = doc.RootElement;
             Assert.Equal("write", root.GetProperty("mode").GetString());
-            Assert.Equal(7, root.GetProperty("applied_count").GetInt32());
+            Assert.Equal(WorkflowLabelPaletteContract.Canonical.Count - 1, root.GetProperty("applied_count").GetInt32());
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/GuideWorkerSignalCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkerSignalCommandTests.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G374: tests for the read-only <c>guide worker signal</c> template
+/// surface — it emits a template per signal kind, the canonical labels,
+/// a marker example, and the host collection commands.
+/// </summary>
+public sealed class GuideWorkerSignalCommandTests
+{
+    [Fact]
+    public void Execute_Json_EmitsTemplatePerKind_AndLabels()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideWorkerSignalCommand.Execute(
+            CreateContext(),
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+
+        var templates = root.GetProperty("templates");
+        var kinds = templates.EnumerateArray().Select(t => t.GetProperty("kind").GetString()).ToHashSet();
+        Assert.Contains("blocker", kinds);
+        Assert.Contains("follow-up", kinds);
+        Assert.Contains("scope-warning", kinds);
+
+        Assert.Equal("intent-signal-sent", root.GetProperty("labels").GetProperty("sent").GetString());
+        Assert.Equal("intent-signal-handled", root.GetProperty("labels").GetProperty("handled").GetString());
+        Assert.Contains("intent-signal", root.GetProperty("marker_example").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HostCommandsReferenceCollectAndHandled()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideWorkerSignalCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer));
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var commands = doc.RootElement.GetProperty("host_commands").EnumerateArray()
+            .Select(c => c.GetString() ?? string.Empty).ToArray();
+        Assert.Contains(commands, c => c.Contains("review collect-signals", StringComparison.Ordinal));
+        Assert.Contains(commands, c => c.Contains("review signal-handled", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_Markdown_RendersTemplatesAndCommandBlocks()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideWorkerSignalCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "markdown" },
+            writer));
+
+        var output = writer.ToString();
+        Assert.Contains("worker signal blocker", output, StringComparison.Ordinal);
+        Assert.Contains("worker signal follow-up", output, StringComparison.Ordinal);
+        Assert.Contains("worker signal scope-warning", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GuideWorkerRouter_DispatchesSignalSubcommand()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideWorkerCommand.Execute(
+            CreateContext(),
+            new[] { "signal", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("worker-signal", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext() => new()
+    {
+        RepoRoot = Directory.GetCurrentDirectory(),
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+        },
+    };
+}

--- a/tests/IntentSystem.Cli.Tests/ReviewCollectSignalsCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCollectSignalsCommandTests.cs
@@ -1,0 +1,254 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G374: tests for the host-side <c>review collect-signals</c> analyzer
+/// and command — pending detection by label + marker, the
+/// already-handled skip (regression guard against reprocessing), the
+/// labelled-but-unmarked degenerate case, and the end-to-end command
+/// path over fake lister + gateway seams.
+/// </summary>
+public sealed class ReviewCollectSignalsCommandTests : IDisposable
+{
+    public ReviewCollectSignalsCommandTests()
+    {
+        Reset();
+    }
+
+    public void Dispose()
+    {
+        Reset();
+    }
+
+    private static void Reset()
+    {
+        ReviewCollectSignalsCommand.ListerFactory = null;
+        ReviewCollectSignalsCommand.GatewayFactory = null;
+    }
+
+    private static GitHubSignalComment SignalComment(string kind, string target, int number, string createdAt, string url)
+        => new()
+        {
+            Body = WorkerSignalContract.BuildCommentBody(kind, target, number, "details"),
+            CreatedAt = createdAt,
+            Url = url,
+        };
+
+    [Fact]
+    public void Analyze_PendingItem_WithMarker_ParsesKind()
+    {
+        var candidates = new[]
+        {
+            new SignalCandidateInput
+            {
+                Target = "issue",
+                Number = 851,
+                Title = "G374",
+                Url = "https://github.com/o/r/issues/851",
+                Labels = new[] { "intent-signal-sent" },
+                Comments = new[] { SignalComment("blocker", "issue", 851, "2026-05-20T07:00:00Z", "c1") },
+            },
+        };
+
+        var result = ReviewCollectSignalsAnalyzer.Analyze("o/r", candidates);
+
+        var pending = Assert.Single(result.PendingSignals);
+        Assert.Equal("blocker", pending.SignalKind);
+        Assert.Equal("issue", pending.Target);
+        Assert.Equal(851, pending.Number);
+        Assert.Equal("c1", pending.CommentRef);
+        Assert.Equal(0, result.HandledSkippedCount);
+        Assert.Equal(0, result.UnmarkedCount);
+    }
+
+    [Fact]
+    public void Analyze_HandledItem_IsSkipped_NotReprocessed()
+    {
+        // Regression guard: an item already converged to intent-signal-handled
+        // (pending marker cleared) must never reappear as pending.
+        var candidates = new[]
+        {
+            new SignalCandidateInput
+            {
+                Target = "issue",
+                Number = 851,
+                Labels = new[] { "intent-signal-handled" },
+                Comments = new[] { SignalComment("blocker", "issue", 851, "2026-05-20T07:00:00Z", "c1") },
+            },
+            new SignalCandidateInput
+            {
+                Target = "pr",
+                Number = 860,
+                Labels = new[] { "intent-signal-sent" },
+                Comments = new[] { SignalComment("follow-up", "pr", 860, "2026-05-20T08:00:00Z", "c2") },
+            },
+        };
+
+        var result = ReviewCollectSignalsAnalyzer.Analyze("o/r", candidates);
+
+        Assert.Equal(1, result.PendingCount);
+        Assert.Equal(1, result.HandledSkippedCount);
+        Assert.Equal("follow-up", result.PendingSignals[0].SignalKind);
+    }
+
+    [Fact]
+    public void Analyze_LatestMarkerWins_WhenMultipleSignalComments()
+    {
+        var candidates = new[]
+        {
+            new SignalCandidateInput
+            {
+                Target = "pr",
+                Number = 860,
+                Labels = new[] { "intent-signal-sent" },
+                Comments = new[]
+                {
+                    SignalComment("follow-up", "pr", 860, "2026-05-20T07:00:00Z", "old"),
+                    SignalComment("scope-warning", "pr", 860, "2026-05-20T09:00:00Z", "new"),
+                },
+            },
+        };
+
+        var result = ReviewCollectSignalsAnalyzer.Analyze("o/r", candidates);
+
+        var pending = Assert.Single(result.PendingSignals);
+        Assert.Equal("scope-warning", pending.SignalKind);
+        Assert.Equal("new", pending.CommentRef);
+    }
+
+    [Fact]
+    public void Analyze_LabelledButUnmarked_CountsAsUnmarkedWithWarning()
+    {
+        var candidates = new[]
+        {
+            new SignalCandidateInput
+            {
+                Target = "issue",
+                Number = 851,
+                Labels = new[] { "intent-signal-sent" },
+                Comments = new[] { new GitHubSignalComment { Body = "ordinary comment", CreatedAt = "2026-05-20T07:00:00Z", Url = "c1" } },
+            },
+        };
+
+        var result = ReviewCollectSignalsAnalyzer.Analyze("o/r", candidates);
+
+        Assert.Empty(result.PendingSignals);
+        Assert.Equal(1, result.UnmarkedCount);
+        Assert.NotEmpty(result.Warnings);
+    }
+
+    [Fact]
+    public void Execute_CollectsAcrossIssuesAndPrs_ViaFakes()
+    {
+        using var workspace = new SignalWorkspace();
+        var lister = new FakeLister
+        {
+            Issues = new[]
+            {
+                new GitHubAutomationIssueCandidate
+                {
+                    Number = 851,
+                    Title = "G374",
+                    Url = "u851",
+                    Labels = new[] { new GitHubAutomationLabel { Name = "intent-signal-sent" } },
+                },
+            },
+            Prs = new[]
+            {
+                new GitHubAutomationPrCandidate
+                {
+                    Number = 860,
+                    Title = "fix",
+                    Url = "u860",
+                    Labels = new[] { new GitHubAutomationLabel { Name = "intent-signal-sent" } },
+                },
+            },
+        };
+        var gateway = new FakeGateway
+        {
+            CommentsByTarget = new Dictionary<string, IReadOnlyList<GitHubSignalComment>>(StringComparer.Ordinal)
+            {
+                ["issue#851"] = new[] { SignalComment("blocker", "issue", 851, "2026-05-20T07:00:00Z", "ic") },
+                ["pr#860"] = new[] { SignalComment("follow-up", "pr", 860, "2026-05-20T08:00:00Z", "pc") },
+            },
+        };
+        ReviewCollectSignalsCommand.ListerFactory = () => lister;
+        ReviewCollectSignalsCommand.GatewayFactory = () => gateway;
+
+        using var writer = new StringWriter();
+        var exit = ReviewCollectSignalsCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        var result = JsonSerializer.Deserialize<ReviewCollectSignalsResult>(writer.ToString())!;
+        Assert.Equal(2, result.PendingCount);
+        Assert.Contains(result.PendingSignals, s => s.Target == "issue" && s.Number == 851 && s.SignalKind == "blocker");
+        Assert.Contains(result.PendingSignals, s => s.Target == "pr" && s.Number == 860 && s.SignalKind == "follow-up");
+    }
+
+    [Fact]
+    public void Execute_RequiresRepo()
+    {
+        using var workspace = new SignalWorkspace();
+        using var writer = new StringWriter();
+        var exit = ReviewCollectSignalsCommand.Execute(workspace.Context, Array.Empty<string>(), writer);
+        Assert.Equal(1, exit);
+        Assert.Contains("--repo", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    internal sealed class FakeLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationIssueCandidate> Issues { get; init; } = Array.Empty<GitHubAutomationIssueCandidate>();
+        public IReadOnlyList<GitHubAutomationPrCandidate> Prs { get; init; } = Array.Empty<GitHubAutomationPrCandidate>();
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => Prs;
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) => Issues;
+    }
+
+    internal sealed class FakeGateway : IGitHubSignalGateway
+    {
+        public IReadOnlyDictionary<string, IReadOnlyList<GitHubSignalComment>> CommentsByTarget { get; init; }
+            = new Dictionary<string, IReadOnlyList<GitHubSignalComment>>(StringComparer.Ordinal);
+
+        public string PostComment(string repo, string kind, int number, string body) =>
+            throw new NotSupportedException("collect-signals must not post comments");
+
+        public IReadOnlyList<GitHubSignalComment> ListComments(string repo, string kind, int number) =>
+            CommentsByTarget.TryGetValue($"{kind}#{number}", out var comments)
+                ? comments
+                : Array.Empty<GitHubSignalComment>();
+    }
+
+    private sealed class SignalWorkspace : IDisposable
+    {
+        public SignalWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("collect-signals-tests-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+                },
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ReviewSignalHandledCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewSignalHandledCommandTests.cs
@@ -1,0 +1,184 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G374: tests for <c>intent-cli review signal-handled</c> — the
+/// dry-run / write split, the add-handled / remove-sent convergence, and
+/// the already-handled / no-pending no-op.
+/// </summary>
+public sealed class ReviewSignalHandledCommandTests : IDisposable
+{
+    public ReviewSignalHandledCommandTests()
+    {
+        ReviewSignalHandledCommand.MutatorFactory = null;
+    }
+
+    public void Dispose()
+    {
+        ReviewSignalHandledCommand.MutatorFactory = null;
+    }
+
+    [Fact]
+    public void Execute_DryRun_PlansConvergence_AppliesNothing()
+    {
+        using var workspace = new SignalWorkspace();
+        var mutator = new FakeMutator { Labels = new[] { "intent-signal-sent" } };
+        ReviewSignalHandledCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exit = ReviewSignalHandledCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--issue", "851", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        var result = JsonSerializer.Deserialize<ReviewSignalHandledResult>(writer.ToString())!;
+        Assert.True(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Contains("intent-signal-handled", result.AddLabels);
+        Assert.Contains("intent-signal-sent", result.RemoveLabels);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_Write_AddsHandled_RemovesSent()
+    {
+        using var workspace = new SignalWorkspace();
+        var mutator = new FakeMutator { Labels = new[] { "intent-signal-sent" } };
+        ReviewSignalHandledCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exit = ReviewSignalHandledCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "860", "--write", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        var result = JsonSerializer.Deserialize<ReviewSignalHandledResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        var applied = Assert.Single(mutator.AppliedTransitions);
+        Assert.Equal("pr", applied.Kind);
+        Assert.Contains("intent-signal-handled", applied.AddLabels);
+        Assert.Contains("intent-signal-sent", applied.RemoveLabels);
+    }
+
+    [Fact]
+    public void Execute_AlreadyHandled_NoOp()
+    {
+        using var workspace = new SignalWorkspace();
+        var mutator = new FakeMutator { Labels = new[] { "intent-signal-handled" } };
+        ReviewSignalHandledCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exit = ReviewSignalHandledCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--issue", "851", "--write", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        var result = JsonSerializer.Deserialize<ReviewSignalHandledResult>(writer.ToString())!;
+        Assert.False(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_NoPendingSignal_WarnsButStillNoOp()
+    {
+        using var workspace = new SignalWorkspace();
+        var mutator = new FakeMutator { Labels = new[] { "intent-target" } };
+        ReviewSignalHandledCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exit = ReviewSignalHandledCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--issue", "851", "--write", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        var result = JsonSerializer.Deserialize<ReviewSignalHandledResult>(writer.ToString())!;
+        // No intent-signal-sent present, but intent-signal-handled is absent,
+        // so the add-handled half still makes this a real (idempotent) change.
+        Assert.True(result.Proceed);
+        Assert.NotEmpty(result.Warnings);
+    }
+
+    [Fact]
+    public void Execute_RequiresExactlyOneTarget()
+    {
+        using var workspace = new SignalWorkspace();
+        using var writer = new StringWriter();
+        var exit = ReviewSignalHandledCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system" },
+            writer);
+        Assert.Equal(1, exit);
+        Assert.Contains("--issue", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    internal sealed class FakeMutator : IGitHubLabelMutator
+    {
+        public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+        public List<AppliedTransition> AppliedTransitions { get; } = new();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            Labels.Select(n => new GitHubAutomationLabel { Name = n }).ToArray();
+
+        public void ApplyLabelTransitions(string repo, string kind, int number,
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels)
+        {
+            AppliedTransitions.Add(new AppliedTransition
+            {
+                Repo = repo,
+                Kind = kind,
+                Number = number,
+                AddLabels = addLabels.ToArray(),
+                RemoveLabels = removeLabels.ToArray(),
+            });
+        }
+
+        public void ApplyReconcileTransitions(string repo, string kind, int number,
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException();
+    }
+
+    internal sealed record AppliedTransition
+    {
+        public required string Repo { get; init; }
+        public required string Kind { get; init; }
+        public required int Number { get; init; }
+        public required IReadOnlyList<string> AddLabels { get; init; }
+        public required IReadOnlyList<string> RemoveLabels { get; init; }
+    }
+
+    private sealed class SignalWorkspace : IDisposable
+    {
+        public SignalWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("signal-handled-tests-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+                },
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerSignalCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerSignalCommandTests.cs
@@ -1,0 +1,344 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G374: tests for <c>intent-cli worker signal &lt;kind&gt;</c> — the
+/// dry-run / write split (no comment posted and no label applied unless
+/// --write), kind/target routing, body-file validation, and the
+/// no-Process.Start / no-nested-provider invariants.
+/// </summary>
+public sealed class WorkerSignalCommandTests : IDisposable
+{
+    public WorkerSignalCommandTests()
+    {
+        Reset();
+    }
+
+    public void Dispose()
+    {
+        Reset();
+    }
+
+    private static void Reset()
+    {
+        WorkerSignalCommand.GatewayFactory = null;
+        WorkerSignalCommand.MutatorFactory = null;
+        WorkerSignalCommand.NestedProviderLauncher = null;
+    }
+
+    [Fact]
+    public void Execute_DryRunBlockerOnIssue_PlansSentLabel_PostsNothing()
+    {
+        using var workspace = new SignalWorkspace();
+        var bodyPath = workspace.WriteBody("cannot build: missing contract");
+        var gateway = new FakeSignalGateway();
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
+        WorkerSignalCommand.GatewayFactory = () => gateway;
+        WorkerSignalCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exit = WorkerSignalCommand.Execute(
+            workspace.Context,
+            new[] { "blocker", "--repo", "J-Tech-Japan/intent-system", "--issue", "851", "--from-file", bodyPath, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        var result = JsonSerializer.Deserialize<WorkerSignalResult>(writer.ToString())!;
+        Assert.Equal("blocker", result.SignalKind);
+        Assert.Equal("issue", result.Target);
+        Assert.Equal(851, result.Number);
+        Assert.False(result.Posted);
+        Assert.False(result.Applied);
+        Assert.Contains("intent-signal-sent", result.AddLabels);
+        Assert.Empty(gateway.Posted);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_WriteBlockerOnIssue_PostsMarkerComment_AddsSentLabel()
+    {
+        using var workspace = new SignalWorkspace();
+        var bodyPath = workspace.WriteBody("cannot build: missing contract");
+        var gateway = new FakeSignalGateway();
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
+        WorkerSignalCommand.GatewayFactory = () => gateway;
+        WorkerSignalCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exit = WorkerSignalCommand.Execute(
+            workspace.Context,
+            new[] { "blocker", "--repo", "J-Tech-Japan/intent-system", "--issue", "851", "--from-file", bodyPath, "--write", "--github-only", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        var result = JsonSerializer.Deserialize<WorkerSignalResult>(writer.ToString())!;
+        Assert.True(result.Posted);
+        Assert.True(result.Applied);
+        Assert.True(result.GithubOnly);
+        Assert.Equal(gateway.Posted[0].CommentRef, result.CommentRef);
+
+        var posted = Assert.Single(gateway.Posted);
+        Assert.Equal("issue", posted.Kind);
+        Assert.Equal(851, posted.Number);
+        Assert.StartsWith(WorkerSignalContract.MarkerPrefix, posted.Body.Split('\n')[0]);
+        Assert.Contains("cannot build: missing contract", posted.Body, StringComparison.Ordinal);
+
+        var applied = Assert.Single(mutator.AppliedTransitions);
+        Assert.Equal("issue", applied.Kind);
+        Assert.Contains("intent-signal-sent", applied.AddLabels);
+    }
+
+    [Fact]
+    public void Execute_WriteFollowUpOnPr_Posts_AndLabels()
+    {
+        using var workspace = new SignalWorkspace();
+        var bodyPath = workspace.WriteBody("found a follow-up defect in adjacent module");
+        var gateway = new FakeSignalGateway();
+        var mutator = new FakeMutator { Labels = new[] { "intent-pr-reviewing" } };
+        WorkerSignalCommand.GatewayFactory = () => gateway;
+        WorkerSignalCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exit = WorkerSignalCommand.Execute(
+            workspace.Context,
+            new[] { "follow-up", "--repo", "J-Tech-Japan/intent-system", "--pr", "860", "--from-file", bodyPath, "--write", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        var posted = Assert.Single(gateway.Posted);
+        Assert.Equal("pr", posted.Kind);
+        Assert.Equal(860, posted.Number);
+    }
+
+    [Fact]
+    public void Execute_AlreadySent_WarnsAndPostsButPlansNoDuplicateLabel()
+    {
+        using var workspace = new SignalWorkspace();
+        var bodyPath = workspace.WriteBody("another blocker observation");
+        var gateway = new FakeSignalGateway();
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-signal-sent" } };
+        WorkerSignalCommand.GatewayFactory = () => gateway;
+        WorkerSignalCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exit = WorkerSignalCommand.Execute(
+            workspace.Context,
+            new[] { "blocker", "--repo", "J-Tech-Japan/intent-system", "--issue", "851", "--from-file", bodyPath, "--write", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        var result = JsonSerializer.Deserialize<WorkerSignalResult>(writer.ToString())!;
+        Assert.True(result.Posted);
+        Assert.False(result.Applied);
+        Assert.Empty(result.AddLabels);
+        Assert.NotEmpty(result.Warnings);
+        Assert.Single(gateway.Posted);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_BlockerOnPr_RejectsDisallowedTarget()
+    {
+        using var workspace = new SignalWorkspace();
+        var bodyPath = workspace.WriteBody("x");
+        WorkerSignalCommand.MutatorFactory = () => new FakeMutator();
+
+        using var writer = new StringWriter();
+        var exit = WorkerSignalCommand.Execute(
+            workspace.Context,
+            new[] { "blocker", "--repo", "J-Tech-Japan/intent-system", "--pr", "860", "--from-file", bodyPath },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("cannot target a pr", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownKind_ReturnsError()
+    {
+        using var workspace = new SignalWorkspace();
+        using var writer = new StringWriter();
+        var exit = WorkerSignalCommand.Execute(
+            workspace.Context,
+            new[] { "bogus", "--repo", "J-Tech-Japan/intent-system", "--issue", "1", "--from-file", "x" },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Unknown signal kind", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingFromFile_ReturnsError()
+    {
+        using var workspace = new SignalWorkspace();
+        WorkerSignalCommand.MutatorFactory = () => new FakeMutator();
+        using var writer = new StringWriter();
+        var exit = WorkerSignalCommand.Execute(
+            workspace.Context,
+            new[] { "blocker", "--repo", "J-Tech-Japan/intent-system", "--issue", "1" },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--from-file", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_EmptyBodyFile_ReturnsError()
+    {
+        using var workspace = new SignalWorkspace();
+        var bodyPath = workspace.WriteBody("   ");
+        WorkerSignalCommand.MutatorFactory = () => new FakeMutator();
+        using var writer = new StringWriter();
+        var exit = WorkerSignalCommand.Execute(
+            workspace.Context,
+            new[] { "blocker", "--repo", "J-Tech-Japan/intent-system", "--issue", "1", "--from-file", bodyPath },
+            writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("must not be empty", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverInvokesNestedProviderLauncher()
+    {
+        using var workspace = new SignalWorkspace();
+        var bodyPath = workspace.WriteBody("body");
+        var invoked = false;
+        WorkerSignalCommand.NestedProviderLauncher = () => { invoked = true; return true; };
+        WorkerSignalCommand.GatewayFactory = () => new FakeSignalGateway();
+        WorkerSignalCommand.MutatorFactory = () => new FakeMutator { Labels = new[] { "intent-target" } };
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, WorkerSignalCommand.Execute(
+            workspace.Context,
+            new[] { "blocker", "--repo", "J-Tech-Japan/intent-system", "--issue", "851", "--from-file", bodyPath, "--write", "--format", "json" },
+            writer));
+
+        Assert.False(invoked, "WorkerSignalCommand must never invoke NestedProviderLauncher.");
+    }
+
+    [Fact]
+    public void SourceScan_CommandContractAndAnalyzer_ContainNoProcessStart()
+    {
+        var command = File.ReadAllText(LocateSourceFile("WorkerSignalCommand.cs"));
+        var contract = File.ReadAllText(LocateSourceFile("WorkerSignalContract.cs"));
+        var analyzer = File.ReadAllText(LocateSourceFile("ReviewCollectSignalsAnalyzer.cs"));
+        var combined = command + "\n" + contract + "\n" + analyzer;
+
+        Assert.DoesNotContain("Process.Start(", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh issue comment", combined, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh pr comment", combined, StringComparison.Ordinal);
+    }
+
+    private static string LocateSourceFile(string fileName)
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, "src", "IntentSystem.Cli", "Commands", fileName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException($"Could not locate source file {fileName}");
+    }
+
+    internal sealed record PostedComment
+    {
+        public required string Repo { get; init; }
+        public required string Kind { get; init; }
+        public required int Number { get; init; }
+        public required string Body { get; init; }
+        public required string CommentRef { get; init; }
+    }
+
+    internal sealed class FakeSignalGateway : IGitHubSignalGateway
+    {
+        public List<PostedComment> Posted { get; } = new();
+        public IReadOnlyList<GitHubSignalComment> CommentsToReturn { get; init; } = Array.Empty<GitHubSignalComment>();
+
+        public string PostComment(string repo, string kind, int number, string body)
+        {
+            var commentRef = $"https://github.com/{repo}/{kind}/{number}#issuecomment-{Posted.Count + 1}";
+            Posted.Add(new PostedComment { Repo = repo, Kind = kind, Number = number, Body = body, CommentRef = commentRef });
+            return commentRef;
+        }
+
+        public IReadOnlyList<GitHubSignalComment> ListComments(string repo, string kind, int number) => CommentsToReturn;
+    }
+
+    internal sealed class FakeMutator : IGitHubLabelMutator
+    {
+        public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+        public List<AppliedTransition> AppliedTransitions { get; } = new();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            Labels.Select(n => new GitHubAutomationLabel { Name = n }).ToArray();
+
+        public void ApplyLabelTransitions(string repo, string kind, int number,
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels)
+        {
+            AppliedTransitions.Add(new AppliedTransition
+            {
+                Repo = repo,
+                Kind = kind,
+                Number = number,
+                AddLabels = addLabels.ToArray(),
+                RemoveLabels = removeLabels.ToArray(),
+            });
+        }
+
+        public void ApplyReconcileTransitions(string repo, string kind, int number,
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException();
+    }
+
+    internal sealed record AppliedTransition
+    {
+        public required string Repo { get; init; }
+        public required string Kind { get; init; }
+        public required int Number { get; init; }
+        public required IReadOnlyList<string> AddLabels { get; init; }
+        public required IReadOnlyList<string> RemoveLabels { get; init; }
+    }
+
+    private sealed class SignalWorkspace : IDisposable
+    {
+        public SignalWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("worker-signal-tests-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+                },
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public string WriteBody(string content)
+        {
+            var path = Path.Combine(RootPath, $"signal-{Guid.NewGuid():N}.md");
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerSignalContractTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerSignalContractTests.cs
@@ -1,0 +1,101 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G374: pure contract tests for the structured worker-signal protocol —
+/// marker generation/parsing, allowed-target rules, comment-body
+/// templating, and label-transition planning for send / handled.
+/// </summary>
+public sealed class WorkerSignalContractTests
+{
+    [Theory]
+    [InlineData("blocker")]
+    [InlineData("follow-up")]
+    [InlineData("scope-warning")]
+    public void Marker_RoundTrips_KindThroughParser(string kind)
+    {
+        var marker = WorkerSignalContract.BuildMarker(kind, "issue", 851);
+
+        Assert.StartsWith(WorkerSignalContract.MarkerPrefix, marker);
+        Assert.Contains($"kind={kind}", marker, StringComparison.Ordinal);
+        Assert.Contains("target=issue#851", marker, StringComparison.Ordinal);
+
+        Assert.True(WorkerSignalContract.TryParseSignalKind(marker, out var parsed));
+        Assert.Equal(kind, parsed);
+    }
+
+    [Fact]
+    public void BuildCommentBody_EmbedsMarkerFirstAndKeepsBody()
+    {
+        var body = WorkerSignalContract.BuildCommentBody("blocker", "issue", 851, "cannot build: missing contract");
+
+        var firstLine = body.Split('\n')[0];
+        Assert.StartsWith(WorkerSignalContract.MarkerPrefix, firstLine);
+        Assert.Contains("cannot build: missing contract", body, StringComparison.Ordinal);
+        Assert.True(WorkerSignalContract.TryParseSignalKind(body, out var kind));
+        Assert.Equal("blocker", kind);
+    }
+
+    [Fact]
+    public void TryParseSignalKind_NonSignalComment_ReturnsFalse()
+    {
+        Assert.False(WorkerSignalContract.TryParseSignalKind("just an ordinary review comment", out _));
+        Assert.False(WorkerSignalContract.TryParseSignalKind("<!-- intent-signal v=1 kind=bogus target=issue#1 -->", out _));
+        Assert.False(WorkerSignalContract.TryParseSignalKind(string.Empty, out _));
+        Assert.False(WorkerSignalContract.TryParseSignalKind(null, out _));
+    }
+
+    [Fact]
+    public void AllowedTargets_EnforceKindRouting()
+    {
+        Assert.True(WorkerSignalContract.IsTargetAllowed("blocker", "issue"));
+        Assert.False(WorkerSignalContract.IsTargetAllowed("blocker", "pr"));
+
+        Assert.True(WorkerSignalContract.IsTargetAllowed("follow-up", "pr"));
+        Assert.False(WorkerSignalContract.IsTargetAllowed("follow-up", "issue"));
+
+        Assert.True(WorkerSignalContract.IsTargetAllowed("scope-warning", "issue"));
+        Assert.True(WorkerSignalContract.IsTargetAllowed("scope-warning", "pr"));
+    }
+
+    [Fact]
+    public void PlanSentTransition_AddsSent_AndClearsStaleHandled()
+    {
+        var plan = WorkerSignalContract.PlanSentTransition(new[] { "intent-signal-handled" });
+
+        Assert.Contains(WorkerSignalContract.Labels.SignalSent, plan.AddLabels);
+        Assert.Contains(WorkerSignalContract.Labels.SignalHandled, plan.RemoveLabels);
+        Assert.True(plan.HasChanges);
+    }
+
+    [Fact]
+    public void PlanSentTransition_AlreadySent_PlansNoAdd()
+    {
+        var plan = WorkerSignalContract.PlanSentTransition(new[] { "intent-signal-sent" });
+
+        Assert.DoesNotContain(WorkerSignalContract.Labels.SignalSent, plan.AddLabels);
+        Assert.Empty(plan.RemoveLabels);
+        Assert.False(plan.HasChanges);
+    }
+
+    [Fact]
+    public void PlanHandledTransition_AddsHandled_AndRemovesSent()
+    {
+        var plan = WorkerSignalContract.PlanHandledTransition(new[] { "intent-signal-sent" });
+
+        Assert.Contains(WorkerSignalContract.Labels.SignalHandled, plan.AddLabels);
+        Assert.Contains(WorkerSignalContract.Labels.SignalSent, plan.RemoveLabels);
+        Assert.True(plan.HasChanges);
+    }
+
+    [Fact]
+    public void PlanHandledTransition_AlreadyHandledNoSent_PlansNoChange()
+    {
+        var plan = WorkerSignalContract.PlanHandledTransition(new[] { "intent-signal-handled" });
+
+        Assert.Empty(plan.AddLabels);
+        Assert.Empty(plan.RemoveLabels);
+        Assert.False(plan.HasChanges);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkflowLabelPaletteAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkflowLabelPaletteAnalyzerTests.cs
@@ -10,10 +10,11 @@ namespace IntentSystem.Cli.Tests;
 public sealed class WorkflowLabelPaletteAnalyzerTests
 {
     [Fact]
-    public void Canonical_PaletteContainsExactlyEightLabels()
+    public void Canonical_PaletteContainsExactlyTenLabels()
     {
         // G366 acceptance: the canonical palette is exhaustive and stable.
-        Assert.Equal(8, WorkflowLabelPaletteContract.Canonical.Count);
+        // G374: extended with the two structured worker-signal labels.
+        Assert.Equal(10, WorkflowLabelPaletteContract.Canonical.Count);
         var names = WorkflowLabelPaletteContract.Canonical.Select(e => e.Name).ToHashSet();
         Assert.Contains("intent-target", names);
         Assert.Contains("intent-issue-in-progress", names);
@@ -23,6 +24,10 @@ public sealed class WorkflowLabelPaletteAnalyzerTests
         Assert.Contains("intent-pr-update-in-progress", names);
         Assert.Contains("intent-pr-rereview-ready", names);
         Assert.Contains("intent-pr-approved", names);
+        // G374: signal-protocol labels are part of the canonical palette so
+        // `automation label-palette-audit` / `-sync` provision them too.
+        Assert.Contains("intent-signal-sent", names);
+        Assert.Contains("intent-signal-handled", names);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #851

## Summary
- Adds a GitHub-native **structured worker signal protocol** so child implementation workers can hand blockers, follow-up findings, and scope/contract-gap warnings back to host review/design automation using only GitHub issue/PR comments + `intent-cli` label transitions — never by reading or mutating host `.intent-cli` / `intents/**` metadata (G300/G333).
- Canonical labels `intent-signal-sent` / `intent-signal-handled` added to the workflow label palette, so `automation label-palette-audit` / `-sync` provision them automatically.
- New CLI surfaces:
  - `worker signal <blocker|follow-up|scope-warning>` — posts a marker-wrapped comment and adds `intent-signal-sent` (dry-run by default).
  - `review collect-signals` — lists pending signals by label **and** structured comment marker; already-handled items drop out of the label query so they are never reprocessed.
  - `review signal-handled` — adds `intent-signal-handled`, removes `intent-signal-sent`.
  - `guide worker signal` — paste-ready blocker/follow-up/scope-warning templates.
- `WorkerSignalContract` holds the pure marker grammar + send/handled label-transition planning; a new `IGitHubSignalGateway` seam isolates `gh` comment post/read so commands and analyzers stay pure and fully unit-tested over fakes.

## Acceptance criteria mapping
- Child can submit a structured signal via GitHub context + intent-cli only → `worker signal`.
- Submitting adds `intent-signal-sent` → `WorkerSignalContract.PlanSentTransition` + command write path.
- Host collection finds pending by label + marker → `review collect-signals` / `ReviewCollectSignalsAnalyzer`.
- Marking handled adds handled / removes sent → `review signal-handled`.
- Already-handled signals not reprocessed → regression test `Analyze_HandledItem_IsSkipped_NotReprocessed`.
- Signal labels in label-palette audit/sync → palette contract + updated count test.

Note: `intents/intent-cli/specs/05-intent-cli-surface.md` is host-owned and absent from the child worktree, so the spec-doc update is deferred to the host (as with G372/G373).

## Test plan
- [x] `dotnet build IntentSystem.sln` — 0 errors.
- [x] New tests pass: contract (marker/transition), `worker signal`, `review collect-signals` (analyzer + command), `review signal-handled`, `guide worker signal`, palette inclusion (61 focused tests green).
- [x] `git diff --check` clean.
- [ ] CI green.

(Pre-existing, unrelated: `ProgramMain_Automation{Check,Complete}DoesNotRequireIntentCliDirectory` fail identically on clean `main` in this environment — `Program.Main` stdout capture — not introduced by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)