### PR TITLE
G378: derive latest execution unit build metadata automatically

### DIFF
--- a/.github/workflows/private-preview-pack.yml
+++ b/.github/workflows/private-preview-pack.yml
@@ -67,11 +67,24 @@ jobs:
           BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           EXPIRES_AT="$(date -u -d '+14 days' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || python3 -c 'import datetime; print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(days=14)).strftime("%Y-%m-%dT%H:%M:%SZ"))')"
           SHORT_SHA="$(git rev-parse --short=7 HEAD)"
+          # G378: derive the latest implemented execution unit from
+          # source-controlled git history (checkout uses fetch-depth: 0)
+          # and pass it explicitly to pack so the preview/baseline
+          # artifacts can never report a stale completed unit. The csproj
+          # also derives this automatically, but pinning it here keeps the
+          # CI artifact metadata deterministic regardless of the MSBuild
+          # target. Falls back to `unknown` (never a stale G-number) when
+          # no `G<n>:` subject is found.
+          LATEST_EXECUTION_UNIT="$(git log -n 300 --format=%s | sed -n 's/^\(G[0-9][0-9]*\)[: ].*/\1/p' | sort -t G -k2 -n | tail -1)"
+          if [ -z "${LATEST_EXECUTION_UNIT}" ]; then
+            LATEST_EXECUTION_UNIT="unknown"
+          fi
           {
             echo "package_version=${PACKAGE_VERSION}"
             echo "build_timestamp=${BUILD_TIMESTAMP}"
             echo "expires_at=${EXPIRES_AT}"
             echo "short_sha=${SHORT_SHA}"
+            echo "latest_execution_unit=${LATEST_EXECUTION_UNIT}"
           } | tee -a "${GITHUB_OUTPUT}"
 
       # G371: each phase carries a stable `id` so the failure-summary
@@ -103,6 +116,7 @@ jobs:
             --configuration Release \
             -o .artifacts/private-preview \
             -p:Version=${{ steps.meta.outputs.package_version }} \
+            -p:IntentSystemLatestExecutionUnit=${{ steps.meta.outputs.latest_execution_unit }} \
             -p:PrivatePreviewChannel=private-preview \
             -p:PrivatePreviewBuildTimestamp=${{ steps.meta.outputs.build_timestamp }} \
             -p:PrivatePreviewExpiresAt=${{ steps.meta.outputs.expires_at }} \
@@ -113,7 +127,8 @@ jobs:
         run: |
           dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
             --configuration Release \
-            -o .artifacts/source-baseline
+            -o .artifacts/source-baseline \
+            -p:IntentSystemLatestExecutionUnit=${{ steps.meta.outputs.latest_execution_unit }}
 
       - name: Verify preview pack embeds AssemblyMetadata
         id: verify

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -22,20 +22,61 @@
       runtime.
 
       IntentSystemLatestExecutionUnit is the latest implemented
-      intent-system G-number at pack/build time. Bump it as new
-      slices land. CI may override via the MSBuild property of the
-      same name.
+      intent-system G-number at pack/build time. G378: it is derived
+      automatically from source-controlled git history by the
+      ResolveIntentCliLatestExecutionUnit target below, so a normal
+      `dotnet pack` from a checkout reports the latest merged unit
+      without a manual property. A controlled CI/release build may still
+      pin it explicitly via -p:IntentSystemLatestExecutionUnit=Gxxx, in
+      which case the derivation is skipped. When no explicit value is
+      given the neutral `unknown` fallback below applies until the
+      derivation target replaces it — a stale hard-coded completed unit
+      (the previous `G360`) is worse than an explicit `unknown`.
 
       The git short SHA is captured from SourceRevisionId
       (set by Microsoft.SourceLink.GitHub or any CI that exports
       SourceRevisionId). When neither is available the SHA segment
       is omitted gracefully.
     -->
-    <IntentSystemLatestExecutionUnit Condition="'$(IntentSystemLatestExecutionUnit)' == ''">G360</IntentSystemLatestExecutionUnit>
+    <!-- G378: record an explicit operator/CI override BEFORE applying the
+         neutral default so the derivation target only fills in an
+         automatically-derived unit when nothing was pinned. -->
+    <IntentSystemLatestExecutionUnitExplicit Condition="'$(IntentSystemLatestExecutionUnit)' != ''">true</IntentSystemLatestExecutionUnitExplicit>
+    <IntentSystemLatestExecutionUnit Condition="'$(IntentSystemLatestExecutionUnit)' == ''">unknown</IntentSystemLatestExecutionUnit>
     <SourceRevisionShortId Condition="'$(SourceRevisionId)' != ''">$(SourceRevisionId.Substring(0, 7))</SourceRevisionShortId>
     <InformationalVersion Condition="'$(SourceRevisionShortId)' != ''">$(Version)-$(SourceRevisionShortId)-$(IntentSystemLatestExecutionUnit)</InformationalVersion>
     <InformationalVersion Condition="'$(SourceRevisionShortId)' == ''">$(Version)-$(IntentSystemLatestExecutionUnit)</InformationalVersion>
   </PropertyGroup>
+
+  <!--
+    G378: derive the latest implemented intent-system execution unit from
+    source-controlled git history at build time, replacing the previous
+    stale hard-coded `G360` fallback. The latest merged unit is the
+    highest `G<n>` that appears as a commit-subject prefix (both squash
+    merges `G377: ... (#858)` and the per-branch commits brought in by a
+    merge commit carry that prefix). Best-effort: when git is unavailable,
+    the checkout has no `G<n>:` subjects, or no match is found, the value
+    stays at the neutral `unknown` fallback rather than a misleading
+    completed unit. Skipped when the operator/CI pinned the unit
+    explicitly via -p:IntentSystemLatestExecutionUnit=... (controlled
+    release builds keep that override). Runs before
+    ResolveIntentCliSourceRevision so the SHA target's
+    InformationalVersion recompute observes the derived unit; the
+    PropertyGroup here also recomputes InformationalVersion so the value
+    is correct even when SourceRevisionId was already supplied (and the
+    SHA target is skipped).
+  -->
+  <Target Name="ResolveIntentCliLatestExecutionUnit" BeforeTargets="ResolveIntentCliSourceRevision;GetAssemblyAttributes;CoreCompile" Condition="'$(IntentSystemLatestExecutionUnitExplicit)' != 'true'">
+    <Exec Command="git log -n 300 --format=%s | sed -n 's/^\(G[0-9][0-9]*\)[: ].*/\1/p' | sort -t G -k2 -n | tail -1" WorkingDirectory="$(MSBuildProjectDirectory)" ConsoleToMSBuild="true" IgnoreExitCode="true" StandardOutputImportance="low" ContinueOnError="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="IntentSystemLatestExecutionUnitFromGit" />
+      <Output TaskParameter="ExitCode" PropertyName="IntentSystemLatestExecutionUnitGitExitCode" />
+    </Exec>
+    <PropertyGroup Condition="'$(IntentSystemLatestExecutionUnitGitExitCode)' == '0' AND '$(IntentSystemLatestExecutionUnitFromGit.Trim())' != ''">
+      <IntentSystemLatestExecutionUnit>$(IntentSystemLatestExecutionUnitFromGit.Trim())</IntentSystemLatestExecutionUnit>
+      <InformationalVersion Condition="'$(SourceRevisionShortId)' != ''">$(Version)-$(SourceRevisionShortId)-$(IntentSystemLatestExecutionUnit)</InformationalVersion>
+      <InformationalVersion Condition="'$(SourceRevisionShortId)' == ''">$(Version)-$(IntentSystemLatestExecutionUnit)</InformationalVersion>
+    </PropertyGroup>
+  </Target>
 
   <!--
     G360: capture the current git short SHA at build time so the

--- a/tests/IntentSystem.Cli.Tests/IntentCliBuildMetadataTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentCliBuildMetadataTests.cs
@@ -1,0 +1,65 @@
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G378: build-validation regression guards for the
+/// <c>intent-cli --version</c> execution-unit metadata. These read the
+/// CLI <c>.csproj</c> source directly so the stale hard-coded fallback
+/// (the old <c>G360</c>) cannot silently return: the no-override default
+/// must be the neutral <c>unknown</c>, the latest unit must be derived
+/// from git history at build time, and the explicit-override path must be
+/// preserved for controlled CI/release builds.
+/// </summary>
+public sealed class IntentCliBuildMetadataTests
+{
+    [Fact]
+    public void Csproj_LatestExecutionUnitDefault_IsNeutralUnknown_NotStaleHardCodedGNumber()
+    {
+        var csproj = File.ReadAllText(LocateCliCsproj());
+
+        // The no-override default must be the neutral `unknown` marker.
+        Assert.Matches(
+            @"<IntentSystemLatestExecutionUnit Condition=""'\$\(IntentSystemLatestExecutionUnit\)' == ''"">unknown</IntentSystemLatestExecutionUnit>",
+            csproj);
+
+        // It must NEVER hard-code a completed G-number as the default —
+        // that is exactly the G360 staleness bug this slice removes.
+        Assert.DoesNotMatch(
+            @"<IntentSystemLatestExecutionUnit Condition=""'\$\(IntentSystemLatestExecutionUnit\)' == ''"">G\d+</IntentSystemLatestExecutionUnit>",
+            csproj);
+    }
+
+    [Fact]
+    public void Csproj_DerivesLatestExecutionUnitFromGit_AndPreservesExplicitOverride()
+    {
+        var csproj = File.ReadAllText(LocateCliCsproj());
+
+        // A best-effort git-derivation target supplies the real unit for
+        // normal packs (no manual MSBuild property required).
+        Assert.Contains("ResolveIntentCliLatestExecutionUnit", csproj, StringComparison.Ordinal);
+        Assert.Contains("git log", csproj, StringComparison.Ordinal);
+
+        // The explicit-override path is preserved: an operator/CI build
+        // pinning -p:IntentSystemLatestExecutionUnit=Gxxx must skip the
+        // derivation. The explicit flag captures that intent.
+        Assert.Contains("IntentSystemLatestExecutionUnitExplicit", csproj, StringComparison.Ordinal);
+        Assert.Matches(
+            @"Condition=""'\$\(IntentSystemLatestExecutionUnitExplicit\)' != 'true'""",
+            csproj);
+    }
+
+    private static string LocateCliCsproj()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(
+                dir.FullName, "src", "IntentSystem.Cli", "IntentSystem.Cli.csproj");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException("Could not locate IntentSystem.Cli.csproj");
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/VersionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionCommandTests.cs
@@ -77,10 +77,12 @@ public sealed class VersionCommandTests : IDisposable
         Assert.StartsWith("intent-cli ", result, StringComparison.Ordinal);
         // Package version segment must be present.
         Assert.Matches(@"intent-cli \d+\.\d+\.\d+", result);
-        // Latest implemented execution unit segment must be present;
-        // the csproj sets G360 by default, but allow any G-number to
-        // future-proof against bumps.
-        Assert.Matches(@"-G\d+$", result);
+        // Latest implemented execution unit segment must be present.
+        // G378: the unit is derived from git history at build time
+        // (e.g. `-G378`); when derivation cannot resolve a unit the
+        // contract uses the neutral `-unknown` marker rather than a
+        // stale hard-coded G-number. Accept either form.
+        Assert.Matches(@"-(G\d+|unknown)$", result);
         // The `+commit` SourceLink suffix must be stripped — the
         // canonical form uses dash-separated segments only.
         Assert.DoesNotContain('+', result);


### PR DESCRIPTION
Closes #859

## Summary
- `intent-cli --version` baked the execution-unit suffix from a hard-coded `<IntentSystemLatestExecutionUnit>G360</...>` fallback in the CLI csproj, so after later units merged the installed binary still reported a stale `G360` (e.g. `0.2.0-801a75b-G360`) unless an operator remembered `-p:IntentSystemLatestExecutionUnit=Gxxx`.
- New best-effort MSBuild target **`ResolveIntentCliLatestExecutionUnit`** derives the latest implemented unit from source-controlled git history (highest `G<n>:` commit-subject prefix), mirroring the existing `ResolveIntentCliSourceRevision` SHA target. A normal `dotnet pack` from a checkout now reports the latest merged unit with no manual property.
- The no-override default is the neutral **`unknown`** (a stale completed unit is worse than explicit `unknown`); the explicit `-p:IntentSystemLatestExecutionUnit=...` override is preserved via an explicit-pin flag that skips derivation.
- **private-preview-pack** CI derives the unit in the meta step (`fetch-depth: 0`) and passes it explicitly to both pack commands, so preview/baseline artifacts can never report a stale unit.

## Acceptance criteria mapping
- Normal local pack reports ≥ G377 without override → auto-derivation yields the latest merged unit (verified: `0.2.0-801a75b-G377`; `G378` after this commit).
- Explicit `-p:IntentSystemLatestExecutionUnit=G999` still produces `G999` → verified.
- Derivation cannot determine → neutral `unknown`, not stale `G360` → default fallback.
- CI preview packaging cannot misleadingly report `G360` → CI derives + passes explicit unit.
- Tests cover the stale-fallback regression → `IntentCliBuildMetadataTests` (csproj default must be `unknown`, never a hard-coded G-number; derivation + override paths present).

Note: the host-owned spec docs `intents/intent-cli/specs/05-intent-cli-surface.md` and `09-language-and-distribution-model.md` are absent from the child worktree, so their updates are deferred to the host (as with prior slices).

## Test plan
- [x] `dotnet build` auto-derivation → `0.2.0-801a75b-G377`; `-p:IntentSystemLatestExecutionUnit=G999` → `G999`.
- [x] Version + build-metadata tests pass; full `IntentSystem.Cli.Tests` → 3236 passed / 1 skipped / 0 failed.
- [x] `git diff --check` clean.
- [ ] CI `private-preview-pack` produces a non-stale version suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)