### PR TITLE
G379: prune legacy provider-run surfaces from default chat-first help

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -34,6 +34,29 @@ internal static class CommandRouter
         "migrate"
     ];
 
+    /// <summary>
+    /// G379: the chat-first subset shown by the default <c>intent-cli --help</c>.
+    /// These are the routine implementation / review / next-slice surfaces from
+    /// the issue's Accepted Baseline. The remaining groups — advanced
+    /// (<c>run</c>) and experimental / legacy (concept-intake <c>intake</c>,
+    /// projection, bug-intent, tasking, safety, etc.) — are classified in
+    /// <c>guide commands list</c> and shown only by <c>intent-cli --help --all</c>,
+    /// so a routine agent does not mistake <c>intent-cli run</c> for the
+    /// implementation/review loop. Every entry must also appear in
+    /// <see cref="CommandGroups"/> (asserted by tests).
+    /// </summary>
+    internal static readonly IReadOnlyList<string> PrimaryCommandGroups = new[]
+    {
+        "guide",
+        "automation",
+        "worker",
+        "review",
+        "issue",
+        "packet",
+        "intent",
+        "closeout"
+    };
+
     private static readonly IReadOnlyList<string> AutomationCommandHelp =
     [
         "automation base-branch-check --repo <r> --pr <n> --actual-base <branch> [--policy direct-main|main-ai]",
@@ -302,10 +325,23 @@ internal static class CommandRouter
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(writer);
 
+        // G379: `intent-cli --help --all` (and the `--help-all` synonym) shows
+        // every command group, including the advanced/legacy/provider-runtime
+        // surfaces hidden from the chat-first default. Checked before the
+        // plain-`--help` branch so the `--all` modifier is honored.
+        if ((args.Length == 2
+                && string.Equals(args[0], "--help", StringComparison.Ordinal)
+                && string.Equals(args[1], "--all", StringComparison.Ordinal))
+            || (args.Length == 1 && string.Equals(args[0], "--help-all", StringComparison.Ordinal)))
+        {
+            WriteHelp(writer, includeAll: true);
+            return 0;
+        }
+
         if (args.Length == 0
             || (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal)))
         {
-            WriteHelp(writer);
+            WriteHelp(writer, includeAll: false);
             return 0;
         }
 
@@ -473,29 +509,61 @@ internal static class CommandRouter
             ["run"] = "`intent-cli run ...` is integration smoke / replay / dogfooding — NOT the primary chat-first path."
         };
 
-    private static void WriteHelp(TextWriter writer)
-    {
-        writer.WriteLine("Available command groups:");
-        foreach (var group in CommandGroups)
-        {
-            writer.WriteLine($"- {group}");
-        }
+    private static void WriteHelp(TextWriter writer) => WriteHelp(writer, includeAll: false);
 
-        writer.WriteLine("Additional top-level commands:");
-        writer.WriteLine($"- {GenerateFromCurrentCommandName}");
+    /// <summary>
+    /// G379: the default <c>intent-cli --help</c> is chat-first. It leads with
+    /// the workflow guides and lists only the primary command groups
+    /// (<see cref="PrimaryCommandGroups"/>) a coding agent reaches for in
+    /// routine implementation / review / next-slice work. Advanced / legacy /
+    /// provider-runtime surfaces (<c>run</c>, concept-intake <c>intake</c>,
+    /// projection, bug-intent, tasking, safety, <c>generate-from-current</c>)
+    /// are NOT shown by default so agents do not mistake <c>intent-cli run</c>
+    /// for the implementation/review loop. They remain fully available via
+    /// <c>intent-cli --help --all</c> and the classified
+    /// <c>intent-cli guide commands list</c> catalog. With
+    /// <paramref name="includeAll"/> the full group list and the
+    /// <see cref="RunRoleNote"/> are emitted.
+    /// </summary>
+    private static void WriteHelp(TextWriter writer, bool includeAll)
+    {
+        writer.WriteLine("intent-cli — chat-first intent workflow CLI.");
+        writer.WriteLine("Routine model: human <-> coding agent (Claude / Codex / Copilot) <-> intent-cli calls <-> GitHub / host metadata.");
+        writer.WriteLine("Ask `intent-cli guide workflow task <task> --format json` or `intent-cli guide prompt-template ...` for current paste-ready instructions rather than probing legacy command surfaces.");
+        writer.WriteLine();
 
         // G334: top-level help must point an external agent at the
         // canonical workflow entries (init / interview / packet /
         // issue / automation / bug repair) so self-discovery does not
-        // depend on local rules or copied skill prompts.
-        writer.WriteLine();
+        // depend on local rules or copied skill prompts. G379 keeps these
+        // first so the chat-first discovery path is the prominent default.
         writer.WriteLine("Workflow guides:");
         foreach (var line in WorkflowGuidePointersHelp)
         {
             writer.WriteLine($"- {line}");
         }
-
         writer.WriteLine();
+
+        if (includeAll)
+        {
+            writer.WriteLine("All command groups:");
+            foreach (var group in CommandGroups)
+            {
+                writer.WriteLine($"- {group}");
+            }
+            writer.WriteLine("Additional top-level commands:");
+            writer.WriteLine($"- {GenerateFromCurrentCommandName}");
+        }
+        else
+        {
+            writer.WriteLine("Primary command groups (chat-first workflow):");
+            foreach (var group in PrimaryCommandGroups)
+            {
+                writer.WriteLine($"- {group}");
+            }
+        }
+        writer.WriteLine();
+
         writer.WriteLine("Per-group help:");
         writer.WriteLine("- `intent-cli <group> --help` (e.g. `intent-cli guide --help`, `intent-cli metadata --help`, `intent-cli migrate --help`) — list the group's subcommands.");
         writer.WriteLine("- `intent-cli guide help [--format markdown|json]` — external-user self-discovery surface with examples + workflow guide pointers.");
@@ -509,9 +577,18 @@ internal static class CommandRouter
         }
 
         writer.WriteLine();
-        foreach (var line in RunRoleNote)
+        if (includeAll)
         {
-            writer.WriteLine(line);
+            foreach (var line in RunRoleNote)
+            {
+                writer.WriteLine(line);
+            }
+        }
+        else
+        {
+            writer.WriteLine("Advanced / legacy surfaces (`run`, concept-intake `intake`, projection, bug-intent, tasking, safety, generate-from-current) are hidden from this chat-first view.");
+            writer.WriteLine("- `intent-cli --help --all` — show every command group, including advanced / legacy ones.");
+            writer.WriteLine("- `intent-cli run` is integration smoke / deterministic replay / local dogfooding only — NOT the implementation/review loop; do not route routine work through it.");
         }
     }
 

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -224,12 +224,21 @@ internal static class Program
         if (args.Length == 1)
         {
             // `intent-cli --help` reaches the top-level help; bare
-            // `intent-cli <group>` reaches per-group help.
+            // `intent-cli <group>` reaches per-group help. G379:
+            // `intent-cli --help-all` is the read-only full-catalog help.
             return string.Equals(args[0], "--help", StringComparison.Ordinal)
+                || string.Equals(args[0], "--help-all", StringComparison.Ordinal)
                 || !args[0].StartsWith('-');
         }
         if (args.Length == 2)
         {
+            // G379: `intent-cli --help --all` is a read-only help shape that
+            // must reach CommandRouter from any cwd (no host state needed).
+            if (string.Equals(args[0], "--help", StringComparison.Ordinal)
+                && string.Equals(args[1], "--all", StringComparison.Ordinal))
+            {
+                return true;
+            }
             return !args[0].StartsWith('-')
                 && (string.Equals(args[1], "--help", StringComparison.Ordinal)
                     || string.Equals(args[1], "help", StringComparison.Ordinal));

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -15,39 +15,74 @@ namespace IntentSystem.Cli.Tests;
 public sealed class CommandRouterTests
 {
     [Fact]
-    public void Execute_GivenNoArguments_WritesHelpIncludingAllCommandGroups()
+    public void Execute_GivenNoArguments_DefaultHelpIsChatFirst_ShowsPrimaryGroups_HidesLegacy()
     {
+        // G379: the default `intent-cli --help` is chat-first. It leads with
+        // the workflow guides and lists only the primary command groups a
+        // routine agent reaches for; it must NOT dump the advanced/legacy
+        // surfaces (`run`, concept-intake `intake`, projection, etc.) or the
+        // RunRoleNote, so an agent never mistakes `intent-cli run` for the
+        // implementation/review loop. The full catalog moves to `--help --all`.
         using var writer = new StringWriter();
 
         var exitCode = CommandRouter.Execute(Array.Empty<string>(), CreateContext("/tmp/intent-system"), writer);
 
         var output = writer.ToString();
         Assert.Equal(0, exitCode);
-        Assert.Contains("project", output, StringComparison.Ordinal);
-        Assert.Contains("projection", output, StringComparison.Ordinal);
-        Assert.Contains("queue", output, StringComparison.Ordinal);
-        Assert.Contains("issue", output, StringComparison.Ordinal);
-        Assert.Contains("run", output, StringComparison.Ordinal);
-        Assert.Contains("review", output, StringComparison.Ordinal);
-        Assert.Contains("interview", output, StringComparison.Ordinal);
-        Assert.Contains("clarify", output, StringComparison.Ordinal);
-        Assert.Contains("intake", output, StringComparison.Ordinal);
-        Assert.Contains("generate-from-current", output, StringComparison.Ordinal);
+
+        // Chat-first lead: workflow guides + the primary group list.
+        Assert.Contains("Workflow guides:", output, StringComparison.Ordinal);
+        Assert.Contains("Primary command groups", output, StringComparison.Ordinal);
+        foreach (var group in CommandRouter.PrimaryCommandGroups)
+        {
+            Assert.Contains($"- {group}", output, StringComparison.Ordinal);
+        }
+
+        // Advanced/legacy groups are NOT listed in the default view, and the
+        // RunRoleNote (which belongs to the full `--all` view) is absent.
+        Assert.DoesNotContain("- run", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("- intake", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("- projection", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("- generate-from-current", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("not the primary production orchestrator", output, StringComparison.Ordinal);
+
+        // The default points at the explicit full-catalog discovery paths.
+        Assert.Contains("intent-cli --help --all", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide commands list", output, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Execute_GivenNoArguments_HelpDescribesRunAsIntegrationSmokeNotPrimaryOrchestrator()
+    public void Execute_GivenHelpAll_ListsEveryCommandGroup_AndGenerateFromCurrent()
     {
-        // G188 — `intent-cli run` is for integration smoke, deterministic
-        // replay, and local dogfooding; production automation lives in the
-        // host-side review/next-slice loop with provider-neutral labels and
-        // durable parent state. The root help output must say so explicitly,
-        // and the canonical wording must come from the shared
-        // CommandRouter.RunRoleNote constant so the docs/help surface cannot
-        // drift from the test assertion.
+        // G379: `intent-cli --help --all` restores the full group catalog,
+        // including the advanced/legacy surfaces hidden from the default.
         using var writer = new StringWriter();
 
-        var exitCode = CommandRouter.Execute(Array.Empty<string>(), CreateContext("/tmp/intent-system"), writer);
+        var exitCode = CommandRouter.Execute(["--help", "--all"], CreateContext("/tmp/intent-system"), writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("All command groups:", output, StringComparison.Ordinal);
+        Assert.Contains("- run", output, StringComparison.Ordinal);
+        Assert.Contains("- intake", output, StringComparison.Ordinal);
+        Assert.Contains("- projection", output, StringComparison.Ordinal);
+        Assert.Contains("- generate-from-current", output, StringComparison.Ordinal);
+        // Workflow guides remain present in the full view too.
+        Assert.Contains("Workflow guides:", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GivenHelpAll_DescribesRunAsIntegrationSmokeNotPrimaryOrchestrator()
+    {
+        // G188 / G379 — `intent-cli run` is for integration smoke, deterministic
+        // replay, and local dogfooding; production automation lives in the
+        // host-side review/next-slice loop. The RunRoleNote now lives in the
+        // full `--help --all` view (the chat-first default omits it), and the
+        // canonical wording must come from the shared CommandRouter.RunRoleNote
+        // constant so the help surface cannot drift from the test assertion.
+        using var writer = new StringWriter();
+
+        var exitCode = CommandRouter.Execute(["--help", "--all"], CreateContext("/tmp/intent-system"), writer);
 
         Assert.Equal(0, exitCode);
         var output = writer.ToString();
@@ -65,6 +100,21 @@ public sealed class CommandRouterTests
         foreach (var line in CommandRouter.RunRoleNote)
         {
             Assert.Contains(line, output, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void PrimaryCommandGroups_AreAllRegisteredCommandGroups()
+    {
+        // G379: every chat-first primary group must be a real command group
+        // so the default help never advertises a group the router can't reach.
+        var groups = typeof(CommandRouter)
+            .GetField("CommandGroups", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)
+            ?.GetValue(null) as string[];
+        Assert.NotNull(groups);
+        foreach (var primary in CommandRouter.PrimaryCommandGroups)
+        {
+            Assert.Contains(primary, groups!);
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -134,7 +134,10 @@ public sealed class PackagedInvocationSmokeTests
             var topLevelHelpOutput = File.ReadAllText(topLevelHelpOutputPath);
 
             Assert.Equal(0, topLevelHelpResult.ExitCode);
-            Assert.Contains("Available command groups", topLevelHelpOutput, StringComparison.Ordinal);
+            // G379: the default top-level help is chat-first — it leads with
+            // workflow guides + the primary command groups (the full catalog
+            // moved behind `intent-cli --help --all`).
+            Assert.Contains("Primary command groups", topLevelHelpOutput, StringComparison.Ordinal);
         }
     }
 


### PR DESCRIPTION
Closes #861

## Summary
- The default `intent-cli --help` listed every command group flatly and led with the `RunRoleNote`, so routine agents probed legacy surfaces and sometimes mistook `intent-cli run` for the implementation/review loop.
- **Default `--help` is now chat-first**: it leads with the workflow guides and lists only the primary command groups (`guide`, `automation`, `worker`, `review`, `issue`, `packet`, `intent`, `closeout`). Advanced/legacy surfaces (`run`, concept-intake `intake`, projection, bug-intent, tasking, safety, `generate-from-current`) and the `RunRoleNote` are hidden, with an explicit pointer to the full catalog.
- **New `intent-cli --help --all`** (and `--help-all` synonym) restores the full group catalog + `RunRoleNote`. `Program.IsHelpCommand` recognizes both shapes so they reach `CommandRouter` from any cwd without host state (no G299).
- Default help steers routine automation to `guide workflow task` / `guide prompt-template` for current instructions, and states `intent-cli run` is dogfooding-only — not the loop path.

`intent-cli guide commands list` already classifies `run` as `advanced` and the concept-intake/provider surfaces as `experimental`, so the catalog-side acceptance was already met; this slice fixes the top-level help.

## Acceptance criteria mapping
- `--help` no longer makes agents think `run` is the impl/review path → primary-groups-only default + an explicit "run is dogfooding-only, not the loop" line.
- Workflow guide commands are the prominent default discovery path → emitted first.
- Legacy/advanced discoverable only via explicit advanced/catalog paths → `--help --all` + `guide commands list`.
- Tests cover top-level help classification → rewritten/added `CommandRouterTests` (chat-first default, `--help --all`, RunRoleNote-in-all, primary-groups-are-real); updated `PackagedInvocationSmokeTests`.
- No default help text recommends provider subprocess launch for routine work → default omits RunRoleNote and warns against routing routine work through `run`.

Note: host-owned spec `intents/intent-cli/specs/05-intent-cli-surface.md` is absent from the child worktree → deferred to host.

## Test plan
- [x] `CommandRouterTests` (120) green; `ProgramTests` + `PackagedInvocationSmoke` + `GuideHelp` green in isolation.
- [x] Manual: default `--help` shows primary groups + hides run/intake; `--help --all` shows full catalog + RunRoleNote.
- [x] `git diff --check` clean. (Full-suite intermittent failures are pre-existing environmental subprocess/global-cwd flakiness, unrelated — they pass in isolation and vary run-to-run.)
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)