### PR TITLE
G380: add guide question-style surface for clarification questions

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -294,6 +294,8 @@ internal static class CommandRouter
                 ["closeout"] = GuideCloseoutCommand.Execute,
                 ["prompt-matrix"] = GuidePromptMatrixCommand.Execute,
                 ["prompt-template"] = GuidePromptTemplateCommand.Execute,
+                // G380: direct clarification-question-style guide surface.
+                ["question-style"] = GuideQuestionStyleCommand.Execute,
                 // G326: role-scoped host ownership model.
                 ["host-ownership"] = GuideHostOwnershipCommand.Execute,
                 // G334: self-discovery help surface for external users.

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -214,6 +214,12 @@ internal static class GuideHelpCommand
             Name = "host-ownership",
             Purpose = "G326 role-scoped host ownership model: which role owns which durable-state slice.",
             Example = "intent-cli guide host-ownership --format json"
+        },
+        new GuideSubcommandEntry
+        {
+            Name = "question-style",
+            Purpose = "G380 direct answer to how to ask product-owner clarification/interview questions: required elements + copyable template (one focused question, options, tradeoffs, recommendation, recording, stop-on-ambiguity).",
+            Example = "intent-cli guide question-style --format json"
         }
     };
 

--- a/src/IntentSystem.Cli/Commands/GuideQuestionStyleCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideQuestionStyleCommand.cs
@@ -1,0 +1,245 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G380: read-only <c>intent-cli guide question-style</c>. The single,
+/// directly-discoverable answer to "質問の方法を intent-cli に聞いて" /
+/// "how should I ask the next clarification question, and what must it
+/// include?". Emits the required elements of a product-owner
+/// clarification / interview question plus a copyable template, so a
+/// chat-first agent does not have to probe the older
+/// <c>interview start/resume/answer</c> surfaces to reconstruct the
+/// guidance. Host-state-free: works from any cwd, never reads queue
+/// state, never launches an AI provider.
+/// </summary>
+internal static class GuideQuestionStyleCommand
+{
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide question-style [--domain <name>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domain, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = Build(domain);
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static GuideQuestionStyleResult Build(string? domain)
+    {
+        var domainArg = string.IsNullOrWhiteSpace(domain) ? "<domain>" : domain;
+
+        var requiredElements = new[]
+        {
+            "Restate the understood request and confirm the in-scope / out-of-scope boundaries before any deep design.",
+            "Ask exactly ONE focused question per turn — never batch multiple decisions into a single message.",
+            "Offer 2-3 concrete options when a choice is useful (skip options for a simple factual gap).",
+            "Give the pros/cons or tradeoffs for each option so the product owner can decide quickly.",
+            "Add a recommendation when you have a clear lean, and say why (omit it when you genuinely have no preference).",
+            "State how the answer will be recorded so the decision becomes durable before packet generation.",
+            "If the intent is ambiguous, stop as clarification-required rather than guessing or proceeding to design.",
+        };
+
+        var template =
+$@"Understood request: <one-line restatement of what you are being asked to build or decide>.
+Scope I'm assuming: <in-scope> / out-of-scope: <out-of-scope> — please correct if wrong.
+
+Question: <exactly one focused decision you need from the product owner>.
+
+Options:
+- A) <option A> — pros: <...>; cons: <...>
+- B) <option B> — pros: <...>; cons: <...>
+- C) <option C> — pros: <...>; cons: <...>   (omit if only two options apply)
+
+Recommendation: <A / B / C> because <reason>.   (omit this line if you have no clear lean)
+
+How I'll record your answer: once you choose, I'll record it durably (see `recording` below) before generating any packet or starting implementation.";
+
+        var prompt =
+$@"Ask product-owner clarification / interview questions the chat-first way: one focused question at a time, grounded in a restatement of the request, with options + tradeoffs + a recommendation when useful, and a clear path to record the answer.
+
+Do this in the conversation directly — you do NOT need to probe `interview start` / `interview resume` / `interview answer` or other older surfaces to figure out the shape. Use the required elements and template below, then record the answer only AFTER the user replies.
+
+If the request is ambiguous and you cannot frame a single concrete question, stop and surface it as clarification-required instead of guessing.";
+
+        return new GuideQuestionStyleResult
+        {
+            Kind = "question-style",
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            Prompt = prompt,
+            RequiredElements = requiredElements,
+            Template = template,
+            Recording = new[]
+            {
+                "Record the answer ONLY after the user replies — never generate a packet from an unrecorded answer.",
+                $"Durable interview Q/A: `intent-cli interview record-answer --domain {domainArg} --question-id <id> --answer \"<the user's choice>\"` (use `intent-cli interview next-question --domain {domainArg} --format json` to get the pending question id).",
+                "Clarification artifacts: `intent-cli clarify record ...` when the decision belongs to an open clarification rather than the interview Q/A.",
+            },
+            AvoidProbing = new[]
+            {
+                "Do not probe the older `interview start` / `interview resume` / `interview answer` commands to derive question style — this command is the direct answer.",
+                "Do not ask several questions at once, and do not proceed to design while a blocking clarification is unanswered.",
+            },
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideQuestionStyleResult result)
+    {
+        writer.WriteLine("# Guide — clarification question style");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: {result.Domain}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Required elements (every clarification question)");
+        foreach (var element in result.RequiredElements)
+        {
+            writer.WriteLine($"- {element}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Copyable question template");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Template);
+        writer.WriteLine("```");
+        writer.WriteLine();
+
+        writer.WriteLine("## Recording the answer");
+        foreach (var line in result.Recording)
+        {
+            writer.WriteLine($"- {line}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Avoid");
+        foreach (var line in result.AvoidProbing)
+        {
+            writer.WriteLine($"- {line}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Prompt");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+    }
+
+    private static bool TryParseArguments(string[] args, out string? domain, out string format, out string error)
+    {
+        domain = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide question-style");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only: how to ask product-owner clarification/interview questions and what each must include, with a copyable template.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}
+
+internal sealed record GuideQuestionStyleResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("required_elements")]
+    public required IReadOnlyList<string> RequiredElements { get; init; }
+
+    [JsonPropertyName("template")]
+    public required string Template { get; init; }
+
+    [JsonPropertyName("recording")]
+    public required IReadOnlyList<string> Recording { get; init; }
+
+    [JsonPropertyName("avoid_probing")]
+    public required IReadOnlyList<string> AvoidProbing { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -161,6 +161,7 @@ internal static class Program
                 || string.Equals(args[1], "worker", StringComparison.Ordinal)
                 || string.Equals(args[1], "closeout", StringComparison.Ordinal)
                 || string.Equals(args[1], "prompt-template", StringComparison.Ordinal)
+                || string.Equals(args[1], "question-style", StringComparison.Ordinal)
                 || string.Equals(args[1], "review", StringComparison.Ordinal)
                 // G334: external-user self-discovery surface. Read-only,
                 // no host state required, so the bootstrap allow-list

--- a/tests/IntentSystem.Cli.Tests/GuideQuestionStyleCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideQuestionStyleCommandTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G380: tests for the direct <c>intent-cli guide question-style</c>
+/// surface — the required elements, the copyable template, the
+/// record-after-answer pointer, and the discourage-old-interview-probing
+/// guidance, in both markdown and JSON.
+/// </summary>
+public sealed class GuideQuestionStyleCommandTests
+{
+    [Fact]
+    public void Execute_Json_IncludesRequiredElements_Template_AndRecording()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideQuestionStyleCommand.Execute(
+            CreateContext(),
+            new[] { "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+
+        Assert.Equal("question-style", root.GetProperty("kind").GetString());
+
+        var elements = root.GetProperty("required_elements").EnumerateArray()
+            .Select(e => e.GetString() ?? string.Empty).ToArray();
+        // The seven required elements the issue enumerates.
+        Assert.Contains(elements, e => e.Contains("Restate", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(elements, e => e.Contains("ONE focused question", StringComparison.Ordinal));
+        Assert.Contains(elements, e => e.Contains("options", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(elements, e => e.Contains("tradeoffs", StringComparison.OrdinalIgnoreCase) || e.Contains("pros/cons", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(elements, e => e.Contains("recommendation", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(elements, e => e.Contains("recorded", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(elements, e => e.Contains("clarification-required", StringComparison.Ordinal));
+
+        // Copyable template with a single focused question + options.
+        var template = root.GetProperty("template").GetString()!;
+        Assert.Contains("Understood request:", template, StringComparison.Ordinal);
+        Assert.Contains("Question:", template, StringComparison.Ordinal);
+        Assert.Contains("Options:", template, StringComparison.Ordinal);
+        Assert.Contains("Recommendation:", template, StringComparison.Ordinal);
+
+        // Recording happens only after the answer, via interview record-answer.
+        var recording = root.GetProperty("recording").EnumerateArray()
+            .Select(r => r.GetString() ?? string.Empty).ToArray();
+        Assert.Contains(recording, r => r.Contains("interview record-answer", StringComparison.Ordinal));
+        Assert.Contains(recording, r => r.Contains("after the user", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Execute_Json_DiscouragesProbingOldInterviewCommands()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideQuestionStyleCommand.Execute(CreateContext(), new[] { "--format", "json" }, writer));
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var avoid = doc.RootElement.GetProperty("avoid_probing").EnumerateArray()
+            .Select(a => a.GetString() ?? string.Empty).ToArray();
+        Assert.Contains(avoid, a => a.Contains("interview start", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_Markdown_RendersAllSectionsAndTemplateFence()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideQuestionStyleCommand.Execute(CreateContext(), new[] { "--format", "markdown" }, writer));
+
+        var output = writer.ToString();
+        Assert.Contains("# Guide — clarification question style", output, StringComparison.Ordinal);
+        Assert.Contains("## Required elements", output, StringComparison.Ordinal);
+        Assert.Contains("## Copyable question template", output, StringComparison.Ordinal);
+        Assert.Contains("## Recording the answer", output, StringComparison.Ordinal);
+        Assert.Contains("Question:", output, StringComparison.Ordinal);
+        Assert.Contains("interview record-answer", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DefaultFormatIsMarkdown()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideQuestionStyleCommand.Execute(CreateContext(), Array.Empty<string>(), writer));
+        Assert.Contains("# Guide — clarification question style", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RejectsUnknownFormat()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideQuestionStyleCommand.Execute(CreateContext(), new[] { "--format", "yaml" }, writer);
+        Assert.Equal(1, exit);
+        Assert.Contains("--format must be", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Router_DispatchesGuideQuestionStyle_ExitZero()
+    {
+        using var writer = new StringWriter();
+        var exit = CommandRouter.Execute(
+            ["guide", "question-style", "--format", "json"],
+            CreateContext(),
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("question-style", writer.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("not yet implemented", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext() => new()
+    {
+        RepoRoot = Directory.GetCurrentDirectory(),
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+        },
+    };
+}


### PR DESCRIPTION
Closes #863

## Summary
- Answering "how should I ask the next clarification question / 質問の方法を intent-cli に聞いて" previously required probing many surfaces (`interview next-question/record-answer/start/resume/answer`, `guide collaborate/rules/prompt-template/prompt-matrix`) — exactly the command-probing the chat-first model should avoid.
- New read-only **`intent-cli guide question-style --format markdown|json`** is the single direct answer. It emits:
  - the required elements — restate + confirm scope, exactly **one** focused question, 2-3 options, pros/cons, a recommendation when useful, how the answer is recorded, and stop-as-clarification-required on ambiguity;
  - a **copyable product-owner question template**;
  - the record-after-answer pointer (`interview record-answer` / `clarify record`), used only **after** the user replies;
  - explicit guidance **not** to probe the old `interview start/resume/answer` commands.
- Host-state-free: wired into the `guide` group, added to `Program.IsGuideOneshotCommand` so it runs from any cwd (no G299), and registered in `GuideHelpCommand.Subcommands` for `guide help` discoverability.

## Acceptance criteria mapping
- One direct command answers the question-style ask → `guide question-style`.
- Returned guide includes required elements + copyable template → asserted in tests.
- Discourages probing old interview start/resume/answer → `avoid_probing` / Avoid section.
- Tests cover markdown and JSON output → `GuideQuestionStyleCommandTests`.

Note: host-owned spec `intents/intent-cli/specs/05-intent-cli-surface.md` is absent from the child worktree → deferred to host.

## Test plan
- [x] `GuideQuestionStyleCommandTests` + `GuideHelp` catalog-match guard green (17).
- [x] Manual: markdown + JSON output from a non-host cwd (host-state-free, exit 0).
- [x] `git diff --check` clean; full `IntentSystem.Cli.Tests` 3243 passed (the 1 intermittent failure is pre-existing environmental flakiness — passes in isolation, unrelated subsystem).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)