### PR TITLE
G381: add persistent goal-seeking interview-mode guide surface

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -296,6 +296,8 @@ internal static class CommandRouter
                 ["prompt-template"] = GuidePromptTemplateCommand.Execute,
                 // G380: direct clarification-question-style guide surface.
                 ["question-style"] = GuideQuestionStyleCommand.Execute,
+                // G381: persistent goal-seeking interview-mode guide surface.
+                ["interview-mode"] = GuideInterviewModeCommand.Execute,
                 // G326: role-scoped host ownership model.
                 ["host-ownership"] = GuideHostOwnershipCommand.Execute,
                 // G334: self-discovery help surface for external users.

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -220,6 +220,12 @@ internal static class GuideHelpCommand
             Name = "question-style",
             Purpose = "G380 direct answer to how to ask product-owner clarification/interview questions: required elements + copyable template (one focused question, options, tradeoffs, recommendation, recording, stop-on-ambiguity).",
             Example = "intent-cli guide question-style --format json"
+        },
+        new GuideSubcommandEntry
+        {
+            Name = "interview-mode",
+            Purpose = "G381 persistent goal-seeking interview protocol: research-first, one question at a time in dependency order, definition-of-ready stop conditions (packet-ready / issue-ready / clarification-required / blocked-by-user-decision / insufficient-context-after-research), decision-record output.",
+            Example = "intent-cli guide interview-mode --format json"
         }
     };
 

--- a/src/IntentSystem.Cli/Commands/GuideInterviewModeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideInterviewModeCommand.cs
@@ -1,0 +1,289 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G381: read-only <c>intent-cli guide interview-mode</c>. The direct
+/// answer to "how do I run a persistent, goal-seeking product-owner
+/// interview?". It strengthens the per-question guidance from
+/// <c>guide question-style</c> (G380) into a durable, repo-backed
+/// protocol: research existing artifacts before asking, walk the
+/// decision tree one focused question at a time, and keep going until a
+/// definition-of-ready stop condition is reached — stopping after a
+/// shallow answer while scope / constraints / acceptance / verification
+/// gaps remain is explicitly not enough. The durable output is a decision
+/// record + packet/issue readiness, not a raw transcript. Host-state-free:
+/// works from any cwd, never reads queue state, never launches an AI
+/// provider.
+/// </summary>
+internal static class GuideInterviewModeCommand
+{
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide interview-mode [--domain <name>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domain, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = Build(domain);
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static GuideInterviewModeResult Build(string? domain)
+    {
+        var domainArg = string.IsNullOrWhiteSpace(domain) ? "<domain>" : domain;
+
+        var prompt =
+$@"Run a persistent, goal-seeking product-owner interview: keep clarifying a broad request until it is packet-ready / issue-ready, or until a structured stop condition is justified. The product owner talks to you in chat; you call intent-cli internally and never operate prompts for them, and never launch an AI provider.
+
+Do NOT stop after a single shallow answer. Stopping is only justified when a definition-of-ready stop condition (below) holds — while scope, constraints, acceptance criteria, or verification remain unresolved, ask the next question. Research the repo / intents / packets / GitHub context BEFORE asking the human anything those artifacts already answer; never make the owner repeat known facts. The durable output is a decision record + packet/issue readiness, not a raw transcript.";
+
+        var questionStructure = new[]
+        {
+            "Current understanding: a one-line restatement of where the shaping stands so the owner can correct drift.",
+            "Why this question matters: the decision or readiness gap it unblocks.",
+            "One focused question: exactly one decision per turn (never batch).",
+            "Options: 2-3 concrete candidates when a choice is useful.",
+            "Pros/cons: the tradeoffs for each option.",
+            "Recommendation: your lean and why (omit when you genuinely have none).",
+            "What the answer will decide: the scope/constraint/acceptance/verification item it resolves.",
+            "Remaining gaps: what is still open after this answer, so progress toward ready is visible.",
+        };
+
+        var agentBehavior = new[]
+        {
+            "Research first: inspect repo files, intents, packets, and GitHub issues/PRs before asking a question the artifacts can already answer.",
+            "One question at a time: ask a single focused decision per turn and wait for the answer.",
+            "Dependency order: walk the decision tree so blocking decisions are resolved before the decisions that depend on them.",
+            "Persist to ready: continue interviewing until an explicit stop condition holds — a shallow answer is not a reason to stop while readiness gaps remain.",
+            "Record durably: capture each answer/decision (see recording) so the result is a decision record, not a transcript; do not generate a packet from unrecorded answers.",
+        };
+
+        var stopConditions = new[]
+        {
+            new GuideInterviewStopCondition
+            {
+                Name = "packet-ready",
+                Meaning = "Scope, constraints, acceptance criteria, and verification are resolved enough to draft the canonical packet; proceed to `intent-cli packet draft` (with operator acceptance).",
+            },
+            new GuideInterviewStopCondition
+            {
+                Name = "issue-ready",
+                Meaning = "The standalone child-issue contract is complete enough to publish; proceed to `intent-cli issue publish-flow` (with operator acceptance).",
+            },
+            new GuideInterviewStopCondition
+            {
+                Name = "clarification-required",
+                Meaning = "A blocking ambiguity remains that only the product owner can resolve; stop and surface it as a structured clarification rather than guessing.",
+            },
+            new GuideInterviewStopCondition
+            {
+                Name = "blocked-by-user-decision",
+                Meaning = "Progress is gated on an explicit product-owner decision that has not been given; stop and name the exact decision needed.",
+            },
+            new GuideInterviewStopCondition
+            {
+                Name = "insufficient-context-after-research",
+                Meaning = "Required facts cannot be found in repo / intents / packets / GitHub and the owner cannot supply them; stop and report the missing context rather than fabricating it.",
+            },
+        };
+
+        return new GuideInterviewModeResult
+        {
+            Kind = "interview-mode",
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            Prompt = prompt,
+            QuestionStructure = questionStructure,
+            AgentBehavior = agentBehavior,
+            StopConditions = stopConditions,
+            DecisionRecord = new[]
+            {
+                "The durable output is a decision record: the resolved decisions, the answers that drove them, and the current readiness — not a raw chat transcript.",
+                $"Record each answer as it arrives: `intent-cli interview record-answer --domain {domainArg} --question-id <id> --answer \"<the owner's decision>\"` (get the pending id from `intent-cli interview next-question --domain {domainArg} --format json`); use `intent-cli clarify record ...` for clarification-scoped decisions.",
+                "Only after readiness is reached and answers are recorded, proceed (with operator acceptance) to `intent-cli packet draft` / `intent-cli issue publish-flow`.",
+            },
+            Related = new[]
+            {
+                "intent-cli guide question-style --format json — the per-question element checklist + copyable template (G380).",
+            },
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideInterviewModeResult result)
+    {
+        writer.WriteLine("# Guide — persistent goal-seeking interview mode");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: {result.Domain}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Protocol");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+        writer.WriteLine();
+
+        writer.WriteLine("## Question structure (each turn)");
+        foreach (var element in result.QuestionStructure)
+        {
+            writer.WriteLine($"- {element}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Agent behavior");
+        foreach (var line in result.AgentBehavior)
+        {
+            writer.WriteLine($"- {line}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Stop conditions");
+        foreach (var condition in result.StopConditions)
+        {
+            writer.WriteLine($"- `{condition.Name}`: {condition.Meaning}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Decision record");
+        foreach (var line in result.DecisionRecord)
+        {
+            writer.WriteLine($"- {line}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Related");
+        foreach (var line in result.Related)
+        {
+            writer.WriteLine($"- {line}");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string? domain, out string format, out string error)
+    {
+        domain = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide interview-mode");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only: persistent goal-seeking interview protocol — research-first, one question at a time, explicit definition-of-ready stop conditions, decision-record output.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}
+
+internal sealed record GuideInterviewModeResult
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("question_structure")]
+    public required IReadOnlyList<string> QuestionStructure { get; init; }
+
+    [JsonPropertyName("agent_behavior")]
+    public required IReadOnlyList<string> AgentBehavior { get; init; }
+
+    [JsonPropertyName("stop_conditions")]
+    public required IReadOnlyList<GuideInterviewStopCondition> StopConditions { get; init; }
+
+    [JsonPropertyName("decision_record")]
+    public required IReadOnlyList<string> DecisionRecord { get; init; }
+
+    [JsonPropertyName("related")]
+    public required IReadOnlyList<string> Related { get; init; }
+}
+
+internal sealed record GuideInterviewStopCondition
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("meaning")]
+    public required string Meaning { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -162,6 +162,7 @@ internal static class Program
                 || string.Equals(args[1], "closeout", StringComparison.Ordinal)
                 || string.Equals(args[1], "prompt-template", StringComparison.Ordinal)
                 || string.Equals(args[1], "question-style", StringComparison.Ordinal)
+                || string.Equals(args[1], "interview-mode", StringComparison.Ordinal)
                 || string.Equals(args[1], "review", StringComparison.Ordinal)
                 // G334: external-user self-discovery surface. Read-only,
                 // no host state required, so the bootstrap allow-list

--- a/tests/IntentSystem.Cli.Tests/GuideInterviewModeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideInterviewModeCommandTests.cs
@@ -1,0 +1,128 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G381: tests for the persistent goal-seeking <c>intent-cli guide
+/// interview-mode</c> surface — the question structure, research-first /
+/// one-at-a-time / persist-to-ready agent behavior, the explicit stop
+/// conditions, and the decision-record output, in markdown and JSON.
+/// </summary>
+public sealed class GuideInterviewModeCommandTests
+{
+    [Fact]
+    public void Execute_Json_IncludesQuestionStructure_Behavior_AndStopConditions()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideInterviewModeCommand.Execute(CreateContext(), new[] { "--format", "json" }, writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+
+        Assert.Equal("interview-mode", root.GetProperty("kind").GetString());
+
+        // The eight question-structure elements the issue enumerates.
+        var structure = root.GetProperty("question_structure").EnumerateArray()
+            .Select(e => e.GetString() ?? string.Empty).ToArray();
+        Assert.Equal(8, structure.Length);
+        Assert.Contains(structure, s => s.Contains("Current understanding", StringComparison.Ordinal));
+        Assert.Contains(structure, s => s.Contains("Why this question matters", StringComparison.Ordinal));
+        Assert.Contains(structure, s => s.Contains("One focused question", StringComparison.Ordinal));
+        Assert.Contains(structure, s => s.Contains("What the answer will decide", StringComparison.Ordinal));
+        Assert.Contains(structure, s => s.Contains("Remaining gaps", StringComparison.Ordinal));
+
+        // The five named stop conditions, in dependency-of-ready order.
+        var stops = root.GetProperty("stop_conditions").EnumerateArray()
+            .Select(s => s.GetProperty("name").GetString() ?? string.Empty).ToArray();
+        Assert.Equal(
+            new[] { "packet-ready", "issue-ready", "clarification-required", "blocked-by-user-decision", "insufficient-context-after-research" },
+            stops);
+    }
+
+    [Fact]
+    public void Execute_Json_RequiresResearchFirst_AndPersistToReady()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideInterviewModeCommand.Execute(CreateContext(), new[] { "--format", "json" }, writer));
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+
+        var behavior = root.GetProperty("agent_behavior").EnumerateArray()
+            .Select(b => b.GetString() ?? string.Empty).ToArray();
+        // Research-before-question is required.
+        Assert.Contains(behavior, b => b.Contains("Research first", StringComparison.Ordinal));
+        // Persist-to-ready: a shallow answer is not a stopping point.
+        Assert.Contains(behavior, b => b.Contains("Persist to ready", StringComparison.Ordinal));
+
+        // The prompt makes clear that stopping after a shallow answer is not enough.
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("shallow answer", prompt, StringComparison.OrdinalIgnoreCase);
+
+        // The durable output is a decision record, not a transcript.
+        var decision = root.GetProperty("decision_record").EnumerateArray()
+            .Select(d => d.GetString() ?? string.Empty).ToArray();
+        Assert.Contains(decision, d => d.Contains("decision record", StringComparison.OrdinalIgnoreCase) && d.Contains("transcript", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(decision, d => d.Contains("interview record-answer", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_Markdown_RendersAllSectionsAndStopConditions()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideInterviewModeCommand.Execute(CreateContext(), new[] { "--format", "markdown" }, writer));
+
+        var output = writer.ToString();
+        Assert.Contains("# Guide — persistent goal-seeking interview mode", output, StringComparison.Ordinal);
+        Assert.Contains("## Question structure", output, StringComparison.Ordinal);
+        Assert.Contains("## Agent behavior", output, StringComparison.Ordinal);
+        Assert.Contains("## Stop conditions", output, StringComparison.Ordinal);
+        Assert.Contains("## Decision record", output, StringComparison.Ordinal);
+        Assert.Contains("`packet-ready`", output, StringComparison.Ordinal);
+        Assert.Contains("`insufficient-context-after-research`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DefaultFormatIsMarkdown()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideInterviewModeCommand.Execute(CreateContext(), Array.Empty<string>(), writer));
+        Assert.Contains("# Guide — persistent goal-seeking interview mode", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RejectsUnknownFormat()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideInterviewModeCommand.Execute(CreateContext(), new[] { "--format", "yaml" }, writer);
+        Assert.Equal(1, exit);
+        Assert.Contains("--format must be", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Router_DispatchesGuideInterviewMode_ExitZero()
+    {
+        using var writer = new StringWriter();
+        var exit = CommandRouter.Execute(
+            ["guide", "interview-mode", "--format", "json"],
+            CreateContext(),
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("interview-mode", writer.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("not yet implemented", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext() => new()
+    {
+        RepoRoot = Directory.GetCurrentDirectory(),
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+        },
+    };
+}


### PR DESCRIPTION
Closes #865

## Summary
- `guide question-style` (G380) describes a single question, but agents often stop after a shallow answer while scope/constraints/acceptance/verification gaps remain. This adds the durable, repo-backed protocol for **persistent product-owner interviews**.
- New read-only **`intent-cli guide interview-mode --format markdown|json`** emits:
  - the per-turn **question structure** — current understanding, why it matters, one focused question, options, pros/cons, recommendation, what the answer decides, remaining gaps;
  - **agent behavior** — research repo/intents/packets/GitHub before asking, one question at a time in dependency order, **persist until ready** (a shallow answer is not a stop), record durably;
  - the explicit **definition-of-ready stop conditions** — `packet-ready`, `issue-ready`, `clarification-required`, `blocked-by-user-decision`, `insufficient-context-after-research`;
  - a **decision-record** output (recorded via `interview record-answer` / `clarify record`), not a raw transcript.
- Host-state-free: wired into the `guide` group + `Program.IsGuideOneshotCommand` allow-list (runs from any cwd, no G299) + `GuideHelpCommand.Subcommands`.

## Acceptance criteria mapping
- A direct command returns a concrete persistent-interview protocol → `guide interview-mode`.
- Makes clear stopping after a shallow answer is not enough → prompt + "Persist to ready" behavior.
- Requires research-before-question → "Research first" behavior.
- Produces a decision-record-oriented result, not a transcript → `decision_record`.
- Tests cover markdown/json → `GuideInterviewModeCommandTests`.

Note: host-owned specs `04-concept-intake-and-interview.md`, `06-interview-and-clarification-artifact-contract.md`, `05-intent-cli-surface.md` are absent from the child worktree → deferred to host.

## Test plan
- [x] `GuideInterviewModeCommandTests` + guide-help catalog-match guard green (7).
- [x] Manual: markdown + JSON from a non-host cwd (host-state-free, exit 0); all 5 stop conditions + 8 structure elements present.
- [x] `git diff --check` clean; full `IntentSystem.Cli.Tests` 3250 passed / 0 failed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)