### PR TITLE
G382: add interview readiness checklist and completion scoring

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -298,6 +298,8 @@ internal static class CommandRouter
                 ["question-style"] = GuideQuestionStyleCommand.Execute,
                 // G381: persistent goal-seeking interview-mode guide surface.
                 ["interview-mode"] = GuideInterviewModeCommand.Execute,
+                // G382: interview readiness checklist + classification.
+                ["interview-readiness"] = GuideInterviewReadinessCommand.Execute,
                 // G326: role-scoped host ownership model.
                 ["host-ownership"] = GuideHostOwnershipCommand.Execute,
                 // G334: self-discovery help surface for external users.

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -226,6 +226,12 @@ internal static class GuideHelpCommand
             Name = "interview-mode",
             Purpose = "G381 persistent goal-seeking interview protocol: research-first, one question at a time in dependency order, definition-of-ready stop conditions (packet-ready / issue-ready / clarification-required / blocked-by-user-decision / insufficient-context-after-research), decision-record output.",
             Example = "intent-cli guide interview-mode --format json"
+        },
+        new GuideSubcommandEntry
+        {
+            Name = "interview-readiness",
+            Purpose = "G382 interview readiness checklist + scoring: pass --resolved <dimensions> to classify packet-ready / issue-ready / clarification-required / remaining-gaps, list missing dimensions, and get the next highest-value question.",
+            Example = "intent-cli guide interview-readiness --resolved goal,scope,target,acceptance,verification --format json"
         }
     };
 

--- a/src/IntentSystem.Cli/Commands/GuideInterviewReadinessCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideInterviewReadinessCommand.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G382: read-only <c>intent-cli guide interview-readiness</c>. The
+/// measurable finish line for the persistent interview mode (G381): it
+/// tells an agent whether an interview has enough resolved information to
+/// draft a packet or publish an issue. With no input it prints the
+/// readiness checklist (all dimensions + the classification legend). With
+/// <c>--resolved &lt;keys&gt;</c> it runs
+/// <see cref="InterviewReadinessAnalyzer"/> and reports the verdict
+/// (<c>packet-ready</c> / <c>issue-ready</c> / <c>clarification-required</c>
+/// / <c>remaining-gaps</c>), the per-dimension checklist, the concrete
+/// missing dimensions, and the next highest-value question. Advisory:
+/// host-state-free, never publishes, never launches an AI provider.
+/// </summary>
+internal static class GuideInterviewReadinessCommand
+{
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide interview-readiness [--resolved <key,key,...>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var resolved, out var hasResolvedFlag, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        // No `--resolved` → emit the static checklist (the "what does
+        // ready mean?" path). With `--resolved` → evaluate the verdict.
+        var result = InterviewReadinessAnalyzer.Analyze(resolved);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result, evaluated: hasResolvedFlag);
+        }
+
+        return 0;
+    }
+
+    private static void WriteMarkdown(TextWriter writer, InterviewReadinessResult result, bool evaluated)
+    {
+        writer.WriteLine("# Guide — interview readiness checklist");
+        writer.WriteLine();
+        writer.WriteLine("Advisory readiness gate for moving an interview to a packet/issue. It does not publish anything; canonical writes still require operator acceptance.");
+        writer.WriteLine();
+
+        if (evaluated)
+        {
+            writer.WriteLine($"## Verdict: `{result.Classification}`");
+            writer.WriteLine($"- {result.Summary}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Dimensions");
+        foreach (var dimension in result.Dimensions)
+        {
+            var mark = evaluated ? (dimension.Resolved ? "[x] " : "[ ] ") : "- ";
+            writer.WriteLine($"{mark}{dimension.Key} ({dimension.Tier}) — {dimension.Name}");
+        }
+        writer.WriteLine();
+
+        if (evaluated)
+        {
+            writer.WriteLine("## Missing");
+            if (result.MissingDimensions.Count == 0)
+            {
+                writer.WriteLine("- (none)");
+            }
+            else
+            {
+                foreach (var key in result.MissingDimensions)
+                {
+                    writer.WriteLine($"- {key}");
+                }
+            }
+            writer.WriteLine();
+
+            if (!string.IsNullOrWhiteSpace(result.NextQuestion))
+            {
+                writer.WriteLine("## Next question");
+                writer.WriteLine($"- ({result.NextQuestionDimension}) {result.NextQuestion}");
+                writer.WriteLine();
+            }
+        }
+
+        writer.WriteLine("## Classification legend");
+        writer.WriteLine("- `packet-ready`: all issue + packet dimensions resolved, no blocking decision — draft the packet (with operator acceptance).");
+        writer.WriteLine("- `issue-ready`: issue-contract dimensions resolved, no blocking decision — publish the issue (with operator acceptance).");
+        writer.WriteLine("- `clarification-required`: a blocking owner/open decision is unresolved — resolve it before drafting.");
+        writer.WriteLine("- `remaining-gaps`: issue-contract dimensions still missing — keep interviewing; ask the next question above.");
+        writer.WriteLine();
+        writer.WriteLine("Evaluate your interview: `intent-cli guide interview-readiness --resolved goal,scope,target,acceptance,verification,... --format json`.");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out IReadOnlyCollection<string> resolved,
+        out bool hasResolvedFlag,
+        out string format,
+        out string error)
+    {
+        var resolvedList = new List<string>();
+        resolved = resolvedList;
+        hasResolvedFlag = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--resolved":
+                    if (index + 1 >= args.Length)
+                    {
+                        error = "--resolved requires a comma-separated list of dimension keys (or an empty value).";
+                        return false;
+                    }
+                    hasResolvedFlag = true;
+                    foreach (var key in args[index + 1].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    {
+                        resolvedList.Add(key);
+                    }
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide interview-readiness");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only readiness checklist + classification (packet-ready / issue-ready / clarification-required / remaining-gaps) with the next highest-value question.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+}

--- a/src/IntentSystem.Cli/Commands/InterviewReadinessAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewReadinessAnalyzer.cs
@@ -1,0 +1,146 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G382: pure classifier that turns the set of interview dimensions an
+/// agent has resolved into a readiness verdict — the measurable finish
+/// line for the persistent interview mode (G381). It never reads host
+/// state or GitHub; the agent passes the dimensions it has resolved and
+/// the analyzer reports whether the interview is ready to become a
+/// packet/issue, which dimensions are still missing, and the next
+/// highest-value question to ask. Advisory only — it does not publish
+/// anything.
+///
+/// Dimensions form three tiers:
+/// - <b>blocking</b> (<c>owner-decision</c>, <c>open-decisions</c>):
+///   while unresolved the verdict is <c>clarification-required</c>
+///   regardless of how complete the rest is — a pending product-owner
+///   decision must be made before drafting.
+/// - <b>issue</b> (goal, scope, non-goals, constraints, target,
+///   acceptance, verification): the standalone child-issue contract core.
+/// - <b>packet</b> (dependencies, risks): the extra thoroughness a packet
+///   draft wants on top of the issue contract.
+/// </summary>
+internal static class InterviewReadinessAnalyzer
+{
+    public static class Classifications
+    {
+        public const string PacketReady = "packet-ready";
+        public const string IssueReady = "issue-ready";
+        public const string ClarificationRequired = "clarification-required";
+        public const string RemainingGaps = "remaining-gaps";
+    }
+
+    public static class Tiers
+    {
+        public const string Blocking = "blocking";
+        public const string Issue = "issue";
+        public const string Packet = "packet";
+    }
+
+    /// <summary>
+    /// The eleven readiness dimensions in next-question priority order
+    /// (highest value first). Blocking decisions come first so a pending
+    /// owner decision is surfaced before documentation gaps.
+    /// </summary>
+    public static readonly IReadOnlyList<InterviewReadinessDimension> Dimensions = new[]
+    {
+        new InterviewReadinessDimension("owner-decision", "Owner / operator decision required", Tiers.Blocking,
+            "Is there a product-owner / operator decision still required before this can proceed? If yes, ask for that exact decision now."),
+        new InterviewReadinessDimension("open-decisions", "Open decisions", Tiers.Blocking,
+            "Which open decisions remain unresolved? Resolve each (or record it as deferred) before drafting."),
+        new InterviewReadinessDimension("goal", "Goal / problem statement", Tiers.Issue,
+            "What is the one-sentence goal / problem this work solves?"),
+        new InterviewReadinessDimension("scope", "Scope", Tiers.Issue,
+            "What is explicitly in scope for this slice?"),
+        new InterviewReadinessDimension("target", "Target repo / path / component", Tiers.Issue,
+            "Which repo, paths, and component does this change target?"),
+        new InterviewReadinessDimension("acceptance", "Acceptance criteria", Tiers.Issue,
+            "What are the concrete, checkable acceptance criteria?"),
+        new InterviewReadinessDimension("verification", "Verification approach", Tiers.Issue,
+            "How will the change be verified (tests / commands / evidence)?"),
+        new InterviewReadinessDimension("constraints", "Constraints", Tiers.Issue,
+            "What constraints (stack, performance, compatibility, policy) bound the solution?"),
+        new InterviewReadinessDimension("non-goals", "Non-goals", Tiers.Issue,
+            "What is explicitly out of scope / a non-goal?"),
+        new InterviewReadinessDimension("dependencies", "Dependencies", Tiers.Packet,
+            "What does this depend on (other units, external services, prior PRs)?"),
+        new InterviewReadinessDimension("risks", "Risks / edge cases", Tiers.Packet,
+            "What are the main risks and edge cases to handle?"),
+    };
+
+    public static InterviewReadinessResult Analyze(IReadOnlyCollection<string> resolvedDimensions)
+    {
+        ArgumentNullException.ThrowIfNull(resolvedDimensions);
+
+        var resolved = new HashSet<string>(
+            resolvedDimensions
+                .Select(d => d?.Trim().ToLowerInvariant() ?? string.Empty)
+                .Where(d => d.Length > 0),
+            StringComparer.Ordinal);
+
+        var statuses = Dimensions
+            .Select(dimension => new InterviewReadinessDimensionStatus
+            {
+                Key = dimension.Key,
+                Name = dimension.Name,
+                Tier = dimension.Tier,
+                Resolved = resolved.Contains(dimension.Key),
+            })
+            .ToArray();
+
+        var missing = statuses.Where(s => !s.Resolved).Select(s => s.Key).ToArray();
+
+        bool AllResolved(string tier) =>
+            Dimensions.Where(d => string.Equals(d.Tier, tier, StringComparison.Ordinal))
+                .All(d => resolved.Contains(d.Key));
+
+        var blockingResolved = AllResolved(Tiers.Blocking);
+        var issueResolved = AllResolved(Tiers.Issue);
+        var packetResolved = AllResolved(Tiers.Packet);
+
+        string classification;
+        if (!blockingResolved)
+        {
+            // A pending owner/open decision blocks drafting regardless of
+            // documentation completeness.
+            classification = Classifications.ClarificationRequired;
+        }
+        else if (issueResolved && packetResolved)
+        {
+            classification = Classifications.PacketReady;
+        }
+        else if (issueResolved)
+        {
+            classification = Classifications.IssueReady;
+        }
+        else
+        {
+            classification = Classifications.RemainingGaps;
+        }
+
+        // Next highest-value question: the first missing dimension in
+        // priority order (Dimensions is already ordered).
+        var nextDimension = Dimensions.FirstOrDefault(d => !resolved.Contains(d.Key));
+
+        var summary = classification switch
+        {
+            Classifications.PacketReady => "All issue + packet dimensions resolved and no blocking decision remains; ready to draft the packet (with operator acceptance).",
+            Classifications.IssueReady => "Issue-contract dimensions resolved and no blocking decision remains; ready to publish the issue (with operator acceptance). Resolve dependencies + risks for packet-ready.",
+            Classifications.ClarificationRequired => "A blocking owner/open decision is unresolved; stop and resolve it before drafting.",
+            _ => $"{missing.Length} dimension(s) still missing; keep interviewing — ask the next highest-value question.",
+        };
+
+        return new InterviewReadinessResult
+        {
+            Classification = classification,
+            Dimensions = statuses,
+            MissingDimensions = missing,
+            NextQuestion = nextDimension is null ? null : nextDimension.NextQuestion,
+            NextQuestionDimension = nextDimension?.Key,
+            Summary = summary,
+        };
+    }
+}
+
+/// <summary>G382: a readiness dimension definition (static catalog).</summary>
+internal sealed record InterviewReadinessDimension(string Key, string Name, string Tier, string NextQuestion);

--- a/src/IntentSystem.Cli/Commands/InterviewReadinessResult.cs
+++ b/src/IntentSystem.Cli/Commands/InterviewReadinessResult.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G382: the readiness verdict produced by
+/// <see cref="InterviewReadinessAnalyzer"/> — the classification, the
+/// per-dimension checklist, the concrete missing dimensions, and the
+/// next highest-value question to ask when not ready.
+/// </summary>
+internal sealed record InterviewReadinessResult
+{
+    [JsonPropertyName("classification")]
+    public required string Classification { get; init; }
+
+    [JsonPropertyName("dimensions")]
+    public required IReadOnlyList<InterviewReadinessDimensionStatus> Dimensions { get; init; }
+
+    [JsonPropertyName("missing_dimensions")]
+    public required IReadOnlyList<string> MissingDimensions { get; init; }
+
+    [JsonPropertyName("next_question")]
+    public string? NextQuestion { get; init; }
+
+    [JsonPropertyName("next_question_dimension")]
+    public string? NextQuestionDimension { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}
+
+internal sealed record InterviewReadinessDimensionStatus
+{
+    [JsonPropertyName("key")]
+    public required string Key { get; init; }
+
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("tier")]
+    public required string Tier { get; init; }
+
+    [JsonPropertyName("resolved")]
+    public required bool Resolved { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -163,6 +163,7 @@ internal static class Program
                 || string.Equals(args[1], "prompt-template", StringComparison.Ordinal)
                 || string.Equals(args[1], "question-style", StringComparison.Ordinal)
                 || string.Equals(args[1], "interview-mode", StringComparison.Ordinal)
+                || string.Equals(args[1], "interview-readiness", StringComparison.Ordinal)
                 || string.Equals(args[1], "review", StringComparison.Ordinal)
                 // G334: external-user self-discovery surface. Read-only,
                 // no host state required, so the bootstrap allow-list

--- a/tests/IntentSystem.Cli.Tests/GuideInterviewReadinessCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideInterviewReadinessCommandTests.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G382: tests for the <c>intent-cli guide interview-readiness</c>
+/// surface — the static checklist (no input), the evaluated verdict with
+/// concrete missing dimensions + next question (with input), and both
+/// output formats.
+/// </summary>
+public sealed class GuideInterviewReadinessCommandTests
+{
+    [Fact]
+    public void Execute_NoResolved_Json_EmitsChecklistWithElevenDimensions()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideInterviewReadinessCommand.Execute(CreateContext(), new[] { "--format", "json" }, writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var dimensions = doc.RootElement.GetProperty("dimensions").EnumerateArray().ToArray();
+        Assert.Equal(11, dimensions.Length);
+        // Every dimension carries a tier classification.
+        Assert.Contains(dimensions, d => d.GetProperty("key").GetString() == "acceptance" && d.GetProperty("tier").GetString() == "issue");
+        Assert.Contains(dimensions, d => d.GetProperty("key").GetString() == "risks" && d.GetProperty("tier").GetString() == "packet");
+        Assert.Contains(dimensions, d => d.GetProperty("key").GetString() == "owner-decision" && d.GetProperty("tier").GetString() == "blocking");
+    }
+
+    [Fact]
+    public void Execute_ResolvedAll_Json_ClassifiesPacketReady_WithNoMissing()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideInterviewReadinessCommand.Execute(
+            CreateContext(),
+            new[]
+            {
+                "--resolved",
+                "owner-decision,open-decisions,goal,scope,non-goals,constraints,target,acceptance,verification,dependencies,risks",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("packet-ready", doc.RootElement.GetProperty("classification").GetString());
+        Assert.Empty(doc.RootElement.GetProperty("missing_dimensions").EnumerateArray());
+    }
+
+    [Fact]
+    public void Execute_ResolvedPartial_Json_ClassifiesRemainingGaps_ListsMissing_AndNextQuestion()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideInterviewReadinessCommand.Execute(
+            CreateContext(),
+            new[] { "--resolved", "owner-decision,open-decisions,goal,scope", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("remaining-gaps", root.GetProperty("classification").GetString());
+
+        var missing = root.GetProperty("missing_dimensions").EnumerateArray().Select(m => m.GetString()).ToArray();
+        Assert.Contains("target", missing);
+        Assert.Contains("acceptance", missing);
+        Assert.Contains("verification", missing);
+
+        Assert.Equal("target", root.GetProperty("next_question_dimension").GetString());
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("next_question").GetString()));
+    }
+
+    [Fact]
+    public void Execute_Markdown_NoResolved_RendersChecklistAndLegend_NoVerdict()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideInterviewReadinessCommand.Execute(CreateContext(), Array.Empty<string>(), writer));
+
+        var output = writer.ToString();
+        Assert.Contains("# Guide — interview readiness checklist", output, StringComparison.Ordinal);
+        Assert.Contains("## Dimensions", output, StringComparison.Ordinal);
+        Assert.Contains("## Classification legend", output, StringComparison.Ordinal);
+        // Without --resolved there is no evaluated verdict header.
+        Assert.DoesNotContain("## Verdict", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_Resolved_RendersVerdictAndCheckboxes()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideInterviewReadinessCommand.Execute(
+            CreateContext(),
+            new[] { "--resolved", "owner-decision,open-decisions,goal,scope" },
+            writer));
+
+        var output = writer.ToString();
+        Assert.Contains("## Verdict: `remaining-gaps`", output, StringComparison.Ordinal);
+        Assert.Contains("[x] goal", output, StringComparison.Ordinal);
+        Assert.Contains("[ ] target", output, StringComparison.Ordinal);
+        Assert.Contains("## Next question", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RejectsUnknownFormat()
+    {
+        using var writer = new StringWriter();
+        var exit = GuideInterviewReadinessCommand.Execute(CreateContext(), new[] { "--format", "yaml" }, writer);
+        Assert.Equal(1, exit);
+        Assert.Contains("--format must be", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Router_DispatchesGuideInterviewReadiness_ExitZero()
+    {
+        using var writer = new StringWriter();
+        var exit = CommandRouter.Execute(
+            ["guide", "interview-readiness", "--resolved", "goal,scope", "--format", "json"],
+            CreateContext(),
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("not yet implemented", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static CliContext CreateContext() => new()
+    {
+        RepoRoot = Directory.GetCurrentDirectory(),
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+        },
+    };
+}

--- a/tests/IntentSystem.Cli.Tests/InterviewReadinessAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/InterviewReadinessAnalyzerTests.cs
@@ -1,0 +1,106 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G382: pure tests for the interview readiness classifier — the four
+/// verdicts (packet-ready / issue-ready / clarification-required /
+/// remaining-gaps), the concrete missing list, and the next-question
+/// priority.
+/// </summary>
+public sealed class InterviewReadinessAnalyzerTests
+{
+    private static readonly string[] AllDimensions =
+    {
+        "owner-decision", "open-decisions", "goal", "scope", "non-goals",
+        "constraints", "target", "acceptance", "verification", "dependencies", "risks",
+    };
+
+    private static readonly string[] IssueDimensions =
+    {
+        "owner-decision", "open-decisions", "goal", "scope", "non-goals",
+        "constraints", "target", "acceptance", "verification",
+    };
+
+    [Fact]
+    public void Analyze_AllDimensionsResolved_IsPacketReady()
+    {
+        var result = InterviewReadinessAnalyzer.Analyze(AllDimensions);
+
+        Assert.Equal(InterviewReadinessAnalyzer.Classifications.PacketReady, result.Classification);
+        Assert.Empty(result.MissingDimensions);
+        Assert.Null(result.NextQuestion);
+    }
+
+    [Fact]
+    public void Analyze_IssueDimensionsResolved_ButNoPacketDims_IsIssueReady()
+    {
+        var result = InterviewReadinessAnalyzer.Analyze(IssueDimensions);
+
+        Assert.Equal(InterviewReadinessAnalyzer.Classifications.IssueReady, result.Classification);
+        Assert.Contains("dependencies", result.MissingDimensions);
+        Assert.Contains("risks", result.MissingDimensions);
+        // Next question is the first missing in priority order (dependencies).
+        Assert.Equal("dependencies", result.NextQuestionDimension);
+    }
+
+    [Fact]
+    public void Analyze_OwnerDecisionPending_IsClarificationRequired_EvenWhenEverythingElseResolved()
+    {
+        var resolved = AllDimensions.Where(d => d != "owner-decision").ToArray();
+
+        var result = InterviewReadinessAnalyzer.Analyze(resolved);
+
+        Assert.Equal(InterviewReadinessAnalyzer.Classifications.ClarificationRequired, result.Classification);
+        // Blocking decision is the highest-priority next question.
+        Assert.Equal("owner-decision", result.NextQuestionDimension);
+    }
+
+    [Fact]
+    public void Analyze_OpenDecisionsPending_IsClarificationRequired()
+    {
+        var resolved = AllDimensions.Where(d => d != "open-decisions").ToArray();
+
+        var result = InterviewReadinessAnalyzer.Analyze(resolved);
+
+        Assert.Equal(InterviewReadinessAnalyzer.Classifications.ClarificationRequired, result.Classification);
+        Assert.Equal("open-decisions", result.NextQuestionDimension);
+    }
+
+    [Fact]
+    public void Analyze_BlockingResolvedButIssueIncomplete_IsRemainingGaps_WithConcreteMissingAndNextQuestion()
+    {
+        var result = InterviewReadinessAnalyzer.Analyze(new[] { "owner-decision", "open-decisions", "goal", "scope" });
+
+        Assert.Equal(InterviewReadinessAnalyzer.Classifications.RemainingGaps, result.Classification);
+        // Concrete missing list.
+        Assert.Contains("target", result.MissingDimensions);
+        Assert.Contains("acceptance", result.MissingDimensions);
+        Assert.Contains("verification", result.MissingDimensions);
+        // Next highest-value question after goal+scope is target.
+        Assert.Equal("target", result.NextQuestionDimension);
+        Assert.False(string.IsNullOrWhiteSpace(result.NextQuestion));
+    }
+
+    [Fact]
+    public void Analyze_EmptyInput_IsClarificationRequired_AndChecklistHasElevenDimensions()
+    {
+        var result = InterviewReadinessAnalyzer.Analyze(Array.Empty<string>());
+
+        // Nothing resolved → blocking decisions unresolved → clarification-required.
+        Assert.Equal(InterviewReadinessAnalyzer.Classifications.ClarificationRequired, result.Classification);
+        Assert.Equal(11, result.Dimensions.Count);
+        Assert.Equal(11, result.MissingDimensions.Count);
+        Assert.Equal("owner-decision", result.NextQuestionDimension);
+    }
+
+    [Fact]
+    public void Analyze_IsCaseInsensitive_AndTrimsInput()
+    {
+        var result = InterviewReadinessAnalyzer.Analyze(new[] { "  GOAL ", "Scope" });
+        var goal = result.Dimensions.Single(d => d.Key == "goal");
+        var scope = result.Dimensions.Single(d => d.Key == "scope");
+        Assert.True(goal.Resolved);
+        Assert.True(scope.Resolved);
+    }
+}


### PR DESCRIPTION
Closes #867

## Summary
- G381 made the interview persistent, but persistence needs a measurable finish line. This adds a readiness gate so an agent can decide when an interview has enough resolved information to draft a packet / publish an issue.
- New pure **`InterviewReadinessAnalyzer`** classifies a resolved-dimension set across **11 dimensions in 3 tiers** — blocking (`owner-decision`, `open-decisions`), issue (`goal`/`scope`/`non-goals`/`constraints`/`target`/`acceptance`/`verification`), packet (`dependencies`/`risks`) — into **`packet-ready` / `issue-ready` / `clarification-required` / `remaining-gaps`**, lists the concrete missing dimensions, and returns the next highest-value question.
- New read-only **`intent-cli guide interview-readiness`**: with no input it prints the checklist + classification legend; with `--resolved <keys>` it reports the verdict, per-dimension checkboxes, missing list, and next question (markdown + JSON). Host-state-free; wired into the guide group + `Program.IsGuideOneshotCommand` allow-list + `GuideHelpCommand.Subcommands`.
- Advisory only — never publishes; canonical writes still require operator acceptance.

## Acceptance criteria mapping
- Agent can ask whether an interview is ready and receive a structured checklist → `guide interview-readiness` (static + evaluated).
- Missing fields listed concretely → `missing_dimensions`.
- Suggests next highest-value question when not ready → `next_question` (priority-ordered).
- Tests cover ready + not-ready examples → `InterviewReadinessAnalyzerTests` (packet-ready / issue-ready / clarification-required / remaining-gaps) + command tests.

Note: host-owned specs `04-concept-intake-and-interview.md`, `06-interview-and-clarification-artifact-contract.md` are absent from the child worktree → deferred to host.

## Test plan
- [x] `InterviewReadinessAnalyzerTests` + `GuideInterviewReadinessCommandTests` + guide-help catalog guard green (15).
- [x] Manual: all 4 classifications from a non-host cwd (host-state-free).
- [x] `git diff --check` clean; full `IntentSystem.Cli.Tests` 3264 passed / 0 failed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)