### PR TITLE
G384: converge redundant in-submodule edits during host review

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
@@ -53,6 +53,16 @@ internal static class AutomationHostReviewDiagnosticsCommand
             return HandleReviewVerificationPolicy(args, writer);
         }
 
+        // G384: internal-submodule-edit redundancy decision lane. Isolated
+        // early-return: classifies a dirty internal submodule edit as
+        // redundant-safe vs protected-operator-work, deduplicates repeated
+        // wakes (--prior-fingerprint), and keeps a failing required CI
+        // visible as the implementation blocker (--required-ci-failing).
+        if (Array.IndexOf(args, "--in-submodule-edit") >= 0)
+        {
+            return HandleInSubmoduleEdit(args, writer);
+        }
+
         if (!TryParseArguments(
                 args,
                 out var repo,
@@ -747,10 +757,168 @@ internal static class AutomationHostReviewDiagnosticsCommand
         return 0;
     }
 
+    /// <summary>
+    /// G384: classify a dirty internal submodule edit via
+    /// <see cref="WorkspaceGuardSubmoduleEditClassifier"/> and emit a stable
+    /// diagnostics classification — `redundant-in-submodule-edit` (bounded
+    /// safe repair), `protected-operator-work` (hard-stop), or, when the
+    /// workspace is safe/redundant-safe and required CI is failing,
+    /// `required-ci-failing` (implementation-actionable). Deduplicates a
+    /// repeated unchanged report via `--prior-fingerprint`. Read-only.
+    /// </summary>
+    private static int HandleInSubmoduleEdit(string[] args, TextWriter writer)
+    {
+        var uniqueLocalContent = false;
+        var requiredCiFailing = false;
+        string submodulePath = "(submodule)";
+        var localFingerprint = string.Empty;
+        var headFingerprint = string.Empty;
+        string? priorFingerprint = null;
+        string? repo = null;
+        int? pr = null;
+        var format = FormatText;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--in-submodule-edit":
+                    break;
+                case "--unique-local-content":
+                    uniqueLocalContent = true;
+                    break;
+                case "--required-ci-failing":
+                    requiredCiFailing = true;
+                    break;
+                case "--path":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        writer.WriteLine("--path requires a value (the dirty submodule path).");
+                        return 1;
+                    }
+                    submodulePath = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--local-fingerprint":
+                    if (index + 1 >= args.Length) { writer.WriteLine("--local-fingerprint requires a value."); return 1; }
+                    localFingerprint = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--pr-head-fingerprint":
+                    if (index + 1 >= args.Length) { writer.WriteLine("--pr-head-fingerprint requires a value."); return 1; }
+                    headFingerprint = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--prior-fingerprint":
+                    if (index + 1 >= args.Length) { writer.WriteLine("--prior-fingerprint requires a value."); return 1; }
+                    priorFingerprint = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { writer.WriteLine("--repo requires a value (e.g. owner/repo)."); return 1; }
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--pr":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var prValue)
+                        || prValue <= 0)
+                    {
+                        writer.WriteLine("--pr requires a positive integer.");
+                        return 1;
+                    }
+                    pr = prValue;
+                    index++;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { writer.WriteLine("--format requires a value (text or json)."); return 1; }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatText, StringComparison.Ordinal) && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        writer.WriteLine($"--format must be 'text' or 'json' (got '{requested}').");
+                        return 1;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+                default:
+                    writer.WriteLine($"Unknown argument '{argument}' for --in-submodule-edit. Supported: --in-submodule-edit [--path <p>] [--local-fingerprint <f>] [--pr-head-fingerprint <f>] [--unique-local-content] [--required-ci-failing] [--prior-fingerprint <f>] [--repo <owner/repo>] [--pr <n>] [--format text|json].");
+                    return 1;
+            }
+        }
+
+        var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
+            isInternalSubmoduleEdit: true,
+            submodulePath,
+            localFingerprint,
+            headFingerprint,
+            uniqueLocalContent,
+            pr);
+
+        var deduplicated = WorkspaceGuardSubmoduleEditClassifier.IsDuplicateReport(priorFingerprint, decision.DedupeFingerprint);
+        var primaryBlocker = WorkspaceGuardSubmoduleEditClassifier.ResolvePrimaryBlocker(requiredCiFailing, decision.Classification);
+
+        // Required CI failing takes precedence as the implementation blocker
+        // when the workspace edit is redundant-safe (or not blocking).
+        string classification;
+        string? recommended;
+        if (string.Equals(primaryBlocker, WorkspaceGuardSubmoduleEditClassifier.Blockers.RequiredCiFailing, StringComparison.Ordinal))
+        {
+            classification = AutomationHostReviewDiagnosticsClassifications.RequiredCiFailing;
+            recommended = repo is not null && pr is not null
+                ? $"intent-cli automation pr-transition --transition request-update --repo {repo} --pr {pr} --write --format json"
+                : null;
+        }
+        else if (string.Equals(decision.Classification, WorkspaceGuardSubmoduleEditClassifier.Classifications.RedundantInSubmoduleEdit, StringComparison.Ordinal))
+        {
+            classification = AutomationHostReviewDiagnosticsClassifications.RedundantInSubmoduleEdit;
+            recommended = decision.RecommendedRepair;
+        }
+        else
+        {
+            classification = AutomationHostReviewDiagnosticsClassifications.ProtectedOperatorWork;
+            recommended = null;
+        }
+
+        var warnings = deduplicated ? new[] { "deduplicated-unchanged-report" } : Array.Empty<string>();
+        var summaryPrefix = deduplicated
+            ? "G384 (deduplicated — unchanged dirty fingerprint since last wake): "
+            : "G384: ";
+
+        var result = new AutomationHostReviewDiagnosticsResult
+        {
+            Repo = repo ?? "(repo)",
+            Classification = classification,
+            Summary = summaryPrefix + decision.Reason
+                + (requiredCiFailing ? " Required CI is failing and remains the visible implementation blocker." : string.Empty),
+            ReadOnly = true,
+            RecommendedNextCommand = recommended,
+            StructuredClarification = null,
+            Details =
+            [
+                new AutomationHostReviewDiagnosticsDetail
+                {
+                    Kind = decision.Classification,
+                    TargetKind = null,
+                    TargetNumber = pr,
+                    TargetUrl = null,
+                    Description = $"path={submodulePath}; safe_repair_available={decision.SafeRepairAvailable.ToString().ToLowerInvariant()}; primary_blocker={primaryBlocker}; required_ci_failing={requiredCiFailing.ToString().ToLowerInvariant()}; dedupe_fingerprint={decision.DedupeFingerprint}",
+                }
+            ],
+            Warnings = warnings,
+            SafeRepairAvailable = decision.SafeRepairAvailable,
+            SafeRepairCategory = decision.SafeRepairAvailable ? SafeRepairCategories.WorkspaceSafeDirty : null,
+        };
+
+        Emit(writer, result, format);
+        return 0;
+    }
+
     private static void WriteHelp(TextWriter writer)
     {
         writer.WriteLine("automation host-review-diagnostics");
-        writer.WriteLine("Usage: intent-cli automation host-review-diagnostics [--repo <owner/repo>] [--workdir <path>] [--candidate <execution-unit>] [--domain <name>] [--clarification-required] [--stale-clarification-metadata] [--reconcile-unsafe-stop <kind> ...] [--reconcile-repairs-available <N>] [--allow-wip-cap-override] [--workspace-safe-dirty] [--pr-draft true|false] [--draft-review-ready] [--draft-findings-present] [--operator-intended-draft] [--review-verification-ac [--standing-policy] [--evidence <kind>] [--false-runtime-claim] [--implementation-actionable] [--pr <n>]] [--format text|json]");
-        writer.WriteLine("Read-only host-loop convergence diagnostic. Classifies stuck-reviewing, missing-target-on-pr, request-update-rereview-conflict, wip-cap-blocked, clarification-required, stale-host-cli, review-pr-actionable, issue-publish-ready, unsafe-metadata, repaired-and-retry, draft-merge-blocked (G297), draft-ready-to-promote / draft-request-update (G376), and true-idle (G286). Stale clarification metadata surfaces in `warnings` without flipping the terminal class. With `--allow-wip-cap-override` (G288) and a complete candidate, an in-flight intent-target item is bypassed for one publish; the override surfaces as `wip-cap-overridden` in `warnings`. With `--pr-draft true` and a selected review PR, the draft decision is draft-aware (G376): pass `--draft-review-ready` (host verified closeout/guide/base/diff and no findings) to get `draft-ready-to-promote` (mark ready + continue) instead of releasing the lease; `--draft-findings-present` yields `draft-request-update`; `--operator-intended-draft` (or no readiness signal) stays fail-closed at `draft-merge-blocked` (G297). With `--review-verification-ac` (G383) the diagnostic classifies a visible/manual/runtime-gated verification AC into `review-pr-actionable` (standing policy permits approval; proceed), `implementation-finding` (route a PR feedback comment + request-update), or `review-policy-gap` (record a host-owned policy decision once; do not re-ask) — pass `--standing-policy` / `--evidence <kind>` / `--false-runtime-claim` / `--implementation-actionable` to drive the classification. Never mutates GitHub or local state.");
+        writer.WriteLine("Usage: intent-cli automation host-review-diagnostics [--repo <owner/repo>] [--workdir <path>] [--candidate <execution-unit>] [--domain <name>] [--clarification-required] [--stale-clarification-metadata] [--reconcile-unsafe-stop <kind> ...] [--reconcile-repairs-available <N>] [--allow-wip-cap-override] [--workspace-safe-dirty] [--pr-draft true|false] [--draft-review-ready] [--draft-findings-present] [--operator-intended-draft] [--review-verification-ac [--standing-policy] [--evidence <kind>] [--false-runtime-claim] [--implementation-actionable] [--pr <n>]] [--in-submodule-edit [--path <p>] [--local-fingerprint <f>] [--pr-head-fingerprint <f>] [--unique-local-content] [--required-ci-failing] [--prior-fingerprint <f>] [--pr <n>]] [--format text|json]");
+        writer.WriteLine("Read-only host-loop convergence diagnostic. Classifies stuck-reviewing, missing-target-on-pr, request-update-rereview-conflict, wip-cap-blocked, clarification-required, stale-host-cli, review-pr-actionable, issue-publish-ready, unsafe-metadata, repaired-and-retry, draft-merge-blocked (G297), draft-ready-to-promote / draft-request-update (G376), and true-idle (G286). Stale clarification metadata surfaces in `warnings` without flipping the terminal class. With `--allow-wip-cap-override` (G288) and a complete candidate, an in-flight intent-target item is bypassed for one publish; the override surfaces as `wip-cap-overridden` in `warnings`. With `--pr-draft true` and a selected review PR, the draft decision is draft-aware (G376): pass `--draft-review-ready` (host verified closeout/guide/base/diff and no findings) to get `draft-ready-to-promote` (mark ready + continue) instead of releasing the lease; `--draft-findings-present` yields `draft-request-update`; `--operator-intended-draft` (or no readiness signal) stays fail-closed at `draft-merge-blocked` (G297). With `--review-verification-ac` (G383) the diagnostic classifies a visible/manual/runtime-gated verification AC into `review-pr-actionable` (standing policy permits approval; proceed), `implementation-finding` (route a PR feedback comment + request-update), or `review-policy-gap` (record a host-owned policy decision once; do not re-ask) — pass `--standing-policy` / `--evidence <kind>` / `--false-runtime-claim` / `--implementation-actionable` to drive the classification. With `--in-submodule-edit` (G384) the diagnostic classifies a dirty internal submodule edit into `redundant-in-submodule-edit` (bounded safe repair when `--local-fingerprint` matches `--pr-head-fingerprint` and no `--unique-local-content`), `protected-operator-work` (unique/unproven — hard-stop), or `required-ci-failing` (when `--required-ci-failing` and the workspace is redundant-safe); `--prior-fingerprint` deduplicates an unchanged repeat. Never mutates GitHub or local state.");
     }
 }

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
@@ -771,6 +771,7 @@ internal static class AutomationHostReviewDiagnosticsCommand
         var uniqueLocalContent = false;
         var requiredCiFailing = false;
         string submodulePath = "(submodule)";
+        string? submoduleRoot = null;
         var localFingerprint = string.Empty;
         var headFingerprint = string.Empty;
         string? priorFingerprint = null;
@@ -798,6 +799,15 @@ internal static class AutomationHostReviewDiagnosticsCommand
                         return 1;
                     }
                     submodulePath = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--submodule-root":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        writer.WriteLine("--submodule-root requires a value (the submodule worktree root, e.g. submodules/X).");
+                        return 1;
+                    }
+                    submoduleRoot = args[index + 1].Trim();
                     index++;
                     break;
                 case "--local-fingerprint":
@@ -848,8 +858,16 @@ internal static class AutomationHostReviewDiagnosticsCommand
             }
         }
 
+        // Derive the submodule worktree root from the path when not supplied
+        // (convention: `submodules/<name>/...`), so the bounded repair points
+        // `git -C` at the submodule root and clears only the relative file.
+        var resolvedRoot = string.IsNullOrWhiteSpace(submoduleRoot)
+            ? DeriveSubmoduleRoot(submodulePath)
+            : submoduleRoot!;
+
         var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
             isInternalSubmoduleEdit: true,
+            resolvedRoot,
             submodulePath,
             localFingerprint,
             headFingerprint,
@@ -913,6 +931,24 @@ internal static class AutomationHostReviewDiagnosticsCommand
 
         Emit(writer, result, format);
         return 0;
+    }
+
+    /// <summary>
+    /// G384: best-effort submodule worktree root from a dirty path. For the
+    /// `submodules/&lt;name&gt;/...` convention this returns
+    /// `submodules/&lt;name&gt;`; otherwise it falls back to the path's first
+    /// segment (or the path itself). Callers should pass `--submodule-root`
+    /// explicitly when the layout differs.
+    /// </summary>
+    private static string DeriveSubmoduleRoot(string dirtyPath)
+    {
+        var normalized = dirtyPath.Replace('\\', '/').TrimStart('/');
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        if (segments.Length >= 2 && string.Equals(segments[0], "submodules", StringComparison.Ordinal))
+        {
+            return $"{segments[0]}/{segments[1]}";
+        }
+        return segments.Length >= 1 ? segments[0] : normalized;
     }
 
     private static void WriteHelp(TextWriter writer)

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsResult.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsResult.cs
@@ -214,6 +214,30 @@ internal static class AutomationHostReviewDiagnosticsClassifications
     public const string ImplementationFinding = "implementation-finding";
 
     /// <summary>
+    /// G384: terminal class returned when an internal submodule working-tree
+    /// edit is provably redundant with the selected PR head (matching diff
+    /// fingerprints, no unique local content). A bounded safe repair clears
+    /// the stale edit so the wake proceeds instead of repeating the
+    /// dirty-unrelated-submodule operator stop every wake.
+    /// </summary>
+    public const string RedundantInSubmoduleEdit = "redundant-in-submodule-edit";
+
+    /// <summary>
+    /// G384: terminal class returned when an internal submodule edit has
+    /// unique or unproven local content. intent-cli refuses auto-repair and
+    /// reports a protected-operator-work blocker (never silently discards
+    /// operator work).
+    /// </summary>
+    public const string ProtectedOperatorWork = "protected-operator-work";
+
+    /// <summary>
+    /// G384: terminal class returned when the selected PR's required CI is
+    /// failing — an implementation-actionable blocker that must stay visible
+    /// even when host-sync also sees a redundant-safe local submodule edit.
+    /// </summary>
+    public const string RequiredCiFailing = "required-ci-failing";
+
+    /// <summary>
     /// G356: terminal class returned when one or more queue items are not
     /// marked Completed even though their linked GitHub PR is already
     /// merged. The host loop should run

--- a/src/IntentSystem.Cli/Commands/WorkspaceGuardSubmoduleEditClassifier.cs
+++ b/src/IntentSystem.Cli/Commands/WorkspaceGuardSubmoduleEditClassifier.cs
@@ -1,0 +1,163 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G384: pure classifier that lets a host review loop converge when a
+/// submodule has an INTERNAL uncommitted edit that is provably redundant
+/// with the selected PR head, while still hard-stopping on unique or
+/// unproven operator work. The pre-G384 behavior repeated the same
+/// `dirty-unrelated-submodule` operator-cleanup stop every wake even when
+/// the local edit was byte-identical to the change already pushed to the
+/// PR head.
+///
+/// Safety invariants:
+/// - Internal submodule edits are more dangerous than gitlink-only
+///   changes, so they are only auto-clearable when the local diff
+///   fingerprint MATCHES the selected PR head / remote fingerprint AND no
+///   unique local content is present. Anything unique or unproven stays a
+///   protected hard-stop — intent-cli never silently discards operator work.
+/// - A failing required CI check is an implementation blocker that must
+///   stay visible even when the workspace edit is redundant-safe; see
+///   <see cref="ResolvePrimaryBlocker"/>.
+/// - Repeated wakes over the same unchanged (path, diff, PR, PR head) are
+///   deduplicated via <see cref="IsDuplicateReport"/> so the loop reports a
+///   stable status instead of re-emitting a long operator stop each time.
+///
+/// No I/O, no git, no GitHub — the command layer supplies the fingerprints.
+/// </summary>
+internal static class WorkspaceGuardSubmoduleEditClassifier
+{
+    public static class Classifications
+    {
+        /// <summary>The dirty path is not an internal submodule edit; this lane does not apply.</summary>
+        public const string NotInSubmoduleLane = "not-in-submodule-lane";
+
+        /// <summary>Internal submodule edit whose diff is identical to the selected PR head — safe to clear.</summary>
+        public const string RedundantInSubmoduleEdit = "redundant-in-submodule-edit";
+
+        /// <summary>Internal submodule edit with unique or unproven content — hard-stop, never auto-cleared.</summary>
+        public const string ProtectedOperatorWork = "protected-operator-work";
+    }
+
+    public static class Blockers
+    {
+        public const string ProtectedOperatorWork = "protected-operator-work";
+        public const string RequiredCiFailing = "required-ci-failing";
+        public const string None = "none";
+    }
+
+    /// <summary>
+    /// Classify an internal-submodule dirty edit.
+    /// </summary>
+    /// <param name="isInternalSubmoduleEdit">The dirty path is an internal (working-tree) edit inside a submodule, not a gitlink-only change.</param>
+    /// <param name="submodulePath">The dirty path (used in the dedupe fingerprint + repair command).</param>
+    /// <param name="localDiffFingerprint">A fingerprint (e.g. blob hash) of the local working-tree edit.</param>
+    /// <param name="prHeadFingerprint">The fingerprint of the same path on the selected PR head / remote commit.</param>
+    /// <param name="hasUniqueLocalContent">True when the local edit contains content not present on the PR head — protects operator work.</param>
+    /// <param name="selectedPr">The selected PR number (or null) — part of the dedupe key.</param>
+    public static WorkspaceGuardSubmoduleEditDecision Classify(
+        bool isInternalSubmoduleEdit,
+        string submodulePath,
+        string localDiffFingerprint,
+        string prHeadFingerprint,
+        bool hasUniqueLocalContent,
+        int? selectedPr)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(submodulePath);
+        var local = (localDiffFingerprint ?? string.Empty).Trim();
+        var head = (prHeadFingerprint ?? string.Empty).Trim();
+        var prText = selectedPr is { } pr ? pr.ToString(System.Globalization.CultureInfo.InvariantCulture) : "none";
+        var dedupeFingerprint = $"{submodulePath}|local={local}|pr={prText}|head={head}";
+
+        if (!isInternalSubmoduleEdit)
+        {
+            return new WorkspaceGuardSubmoduleEditDecision
+            {
+                Classification = Classifications.NotInSubmoduleLane,
+                SafeRepairAvailable = false,
+                RecommendedRepair = null,
+                DedupeFingerprint = dedupeFingerprint,
+                Reason = "Not an internal submodule working-tree edit; this lane does not apply (use the existing gitlink / safe-stash handling).",
+            };
+        }
+
+        // Unique local content is never auto-cleared — protect operator work.
+        if (hasUniqueLocalContent)
+        {
+            return new WorkspaceGuardSubmoduleEditDecision
+            {
+                Classification = Classifications.ProtectedOperatorWork,
+                SafeRepairAvailable = false,
+                RecommendedRepair = null,
+                DedupeFingerprint = dedupeFingerprint,
+                Reason = "Internal submodule edit has unique local content; refuse auto-repair and surface a protected-operator-work blocker (intent-cli never silently discards operator work).",
+            };
+        }
+
+        // Redundant only when the local fingerprint provably matches the PR
+        // head fingerprint (both non-empty). Anything else is unproven →
+        // hard-stop.
+        if (local.Length > 0 && head.Length > 0
+            && string.Equals(local, head, StringComparison.Ordinal))
+        {
+            return new WorkspaceGuardSubmoduleEditDecision
+            {
+                Classification = Classifications.RedundantInSubmoduleEdit,
+                SafeRepairAvailable = true,
+                RecommendedRepair = $"git -C {submodulePath} checkout -- . (clears the redundant edit; it is byte-identical to the selected PR head, so no unique content is lost)",
+                DedupeFingerprint = dedupeFingerprint,
+                Reason = "Internal submodule edit is byte-identical to the selected PR head (matching diff fingerprints) with no unique local content; it is redundant/stale and can be cleared safely so the wake proceeds.",
+            };
+        }
+
+        return new WorkspaceGuardSubmoduleEditDecision
+        {
+            Classification = Classifications.ProtectedOperatorWork,
+            SafeRepairAvailable = false,
+            RecommendedRepair = null,
+            DedupeFingerprint = dedupeFingerprint,
+            Reason = "Internal submodule edit redundancy is unproven (missing or non-matching fingerprints); refuse auto-repair and keep the protected-operator-work hard-stop until redundancy is proven against the PR head.",
+        };
+    }
+
+    /// <summary>
+    /// G384: deduplicate repeated wake reports — true when the prior and
+    /// current dedupe fingerprints are identical (same path, local diff,
+    /// selected PR, and PR head), so diagnostics can emit a stable status
+    /// instead of re-emitting a long operator stop each wake.
+    /// </summary>
+    public static bool IsDuplicateReport(string? priorDedupeFingerprint, string currentDedupeFingerprint)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(currentDedupeFingerprint);
+        return !string.IsNullOrWhiteSpace(priorDedupeFingerprint)
+            && string.Equals(priorDedupeFingerprint.Trim(), currentDedupeFingerprint, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G384: a failing required CI check must remain visible as the
+    /// implementation blocker even when the workspace edit is
+    /// redundant-safe. When the workspace is a protected hard-stop, that is
+    /// the primary blocker (operator must resolve it first), but the CI
+    /// status is still reported separately. Otherwise (redundant-safe or
+    /// not-in-lane) a failing required CI is the primary, implementation-
+    /// actionable blocker; with no CI failure the wake may proceed.
+    /// </summary>
+    public static string ResolvePrimaryBlocker(bool requiredCiFailing, string workspaceClassification)
+    {
+        if (string.Equals(workspaceClassification, Classifications.ProtectedOperatorWork, StringComparison.Ordinal))
+        {
+            return Blockers.ProtectedOperatorWork;
+        }
+
+        return requiredCiFailing ? Blockers.RequiredCiFailing : Blockers.None;
+    }
+}
+
+/// <summary>G384: the verdict from <see cref="WorkspaceGuardSubmoduleEditClassifier.Classify"/>.</summary>
+internal sealed record WorkspaceGuardSubmoduleEditDecision
+{
+    public required string Classification { get; init; }
+    public required bool SafeRepairAvailable { get; init; }
+    public string? RecommendedRepair { get; init; }
+    public required string DedupeFingerprint { get; init; }
+    public required string Reason { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/WorkspaceGuardSubmoduleEditClassifier.cs
+++ b/src/IntentSystem.Cli/Commands/WorkspaceGuardSubmoduleEditClassifier.cs
@@ -49,24 +49,33 @@ internal static class WorkspaceGuardSubmoduleEditClassifier
     /// Classify an internal-submodule dirty edit.
     /// </summary>
     /// <param name="isInternalSubmoduleEdit">The dirty path is an internal (working-tree) edit inside a submodule, not a gitlink-only change.</param>
-    /// <param name="submodulePath">The dirty path (used in the dedupe fingerprint + repair command).</param>
+    /// <param name="submoduleRoot">The submodule worktree root (e.g. <c>submodules/X</c>) — used as <c>git -C</c> in the bounded repair.</param>
+    /// <param name="dirtyPath">The dirty path, either full (under the root) or relative to the root; the relative form is used in the repair so only the proven file is cleared.</param>
     /// <param name="localDiffFingerprint">A fingerprint (e.g. blob hash) of the local working-tree edit.</param>
     /// <param name="prHeadFingerprint">The fingerprint of the same path on the selected PR head / remote commit.</param>
     /// <param name="hasUniqueLocalContent">True when the local edit contains content not present on the PR head — protects operator work.</param>
     /// <param name="selectedPr">The selected PR number (or null) — part of the dedupe key.</param>
     public static WorkspaceGuardSubmoduleEditDecision Classify(
         bool isInternalSubmoduleEdit,
-        string submodulePath,
+        string submoduleRoot,
+        string dirtyPath,
         string localDiffFingerprint,
         string prHeadFingerprint,
         bool hasUniqueLocalContent,
         int? selectedPr)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(submodulePath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(submoduleRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(dirtyPath);
+        var root = submoduleRoot.Replace('\\', '/').TrimEnd('/');
+        // The dirty path may arrive full (under the root) or already relative;
+        // derive the path RELATIVE to the submodule root so the repair clears
+        // only the proven-redundant file, never the whole submodule.
+        var relativePath = RelativeToRoot(root, dirtyPath);
+        var fullPath = $"{root}/{relativePath}";
         var local = (localDiffFingerprint ?? string.Empty).Trim();
         var head = (prHeadFingerprint ?? string.Empty).Trim();
         var prText = selectedPr is { } pr ? pr.ToString(System.Globalization.CultureInfo.InvariantCulture) : "none";
-        var dedupeFingerprint = $"{submodulePath}|local={local}|pr={prText}|head={head}";
+        var dedupeFingerprint = $"{fullPath}|local={local}|pr={prText}|head={head}";
 
         if (!isInternalSubmoduleEdit)
         {
@@ -103,7 +112,10 @@ internal static class WorkspaceGuardSubmoduleEditClassifier
             {
                 Classification = Classifications.RedundantInSubmoduleEdit,
                 SafeRepairAvailable = true,
-                RecommendedRepair = $"git -C {submodulePath} checkout -- . (clears the redundant edit; it is byte-identical to the selected PR head, so no unique content is lost)",
+                // -C points at the submodule WORKTREE ROOT; the pathspec is the
+                // single relative file, so only the proven-redundant file is
+                // cleared, never arbitrary submodule content.
+                RecommendedRepair = $"git -C {root} checkout -- {relativePath} (clears only the redundant file; it is byte-identical to the selected PR head, so no unique content is lost)",
                 DedupeFingerprint = dedupeFingerprint,
                 Reason = "Internal submodule edit is byte-identical to the selected PR head (matching diff fingerprints) with no unique local content; it is redundant/stale and can be cleared safely so the wake proceeds.",
             };
@@ -117,6 +129,25 @@ internal static class WorkspaceGuardSubmoduleEditClassifier
             DedupeFingerprint = dedupeFingerprint,
             Reason = "Internal submodule edit redundancy is unproven (missing or non-matching fingerprints); refuse auto-repair and keep the protected-operator-work hard-stop until redundancy is proven against the PR head.",
         };
+    }
+
+    /// <summary>
+    /// G384: derive the path relative to the submodule worktree root. The
+    /// dirty path may arrive full (e.g.
+    /// <c>submodules/X/.github/workflows/ci.yml</c> with root
+    /// <c>submodules/X</c>) or already relative
+    /// (<c>.github/workflows/ci.yml</c>); both yield the relative form so the
+    /// bounded repair (<c>git -C &lt;root&gt; checkout -- &lt;relative&gt;</c>)
+    /// targets exactly the redundant file.
+    /// </summary>
+    internal static string RelativeToRoot(string submoduleRoot, string dirtyPath)
+    {
+        var root = submoduleRoot.Replace('\\', '/').TrimEnd('/');
+        var path = dirtyPath.Replace('\\', '/').TrimStart('/');
+        var prefix = root + "/";
+        return path.StartsWith(prefix, StringComparison.Ordinal)
+            ? path[prefix.Length..]
+            : path;
     }
 
     /// <summary>

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
@@ -949,6 +949,86 @@ public sealed class AutomationHostReviewDiagnosticsCommandTests : IDisposable
         Assert.Equal("implementation-finding", result.Classification);
     }
 
+    // ── G384 redundant in-submodule-edit decision lane ─────────────────
+
+    [Fact]
+    public void Execute_InSubmoduleEdit_RedundantPrHeadMatch_ClassifiesRedundant_WithSafeRepair()
+    {
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+            workspace.Context,
+            ["--in-submodule-edit", "--path", "submodules/X/.github/workflows/ci.yml",
+             "--local-fingerprint", "abc123", "--pr-head-fingerprint", "abc123", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+        Assert.Equal("redundant-in-submodule-edit", result.Classification);
+        Assert.True(result.SafeRepairAvailable);
+        Assert.NotNull(result.RecommendedNextCommand);
+    }
+
+    [Fact]
+    public void Execute_InSubmoduleEdit_UniqueLocalContent_ClassifiesProtectedOperatorWork()
+    {
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+            workspace.Context,
+            ["--in-submodule-edit", "--path", "submodules/X/f.cs",
+             "--local-fingerprint", "abc", "--pr-head-fingerprint", "abc", "--unique-local-content", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+        Assert.Equal("protected-operator-work", result.Classification);
+        Assert.False(result.SafeRepairAvailable);
+    }
+
+    [Fact]
+    public void Execute_InSubmoduleEdit_RedundantButRequiredCiFailing_SurfacesCiBlocker()
+    {
+        // Required CI failing must stay the visible implementation blocker
+        // even when the local submodule edit is redundant-safe.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+            workspace.Context,
+            ["--in-submodule-edit", "--path", "submodules/X/ci.yml",
+             "--local-fingerprint", "abc", "--pr-head-fingerprint", "abc",
+             "--required-ci-failing", "--repo", "owner/repo", "--pr", "1090", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+        Assert.Equal("required-ci-failing", result.Classification);
+        Assert.NotNull(result.RecommendedNextCommand);
+        Assert.Contains("request-update", result.RecommendedNextCommand!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_InSubmoduleEdit_SameFingerprintAcrossWakes_DeduplicatesReport()
+    {
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+            workspace.Context,
+            ["--in-submodule-edit", "--path", "submodules/X/ci.yml",
+             "--local-fingerprint", "abc", "--pr-head-fingerprint", "abc", "--pr", "1090",
+             "--prior-fingerprint", "submodules/X/ci.yml|local=abc|pr=1090|head=abc", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+        Assert.Contains("deduplicated-unchanged-report", result.Warnings);
+        Assert.Contains("deduplicated", result.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void Execute_NextSliceProbe_AutoPopulatesCandidate_WhenDomainFlagOrConfigPresent()
     {

--- a/tests/IntentSystem.Cli.Tests/WorkspaceGuardSubmoduleEditClassifierTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkspaceGuardSubmoduleEditClassifierTests.cs
@@ -4,8 +4,9 @@ namespace IntentSystem.Cli.Tests;
 
 /// <summary>
 /// G384: pure tests for the redundant-in-submodule-edit classifier — the
-/// PR-head-match redundant case, the protected unique/unproven cases, the
-/// dedupe fingerprint, and the required-CI blocker precedence.
+/// PR-head-match redundant case (with a bounded per-file repair command),
+/// the protected unique/unproven cases, the dedupe fingerprint, and the
+/// required-CI blocker precedence.
 /// </summary>
 public sealed class WorkspaceGuardSubmoduleEditClassifierTests
 {
@@ -14,7 +15,8 @@ public sealed class WorkspaceGuardSubmoduleEditClassifierTests
     {
         var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
             isInternalSubmoduleEdit: true,
-            submodulePath: "submodules/X/.github/workflows/ci.yml",
+            submoduleRoot: "submodules/X",
+            dirtyPath: ".github/workflows/ci.yml",
             localDiffFingerprint: "abc123",
             prHeadFingerprint: "abc123",
             hasUniqueLocalContent: false,
@@ -26,11 +28,50 @@ public sealed class WorkspaceGuardSubmoduleEditClassifierTests
     }
 
     [Fact]
+    public void Classify_RedundantNestedFilePath_RepairTargetsSubmoduleRootAndRelativeFile()
+    {
+        // G384 review follow-up: -C must point at the submodule WORKTREE ROOT,
+        // and the pathspec must be the single relative file (never `.` / the
+        // whole submodule). A full dirty path is accepted and reduced to the
+        // relative form.
+        var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
+            isInternalSubmoduleEdit: true,
+            submoduleRoot: "submodules/X",
+            dirtyPath: "submodules/X/.github/workflows/ci.yml",
+            localDiffFingerprint: "abc123",
+            prHeadFingerprint: "abc123",
+            hasUniqueLocalContent: false,
+            selectedPr: 1090);
+
+        Assert.Equal(WorkspaceGuardSubmoduleEditClassifier.Classifications.RedundantInSubmoduleEdit, decision.Classification);
+        Assert.NotNull(decision.RecommendedRepair);
+        // -C targets the submodule root; pathspec is the single relative file.
+        Assert.Contains("git -C submodules/X checkout -- .github/workflows/ci.yml", decision.RecommendedRepair!, StringComparison.Ordinal);
+        // The broken form (-C pointing at the file) must NOT appear.
+        Assert.DoesNotContain("git -C submodules/X/.github", decision.RecommendedRepair!, StringComparison.Ordinal);
+        // Never the whole-submodule pathspec.
+        Assert.DoesNotContain("checkout -- .\n", decision.RecommendedRepair!, StringComparison.Ordinal);
+        Assert.DoesNotContain("checkout -- . ", decision.RecommendedRepair!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RelativeToRoot_StripsRootPrefix_OrLeavesRelativeUnchanged()
+    {
+        Assert.Equal(
+            ".github/workflows/ci.yml",
+            WorkspaceGuardSubmoduleEditClassifier.RelativeToRoot("submodules/X", "submodules/X/.github/workflows/ci.yml"));
+        Assert.Equal(
+            ".github/workflows/ci.yml",
+            WorkspaceGuardSubmoduleEditClassifier.RelativeToRoot("submodules/X", ".github/workflows/ci.yml"));
+    }
+
+    [Fact]
     public void Classify_UniqueLocalContent_IsProtected_NoAutoRepair()
     {
         var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
             isInternalSubmoduleEdit: true,
-            submodulePath: "submodules/X/f.cs",
+            submoduleRoot: "submodules/X",
+            dirtyPath: "f.cs",
             localDiffFingerprint: "abc",
             prHeadFingerprint: "abc",
             hasUniqueLocalContent: true,
@@ -46,7 +87,8 @@ public sealed class WorkspaceGuardSubmoduleEditClassifierTests
     {
         var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
             isInternalSubmoduleEdit: true,
-            submodulePath: "submodules/X/f.cs",
+            submoduleRoot: "submodules/X",
+            dirtyPath: "f.cs",
             localDiffFingerprint: "abc",
             prHeadFingerprint: "different",
             hasUniqueLocalContent: false,
@@ -59,10 +101,10 @@ public sealed class WorkspaceGuardSubmoduleEditClassifierTests
     [Fact]
     public void Classify_MissingFingerprints_IsProtected_NotRedundant()
     {
-        // Empty fingerprints are not "matching" — redundancy must be proven.
         var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
             isInternalSubmoduleEdit: true,
-            submodulePath: "submodules/X/f.cs",
+            submoduleRoot: "submodules/X",
+            dirtyPath: "f.cs",
             localDiffFingerprint: "",
             prHeadFingerprint: "",
             hasUniqueLocalContent: false,
@@ -76,7 +118,8 @@ public sealed class WorkspaceGuardSubmoduleEditClassifierTests
     {
         var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
             isInternalSubmoduleEdit: false,
-            submodulePath: "submodules/X",
+            submoduleRoot: "submodules/X",
+            dirtyPath: "f.cs",
             localDiffFingerprint: "abc",
             prHeadFingerprint: "abc",
             hasUniqueLocalContent: false,
@@ -88,9 +131,9 @@ public sealed class WorkspaceGuardSubmoduleEditClassifierTests
     [Fact]
     public void IsDuplicateReport_SameFingerprint_IsTrue_DifferentIsFalse()
     {
-        var a = WorkspaceGuardSubmoduleEditClassifier.Classify(true, "p", "abc", "abc", false, 1090);
-        var b = WorkspaceGuardSubmoduleEditClassifier.Classify(true, "p", "abc", "abc", false, 1090);
-        var c = WorkspaceGuardSubmoduleEditClassifier.Classify(true, "p", "xyz", "xyz", false, 1090);
+        var a = WorkspaceGuardSubmoduleEditClassifier.Classify(true, "submodules/X", "f", "abc", "abc", false, 1090);
+        var b = WorkspaceGuardSubmoduleEditClassifier.Classify(true, "submodules/X", "f", "abc", "abc", false, 1090);
+        var c = WorkspaceGuardSubmoduleEditClassifier.Classify(true, "submodules/X", "f", "xyz", "xyz", false, 1090);
 
         Assert.True(WorkspaceGuardSubmoduleEditClassifier.IsDuplicateReport(a.DedupeFingerprint, b.DedupeFingerprint));
         Assert.False(WorkspaceGuardSubmoduleEditClassifier.IsDuplicateReport(a.DedupeFingerprint, c.DedupeFingerprint));
@@ -100,22 +143,18 @@ public sealed class WorkspaceGuardSubmoduleEditClassifierTests
     [Fact]
     public void ResolvePrimaryBlocker_FailingCiVisibleEvenWhenRedundantSafe()
     {
-        // Redundant-safe workspace + failing required CI → CI is the primary
-        // (implementation-actionable) blocker.
         Assert.Equal(
             WorkspaceGuardSubmoduleEditClassifier.Blockers.RequiredCiFailing,
             WorkspaceGuardSubmoduleEditClassifier.ResolvePrimaryBlocker(
                 requiredCiFailing: true,
                 WorkspaceGuardSubmoduleEditClassifier.Classifications.RedundantInSubmoduleEdit));
 
-        // Protected operator work is the primary blocker regardless of CI.
         Assert.Equal(
             WorkspaceGuardSubmoduleEditClassifier.Blockers.ProtectedOperatorWork,
             WorkspaceGuardSubmoduleEditClassifier.ResolvePrimaryBlocker(
                 requiredCiFailing: true,
                 WorkspaceGuardSubmoduleEditClassifier.Classifications.ProtectedOperatorWork));
 
-        // Redundant-safe + green CI → nothing blocks.
         Assert.Equal(
             WorkspaceGuardSubmoduleEditClassifier.Blockers.None,
             WorkspaceGuardSubmoduleEditClassifier.ResolvePrimaryBlocker(

--- a/tests/IntentSystem.Cli.Tests/WorkspaceGuardSubmoduleEditClassifierTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkspaceGuardSubmoduleEditClassifierTests.cs
@@ -1,0 +1,125 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G384: pure tests for the redundant-in-submodule-edit classifier — the
+/// PR-head-match redundant case, the protected unique/unproven cases, the
+/// dedupe fingerprint, and the required-CI blocker precedence.
+/// </summary>
+public sealed class WorkspaceGuardSubmoduleEditClassifierTests
+{
+    [Fact]
+    public void Classify_RedundantWithPrHeadMatch_IsRedundant_WithSafeRepair()
+    {
+        var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
+            isInternalSubmoduleEdit: true,
+            submodulePath: "submodules/X/.github/workflows/ci.yml",
+            localDiffFingerprint: "abc123",
+            prHeadFingerprint: "abc123",
+            hasUniqueLocalContent: false,
+            selectedPr: 1090);
+
+        Assert.Equal(WorkspaceGuardSubmoduleEditClassifier.Classifications.RedundantInSubmoduleEdit, decision.Classification);
+        Assert.True(decision.SafeRepairAvailable);
+        Assert.NotNull(decision.RecommendedRepair);
+    }
+
+    [Fact]
+    public void Classify_UniqueLocalContent_IsProtected_NoAutoRepair()
+    {
+        var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
+            isInternalSubmoduleEdit: true,
+            submodulePath: "submodules/X/f.cs",
+            localDiffFingerprint: "abc",
+            prHeadFingerprint: "abc",
+            hasUniqueLocalContent: true,
+            selectedPr: 1090);
+
+        Assert.Equal(WorkspaceGuardSubmoduleEditClassifier.Classifications.ProtectedOperatorWork, decision.Classification);
+        Assert.False(decision.SafeRepairAvailable);
+        Assert.Null(decision.RecommendedRepair);
+    }
+
+    [Fact]
+    public void Classify_UnprovenRedundancy_FingerprintsDiffer_IsProtected()
+    {
+        var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
+            isInternalSubmoduleEdit: true,
+            submodulePath: "submodules/X/f.cs",
+            localDiffFingerprint: "abc",
+            prHeadFingerprint: "different",
+            hasUniqueLocalContent: false,
+            selectedPr: 1090);
+
+        Assert.Equal(WorkspaceGuardSubmoduleEditClassifier.Classifications.ProtectedOperatorWork, decision.Classification);
+        Assert.False(decision.SafeRepairAvailable);
+    }
+
+    [Fact]
+    public void Classify_MissingFingerprints_IsProtected_NotRedundant()
+    {
+        // Empty fingerprints are not "matching" — redundancy must be proven.
+        var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
+            isInternalSubmoduleEdit: true,
+            submodulePath: "submodules/X/f.cs",
+            localDiffFingerprint: "",
+            prHeadFingerprint: "",
+            hasUniqueLocalContent: false,
+            selectedPr: null);
+
+        Assert.Equal(WorkspaceGuardSubmoduleEditClassifier.Classifications.ProtectedOperatorWork, decision.Classification);
+    }
+
+    [Fact]
+    public void Classify_NotInternalSubmoduleEdit_IsNotInLane()
+    {
+        var decision = WorkspaceGuardSubmoduleEditClassifier.Classify(
+            isInternalSubmoduleEdit: false,
+            submodulePath: "submodules/X",
+            localDiffFingerprint: "abc",
+            prHeadFingerprint: "abc",
+            hasUniqueLocalContent: false,
+            selectedPr: 1090);
+
+        Assert.Equal(WorkspaceGuardSubmoduleEditClassifier.Classifications.NotInSubmoduleLane, decision.Classification);
+    }
+
+    [Fact]
+    public void IsDuplicateReport_SameFingerprint_IsTrue_DifferentIsFalse()
+    {
+        var a = WorkspaceGuardSubmoduleEditClassifier.Classify(true, "p", "abc", "abc", false, 1090);
+        var b = WorkspaceGuardSubmoduleEditClassifier.Classify(true, "p", "abc", "abc", false, 1090);
+        var c = WorkspaceGuardSubmoduleEditClassifier.Classify(true, "p", "xyz", "xyz", false, 1090);
+
+        Assert.True(WorkspaceGuardSubmoduleEditClassifier.IsDuplicateReport(a.DedupeFingerprint, b.DedupeFingerprint));
+        Assert.False(WorkspaceGuardSubmoduleEditClassifier.IsDuplicateReport(a.DedupeFingerprint, c.DedupeFingerprint));
+        Assert.False(WorkspaceGuardSubmoduleEditClassifier.IsDuplicateReport(null, a.DedupeFingerprint));
+    }
+
+    [Fact]
+    public void ResolvePrimaryBlocker_FailingCiVisibleEvenWhenRedundantSafe()
+    {
+        // Redundant-safe workspace + failing required CI → CI is the primary
+        // (implementation-actionable) blocker.
+        Assert.Equal(
+            WorkspaceGuardSubmoduleEditClassifier.Blockers.RequiredCiFailing,
+            WorkspaceGuardSubmoduleEditClassifier.ResolvePrimaryBlocker(
+                requiredCiFailing: true,
+                WorkspaceGuardSubmoduleEditClassifier.Classifications.RedundantInSubmoduleEdit));
+
+        // Protected operator work is the primary blocker regardless of CI.
+        Assert.Equal(
+            WorkspaceGuardSubmoduleEditClassifier.Blockers.ProtectedOperatorWork,
+            WorkspaceGuardSubmoduleEditClassifier.ResolvePrimaryBlocker(
+                requiredCiFailing: true,
+                WorkspaceGuardSubmoduleEditClassifier.Classifications.ProtectedOperatorWork));
+
+        // Redundant-safe + green CI → nothing blocks.
+        Assert.Equal(
+            WorkspaceGuardSubmoduleEditClassifier.Blockers.None,
+            WorkspaceGuardSubmoduleEditClassifier.ResolvePrimaryBlocker(
+                requiredCiFailing: false,
+                WorkspaceGuardSubmoduleEditClassifier.Classifications.RedundantInSubmoduleEdit));
+    }
+}


### PR DESCRIPTION
Closes #871

## Summary
- A host review loop repeatedly stopped on `dirty-unrelated-submodule` when a submodule had an internal uncommitted edit **byte-identical to the change already on the selected PR head**, re-emitting the same operator cleanup stop every wake — while a failing required CI (the real blocker) was obscured.
- New pure **`WorkspaceGuardSubmoduleEditClassifier`** classifies an internal submodule edit:
  - **`redundant-in-submodule-edit`** — only when the local diff fingerprint matches the PR-head fingerprint **and** there is no unique local content → bounded safe repair.
  - **`protected-operator-work`** — unique or unproven → hard-stop, never auto-cleared (intent-cli never silently discards operator work).
  - `IsDuplicateReport` (dedupe by `path|local|pr|head` fingerprint) + `ResolvePrimaryBlocker` (a failing required CI stays the visible implementation blocker when the workspace is redundant-safe).
- **`automation host-review-diagnostics --in-submodule-edit`** (isolated early-return) emits the stable classification + safe-repair / request-update routing, deduplicates an unchanged repeat via `--prior-fingerprint`, and surfaces `required-ci-failing` precedence.

## Acceptance criteria mapping
- Redundant (diff identical to PR head) → `redundant-in-submodule-edit` + safe repair path ✓
- Unique local content → still refuses auto-repair, `protected-operator-work` ✓
- Same unchanged fingerprint across wakes → deduplicated stable status (`deduplicated-unchanged-report`) ✓
- Failing required CI → `required-ci-failing` included/prioritized, routed implementation-actionable once workspace is redundant-safe ✓
- Tests cover redundant PR-head match, unique local edit, same-fingerprint dedupe, required-CI precedence (+ unproven case) ✓

Note: host-owned spec `intents/intent-cli/specs/05-intent-cli-surface.md` is absent from the child worktree → deferred to host. (A `guide` discoverability surface / host-loop prompt note can follow if the reviewer wants it — kept this PR focused on the deterministic diagnostics classification the acceptance criteria name.)

## Test plan
- [x] Classifier (8) + diagnostics lane (4) + existing diagnostics (58) green; full `IntentSystem.Cli.Tests` 3294 passed (the 1 intermittent failure is the known flaky real-subprocess `DirectRunLauncher` test — passes in isolation, unrelated).
- [x] Manual: all 5 lane cases. `git diff --check` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)