### PR TITLE
G385: harden github-only worker next-action against gh JSON contamination

### DIFF
--- a/src/IntentSystem.Cli/Commands/GitHubCliJsonBoundary.cs
+++ b/src/IntentSystem.Cli/Commands/GitHubCliJsonBoundary.cs
@@ -1,0 +1,233 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G385: pure, process-free boundary that hardens parsing of <c>gh issue
+/// list</c> / <c>gh pr list</c> JSON for the github-only worker selector
+/// (<c>intent-cli worker next-action --github-only</c>).
+///
+/// Why this exists: a child implementation loop observed
+/// <c>could not parse gh issue list ... JSON: 'u' is invalid after a value
+/// ... BytePositionInLine: 366</c> — a raw <see cref="JsonException"/> leaking
+/// to the operator because <c>gh</c> stdout was contaminated with trailing
+/// non-JSON text (an update notice / warning printed alongside the array,
+/// likely under Windows PowerShell native-command capture). A raw parser
+/// exception is poor operator guidance.
+///
+/// This boundary:
+/// - parses only the stdout JSON stream (callers already capture stdout and
+///   stderr separately);
+/// - normalizes legitimate encoding artifacts (a leading UTF-8 BOM and
+///   surrounding whitespace) so otherwise-valid JSON still parses;
+/// - applies a clear refusal when stdout is not exactly a valid JSON array:
+///   any leading/trailing contamination (update notices, progress/warning
+///   lines printed to stdout, trailing native-command text) yields a
+///   structured <c>github-json-invalid</c> diagnostic (classification +
+///   repo/command family + byte/line if available + a redacted output preview
+///   + a recommended retry/preflight) instead of a raw exception. Silent
+///   best-effort recovery is intentionally avoided so a contaminated
+///   environment is surfaced to the operator, not masked;
+/// - classifies a non-zero <c>gh</c> exit into <c>github-auth-failed</c> vs
+///   <c>github-command-failed</c>.
+///
+/// No I/O, no <c>Process.Start</c> — the lister adapter supplies the captured
+/// stdout/stderr/exit code, so every branch is unit-testable with fixtures
+/// (including the JTJ_Estivo byte-366 error shape and Windows PowerShell
+/// output contamination).
+/// </summary>
+internal static partial class GitHubCliJsonBoundary
+{
+    /// <summary>
+    /// Stable classifications surfaced to the operator/agent. <c>valid</c> is
+    /// the success case; the others are the github-only failure family.
+    /// (<c>no-actionable-target</c> / <c>ambiguous-target</c> are selection
+    /// outcomes owned by the analyzer layer, not this parser boundary.)
+    /// </summary>
+    public static class Classifications
+    {
+        public const string Valid = "valid";
+        public const string GithubJsonInvalid = "github-json-invalid";
+        public const string GithubCommandFailed = "github-command-failed";
+        public const string GithubAuthFailed = "github-auth-failed";
+    }
+
+    private const int DefaultPreviewLength = 240;
+
+    /// <summary>
+    /// Extract the JSON array payload from possibly-contaminated <c>gh</c>
+    /// stdout. Returns a successful extraction (with the cleaned JSON ready to
+    /// deserialize) or a structured <c>github-json-invalid</c> diagnostic.
+    /// </summary>
+    /// <param name="stdout">Raw captured <c>gh</c> stdout (may include a BOM or surrounding non-JSON text).</param>
+    /// <param name="callDescription">Human-readable call descriptor, e.g. <c>`gh issue list` for owner/repo</c>; carries the gh command family and repo into the diagnostic.</param>
+    public static GitHubCliJsonExtraction ExtractJsonArray(string? stdout, string callDescription)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(callDescription);
+
+        var raw = stdout ?? string.Empty;
+        // PowerShell / native-command capture can prepend a UTF-8 BOM.
+        if (raw.Length > 0 && raw[0] == '\uFEFF')
+        {
+            raw = raw[1..];
+        }
+
+        var trimmed = raw.Trim();
+        if (trimmed.Length == 0)
+        {
+            return Invalid(
+                callDescription,
+                "gh produced no stdout (empty output)",
+                errorByte: null,
+                errorLine: null,
+                preview: string.Empty);
+        }
+
+        // The whole trimmed payload (after BOM strip) must be exactly a valid
+        // JSON array. This is the clean macOS/zsh case and preserves the
+        // pre-G385 result for legitimate output.
+        if (TryValidateJsonArray(trimmed, out var parseError))
+        {
+            return new GitHubCliJsonExtraction
+            {
+                Succeeded = true,
+                Classification = Classifications.Valid,
+                Json = trimmed,
+            };
+        }
+
+        // Anything else — trailing update notices, leading warnings, or other
+        // native-command contamination — is refused with a structured,
+        // sanitized diagnostic (byte/line position if the JSON parser reported
+        // one) rather than a raw parser exception.
+        return Invalid(
+            callDescription,
+            "gh stdout was not valid JSON",
+            errorByte: parseError?.BytePositionInLine,
+            errorLine: parseError?.LineNumber,
+            preview: trimmed);
+    }
+
+    /// <summary>
+    /// Classify a non-zero <c>gh</c> exit into <c>github-auth-failed</c> (when
+    /// the captured output mentions an authentication problem) vs the generic
+    /// <c>github-command-failed</c>.
+    /// </summary>
+    public static string ClassifyProcessFailure(string? stderr, string? stdout)
+    {
+        var combined = (stderr ?? string.Empty) + "\n" + (stdout ?? string.Empty);
+        return AuthFailureRegex().IsMatch(combined)
+            ? Classifications.GithubAuthFailed
+            : Classifications.GithubCommandFailed;
+    }
+
+    /// <summary>
+    /// Sanitize an output snippet for safe inclusion in a diagnostic: collapse
+    /// whitespace/newlines to a single line, redact token-like substrings
+    /// (GitHub PATs, <c>Bearer</c> tokens), and cap the length.
+    /// </summary>
+    public static string SanitizePreview(string? raw, int maxLength = DefaultPreviewLength)
+    {
+        if (string.IsNullOrEmpty(raw))
+        {
+            return string.Empty;
+        }
+
+        var collapsed = WhitespaceRegex().Replace(raw, " ").Trim();
+        var redacted = TokenRegex().Replace(collapsed, "***redacted***");
+        return redacted.Length > maxLength
+            ? redacted[..maxLength] + "…(truncated)"
+            : redacted;
+    }
+
+    private static GitHubCliJsonExtraction Invalid(
+        string callDescription,
+        string summary,
+        long? errorByte,
+        long? errorLine,
+        string preview)
+    {
+        var sanitized = SanitizePreview(preview);
+        var location = errorLine is { } line && errorByte is { } position
+            ? $" (line {line}, byte {position})"
+            : string.Empty;
+        var previewClause = sanitized.Length == 0
+            ? string.Empty
+            : $" sanitized preview: \"{sanitized}\".";
+
+        var message =
+            $"could not parse {callDescription}: {summary}{location}.{previewClause}"
+            + " Recommended: inspect raw output with `gh issue list --repo <owner/repo>"
+            + " --json number,title,labels,url`, ensure no shell-profile/update-notice/warning"
+            + " text contaminates stdout (especially under Windows PowerShell), then retry"
+            + " `intent-cli worker next-action --github-only`.";
+
+        return new GitHubCliJsonExtraction
+        {
+            Succeeded = false,
+            Classification = Classifications.GithubJsonInvalid,
+            DiagnosticMessage = message,
+            ErrorByteOffset = errorByte,
+            ErrorLineNumber = errorLine,
+            Preview = sanitized,
+            RecommendedAction = "inspect-gh-output-and-retry",
+        };
+    }
+
+    private static bool TryValidateJsonArray(string candidate, out JsonException? error)
+    {
+        error = null;
+        try
+        {
+            using var document = JsonDocument.Parse(candidate);
+            return document.RootElement.ValueKind == JsonValueKind.Array;
+        }
+        catch (JsonException exception)
+        {
+            error = exception;
+            return false;
+        }
+    }
+
+    [GeneratedRegex(
+        @"gh auth login|not logged in|authentication failed|requires authentication|bad credentials|unauthorized|http 401|\b401\b|token has expired|invalid token|no authentication token",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant)]
+    private static partial Regex AuthFailureRegex();
+
+    [GeneratedRegex(
+        @"gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|Bearer\s+[A-Za-z0-9._\-]+",
+        RegexOptions.CultureInvariant)]
+    private static partial Regex TokenRegex();
+
+    [GeneratedRegex(@"\s+", RegexOptions.CultureInvariant)]
+    private static partial Regex WhitespaceRegex();
+}
+
+/// <summary>
+/// G385: the verdict from <see cref="GitHubCliJsonBoundary.ExtractJsonArray"/>.
+/// On success, <see cref="Json"/> is a validated JSON array ready to
+/// deserialize; on failure, <see cref="DiagnosticMessage"/> carries the
+/// sanitized structured diagnostic.
+/// </summary>
+internal sealed record GitHubCliJsonExtraction
+{
+    public required bool Succeeded { get; init; }
+
+    public required string Classification { get; init; }
+
+    /// <summary>The validated JSON array payload to deserialize (success only).</summary>
+    public string Json { get; init; } = "[]";
+
+    /// <summary>Operator-facing, sanitized diagnostic with a recommended action (failure only).</summary>
+    public string DiagnosticMessage { get; init; } = string.Empty;
+
+    public long? ErrorByteOffset { get; init; }
+
+    public long? ErrorLineNumber { get; init; }
+
+    /// <summary>Redacted, length-capped preview of the offending output (failure only).</summary>
+    public string Preview { get; init; } = string.Empty;
+
+    public string RecommendedAction { get; init; } = string.Empty;
+}

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -245,25 +245,52 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
 
         if (exitCode != 0)
         {
+            // G385: classify the failure (auth vs generic) and surface a
+            // sanitized preview instead of the raw, possibly secret-bearing
+            // gh output.
+            var classification = GitHubCliJsonBoundary.ClassifyProcessFailure(stderr, stdout);
             var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
             throw new InvalidOperationException(
-                $"`gh` failed to {description} with exit {exitCode}: {errorBody.Trim()}");
+                $"[{classification}] `gh` failed to {description} with exit {exitCode}: "
+                + GitHubCliJsonBoundary.SanitizePreview(errorBody));
         }
 
         return stdout;
     }
 
-    private static IReadOnlyList<T> DeserializeList<T>(string stdout, string callDescription)
+    /// <summary>
+    /// G385: deserialize the candidate list through the hardened JSON boundary.
+    /// Internal so adapter tests can lock the contamination contract without a
+    /// real <c>gh</c> subprocess.
+    /// </summary>
+    internal static IReadOnlyList<T> DeserializeList<T>(string stdout, string callDescription)
     {
+        // G385: harden the parser boundary against contaminated stdout (BOM,
+        // trailing update notices, warning lines printed alongside the array —
+        // observed under Windows PowerShell native-command capture). Parse only
+        // the validated JSON array; on genuine failure raise a structured,
+        // sanitized diagnostic rather than a raw JsonException.
+        var extraction = GitHubCliJsonBoundary.ExtractJsonArray(stdout, callDescription);
+        if (!extraction.Succeeded)
+        {
+            throw new InvalidOperationException(
+                $"[{extraction.Classification}] {extraction.DiagnosticMessage}");
+        }
+
         try
         {
-            var result = JsonSerializer.Deserialize<List<T>>(stdout);
+            var result = JsonSerializer.Deserialize<List<T>>(extraction.Json);
             return (IReadOnlyList<T>?)result ?? Array.Empty<T>();
         }
         catch (JsonException exception)
         {
+            // The array shape was already validated, so a typed-deserialize
+            // failure here is a schema mismatch, not contamination — still
+            // surface a sanitized, classified diagnostic.
             throw new InvalidOperationException(
-                $"could not parse {callDescription} JSON: {exception.Message}",
+                $"[{GitHubCliJsonBoundary.Classifications.GithubJsonInvalid}] could not map {callDescription} "
+                + $"JSON to the expected shape: {exception.Message}; sanitized preview: "
+                + $"\"{GitHubCliJsonBoundary.SanitizePreview(extraction.Json)}\"",
                 exception);
         }
     }

--- a/tests/IntentSystem.Cli.Tests/GitHubCliJsonBoundaryTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GitHubCliJsonBoundaryTests.cs
@@ -1,0 +1,174 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G385: tests for the pure <see cref="GitHubCliJsonBoundary"/> that hardens
+/// the github-only worker selector against contaminated <c>gh issue list</c> /
+/// <c>gh pr list</c> stdout. Covers the clean macOS/zsh case, Windows
+/// PowerShell-style BOM/trailing contamination (the JTJ_Estivo byte-366 error
+/// shape), malformed JSON diagnostics, gh process-failure classification, and
+/// secret-redacting preview sanitization.
+/// </summary>
+public sealed class GitHubCliJsonBoundaryTests
+{
+    private const string Call = "`gh issue list` for J-Tech-Japan/JTJ_Estivo";
+
+    [Fact]
+    public void ExtractJsonArray_ValidArray_SucceedsAndPreservesPayload()
+    {
+        const string stdout = "[{\"number\":78,\"title\":\"x\",\"labels\":[{\"name\":\"intent-target\"}]}]";
+
+        var result = GitHubCliJsonBoundary.ExtractJsonArray(stdout, Call);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(GitHubCliJsonBoundary.Classifications.Valid, result.Classification);
+        Assert.Equal(stdout, result.Json);
+    }
+
+    [Fact]
+    public void ExtractJsonArray_EmptyArray_Succeeds()
+    {
+        var result = GitHubCliJsonBoundary.ExtractJsonArray("[]", Call);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(GitHubCliJsonBoundary.Classifications.Valid, result.Classification);
+        Assert.Equal("[]", result.Json);
+    }
+
+    [Fact]
+    public void ExtractJsonArray_LeadingBomAndWhitespace_IsNormalizedAndSucceeds()
+    {
+        // PowerShell / native-command capture can prepend a UTF-8 BOM and
+        // surrounding whitespace — both are legitimate encoding artifacts, not
+        // contamination, so valid JSON still parses.
+        const string stdout = "\uFEFF\r\n  [{\"number\":78}]  \r\n";
+
+        var result = GitHubCliJsonBoundary.ExtractJsonArray(stdout, Call);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("[{\"number\":78}]", result.Json);
+    }
+
+    [Fact]
+    public void ExtractJsonArray_TrailingUpdateNotice_RefusesWithStructuredDiagnostic()
+    {
+        // Reproduces the JTJ_Estivo failure: a valid array followed by a gh
+        // update notice on stdout. The parser fails at the 'u' after the
+        // closing bracket — must refuse, not throw a raw exception.
+        const string stdout =
+            "[{\"number\":78}]update available: a new release of gh (2.40.0) is available";
+
+        var result = GitHubCliJsonBoundary.ExtractJsonArray(stdout, Call);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(GitHubCliJsonBoundary.Classifications.GithubJsonInvalid, result.Classification);
+        Assert.Contains(Call, result.DiagnosticMessage, StringComparison.Ordinal);
+        Assert.Contains("worker next-action --github-only", result.DiagnosticMessage, StringComparison.Ordinal);
+        Assert.Equal("inspect-gh-output-and-retry", result.RecommendedAction);
+    }
+
+    [Fact]
+    public void ExtractJsonArray_MalformedJson_ReportsByteAndLineLocation()
+    {
+        const string stdout = "[{\"number\":78,}]"; // trailing comma -> invalid
+
+        var result = GitHubCliJsonBoundary.ExtractJsonArray(stdout, Call);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(GitHubCliJsonBoundary.Classifications.GithubJsonInvalid, result.Classification);
+        Assert.NotNull(result.ErrorByteOffset);
+        Assert.NotNull(result.ErrorLineNumber);
+        Assert.Contains("byte", result.DiagnosticMessage, StringComparison.Ordinal);
+        Assert.Contains("line", result.DiagnosticMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExtractJsonArray_LeadingWarningLine_Refuses()
+    {
+        const string stdout = "[WARN] gh: rate limit nearly exhausted\n[{\"number\":78}]";
+
+        var result = GitHubCliJsonBoundary.ExtractJsonArray(stdout, Call);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(GitHubCliJsonBoundary.Classifications.GithubJsonInvalid, result.Classification);
+    }
+
+    [Fact]
+    public void ExtractJsonArray_NonArrayJson_Refuses()
+    {
+        // A bare object is valid JSON but not the expected array shape.
+        var result = GitHubCliJsonBoundary.ExtractJsonArray("{\"message\":\"Not Found\"}", Call);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(GitHubCliJsonBoundary.Classifications.GithubJsonInvalid, result.Classification);
+    }
+
+    [Fact]
+    public void ExtractJsonArray_EmptyStdout_Refuses()
+    {
+        var result = GitHubCliJsonBoundary.ExtractJsonArray("   \r\n  ", Call);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(GitHubCliJsonBoundary.Classifications.GithubJsonInvalid, result.Classification);
+        Assert.Contains("empty", result.DiagnosticMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ExtractJsonArray_RequiresCallDescription()
+    {
+        Assert.Throws<ArgumentException>(
+            () => GitHubCliJsonBoundary.ExtractJsonArray("[]", "  "));
+    }
+
+    [Theory]
+    [InlineData("gh: To get started with GitHub CLI, please run: gh auth login")]
+    [InlineData("HTTP 401: Bad credentials")]
+    [InlineData("error: requires authentication")]
+    public void ClassifyProcessFailure_AuthMarkers_AreAuthFailed(string stderr)
+    {
+        Assert.Equal(
+            GitHubCliJsonBoundary.Classifications.GithubAuthFailed,
+            GitHubCliJsonBoundary.ClassifyProcessFailure(stderr, stdout: string.Empty));
+    }
+
+    [Fact]
+    public void ClassifyProcessFailure_GenericError_IsCommandFailed()
+    {
+        Assert.Equal(
+            GitHubCliJsonBoundary.Classifications.GithubCommandFailed,
+            GitHubCliJsonBoundary.ClassifyProcessFailure(
+                stderr: "could not resolve to a Repository with the name 'owner/repo'",
+                stdout: string.Empty));
+    }
+
+    [Fact]
+    public void SanitizePreview_RedactsTokensAndCollapsesWhitespace()
+    {
+        const string raw = "auth failed\n  token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 used";
+
+        var preview = GitHubCliJsonBoundary.SanitizePreview(raw);
+
+        Assert.DoesNotContain("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", preview, StringComparison.Ordinal);
+        Assert.Contains("***redacted***", preview, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", preview, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SanitizePreview_RedactsBearerToken()
+    {
+        var preview = GitHubCliJsonBoundary.SanitizePreview("Authorization: Bearer abc.def.ghi-123");
+
+        Assert.DoesNotContain("abc.def.ghi-123", preview, StringComparison.Ordinal);
+        Assert.Contains("***redacted***", preview, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SanitizePreview_TruncatesLongOutput()
+    {
+        var preview = GitHubCliJsonBoundary.SanitizePreview(new string('x', 1000), maxLength: 50);
+
+        Assert.Contains("(truncated)", preview, StringComparison.Ordinal);
+        Assert.True(preview.Length < 1000);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
@@ -417,6 +417,43 @@ public sealed class WorkerNextActionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Adapter_DeserializeList_ValidStdout_MapsToTypedCandidates()
+    {
+        // G385: clean stdout still yields the same candidates after the
+        // hardened boundary (no behavior change for legitimate output).
+        const string stdout =
+            "[{\"number\":78,\"title\":\"x\",\"url\":\"https://example.com/issue/78\","
+            + "\"labels\":[{\"name\":\"intent-target\"}],\"state\":\"OPEN\"}]";
+
+        var candidates = GhCliGitHubAutomationCandidateLister.DeserializeList<GitHubAutomationIssueCandidate>(
+            stdout, "`gh issue list` for J-Tech-Japan/intent-system");
+
+        var candidate = Assert.Single(candidates);
+        Assert.Equal(78, candidate.Number);
+    }
+
+    [Fact]
+    public void Adapter_DeserializeList_ContaminatedStdout_ThrowsClassifiedDiagnostic()
+    {
+        // G385: the JTJ_Estivo byte-366 shape — a valid array followed by a gh
+        // update notice — must raise a classified, sanitized diagnostic, not a
+        // raw JsonException.
+        const string stdout =
+            "[{\"number\":78}]A new release of gh is available: 2.40.0 → 2.50.0";
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => GhCliGitHubAutomationCandidateLister.DeserializeList<GitHubAutomationIssueCandidate>(
+                stdout, "`gh issue list` for J-Tech-Japan/JTJ_Estivo"));
+
+        Assert.Contains(
+            $"[{GitHubCliJsonBoundary.Classifications.GithubJsonInvalid}]",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.Contains("J-Tech-Japan/JTJ_Estivo", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("worker next-action --github-only", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_NeverInvokesNestedProviderLauncher()
     {
         using var workspace = new WorkerNextActionWorkspace();


### PR DESCRIPTION
## Summary

Hardens `intent-cli worker next-action --github-only` against contaminated `gh issue list` / `gh pr list` stdout so the child implementation loop gets actionable structured diagnostics instead of a raw `JsonException` (the observed JTJ_Estivo `... 'u' is invalid after a value ... BytePositionInLine: 366` failure).

- New pure, process-free `GitHubCliJsonBoundary`:
  - normalizes legitimate encoding artifacts (leading UTF-8 BOM + surrounding whitespace) so valid JSON still parses;
  - requires the payload to be **exactly** a valid JSON array — any leading/trailing contamination (gh update notices, warning lines, trailing native-command text, e.g. under Windows PowerShell) is **refused** with a structured `github-json-invalid` diagnostic carrying the repo/command family, byte/line location, a **redacted** output preview, and a recommended retry/preflight (no silent best-effort recovery — a contaminated environment is surfaced, not masked);
  - classifies a non-zero `gh` exit into `github-auth-failed` vs `github-command-failed`.
- Wires the boundary into `GhCliGitHubAutomationCandidateLister` (parse path + non-zero-exit path), keeping valid output behavior unchanged.

## Acceptance criteria mapping

- Valid JSON → same candidate selected (`Adapter_DeserializeList_ValidStdout_MapsToTypedCandidates`).
- stderr warnings ignored — only stdout JSON is parsed (callers already capture streams separately).
- BOM/whitespace (PowerShell-style) normalized for valid JSON (`ExtractJsonArray_LeadingBomAndWhitespace_IsNormalizedAndSucceeds`).
- Trailing non-JSON text → `github-json-invalid` with sanitized context + recommended retry, not a raw exception (`...TrailingUpdateNotice_RefusesWithStructuredDiagnostic`, `Adapter_DeserializeList_ContaminatedStdout_ThrowsClassifiedDiagnostic`).
- Malformed JSON → repo + gh command family + byte/line + sanitized preview (`...MalformedJson_ReportsByteAndLineLocation`).
- Secrets redacted in previews (`SanitizePreview_RedactsTokens...`, `...RedactsBearerToken`).
- Host-state-free `--github-only` selection preserved.

Note: the issue also names `intents/intent-cli/specs/05-intent-cli-surface.md`, but that path is host-owned and absent from this GitHub-contract-only child worktree (G300/G330/G333); the spec note is host-side. The code + tests are the child-loop deliverable here.

## Test plan

- [x] `GitHubCliJsonBoundaryTests` (16) + `WorkerNextActionCommandTests` (incl. 2 new adapter tests) pass.
- [x] Full `IntentSystem.Cli.Tests` suite green except one known flaky env test (`WorkerCompleteCommandTests.Execute_G347_AllowsPrCreatedWhenIssueBodyHasNoBaseBranchSection`) that passes in isolation and is unrelated to this change.
- [x] `dotnet build` clean; `git diff --check` clean.

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)