### PR TITLE
G386: publish intent-cli from GitHub Releases to NuGet and self-contained binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,263 @@
+# G386: release-driven distribution for intent-cli.
+#
+# Triggered by publishing a GitHub Release (or manually via
+# workflow_dispatch for a dry run). It does three things:
+#
+#   1. Builds and packs the official `intent-cli` .nupkg (release build —
+#      NO PrivatePreview* / expiry properties, so the artifact carries no
+#      build-time expiry contract; see IntentSystem.Cli.csproj G367 block
+#      and PrivatePreviewExpiryGate). When `NUGET_API_KEY` is present and
+#      the run was triggered by a real release, the package is pushed to
+#      NuGet.org. On forks / missing secrets the publish step is skipped
+#      cleanly so the workflow still builds and attaches artifacts.
+#
+#   2. Builds SDK-free self-contained single-file binaries for
+#      osx-arm64, win-x64, and linux-x64 on matching runners, smoke-tests
+#      `intent-cli --version`, and archives each with a SHA-256 sidecar.
+#
+#   3. Attaches the .nupkg and the per-platform binary archives (plus
+#      checksums) to the triggering GitHub Release.
+#
+# Non-SDK users install by downloading a release binary; SDK users run
+# `dotnet tool install -g intent-cli`. See README.md "Install".
+name: release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build for a dry run (e.g. 0.2.0). Defaults to a dryrun suffix. Real releases derive the version from the release tag."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  nupkg:
+    name: NuGet package
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          dotnet-quality: preview
+
+      - name: Resolve release version
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            RAW="${{ github.event.release.tag_name }}"
+          else
+            RAW="${{ github.event.inputs.version }}"
+          fi
+          # Strip a leading v from tags like v0.2.0.
+          VERSION="${RAW#v}"
+          if [ -z "${VERSION}" ]; then
+            VERSION="0.2.0-dryrun.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          fi
+          echo "version=${VERSION}" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Restore
+        run: dotnet restore IntentSystem.sln
+
+      - name: Build
+        run: dotnet build IntentSystem.sln --configuration Release --no-restore
+
+      - name: Test
+        run: |
+          dotnet test IntentSystem.sln --configuration Release --no-build \
+            --logger "trx;LogFileName=test-results.trx" \
+            --results-directory "${GITHUB_WORKSPACE}/.artifacts/test-results"
+
+      - name: Pack release .nupkg (no preview/expiry properties)
+        run: |
+          dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
+            --configuration Release \
+            -o .artifacts/release \
+            -p:Version=${{ steps.ver.outputs.version }}
+
+      - name: Generate SHA256 checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd .artifacts/release
+          for f in intent-cli.*.nupkg; do
+            sha256sum "${f}" > "${f}.sha256"
+          done
+          cat ./*.sha256
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: intent-cli-nupkg-${{ steps.ver.outputs.version }}
+          path: .artifacts/release/*
+
+      - name: Attach .nupkg to GitHub Release
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            .artifacts/release/intent-cli.*.nupkg \
+            .artifacts/release/intent-cli.*.nupkg.sha256 \
+            --repo "${{ github.repository }}" --clobber
+
+      - name: Publish to NuGet.org (guarded; skips on forks / missing secret)
+        if: ${{ github.event_name == 'release' }}
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${NUGET_API_KEY:-}" ]; then
+            echo "NUGET_API_KEY is not set (fork or missing secret); skipping NuGet publish."
+            echo "Artifacts were still built and attached to the release."
+            exit 0
+          fi
+          dotnet nuget push .artifacts/release/intent-cli.*.nupkg \
+            --api-key "${NUGET_API_KEY}" \
+            --source "https://api.nuget.org/v3/index.json" \
+            --skip-duplicate
+
+  binaries:
+    name: Self-contained ${{ matrix.rid }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: osx-arm64
+            os: macos-latest
+          - rid: win-x64
+            os: windows-latest
+          - rid: linux-x64
+            os: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          dotnet-quality: preview
+
+      - name: Resolve release version
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            RAW="${{ github.event.release.tag_name }}"
+          else
+            RAW="${{ github.event.inputs.version }}"
+          fi
+          VERSION="${RAW#v}"
+          if [ -z "${VERSION}" ]; then
+            VERSION="0.2.0-dryrun.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          fi
+          echo "version=${VERSION}" | tee -a "${GITHUB_OUTPUT}"
+
+      # Self-contained single-file publish bundles the .NET runtime, so the
+      # produced binary runs without a preinstalled .NET SDK. No
+      # PrivatePreview* properties are passed, so there is no build-time
+      # expiry contract on release binaries.
+      - name: Publish self-contained single-file binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet publish src/IntentSystem.Cli/IntentSystem.Cli.csproj \
+            --configuration Release \
+            -r ${{ matrix.rid }} \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:IncludeNativeLibrariesForSelfExtract=true \
+            -p:Version=${{ steps.ver.outputs.version }} \
+            -o "publish/${{ matrix.rid }}"
+
+      # The published apphost is named after the assembly
+      # (IntentSystem.Cli); stage it under the user-facing `intent-cli`
+      # command name for the release asset.
+      - name: Stage binary as intent-cli
+        id: stage
+        shell: bash
+        run: |
+          set -euo pipefail
+          RID="${{ matrix.rid }}"
+          SRCDIR="publish/${RID}"
+          mkdir -p stage
+          if [ "${RID}" = "win-x64" ]; then
+            cp "${SRCDIR}/IntentSystem.Cli.exe" "stage/intent-cli.exe"
+            echo "bin=stage/intent-cli.exe" | tee -a "${GITHUB_OUTPUT}"
+          else
+            cp "${SRCDIR}/IntentSystem.Cli" "stage/intent-cli"
+            chmod +x "stage/intent-cli"
+            echo "bin=stage/intent-cli" | tee -a "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Smoke test --version (no .NET SDK needed by the self-contained binary)
+        shell: bash
+        run: |
+          set -euo pipefail
+          "${{ steps.stage.outputs.bin }}" --version
+
+      - name: Archive + checksum
+        id: pack
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          RID="${{ matrix.rid }}"
+          NAME="intent-cli-${VERSION}-${RID}"
+          mkdir -p dist
+          if [ "${RID}" = "win-x64" ]; then
+            ASSET="dist/${NAME}.zip"
+            7z a -tzip "${ASSET}" "./stage/intent-cli.exe" >/dev/null
+          else
+            ASSET="dist/${NAME}.tar.gz"
+            tar -czf "${ASSET}" -C stage "intent-cli"
+          fi
+          if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "${ASSET}" > "${ASSET}.sha256"
+          else
+            shasum -a 256 "${ASSET}" > "${ASSET}.sha256"
+          fi
+          echo "asset=${ASSET}" | tee -a "${GITHUB_OUTPUT}"
+          cat "${ASSET}.sha256"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: intent-cli-${{ matrix.rid }}-${{ steps.ver.outputs.version }}
+          path: dist/*
+
+      - name: Attach binary to GitHub Release
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ steps.pack.outputs.asset }}" \
+            "${{ steps.pack.outputs.asset }}.sha256" \
+            --repo "${{ github.repository }}" --clobber

--- a/README.md
+++ b/README.md
@@ -1,5 +1,57 @@
 # intent-system
 
+## Install
+
+`intent-cli` is published from GitHub Releases (G386). Each release publishes the
+NuGet package and attaches SDK-free self-contained binaries for macOS, Windows,
+and Linux.
+
+### With a .NET SDK (NuGet)
+
+If you have a .NET 10 SDK, install the global tool from NuGet.org:
+
+```bash
+dotnet tool install -g intent-cli
+# later, to upgrade:
+dotnet tool update -g intent-cli
+```
+
+Then run `intent-cli --version` to confirm the install.
+
+### Without a .NET SDK (self-contained binary)
+
+Download the archive for your platform from the
+[latest GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/latest)
+and run it directly — the .NET runtime is bundled, so no SDK is required.
+
+| Platform | Asset |
+| --- | --- |
+| macOS (Apple Silicon) | `intent-cli-<version>-osx-arm64.tar.gz` |
+| Windows (x64) | `intent-cli-<version>-win-x64.zip` |
+| Linux (x64) | `intent-cli-<version>-linux-x64.tar.gz` |
+
+Each archive ships with a `.sha256` sidecar; verify it before use. Example for
+macOS / Linux:
+
+```bash
+# 1. Verify the checksum (run from the folder containing both files).
+shasum -a 256 -c intent-cli-<version>-osx-arm64.tar.gz.sha256
+
+# 2. Extract and place the binary on your PATH.
+tar -xzf intent-cli-<version>-osx-arm64.tar.gz
+chmod +x intent-cli
+sudo mv intent-cli /usr/local/bin/
+
+# 3. Confirm.
+intent-cli --version
+```
+
+On Windows, verify with `CertUtil -hashfile intent-cli-<version>-win-x64.zip SHA256`,
+unzip, and place `intent-cli.exe` on your `PATH`.
+
+Release binaries carry no build-time expiry (unlike the
+`private-preview-pack` artifacts described below).
+
 ## Project-local best-practice inputs
 
 Project-local best-practice and model-registry starter docs live under:

--- a/tests/IntentSystem.Cli.Tests/ReleaseWorkflowContractTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseWorkflowContractTests.cs
@@ -1,0 +1,93 @@
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G386: regression guards for the release-driven distribution workflow
+/// (<c>.github/workflows/release.yml</c>). The deliverable is a GitHub
+/// Actions workflow, so — like <see cref="IntentCliBuildMetadataTests"/>
+/// reads the CLI <c>.csproj</c> directly — these read the workflow source
+/// and lock the contract that cannot be exercised by a normal unit test:
+/// release-triggered, NuGet publish guarded against forks/missing secrets,
+/// self-contained binaries for the three target RIDs, and NO build-time
+/// expiry properties on release artifacts.
+/// </summary>
+public sealed class ReleaseWorkflowContractTests
+{
+    [Fact]
+    public void ReleaseWorkflow_TriggersOnPublishedRelease()
+    {
+        var workflow = File.ReadAllText(LocateReleaseWorkflow());
+
+        Assert.Contains("on:", workflow, StringComparison.Ordinal);
+        Assert.Contains("release:", workflow, StringComparison.Ordinal);
+        Assert.Contains("types: [published]", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_PacksAndPublishesNuGet_GuardedAgainstForksAndMissingSecret()
+    {
+        var workflow = File.ReadAllText(LocateReleaseWorkflow());
+
+        // Packs the official tool package.
+        Assert.Contains("dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj", workflow, StringComparison.Ordinal);
+        // Pushes to NuGet.org.
+        Assert.Contains("dotnet nuget push", workflow, StringComparison.Ordinal);
+        Assert.Contains("https://api.nuget.org/v3/index.json", workflow, StringComparison.Ordinal);
+        // The publish must be guarded: only on a real release, and skip when
+        // the secret is absent (forks / missing NUGET_API_KEY).
+        Assert.Contains("NUGET_API_KEY", workflow, StringComparison.Ordinal);
+        Assert.Contains("github.event_name == 'release'", workflow, StringComparison.Ordinal);
+        Assert.Contains("skipping NuGet publish", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_BuildsSelfContainedBinariesForAllThreeRids()
+    {
+        var workflow = File.ReadAllText(LocateReleaseWorkflow());
+
+        Assert.Contains("--self-contained true", workflow, StringComparison.Ordinal);
+        Assert.Contains("-p:PublishSingleFile=true", workflow, StringComparison.Ordinal);
+        Assert.Contains("osx-arm64", workflow, StringComparison.Ordinal);
+        Assert.Contains("win-x64", workflow, StringComparison.Ordinal);
+        Assert.Contains("linux-x64", workflow, StringComparison.Ordinal);
+        // A --version smoke test proves the binary runs.
+        Assert.Contains("--version", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_AttachesAssetsAndChecksumsToRelease()
+    {
+        var workflow = File.ReadAllText(LocateReleaseWorkflow());
+
+        Assert.Contains("gh release upload", workflow, StringComparison.Ordinal);
+        Assert.Contains(".sha256", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_DoesNotEmbedPreviewExpiryProperties()
+    {
+        var workflow = File.ReadAllText(LocateReleaseWorkflow());
+
+        // Release artifacts must carry no build-time expiry contract — the
+        // PrivatePreview* properties (consumed by the csproj G367 block and
+        // the PrivatePreviewExpiryGate) must never be passed here.
+        Assert.DoesNotContain("PrivatePreviewChannel", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("PrivatePreviewExpiresAt", workflow, StringComparison.Ordinal);
+    }
+
+    private static string LocateReleaseWorkflow()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir.FullName, ".github", "workflows", "release.yml");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new FileNotFoundException("Could not locate .github/workflows/release.yml");
+    }
+}


### PR DESCRIPTION
## Summary

Makes official `intent-cli` distribution release-driven. Adds `.github/workflows/release.yml`, triggered on GitHub Release publication (plus `workflow_dispatch` for dry runs):

- **NuGet**: builds + tests + packs the official `.nupkg` (release build — **no** `PrivatePreview*` expiry properties, so release artifacts carry no build-time expiry) and pushes to NuGet.org **guarded** by `NUGET_API_KEY` presence and a real `release` event — skips cleanly on forks / missing secrets while still building and attaching artifacts.
- **Self-contained binaries**: single-file, runtime-bundled builds for `osx-arm64`, `win-x64`, `linux-x64` on matching runners; smoke-tests `intent-cli --version`; archives each (`.tar.gz` / `.zip`) with a `.sha256` sidecar.
- **Release assets**: attaches the `.nupkg` and per-platform archives + checksums to the triggering release via `gh release upload --clobber`.
- **Docs**: README `## Install` section covering SDK users (`dotnet tool install -g intent-cli`) and non-SDK users (download + checksum-verify + extract).

## Acceptance criteria mapping

- Release → workflow produces a `.nupkg` and publishes to NuGet.org when `NUGET_API_KEY` is present ✓
- Self-contained binaries for macOS/Windows/Linux with clear asset names (`intent-cli-<version>-<rid>.{tar.gz,zip}`) ✓
- Binaries run `intent-cli --version` without a .NET SDK — self-contained single-file (verified locally on osx-arm64; binary is a standalone Mach-O that prints the version) ✓
- No release binary fails due to build-time expiry — release build passes none of the `PrivatePreview*` props, so `PrivatePreviewExpiryGate` treats it as an unrestricted source build ✓
- Docs include both install paths ✓
- Safe on forks / missing secrets — publish step skips, artifacts still built/attached ✓

License metadata is the explicit paired follow-up slice **G387** and is intentionally not added here (the nuspec already carries version + repository URL + readme).

## Verification

- [x] `release.yml` YAML parses (`yaml.safe_load`).
- [x] Local dry-run self-contained publish (`osx-arm64`, single-file) builds and runs `intent-cli --version` SDK-free.
- [x] Local dry-run `dotnet pack` — nuspec includes id/version/authors/readme/description/tags/repository(url+commit).
- [x] `ReleaseWorkflowContractTests` (5) green: release trigger, guarded NuGet publish, three-RID self-contained matrix, asset+checksum attach, no-expiry invariant.
- [x] `git diff --check` clean.
- [ ] End-to-end GitHub Actions run on a real release (cannot run Actions locally; the matrix smoke-tests + checksums are the in-workflow gates).

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)