### PR TITLE
G388: resolve configured implementation base branch in guide before defaulting to main

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -130,7 +130,7 @@ internal static class GuidePromptMatrixCommand
         var branchDecision = ImplementationBaseBranchResolver.Resolve(
             explicitBranch: implementationBase,
             configuredBranch: context.Config.Project.ImplementationBaseBranch,
-            sameRepoTopologyBranch: null,
+            sameRepoTopologyBranch: ResolveSameRepoTopologyBranch(context, topology),
             policyDefaultBranch: policyDefaultBranch,
             allowOverride: allowBaseBranchOverride);
         if (branchDecision.HasConflict)
@@ -171,6 +171,37 @@ internal static class GuidePromptMatrixCommand
         => string.IsNullOrWhiteSpace(baseBranchPolicy)
             ? context.Config.Project.BaseBranchPolicy
             : baseBranchPolicy;
+
+    /// <summary>
+    /// G388 (review follow-up): the same-repo-topology precedence tier of
+    /// <see cref="ImplementationBaseBranchResolver"/>. When same-repo topology
+    /// is in effect — via <c>--topology same-repo</c> or the persisted
+    /// <see cref="ProjectConfig.SameRepoTopology"/> flag — the same-repo
+    /// integration branch (the metadata write branch, falling back to the
+    /// single-field metadata branch) is supplied so the guide resolves a
+    /// topology-derived branch instead of silently defaulting to <c>main</c>
+    /// when no explicit / domain-config branch is set. Returns null when
+    /// same-repo topology is not active or no metadata branch is configured,
+    /// which leaves the resolver to fall through to the policy default.
+    /// </summary>
+    private static string? ResolveSameRepoTopologyBranch(CliContext context, string? topology)
+    {
+        var sameRepo = string.Equals(topology, TopologySameRepo, StringComparison.Ordinal)
+            || context.Config.Project.SameRepoTopology;
+        if (!sameRepo)
+        {
+            return null;
+        }
+
+        var writeBranch = context.Config.Project.MetadataWriteBranch;
+        if (!string.IsNullOrWhiteSpace(writeBranch))
+        {
+            return writeBranch.Trim();
+        }
+
+        var metadataBranch = context.Config.Project.MetadataBranch;
+        return string.IsNullOrWhiteSpace(metadataBranch) ? null : metadataBranch.Trim();
+    }
 
     private static IReadOnlyList<GuidePromptMatrixEntry> BuildEntries(
         CliContext context,

--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -79,7 +79,7 @@ internal static class GuidePromptMatrixCommand
     private const string TopologySameRepo = "same-repo";
 
     private const string UsageLine =
-        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--topology same-repo] [--domain <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic|copilot|copilot-cloud|copilot-local] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--format markdown|json]";
+        "Usage: intent-cli guide prompt-matrix [--mode child-loop|host-loop|child-oneshot|host-oneshot] [--topology same-repo] [--domain <name>] [--target-repo <owner/repo>] [--agent claude|codex|generic|copilot|copilot-cloud|copilot-local] [--frequency <NNm|NNh>] [--base-branch-policy direct-main|main-ai] [--implementation-base <branch>] [--allow-base-branch-override] [--format markdown|json]";
 
     private static readonly string[] ForbiddenSources =
     [
@@ -112,14 +112,34 @@ internal static class GuidePromptMatrixCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var mode, out var format, out var domain, out var targetRepo, out var agent, out var frequency, out var baseBranchPolicy, out var topology, out var error))
+        if (!TryParseArguments(args, out var mode, out var format, out var domain, out var targetRepo, out var agent, out var frequency, out var baseBranchPolicy, out var topology, out var implementationBase, out var allowBaseBranchOverride, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
             return 1;
         }
 
-        var entries = BuildEntries(context, mode, domain, targetRepo, agent, frequency, baseBranchPolicy, topology);
+        // G388: resolve the effective implementation / PR base branch via the
+        // shared precedence resolver (explicit arg > domain config > same-repo
+        // topology > policy default) so the guide is the deterministic source
+        // of the branch and agrees with `automation summary`. A conflict
+        // between an explicit branch and the configured branch is a hard stop
+        // unless --allow-base-branch-override was passed.
+        var resolvedPolicy = ResolveEffectivePolicy(context, baseBranchPolicy);
+        var policyDefaultBranch = BaseBranchPolicyContract.ResolveExpectedBaseBranch(resolvedPolicy);
+        var branchDecision = ImplementationBaseBranchResolver.Resolve(
+            explicitBranch: implementationBase,
+            configuredBranch: context.Config.Project.ImplementationBaseBranch,
+            sameRepoTopologyBranch: null,
+            policyDefaultBranch: policyDefaultBranch,
+            allowOverride: allowBaseBranchOverride);
+        if (branchDecision.HasConflict)
+        {
+            writer.WriteLine(branchDecision.Diagnostic);
+            return 1;
+        }
+
+        var entries = BuildEntries(context, mode, domain, targetRepo, agent, frequency, baseBranchPolicy, topology, branchDecision, policyDefaultBranch);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -142,6 +162,16 @@ internal static class GuidePromptMatrixCommand
         return 0;
     }
 
+    /// <summary>
+    /// G346/G388: when <c>--base-branch-policy</c> is omitted, fall back to the
+    /// persisted host/domain config value (default <c>direct-main</c> when not
+    /// configured).
+    /// </summary>
+    private static string ResolveEffectivePolicy(CliContext context, string? baseBranchPolicy)
+        => string.IsNullOrWhiteSpace(baseBranchPolicy)
+            ? context.Config.Project.BaseBranchPolicy
+            : baseBranchPolicy;
+
     private static IReadOnlyList<GuidePromptMatrixEntry> BuildEntries(
         CliContext context,
         string? mode,
@@ -150,15 +180,13 @@ internal static class GuidePromptMatrixCommand
         string? agent,
         string? frequency,
         string? baseBranchPolicy,
-        string? topology)
+        string? topology,
+        ImplementationBaseBranchDecision branchDecision,
+        string policyDefaultBranch)
     {
         var domainPlaceholder = string.IsNullOrWhiteSpace(domain) ? "<DOMAIN>" : domain;
         var targetRepoPlaceholder = string.IsNullOrWhiteSpace(targetRepo) ? "<TARGET-REPO>" : targetRepo;
-        // G346: when --base-branch-policy is omitted, fall back to the persisted
-        // host/domain config value (default direct-main when not configured).
-        var resolvedPolicy = string.IsNullOrWhiteSpace(baseBranchPolicy)
-            ? context.Config.Project.BaseBranchPolicy
-            : baseBranchPolicy;
+        var resolvedPolicy = ResolveEffectivePolicy(context, baseBranchPolicy);
 
         var isSameRepo = string.Equals(topology, TopologySameRepo, StringComparison.Ordinal);
 
@@ -200,18 +228,66 @@ internal static class GuidePromptMatrixCommand
                     : BuildHostOneshot(domainPlaceholder, targetRepoPlaceholder, resolvedPolicy)
         };
 
-        if (mode is null)
+        IReadOnlyList<GuidePromptMatrixEntry> selected = mode is null
+            ? all
+            : mode switch
+            {
+                ModeChildLoop => [all[0]],
+                ModeHostLoop => [all[1]],
+                ModeChildOneshot => [all[2]],
+                ModeHostOneshot => [all[3]],
+                _ => all
+            };
+
+        // G388: apply the resolved effective implementation/PR base branch so
+        // every entry reports the same branch as `automation summary`. For the
+        // policy default (no config/explicit override) this is a no-op and the
+        // entries are byte-identical to the pre-G388 output.
+        return selected
+            .Select(entry => ApplyEffectiveBaseBranch(entry, branchDecision, policyDefaultBranch))
+            .ToList();
+    }
+
+    /// <summary>
+    /// G388: rewrite an entry's expected base branch to the resolved effective
+    /// branch. When the effective branch differs from the policy default (a
+    /// configured / explicit / topology override) the rendered
+    /// <c>expected base branch: `&lt;default&gt;`</c> token and the
+    /// <c>expected_base_branch</c> field are updated and an override note is
+    /// appended. The resolution source / default-note are always recorded as
+    /// structured fields so the guide states whether the branch is a default
+    /// and where to configure a different one.
+    /// </summary>
+    private static GuidePromptMatrixEntry ApplyEffectiveBaseBranch(
+        GuidePromptMatrixEntry entry,
+        ImplementationBaseBranchDecision decision,
+        string policyDefaultBranch)
+    {
+        var prompt = entry.Prompt;
+        var expected = entry.ExpectedBaseBranch;
+
+        var isOverride = !string.IsNullOrEmpty(expected)
+            && !string.Equals(decision.Branch, policyDefaultBranch, StringComparison.Ordinal);
+        if (isOverride)
         {
-            return all;
+            prompt = prompt.Replace(
+                $"expected base branch: `{policyDefaultBranch}`",
+                $"expected base branch: `{decision.Branch}`",
+                StringComparison.Ordinal);
+            prompt +=
+                $"\n\n> Effective implementation / PR base branch: `{decision.Branch}` "
+                + $"(source: {decision.Source}). This overrides the `{policyDefaultBranch}` "
+                + $"base-branch-policy default; open the PR against `{decision.Branch}`.";
+            expected = decision.Branch;
         }
 
-        return mode switch
+        return entry with
         {
-            ModeChildLoop => [all[0]],
-            ModeHostLoop => [all[1]],
-            ModeChildOneshot => [all[2]],
-            ModeHostOneshot => [all[3]],
-            _ => all
+            ExpectedBaseBranch = expected,
+            ImplementationBaseBranchSource = decision.Source,
+            ImplementationBaseBranchIsDefault = decision.IsDefault,
+            ImplementationBaseBranchNote = string.IsNullOrEmpty(decision.Note) ? null : decision.Note,
+            Prompt = prompt,
         };
     }
 
@@ -1271,6 +1347,8 @@ Hard rules:
         out string? frequency,
         out string? baseBranchPolicy,
         out string? topology,
+        out string? implementationBase,
+        out bool allowBaseBranchOverride,
         out string error)
     {
         mode = null;
@@ -1281,6 +1359,8 @@ Hard rules:
         frequency = null;
         baseBranchPolicy = null;
         topology = null;
+        implementationBase = null;
+        allowBaseBranchOverride = false;
         error = string.Empty;
 
         for (var index = 0; index < args.Length; index++)
@@ -1403,6 +1483,25 @@ Hard rules:
                     index++;
                     break;
 
+                case "--implementation-base":
+                    // G388: explicit operator-supplied implementation / PR base
+                    // branch. Highest precedence; validated against the
+                    // configured branch unless --allow-base-branch-override.
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--implementation-base requires a value (e.g. develop-v2).";
+                        return false;
+                    }
+                    implementationBase = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--allow-base-branch-override":
+                    // G388: let an explicit --implementation-base win over a
+                    // differing configured branch instead of producing a conflict.
+                    allowBaseBranchOverride = true;
+                    break;
+
                 case "--topology":
                     // G348: only 'same-repo' is a recognized topology value.
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
@@ -1446,6 +1545,8 @@ Hard rules:
         writer.WriteLine("--agent values: claude (same-thread `/loop`), codex (current-thread heartbeat), generic, copilot / copilot-cloud (G345 — cloud/assignment-oriented; supported for child-oneshot, returns structured unsupported-loop guidance for child-loop, structured host-oneshot-human-driven guidance for host-oneshot, and structured unsupported-mode-agent-combination for host-loop), copilot-local (G349 — local Copilot coding-agent in a host cwd; can exec intent-cli for host operations; child cwd usage remains host-state-free).");
         writer.WriteLine("--frequency examples: 5m, 20m, 1h. Omit to keep the rendered prompt's ask-the-operator instruction.");
         writer.WriteLine($"--base-branch-policy values: {CliRuntimeContracts.DirectMainBaseBranchPolicy} (default; child PRs target `{CliRuntimeContracts.DirectMainBaseBranch}`), {CliRuntimeContracts.MainAiBaseBranchPolicy} (child PRs target `{CliRuntimeContracts.MainAiIntegrationBaseBranch}`).");
+        writer.WriteLine("--implementation-base <branch> (G388): explicit implementation/PR base branch. Highest precedence; resolution order is explicit > domain config (`implementation_base_branch`) > same-repo topology > policy default. A configured branch (e.g. `develop-v2`) is emitted as the expected base branch instead of the policy default. An explicit value conflicting with the configured branch is a hard stop unless --allow-base-branch-override is passed.");
+        writer.WriteLine("--allow-base-branch-override (G388): let --implementation-base win over a differing configured branch instead of erroring with a conflict diagnostic.");
         writer.WriteLine($"--topology values: {TopologySameRepo} (G348 — adds same-repo forbidden-path guidance to child prompts; host intent metadata paths `.intent-cli/**` and `intents/**` are visible but forbidden for implementation agents).");
     }
 
@@ -1491,6 +1592,28 @@ internal sealed record GuidePromptMatrixEntry
 
     [JsonPropertyName("expected_base_branch")]
     public string? ExpectedBaseBranch { get; init; }
+
+    /// <summary>
+    /// G388: which precedence tier resolved the expected base branch
+    /// (<c>explicit-argument</c> / <c>domain-config</c> /
+    /// <c>same-repo-topology</c> / <c>policy-default</c>).
+    /// </summary>
+    [JsonPropertyName("implementation_base_branch_source")]
+    public string? ImplementationBaseBranchSource { get; init; }
+
+    /// <summary>
+    /// G388: true when the expected base branch is the policy default rather
+    /// than a configured / explicit value.
+    /// </summary>
+    [JsonPropertyName("implementation_base_branch_is_default")]
+    public bool? ImplementationBaseBranchIsDefault { get; init; }
+
+    /// <summary>
+    /// G388: operator-facing note stating that the branch is a default and
+    /// where to configure a different one; null when not defaulting.
+    /// </summary>
+    [JsonPropertyName("implementation_base_branch_note")]
+    public string? ImplementationBaseBranchNote { get; init; }
 
     /// <summary>
     /// G348: topology hint; <c>"same-repo"</c> when <c>--topology same-repo</c>

--- a/src/IntentSystem.Cli/Commands/ImplementationBaseBranchResolver.cs
+++ b/src/IntentSystem.Cli/Commands/ImplementationBaseBranchResolver.cs
@@ -1,0 +1,158 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G388: pure resolver for the effective implementation / PR base branch that
+/// <c>intent-cli guide</c> emits, so the guide is the deterministic source of
+/// the fixed branch condition instead of an AI agent hand-reading local files.
+///
+/// The reported bug: a domain configured with
+/// <c>implementation_base_branch = develop-v2</c> still saw <c>guide</c> emit
+/// the <c>direct-main/main</c> default, because the guide consulted only the
+/// <c>base_branch_policy</c> name and not the configured branch (which
+/// <c>automation summary</c> already honors via G350/G362). This resolver
+/// centralizes the precedence so every guide surface agrees with
+/// <c>automation summary</c>:
+///
+/// <list type="number">
+/// <item><description>explicit CLI / setup argument (<c>--implementation-base</c>)</description></item>
+/// <item><description>domain config / automation bindings (<c>implementation_base_branch</c>)</description></item>
+/// <item><description>same-repo topology mapping when applicable</description></item>
+/// <item><description>default from the base-branch policy (<c>direct-main</c> → <c>main</c>)</description></item>
+/// </list>
+///
+/// When an explicit argument and a configured branch disagree the resolver
+/// returns a structured conflict (so the guide can refuse rather than silently
+/// pick one) unless an explicit override is allowed. When nothing is
+/// configured it returns the policy default flagged as a default, with a note
+/// telling the operator where to configure a different branch.
+///
+/// No I/O — the command layer supplies the candidate strings (read from config
+/// / bindings / args), so every branch is unit-testable.
+/// </summary>
+internal static class ImplementationBaseBranchResolver
+{
+    /// <summary>Where the resolved branch came from (the winning precedence tier).</summary>
+    public static class Sources
+    {
+        public const string Explicit = "explicit-argument";
+        public const string DomainConfig = "domain-config";
+        public const string SameRepoTopology = "same-repo-topology";
+        public const string Default = "policy-default";
+        public const string Conflict = "conflict";
+    }
+
+    /// <summary>
+    /// Resolve the effective implementation / PR base branch.
+    /// </summary>
+    /// <param name="explicitBranch">Operator-supplied branch (e.g. <c>--implementation-base develop-v2</c>); highest precedence.</param>
+    /// <param name="configuredBranch">Branch from domain config / bindings (<c>implementation_base_branch</c>).</param>
+    /// <param name="sameRepoTopologyBranch">Branch implied by same-repo topology mapping, when applicable.</param>
+    /// <param name="policyDefaultBranch">The base-branch-policy default (e.g. <c>main</c> for <c>direct-main</c>); the final fallback.</param>
+    /// <param name="allowOverride">When true an explicit branch wins over a differing configured branch instead of producing a conflict.</param>
+    public static ImplementationBaseBranchDecision Resolve(
+        string? explicitBranch,
+        string? configuredBranch,
+        string? sameRepoTopologyBranch,
+        string policyDefaultBranch,
+        bool allowOverride = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(policyDefaultBranch);
+
+        var explicitTrimmed = Normalize(explicitBranch);
+        var configTrimmed = Normalize(configuredBranch);
+        var topologyTrimmed = Normalize(sameRepoTopologyBranch);
+        var defaultTrimmed = Normalize(policyDefaultBranch);
+
+        // Conflict: an explicit branch disagrees with the configured branch and
+        // no override was requested. Refuse with a structured diagnostic rather
+        // than silently choosing one.
+        if (explicitTrimmed.Length > 0
+            && configTrimmed.Length > 0
+            && !string.Equals(explicitTrimmed, configTrimmed, StringComparison.Ordinal)
+            && !allowOverride)
+        {
+            return new ImplementationBaseBranchDecision
+            {
+                Resolved = false,
+                Branch = string.Empty,
+                Source = Sources.Conflict,
+                IsDefault = false,
+                HasConflict = true,
+                Diagnostic =
+                    $"implementation base branch conflict: explicit '--implementation-base {explicitTrimmed}' "
+                    + $"disagrees with the configured 'implementation_base_branch = {configTrimmed}'. "
+                    + "Re-run with the matching branch, fix the domain config, or pass the override flag "
+                    + "to intentionally use the explicit branch.",
+                Note = string.Empty,
+            };
+        }
+
+        if (explicitTrimmed.Length > 0)
+        {
+            return Decision(explicitTrimmed, Sources.Explicit, isDefault: false);
+        }
+
+        if (configTrimmed.Length > 0)
+        {
+            return Decision(configTrimmed, Sources.DomainConfig, isDefault: false);
+        }
+
+        if (topologyTrimmed.Length > 0)
+        {
+            return Decision(topologyTrimmed, Sources.SameRepoTopology, isDefault: false);
+        }
+
+        return new ImplementationBaseBranchDecision
+        {
+            Resolved = true,
+            Branch = defaultTrimmed,
+            Source = Sources.Default,
+            IsDefault = true,
+            HasConflict = false,
+            Diagnostic = string.Empty,
+            Note =
+                $"using policy default base branch '{defaultTrimmed}'. "
+                + "To target a different branch, set 'implementation_base_branch' in the domain config / "
+                + "automation bindings, or pass '--implementation-base <branch>'.",
+        };
+    }
+
+    private static ImplementationBaseBranchDecision Decision(string branch, string source, bool isDefault)
+        => new()
+        {
+            Resolved = true,
+            Branch = branch,
+            Source = source,
+            IsDefault = isDefault,
+            HasConflict = false,
+            Diagnostic = string.Empty,
+            Note = string.Empty,
+        };
+
+    private static string Normalize(string? value) => (value ?? string.Empty).Trim();
+}
+
+/// <summary>G388: the verdict from <see cref="ImplementationBaseBranchResolver.Resolve"/>.</summary>
+internal sealed record ImplementationBaseBranchDecision
+{
+    /// <summary>True when a branch was resolved; false only on an unresolved conflict.</summary>
+    public required bool Resolved { get; init; }
+
+    /// <summary>The effective implementation / PR base branch (empty on conflict).</summary>
+    public required string Branch { get; init; }
+
+    /// <summary>Which precedence tier won (see <see cref="ImplementationBaseBranchResolver.Sources"/>).</summary>
+    public required string Source { get; init; }
+
+    /// <summary>True when the branch is the policy default rather than an explicit/configured value.</summary>
+    public required bool IsDefault { get; init; }
+
+    /// <summary>True when an explicit branch conflicted with a configured branch and no override was allowed.</summary>
+    public required bool HasConflict { get; init; }
+
+    /// <summary>Operator-facing conflict diagnostic (set only when <see cref="HasConflict"/>).</summary>
+    public required string Diagnostic { get; init; }
+
+    /// <summary>Operator-facing note explaining a defaulted branch and where to configure it (set only when <see cref="IsDefault"/>).</summary>
+    public required string Note { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -2480,4 +2480,108 @@ public sealed class GuidePromptMatrixCommandTests
         Assert.Contains("stale-review-lease", prompt, StringComparison.Ordinal);
         Assert.Contains("workspace-safe-dirty", prompt, StringComparison.Ordinal);
     }
+
+    // ── G388 implementation base branch resolution ──────────────────────────
+
+    [Fact]
+    public void Execute_G388_DomainConfigDevelopV2_EmitsDevelopV2AsExpectedBaseBranch()
+    {
+        // AC: domain config implementation_base_branch=develop-v2 must make the
+        // guide emit develop-v2, not the direct-main/main default.
+        using var writer = new StringWriter();
+        var exit = GuidePromptMatrixCommand.Execute(
+            CreateContextWithImplementationBaseBranch("develop-v2"),
+            ["--mode", "child-loop", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        var root = JsonDocument.Parse(writer.ToString()).RootElement;
+        Assert.Equal("develop-v2", root.GetProperty("expected_base_branch").GetString());
+        Assert.Equal("domain-config", root.GetProperty("implementation_base_branch_source").GetString());
+        Assert.False(root.GetProperty("implementation_base_branch_is_default").GetBoolean());
+        Assert.Contains("expected base branch: `develop-v2`", root.GetProperty("prompt").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G388_NoConfig_DefaultsToMain_AndStatesItIsADefault()
+    {
+        using var writer = new StringWriter();
+        var exit = GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "child-loop", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        var root = JsonDocument.Parse(writer.ToString()).RootElement;
+        Assert.Equal("main", root.GetProperty("expected_base_branch").GetString());
+        Assert.Equal("policy-default", root.GetProperty("implementation_base_branch_source").GetString());
+        Assert.True(root.GetProperty("implementation_base_branch_is_default").GetBoolean());
+        // Must state where to configure a different branch.
+        Assert.Contains("implementation_base_branch", root.GetProperty("implementation_base_branch_note").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G388_ExplicitImplementationBaseOverride_WinsOverConfig()
+    {
+        using var writer = new StringWriter();
+        var exit = GuidePromptMatrixCommand.Execute(
+            CreateContextWithImplementationBaseBranch("main"),
+            ["--mode", "child-loop", "--implementation-base", "develop-v2", "--allow-base-branch-override", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        var root = JsonDocument.Parse(writer.ToString()).RootElement;
+        Assert.Equal("develop-v2", root.GetProperty("expected_base_branch").GetString());
+        Assert.Equal("explicit-argument", root.GetProperty("implementation_base_branch_source").GetString());
+    }
+
+    [Fact]
+    public void Execute_G388_ExplicitConflictsWithConfig_NoOverride_FailsWithDiagnostic()
+    {
+        using var writer = new StringWriter();
+        var exit = GuidePromptMatrixCommand.Execute(
+            CreateContextWithImplementationBaseBranch("develop-v2"),
+            ["--mode", "child-loop", "--implementation-base", "main", "--format", "json"],
+            writer);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("conflict", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("develop-v2", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G388_DevelopV2_AllModesAgreeOnExpectedBaseBranch()
+    {
+        // AC: prompt-matrix entries agree on the same effective branch for the
+        // same cwd/domain/repo (consistency with automation summary).
+        using var writer = new StringWriter();
+        var exit = GuidePromptMatrixCommand.Execute(
+            CreateContextWithImplementationBaseBranch("develop-v2"),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        foreach (var entry in JsonDocument.Parse(writer.ToString()).RootElement.EnumerateArray())
+        {
+            Assert.Equal("develop-v2", entry.GetProperty("expected_base_branch").GetString());
+        }
+    }
+
+    private static CliContext CreateContextWithImplementationBaseBranch(string implementationBaseBranch)
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "aic",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                    ImplementationBaseBranch = implementationBaseBranch
+                }
+            }
+        };
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -2567,6 +2567,44 @@ public sealed class GuidePromptMatrixCommandTests
         }
     }
 
+    [Fact]
+    public void Execute_G388_SameRepoTopology_ResolvesMetadataWriteBranch_WhenNoExplicitOrConfig()
+    {
+        // Review follow-up: the same-repo topology precedence tier must be
+        // reachable at the command level — with same-repo topology active and
+        // no explicit/domain-config branch, the guide resolves the same-repo
+        // integration (metadata write) branch instead of defaulting to main.
+        using var writer = new StringWriter();
+        var exit = GuidePromptMatrixCommand.Execute(
+            CreateContextWithSameRepoTopology(metadataWriteBranch: "main-metadata"),
+            ["--mode", "child-loop", "--topology", "same-repo", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        var root = JsonDocument.Parse(writer.ToString()).RootElement;
+        Assert.Equal("main-metadata", root.GetProperty("expected_base_branch").GetString());
+        Assert.Equal("same-repo-topology", root.GetProperty("implementation_base_branch_source").GetString());
+        Assert.False(root.GetProperty("implementation_base_branch_is_default").GetBoolean());
+        Assert.Contains("expected base branch: `main-metadata`", root.GetProperty("prompt").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G388_DomainConfig_WinsOverSameRepoTopologyBranch()
+    {
+        // Precedence: domain config (implementation_base_branch) outranks the
+        // same-repo topology tier.
+        using var writer = new StringWriter();
+        var exit = GuidePromptMatrixCommand.Execute(
+            CreateContextWithSameRepoTopology(metadataWriteBranch: "main-metadata", implementationBaseBranch: "develop-v2"),
+            ["--mode", "child-loop", "--topology", "same-repo", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        var root = JsonDocument.Parse(writer.ToString()).RootElement;
+        Assert.Equal("develop-v2", root.GetProperty("expected_base_branch").GetString());
+        Assert.Equal("domain-config", root.GetProperty("implementation_base_branch_source").GetString());
+    }
+
     private static CliContext CreateContextWithImplementationBaseBranch(string implementationBaseBranch)
     {
         return new CliContext
@@ -2579,6 +2617,28 @@ public sealed class GuidePromptMatrixCommandTests
                     Domain = "aic",
                     ArtifactRoot = ".intent-cli",
                     WorktreeRoot = ".intent-cli/worktrees",
+                    ImplementationBaseBranch = implementationBaseBranch
+                }
+            }
+        };
+    }
+
+    private static CliContext CreateContextWithSameRepoTopology(
+        string metadataWriteBranch,
+        string implementationBaseBranch = "")
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "aic",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                    SameRepoTopology = true,
+                    MetadataWriteBranch = metadataWriteBranch,
                     ImplementationBaseBranch = implementationBaseBranch
                 }
             }

--- a/tests/IntentSystem.Cli.Tests/ImplementationBaseBranchResolverTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ImplementationBaseBranchResolverTests.cs
@@ -1,0 +1,118 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G388: tests for the pure implementation/PR base-branch precedence resolver.
+/// Covers the four required cases — a <c>develop-v2</c> domain config, the
+/// direct-main default, an explicit override, and an explicit/config conflict —
+/// plus the same-repo topology tier and the defaulted-branch note.
+/// </summary>
+public sealed class ImplementationBaseBranchResolverTests
+{
+    [Fact]
+    public void Resolve_DomainConfigDevelopV2_WinsOverPolicyDefault()
+    {
+        var decision = ImplementationBaseBranchResolver.Resolve(
+            explicitBranch: null,
+            configuredBranch: "develop-v2",
+            sameRepoTopologyBranch: null,
+            policyDefaultBranch: "main");
+
+        Assert.True(decision.Resolved);
+        Assert.Equal("develop-v2", decision.Branch);
+        Assert.Equal(ImplementationBaseBranchResolver.Sources.DomainConfig, decision.Source);
+        Assert.False(decision.IsDefault);
+        Assert.False(decision.HasConflict);
+    }
+
+    [Fact]
+    public void Resolve_NoConfig_DefaultsToPolicyBranch_WithNote()
+    {
+        var decision = ImplementationBaseBranchResolver.Resolve(
+            explicitBranch: null,
+            configuredBranch: null,
+            sameRepoTopologyBranch: null,
+            policyDefaultBranch: "main");
+
+        Assert.True(decision.Resolved);
+        Assert.Equal("main", decision.Branch);
+        Assert.Equal(ImplementationBaseBranchResolver.Sources.Default, decision.Source);
+        Assert.True(decision.IsDefault);
+        Assert.False(decision.HasConflict);
+        // Must state it is a default and where to configure a different branch.
+        Assert.Contains("default", decision.Note, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("implementation_base_branch", decision.Note, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Resolve_ExplicitArgument_WinsOverConfig_WhenOverrideAllowed()
+    {
+        var decision = ImplementationBaseBranchResolver.Resolve(
+            explicitBranch: "develop-v2",
+            configuredBranch: "main",
+            sameRepoTopologyBranch: null,
+            policyDefaultBranch: "main",
+            allowOverride: true);
+
+        Assert.True(decision.Resolved);
+        Assert.Equal("develop-v2", decision.Branch);
+        Assert.Equal(ImplementationBaseBranchResolver.Sources.Explicit, decision.Source);
+        Assert.False(decision.HasConflict);
+    }
+
+    [Fact]
+    public void Resolve_ExplicitConflictsWithConfig_NoOverride_ReturnsStructuredConflict()
+    {
+        var decision = ImplementationBaseBranchResolver.Resolve(
+            explicitBranch: "main",
+            configuredBranch: "develop-v2",
+            sameRepoTopologyBranch: null,
+            policyDefaultBranch: "main",
+            allowOverride: false);
+
+        Assert.False(decision.Resolved);
+        Assert.True(decision.HasConflict);
+        Assert.Equal(ImplementationBaseBranchResolver.Sources.Conflict, decision.Source);
+        Assert.Equal(string.Empty, decision.Branch);
+        Assert.Contains("conflict", decision.Diagnostic, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("develop-v2", decision.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Resolve_ExplicitMatchesConfig_NoConflict()
+    {
+        var decision = ImplementationBaseBranchResolver.Resolve(
+            explicitBranch: "develop-v2",
+            configuredBranch: "develop-v2",
+            sameRepoTopologyBranch: null,
+            policyDefaultBranch: "main");
+
+        Assert.True(decision.Resolved);
+        Assert.False(decision.HasConflict);
+        Assert.Equal("develop-v2", decision.Branch);
+        Assert.Equal(ImplementationBaseBranchResolver.Sources.Explicit, decision.Source);
+    }
+
+    [Fact]
+    public void Resolve_SameRepoTopology_UsedWhenNoExplicitOrConfig()
+    {
+        var decision = ImplementationBaseBranchResolver.Resolve(
+            explicitBranch: null,
+            configuredBranch: null,
+            sameRepoTopologyBranch: "main-metadata",
+            policyDefaultBranch: "main");
+
+        Assert.True(decision.Resolved);
+        Assert.Equal("main-metadata", decision.Branch);
+        Assert.Equal(ImplementationBaseBranchResolver.Sources.SameRepoTopology, decision.Source);
+        Assert.False(decision.IsDefault);
+    }
+
+    [Fact]
+    public void Resolve_BlankPolicyDefault_Throws()
+    {
+        Assert.Throws<ArgumentException>(
+            () => ImplementationBaseBranchResolver.Resolve(null, null, null, "  "));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the reported bug where a domain configured with `implementation_base_branch = develop-v2` still saw `intent-cli guide` emit the `direct-main/main` default (because the guide consulted only the policy name, not the configured branch that `automation summary` already honors via G350/G362).

- **New pure `ImplementationBaseBranchResolver`** — precedence: **explicit argument → domain config (`implementation_base_branch`) → same-repo topology → policy default**. Returns a structured **conflict** when an explicit branch disagrees with the configured branch (unless overridden), and a **default note** stating it is a default and where to configure a different branch.
- **Wired into `guide prompt-matrix`**: a configured branch such as `develop-v2` is now emitted as the expected PR base branch across all modes, so the guide agrees with `automation summary`. Added `--implementation-base <branch>` and `--allow-base-branch-override`; a conflicting explicit branch is a hard stop with a diagnostic (exit 1). New structured fields `implementation_base_branch_source` / `_is_default` / `_note` record the resolution and default guidance.
- **Default-config output is byte-identical** to pre-G388 (the override path only triggers when a non-default branch is resolved), so all existing prompt-matrix tests pass unchanged.

## Acceptance criteria mapping

- develop-v2 config → guide emits `develop-v2` ✓ (`expected_base_branch=develop-v2`, source `domain-config`)
- explicit `--implementation-base` validated/used ✓
- conflicting config + explicit → structured conflict diagnostic unless override ✓
- missing config → defaults to `main`, states it is a default + where to configure (`implementation_base_branch_source=policy-default`, `_note`) ✓
- automation summary and prompt-matrix agree ✓ (both prefer `config.ImplementationBaseBranch` over the policy default; all-modes agreement covered by a test)
- tests cover develop-v2 / direct-main default / explicit override / conflict ✓

## Scope note

This delivers the resolver + the canonical `guide prompt-matrix` surface (the loop-setup prompt generator named in the bug report). The remaining acceptance items that touch **host-owned spec docs** (`intents/intent-cli/specs/05-…`, `18-…`) are not present in this GitHub-contract-only child worktree (G300/G330/G333), and the dedicated workflow-task setup-prompt slot / host-init injection are reachable follow-ups that can reuse this resolver. Child guidance remains host-state-free and GitHub-only (unchanged, not regressed).

## Verification

- [x] `ImplementationBaseBranchResolverTests` (7) + 5 new `GuidePromptMatrixCommandTests` green.
- [x] Full `IntentSystem.Cli.Tests` suite: **3335 passed, 1 skipped, 0 failed** (existing prompt-matrix output byte-identical for default config).
- [x] `dotnet build` clean; `git diff --check` clean.

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)