### PR TITLE
G389: enforce child worker terminal contracts (ambiguous-contract + terminal-outcome metadata)

### DIFF
--- a/src/IntentSystem.Cli/Commands/IssueContractAmbiguityAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/IssueContractAmbiguityAnalyzer.cs
@@ -1,0 +1,100 @@
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G389: pure detector for an ambiguous child-implementation contract — an
+/// issue that declares more than one execution-unit / packet identity as its
+/// primary scope. The observed failure: a child loop selected an issue that
+/// bundled multiple packets, made partial local commits, and released the
+/// lease without a PR. <c>issue-to-pr</c> requires exactly one self-contained
+/// unit of work, so <c>worker complete</c> uses this to refuse with
+/// <c>ambiguous-contract</c> rather than completing a multi-unit issue.
+///
+/// Precision matters: a normal issue lists several prior units under a
+/// <c>## Related Links</c> section (e.g. <c>- G300 ...</c>, <c>- G311 ...</c>),
+/// which must NOT be treated as the issue's own scope. Only PRIMARY identity
+/// declarations count:
+/// <list type="bullet">
+/// <item><description>the leading <c>G&lt;n&gt;</c> of the issue title;</description></item>
+/// <item><description>the leading <c>G&lt;n&gt;</c> of any H1 (<c>#</c>) heading.</description></item>
+/// </list>
+/// Incidental references in body prose, bullet lists, and <c>##</c>/lower
+/// sections (Related Links, etc.) are ignored. More than one distinct primary
+/// unit ⇒ ambiguous.
+///
+/// No I/O — the command layer supplies the title/body strings, so the detector
+/// is fully unit-testable.
+/// </summary>
+internal static partial class IssueContractAmbiguityAnalyzer
+{
+    public static IssueContractAmbiguityResult Analyze(string? title, string? body)
+    {
+        var units = new SortedSet<string>(StringComparer.Ordinal);
+
+        var titleUnit = ExtractLeadingUnit(title);
+        if (titleUnit is not null)
+        {
+            units.Add(titleUnit);
+        }
+
+        var normalized = (body ?? string.Empty).Replace("\r\n", "\n", StringComparison.Ordinal);
+        foreach (var rawLine in normalized.Split('\n'))
+        {
+            var trimmed = rawLine.TrimStart();
+            // H1 only: starts with "# " but not "## " (lower headings and
+            // bullet lists like Related Links are intentionally excluded).
+            if (!trimmed.StartsWith("# ", StringComparison.Ordinal)
+                || trimmed.StartsWith("## ", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var headingUnit = ExtractLeadingUnit(trimmed[2..]);
+            if (headingUnit is not null)
+            {
+                units.Add(headingUnit);
+            }
+        }
+
+        var isAmbiguous = units.Count > 1;
+        var unitList = units.ToArray();
+        return new IssueContractAmbiguityResult
+        {
+            IsAmbiguous = isAmbiguous,
+            PrimaryUnits = unitList,
+            Diagnostic = isAmbiguous
+                ? $"issue declares multiple execution-unit / packet identities ({string.Join(", ", unitList)}); "
+                  + "issue-to-pr requires a single self-contained unit of work. Split the issue into one packet "
+                  + "per execution unit on the host/design side, then re-select."
+                : string.Empty,
+        };
+    }
+
+    private static string? ExtractLeadingUnit(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        var match = LeadingUnitRegex().Match(text.Trim());
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    [GeneratedRegex(@"^(G\d+)\b", RegexOptions.CultureInvariant)]
+    private static partial Regex LeadingUnitRegex();
+}
+
+/// <summary>G389: the verdict from <see cref="IssueContractAmbiguityAnalyzer.Analyze"/>.</summary>
+internal sealed record IssueContractAmbiguityResult
+{
+    /// <summary>True when more than one distinct primary execution-unit identity was declared.</summary>
+    public required bool IsAmbiguous { get; init; }
+
+    /// <summary>The distinct primary execution-unit identities found (title + H1 headings).</summary>
+    public required IReadOnlyList<string> PrimaryUnits { get; init; }
+
+    /// <summary>Operator-facing diagnostic (set only when <see cref="IsAmbiguous"/>).</summary>
+    public required string Diagnostic { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
@@ -118,6 +118,17 @@ internal static class WorkerCompleteCommand
             return 1;
         }
 
+        // G389: refuse to complete an issue whose contract bundles multiple
+        // execution-unit / packet identities — `issue-to-pr` requires a single
+        // self-contained unit of work, not a multi-packet issue. Best-effort:
+        // an inconclusive issue lookup allows completion so a transient `gh`
+        // failure never blocks a valid single-unit PR.
+        if (isPrCreatedOutcome
+            && TryCheckIssueContractAmbiguity(repo!, number, writer) == IssueContractCheckOutcome.Ambiguous)
+        {
+            return 1;
+        }
+
         // G311: gate `--kind issue --outcome pr-created` on a deterministic
         // GitHub closing reference (`Closes/Fixes/Resolves #<source-issue>`)
         // in the PR body. Refuse to mark complete when the reference is
@@ -460,6 +471,61 @@ internal static class WorkerCompleteCommand
     /// returns <see cref="BaseBranchCheckOutcome.Ok"/> on match or when the check is
     /// inconclusive (lookup error, section absent).
     /// </summary>
+    /// <summary>
+    /// G389: outcome of the multi-packet contract-ambiguity gate.
+    /// </summary>
+    private enum IssueContractCheckOutcome
+    {
+        /// <summary>Single-unit contract (or inconclusive lookup) — completion may proceed.</summary>
+        Ok,
+        /// <summary>Issue declares multiple execution-unit / packet identities — refuse.</summary>
+        Ambiguous,
+    }
+
+    /// <summary>
+    /// G389: fetch the source issue and refuse completion when its contract
+    /// declares more than one execution-unit / packet identity (see
+    /// <see cref="IssueContractAmbiguityAnalyzer"/>). Best-effort: an
+    /// inconclusive lookup returns <see cref="IssueContractCheckOutcome.Ok"/>
+    /// so transient GitHub failures do not block a valid single-unit PR.
+    /// </summary>
+    private static IssueContractCheckOutcome TryCheckIssueContractAmbiguity(
+        string repo,
+        int issueNumber,
+        TextWriter writer)
+    {
+        IGitHubIssueLookup issueLookup;
+        try
+        {
+            issueLookup = IssueLookupFactory?.Invoke() ?? new GhCliGitHubIssueLookup();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            return IssueContractCheckOutcome.Ok;
+        }
+
+        GitHubIssueLookupResult issueResult;
+        try
+        {
+            issueResult = issueLookup.Lookup(repo, issueNumber);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            _ = exception;
+            return IssueContractCheckOutcome.Ok;
+        }
+
+        var ambiguity = IssueContractAmbiguityAnalyzer.Analyze(issueResult.Title, issueResult.Body);
+        if (!ambiguity.IsAmbiguous)
+        {
+            return IssueContractCheckOutcome.Ok;
+        }
+
+        writer.WriteLine(
+            $"refused to complete issue #{issueNumber} as `pr-created`: ambiguous-contract — {ambiguity.Diagnostic}");
+        return IssueContractCheckOutcome.Ambiguous;
+    }
+
     private static BaseBranchCheckOutcome TryCheckBaseBranchFromIssue(
         string repo,
         int issueNumber,

--- a/src/IntentSystem.Cli/Commands/WorkerNextActionAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerNextActionAnalyzer.cs
@@ -64,6 +64,9 @@ internal static class WorkerNextActionAnalyzer
                 RecommendedWorkflow = WorkerNextActionConstants.RecommendedWorkflows.PrCommentFix,
                 Warnings = warnings,
                 SourceClassification = WorkerNextActionConstants.SourceClassifications.RepairRequired,
+                MustCreatePr = false,
+                AllowedTerminalOutcomes = WorkerNextActionConstants.TerminalOutcomes.PrCommentFixAllowed,
+                ForbiddenTerminalOutcomes = WorkerNextActionConstants.TerminalOutcomes.PrCommentFixForbidden,
             };
         }
 
@@ -139,6 +142,9 @@ internal static class WorkerNextActionAnalyzer
                 RecommendedWorkflow = WorkerNextActionConstants.RecommendedWorkflows.GhIssueToPr,
                 Warnings = warnings,
                 SourceClassification = WorkerNextActionConstants.SourceClassifications.ReadyToImplement,
+                MustCreatePr = true,
+                AllowedTerminalOutcomes = WorkerNextActionConstants.TerminalOutcomes.IssueToPrAllowed,
+                ForbiddenTerminalOutcomes = WorkerNextActionConstants.TerminalOutcomes.IssueToPrForbidden,
             };
         }
 

--- a/src/IntentSystem.Cli/Commands/WorkerNextActionResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerNextActionResult.cs
@@ -45,6 +45,21 @@ internal sealed record WorkerNextActionResult
     [JsonPropertyName("warnings")]
     public required IReadOnlyList<string> Warnings { get; init; }
 
+    /// <summary>
+    /// G389: true for <c>issue-to-pr</c> — the terminal output must be a GitHub
+    /// PR, not local commits. Null for actions where it does not apply.
+    /// </summary>
+    [JsonPropertyName("must_create_pr")]
+    public bool? MustCreatePr { get; init; }
+
+    /// <summary>G389: the outcome values a wake on this action may legitimately end in.</summary>
+    [JsonPropertyName("allowed_terminal_outcomes")]
+    public IReadOnlyList<string>? AllowedTerminalOutcomes { get; init; }
+
+    /// <summary>G389: outcome states that are never a valid terminal result (e.g. local commits with no PR).</summary>
+    [JsonPropertyName("forbidden_terminal_outcomes")]
+    public IReadOnlyList<string>? ForbiddenTerminalOutcomes { get; init; }
+
     [JsonPropertyName("source_classification")]
     public string? SourceClassification { get; init; }
 
@@ -97,6 +112,50 @@ internal static class WorkerNextActionConstants
     {
         public const string PrCommentFix = "pr-comment-fix";
         public const string GhIssueToPr = "gh-issue-to-pr";
+    }
+
+    /// <summary>
+    /// G389: explicit allowed / forbidden terminal outcomes per action, so an
+    /// AI agent cannot finish a wake in an invalid state (e.g. local commits
+    /// with no PR). Surfaced on <see cref="WorkerNextActionResult"/> alongside
+    /// <see cref="WorkerNextActionResult.MustCreatePr"/>.
+    /// </summary>
+    public static class TerminalOutcomes
+    {
+        public static readonly IReadOnlyList<string> IssueToPrAllowed = new[]
+        {
+            "pr-created",
+            "declined-contract-incomplete",
+            "clarification-required",
+            "already-resolved",
+            "ambiguous-contract",
+            "failed",
+            "label-cleanup-required",
+        };
+
+        public static readonly IReadOnlyList<string> IssueToPrForbidden = new[]
+        {
+            "local-commits-only",
+            "partial-work-no-pr",
+            "lease-released-without-pr",
+        };
+
+        public static readonly IReadOnlyList<string> PrCommentFixAllowed = new[]
+        {
+            "repair-pushed",
+            "no-actionable-comments",
+            "already-resolved",
+            "clarification-required",
+            "host-artifact-repair-required",
+            "failed",
+            "label-cleanup-required",
+        };
+
+        public static readonly IReadOnlyList<string> PrCommentFixForbidden = new[]
+        {
+            "local-commits-only",
+            "lease-released-without-push",
+        };
     }
 
     public static class SourceClassifications

--- a/tests/IntentSystem.Cli.Tests/IssueContractAmbiguityAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueContractAmbiguityAnalyzerTests.cs
@@ -1,0 +1,79 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G389: tests for the ambiguous multi-packet contract detector. A normal
+/// single-unit issue (even one whose Related Links cite many prior G-numbers)
+/// must NOT be flagged; an issue declaring multiple primary execution-unit
+/// identities (title or H1 headings) must be.
+/// </summary>
+public sealed class IssueContractAmbiguityAnalyzerTests
+{
+    [Fact]
+    public void Analyze_SingleUnit_WithRelatedLinks_IsNotAmbiguous()
+    {
+        const string title = "G389 Enforce child worker terminal contracts";
+        const string body =
+            "# G389 Enforce child worker terminal contracts\n\n"
+            + "## Goal\nMake completion enforce the contract.\n\n"
+            + "## Related Links\n- G300 child worker commands.\n- G311 mandatory PR closing reference.\n- G388 branch resolution.\n";
+
+        var result = IssueContractAmbiguityAnalyzer.Analyze(title, body);
+
+        Assert.False(result.IsAmbiguous);
+        Assert.Equal(new[] { "G389" }, result.PrimaryUnits);
+        Assert.Equal(string.Empty, result.Diagnostic);
+    }
+
+    [Fact]
+    public void Analyze_MultipleH1Units_IsAmbiguous()
+    {
+        const string title = "G390 + G391 bundle";
+        const string body =
+            "# G390 First packet\n\n## Goal\nA.\n\n"
+            + "# G391 Second packet\n\n## Goal\nB.\n";
+
+        var result = IssueContractAmbiguityAnalyzer.Analyze(title, body);
+
+        Assert.True(result.IsAmbiguous);
+        Assert.Contains("G390", result.PrimaryUnits);
+        Assert.Contains("G391", result.PrimaryUnits);
+        Assert.Contains("multiple execution-unit", result.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Analyze_TitleUnitDiffersFromSingleH1_IsAmbiguous()
+    {
+        // Title says one unit, body H1 declares a different one — ambiguous.
+        var result = IssueContractAmbiguityAnalyzer.Analyze(
+            "G390 something",
+            "# G391 different unit\n\n## Goal\nx.\n");
+
+        Assert.True(result.IsAmbiguous);
+        Assert.Equal(new[] { "G390", "G391" }, result.PrimaryUnits);
+    }
+
+    [Fact]
+    public void Analyze_RelatedLinksWithManyGNumbers_StillSingleUnit()
+    {
+        // Many G-numbers as bullets must not trip the detector.
+        const string body =
+            "# G347 base branch policy propagation\n\n"
+            + "## Related Links\n- G300\n- G305\n- G311\n- G346\n- G350\n- G362\n- G372\n- G388\n";
+
+        var result = IssueContractAmbiguityAnalyzer.Analyze("G347 base branch policy", body);
+
+        Assert.False(result.IsAmbiguous);
+        Assert.Equal(new[] { "G347" }, result.PrimaryUnits);
+    }
+
+    [Fact]
+    public void Analyze_NoUnitIdentity_IsNotAmbiguous()
+    {
+        var result = IssueContractAmbiguityAnalyzer.Analyze("Fix a typo", "# Fix a typo\n\nNo G-number here.\n");
+
+        Assert.False(result.IsAmbiguous);
+        Assert.Empty(result.PrimaryUnits);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -29,11 +29,12 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         // G311-focused tests override this factory to exercise the
         // gate's failure paths.
         WorkerCompleteCommand.PrLookupFactory = () => new PermissivePrLookup();
-        // G347: permissive default — pre-existing tests don't set a baseRefName
-        // on the fake PR lookup (empty string), so the G347 check is skipped
-        // entirely for them. Set the factory to null here; G347-focused tests
-        // set it explicitly.
-        WorkerCompleteCommand.IssueLookupFactory = null;
+        // G347/G389: permissive default — a single-unit stub issue (no
+        // baseRefName-driven mismatch, no multi-packet ambiguity) so the
+        // G347 base-branch and G389 ambiguous-contract gates are hermetic and
+        // pass for pre-existing tests. G347/G389-focused tests override this
+        // factory to exercise the failure paths.
+        WorkerCompleteCommand.IssueLookupFactory = () => new StubIssueLookup();
     }
 
     public void Dispose()
@@ -1339,6 +1340,50 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         Assert.Equal(0, exitCode);
         var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
         Assert.True(result.Proceed);
+    }
+
+    [Fact]
+    public void Execute_G389_RefusesPrCreatedWhenIssueContractBundlesMultipleUnits()
+    {
+        // G389 AC: an issue whose body declares multiple execution-unit
+        // identities (multiple H1 packets) must be refused as ambiguous-contract,
+        // with no label mutation applied.
+        using var workspace = new WorkerCompleteWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-issue-in-progress" },
+        };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+        WorkerCompleteCommand.PrLookupFactory = () => new StubPrLookup
+        {
+            Body = "Closes #797",
+            ClosingIssuesReferences = new[]
+            {
+                new GitHubPrClosingIssueReference { Number = 797, Repository = null },
+            },
+        };
+        WorkerCompleteCommand.IssueLookupFactory = () => new StubIssueLookup
+        {
+            Body = "# G390 First packet\n\n## Goal\nA.\n\n# G391 Second packet\n\n## Goal\nB.\n",
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "797",
+                "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated,
+                "--pr", "800",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("ambiguous-contract", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(mutator.AppliedTransitions);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerNextActionCommandTests.cs
@@ -417,6 +417,67 @@ public sealed class WorkerNextActionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_G389_IssueToPr_CarriesMustCreatePrAndTerminalOutcomes()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        WorkerNextActionCommand.CandidateListerFactory = () => new FakeLister
+        {
+            Issues = new[]
+            {
+                BuildIssue(517, "Eligible", "https://github.com/J-Tech-Japan/intent-system/issues/517",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target" }),
+            },
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--github-only", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var root = JsonDocument.Parse(writer.ToString()).RootElement;
+        Assert.Equal("issue-to-pr", root.GetProperty("action").GetString());
+        Assert.True(root.GetProperty("must_create_pr").GetBoolean());
+        var allowed = root.GetProperty("allowed_terminal_outcomes").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains("pr-created", allowed);
+        Assert.Contains("ambiguous-contract", allowed);
+        var forbidden = root.GetProperty("forbidden_terminal_outcomes").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains("local-commits-only", forbidden);
+        Assert.Contains("lease-released-without-pr", forbidden);
+    }
+
+    [Fact]
+    public void Execute_G389_PrCommentFix_MustCreatePrIsFalse_WithRepairTerminalOutcomes()
+    {
+        using var workspace = new WorkerNextActionWorkspace();
+        WorkerNextActionCommand.CandidateListerFactory = () => new FakeLister
+        {
+            Prs = new[]
+            {
+                BuildPr(514, "Repair me", "https://github.com/J-Tech-Japan/intent-system/pull/514",
+                    createdAt: "2026-04-30T00:00:00Z",
+                    labels: new[] { "intent-target", "intent-pr-request-update" }),
+            },
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerNextActionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--github-only", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var root = JsonDocument.Parse(writer.ToString()).RootElement;
+        Assert.Equal("pr-comment-fix", root.GetProperty("action").GetString());
+        Assert.False(root.GetProperty("must_create_pr").GetBoolean());
+        var allowed = root.GetProperty("allowed_terminal_outcomes").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains("repair-pushed", allowed);
+        Assert.Contains("host-artifact-repair-required", allowed);
+    }
+
+    [Fact]
     public void Adapter_DeserializeList_ValidStdout_MapsToTypedCandidates()
     {
         // G385: clean stdout still yields the same candidates after the


### PR DESCRIPTION
## Summary

Hardens the child-worker terminal contract for `issue-to-pr` so an AI agent cannot finish a wake in an invalid state. Several requirements were already enforced by `worker complete` (`--pr` required = local-commit-only gate, G311 closing reference, G347 base branch); this slice adds the two cleanly-missing pieces:

- **Ambiguous multi-packet detection** — new pure `IssueContractAmbiguityAnalyzer` flags an issue that declares more than one *primary* execution-unit identity (the title's leading `G<n>` + any H1 `# G<n>` headings). Incidental references (Related Links bullets, `##` sections, prose) are deliberately ignored to avoid false positives. `worker complete --kind issue --outcome pr-created` now **refuses** an ambiguous issue as `ambiguous-contract` and applies no labels.
- **`worker next-action` terminal-outcome metadata** — `issue-to-pr` carries `must_create_pr: true` plus `allowed_terminal_outcomes` / `forbidden_terminal_outcomes` (forbidding `local-commits-only` / `partial-work-no-pr` / `lease-released-without-pr`); `pr-comment-fix` carries `must_create_pr: false` with its repair outcomes.

## Acceptance criteria mapping

- `next-action` issue-to-pr includes `must_create_pr` + allowed/forbidden terminal outcomes ✓
- `worker complete --outcome pr-created` fails when no PR supplied ✓ (pre-existing `--pr` gate)
- fails when PR doesn't exist / wrong base / missing-or-multiple closing ref ✓ (pre-existing G311/G347; PR lookup failure already errors)
- local-commit-only is not a terminal success ✓ (the `--pr` gate + forbidden-outcome metadata)
- multi-execution-unit issue → `ambiguous-contract` ✓ (new)
- tests for the above ✓

## Scope note

Builds on the existing enforcement rather than rewriting the worker state machine. Guidance-snapshot updates in `intents/intent-cli/specs/05-…` are host-owned and not present in this GitHub-contract-only child worktree; the `must_create_pr` / forbidden-outcome metadata on `next-action` is the machine-readable contract the child guidance consumes. A draft-PR (ready-for-review) gate and a dedicated `partial-work` continuation outcome are reachable follow-ups.

## Verification

- [x] `IssueContractAmbiguityAnalyzerTests` (5), `WorkerCompleteCommandTests` (incl. ambiguous-contract refusal), `WorkerNextActionCommandTests` (terminal-outcome metadata for both actions) — green; worker-complete harness made hermetic (default single-unit stub issue lookup).
- [x] Full `IntentSystem.Cli.Tests`: **3344 passed, 1 skipped, 1 failed** — the lone failure (`ProgramTests.Main_GivenGuideHostOwnershipFromChildCwdWithoutIntentCli_Succeeds`) passes in isolation; it's a known flaky `Program.Main` cwd/Console env test, unrelated to this change.
- [x] `dotnet build` clean; `git diff --check` clean.

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)