### PR TITLE
G391: promote publish-artifact selected-PR evidence to writeable recovery under --pr

### DIFF
--- a/src/IntentSystem.Cli/Commands/PublishRecoveryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PublishRecoveryAnalyzer.cs
@@ -99,10 +99,22 @@ internal static class PublishRecoveryAnalyzer
             };
         }
 
-        // Filter candidates to only those whose linked_issue matches a
-        // closing-issue reference of the selected PR.
+        // Filter candidates to those tied to the selected PR's closing issue.
+        // Two evidence sources qualify:
+        //   1. queue-state linked_issue already matches (Lane B / G315); or
+        //   2. G391: the queue item's publish-artifact created_issue matches,
+        //      even when linked_issue is still null. This is the same
+        //      deterministic selected-PR evidence `reconcile` reports as
+        //      advisory; including it lets the G303 publish-artifact lane in
+        //      Analyze promote it to a high-confidence writeable repair (with
+        //      its existing repo / unique-closing-PR / single-unit guards),
+        //      instead of `publish-recovery --pr` silently returning no repair.
         var scopedCandidates = candidates
-            .Where(c => c.LinkedIssueNumber is int n && closingIssues.Contains(n))
+            .Where(c =>
+                (c.LinkedIssueNumber is int n && closingIssues.Contains(n))
+                || (c.LinkedIssueNumber is null
+                    && c.PublishArtifact?.CreatedIssueNumber is int created
+                    && closingIssues.Contains(created)))
             .ToArray();
 
         if (scopedCandidates.Length == 0)

--- a/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
@@ -315,6 +315,80 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_G391_SameRepoArtifactOnly_WriteThenCloseoutPlanBecomesReady()
+    {
+        // G391 review follow-up: end-to-end AC evidence for the AIC-style
+        // same-repo (intent-metadata) topology. An artifact-only queue item
+        // (linked_issue = null, linked_pr = null) plus a publish.yaml whose
+        // created issue (#3641) is uniquely closed by PR #3642:
+        //   1. `publish-recovery --pr 3642 --write` promotes the artifact
+        //      evidence to a high-confidence repair, writes linked_pr (and
+        //      linked_issue) to the same-repo metadata root, and appends a run
+        //      event; then
+        //   2. `review closeout-plan --pr 3642` becomes ready.
+        using var workspace = new RecoveryWorkspace(sameRepoMetadata: true);
+        workspace.WriteQueueState(BuildQueueState("G391", linkedIssue: null, linkedPr: null));
+        workspace.WritePublishArtifact("G391", createdIssueNumber: 3641);
+        // Complete child-issue contract so closeout-plan has no packet gaps.
+        File.WriteAllText(
+            Path.Combine(workspace.RootPath, ".intent-cli", "issues", "G391", "github-body.md"),
+            BuildCompleteContractBodyForCloseout());
+
+        AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
+            new[] { BuildPr(3642, "Closes #3641") });
+
+        using var recoveryWriter = new StringWriter();
+        var recoveryExit = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "3642", "--write", "--format", "json"],
+            recoveryWriter);
+
+        Assert.Equal(0, recoveryExit);
+        using (var recoveryDoc = JsonDocument.Parse(recoveryWriter.ToString()))
+        {
+            Assert.Equal(1, recoveryDoc.RootElement.GetProperty("applied_count").GetInt32());
+            Assert.Equal(
+                "same-repo-metadata-linkage-repair-ready",
+                recoveryDoc.RootElement.GetProperty("same_repo_metadata_linkage_classification").GetString());
+        }
+        // linked_pr (and linked_issue) written to the same-repo metadata root.
+        var queueAfter = QueueStateSerializer.Deserialize(
+            File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.Contains("/pull/3642", queueAfter.Items[0].LinkedPr!, StringComparison.Ordinal);
+        Assert.NotNull(queueAfter.Items[0].LinkedIssue);
+        Assert.Equal(3641, queueAfter.Items[0].LinkedIssue!.Number);
+        // Durable run event appended (G390).
+        Assert.Contains(
+            AutomationPublishRecoveryCommand.RecoveryRunEventName,
+            File.ReadAllText(Path.Combine(workspace.RootPath, ".intent-cli", "runs.jsonl")),
+            StringComparison.Ordinal);
+
+        // closeout-plan retry now becomes ready.
+        using var closeoutWriter = new StringWriter();
+        var closeoutExit = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "3642", "--format", "json"],
+            closeoutWriter);
+
+        Assert.Equal(0, closeoutExit);
+        using var closeoutDoc = JsonDocument.Parse(closeoutWriter.ToString());
+        Assert.True(closeoutDoc.RootElement.GetProperty("ready").GetBoolean());
+    }
+
+    private static string BuildCompleteContractBodyForCloseout() =>
+        "## Goal\nx\n\n"
+        + "## Why This Slice Exists Now\nx\n\n"
+        + "## Current Observed State\nx\n\n"
+        + "## Accepted Baseline You May Assume\nx\n\n"
+        + "## Target Repo / Path / Part\nx\n\n"
+        + "## In Scope\n- x\n\n"
+        + "## Out Of Scope\n- x\n\n"
+        + "## Acceptance Criteria\n- x\n\n"
+        + "## Verification\nx\n\n"
+        + "## Related Links\n- x\n\n"
+        + "## Base Branch Policy\nPolicy: `direct-main`\nExpected PR base branch: `main`\n";
+
+    [Fact]
     public void Execute_LinkedIssuePresentNoPr_NoClosingPr_StaysUnsafe_NoMutation()
     {
         using var workspace = new RecoveryWorkspace();

--- a/tests/IntentSystem.Cli.Tests/PublishRecoveryAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PublishRecoveryAnalyzerTests.cs
@@ -499,6 +499,99 @@ public sealed class PublishRecoveryAnalyzerTests
         Assert.Empty(result.UnsafeStops);
     }
 
+    // ----- G391: promote publish-artifact selected-PR evidence under --pr -----
+
+    [Fact]
+    public void AnalyzeScopedToPr_G391_PublishArtifactCreatedIssueMatches_LinkedIssueNull_PromotesToHighConfidenceRepair()
+    {
+        // AIC #3642 / #3641 shape: the queue item has linked_issue = null, but
+        // its publish.yaml records created_issue_number = 3641 and PR #3642
+        // uniquely closes #3641. Before G391, AnalyzeScopedToPr scoped only by
+        // linked_issue and returned a no-op; now the artifact evidence is
+        // promoted to a high-confidence writeable repair.
+        var artifact = BuildPublishArtifact("G391", createdIssueNumber: 3641,
+            createdIssueUrl: "https://github.com/J-Tech-Japan/intent-system/issues/3641");
+        var candidate = NewCandidate("G391", artifact);
+        var pr3642 = BuildPr(3642, "G391 implement", "Closes #3641");
+
+        var result = PublishRecoveryAnalyzer.AnalyzeScopedToPr(
+            "J-Tech-Japan/intent-system",
+            new[] { candidate },
+            new[] { pr3642 },
+            prNumber: 3642);
+
+        Assert.Single(result.SafeRepairs);
+        Assert.Empty(result.UnsafeStops);
+        var repair = result.SafeRepairs[0];
+        Assert.Equal("G391", repair.ExecutionUnit);
+        Assert.Equal(3641, repair.LinkedIssueNumber);
+        Assert.Equal(3642, repair.LinkedPrNumber);
+        Assert.Equal("high", repair.Confidence);
+    }
+
+    [Fact]
+    public void AnalyzeScopedToPr_G391_MultipleClosingPrsForArtifactIssue_RefusesWithConcreteReason()
+    {
+        // Promotion must refuse with a concrete reason (not a silent no-op)
+        // when more than one open PR closes the artifact's created issue.
+        var artifact = BuildPublishArtifact("G391", createdIssueNumber: 3641,
+            createdIssueUrl: "https://github.com/J-Tech-Japan/intent-system/issues/3641");
+        var candidate = NewCandidate("G391", artifact);
+        var pr3642 = BuildPr(3642, "first", "Closes #3641");
+        var pr3643 = BuildPr(3643, "second", "Closes #3641");
+
+        var result = PublishRecoveryAnalyzer.AnalyzeScopedToPr(
+            "J-Tech-Japan/intent-system",
+            new[] { candidate },
+            new[] { pr3642, pr3643 },
+            prNumber: 3642);
+
+        Assert.Empty(result.SafeRepairs);
+        Assert.Single(result.UnsafeStops);
+        Assert.Equal(PublishRecoveryAnalyzer.UnsafeMultipleClosingPrs, result.UnsafeStops[0].Kind);
+    }
+
+    [Fact]
+    public void AnalyzeScopedToPr_G391_ArtifactUrlForDifferentRepo_RefusesWithRepoMismatch()
+    {
+        // Wrong-repo guard: when the artifact's created issue URL belongs to a
+        // different repo, promotion is refused (not silently applied).
+        var artifact = BuildPublishArtifact("G391", createdIssueNumber: 3641,
+            createdIssueUrl: "https://github.com/other-org/other-repo/issues/3641");
+        var candidate = NewCandidate("G391", artifact);
+        var pr3642 = BuildPr(3642, "G391", "Closes #3641");
+
+        var result = PublishRecoveryAnalyzer.AnalyzeScopedToPr(
+            "J-Tech-Japan/intent-system",
+            new[] { candidate },
+            new[] { pr3642 },
+            prNumber: 3642);
+
+        Assert.Empty(result.SafeRepairs);
+        Assert.Single(result.UnsafeStops);
+        Assert.Equal(PublishRecoveryAnalyzer.UnsafeRepoMismatch, result.UnsafeStops[0].Kind);
+    }
+
+    [Fact]
+    public void AnalyzeScopedToPr_G391_ArtifactCreatedIssueDoesNotMatchPr_RemainsNoOp()
+    {
+        // Negative guard: an artifact whose created issue does NOT match the
+        // selected PR's closing issue must not be promoted.
+        var artifact = BuildPublishArtifact("G391", createdIssueNumber: 9999,
+            createdIssueUrl: "https://github.com/J-Tech-Japan/intent-system/issues/9999");
+        var candidate = NewCandidate("G391", artifact);
+        var pr3642 = BuildPr(3642, "G391", "Closes #3641");
+
+        var result = PublishRecoveryAnalyzer.AnalyzeScopedToPr(
+            "J-Tech-Japan/intent-system",
+            new[] { candidate },
+            new[] { pr3642 },
+            prNumber: 3642);
+
+        Assert.Empty(result.SafeRepairs);
+        Assert.Empty(result.UnsafeStops);
+    }
+
     private static PublishRecoveryCandidate NewLinkedIssueCandidate(
         string executionUnit,
         string linkedIssueRepo,


### PR DESCRIPTION
## Summary

Fixes the G390 gap where `publish-recovery --pr <n>` returned no repair for a selected PR whose queue item has `linked_issue = null` but whose `publish.yaml` records the created issue — the observed AIC PR #3642 / issue #3641 case (`reconcile` saw the relationship as advisory; `publish-recovery --pr` produced no writeable repair).

Root cause: `PublishRecoveryAnalyzer.AnalyzeScopedToPr` scoped candidates **only** by `linked_issue`, so an artifact-only queue item was excluded and the G303 publish-artifact lane (which already recovers both `linked_issue` and `linked_pr` from the artifact + unique closing PR) never ran under `--pr`.

Fix: extend the scoped filter to also include candidates whose **publish-artifact `created_issue` matches the selected PR's closing issue** (when `linked_issue` is null). The existing G303 lane then promotes it to a high-confidence writeable repair, under its existing guards (repo match, unique closing PR, single execution unit), and its specific unsafe stops now surface as **concrete refusal reasons** under `--pr` instead of a silent no-op.

## Acceptance criteria mapping

- AIC-style fixture (issue #3641 / PR #3642), `publish-recovery --pr 3642` reports one high-confidence repair ✓
- `--write` writes `linked_pr` and appends a valid run event ✓ (the run-event append landed in G390 `ApplyRepairs`; this PR makes the scoped repair reach it)
- advisory-but-refused → concrete refusal reason instead of "no repair" ✓ (multiple-closing-PR / wrong-repo unsafe stops now surface under `--pr`)
- safe promotion / unsafe ambiguity / wrong repo / non-matching-artifact no-op covered by tests ✓

## Scope note

Builds on the G390 cores (run-event-on-write, same-repo linkage diagnostics, review-lease preservation). The same-repo metadata-branch **write-target resolution** (reading/writing `intent-metadata` rather than the implementation branch) and the live `closeout-plan` retry remain the deeper host-runtime follow-up noted in G390/#884; this PR closes the specific selected-PR-evidence promotion regression. Spec docs (`intents/intent-cli/specs/05`, `18`) are host-owned and absent from this child worktree.

## Verification

- [x] `PublishRecoveryAnalyzerTests` (+4 G391 cases) and `AutomationPublishRecoveryCommandTests` green (42/42).
- [x] Full `IntentSystem.Cli.Tests`: **3363 passed, 1 skipped, 1 failed** — the failure (`AutomationCheckCommandTests.Execute_WorkdirChangesRepoInferenceRoot`) passes in isolation; it's a known flaky global-cwd/repo-inference env test, unrelated to this change.
- [x] `dotnet build` clean; `git diff --check` clean.

Closes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)