### PR TITLE
G393: guide-first onboarding entrypoint (intent-cli guide start)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,22 @@
 このリポジトリで agent が作業するときは、Issue 本文を主入力としつつ、
 このファイルを repo 全体の baseline guide として使う。
 
+## Ask intent-cli first (guide-first)
+
+intent / packet / issue / review / implementation-loop の作業を始める前に、まず
+`intent-cli guide start` を実行し、そのフェーズ向けの `intent-cli guide …`
+コマンドに従う。記憶やコピーした prompt から始めない。label / metadata の遷移は
+intent-cli のコマンド経由で行い、手編集しない。詳細ルールは intent-cli の guidance
+が source of truth（このファイルに長い spec を写経しない）。
+
+- Implementation 側 agent は **GitHub-contract-only / metadata-free**：host の
+  `.intent-cli` / queue-state / metadata branch / `intents/**` は読まない。Issue
+  本文を standalone contract として扱う。
+- Host / design 側 agent は metadata を扱ってよいが、手編集の前に intent-cli へ
+  現在のコマンド・guidance を尋ねる。
+- どの agent (Codex / Claude / Copilot / Cursor / OpenCode / Antigravity など) でも
+  同じ `intent-cli guide start` を入口にする。
+
 ## Baseline
 
 - 実装言語は `C# / .NET`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,15 @@
 このリポジトリで Claude Code が作業するときは、Issue 本文を主入力としつつ、
 repo 全体の baseline は [AGENTS.md](./AGENTS.md) に従う。
 
+## Ask intent-cli first (guide-first)
+
+このリポジトリの workflow は `intent-cli` が権威。intent / packet / issue / review /
+implementation-loop を始める前に `intent-cli guide start` を実行し、フェーズ向けの
+`intent-cli guide …` コマンドに従う。metadata / label の挙動を推測したり、長いルールを
+ここに写経しない（intent-cli の guidance が source of truth）。implementation 作業は
+**GitHub-contract-only**（issue/PR + repo code のみ、host の `.intent-cli` metadata は
+読まない）。詳しい役割分担は `intent-cli guide start` を参照。
+
 ## Reading Order
 
 1. GitHub Issue 本文

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -280,6 +280,9 @@ internal static class CommandRouter
             },
             ["guide"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
+                // G393: guide-first entrypoint — the single obvious command an
+                // agent runs before intent/packet/issue/review/loop work.
+                ["start"] = GuideStartCommand.Execute,
                 ["oneshot"] = GuideOneshotCommand.Execute,
                 ["automation"] = GuideAutomationCommand.Execute,
                 ["review"] = GuideReviewCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -121,6 +121,12 @@ internal static class GuideHelpCommand
     {
         new GuideSubcommandEntry
         {
+            Name = "start",
+            Purpose = "Guide-first entrypoint (G393): the single command to run before intent/packet/issue/review/loop work. Points at the per-phase guide command, states the host/design vs metadata-free child-implementation roles, and emits short AGENTS.md/CLAUDE.md guide-first snippets.",
+            Example = "intent-cli guide start --format json"
+        },
+        new GuideSubcommandEntry
+        {
             Name = "help",
             Purpose = "List guide subcommands with examples and workflow-guide pointers (this surface).",
             Example = "intent-cli guide help --format json"

--- a/src/IntentSystem.Cli/Commands/GuideStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideStartCommand.cs
@@ -1,0 +1,338 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G393: Read-only <c>intent-cli guide start</c> — the single, obvious
+/// guide-first entrypoint. Any agent family (Codex, Claude, Copilot, Cursor,
+/// OpenCode, Antigravity, …) runs this one command first to discover which
+/// <c>intent-cli guide …</c> command to use for the phase of work it is about
+/// to start, learn the guide-first rule, and see the host/design vs.
+/// child-implementation role split. Detailed, drift-prone workflow rules are
+/// intentionally NOT duplicated here — they live behind the per-phase guide
+/// commands this entrypoint points at. Also emits short, ready-to-paste
+/// AGENTS.md / CLAUDE.md snippets so a repository can carry the same
+/// "ask intent-cli first" rule without copying a full workflow spec. Never
+/// mutates state; never launches an AI provider.
+/// </summary>
+internal static class GuideStartCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide start [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildResult();
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    internal static GuideStartResult BuildResult()
+    {
+        return new GuideStartResult
+        {
+            Summary =
+                "Guide-first entrypoint. Before doing intent / packet / issue / review / loop work, ask intent-cli "
+                + "which guide command to run — do not start from memory, copied prompts, repo files, or ordinary "
+                + "GitHub behavior. intent-cli is the workflow and metadata authority.",
+            GuideFirstRule = new[]
+            {
+                "Ask intent-cli first: run the per-phase `intent-cli guide …` command below before acting.",
+                "Use intent-cli-supported commands for transitions; do not hand-edit queue-state, workflow labels, "
+                    + "packet/publish metadata, or other host artifacts when an `intent-cli automation` / "
+                    + "`intent-cli worker` command owns that transition.",
+                "Detailed, drift-prone rules stay in intent-cli guidance output — not copied into repo files or "
+                    + "agent prompts. Re-ask the guide command when you resume work; it reflects the installed CLI.",
+                "intent-cli never launches Claude, Codex, or any AI provider, and `intent-cli run` is not the "
+                    + "production orchestrator.",
+            },
+            WorkflowPhases = new[]
+            {
+                new GuideStartPhase
+                {
+                    Phase = "design-and-intent",
+                    When = "Capturing intent, interviewing the owner, clarifying scope before any packet/issue.",
+                    GuideCommand = "intent-cli guide workflow task intent-interview --format json",
+                    Side = "host/design",
+                    Note = "Free-form design chats most often skip intent-cli — ask here first.",
+                },
+                new GuideStartPhase
+                {
+                    Phase = "packet-draft",
+                    When = "Scaffolding the canonical packet (packet.yaml / implementation.md / review-context.md / github-body.md).",
+                    GuideCommand = "intent-cli guide workflow task packet-draft --format json",
+                    Side = "host/design",
+                    Note = "Packet authoring is host/design work; the child loop never hand-writes packets.",
+                },
+                new GuideStartPhase
+                {
+                    Phase = "issue-publish",
+                    When = "Publishing a reviewed Standalone Child Issue Contract to GitHub.",
+                    GuideCommand = "intent-cli guide workflow task issue-publish --format json",
+                    Side = "host/design",
+                    Note = "`intent-target` is applied by the publish boundary command, never by hand.",
+                },
+                new GuideStartPhase
+                {
+                    Phase = "implementation-loop",
+                    When = "Turning an intent-target issue into a PR, or repairing a PR from review feedback.",
+                    GuideCommand = "intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>",
+                    Side = "child-implementation",
+                    Note = "GitHub-contract-only & metadata-free: issue/PR + repo code are the source of truth.",
+                },
+                new GuideStartPhase
+                {
+                    Phase = "review-next-slice-loop",
+                    When = "Reviewing PRs against the packet/intent contract, approving/merging, and cutting the next slice.",
+                    GuideCommand = "intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>",
+                    Side = "host/design",
+                    Note = "Host-side review owns label transitions via `intent-cli automation`.",
+                },
+                new GuideStartPhase
+                {
+                    Phase = "recovery",
+                    When = "A loop looks wrong, stuck, or you are unsure whether a fix is in scope.",
+                    GuideCommand = "intent-cli worker pr-comment-preflight --repo <owner>/<repo> --pr <n> --format json  # or issue-preflight / automation doctor",
+                    Side = "either",
+                    Note = "Ask the read-only preflight/doctor surfaces to classify a safe repair instead of hand-fixing state.",
+                },
+            },
+            AgentRoles = new[]
+            {
+                new GuideStartRole
+                {
+                    Role = "child-implementation",
+                    SourceOfTruth = "the GitHub issue/PR + repo-local code",
+                    Rule =
+                        "Implementation-side agents are GitHub-contract-only and metadata-free: they MUST NOT read or "
+                        + "mutate host `.intent-cli/`, queue-state, metadata branches, or `intents/**`. Treat the issue "
+                        + "body as the standalone contract and record outcomes via `intent-cli worker`.",
+                },
+                new GuideStartRole
+                {
+                    Role = "host/design",
+                    SourceOfTruth = "parent host `.intent-cli/` state + intent tree",
+                    Rule =
+                        "Host/design-side agents may operate on metadata, but MUST ask intent-cli for the current "
+                        + "command/guidance first and prefer intent-cli-supported transitions before hand-editing "
+                        + "metadata or labels.",
+                },
+            },
+            MultiAgentNote =
+                "Every agent family — Codex, Claude, Copilot, Cursor, OpenCode, Antigravity, and other local/host "
+                + "agents — uses this same `intent-cli guide start` entrypoint. Repositories carry only a short "
+                + "guide-first rule (see the snippets below); they do not embed a full workflow spec that can drift.",
+            RepositoryInstructionSnippets = new GuideStartSnippets
+            {
+                AgentsMd =
+                    "## intent-cli is the workflow authority\n\n"
+                    + "Before any intent / packet / issue / review / implementation-loop work, run "
+                    + "`intent-cli guide start` and follow the per-phase `intent-cli guide …` command it points at. "
+                    + "Do not start from memory or copied prompts. Use intent-cli-supported commands for label/metadata "
+                    + "transitions — never hand-edit them. Implementation agents are GitHub-contract-only (issue/PR + "
+                    + "repo code; no host metadata).",
+                ClaudeMd =
+                    "## Ask intent-cli first\n\n"
+                    + "This repo's workflow is driven by `intent-cli`. Run `intent-cli guide start` to discover the "
+                    + "right `intent-cli guide …` command for your current phase, then follow it. Don't guess "
+                    + "metadata/label behavior or copy long rules here — intent-cli guidance is the source of truth, "
+                    + "and implementation work stays GitHub-contract-only (no host `.intent-cli` metadata).",
+            },
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideStartResult result)
+    {
+        writer.WriteLine("# Guide start — ask intent-cli first");
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+        writer.WriteLine();
+
+        writer.WriteLine("## Guide-first rule");
+        foreach (var rule in result.GuideFirstRule)
+        {
+            writer.WriteLine($"- {rule}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Which guide command for which phase");
+        writer.WriteLine();
+        foreach (var phase in result.WorkflowPhases)
+        {
+            writer.WriteLine($"### {phase.Phase} ({phase.Side})");
+            writer.WriteLine($"- when: {phase.When}");
+            writer.WriteLine($"- run: `{phase.GuideCommand}`");
+            writer.WriteLine($"- note: {phase.Note}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Agent roles");
+        foreach (var role in result.AgentRoles)
+        {
+            writer.WriteLine($"### {role.Role}");
+            writer.WriteLine($"- source of truth: {role.SourceOfTruth}");
+            writer.WriteLine($"- rule: {role.Rule}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Works the same across agents");
+        writer.WriteLine(result.MultiAgentNote);
+        writer.WriteLine();
+
+        writer.WriteLine("## Repository instruction snippets");
+        writer.WriteLine();
+        writer.WriteLine("Paste into `AGENTS.md`:");
+        writer.WriteLine();
+        writer.WriteLine("```markdown");
+        writer.WriteLine(result.RepositoryInstructionSnippets.AgentsMd);
+        writer.WriteLine("```");
+        writer.WriteLine();
+        writer.WriteLine("Paste into `CLAUDE.md`:");
+        writer.WriteLine();
+        writer.WriteLine("```markdown");
+        writer.WriteLine(result.RepositoryInstructionSnippets.ClaudeMd);
+        writer.WriteLine("```");
+    }
+
+    private static bool TryParseArguments(string[] args, out string format, out string error)
+    {
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide start");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Guide-first entrypoint: the single command to run before intent/packet/issue/review/loop work; points at the per-phase guide command and emits AGENTS.md/CLAUDE.md snippets.");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true
+    };
+}
+
+internal sealed record GuideStartResult
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("guide_first_rule")]
+    public required IReadOnlyList<string> GuideFirstRule { get; init; }
+
+    [JsonPropertyName("workflow_phases")]
+    public required IReadOnlyList<GuideStartPhase> WorkflowPhases { get; init; }
+
+    [JsonPropertyName("agent_roles")]
+    public required IReadOnlyList<GuideStartRole> AgentRoles { get; init; }
+
+    [JsonPropertyName("multi_agent_note")]
+    public required string MultiAgentNote { get; init; }
+
+    [JsonPropertyName("repository_instruction_snippets")]
+    public required GuideStartSnippets RepositoryInstructionSnippets { get; init; }
+}
+
+internal sealed record GuideStartPhase
+{
+    [JsonPropertyName("phase")]
+    public required string Phase { get; init; }
+
+    [JsonPropertyName("when")]
+    public required string When { get; init; }
+
+    [JsonPropertyName("guide_command")]
+    public required string GuideCommand { get; init; }
+
+    [JsonPropertyName("side")]
+    public required string Side { get; init; }
+
+    [JsonPropertyName("note")]
+    public required string Note { get; init; }
+}
+
+internal sealed record GuideStartRole
+{
+    [JsonPropertyName("role")]
+    public required string Role { get; init; }
+
+    [JsonPropertyName("source_of_truth")]
+    public required string SourceOfTruth { get; init; }
+
+    [JsonPropertyName("rule")]
+    public required string Rule { get; init; }
+}
+
+internal sealed record GuideStartSnippets
+{
+    [JsonPropertyName("agents_md")]
+    public required string AgentsMd { get; init; }
+
+    [JsonPropertyName("claude_md")]
+    public required string ClaudeMd { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideStartCommandTests.cs
@@ -1,0 +1,140 @@
+using System.Linq;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G393: tests for the guide-first entrypoint `intent-cli guide start`.
+/// Covers the per-phase guide-command map (design/packet, implementation
+/// loop, review-next-slice loop), the metadata-free child / ask-first host
+/// role split, and the AGENTS.md / CLAUDE.md guide-first snippets.
+/// </summary>
+public sealed class GuideStartCommandTests
+{
+    [Fact]
+    public void Execute_DefaultMarkdown_EmitsGuideFirstSectionsAndSnippets()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide start — ask intent-cli first", output, StringComparison.Ordinal);
+        Assert.Contains("## Guide-first rule", output, StringComparison.Ordinal);
+        Assert.Contains("## Which guide command for which phase", output, StringComparison.Ordinal);
+        Assert.Contains("## Agent roles", output, StringComparison.Ordinal);
+        Assert.Contains("Paste into `AGENTS.md`:", output, StringComparison.Ordinal);
+        Assert.Contains("Paste into `CLAUDE.md`:", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide start", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_CoversDesignImplementationAndReviewPhases()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+
+        var phases = root.GetProperty("workflow_phases").EnumerateArray().ToArray();
+        var phaseNames = phases.Select(p => p.GetProperty("phase").GetString()!).ToArray();
+        // AC#5: at least design/packet, implementation loop, review-next-slice loop.
+        Assert.Contains("packet-draft", phaseNames);
+        Assert.Contains("implementation-loop", phaseNames);
+        Assert.Contains("review-next-slice-loop", phaseNames);
+
+        // Each phase points at a concrete intent-cli guide command.
+        Assert.All(phases, p =>
+            Assert.StartsWith("intent-cli ", p.GetProperty("guide_command").GetString()!, StringComparison.Ordinal));
+
+        // The implementation loop phase points at the child-implement oneshot.
+        var impl = phases.Single(p => p.GetProperty("phase").GetString() == "implementation-loop");
+        Assert.Contains("child-implement-or-update", impl.GetProperty("guide_command").GetString()!, StringComparison.Ordinal);
+        Assert.Equal("child-implementation", impl.GetProperty("side").GetString());
+
+        // The review/next-slice phase points at the host-review oneshot.
+        var review = phases.Single(p => p.GetProperty("phase").GetString() == "review-next-slice-loop");
+        Assert.Contains("host-review-next-slice", review.GetProperty("guide_command").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_StatesMetadataFreeChildAndAskFirstHostRoles()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var roles = document.RootElement.GetProperty("agent_roles").EnumerateArray().ToArray();
+
+        var child = roles.Single(r => r.GetProperty("role").GetString() == "child-implementation");
+        var childRule = child.GetProperty("rule").GetString()!;
+        // AC#3: implementation-side agents are GitHub-contract-only & metadata-free.
+        Assert.Contains("metadata-free", childRule, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("MUST NOT", childRule, StringComparison.Ordinal);
+
+        var host = roles.Single(r => r.GetProperty("role").GetString() == "host/design");
+        var hostRule = host.GetProperty("rule").GetString()!;
+        // AC#4: host/design agents ask intent-cli before hand-editing metadata.
+        Assert.Contains("ask intent-cli", hostRule, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("before hand-editing", hostRule, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_SnippetsAreShortGuideFirstRulesNotFullSpecs()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var snippets = document.RootElement.GetProperty("repository_instruction_snippets");
+
+        var agentsMd = snippets.GetProperty("agents_md").GetString()!;
+        var claudeMd = snippets.GetProperty("claude_md").GetString()!;
+
+        // AC#2: short guide-first rule, not a long copied spec.
+        Assert.Contains("intent-cli guide start", agentsMd, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide start", claudeMd, StringComparison.Ordinal);
+        Assert.True(agentsMd.Length < 700, $"AGENTS.md snippet should stay short (was {agentsMd.Length}).");
+        Assert.True(claudeMd.Length < 700, $"CLAUDE.md snippet should stay short (was {claudeMd.Length}).");
+
+        // Multi-agent note names several agent families using the same entrypoint.
+        var multi = document.RootElement.GetProperty("multi_agent_note").GetString()!;
+        Assert.Contains("Codex", multi, StringComparison.Ordinal);
+        Assert.Contains("Claude", multi, StringComparison.Ordinal);
+        Assert.Contains("Copilot", multi, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), ["--bogus"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Usage: intent-cli guide start", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
Implements G393 (issue #893): a single, obvious guide-first entrypoint so any agent family asks `intent-cli` for guidance before intent/packet/issue/review/loop work.

- **`intent-cli guide start`** (new, read-only): emits the guide-first rule; a per-phase map (`design-and-intent`, `packet-draft`, `issue-publish`, `implementation-loop`, `review-next-slice-loop`, `recovery`) where each phase points at the exact `intent-cli guide …` command; the **host/design vs child-implementation** role split (child = GitHub-contract-only & metadata-free; host = ask intent-cli before hand-editing metadata); a multi-agent note (Codex/Claude/Copilot/Cursor/OpenCode/Antigravity use the same entrypoint); and short ready-to-paste **AGENTS.md / CLAUDE.md** snippets. JSON + markdown. Detailed, drift-prone rules stay behind the per-phase guide commands — not duplicated here. Wired into `CommandRouter` and the `GuideHelpCommand` catalog (so it's discoverable via `guide --help` / `guide help`).
- **AGENTS.md / CLAUDE.md**: add a short "Ask intent-cli first (guide-first)" section — a rule, not a copied workflow spec — pointing at `intent-cli guide start` and stating the metadata-free child / ask-first host rules.

## Acceptance criteria
- Single obvious command to discover the right guide command before intent/packet/issue/review/loop work → `intent-cli guide start` ✓
- AGENTS.md / CLAUDE.md snippets are a short guide-first rule, not a long copied spec ✓ (generated by the command + added to the repo files; test asserts snippet length)
- Guidance states implementation-side agents are GitHub-contract-only & metadata-free ✓
- Guidance states host/design-side agents use intent-cli-supported commands before hand-editing metadata ✓
- Tests/snapshots cover guide-first output for design/packet, implementation loop, and review-next-slice loop ✓

## Verification
- [x] `GuideStartCommandTests` (5 tests) + catalog-mirror router test — focused run green.
- [x] Full suite: 3387 passed, 1 skipped, 0 failed.
- [x] `git diff --check` clean.

Closes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)