### PR TITLE
G396: bilingual OSS docs (docs/en, docs/ja)

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ artifacts described below).
 ## Documentation
 
 - Bilingual onboarding docs (installation, project start, intent organization,
-  loop setup, recovery) are organized under **`docs/ja/`** (日本語) and
-  **`docs/en/`** (English), introduced by slice **G396**.
+  packet/issue creation, implementation & review loop setup, recovery) —
+  **English: [`docs/en/`](./docs/en/index.md)**, **日本語: [`docs/ja/`](./docs/ja/index.md)**.
 - Local coding-automation prompt templates:
   [`docs/automation-templates/`](./docs/automation-templates/README.md).
 

--- a/docs/en/01-install.md
+++ b/docs/en/01-install.md
@@ -1,0 +1,35 @@
+# Install
+
+> **Ask intent-cli first.** After installing, run `intent-cli guide start` before
+> doing any workflow work. ← [docs index](index.md)
+
+The basic path is the .NET global tool from NuGet.org (requires a **.NET 10
+SDK**; check with `dotnet --version`). The same commands work on macOS, Windows,
+and Linux:
+
+```bash
+# Install
+dotnet tool install -g intent-cli
+
+# Upgrade in place
+dotnet tool update -g intent-cli
+
+# Verify
+intent-cli --version
+```
+
+If `~/.dotnet/tools` (macOS/Linux) or `%USERPROFILE%\.dotnet\tools` (Windows) is
+not on your `PATH`, the install output prints the line to add.
+
+**No .NET SDK?** Download the self-contained binary for your platform from the
+[latest GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/latest);
+the runtime is bundled. Verify the `.sha256` sidecar before use. See the
+[root README](../../README.md#install-without-a-net-sdk) for the full steps.
+
+**Internal testers** consuming the `private-preview-pack` artifact: see the
+[root README private-preview section](../../README.md#private-preview-install).
+
+## Next
+
+Confirmed `intent-cli --version`? Continue to
+[Start a project](02-project-start.md) — but run `intent-cli guide start` first.

--- a/docs/en/02-project-start.md
+++ b/docs/en/02-project-start.md
@@ -1,0 +1,38 @@
+# Start a project
+
+> **Ask intent-cli first:** `intent-cli guide start` → then the
+> `design-and-intent` / project-start guidance it points at. ← [docs index](index.md)
+
+This is **host/design** work (you may touch metadata, but ask intent-cli for the
+current command before hand-editing it).
+
+## Initialize and inspect
+
+```bash
+# Initialize a host domain (read-only without --write)
+intent-cli intent init --domain <name> [--target-repo <owner>/<repo>] --write
+
+# Inspect current baseline / WIP / queued packets (read-only)
+intent-cli intent status
+
+# Ask what the work surfaces expect
+intent-cli guide intent-work --format json
+```
+
+## Ask-intent-cli prompt template
+
+> Before starting on `<owner>/<repo>` domain `<name>`, run
+> `intent-cli guide start` and `intent-cli intent status`, then follow the
+> guide command for the phase I'm in. Use intent-cli transitions for any
+> label/metadata change; never hand-edit.
+
+## Metadata / label safety
+
+- `intent-target`, `intent-pr-*` and other workflow labels are applied by
+  `intent-cli automation` / `intent-cli worker` commands — never by hand.
+- Canonical state lives in the host repo's `.intent-cli/`; read it through
+  intent-cli surfaces, don't edit `queue-state.json` directly.
+
+## Next
+
+[Organize & maintain intents](03-intents.md).

--- a/docs/en/03-intents.md
+++ b/docs/en/03-intents.md
@@ -1,0 +1,36 @@
+# Organize & maintain intents
+
+> **Ask intent-cli first:** `intent-cli guide start` →
+> `intent-cli guide workflow task intent-interview --format json`. ← [docs index](index.md)
+
+**Host/design** work: capture and compile durable intent before cutting any
+slice.
+
+```bash
+# Durable per-domain Q/A artifact
+intent-cli interview next-question
+intent-cli interview record-answer ...
+intent-cli interview compile
+
+# Suggested end-to-end flow / readiness
+intent-cli guide workflow --format json
+intent-cli intent status --format json
+```
+
+## Ask-intent-cli prompt template
+
+> I'm organizing intents for domain `<name>`. Run `intent-cli guide start` then
+> the `intent-interview` workflow guide, and use `intent-cli interview …` to
+> record answers. Don't invent rules — ask intent-cli for current guidance.
+
+## Metadata / label safety
+
+- Interview/draft artifacts are written through `intent-cli interview …`
+  (`record-answer` is the only mutation here); don't hand-edit the durable Q/A
+  files.
+- Child implementation agents do **not** read the intent tree (`intents/**`) or
+  host metadata — that's host/design territory.
+
+## Next
+
+[Create packets & publish issues](04-packets-issues.md).

--- a/docs/en/04-packets-issues.md
+++ b/docs/en/04-packets-issues.md
@@ -1,0 +1,35 @@
+# Create packets & publish issues
+
+> **Ask intent-cli first:** `intent-cli guide start` →
+> `intent-cli guide workflow task packet-draft --format json` and
+> `… task issue-publish --format json`. ← [docs index](index.md)
+
+**Host/design** work. A packet scaffolds the canonical files; the publish
+boundary turns a reviewed Standalone Child Issue Contract into a GitHub issue.
+
+```bash
+# Scaffold the packet (packet.yaml / implementation.md / review-context.md / github-body.md)
+intent-cli packet draft --execution-unit <id> --target-repo <owner>/<repo> --format markdown
+
+# Enforce the Standalone Child Issue Contract, then publish
+intent-cli issue validate-body ...
+intent-cli issue publish-flow <id> --repo <owner>/<repo> --write --format json
+intent-cli automation issue-publish --issue <n> --write --format json
+```
+
+## Ask-intent-cli prompt template
+
+> I'm drafting packet `<id>` and publishing its issue to `<owner>/<repo>`. Run
+> `intent-cli guide start`, then the `packet-draft` and `issue-publish` workflow
+> guides, and apply `intent-target` only via the publish/automation command.
+
+## Metadata / label safety
+
+- **`intent-target` is applied by the publish boundary command, never by hand**,
+  and never by a child implementation agent.
+- The issue body must be a **standalone contract** — a child agent will treat it
+  as the only source of truth (no host metadata access).
+
+## Next
+
+[Implementation loop setup](05-implementation-loop.md).

--- a/docs/en/05-implementation-loop.md
+++ b/docs/en/05-implementation-loop.md
@@ -1,0 +1,48 @@
+# Implementation loop setup
+
+> **Ask intent-cli first:** `intent-cli guide start` →
+> `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`.
+> ← [docs index](index.md)
+
+This is **child-implementation** work and is **GitHub-contract-only &
+metadata-free**: the issue/PR and repo-local code are the only source of truth.
+Never read or mutate host `.intent-cli/`, queue-state, metadata branches, or
+`intents/**`.
+
+## The loop (one action per wake)
+
+The oneshot prompt is authoritative; in outline:
+
+```bash
+# 1. Select exactly one target (no manual label-walking)
+intent-cli worker next-action --repo <owner>/<repo> --github-only --format json
+
+# 2. issue-to-pr: claim, implement smallest change, open ready-for-review PR
+intent-cli worker claim --kind issue --number <n> --repo <owner>/<repo> --github-only --write --format json
+#    PR body MUST contain `Closes #<n>`; start from origin/main.
+intent-cli worker result-summary --kind issue-to-pr --repo <owner>/<repo> --issue <n> --pr <pr> --outcome <outcome> --format json
+intent-cli worker complete --kind issue --number <n> --repo <owner>/<repo> --github-only --outcome <outcome> --pr <pr> --write --format json
+```
+
+`pr-comment-fix` targets follow the same claim → repair → result-summary →
+complete shape on the existing PR branch.
+
+## Ask-intent-cli prompt template
+
+> Run the child implementation loop for `<owner>/<repo>` from this worktree.
+> Get the prompt via `intent-cli guide oneshot --kind child-implement-or-update`.
+> Select work only via `intent-cli worker next-action`; process at most one
+> action; all label transitions through intent-cli worker, never raw `gh`.
+
+## Metadata / label safety
+
+- All workflow-label transitions go through `intent-cli worker` — no raw
+  `gh ... --add-label`.
+- A child agent never applies `intent-target` (host-owned) or `intent-pr-created`
+  (issue-side marker) to a PR.
+- `linked_pr_synced: false` from `worker complete` is the expected child-cwd
+  warning — record it and move on.
+
+## Next
+
+[Review / next-slice loop setup](06-review-next-slice-loop.md).

--- a/docs/en/06-review-next-slice-loop.md
+++ b/docs/en/06-review-next-slice-loop.md
@@ -1,0 +1,41 @@
+# Review / next-slice loop setup
+
+> **Ask intent-cli first:** `intent-cli guide start` →
+> `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`.
+> ← [docs index](index.md)
+
+This is **host/review** work. It reviews PRs against the packet/intent contract,
+requests updates, approves/merges, and cuts the next slice. It may operate on
+host metadata, but always via `intent-cli`-supported transitions.
+
+```bash
+# Get the authoritative review/next-slice prompt
+intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>
+
+# PR-specific review guidance (checklist, packet refs, approval/request-update reqs)
+intent-cli guide review --pr <n> --repo <owner>/<repo> --format json
+
+# Label transitions (review-start, request-update, approve, …) — never by hand
+intent-cli automation pr-transition --transition <name> --write --format json
+```
+
+## Ask-intent-cli prompt template
+
+> Run the host review / next-slice loop for domain `<name>` / `<owner>/<repo>`.
+> Use `intent-cli guide oneshot --kind host-review-next-slice` and
+> `intent-cli guide review --pr <n>`. Apply every label transition via
+> `intent-cli automation`, and tie approvals to packet/intent evidence, not just
+> green tests.
+
+## Metadata / label safety
+
+- Review label transitions (`intent-pr-reviewing`, `intent-pr-request-update`,
+  `intent-pr-approved`, …) are applied by `intent-cli automation`, never by hand.
+- Passing tests is **necessary but not sufficient** — approval requires
+  packet/intent conformance evidence (see `guide review`).
+- Current-PR acceptance-criterion blockers get a durable PR comment before
+  completing as request-update/clarification (see [recovery](07-recovery.md)).
+
+## Next
+
+[Recover when a loop looks wrong](07-recovery.md).

--- a/docs/en/07-recovery.md
+++ b/docs/en/07-recovery.md
@@ -1,0 +1,43 @@
+# Recover when a loop looks wrong
+
+> **Ask intent-cli first** — don't hand-fix state. Run `intent-cli guide start`,
+> then the read-only preflight/doctor surfaces below. ← [docs index](index.md)
+
+When a loop looks stuck, wrong, or you're unsure whether a fix is in scope, ask
+`intent-cli` to classify it and tell you which command (if any) owns the repair —
+instead of editing labels or metadata directly.
+
+```bash
+# Is this PR's review feedback a safe, in-scope child repair?
+intent-cli worker pr-comment-preflight --repo <owner>/<repo> --pr <n> --format json
+
+# Is this issue safe to (re)claim as issue-to-pr?
+intent-cli worker issue-preflight --repo <owner>/<repo> --issue <n> --format json
+
+# CLI freshness / host-state resolution
+intent-cli automation doctor --format json
+```
+
+Read the result: `actionable` / `safe_repair_available` / `repair_category` tell
+you whether a child-loop-owned repair exists. Host-owned categories surface as
+`host-artifact-repair-required` and return to the host loop.
+
+## Ask-intent-cli prompt template
+
+> A loop looks wrong on `<owner>/<repo>` (PR/issue `<n>`). Before touching
+> anything, run the matching `intent-cli worker …-preflight` and
+> `intent-cli automation doctor`, and only apply a repair the CLI says is safe
+> and in scope. Don't hand-edit labels or metadata.
+
+## Metadata / label safety
+
+- Recovery never means hand-editing `queue-state.json` or labels; the preflight
+  surfaces are read-only and name the owning command.
+- Child implementation agents only own `child-selector-label-gap` repairs;
+  everything else is host/review-owned.
+- Durable PR blocker comments (not chat-only) record current-PR AC blockers; a
+  broader capability gap routes to a follow-up issue/packet/signal.
+
+## Back to start
+
+Return to the [docs index](index.md) or re-run `intent-cli guide start`.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,0 +1,44 @@
+# intent-cli documentation (English)
+
+> 日本語版は [`../ja/index.md`](../ja/index.md) を参照してください.
+
+`intent-cli` is **deterministic support tooling** for an intent-driven
+development workflow on top of GitHub. These pages give a little more structure
+than the [root README](../../README.md) without requiring you to read the
+internal design notes.
+
+## The one rule: ask intent-cli first
+
+Before any intent / packet / issue / review / implementation-loop work, run:
+
+```bash
+intent-cli guide start
+```
+
+It points you at the exact `intent-cli guide …` command for your phase. Don't
+start from memory, copied prompts, or ordinary GitHub habits, and don't
+hand-edit metadata or labels when an `intent-cli` command owns the transition.
+Every page below repeats this rule because it is the difference between a smooth
+loop and a broken one.
+
+## Pages
+
+1. [Install](01-install.md)
+2. [Start a project](02-project-start.md)
+3. [Organize & maintain intents](03-intents.md)
+4. [Create packets & publish issues](04-packets-issues.md)
+5. [Implementation loop setup](05-implementation-loop.md)
+6. [Review / next-slice loop setup](06-review-next-slice-loop.md)
+7. [Recover when a loop looks wrong](07-recovery.md)
+
+## Two agent roles (read this once)
+
+| Role | Source of truth | Responsibilities |
+| --- | --- | --- |
+| **Host / review agent** | parent host `.intent-cli/` state + intent tree | publish issues, apply `intent-target`, review/approve/merge, cut next slices, label transitions via `intent-cli automation` |
+| **Child implementation agent** | the **GitHub issue/PR + repo-local code** (not host metadata) | implement the issue contract, open/update the PR, record outcomes via `intent-cli worker` |
+
+Child implementation agents are **GitHub-contract-only**: they must not read or
+mutate host `.intent-cli/`, queue-state, metadata branches, or `intents/**`.
+Host/review agents may operate on metadata, but ask `intent-cli` for the current
+command first and prefer its transitions over hand edits.

--- a/docs/ja/01-install.md
+++ b/docs/ja/01-install.md
@@ -1,0 +1,35 @@
+# インストール
+
+> **まず intent-cli に聞く。** インストール後、ワークフロー作業の前に
+> `intent-cli guide start` を実行する。 ← [ドキュメント索引](index.md)
+
+基本ルートは NuGet.org の .NET グローバルツール（**.NET 10 SDK** が必要。
+`dotnet --version` で確認）。macOS / Windows / Linux で同じコマンド:
+
+```bash
+# インストール
+dotnet tool install -g intent-cli
+
+# その場でアップグレード
+dotnet tool update -g intent-cli
+
+# 確認
+intent-cli --version
+```
+
+`~/.dotnet/tools`（macOS/Linux）または `%USERPROFILE%\.dotnet\tools`（Windows）が
+`PATH` に無い場合、インストール出力に追加すべき行が表示されます。
+
+**.NET SDK が無い場合**は、各プラットフォーム向けの self-contained バイナリを
+[最新 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/latest)
+から取得（ランタイム同梱）。使用前に `.sha256` を検証する。手順は
+[ルート README](../../README.md#install-without-a-net-sdk) を参照。
+
+**社内テスター**（`private-preview-pack` アーティファクト利用）は
+[ルート README の private-preview セクション](../../README.md#private-preview-install)
+を参照。
+
+## 次へ
+
+`intent-cli --version` を確認したら [プロジェクト開始](02-project-start.md) へ。
+ただし先に `intent-cli guide start` を実行する。

--- a/docs/ja/02-project-start.md
+++ b/docs/ja/02-project-start.md
@@ -1,0 +1,37 @@
+# プロジェクト開始
+
+> **まず intent-cli に聞く:** `intent-cli guide start` → 案内される
+> `design-and-intent` / プロジェクト開始ガイド。 ← [ドキュメント索引](index.md)
+
+これは **host/design** 作業（metadata を触ってよいが、手編集の前に intent-cli へ
+現在のコマンドを尋ねる）。
+
+## 初期化と確認
+
+```bash
+# host domain を初期化（--write なしは read-only）
+intent-cli intent init --domain <name> [--target-repo <owner>/<repo>] --write
+
+# 現在の baseline / WIP / キュー済み packet を確認（read-only）
+intent-cli intent status
+
+# 作業サーフェスが期待する内容を尋ねる
+intent-cli guide intent-work --format json
+```
+
+## ask-intent-cli プロンプトテンプレート
+
+> `<owner>/<repo>` の domain `<name>` を始める前に、`intent-cli guide start` と
+> `intent-cli intent status` を実行し、フェーズに対応する guide コマンドに従う。
+> label/metadata の変更は intent-cli の遷移を使い、手編集しない。
+
+## metadata / label の安全境界
+
+- `intent-target` や `intent-pr-*` などのワークフロー label は
+  `intent-cli automation` / `intent-cli worker` が付与する。手作業では行わない。
+- 正本の状態は host repo の `.intent-cli/` にある。intent-cli のサーフェス経由で読み、
+  `queue-state.json` を直接編集しない。
+
+## 次へ
+
+[intent の整理・保守](03-intents.md)。

--- a/docs/ja/03-intents.md
+++ b/docs/ja/03-intents.md
@@ -1,0 +1,34 @@
+# intent の整理・保守
+
+> **まず intent-cli に聞く:** `intent-cli guide start` →
+> `intent-cli guide workflow task intent-interview --format json`。 ← [ドキュメント索引](index.md)
+
+**host/design** 作業: slice を切り出す前に、永続的な intent を収集・コンパイルする。
+
+```bash
+# domain ごとの永続 Q/A アーティファクト
+intent-cli interview next-question
+intent-cli interview record-answer ...
+intent-cli interview compile
+
+# 推奨フロー / 準備状況
+intent-cli guide workflow --format json
+intent-cli intent status --format json
+```
+
+## ask-intent-cli プロンプトテンプレート
+
+> domain `<name>` の intent を整理する。`intent-cli guide start` の後に
+> `intent-interview` ワークフローガイドを実行し、`intent-cli interview …` で
+> 回答を記録する。ルールを発明せず、現在のガイドを intent-cli に尋ねる。
+
+## metadata / label の安全境界
+
+- interview/draft アーティファクトは `intent-cli interview …` 経由で書き込む
+  （ここでの変更は `record-answer` のみ）。永続 Q/A ファイルを手編集しない。
+- child implementation agent は intent tree（`intents/**`）や host metadata を
+  **読まない** — これは host/design の領域。
+
+## 次へ
+
+[packet 作成と issue 公開](04-packets-issues.md)。

--- a/docs/ja/04-packets-issues.md
+++ b/docs/ja/04-packets-issues.md
@@ -1,0 +1,35 @@
+# packet 作成と issue 公開
+
+> **まず intent-cli に聞く:** `intent-cli guide start` →
+> `intent-cli guide workflow task packet-draft --format json` と
+> `… task issue-publish --format json`。 ← [ドキュメント索引](index.md)
+
+**host/design** 作業。packet が正本ファイルを scaffold し、公開境界がレビュー済みの
+Standalone Child Issue Contract を GitHub issue にする。
+
+```bash
+# packet を scaffold（packet.yaml / implementation.md / review-context.md / github-body.md）
+intent-cli packet draft --execution-unit <id> --target-repo <owner>/<repo> --format markdown
+
+# Standalone Child Issue Contract を検証してから公開
+intent-cli issue validate-body ...
+intent-cli issue publish-flow <id> --repo <owner>/<repo> --write --format json
+intent-cli automation issue-publish --issue <n> --write --format json
+```
+
+## ask-intent-cli プロンプトテンプレート
+
+> packet `<id>` を作成し、その issue を `<owner>/<repo>` に公開する。
+> `intent-cli guide start` の後に `packet-draft` と `issue-publish` のワークフロー
+> ガイドを実行し、`intent-target` は公開/automation コマンド経由でのみ付与する。
+
+## metadata / label の安全境界
+
+- **`intent-target` は公開境界コマンドが付与する。手作業では付けない**。
+  child implementation agent も付けない。
+- issue 本文は **standalone contract** であること — child agent はそれを唯一の
+  source of truth として扱う（host metadata にはアクセスしない）。
+
+## 次へ
+
+[実装ループの設定](05-implementation-loop.md)。

--- a/docs/ja/05-implementation-loop.md
+++ b/docs/ja/05-implementation-loop.md
@@ -1,0 +1,48 @@
+# 実装ループの設定
+
+> **まず intent-cli に聞く:** `intent-cli guide start` →
+> `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`。
+> ← [ドキュメント索引](index.md)
+
+これは **child-implementation** 作業で、**GitHub-contract-only かつ
+metadata-free**: issue/PR と repo ローカルのコードのみが source of truth。
+host の `.intent-cli/`、queue-state、metadata branch、`intents/**` を読んだり
+変更したりしない。
+
+## ループ（1 wake で 1 アクション）
+
+oneshot prompt が正本。概要:
+
+```bash
+# 1. 対象を 1 つだけ選ぶ（手動の label-walking はしない）
+intent-cli worker next-action --repo <owner>/<repo> --github-only --format json
+
+# 2. issue-to-pr: claim → 最小実装 → ready-for-review の PR を作成
+intent-cli worker claim --kind issue --number <n> --repo <owner>/<repo> --github-only --write --format json
+#    PR 本文に `Closes #<n>` を必ず含める。origin/main から開始する。
+intent-cli worker result-summary --kind issue-to-pr --repo <owner>/<repo> --issue <n> --pr <pr> --outcome <outcome> --format json
+intent-cli worker complete --kind issue --number <n> --repo <owner>/<repo> --github-only --outcome <outcome> --pr <pr> --write --format json
+```
+
+`pr-comment-fix` の対象も、既存 PR ブランチ上で claim → 修正 → result-summary →
+complete という同じ形に従う。
+
+## ask-intent-cli プロンプトテンプレート
+
+> このワークツリーから `<owner>/<repo>` の child implementation ループを回す。
+> prompt は `intent-cli guide oneshot --kind child-implement-or-update` で取得。
+> 作業の選択は `intent-cli worker next-action` のみ。1 wake で最大 1 アクション。
+> label 遷移はすべて intent-cli worker 経由で、raw `gh` は使わない。
+
+## metadata / label の安全境界
+
+- ワークフロー label 遷移はすべて `intent-cli worker` 経由 — raw `gh ... --add-label`
+  は使わない。
+- child agent は PR に `intent-target`（host 所有）や `intent-pr-created`
+  （issue 側マーカー）を付けない。
+- `worker complete` の `linked_pr_synced: false` は child-cwd で想定される警告 —
+  記録して先に進む。
+
+## 次へ
+
+[レビュー / next-slice ループの設定](06-review-next-slice-loop.md)。

--- a/docs/ja/06-review-next-slice-loop.md
+++ b/docs/ja/06-review-next-slice-loop.md
@@ -1,0 +1,41 @@
+# レビュー / next-slice ループの設定
+
+> **まず intent-cli に聞く:** `intent-cli guide start` →
+> `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`。
+> ← [ドキュメント索引](index.md)
+
+これは **host/review** 作業。PR を packet/intent 契約に照らしてレビューし、更新を
+要求し、approve/merge し、next slice を切り出す。host metadata を扱ってよいが、
+常に `intent-cli` がサポートする遷移を使う。
+
+```bash
+# レビュー / next-slice の正本 prompt を取得
+intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>
+
+# PR 固有のレビューガイド（チェックリスト、packet 参照、approve/request-update 要件）
+intent-cli guide review --pr <n> --repo <owner>/<repo> --format json
+
+# label 遷移（review-start、request-update、approve …）— 手作業では行わない
+intent-cli automation pr-transition --transition <name> --write --format json
+```
+
+## ask-intent-cli プロンプトテンプレート
+
+> domain `<name>` / `<owner>/<repo>` の host review / next-slice ループを回す。
+> `intent-cli guide oneshot --kind host-review-next-slice` と
+> `intent-cli guide review --pr <n>` を使う。label 遷移はすべて
+> `intent-cli automation` 経由で、approve は green テストだけでなく
+> packet/intent の証跡に紐づける。
+
+## metadata / label の安全境界
+
+- レビュー label 遷移（`intent-pr-reviewing`、`intent-pr-request-update`、
+  `intent-pr-approved` …）は `intent-cli automation` が付与する。手作業では行わない。
+- テスト通過は **必要だが十分ではない** — approve には packet/intent への
+  適合証跡が必要（`guide review` 参照）。
+- 現在 PR の受け入れ基準ブロッカーは、request-update/clarification として完了する前に
+  永続的な PR コメントを残す（[復旧](07-recovery.md) 参照）。
+
+## 次へ
+
+[ループがおかしいときの復旧](07-recovery.md)。

--- a/docs/ja/07-recovery.md
+++ b/docs/ja/07-recovery.md
@@ -1,0 +1,42 @@
+# ループがおかしいときの復旧
+
+> **まず intent-cli に聞く** — 状態を手で直さない。`intent-cli guide start` の後、
+> 以下の read-only な preflight/doctor サーフェスを実行する。 ← [ドキュメント索引](index.md)
+
+ループが詰まっている・おかしい・修正が scope 内か不明なときは、label や metadata を
+直接編集する代わりに、`intent-cli` に分類させ、（あれば）どのコマンドが修復を
+所有するかを尋ねる。
+
+```bash
+# この PR のレビュー指摘は安全で scope 内の child 修復か？
+intent-cli worker pr-comment-preflight --repo <owner>/<repo> --pr <n> --format json
+
+# この issue を issue-to-pr として（再）claim して安全か？
+intent-cli worker issue-preflight --repo <owner>/<repo> --issue <n> --format json
+
+# CLI の鮮度 / host-state 解決
+intent-cli automation doctor --format json
+```
+
+結果を読む: `actionable` / `safe_repair_available` / `repair_category` が、
+child-loop 所有の修復が存在するかを示す。host 所有のカテゴリは
+`host-artifact-repair-required` として現れ、host ループへ戻す。
+
+## ask-intent-cli プロンプトテンプレート
+
+> `<owner>/<repo>`（PR/issue `<n>`）でループがおかしい。何も触る前に、対応する
+> `intent-cli worker …-preflight` と `intent-cli automation doctor` を実行し、CLI が
+> 安全かつ scope 内と判断した修復のみ適用する。label/metadata を手編集しない。
+
+## metadata / label の安全境界
+
+- 復旧は `queue-state.json` や label の手編集を意味しない。preflight サーフェスは
+  read-only で、所有コマンドを示す。
+- child implementation agent が所有する修復は `child-selector-label-gap` のみ。
+  それ以外は host/review 所有。
+- 永続的な PR ブロッカーコメント（チャットだけにしない）が現在 PR の AC ブロッカーを
+  記録する。より広い能力ギャップは follow-up issue/packet/signal に振り分ける。
+
+## 索引へ戻る
+
+[ドキュメント索引](index.md) に戻るか、`intent-cli guide start` を再実行する。

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -1,0 +1,42 @@
+# intent-cli ドキュメント（日本語）
+
+> English version: [`../en/index.md`](../en/index.md)
+
+`intent-cli` は、GitHub 上で intent 駆動の開発ワークフローを回すための
+**決定論的なサポートツール** です。これらのページは、内部設計ノートを全部読まなくても
+[ルート README](../../README.md) より少しだけ構造化された案内を提供します。
+
+## 唯一のルール: まず intent-cli に聞く
+
+intent / packet / issue / review / implementation-loop の作業を始める前に、まず実行する:
+
+```bash
+intent-cli guide start
+```
+
+現在のフェーズに対応する `intent-cli guide …` コマンドを案内してくれます。記憶や
+コピーした prompt、通常の GitHub 操作の感覚から始めない。`intent-cli` のコマンドが
+遷移を所有している label / metadata は手編集しない。以下の各ページがこのルールを
+繰り返すのは、これがループの成否を分けるからです。
+
+## ページ一覧
+
+1. [インストール](01-install.md)
+2. [プロジェクト開始](02-project-start.md)
+3. [intent の整理・保守](03-intents.md)
+4. [packet 作成と issue 公開](04-packets-issues.md)
+5. [実装ループの設定](05-implementation-loop.md)
+6. [レビュー / next-slice ループの設定](06-review-next-slice-loop.md)
+7. [ループがおかしいときの復旧](07-recovery.md)
+
+## 2 つの agent ロール（最初に一度だけ読む）
+
+| ロール | source of truth | 責務 |
+| --- | --- | --- |
+| **Host / review agent** | 親 host の `.intent-cli/` 状態 + intent tree | issue 公開、`intent-target` 付与、review/approve/merge、next slice 切り出し、`intent-cli automation` 経由の label 遷移 |
+| **Child implementation agent** | **GitHub の issue/PR + repo ローカルのコード**（host metadata ではない） | issue 契約の実装、PR の作成/更新、`intent-cli worker` での結果記録 |
+
+Child implementation agent は **GitHub-contract-only**: host の `.intent-cli/`、
+queue-state、metadata branch、`intents/**` を読んだり変更したりしない。
+Host/review agent は metadata を扱ってよいが、手編集の前に `intent-cli` へ現在の
+コマンドを尋ね、その遷移を優先する。


### PR DESCRIPTION
## Summary
Adds the public bilingual documentation tree that G395's README Documentation section forward-referenced.

- `docs/en/` and `docs/ja/` each with `index.md` + 7 pages: install, project start, intents maintenance, packet/issue creation, implementation-loop setup, review/next-slice-loop setup, recovery. Indexes link every page; the two languages are page-for-page parallel.
- Every page opens with an "ask intent-cli first" banner pointing at `intent-cli guide start` and the per-phase guide command, plus a short ask-intent-cli prompt template and a metadata/label safety-boundary note.
- Docs distinguish host/review responsibilities (may touch metadata via intent-cli transitions) from child-implementation (GitHub-contract-only, metadata-free) work.
- README Documentation section now links the real `docs/en/index.md` and `docs/ja/index.md`.

## Test plan
- [x] EN/JA parity (8 files each)
- [x] index links resolve to existing pages
- [x] `git diff --check` clean (no whitespace errors)

Closes #895