### PR TITLE
G397: onboarding + ask-intent-cli loop templates in guide start

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideStartCommand.cs
@@ -149,10 +149,65 @@ internal static class GuideStartCommand
                         + "metadata or labels.",
                 },
             },
+            OnboardingGuidance = new GuideStartOnboarding
+            {
+                InstallAndVerify =
+                    "Install the `intent-cli` .NET tool, then verify with `intent-cli --version` and "
+                    + "`intent-cli automation doctor --format json` (reports CLI freshness / host-state). SDK and tool "
+                    + "install steps for macOS / Windows / Linux: `docs/en/01-install.md` (`docs/ja/01-install.md`).",
+                ProjectStart =
+                    "Stand up a new host project / domain with `intent-cli guide workflow task init-host --format json`; "
+                    + "for the zero-local-rules first-call sequence run `intent-cli guide onboarding --format json`.",
+                AskIntentCliFirst =
+                    "After install, ask intent-cli — not memory or copied prompts — for each next step: re-run "
+                    + "`intent-cli guide start` whenever you resume, and use the per-phase guide command it points at.",
+            },
+            AskIntentCliTemplates = new[]
+            {
+                new GuideStartTemplate
+                {
+                    Name = "implementation-loop",
+                    Side = "child-implementation",
+                    When = "Run a recurring loop that turns intent-target issues into PRs and applies PR-comment fixes.",
+                    Template =
+                        "Run the intent-cli child implementation loop for `<owner>/<repo>` (domain `<domain>`) using "
+                        + "agent `<agent>` at `<frequency>` cadence, from child worktree cwd `<cwd>`. Each wake, process "
+                        + "at most one action:\n"
+                        + "1. Confirm `<cwd>` is the worktree root and the repo is `<owner>/<repo>`; `git fetch --all --prune`.\n"
+                        + "2. Run `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>` and "
+                        + "follow it verbatim.\n"
+                        + "3. Choose work ONLY via `intent-cli worker next-action --repo <owner>/<repo> --github-only "
+                        + "--format json`; make every label transition through `intent-cli worker` / `intent-cli "
+                        + "automation`, never raw `gh` label edits.\n"
+                        + "Child implementation agents are GitHub-contract-only and do NOT need host metadata: the issue/PR "
+                        + "body and repo-local code are the only source of truth; never read or mutate host `.intent-cli/`, "
+                        + "queue-state, or `intents/**`.",
+                },
+                new GuideStartTemplate
+                {
+                    Name = "review-next-slice-loop",
+                    Side = "host/design",
+                    When = "Run a recurring loop that reviews PRs against the contract, approves/merges, and cuts the next slice.",
+                    Template =
+                        "Run the intent-cli host review / next-slice loop for `<owner>/<repo>` (domain `<domain>`) using "
+                        + "agent `<agent>` at `<frequency>` cadence, from host worktree cwd `<cwd>`. Each wake:\n"
+                        + "1. Run `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>` and follow "
+                        + "it verbatim.\n"
+                        + "2. Review the open PR against the packet/intent contract with `intent-cli guide review --pr <n> "
+                        + "--repo <owner>/<repo> --format json`.\n"
+                        + "3. Apply review label transitions ONLY via `intent-cli automation pr-transition`; approve on "
+                        + "packet/intent evidence (green tests are necessary but not sufficient), then cut the next slice "
+                        + "once merged.\n"
+                        + "Host/review agents may touch metadata, but ask intent-cli for the current supported transition "
+                        + "before hand-editing labels or queue-state.",
+                },
+            },
             MultiAgentNote =
                 "Every agent family — Codex, Claude, Copilot, Cursor, OpenCode, Antigravity, and other local/host "
                 + "agents — uses this same `intent-cli guide start` entrypoint. Repositories carry only a short "
-                + "guide-first rule (see the snippets below); they do not embed a full workflow spec that can drift.",
+                + "guide-first rule (see the snippets below); they do not embed a full workflow spec that can drift. "
+                + "Fill the `<domain>` / `<agent>` / `<frequency>` / `<cwd>` / `<owner>/<repo>` placeholders in the "
+                + "ask-intent-cli templates from your local bindings before scheduling a loop.",
             RepositoryInstructionSnippets = new GuideStartSnippets
             {
                 AgentsMd =
@@ -203,6 +258,27 @@ internal static class GuideStartCommand
             writer.WriteLine($"### {role.Role}");
             writer.WriteLine($"- source of truth: {role.SourceOfTruth}");
             writer.WriteLine($"- rule: {role.Rule}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Install & onboarding");
+        writer.WriteLine($"- install / verify: {result.OnboardingGuidance.InstallAndVerify}");
+        writer.WriteLine($"- project start: {result.OnboardingGuidance.ProjectStart}");
+        writer.WriteLine($"- ask intent-cli first: {result.OnboardingGuidance.AskIntentCliFirst}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Ask-intent-cli loop prompt templates");
+        writer.WriteLine();
+        writer.WriteLine("Fill the `<domain>` / `<agent>` / `<frequency>` / `<cwd>` / `<owner>/<repo>` placeholders before scheduling.");
+        writer.WriteLine();
+        foreach (var template in result.AskIntentCliTemplates)
+        {
+            writer.WriteLine($"### {template.Name} ({template.Side})");
+            writer.WriteLine($"- when: {template.When}");
+            writer.WriteLine();
+            writer.WriteLine("```text");
+            writer.WriteLine(template.Template);
+            writer.WriteLine("```");
             writer.WriteLine();
         }
 
@@ -291,6 +367,12 @@ internal sealed record GuideStartResult
     [JsonPropertyName("agent_roles")]
     public required IReadOnlyList<GuideStartRole> AgentRoles { get; init; }
 
+    [JsonPropertyName("onboarding_guidance")]
+    public required GuideStartOnboarding OnboardingGuidance { get; init; }
+
+    [JsonPropertyName("ask_intent_cli_templates")]
+    public required IReadOnlyList<GuideStartTemplate> AskIntentCliTemplates { get; init; }
+
     [JsonPropertyName("multi_agent_note")]
     public required string MultiAgentNote { get; init; }
 
@@ -335,4 +417,31 @@ internal sealed record GuideStartSnippets
 
     [JsonPropertyName("claude_md")]
     public required string ClaudeMd { get; init; }
+}
+
+internal sealed record GuideStartOnboarding
+{
+    [JsonPropertyName("install_and_verify")]
+    public required string InstallAndVerify { get; init; }
+
+    [JsonPropertyName("project_start")]
+    public required string ProjectStart { get; init; }
+
+    [JsonPropertyName("ask_intent_cli_first")]
+    public required string AskIntentCliFirst { get; init; }
+}
+
+internal sealed record GuideStartTemplate
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("side")]
+    public required string Side { get; init; }
+
+    [JsonPropertyName("when")]
+    public required string When { get; init; }
+
+    [JsonPropertyName("template")]
+    public required string Template { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideStartCommandTests.cs
@@ -112,6 +112,81 @@ public sealed class GuideStartCommandTests
     }
 
     [Fact]
+    public void Execute_Json_EmitsLoopPromptTemplatesWithRequiredPlaceholders()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var templates = document.RootElement.GetProperty("ask_intent_cli_templates").EnumerateArray().ToArray();
+        var names = templates.Select(t => t.GetProperty("name").GetString()!).ToArray();
+
+        // G397 AC: implementation loop AND review/next-slice loop prompt templates.
+        Assert.Contains("implementation-loop", names);
+        Assert.Contains("review-next-slice-loop", names);
+
+        // G397 AC: every template pins domain, agent, frequency, cwd, and target-repo placeholders.
+        string[] requiredPlaceholders =
+        [
+            "<domain>", "<agent>", "<frequency>", "<cwd>", "<owner>/<repo>"
+        ];
+        Assert.All(templates, t =>
+        {
+            var body = t.GetProperty("template").GetString()!;
+            Assert.All(requiredPlaceholders, ph =>
+                Assert.Contains(ph, body, StringComparison.Ordinal));
+        });
+    }
+
+    [Fact]
+    public void Execute_Json_ImplementationTemplateSaysChildDoesNotNeedHostMetadata()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var templates = document.RootElement.GetProperty("ask_intent_cli_templates").EnumerateArray().ToArray();
+
+        var impl = templates.Single(t => t.GetProperty("name").GetString() == "implementation-loop");
+        var body = impl.GetProperty("template").GetString()!;
+        // G397 AC: guidance says child implementation agents do not need host metadata.
+        Assert.Contains("do NOT need host metadata", body, StringComparison.Ordinal);
+        Assert.Equal("child-implementation", impl.GetProperty("side").GetString());
+    }
+
+    [Fact]
+    public void Execute_Json_EmitsInstallAndOnboardingGuidance()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var onboarding = document.RootElement.GetProperty("onboarding_guidance");
+
+        // G397 AC: a user can ask intent-cli for install/onboarding guidance.
+        Assert.Contains("install", onboarding.GetProperty("install_and_verify").GetString()!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli", onboarding.GetProperty("project_start").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide start", onboarding.GetProperty("ask_intent_cli_first").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DefaultMarkdown_RendersTemplatesAndOnboardingSections()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("## Install & onboarding", output, StringComparison.Ordinal);
+        Assert.Contains("## Ask-intent-cli loop prompt templates", output, StringComparison.Ordinal);
+        Assert.Contains("implementation-loop", output, StringComparison.Ordinal);
+        Assert.Contains("review-next-slice-loop", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownArgument_ReturnsUsageError()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary
Extends the `intent-cli guide start` single-obvious guide surface so users and agents can ask intent-cli itself for OSS onboarding and the canonical loop prompt templates, rather than copying drift-prone prompts.

- **`onboarding_guidance`**: install/verify (`intent-cli --version`, `automation doctor`, `docs/en|ja/01-install.md`), project start (`guide workflow task init-host`, `guide onboarding`), ask-intent-cli-first reminder.
- **`ask_intent_cli_templates`**: paste-ready `implementation-loop` and `review-next-slice-loop` prompts, each carrying `<domain>` / `<agent>` / `<frequency>` / `<cwd>` / `<owner>/<repo>` placeholders.
- The implementation-loop template states child agents are GitHub-contract-only and do **not** need host metadata; the review template keeps host metadata behind intent-cli transitions.
- Markdown writer renders new "Install & onboarding" and "Ask-intent-cli loop prompt templates" sections.

## Acceptance Criteria mapping
- Ask intent-cli for install/onboarding guidance → `onboarding_guidance`.
- Ask intent-cli for implementation-loop and review/next-slice-loop prompt templates → `ask_intent_cli_templates`.
- Tests pin domain/agent/frequency/cwd/target-repo placeholders → `Execute_Json_EmitsLoopPromptTemplatesWithRequiredPlaceholders`.
- Guidance says child implementation agents don't need host metadata → `Execute_Json_ImplementationTemplateSaysChildDoesNotNeedHostMetadata`.

## Test plan
- [x] `dotnet test --filter GuideStartCommandTests` → 9/9 pass (5 existing + 4 new)

Closes #897