### PR TITLE
G402: Make next-slice publisher ownership guidance non-interactive

### DIFF
--- a/docs/automation-templates/host-next-slice-loop.md
+++ b/docs/automation-templates/host-next-slice-loop.md
@@ -159,6 +159,27 @@ Dry-run the same command without `--write` to capture the planned
 Raw `gh issue edit` label mutation is not the normal path for this
 installed transition.
 
+## Publish ownership rule (non-interactive)
+
+When the next-slice conditions are met — the candidate is
+`issue-cut-ready`, the WIP cap is clear, no Hard Clarification
+exists, and metadata safety gates pass — publish the issue through
+`intent-cli`. Do **not** ask the operator whether to proceed or
+which publisher should own the step.
+
+If a concurrent or prior publisher is observed in the host state
+(e.g. another automation session recently published a candidate),
+that observation is **context only**. It does not change the
+publish decision. Proceed via `intent-cli issue publish-reviewed`
+(or the equivalent host surface) without asking the operator.
+
+Publish ownership follows `intent-cli` as the single source of
+truth. Asking "should I publish?" or "who should own this?" is
+always wrong when the conditions above are satisfied. The only
+valid reason to stop is a genuine contract incompleteness or a
+hard metadata-safety failure — not the presence of a concurrent
+publisher note.
+
 ## What this template forbids
 
 - Authoring implementation changes. Next-slice planning describes
@@ -176,6 +197,9 @@ installed transition.
 - Asking `intent-cli` to launch an AI provider.
 - Mass-editing parent-host packet content. Use `metadata update`
   only with an explicit supported mode.
+- Asking the operator whether to publish or who should own the
+  publish step when next-slice conditions are already satisfied.
+  Concurrent publisher state is informational only.
 
 ## Boundary against the coding-automation loop
 

--- a/src/IntentSystem.Cli/Commands/GuideOneshotCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOneshotCommand.cs
@@ -249,8 +249,8 @@ Workflow:
 8. If review requires repair: leave an actionable PR comment and move the PR to the request-update state according to installed/runbook-supported transition behavior.
 9. If no PR is available, still run Stage 2 next-slice once.
 10. Do not cut a new child issue while any open child issue/PR with `intent-target` remains.
-11. If next-slice is clear and WIP cap is empty, create/publish exactly one child issue and preload future packets only when they satisfy the Child Issue Contract.
-12. If clarification is required, stop and report: background, question, options, pros/cons, and recommendation.
+11. If next-slice is clear and WIP cap is empty, create/publish exactly one child issue and preload future packets only when they satisfy the Child Issue Contract. If a concurrent or prior publisher is observed in the host state (e.g. another automation has recently published), treat that as informational context only — do NOT ask the operator whether to proceed or who should own the publish step. Publish ownership follows `intent-cli` as the single source of truth; it is never a question for the operator chat.
+12. If clarification is required, stop and report: background, question, options, pros/cons, and recommendation. Publish ownership disambiguation is NOT a valid clarification reason; proceed through `intent-cli` even when a concurrent publisher is observed.
 13. Commit and push parent host changes directly to `main` per `AGENTS.md`. Do not create a PR.
 
 Final report must include:
@@ -293,8 +293,8 @@ Workflow:
 8. If review requires repair: leave an actionable PR comment and move the PR to the request-update state according to installed/runbook-supported transition behavior.
 9. If no PR is available, still run Stage 2 next-slice once.
 10. Do not cut a new child issue while any open child issue/PR with `intent-target` remains.
-11. If next-slice is clear and WIP cap is empty, create/publish exactly one child issue and preload future packets only when they satisfy the Child Issue Contract.
-12. If clarification is required, stop and report: background, question, options, pros/cons, and recommendation.
+11. If next-slice is clear and WIP cap is empty, create/publish exactly one child issue and preload future packets only when they satisfy the Child Issue Contract. If a concurrent or prior publisher is observed in the host state (e.g. another automation has recently published), treat that as informational context only — do NOT ask the operator whether to proceed or who should own the publish step. Publish ownership follows `intent-cli` as the single source of truth; it is never a question for the operator chat.
+12. If clarification is required, stop and report: background, question, options, pros/cons, and recommendation. Publish ownership disambiguation is NOT a valid clarification reason; proceed through `intent-cli` even when a concurrent publisher is observed.
 13. Commit and push parent host changes directly to `main` per `AGENTS.md`. Do not create a PR.
 
 Final report must include:

--- a/tests/IntentSystem.Cli.Tests/GuideOneshotCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOneshotCommandTests.cs
@@ -204,6 +204,83 @@ public sealed class GuideOneshotCommandTests
         Assert.DoesNotContain("intents/rules/automations/runbook.md", GuideOneshotCommand.HostSekibanAsAServicePrompt, StringComparison.Ordinal);
     }
 
+    // ── G402 publish ownership non-interactive contract ───────────────────────
+
+    /// <summary>
+    /// G402: the host review/next-slice prompt for intent-cli must instruct the
+    /// operator NOT to ask about publish ownership when a concurrent publisher
+    /// is observed.
+    /// </summary>
+    [Fact]
+    public void HostIntentCliPrompt_ContainsPublishOwnershipRule_DoNotAskOperator()
+    {
+        // The prompt must say publish ownership is never a question for the
+        // operator chat, so automated host loops never pause to ask.
+        Assert.Contains(
+            "do NOT ask the operator",
+            GuideOneshotCommand.HostIntentCliPrompt,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "Publish ownership follows",
+            GuideOneshotCommand.HostIntentCliPrompt,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G402: the host review/next-slice prompt must encode that publish
+    /// ownership disambiguation is NOT a valid clarification reason.
+    /// </summary>
+    [Fact]
+    public void HostIntentCliPrompt_PublishOwnershipDisambiguationNotAClarificationReason()
+    {
+        Assert.Contains(
+            "Publish ownership disambiguation is NOT a valid clarification reason",
+            GuideOneshotCommand.HostIntentCliPrompt,
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G402: the guidance emitted by Execute for intent-cli domain must
+    /// include the non-interactive publish ownership rule so an automation
+    /// that observes a concurrent publisher proceeds without asking.
+    /// </summary>
+    [Fact]
+    public void Execute_HostReviewNextSlice_IntentCli_EmitsConcurrentPublisherOwnershipRule()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOneshotCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        // Must explicitly prohibit asking the operator.
+        Assert.Contains("do NOT ask the operator", output, StringComparison.OrdinalIgnoreCase);
+        // Must reference the concurrent publisher scenario.
+        Assert.Contains("concurrent", output, StringComparison.OrdinalIgnoreCase);
+        // Must name intent-cli as the source of truth for publish ownership.
+        Assert.Contains("intent-cli", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("single source of truth", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G402: same non-interactive ownership rule must be present in the
+    /// sekiban-as-a-service host prompt.
+    /// </summary>
+    [Fact]
+    public void HostSekibanAsAServicePrompt_ContainsPublishOwnershipRule_DoNotAskOperator()
+    {
+        Assert.Contains(
+            "do NOT ask the operator",
+            GuideOneshotCommand.HostSekibanAsAServicePrompt,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            "Publish ownership disambiguation is NOT a valid clarification reason",
+            GuideOneshotCommand.HostSekibanAsAServicePrompt,
+            StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext


### PR DESCRIPTION
## Summary

- Add explicit publish ownership rule to `guide oneshot --kind host-review-next-slice`: when next-slice conditions are met, publish via `intent-cli` without asking the operator — even when a concurrent publisher is observed in host state.
- Update `docs/automation-templates/host-next-slice-loop.md` with a dedicated "Publish ownership rule (non-interactive)" section and a corresponding bullet in the forbids list.
- Add four acceptance tests in `GuideOneshotCommandTests` covering the non-interactive ownership contract for both `intent-cli` and `sekiban-as-a-service` host domains.

## Changed files

- `src/IntentSystem.Cli/Commands/GuideOneshotCommand.cs` — steps 11 & 12 updated in both host prompts
- `docs/automation-templates/host-next-slice-loop.md` — new section + forbids bullet
- `tests/IntentSystem.Cli.Tests/GuideOneshotCommandTests.cs` — four new G402 tests

## Test plan

- [x] All existing `GuideOneshotCommandTests` pass (20/20)
- [x] Four new G402 acceptance tests pass
- [x] Full solution builds with zero errors (`dotnet build --configuration Release`)
- [x] Pre-existing flaky test (`AutomationCheck_AndWorkerNextAction_AgreeOnPrCommentFixUnderChildWorkdirContext`) confirmed pre-existing failure unrelated to G402 changes

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)