### PR TITLE
G403: Define flexible intent knowledge tree layout and manifest

### DIFF
--- a/docs/en/03-intents.md
+++ b/docs/en/03-intents.md
@@ -31,6 +31,25 @@ intent-cli intent status --format json
 - Child implementation agents do **not** read the intent tree (`intents/**`) or
   host metadata — that's host/design territory.
 
+## Intent knowledge-tree layout (tree-v1)
+
+New domains should organize intent into discoverable folders rather than a single flat
+file. The **tree-v1** layout defines recommended categories (`identity`, `product`,
+`features`, `technology`, `operations`, `decisions`, `clarifications`, `packets`, `links`)
+and a manifest schema that supports custom folder names and project types.
+
+```bash
+# Get current tree-layout authoring guidance
+intent-cli guide intent-work setup \
+  --kind tree-layout \
+  --domain <name> \
+  --target-repo <owner/repo> \
+  --format markdown
+```
+
+See [Intent knowledge-tree layout (tree-v1)](03a-intent-tree-layout.md) for the full spec,
+manifest schema, project type examples, and cross-linking rules.
+
 ## Next
 
 [Create packets & publish issues](04-packets-issues.md).

--- a/docs/en/03a-intent-tree-layout.md
+++ b/docs/en/03a-intent-tree-layout.md
@@ -1,0 +1,160 @@
+# Intent knowledge-tree layout (tree-v1)
+
+> **Ask intent-cli first:** `intent-cli guide intent-work setup --kind tree-layout --domain <name> --target-repo <owner/repo>` ← [Organize intents](03-intents.md)
+
+This page describes the **tree-v1** flexible intent knowledge-tree layout for new
+domains. Existing flat-file domains do not need to migrate immediately — tree-v1
+is a recommended default for new domains, not a hard requirement for existing ones.
+
+## Why tree-v1
+
+Flat intent files work for small, early-stage projects. As a domain grows, a single
+file becomes hard to search, review, link, and analyze. Tree-v1 organizes intent
+into discoverable folders so mission/vision/values, feature requirements, technology
+choices, loop operations, decisions, and clarifications are findable by path and
+cross-linked.
+
+## Manifest
+
+Each domain following tree-v1 provides a manifest at
+`intents/<domain>/manifest.yaml`:
+
+```yaml
+version: "1"
+layout_version: tree-v1
+project_type: product-app   # product-app | library-tool | infrastructure | research-prototype
+target_repo: <owner/repo>
+branch_policy: direct-main
+metadata_policy: host-metadata
+entrypoints:
+  - identity/mission.md
+  - README.md
+categories:
+  identity: identity/
+  product: product/
+  features: features/
+  technology: technology/
+  operations: operations/
+  decisions: decisions/
+  clarifications: clarifications/
+  packets: packets/
+  links: links/
+```
+
+Category paths under `categories:` are configurable — rename or omit any
+category that does not fit your project type (see [Project type examples](#project-type-examples)).
+
+## Recommended categories
+
+| Category | Path | Purpose |
+|---|---|---|
+| `identity` | `identity/` | Mission, vision, values, principles, glossary |
+| `product` | `product/` | Overview, users, journeys, non-goals |
+| `features` | `features/` | One subfolder per feature — overview, requirements, acceptance, decisions, open questions, packets, links |
+| `technology` | `technology/` | Architecture, languages, libraries, frontend, backend, data, cloud, security, testing, observability, deployment |
+| `operations` | `operations/` | Implementation loop, review loop, release, recovery |
+| `decisions` | `decisions/` | ADR-style records (`<NNNN>-<slug>.md`) |
+| `clarifications` | `clarifications/` | `open.md`, `answered.md`, `log.md` |
+| `packets` | `packets/` | Roadmap, backlog, waves |
+| `links` | `links/` | GitHub repos, external docs, related projects |
+
+All category names are optional and configurable.
+
+## Feature folder layout
+
+Each feature lives in `features/<feature-slug>/`:
+
+```
+features/
+  auth/
+    overview.md          # Goal, motivation, acceptance summary
+    requirements.md      # Detailed requirements
+    acceptance.md        # Acceptance criteria
+    decisions.md         # Feature-specific design decisions
+    open-questions.md    # Unresolved questions (link to clarifications/)
+    packets.md           # Execution unit list (link to packets/ or GitHub issues)
+    links.md             # References
+```
+
+## Cross-linking rules
+
+Cross-links keep the tree navigable and prevent duplication:
+
+- **Feature overview pages** must link to relevant decisions, clarifications,
+  packets, and GitHub issues.
+- **Decision records** must link to the feature(s) and clarification(s) that
+  motivated them.
+- **Clarification entries** must link back to the feature or decision they block.
+- **Packet pages** must link to the GitHub issue once published.
+- Do not duplicate content across files — use relative Markdown links instead.
+
+## Project type examples
+
+### `product-app`
+
+Use all recommended categories. No changes needed from the manifest default.
+
+### `library-tool`
+
+Replace `product/` with `api/` and `users/`; omit `links/` if unused:
+
+```yaml
+categories:
+  identity: identity/
+  api: api/
+  users: users/
+  features: features/
+  technology: technology/
+  operations: operations/
+  decisions: decisions/
+  clarifications: clarifications/
+  packets: packets/
+```
+
+### `infrastructure`
+
+Replace `product/` with `environments/`; add `runbooks/` under operations:
+
+```yaml
+categories:
+  identity: identity/
+  environments: environments/
+  features: features/
+  technology: technology/
+  operations: operations/
+  runbooks: runbooks/
+  decisions: decisions/
+  clarifications: clarifications/
+  packets: packets/
+```
+
+### `research-prototype`
+
+Replace `product/` with `hypothesis/`; replace `operations/` with `experiments/`:
+
+```yaml
+categories:
+  identity: identity/
+  hypothesis: hypothesis/
+  features: features/
+  technology: technology/
+  experiments: experiments/
+  decisions: decisions/
+  clarifications: clarifications/
+  packets: packets/
+```
+
+## Agent guidance
+
+Agents authoring or updating intent content should:
+
+1. Run `intent-cli guide intent-work setup --kind tree-layout --domain <name> --target-repo <owner/repo>` for current guidance.
+2. **Prefer tree placement** over appending to a flat file — put new content in the appropriate category folder.
+3. **Add cross-links** when creating or updating feature pages, decisions, or clarifications.
+4. **Present changes to the operator** before writing the manifest or migrating existing flat files.
+5. Never publish a GitHub issue in the same wake as tree-layout authoring.
+
+## Related docs
+
+- [Organize & maintain intents](03-intents.md)
+- [Create packets & publish issues](04-packets-issues.md)

--- a/docs/ja/03-intents.md
+++ b/docs/ja/03-intents.md
@@ -29,6 +29,22 @@ intent-cli intent status --format json
 - child implementation agent は intent tree（`intents/**`）や host metadata を
   **読まない** — これは host/design の領域。
 
+## Intent ナレッジツリーレイアウト (tree-v1)
+
+新規ドメインは、単一のフラットファイルではなく発見しやすいフォルダに intent を整理することを推奨します。
+**tree-v1** レイアウトは推奨カテゴリ（`identity`、`product`、`features`、`technology`、`operations`、`decisions`、`clarifications`、`packets`、`links`）と、カスタムフォルダ名およびプロジェクトタイプをサポートするマニフェストスキーマを定義します。
+
+```bash
+# ツリーレイアウト作成の現在のガイダンスを取得
+intent-cli guide intent-work setup \
+  --kind tree-layout \
+  --domain <name> \
+  --target-repo <owner/repo> \
+  --format markdown
+```
+
+完全な仕様、マニフェストスキーマ、プロジェクトタイプの例、相互リンクのルールは [Intent ナレッジツリーレイアウト (tree-v1)](03a-intent-tree-layout.md) を参照してください。
+
 ## 次へ
 
 [packet 作成と issue 公開](04-packets-issues.md)。

--- a/docs/ja/03a-intent-tree-layout.md
+++ b/docs/ja/03a-intent-tree-layout.md
@@ -1,0 +1,152 @@
+# Intent ナレッジツリーレイアウト (tree-v1)
+
+> **まず intent-cli に聞く:** `intent-cli guide intent-work setup --kind tree-layout --domain <name> --target-repo <owner/repo>` ← [intent の整理](03-intents.md)
+
+このページでは、新規ドメイン向けの **tree-v1** フレキシブル intent ナレッジツリーレイアウトについて説明します。
+既存のフラットファイルドメインはすぐに移行する必要はありません。tree-v1 は新規ドメインへの推奨デフォルトであり、既存ドメインへの強制要件ではありません。
+
+## なぜ tree-v1 か
+
+フラット intent ファイルは小規模・初期段階のプロジェクトで機能します。ドメインが成長すると、単一ファイルは検索・レビュー・リンク・分析が困難になります。
+tree-v1 は intent を発見しやすいフォルダに整理し、ミッション/ビジョン/バリュー、機能要件、技術的選択、ループ運用、決定事項、明確化事項をパスで参照・相互リンクできるようにします。
+
+## マニフェスト
+
+tree-v1 に従う各ドメインは `intents/<domain>/manifest.yaml` にマニフェストを提供します:
+
+```yaml
+version: "1"
+layout_version: tree-v1
+project_type: product-app   # product-app | library-tool | infrastructure | research-prototype
+target_repo: <owner/repo>
+branch_policy: direct-main
+metadata_policy: host-metadata
+entrypoints:
+  - identity/mission.md
+  - README.md
+categories:
+  identity: identity/
+  product: product/
+  features: features/
+  technology: technology/
+  operations: operations/
+  decisions: decisions/
+  clarifications: clarifications/
+  packets: packets/
+  links: links/
+```
+
+`categories:` 配下のカテゴリパスは設定可能です。プロジェクトタイプに合わせて任意のカテゴリを名前変更・省略できます（[プロジェクトタイプの例](#プロジェクトタイプの例)参照）。
+
+## 推奨カテゴリ
+
+| カテゴリ | パス | 用途 |
+|---|---|---|
+| `identity` | `identity/` | ミッション、ビジョン、バリュー、原則、用語集 |
+| `product` | `product/` | 概要、ユーザー、ジャーニー、非目標 |
+| `features` | `features/` | 機能ごとのサブフォルダ — 概要、要件、受け入れ基準、決定事項、未解決の質問、パケット、リンク |
+| `technology` | `technology/` | アーキテクチャ、言語、ライブラリ、フロントエンド、バックエンド、データ、クラウド、セキュリティ、テスト、オブザーバビリティ、デプロイ |
+| `operations` | `operations/` | 実装ループ、レビューループ、リリース、リカバリ |
+| `decisions` | `decisions/` | ADR スタイルの記録（`<NNNN>-<slug>.md`） |
+| `clarifications` | `clarifications/` | `open.md`、`answered.md`、`log.md` |
+| `packets` | `packets/` | ロードマップ、バックログ、ウェーブ |
+| `links` | `links/` | GitHub リポジトリ、外部ドキュメント、関連プロジェクト |
+
+すべてのカテゴリ名はオプションかつ設定可能です。
+
+## 機能フォルダレイアウト
+
+各機能は `features/<feature-slug>/` に配置します:
+
+```
+features/
+  auth/
+    overview.md          # ゴール、動機、受け入れ基準サマリー
+    requirements.md      # 詳細要件
+    acceptance.md        # 受け入れ基準
+    decisions.md         # 機能固有の設計決定
+    open-questions.md    # 未解決の質問（clarifications/ へのリンク）
+    packets.md           # 実行ユニット一覧（packets/ または GitHub issues へのリンク）
+    links.md             # 参照リンク
+```
+
+## 相互リンクのルール
+
+相互リンクはツリーをナビゲートしやすくし、コンテンツの重複を防ぎます:
+
+- **機能概要ページ** は、関連する決定事項、明確化事項、パケット、GitHub issues にリンクする必要があります。
+- **決定事項レコード** は、それを動機づけた機能と明確化事項にリンクする必要があります。
+- **明確化エントリ** は、それがブロックしている機能または決定事項にリンクバックする必要があります。
+- **パケットページ** は、公開後に GitHub issue にリンクする必要があります。
+- ファイル間でコンテンツを重複させず、相対 Markdown リンクを使用します。
+
+## プロジェクトタイプの例
+
+### `product-app`
+
+推奨カテゴリをすべて使用します。マニフェストのデフォルトから変更不要です。
+
+### `library-tool`
+
+`product/` を `api/` と `users/` に置き換え、不要な場合は `links/` を省略します:
+
+```yaml
+categories:
+  identity: identity/
+  api: api/
+  users: users/
+  features: features/
+  technology: technology/
+  operations: operations/
+  decisions: decisions/
+  clarifications: clarifications/
+  packets: packets/
+```
+
+### `infrastructure`
+
+`product/` を `environments/` に置き換え、operations 配下に `runbooks/` を追加します:
+
+```yaml
+categories:
+  identity: identity/
+  environments: environments/
+  features: features/
+  technology: technology/
+  operations: operations/
+  runbooks: runbooks/
+  decisions: decisions/
+  clarifications: clarifications/
+  packets: packets/
+```
+
+### `research-prototype`
+
+`product/` を `hypothesis/` に、`operations/` を `experiments/` に置き換えます:
+
+```yaml
+categories:
+  identity: identity/
+  hypothesis: hypothesis/
+  features: features/
+  technology: technology/
+  experiments: experiments/
+  decisions: decisions/
+  clarifications: clarifications/
+  packets: packets/
+```
+
+## エージェントへのガイダンス
+
+intent コンテンツを作成・更新するエージェントは以下を行う必要があります:
+
+1. `intent-cli guide intent-work setup --kind tree-layout --domain <name> --target-repo <owner/repo>` を実行して最新ガイダンスを確認する。
+2. フラットファイルへの追記より**ツリー配置を優先**する — 新しいコンテンツは適切なカテゴリフォルダに配置する。
+3. 機能ページ、決定事項、明確化事項を作成・更新する際に**相互リンクを追加**する。
+4. マニフェストの書き込みや既存フラットファイルの移行前に**オペレーターに変更を提示**する。
+5. tree-layout 作業と同じウェイクで GitHub issue を公開しない。
+
+## 関連ドキュメント
+
+- [intent の整理・保守](03-intents.md)
+- [packet 作成と issue 公開](04-packets-issues.md)

--- a/src/IntentSystem.Cli/Commands/GuideIntentWorkSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideIntentWorkSetupCommand.cs
@@ -22,9 +22,10 @@ internal static class GuideIntentWorkSetupCommand
     private const string KindPacketPreload = "packet-preload";
     private const string KindClarification = "clarification";
     private const string KindIntentShape = "intent-shape";
+    private const string KindTreeLayout = "tree-layout";
 
     private const string UsageLine =
-        "Usage: intent-cli guide intent-work setup --kind <domain-organize|next-slice|packet-preload|clarification|intent-shape> "
+        "Usage: intent-cli guide intent-work setup --kind <domain-organize|next-slice|packet-preload|clarification|intent-shape|tree-layout> "
         + "--domain <domain> --target-repo <owner/repo> [--format markdown|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
@@ -67,13 +68,14 @@ internal static class GuideIntentWorkSetupCommand
             KindPacketPreload => BuildPacketPreload(domain!, targetRepo!),
             KindClarification => BuildClarification(domain!, targetRepo!),
             KindIntentShape => BuildIntentShape(domain!, targetRepo!),
+            KindTreeLayout => BuildTreeLayout(domain!, targetRepo!),
             _ => null
         };
 
         if (result is null)
         {
             writer.WriteLine(
-                $"--kind must be '{KindDomainOrganize}', '{KindNextSlice}', '{KindPacketPreload}', '{KindClarification}', or '{KindIntentShape}' (got '{kind}').");
+                $"--kind must be '{KindDomainOrganize}', '{KindNextSlice}', '{KindPacketPreload}', '{KindClarification}', '{KindIntentShape}', or '{KindTreeLayout}' (got '{kind}').");
             writer.WriteLine(UsageLine);
             return 1;
         }
@@ -430,6 +432,111 @@ Hard rules:
         };
     }
 
+    private static GuideIntentWorkSetupResult BuildTreeLayout(string domain, string targetRepo)
+    {
+        var prompt =
+$@"Organize and author the intent knowledge tree for domain `{domain}` against `{targetRepo}` using the tree-v1 flexible layout. Do not publish any GitHub issue unless the operator explicitly approves it.
+
+First-call sequence (read-only; required before any mutation):
+1. `intent-cli guide model --format json` — confirm chat-first / CLI-internal collaboration model.
+2. `intent-cli guide onboarding --format json` — first-call sequence for a fresh agent.
+3. `intent-cli guide commands list --format json` — surface `primary` / `support` / `advanced` / `experimental` buckets.
+4. `intent-cli automation summary --format json` — canonical label-driven contract and capability JSON.
+5. `intent-cli intent status --domain {domain} --format json` — current baseline / WIP / queued / clarifications.
+6. `intent-cli intent search --domain {domain} --format json` — locate related intents across the domain.
+
+Tree-v1 layout rules:
+1. New domains should organize intents into discoverable folders under `intents/{domain}/` rather than appending everything to one flat file.
+2. Provide a manifest at `intents/{domain}/manifest.yaml` with the following shape:
+   ```yaml
+   version: ""1""
+   layout_version: tree-v1
+   project_type: <product-app|library-tool|infrastructure|research-prototype>
+   target_repo: {targetRepo}
+   branch_policy: direct-main
+   metadata_policy: host-metadata
+   entrypoints:
+     - identity/mission.md
+     - README.md
+   categories:
+     identity: identity/
+     product: product/
+     features: features/
+     technology: technology/
+     operations: operations/
+     decisions: decisions/
+     clarifications: clarifications/
+     packets: packets/
+     links: links/
+   ```
+3. Recommended category purposes:
+   - `identity/`: mission, vision, values, principles, glossary
+   - `product/`: overview, users, journeys, non-goals
+   - `features/`: one subfolder per feature — overview, requirements, acceptance criteria, decisions, open questions, packets, links
+   - `technology/`: architecture, languages, libraries, frontend, backend, data, cloud, security, testing, observability, deployment
+   - `operations/`: implementation loop, review loop, release, recovery
+   - `decisions/`: ADR-style records (one file per decision, named `<NNNN>-<slug>.md`)
+   - `clarifications/`: open.md, answered.md, log.md
+   - `packets/`: roadmap, backlog, waves
+   - `links/`: GitHub repos, external docs, related projects
+4. Category names are configurable. Adapt them for the project type:
+   - product-app: use all recommended categories.
+   - library-tool: replace `product/` with `api/` and `users/`; omit `links/` if unused.
+   - infrastructure: replace `product/` with `environments/`; add `runbooks/` under `operations/`.
+   - research-prototype: replace `product/` with `hypothesis/`; replace `operations/` with `experiments/`.
+5. Cross-linking rules:
+   - Feature overview pages MUST link to relevant decisions, clarifications, packets, and GitHub issues.
+   - Decision records MUST link to the feature(s) and clarification(s) that motivated them.
+   - Clarification entries MUST link back to the feature or decision they block.
+   - Packet pages MUST link to the GitHub issue once published.
+   - Do not duplicate content across files; use relative Markdown links instead.
+
+Tree-layout authoring steps:
+1. Confirm cwd is the parent host repo root.
+2. Check `intent status` output — if a manifest already exists, read it before proposing changes.
+3. If no manifest exists, propose a manifest draft matching the project type. Present it to the operator for acceptance before writing.
+4. After acceptance: write `intents/{domain}/manifest.yaml`. Create the recommended category folders with empty `.gitkeep` files to make them visible without forcing content.
+5. For existing flat intent files: propose a migration plan that moves sections to the appropriate category folders. Present to operator; apply only after acceptance.
+6. After the tree skeleton is in place: add cross-links between feature pages, decisions, clarifications, and packets.
+7. Commit and push the parent state. Do not publish any GitHub issue in this wake.
+
+Hard rules:
+- Do not read `intents/rules/**`, local skill files, or copied prompt files. Use `intent-cli guide ...` and `intent-cli intent ...` instead.
+- Do not call `intent-cli run`. `run` is advanced runtime, not the intent-work path.
+- Do not run `dotnet run` as a fallback for `intent-cli`.
+- Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
+- All label transitions go through installed `intent-cli automation` commands.
+- Prefer tree placement and cross-links over appending all intent information into one file.
+- Existing flat-file domains do not require immediate migration; tree-v1 is recommended for new domains.
+- Do not publish a GitHub issue in this wake.";
+
+        return new GuideIntentWorkSetupResult
+        {
+            Kind = KindTreeLayout,
+            Domain = domain,
+            TargetRepo = targetRepo,
+            Prompt = prompt,
+            FirstCalls = new[]
+            {
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                "intent-cli automation summary --format json",
+                $"intent-cli intent status --domain {domain} --format json",
+                $"intent-cli intent search --domain {domain} --format json"
+            },
+            ForbiddenSources = new[]
+            {
+                "intents/rules/**",
+                "local skill files",
+                "copied prompt files"
+            },
+            ClarificationFormat = "background, question, options, pros/cons, and recommendation",
+            IssuePublishBoundary = "Do not publish a GitHub issue in this wake. Tree-layout authoring is a host-side structural step; issue publication follows after the intent tree is organized.",
+            WorktreeFriendly = "The prompt names the parent host repo worktree root as cwd and references domain/target-repo from arguments; no operator-specific paths are hard-coded, so it works across host-side worktrees."
+        };
+    }
+
     private static void WriteMarkdown(TextWriter writer, GuideIntentWorkSetupResult result)
     {
         writer.WriteLine($"# Guide intent-work setup — {result.Kind}");
@@ -577,6 +684,7 @@ Hard rules:
         writer.WriteLine($"- {KindPacketPreload}    (--domain, --target-repo required)");
         writer.WriteLine($"- {KindClarification}   (--domain, --target-repo required)");
         writer.WriteLine($"- {KindIntentShape}     (--domain, --target-repo required)");
+        writer.WriteLine($"- {KindTreeLayout}      (--domain, --target-repo required)");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/tests/IntentSystem.Cli.Tests/GuideIntentWorkSetupCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideIntentWorkSetupCommandTests.cs
@@ -532,6 +532,171 @@ public sealed class GuideIntentWorkSetupCommandTests
         Assert.Contains("recommendation", format, StringComparison.OrdinalIgnoreCase);
     }
 
+    // ── G403 tree-layout ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_TreeLayoutMarkdown_EmitsPasteReadyPromptAndForbiddenSources()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "tree-layout", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide intent-work setup — tree-layout", output, StringComparison.Ordinal);
+        Assert.Contains("domain: intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("target repo: J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("## First-call sequence", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide model --format json", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent status --domain intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli intent search --domain intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("## Forbidden rule sources", output, StringComparison.Ordinal);
+        Assert.Contains("intents/rules/**", output, StringComparison.Ordinal);
+        Assert.Contains("## Prompt", output, StringComparison.Ordinal);
+        Assert.Contains("tree-v1", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_TreeLayoutJson_EmitsStructuredFieldsWithTreeV1Content()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "tree-layout", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("tree-layout", root.GetProperty("kind").GetString());
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal("J-Tech-Japan/intent-system", root.GetProperty("target_repo").GetString());
+        Assert.Equal(6, root.GetProperty("first_calls").GetArrayLength());
+        Assert.True(root.GetProperty("forbidden_sources").GetArrayLength() >= 3);
+        var prompt = root.GetProperty("prompt").GetString()!;
+        Assert.Contains("tree-v1", prompt, StringComparison.Ordinal);
+        Assert.Contains("manifest.yaml", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G403: the tree-layout prompt must describe the recommended categories
+    /// so agents know where to place mission/vision, features, technology, etc.
+    /// </summary>
+    [Fact]
+    public void Execute_TreeLayoutPrompt_ContainsAllRecommendedCategories()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "tree-layout", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("identity", prompt, StringComparison.Ordinal);
+        Assert.Contains("product", prompt, StringComparison.Ordinal);
+        Assert.Contains("features", prompt, StringComparison.Ordinal);
+        Assert.Contains("technology", prompt, StringComparison.Ordinal);
+        Assert.Contains("operations", prompt, StringComparison.Ordinal);
+        Assert.Contains("decisions", prompt, StringComparison.Ordinal);
+        Assert.Contains("clarifications", prompt, StringComparison.Ordinal);
+        Assert.Contains("packets", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G403: the tree-layout prompt must include cross-linking rules so agents
+    /// know to link feature pages, decisions, clarifications, and packets.
+    /// </summary>
+    [Fact]
+    public void Execute_TreeLayoutPrompt_ContainsCrossLinkingRules()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "tree-layout", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Cross-linking", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("GitHub issue", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G403: the tree-layout prompt must encode the preference for tree placement
+    /// over appending content to flat files.
+    /// </summary>
+    [Fact]
+    public void Execute_TreeLayoutPrompt_PrefersTreePlacementOverFlatFile()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "tree-layout", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Prefer tree placement", prompt, StringComparison.Ordinal);
+        Assert.Contains("flat file", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G403: the tree-layout prompt must state that existing flat-file domains
+    /// do not require immediate migration.
+    /// </summary>
+    [Fact]
+    public void Execute_TreeLayoutPrompt_ExistingDomainsNotForcedToMigrate()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "tree-layout", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Existing flat-file domains do not require immediate migration", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G403: the tree-layout prompt must ban GitHub issue publication in the
+    /// same wake as tree-layout authoring.
+    /// </summary>
+    [Fact]
+    public void Execute_TreeLayoutPrompt_BansIssuPublicationInSameWake()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "tree-layout", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Do not publish a GitHub issue in this wake", prompt, StringComparison.Ordinal);
+        // issue_publish_boundary must also encode the restriction
+        Assert.Contains("issue publication follows", document.RootElement.GetProperty("issue_publish_boundary").GetString()!, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G403: tree-layout must appear in the help output alongside the other kinds.
+    /// </summary>
+    [Fact]
+    public void Execute_Help_IncludesTreeLayoutKind()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("tree-layout", writer.ToString(), StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext


### PR DESCRIPTION
## Summary

- Add `tree-layout` kind to `guide intent-work setup` — emits paste-ready prompt with tree-v1 manifest schema, all recommended categories, cross-linking rules, four project-type examples, and the rule to prefer tree placement over flat-file appending
- New English doc `docs/en/03a-intent-tree-layout.md` — full tree-v1 spec with manifest schema, feature folder layout, cross-linking rules, project type examples, agent guidance
- New Japanese doc `docs/ja/03a-intent-tree-layout.md` — Japanese equivalent
- Updated `docs/en/03-intents.md` and `docs/ja/03-intents.md` to reference new tree-layout docs and show the CLI command

## Changed files

- `src/IntentSystem.Cli/Commands/GuideIntentWorkSetupCommand.cs` — new `tree-layout` kind + `BuildTreeLayout` method
- `docs/en/03a-intent-tree-layout.md` — new English spec doc
- `docs/ja/03a-intent-tree-layout.md` — new Japanese spec doc
- `docs/en/03-intents.md`, `docs/ja/03-intents.md` — reference new tree-layout docs
- `tests/IntentSystem.Cli.Tests/GuideIntentWorkSetupCommandTests.cs` — 8 new G403 acceptance tests

## Test plan

- [x] All `GuideIntentWorkSetup` tests pass (50/50, including 8 new G403 tests)
- [x] Solution builds with zero errors (`dotnet build --configuration Release`)
- Tests cover: manifest.yaml reference, all recommended categories, cross-linking rules, flat-file preference language, migration non-requirement, issue-publication ban, and help output

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)