### PR TITLE
G404: Add intent tree init and add-feature commands

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -314,6 +314,8 @@ internal static class CommandRouter
             {
                 ["host-check"] = IntentHostCheckCommand.Execute,
                 ["init"] = IntentInitCommand.Execute,
+                ["init-tree"] = IntentInitTreeCommand.Execute,
+                ["add-feature"] = IntentAddFeatureCommand.Execute,
                 ["status"] = IntentStatusCommand.Execute,
                 ["search"] = IntentSearchCommand.Execute,
                 ["explain"] = IntentExplainCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/IntentAddFeatureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentAddFeatureCommand.cs
@@ -359,6 +359,32 @@ internal static class IntentAddFeatureCommand
     private static string ResolvePath(string hostRepoRoot, string relativePath) =>
         Path.Combine(hostRepoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
 
+    /// <summary>
+    /// Validates that a value is a safe slug: letters, digits, hyphens, and underscores only.
+    /// Mirrors the slug guard in <see cref="IntentInitCommand"/> and <see cref="IntentInitTreeCommand"/>
+    /// to prevent path-traversal when domain/feature values are interpolated into file system paths.
+    /// </summary>
+    internal static bool IsValidSlug(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            var isValid = char.IsLetterOrDigit(character)
+                || character == '-'
+                || character == '_';
+            if (!isValid)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private static bool TryParseArguments(
         string[] args,
         out IntentAddFeatureRequest request,
@@ -422,9 +448,21 @@ internal static class IntentAddFeatureCommand
             return false;
         }
 
+        if (!IsValidSlug(domain))
+        {
+            error = $"intent add-feature '--domain' value '{domain}' must be a slug (letters, digits, '-', '_').";
+            return false;
+        }
+
         if (string.IsNullOrWhiteSpace(featureName))
         {
             error = "intent add-feature requires '--name <feature-slug>'.";
+            return false;
+        }
+
+        if (!IsValidSlug(featureName))
+        {
+            error = $"intent add-feature '--name' value '{featureName}' must be a slug (letters, digits, '-', '_').";
             return false;
         }
 

--- a/src/IntentSystem.Cli/Commands/IntentAddFeatureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentAddFeatureCommand.cs
@@ -1,0 +1,518 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G404: <c>intent-cli intent add-feature</c> — add a feature folder skeleton
+/// under <c>features/&lt;slug&gt;/</c> inside an existing tree-v1 intent domain.
+///
+/// Creates cross-linked starter files:
+/// <list type="bullet">
+///   <item><c>overview.md</c> — goals, motivation, acceptance-criteria summary</item>
+///   <item><c>requirements.md</c> — detailed requirements</item>
+///   <item><c>acceptance.md</c> — acceptance criteria</item>
+///   <item><c>decisions.md</c> — feature-specific design decisions</item>
+///   <item><c>open-questions.md</c> — open questions (links to clarifications/)</item>
+///   <item><c>packets.md</c> — execution units (links to packets/ or GitHub issues)</item>
+///   <item><c>links.md</c> — reference links</item>
+/// </list>
+///
+/// Idempotent: existing files are preserved; missing files are created only when
+/// <c>--write</c> is supplied. Without <c>--write</c> the command is a dry-run.
+///
+/// Also creates or updates <c>features/index.md</c> to cross-link the new feature.
+///
+/// Refuses to run inside an automation child worktree.
+/// </summary>
+internal static class IntentAddFeatureCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli intent add-feature --domain <name> --name <feature-slug> "
+        + "[--write] [--format markdown|json]";
+
+    /// <summary>Starter file names created per feature folder.</summary>
+    internal static readonly string[] FeatureFiles =
+    [
+        "overview.md",
+        "requirements.md",
+        "acceptance.md",
+        "decisions.md",
+        "open-questions.md",
+        "packets.md",
+        "links.md"
+    ];
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(UsageLine);
+            writer.WriteLine("Adds a feature folder skeleton to an existing tree-v1 intent domain.");
+            writer.WriteLine();
+            writer.WriteLine("Creates starter files: " + string.Join(", ", FeatureFiles));
+            writer.WriteLine("Also creates or updates features/index.md with a cross-link.");
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var request, out var parseError))
+        {
+            writer.WriteLine(parseError);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        try
+        {
+            var result = ExecuteCore(context.RepoRoot, request);
+            WriteOutput(writer, request.Format, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IntentAddFeatureResult ExecuteCore(string hostRepoRoot, IntentAddFeatureRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostRepoRoot);
+        ArgumentNullException.ThrowIfNull(request);
+
+        EnsureNotChildWorktree(hostRepoRoot);
+
+        // Build planned file list: feature files + features index
+        var planned = new List<string>();
+        var featureBase = $"intents/{request.Domain}/features/{request.FeatureName}/";
+
+        foreach (var fileName in FeatureFiles)
+        {
+            planned.Add($"{featureBase}{fileName}");
+        }
+
+        var featuresIndexPath = $"intents/{request.Domain}/features/index.md";
+        planned.Add(featuresIndexPath);
+
+        var written = new List<string>();
+        var existing = new List<string>();
+        var updated = new List<string>();
+
+        // Feature starter files (idempotent: never overwrite)
+        foreach (var relativePath in planned.Where(p => !string.Equals(p, featuresIndexPath, StringComparison.Ordinal)))
+        {
+            var absolutePath = ResolvePath(hostRepoRoot, relativePath);
+            if (File.Exists(absolutePath))
+            {
+                existing.Add(relativePath);
+                continue;
+            }
+
+            if (!request.Write)
+            {
+                continue;
+            }
+
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absolutePath)
+                ?? throw new InvalidOperationException($"No parent directory for '{absolutePath}'."));
+            File.WriteAllText(absolutePath, RenderFeatureFile(relativePath, request));
+            written.Add(relativePath);
+        }
+
+        // features/index.md: create or append cross-link entry
+        HandleFeaturesIndex(hostRepoRoot, featuresIndexPath, request, written, existing, updated);
+
+        var nextSteps = BuildNextSteps(request, written.Count, existing.Count);
+
+        return new IntentAddFeatureResult
+        {
+            Domain = request.Domain,
+            FeatureName = request.FeatureName,
+            WriteApplied = request.Write,
+            PlannedPaths = planned,
+            WrittenPaths = written,
+            UpdatedPaths = updated,
+            ExistingPaths = existing,
+            NextSteps = nextSteps
+        };
+    }
+
+    private static void HandleFeaturesIndex(
+        string hostRepoRoot,
+        string featuresIndexPath,
+        IntentAddFeatureRequest request,
+        List<string> written,
+        List<string> existing,
+        List<string> updated)
+    {
+        var absoluteIndex = ResolvePath(hostRepoRoot, featuresIndexPath);
+        var featureLink = $"- [{request.FeatureName}]({request.FeatureName}/overview.md)";
+
+        if (!File.Exists(absoluteIndex))
+        {
+            if (!request.Write)
+            {
+                return;
+            }
+
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absoluteIndex)
+                ?? throw new InvalidOperationException($"No parent directory for '{absoluteIndex}'."));
+            File.WriteAllText(absoluteIndex, RenderFeaturesIndex(request, featureLink));
+            written.Add(featuresIndexPath);
+            return;
+        }
+
+        // Index exists — check if this feature is already listed
+        var content = File.ReadAllText(absoluteIndex);
+        if (content.Contains($"]({request.FeatureName}/", StringComparison.Ordinal))
+        {
+            existing.Add(featuresIndexPath);
+            return;
+        }
+
+        if (!request.Write)
+        {
+            return;
+        }
+
+        // Append the feature link before the end of the file
+        var trimmed = content.TrimEnd();
+        var newContent = trimmed + Environment.NewLine + featureLink + Environment.NewLine;
+        File.WriteAllText(absoluteIndex, newContent);
+        updated.Add(featuresIndexPath);
+    }
+
+    private static string RenderFeatureFile(string relativePath, IntentAddFeatureRequest request)
+    {
+        var fileName = Path.GetFileName(relativePath);
+        return fileName switch
+        {
+            "overview.md" => RenderOverview(request),
+            "requirements.md" => RenderRequirements(request),
+            "acceptance.md" => RenderAcceptance(request),
+            "decisions.md" => RenderDecisions(request),
+            "open-questions.md" => RenderOpenQuestions(request),
+            "packets.md" => RenderPackets(request),
+            "links.md" => RenderLinks(request),
+            _ => throw new InvalidOperationException($"intent add-feature has no template for '{fileName}'.")
+        };
+    }
+
+    private static string RenderOverview(IntentAddFeatureRequest r) =>
+        $"""
+        # {r.FeatureName} — overview
+
+        > **Ask intent-cli first:** `intent-cli guide intent-work setup --kind tree-layout --domain {r.Domain} --format markdown`
+
+        ## Goals
+
+        _[Describe the goals and motivation for this feature.]_
+
+        ## Acceptance criteria summary
+
+        _[List high-level acceptance criteria here; see [acceptance.md](acceptance.md) for details.]_
+
+        ## Related
+
+        - [requirements.md](requirements.md)
+        - [acceptance.md](acceptance.md)
+        - [decisions.md](decisions.md)
+        - [open-questions.md](open-questions.md)
+        - [packets.md](packets.md)
+        """;
+
+    private static string RenderRequirements(IntentAddFeatureRequest r) =>
+        $"""
+        # {r.FeatureName} — requirements
+
+        > See [overview.md](overview.md) for goals.
+
+        ## Functional requirements
+
+        _[List detailed functional requirements.]_
+
+        ## Non-functional requirements
+
+        _[List performance, security, reliability, and other non-functional requirements.]_
+        """;
+
+    private static string RenderAcceptance(IntentAddFeatureRequest r) =>
+        $"""
+        # {r.FeatureName} — acceptance criteria
+
+        > See [overview.md](overview.md) for goals.
+
+        ## Criteria
+
+        - [ ] _[Criterion 1]_
+        - [ ] _[Criterion 2]_
+        """;
+
+    private static string RenderDecisions(IntentAddFeatureRequest r) =>
+        $"""
+        # {r.FeatureName} — design decisions
+
+        > See [overview.md](overview.md) for goals and [../../decisions/](../../decisions/) for cross-domain ADRs.
+
+        ## Decisions
+
+        _[Record feature-specific design decisions here. Link to cross-domain ADRs in decisions/ if applicable.]_
+        """;
+
+    private static string RenderOpenQuestions(IntentAddFeatureRequest r) =>
+        $"""
+        # {r.FeatureName} — open questions
+
+        > See [../../clarifications/open.md](../../clarifications/open.md) for domain-level open questions.
+
+        ## Open questions blocking this feature
+
+        _[List unresolved questions. Link back to clarifications/ entries that block this feature.]_
+        """;
+
+    private static string RenderPackets(IntentAddFeatureRequest r) =>
+        $"""
+        # {r.FeatureName} — packets
+
+        > See [../../packets/](../../packets/) for domain-level packet list.
+
+        ## Execution units
+
+        _[List implementation packets for this feature. Link to packets/ entries and GitHub issues once published.]_
+        """;
+
+    private static string RenderLinks(IntentAddFeatureRequest r) =>
+        $"""
+        # {r.FeatureName} — links
+
+        > See [overview.md](overview.md) for context.
+
+        ## Reference links
+
+        _[List external references, related GitHub issues, prior art, and relevant documentation.]_
+        """;
+
+    private static string RenderFeaturesIndex(IntentAddFeatureRequest request, string firstFeatureLink) =>
+        $"""
+        # {request.Domain} — features
+
+        > **Ask intent-cli first:** `intent-cli guide intent-work setup --kind tree-layout --domain {request.Domain} --format markdown`
+
+        ## Feature list
+
+        {firstFeatureLink}
+        """;
+
+    private static IReadOnlyList<string> BuildNextSteps(
+        IntentAddFeatureRequest request,
+        int writtenCount,
+        int existingCount)
+    {
+        var verb = request.Write
+            ? (writtenCount == 0 ? "Already added" : "Added")
+            : "Plan";
+
+        var steps = new List<string>
+        {
+            $"{verb}: feature '{request.FeatureName}' under domain '{request.Domain}' (written: {writtenCount}, existing: {existingCount})."
+        };
+
+        if (!request.Write)
+        {
+            steps.Add(
+                $"Re-run with --write to create the planned files: "
+                + $"intent-cli intent add-feature --domain {request.Domain} --name {request.FeatureName} --write");
+        }
+
+        steps.Add($"Edit `intents/{request.Domain}/features/{request.FeatureName}/overview.md` with goals and acceptance criteria.");
+        steps.Add($"Fill requirements in `intents/{request.Domain}/features/{request.FeatureName}/requirements.md`.");
+        steps.Add($"Link open questions to `intents/{request.Domain}/clarifications/open.md`.");
+        steps.Add($"Run `intent-cli guide intent-work setup --kind tree-layout --domain {request.Domain} --format markdown` for authoring guidance.");
+        return steps;
+    }
+
+    private static void EnsureNotChildWorktree(string hostRepoRoot)
+    {
+        var normalized = Path.GetFullPath(hostRepoRoot).Replace('\\', '/');
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = 0; i + 1 < segments.Length; i++)
+        {
+            if (string.Equals(segments[i], ".intent-cli", StringComparison.Ordinal)
+                && string.Equals(segments[i + 1], "worktrees", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Refusing to run 'intent add-feature' inside an automation child worktree at '{hostRepoRoot}'. "
+                    + "Run this command from the parent host repository.");
+            }
+        }
+    }
+
+    private static string ResolvePath(string hostRepoRoot, string relativePath) =>
+        Path.Combine(hostRepoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+    private static bool TryParseArguments(
+        string[] args,
+        out IntentAddFeatureRequest request,
+        out string error)
+    {
+        request = default!;
+        error = string.Empty;
+
+        string? domain = null;
+        string? featureName = null;
+        var write = false;
+        var format = FormatMarkdown;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--domain":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--domain'.";
+                        return false;
+                    }
+                    domain = args[++i].Trim();
+                    break;
+                case "--name":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--name'.";
+                        return false;
+                    }
+                    featureName = args[++i].Trim();
+                    break;
+                case "--write":
+                    write = true;
+                    break;
+                case "--format":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--format'.";
+                        return false;
+                    }
+                    var fmt = args[++i].Trim();
+                    if (!string.Equals(fmt, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(fmt, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{fmt}').";
+                        return false;
+                    }
+                    format = fmt;
+                    break;
+                default:
+                    error = $"Unknown option '{args[i]}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            error = "intent add-feature requires '--domain <name>'.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(featureName))
+        {
+            error = "intent add-feature requires '--name <feature-slug>'.";
+            return false;
+        }
+
+        request = new IntentAddFeatureRequest
+        {
+            Domain = domain!,
+            FeatureName = featureName!,
+            Write = write,
+            Format = format
+        };
+        return true;
+    }
+
+    private static void WriteOutput(TextWriter writer, string format, IntentAddFeatureResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        WriteMarkdown(writer, result);
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IntentAddFeatureResult result)
+    {
+        var verb = result.WriteApplied ? "Written" : "Planned (dry-run)";
+        writer.WriteLine($"# intent add-feature — {result.Domain}/{result.FeatureName}");
+        writer.WriteLine();
+        writer.WriteLine($"- write-applied: {result.WriteApplied}");
+        writer.WriteLine();
+
+        writer.WriteLine($"## {verb} ({result.WrittenPaths.Count} written, {result.UpdatedPaths.Count} updated, {result.ExistingPaths.Count} existing)");
+        writer.WriteLine();
+        foreach (var p in result.WrittenPaths)
+        {
+            writer.WriteLine($"- [created] {p}");
+        }
+        foreach (var p in result.UpdatedPaths)
+        {
+            writer.WriteLine($"- [updated] {p}");
+        }
+        foreach (var p in result.ExistingPaths)
+        {
+            writer.WriteLine($"- [existing] {p}");
+        }
+        foreach (var p in result.PlannedPaths
+            .Where(p => !result.WrittenPaths.Contains(p)
+                     && !result.UpdatedPaths.Contains(p)
+                     && !result.ExistingPaths.Contains(p)))
+        {
+            writer.WriteLine($"- [planned] {p}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Next steps");
+        writer.WriteLine();
+        foreach (var step in result.NextSteps)
+        {
+            writer.WriteLine($"- {step}");
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+    internal sealed record IntentAddFeatureRequest
+    {
+        public required string Domain { get; init; }
+        public required string FeatureName { get; init; }
+        public required bool Write { get; init; }
+        public required string Format { get; init; }
+    }
+}
+
+internal sealed record IntentAddFeatureResult
+{
+    public required string Domain { get; init; }
+    public required string FeatureName { get; init; }
+    public required bool WriteApplied { get; init; }
+    public required IReadOnlyList<string> PlannedPaths { get; init; }
+    public required IReadOnlyList<string> WrittenPaths { get; init; }
+    public required IReadOnlyList<string> UpdatedPaths { get; init; }
+    public required IReadOnlyList<string> ExistingPaths { get; init; }
+    public required IReadOnlyList<string> NextSteps { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/IntentInitTreeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentInitTreeCommand.cs
@@ -429,6 +429,12 @@ internal static class IntentInitTreeCommand
             return false;
         }
 
+        if (!IsValidSlug(domain))
+        {
+            error = $"intent init-tree '--domain' value '{domain}' must be a slug (letters, digits, '-', '_').";
+            return false;
+        }
+
         request = new IntentInitTreeRequest
         {
             Domain = domain!,
@@ -437,6 +443,32 @@ internal static class IntentInitTreeCommand
             Write = write,
             Format = format
         };
+        return true;
+    }
+
+    /// <summary>
+    /// Validates that a value is a safe slug: letters, digits, hyphens, and underscores only.
+    /// This mirrors the slug guard in <see cref="IntentInitCommand"/> and prevents path-traversal
+    /// attacks when domain or feature values are interpolated into file system paths.
+    /// </summary>
+    internal static bool IsValidSlug(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            var isValid = char.IsLetterOrDigit(character)
+                || character == '-'
+                || character == '_';
+            if (!isValid)
+            {
+                return false;
+            }
+        }
+
         return true;
     }
 

--- a/src/IntentSystem.Cli/Commands/IntentInitTreeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentInitTreeCommand.cs
@@ -1,0 +1,521 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G404: <c>intent-cli intent init-tree</c> — initialize a new intent domain
+/// with the flexible tree-v1 layout (G403). Creates <c>manifest.yaml</c>,
+/// recommended category folders with <c>.gitkeep</c> placeholders, a domain
+/// <c>README.md</c>, and an identity starter file.
+///
+/// Idempotent: existing files are preserved (reported as <c>existing</c>);
+/// missing files are created only when <c>--write</c> is supplied. Without
+/// <c>--write</c> the command is a dry-run that shows what would be created.
+///
+/// Refuses to run inside an automation child worktree to match the safety
+/// posture of <see cref="IntentInitCommand"/>.
+/// </summary>
+internal static class IntentInitTreeCommand
+{
+    internal const string ProjectTypeProductApp = "product-app";
+    internal const string ProjectTypeLibraryTool = "library-tool";
+    internal const string ProjectTypeInfrastructure = "infrastructure";
+    internal const string ProjectTypeResearchPrototype = "research-prototype";
+
+    private static readonly string[] KnownProjectTypes =
+    [
+        ProjectTypeProductApp,
+        ProjectTypeLibraryTool,
+        ProjectTypeInfrastructure,
+        ProjectTypeResearchPrototype
+    ];
+
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli intent init-tree --domain <name> --target-repo <owner/repo> "
+        + "[--project-type product-app|library-tool|infrastructure|research-prototype] "
+        + "[--write] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(UsageLine);
+            writer.WriteLine("Initializes a new intent domain with the tree-v1 flexible layout (G403).");
+            writer.WriteLine();
+            writer.WriteLine("Project types:");
+            foreach (var pt in KnownProjectTypes)
+            {
+                writer.WriteLine($"  {pt}");
+            }
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var request, out var parseError))
+        {
+            writer.WriteLine(parseError);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        try
+        {
+            var result = ExecuteCore(context.RepoRoot, request);
+            WriteOutput(writer, request.Format, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IntentInitTreeResult ExecuteCore(string hostRepoRoot, IntentInitTreeRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostRepoRoot);
+        ArgumentNullException.ThrowIfNull(request);
+
+        EnsureNotChildWorktree(hostRepoRoot);
+
+        var categories = ResolveCategories(request.ProjectType);
+
+        // Build the planned file list: manifest, README, category .gitkeeps, identity starter
+        var planned = new List<string>();
+        planned.Add($"intents/{request.Domain}/manifest.yaml");
+        planned.Add($"intents/{request.Domain}/README.md");
+
+        foreach (var (_, path) in categories)
+        {
+            planned.Add($"intents/{request.Domain}/{path}.gitkeep");
+        }
+
+        planned.Add($"intents/{request.Domain}/identity/mission.md");
+
+        var written = new List<string>();
+        var existing = new List<string>();
+
+        foreach (var relativePath in planned)
+        {
+            var absolutePath = ResolvePath(hostRepoRoot, relativePath);
+            if (File.Exists(absolutePath))
+            {
+                existing.Add(relativePath);
+                continue;
+            }
+
+            if (!request.Write)
+            {
+                continue;
+            }
+
+            Directory.CreateDirectory(
+                Path.GetDirectoryName(absolutePath)
+                ?? throw new InvalidOperationException($"No parent directory for '{absolutePath}'."));
+            File.WriteAllText(absolutePath, RenderContent(relativePath, request, categories));
+            written.Add(relativePath);
+        }
+
+        var nextSteps = BuildNextSteps(request, written.Count, existing.Count);
+
+        return new IntentInitTreeResult
+        {
+            Domain = request.Domain,
+            TargetRepo = request.TargetRepo,
+            ProjectType = request.ProjectType,
+            WriteApplied = request.Write,
+            PlannedPaths = planned,
+            WrittenPaths = written,
+            ExistingPaths = existing,
+            NextSteps = nextSteps,
+            Categories = categories.ToDictionary(kvp => kvp.Key, kvp => kvp.Value)
+        };
+    }
+
+    /// <summary>Returns the ordered category map for a given project type.</summary>
+    internal static IReadOnlyList<KeyValuePair<string, string>> ResolveCategories(string projectType)
+    {
+        return projectType switch
+        {
+            ProjectTypeLibraryTool => new[]
+            {
+                new KeyValuePair<string, string>("identity", "identity/"),
+                new KeyValuePair<string, string>("api", "api/"),
+                new KeyValuePair<string, string>("users", "users/"),
+                new KeyValuePair<string, string>("features", "features/"),
+                new KeyValuePair<string, string>("technology", "technology/"),
+                new KeyValuePair<string, string>("operations", "operations/"),
+                new KeyValuePair<string, string>("decisions", "decisions/"),
+                new KeyValuePair<string, string>("clarifications", "clarifications/"),
+                new KeyValuePair<string, string>("packets", "packets/")
+            },
+            ProjectTypeInfrastructure => new[]
+            {
+                new KeyValuePair<string, string>("identity", "identity/"),
+                new KeyValuePair<string, string>("environments", "environments/"),
+                new KeyValuePair<string, string>("features", "features/"),
+                new KeyValuePair<string, string>("technology", "technology/"),
+                new KeyValuePair<string, string>("operations", "operations/"),
+                new KeyValuePair<string, string>("runbooks", "runbooks/"),
+                new KeyValuePair<string, string>("decisions", "decisions/"),
+                new KeyValuePair<string, string>("clarifications", "clarifications/"),
+                new KeyValuePair<string, string>("packets", "packets/")
+            },
+            ProjectTypeResearchPrototype => new[]
+            {
+                new KeyValuePair<string, string>("identity", "identity/"),
+                new KeyValuePair<string, string>("hypothesis", "hypothesis/"),
+                new KeyValuePair<string, string>("features", "features/"),
+                new KeyValuePair<string, string>("technology", "technology/"),
+                new KeyValuePair<string, string>("experiments", "experiments/"),
+                new KeyValuePair<string, string>("decisions", "decisions/"),
+                new KeyValuePair<string, string>("clarifications", "clarifications/"),
+                new KeyValuePair<string, string>("packets", "packets/")
+            },
+            _ /* product-app */ => new[]
+            {
+                new KeyValuePair<string, string>("identity", "identity/"),
+                new KeyValuePair<string, string>("product", "product/"),
+                new KeyValuePair<string, string>("features", "features/"),
+                new KeyValuePair<string, string>("technology", "technology/"),
+                new KeyValuePair<string, string>("operations", "operations/"),
+                new KeyValuePair<string, string>("decisions", "decisions/"),
+                new KeyValuePair<string, string>("clarifications", "clarifications/"),
+                new KeyValuePair<string, string>("packets", "packets/"),
+                new KeyValuePair<string, string>("links", "links/")
+            }
+        };
+    }
+
+    private static string RenderContent(
+        string relativePath,
+        IntentInitTreeRequest request,
+        IReadOnlyList<KeyValuePair<string, string>> categories)
+    {
+        if (relativePath.EndsWith("manifest.yaml", StringComparison.Ordinal))
+        {
+            return RenderManifest(request, categories);
+        }
+
+        if (relativePath.EndsWith($"intents/{request.Domain}/README.md", StringComparison.Ordinal))
+        {
+            return RenderDomainReadme(request, categories);
+        }
+
+        if (relativePath.EndsWith(".gitkeep", StringComparison.Ordinal))
+        {
+            return string.Empty;
+        }
+
+        if (relativePath.EndsWith("identity/mission.md", StringComparison.Ordinal))
+        {
+            return RenderMissionStarter(request);
+        }
+
+        throw new InvalidOperationException($"intent init-tree has no template for '{relativePath}'.");
+    }
+
+    private static string RenderManifest(
+        IntentInitTreeRequest request,
+        IReadOnlyList<KeyValuePair<string, string>> categories)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("version: \"1\"");
+        sb.AppendLine("layout_version: tree-v1");
+        sb.AppendLine($"project_type: {request.ProjectType}");
+        if (!string.IsNullOrWhiteSpace(request.TargetRepo))
+        {
+            sb.AppendLine($"target_repo: {request.TargetRepo}");
+        }
+        sb.AppendLine("branch_policy: direct-main");
+        sb.AppendLine("metadata_policy: host-metadata");
+        sb.AppendLine("entrypoints:");
+        sb.AppendLine("  - identity/mission.md");
+        sb.AppendLine("  - README.md");
+        sb.AppendLine("categories:");
+        foreach (var (key, path) in categories)
+        {
+            sb.AppendLine($"  {key}: {path}");
+        }
+        return sb.ToString();
+    }
+
+    private static string RenderDomainReadme(
+        IntentInitTreeRequest request,
+        IReadOnlyList<KeyValuePair<string, string>> categories)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"# {request.Domain} intent tree");
+        sb.AppendLine();
+        sb.AppendLine("> **Ask intent-cli first:** `intent-cli guide intent-work setup --kind tree-layout "
+            + $"--domain {request.Domain}"
+            + (string.IsNullOrWhiteSpace(request.TargetRepo) ? string.Empty : $" --target-repo {request.TargetRepo}")
+            + " --format markdown`");
+        sb.AppendLine();
+        sb.AppendLine($"Layout: tree-v1 · Project type: {request.ProjectType}");
+        sb.AppendLine();
+        sb.AppendLine("## Categories");
+        sb.AppendLine();
+        foreach (var (key, path) in categories)
+        {
+            sb.AppendLine($"- [{key}/]({path})");
+        }
+        sb.AppendLine();
+        sb.AppendLine("## Cross-linking rules");
+        sb.AppendLine();
+        sb.AppendLine("- Feature pages must link to related decisions, clarifications, packets, and GitHub issues.");
+        sb.AppendLine("- Decision records must link to the feature(s) that motivated them.");
+        sb.AppendLine("- Clarification entries must link back to the feature or decision they block.");
+        sb.AppendLine("- Packet pages must link to the GitHub issue once published.");
+        return sb.ToString();
+    }
+
+    private static string RenderMissionStarter(IntentInitTreeRequest request)
+    {
+        return $"""
+        # Mission
+
+        > Ask intent-cli for guidance before editing:
+        > `intent-cli guide intent-work setup --kind tree-layout --domain {request.Domain} --format markdown`
+
+        ## Mission statement
+
+        _[Describe the mission of this domain in one or two sentences.]_
+
+        ## Vision
+
+        _[Describe the desired future state this domain is working toward.]_
+
+        ## Values / principles
+
+        _[List the guiding principles that constrain how this domain operates.]_
+
+        ## Glossary
+
+        _[Define key terms specific to this domain.]_
+        """;
+    }
+
+    private static IReadOnlyList<string> BuildNextSteps(
+        IntentInitTreeRequest request,
+        int writtenCount,
+        int existingCount)
+    {
+        var verb = request.Write
+            ? (writtenCount == 0 ? "Already initialized" : "Initialized")
+            : "Plan";
+
+        var steps = new List<string>
+        {
+            $"{verb}: domain '{request.Domain}' tree-v1 (written: {writtenCount}, existing: {existingCount})."
+        };
+
+        if (!request.Write)
+        {
+            steps.Add(
+                $"Re-run with --write to create the planned files: "
+                + $"intent-cli intent init-tree --domain {request.Domain}"
+                + (string.IsNullOrWhiteSpace(request.TargetRepo) ? string.Empty : $" --target-repo {request.TargetRepo}")
+                + $" --project-type {request.ProjectType} --write");
+        }
+
+        steps.Add($"Edit `intents/{request.Domain}/identity/mission.md` with the domain's mission and vision.");
+        steps.Add($"Add a feature: intent-cli intent add-feature --domain {request.Domain} --name <feature> --write");
+        steps.Add($"Run `intent-cli guide intent-work setup --kind tree-layout --domain {request.Domain} --format markdown` for tree authoring guidance.");
+        return steps;
+    }
+
+    private static void EnsureNotChildWorktree(string hostRepoRoot)
+    {
+        var normalized = Path.GetFullPath(hostRepoRoot).Replace('\\', '/');
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = 0; i + 1 < segments.Length; i++)
+        {
+            if (string.Equals(segments[i], ".intent-cli", StringComparison.Ordinal)
+                && string.Equals(segments[i + 1], "worktrees", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Refusing to run 'intent init-tree' inside an automation child worktree at '{hostRepoRoot}'. "
+                    + "Run this command from the parent host repository.");
+            }
+        }
+    }
+
+    private static string ResolvePath(string hostRepoRoot, string relativePath) =>
+        Path.Combine(hostRepoRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+
+    private static bool TryParseArguments(
+        string[] args,
+        out IntentInitTreeRequest request,
+        out string error)
+    {
+        request = default!;
+        error = string.Empty;
+
+        string? domain = null;
+        string? targetRepo = null;
+        var projectType = ProjectTypeProductApp;
+        var write = false;
+        var format = FormatMarkdown;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--domain":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--domain'.";
+                        return false;
+                    }
+                    domain = args[++i].Trim();
+                    break;
+                case "--target-repo":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--target-repo'.";
+                        return false;
+                    }
+                    targetRepo = args[++i].Trim();
+                    break;
+                case "--project-type":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--project-type'.";
+                        return false;
+                    }
+                    var pt = args[++i].Trim();
+                    if (!Array.Exists(KnownProjectTypes, p => string.Equals(p, pt, StringComparison.Ordinal)))
+                    {
+                        error = $"--project-type must be one of: {string.Join(", ", KnownProjectTypes)} (got '{pt}').";
+                        return false;
+                    }
+                    projectType = pt;
+                    break;
+                case "--write":
+                    write = true;
+                    break;
+                case "--format":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--format'.";
+                        return false;
+                    }
+                    var fmt = args[++i].Trim();
+                    if (!string.Equals(fmt, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(fmt, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{fmt}').";
+                        return false;
+                    }
+                    format = fmt;
+                    break;
+                default:
+                    error = $"Unknown option '{args[i]}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            error = "intent init-tree requires '--domain <name>'.";
+            return false;
+        }
+
+        request = new IntentInitTreeRequest
+        {
+            Domain = domain!,
+            TargetRepo = targetRepo,
+            ProjectType = projectType,
+            Write = write,
+            Format = format
+        };
+        return true;
+    }
+
+    private static void WriteOutput(TextWriter writer, string format, IntentInitTreeResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        WriteMarkdown(writer, result);
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IntentInitTreeResult result)
+    {
+        var verb = result.WriteApplied ? "Written" : "Planned (dry-run)";
+        writer.WriteLine($"# intent init-tree — {result.Domain}");
+        writer.WriteLine();
+        writer.WriteLine($"- project-type: {result.ProjectType}");
+        if (!string.IsNullOrWhiteSpace(result.TargetRepo))
+        {
+            writer.WriteLine($"- target-repo: {result.TargetRepo}");
+        }
+        writer.WriteLine($"- write-applied: {result.WriteApplied}");
+        writer.WriteLine();
+
+        writer.WriteLine($"## {verb} ({result.WrittenPaths.Count} written, {result.ExistingPaths.Count} existing)");
+        writer.WriteLine();
+        foreach (var p in result.WrittenPaths)
+        {
+            writer.WriteLine($"- [created] {p}");
+        }
+        foreach (var p in result.ExistingPaths)
+        {
+            writer.WriteLine($"- [existing] {p}");
+        }
+        foreach (var p in result.PlannedPaths
+            .Where(p => !result.WrittenPaths.Contains(p) && !result.ExistingPaths.Contains(p)))
+        {
+            writer.WriteLine($"- [planned] {p}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Next steps");
+        writer.WriteLine();
+        foreach (var step in result.NextSteps)
+        {
+            writer.WriteLine($"- {step}");
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+    internal sealed record IntentInitTreeRequest
+    {
+        public required string Domain { get; init; }
+        public string? TargetRepo { get; init; }
+        public required string ProjectType { get; init; }
+        public required bool Write { get; init; }
+        public required string Format { get; init; }
+    }
+}
+
+internal sealed record IntentInitTreeResult
+{
+    public required string Domain { get; init; }
+    public string? TargetRepo { get; init; }
+    public required string ProjectType { get; init; }
+    public required bool WriteApplied { get; init; }
+    public required IReadOnlyList<string> PlannedPaths { get; init; }
+    public required IReadOnlyList<string> WrittenPaths { get; init; }
+    public required IReadOnlyList<string> ExistingPaths { get; init; }
+    public required IReadOnlyList<string> NextSteps { get; init; }
+    public required IReadOnlyDictionary<string, string> Categories { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentAddFeatureCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentAddFeatureCommandTests.cs
@@ -1,0 +1,372 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>G404 tests for <c>intent-cli intent add-feature</c>.</summary>
+public sealed class IntentAddFeatureCommandTests
+{
+    // ──────────────────────────────────────────────
+    // Dry-run (no --write)
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithoutWrite_PerformsDryRun_AndCreatesNoFiles()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(Directory.Exists(Path.Combine(hostRoot, "intents", "auth", "features", "login")));
+
+        var output = writer.ToString();
+        Assert.Contains("--write", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Default add-feature
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithWrite_CreatesAllSevenFeatureFiles()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var featureDir = Path.Combine(hostRoot, "intents", "auth", "features", "login");
+
+        foreach (var fileName in IntentAddFeatureCommand.FeatureFiles)
+        {
+            Assert.True(File.Exists(Path.Combine(featureDir, fileName)),
+                $"Expected feature file '{fileName}' to exist.");
+        }
+    }
+
+    [Fact]
+    public void Execute_WithWrite_CreatesOrUpdatesFeatureIndex()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            writer);
+
+        var indexPath = Path.Combine(hostRoot, "intents", "auth", "features", "index.md");
+        Assert.True(File.Exists(indexPath));
+
+        var indexContent = File.ReadAllText(indexPath);
+        Assert.Contains("login", indexContent, StringComparison.Ordinal);
+        Assert.Contains("login/overview.md", indexContent, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithWrite_SecondFeature_AppendsToExistingIndex()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+
+        // First feature
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            TextWriter.Null);
+
+        // Second feature
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "mfa", "--write"],
+            TextWriter.Null);
+
+        var indexPath = Path.Combine(hostRoot, "intents", "auth", "features", "index.md");
+        var indexContent = File.ReadAllText(indexPath);
+        Assert.Contains("login/overview.md", indexContent, StringComparison.Ordinal);
+        Assert.Contains("mfa/overview.md", indexContent, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Cross-linking content
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithWrite_OverviewContainsCrossLinks()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            TextWriter.Null);
+
+        var overview = File.ReadAllText(
+            Path.Combine(hostRoot, "intents", "auth", "features", "login", "overview.md"));
+
+        Assert.Contains("requirements.md", overview, StringComparison.Ordinal);
+        Assert.Contains("acceptance.md", overview, StringComparison.Ordinal);
+        Assert.Contains("decisions.md", overview, StringComparison.Ordinal);
+        Assert.Contains("open-questions.md", overview, StringComparison.Ordinal);
+        Assert.Contains("packets.md", overview, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithWrite_OpenQuestionsLinksBackToClarifications()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            TextWriter.Null);
+
+        var openQuestions = File.ReadAllText(
+            Path.Combine(hostRoot, "intents", "auth", "features", "login", "open-questions.md"));
+
+        Assert.Contains("clarifications", openQuestions, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithWrite_PacketsFileLinksBackToPacketsFolder()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            TextWriter.Null);
+
+        var packets = File.ReadAllText(
+            Path.Combine(hostRoot, "intents", "auth", "features", "login", "packets.md"));
+
+        Assert.Contains("packets", packets, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Idempotency
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithWrite_Idempotent_DoesNotOverwriteExistingFeatureFiles()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+
+        // First run: creates files
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            TextWriter.Null);
+
+        // Modify a feature file
+        var overviewPath = Path.Combine(hostRoot, "intents", "auth", "features", "login", "overview.md");
+        File.WriteAllText(overviewPath, "# Custom overview");
+
+        // Second run: must not overwrite
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            TextWriter.Null);
+
+        Assert.Equal("# Custom overview", File.ReadAllText(overviewPath));
+    }
+
+    [Fact]
+    public void Execute_SecondRun_ReportsExistingFiles_WrittenCountZero()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+
+        // First run
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            TextWriter.Null);
+
+        // Second run
+        using var writer = new StringWriter();
+        var exitCode = IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        var result = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+        var written = result.GetProperty("written_paths").GetArrayLength();
+        Assert.Equal(0, written);
+    }
+
+    [Fact]
+    public void Execute_Idempotent_IndexNotDuplicated()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+
+        // Run twice
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            TextWriter.Null);
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            TextWriter.Null);
+
+        var indexPath = Path.Combine(hostRoot, "intents", "auth", "features", "index.md");
+        var content = File.ReadAllText(indexPath);
+        // Count occurrences of login/overview.md — should be exactly one
+        var occurrences = content.Split("login/overview.md").Length - 1;
+        Assert.Equal(1, occurrences);
+    }
+
+    // ──────────────────────────────────────────────
+    // JSON output
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_FormatJson_OutputIsValidJson()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", "login", "--format", "json"],
+            writer);
+
+        var json = writer.ToString();
+        var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+        Assert.Equal("auth", element.GetProperty("domain").GetString());
+        Assert.Equal("login", element.GetProperty("feature_name").GetString());
+    }
+
+    // ──────────────────────────────────────────────
+    // Argument validation
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_MissingDomain_ReturnsExitCode1()
+    {
+        using var tmp = new TemporaryDirectory();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAddFeatureCommand.Execute(
+            CreateContext(tmp.CreateDirectory("host")),
+            ["--name", "login"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--domain", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MissingName_ReturnsExitCode1()
+    {
+        using var tmp = new TemporaryDirectory();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAddFeatureCommand.Execute(
+            CreateContext(tmp.CreateDirectory("host")),
+            ["--domain", "auth"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--name", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Help_ReturnsZeroAndUsage()
+    {
+        using var tmp = new TemporaryDirectory();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAddFeatureCommand.Execute(
+            CreateContext(tmp.CreateDirectory("host")),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("add-feature", output, StringComparison.Ordinal);
+        Assert.Contains("--domain", output, StringComparison.Ordinal);
+        Assert.Contains("--name", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Child worktree refusal
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_InsideChildWorktree_ReturnsExitCode1()
+    {
+        using var tmp = new TemporaryDirectory();
+        var childRoot = tmp.CreateDirectory(".intent-cli/worktrees/some-branch");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAddFeatureCommand.Execute(
+            CreateContext(childRoot),
+            ["--domain", "auth", "--name", "login", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("child worktree", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ──────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────
+
+    private static CliContext CreateContext(string repoRoot) =>
+        new()
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "bootstrap",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath =
+            Directory.CreateTempSubdirectory("intent-cli-add-feature-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentAddFeatureCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentAddFeatureCommandTests.cs
@@ -311,6 +311,92 @@ public sealed class IntentAddFeatureCommandTests
     }
 
     // ──────────────────────────────────────────────
+    // Slug validation — path-traversal safety
+    // ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("../outside")]
+    [InlineData("feature/../../other")]
+    [InlineData("auth domain")]
+    [InlineData("auth!")]
+    [InlineData("../etc/passwd")]
+    public void Execute_InvalidDomainSlug_ReturnsExitCode1_AndCreatesNoFiles(string badDomain)
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", badDomain, "--name", "login", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("slug", output, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(Path.Combine(hostRoot, "intents")));
+    }
+
+    [Theory]
+    [InlineData("../outside")]
+    [InlineData("feature/../../other")]
+    [InlineData("auth domain")]
+    [InlineData("login!")]
+    public void Execute_InvalidFeatureNameSlug_ReturnsExitCode1_AndCreatesNoFiles(string badName)
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--name", badName, "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("slug", output, StringComparison.OrdinalIgnoreCase);
+        Assert.False(Directory.Exists(Path.Combine(hostRoot, "intents")));
+    }
+
+    [Theory]
+    [InlineData("auth", "login")]
+    [InlineData("my-domain", "user-auth")]
+    [InlineData("domain_v2", "feature_1")]
+    public void Execute_ValidSlugs_ReturnsZero(string domain, string featureName)
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAddFeatureCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", domain, "--name", featureName, "--write"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Theory]
+    [InlineData("../outside")]
+    [InlineData("feature/../../other")]
+    [InlineData("auth domain")]
+    [InlineData("auth!")]
+    public void IsValidSlug_RejectsUnsafeValues(string value)
+    {
+        Assert.False(IntentAddFeatureCommand.IsValidSlug(value));
+    }
+
+    [Theory]
+    [InlineData("auth")]
+    [InlineData("my-feature")]
+    [InlineData("feature_v2")]
+    public void IsValidSlug_AcceptsSafeValues(string value)
+    {
+        Assert.True(IntentAddFeatureCommand.IsValidSlug(value));
+    }
+
+    // ──────────────────────────────────────────────
     // Child worktree refusal
     // ──────────────────────────────────────────────
 

--- a/tests/IntentSystem.Cli.Tests/IntentInitTreeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentInitTreeCommandTests.cs
@@ -1,0 +1,363 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>G404 tests for <c>intent-cli intent init-tree</c>.</summary>
+public sealed class IntentInitTreeCommandTests
+{
+    // ──────────────────────────────────────────────
+    // Dry-run (no --write)
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithoutWrite_PerformsDryRun_AndCreatesNoFiles()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--target-repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(Directory.Exists(Path.Combine(hostRoot, "intents", "auth")));
+
+        var output = writer.ToString();
+        Assert.Contains("dry-run", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--write", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Default init (product-app)
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithWrite_DefaultProjectType_CreatesExpectedFiles()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--target-repo", "owner/repo", "--write"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+
+        var domainRoot = Path.Combine(hostRoot, "intents", "auth");
+        Assert.True(File.Exists(Path.Combine(domainRoot, "manifest.yaml")));
+        Assert.True(File.Exists(Path.Combine(domainRoot, "README.md")));
+        Assert.True(File.Exists(Path.Combine(domainRoot, "identity", "mission.md")));
+    }
+
+    [Fact]
+    public void Execute_WithWrite_DefaultProjectType_CreatesAllRecommendedCategories()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            writer);
+
+        var domainRoot = Path.Combine(hostRoot, "intents", "auth");
+        // product-app expected categories
+        foreach (var cat in new[] { "identity", "product", "features", "technology", "operations", "decisions", "clarifications", "packets", "links" })
+        {
+            Assert.True(
+                File.Exists(Path.Combine(domainRoot, cat, ".gitkeep")),
+                $"Expected .gitkeep in category '{cat}'");
+        }
+    }
+
+    [Fact]
+    public void Execute_WithWrite_ManifestContainsTreeV1AndProjectType()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--target-repo", "owner/repo", "--write"],
+            writer);
+
+        var manifest = File.ReadAllText(Path.Combine(hostRoot, "intents", "auth", "manifest.yaml"));
+        Assert.Contains("layout_version: tree-v1", manifest, StringComparison.Ordinal);
+        Assert.Contains("project_type: product-app", manifest, StringComparison.Ordinal);
+        Assert.Contains("target_repo: owner/repo", manifest, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Custom project types
+    // ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("library-tool", "api", "users")]
+    [InlineData("infrastructure", "environments", "runbooks")]
+    [InlineData("research-prototype", "hypothesis", "experiments")]
+    public void Execute_WithWrite_CustomProjectType_CreatesTypeSpecificCategories(
+        string projectType, string expectedCat1, string expectedCat2)
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "sdk", "--project-type", projectType, "--write"],
+            writer);
+
+        var domainRoot = Path.Combine(hostRoot, "intents", "sdk");
+        Assert.True(File.Exists(Path.Combine(domainRoot, expectedCat1, ".gitkeep")),
+            $"Expected .gitkeep in '{expectedCat1}' for project-type '{projectType}'");
+        Assert.True(File.Exists(Path.Combine(domainRoot, expectedCat2, ".gitkeep")),
+            $"Expected .gitkeep in '{expectedCat2}' for project-type '{projectType}'");
+    }
+
+    [Fact]
+    public void Execute_WithWrite_LibraryTool_HasApiAndUsers_NotProduct()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "sdk", "--project-type", "library-tool", "--write"],
+            writer);
+
+        var domainRoot = Path.Combine(hostRoot, "intents", "sdk");
+        Assert.True(File.Exists(Path.Combine(domainRoot, "api", ".gitkeep")));
+        Assert.True(File.Exists(Path.Combine(domainRoot, "users", ".gitkeep")));
+        Assert.False(File.Exists(Path.Combine(domainRoot, "product", ".gitkeep")));
+        Assert.False(File.Exists(Path.Combine(domainRoot, "links", ".gitkeep")));
+    }
+
+    // ──────────────────────────────────────────────
+    // Idempotency
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithWrite_Idempotent_DoesNotOverwriteExistingFiles()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer1 = new StringWriter();
+        using var writer2 = new StringWriter();
+
+        // First run: creates files
+        IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            writer1);
+
+        // Modify a file
+        var missionPath = Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md");
+        File.WriteAllText(missionPath, "# Custom mission content");
+
+        // Second run: must not overwrite
+        IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            writer2);
+
+        Assert.Equal("# Custom mission content", File.ReadAllText(missionPath));
+
+        var output2 = writer2.ToString();
+        Assert.Contains("[existing]", output2, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_SecondRun_ReportsExistingNotCreated()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+
+        // First run
+        IntentInitTreeCommand.Execute(CreateContext(hostRoot), ["--domain", "auth", "--write"], TextWriter.Null);
+
+        // Second run
+        using var writer = new StringWriter();
+        var exitCode = IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        var result = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+        var written = result.GetProperty("written_paths").GetArrayLength();
+        Assert.Equal(0, written);
+    }
+
+    // ──────────────────────────────────────────────
+    // JSON output
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_FormatJson_OutputIsValidJson()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--format", "json"],
+            writer);
+
+        var json = writer.ToString();
+        var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+        Assert.Equal("auth", element.GetProperty("domain").GetString());
+        Assert.Equal("product-app", element.GetProperty("project_type").GetString());
+    }
+
+    // ──────────────────────────────────────────────
+    // Argument validation
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_MissingDomain_ReturnExitCode1()
+    {
+        using var tmp = new TemporaryDirectory();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitTreeCommand.Execute(
+            CreateContext(tmp.CreateDirectory("host")),
+            ["--target-repo", "owner/repo"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--domain", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownProjectType_ReturnsExitCode1()
+    {
+        using var tmp = new TemporaryDirectory();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitTreeCommand.Execute(
+            CreateContext(tmp.CreateDirectory("host")),
+            ["--domain", "auth", "--project-type", "bogus-type"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public void Execute_Help_ReturnsZeroAndUsage()
+    {
+        using var tmp = new TemporaryDirectory();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitTreeCommand.Execute(
+            CreateContext(tmp.CreateDirectory("host")),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("init-tree", output, StringComparison.Ordinal);
+        Assert.Contains("--domain", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Child worktree refusal
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_InsideChildWorktree_ReturnsExitCode1()
+    {
+        using var tmp = new TemporaryDirectory();
+        var childRoot = tmp.CreateDirectory(".intent-cli/worktrees/some-branch");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitTreeCommand.Execute(
+            CreateContext(childRoot),
+            ["--domain", "auth", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("child worktree", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ──────────────────────────────────────────────
+    // ResolveCategories unit tests
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveCategories_ProductApp_IncludesAllNineCategories()
+    {
+        var categories = IntentInitTreeCommand.ResolveCategories(IntentInitTreeCommand.ProjectTypeProductApp);
+        var keys = categories.Select(c => c.Key).ToList();
+        Assert.Contains("identity", keys);
+        Assert.Contains("product", keys);
+        Assert.Contains("features", keys);
+        Assert.Contains("technology", keys);
+        Assert.Contains("operations", keys);
+        Assert.Contains("decisions", keys);
+        Assert.Contains("clarifications", keys);
+        Assert.Contains("packets", keys);
+        Assert.Contains("links", keys);
+        Assert.Equal(9, categories.Count);
+    }
+
+    [Fact]
+    public void ResolveCategories_LibraryTool_HasApiAndUsersNotProductOrLinks()
+    {
+        var categories = IntentInitTreeCommand.ResolveCategories(IntentInitTreeCommand.ProjectTypeLibraryTool);
+        var keys = categories.Select(c => c.Key).ToList();
+        Assert.Contains("api", keys);
+        Assert.Contains("users", keys);
+        Assert.DoesNotContain("product", keys);
+        Assert.DoesNotContain("links", keys);
+    }
+
+    // ──────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────
+
+    private static CliContext CreateContext(string repoRoot) =>
+        new()
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "bootstrap",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath =
+            Directory.CreateTempSubdirectory("intent-cli-init-tree-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentInitTreeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentInitTreeCommandTests.cs
@@ -252,6 +252,72 @@ public sealed class IntentInitTreeCommandTests
         Assert.Equal(1, exitCode);
     }
 
+    // ──────────────────────────────────────────────
+    // Slug validation — path-traversal safety
+    // ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("../outside")]
+    [InlineData("feature/../../other")]
+    [InlineData("auth domain")]
+    [InlineData("auth!")]
+    [InlineData("../etc/passwd")]
+    public void Execute_InvalidDomainSlug_ReturnsExitCode1_AndCreatesNoFiles(string badDomain)
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", badDomain, "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("slug", output, StringComparison.OrdinalIgnoreCase);
+        // No files must have been created
+        Assert.False(Directory.Exists(Path.Combine(hostRoot, "intents")));
+    }
+
+    [Theory]
+    [InlineData("auth")]
+    [InlineData("my-domain")]
+    [InlineData("domain_v2")]
+    [InlineData("Auth123")]
+    public void Execute_ValidDomainSlug_ReturnsZero(string goodDomain)
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", goodDomain, "--write"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Theory]
+    [InlineData("../outside")]
+    [InlineData("feature/../../other")]
+    [InlineData("auth domain")]
+    [InlineData("auth!")]
+    public void IsValidSlug_RejectsUnsafeValues(string value)
+    {
+        Assert.False(IntentInitTreeCommand.IsValidSlug(value));
+    }
+
+    [Theory]
+    [InlineData("auth")]
+    [InlineData("my-domain")]
+    [InlineData("domain_v2")]
+    public void IsValidSlug_AcceptsSafeValues(string value)
+    {
+        Assert.True(IntentInitTreeCommand.IsValidSlug(value));
+    }
+
     [Fact]
     public void Execute_Help_ReturnsZeroAndUsage()
     {


### PR DESCRIPTION
## Summary

- Adds `intent-cli intent init-tree` to initialize a new intent domain with the tree-v1 flexible layout (manifest.yaml, README.md, category scaffolding, identity starter).
- Adds `intent-cli intent add-feature` to create cross-linked feature starter files (overview, requirements, acceptance, decisions, open-questions, packets, links) and maintain a features/index.md.
- Both commands are idempotent dry-runs by default; write only with `--write`; refuse to run inside automation child worktrees.
- 32 focused tests covering default init, custom project types, add-feature, idempotency, JSON output, argument validation, and child-worktree refusal.

Closes #909

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~IntentInitTreeCommand|FullyQualifiedName~IntentAddFeatureCommand"` — 32 passed
- [x] Full test suite — 1 pre-existing flaky test (`WorkerCompleteCommandTests.Execute_IssuePrCreatedRerunIdempotent_DoesNotDoubleSyncLinkedPr`), passes in isolation; unrelated to this change
- [x] `git diff --check` — clean
- [x] Build succeeds with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)