### PR TITLE
G405: Add flat-to-tree restructure assistant and intent tree lint

### DIFF
--- a/docs/en/03b-flat-to-tree-restructure.md
+++ b/docs/en/03b-flat-to-tree-restructure.md
@@ -1,0 +1,117 @@
+# Flat-to-Tree Restructure (G405)
+
+> **Ask intent-cli first:** `intent-cli guide intent-work setup --kind restructure --domain <name> --target-repo <owner/repo>`
+> ← [intent management](03-intents.md)
+
+This page describes the design-AI-assisted workflow for restructuring an existing flat intent domain into the tree-v1 layout (G403/G404).
+
+## When to use this
+
+Use the restructure workflow when an existing flat intent domain grows large enough that:
+- A single file is hard to search, review, or cross-link.
+- You want to adopt tree-v1 organization without discarding existing content.
+
+Existing flat domains remain valid. Restructuring is gradual and optional.
+
+## Roles and responsibilities
+
+| Actor | Responsibility |
+|---|---|
+| **intent-cli** | Deterministic analysis, proposed moves, reference maps, safety checks, linting, validation. Does NOT make semantic grouping decisions. |
+| **Host/design AI + operator** | Semantic grouping decisions, moving/rewriting content, updating links, committing the result for review. |
+
+## Step-by-step workflow
+
+### 1. Analyze the flat domain (read-only)
+
+```bash
+intent-cli intent analyze-tree --domain <name> --format markdown
+```
+
+This outputs:
+- Flat files found and their sizes
+- Proposed category destinations for each H2/H3 heading (keyword heuristics — review and adjust)
+- Detected references: markdown links, heading anchors, execution-unit IDs (e.g. G405), packet paths, GitHub issue/PR URLs
+- Migration reference map: old path + heading → proposed new path
+
+### 2. Lint before restructuring
+
+```bash
+intent-cli intent lint-layout --domain <name> --format markdown
+```
+
+Note all `LARGE-FLAT-FILE`, `MISSING-MANIFEST`, and `BROKEN-RELATIVE-LINK` warnings.
+
+### 3. Initialize the tree (if not already done)
+
+```bash
+intent-cli intent init-tree --domain <name> --target-repo <owner/repo> --write
+```
+
+Add feature folders as needed:
+
+```bash
+intent-cli intent add-feature --domain <name> --name <feature> --write
+```
+
+### 4. Host/design AI reorganizes with operator
+
+Using the analysis plan as input, the design AI (with operator supervision):
+1. Decides final category groupings (intent-cli suggestions are a starting point).
+2. Moves or copies content blocks from flat files into the suggested destinations.
+3. Updates markdown links and heading anchors.
+4. Preserves original references: packet paths, GitHub issue/PR URLs, execution-unit IDs.
+
+### 5. Optional: generate backup + stub files
+
+```bash
+intent-cli intent analyze-tree --domain <name> --write
+```
+
+Creates:
+- `.restructure-backup/` copies of flat files (non-destructive)
+- Destination stub files with placeholders
+
+### 6. Lint after restructuring
+
+```bash
+intent-cli intent lint-layout --domain <name> --format markdown
+```
+
+Verify:
+- `BROKEN-RELATIVE-LINK` count has not increased
+- `MISSING-FEATURES-INDEX` and `MISSING-FEATURE-OVERVIEW` resolved
+- No `LARGE-FLAT-FILE` warnings remain for moved files
+
+### 7. Commit for review
+
+Commit the restructure as a normal reviewable change. The commit should:
+- Reference which flat files were reorganized
+- List categories created and features added
+- Include the migration reference map
+- Note that original references (GitHub URLs, execution-unit IDs) are preserved
+
+**Review checklist:**
+- [ ] All original headings are traceable to a destination file
+- [ ] Markdown links updated and resolve correctly
+- [ ] Execution-unit IDs and GitHub URLs still present
+- [ ] `manifest.yaml` and `features/index.md` updated
+- [ ] Original flat files backed up or removed with explicit confirmation
+
+## Lint codes reference
+
+| Code | Description | Fix |
+|---|---|---|
+| `MISSING-DOMAIN` | Domain directory does not exist | Run `intent init-tree --write` |
+| `MISSING-MANIFEST` | No `manifest.yaml` (flat domain) | Run `intent init-tree --write` |
+| `MISSING-CATEGORY-FOLDER` | Category listed in manifest but folder absent | Create folder or re-run `init-tree --write` |
+| `LARGE-FLAT-FILE` | Flat file exceeds size threshold | Run `analyze-tree` to plan restructure |
+| `BROKEN-RELATIVE-LINK` | Relative link does not resolve | Update link or create missing file |
+| `MISSING-FEATURES-INDEX` | `features/` exists but `features/index.md` is missing | Run `add-feature --write` |
+| `MISSING-FEATURE-OVERVIEW` | Feature folder missing `overview.md` | Add `overview.md` with goals and criteria |
+
+## Related documents
+
+- [Intent management](03-intents.md)
+- [Intent knowledge tree layout (tree-v1)](03a-intent-tree-layout.md)
+- [Packet creation and issue publishing](04-packets-issues.md)

--- a/docs/ja/03b-flat-to-tree-restructure.md
+++ b/docs/ja/03b-flat-to-tree-restructure.md
@@ -1,0 +1,117 @@
+# フラットからツリーへの再構成 (G405)
+
+> **まず intent-cli に聞く:** `intent-cli guide intent-work setup --kind restructure --domain <name> --target-repo <owner/repo>`
+> ← [intent の整理](03-intents.md)
+
+このページでは、既存のフラット intent ドメインを tree-v1 レイアウト (G403/G404) に再構成するための、デザイン AI 支援ワークフローを説明します。
+
+## いつ使うか
+
+次のような場合に再構成ワークフローを使用してください：
+- 単一のファイルが大きすぎて検索・レビュー・相互リンクが困難になった場合
+- 既存のコンテンツを破棄せずに tree-v1 構成を採用したい場合
+
+既存のフラットドメインは引き続き有効です。再構成は段階的かつ任意です。
+
+## 役割と責任
+
+| アクター | 責任 |
+|---|---|
+| **intent-cli** | 決定論的な分析、移動提案、参照マップ、安全チェック、lint、検証。セマンティックなグループ化判断は行わない。 |
+| **ホスト/デザイン AI + オペレーター** | セマンティックなグループ化判断、コンテンツの移動・書き換え、リンクの更新、レビュー用コミット。 |
+
+## ステップバイステップワークフロー
+
+### 1. フラットドメインの分析（読み取り専用）
+
+```bash
+intent-cli intent analyze-tree --domain <name> --format markdown
+```
+
+出力内容：
+- フラットファイルとサイズ一覧
+- 各 H2/H3 見出しに対するカテゴリ先の提案（キーワードヒューリスティック — 確認して調整してください）
+- 検出された参照：Markdown リンク、見出しアンカー、実行ユニット ID（例: G405）、パケットパス、GitHub issue/PR URL
+- 移行参照マップ：旧パス + 見出し → 提案新パス
+
+### 2. 再構成前の lint
+
+```bash
+intent-cli intent lint-layout --domain <name> --format markdown
+```
+
+`LARGE-FLAT-FILE`、`MISSING-MANIFEST`、`BROKEN-RELATIVE-LINK` の警告を確認してください。
+
+### 3. ツリーの初期化（未初期化の場合）
+
+```bash
+intent-cli intent init-tree --domain <name> --target-repo <owner/repo> --write
+```
+
+必要に応じて機能フォルダを追加：
+
+```bash
+intent-cli intent add-feature --domain <name> --name <feature> --write
+```
+
+### 4. ホスト/デザイン AI がオペレーターと協働して再構成
+
+分析計画を入力として、デザイン AI（オペレーターの監督のもと）：
+1. 最終カテゴリグループを決定（intent-cli の提案は出発点）
+2. フラットファイルからコンテンツブロックを提案先に移動またはコピー
+3. Markdown リンクと見出しアンカーを更新
+4. 元の参照（パケットパス、GitHub issue/PR URL、実行ユニット ID）を維持
+
+### 5. オプション：バックアップ + スタブファイルの生成
+
+```bash
+intent-cli intent analyze-tree --domain <name> --write
+```
+
+作成されるもの：
+- フラットファイルの `.restructure-backup/` コピー（非破壊的）
+- プレースホルダー付きのスタブファイル
+
+### 6. 再構成後の lint
+
+```bash
+intent-cli intent lint-layout --domain <name> --format markdown
+```
+
+確認事項：
+- `BROKEN-RELATIVE-LINK` の数が増えていない
+- `MISSING-FEATURES-INDEX` と `MISSING-FEATURE-OVERVIEW` が解消されている
+- 移動済みファイルに `LARGE-FLAT-FILE` 警告が残っていない
+
+### 7. レビュー用コミット
+
+再構成を通常のレビュー可能な変更としてコミットします：
+- 再構成したフラットファイルを記載
+- 作成したカテゴリと機能を列挙
+- 移行参照マップを含める
+- 元の参照（GitHub URL、実行ユニット ID）が保持されていることを記載
+
+**レビューチェックリスト：**
+- [ ] 全ての元の見出しが宛先ファイルに追跡可能
+- [ ] Markdown リンクが更新され正しく解決される
+- [ ] 実行ユニット ID と GitHub URL が存在する
+- [ ] `manifest.yaml` と `features/index.md` が更新されている
+- [ ] 元のフラットファイルがバックアップされているか、明示的な確認の上で削除されている
+
+## Lint コードリファレンス
+
+| コード | 説明 | 修正方法 |
+|---|---|---|
+| `MISSING-DOMAIN` | ドメインディレクトリが存在しない | `intent init-tree --write` を実行 |
+| `MISSING-MANIFEST` | `manifest.yaml` がない（フラットドメイン） | `intent init-tree --write` を実行 |
+| `MISSING-CATEGORY-FOLDER` | マニフェストに記載のカテゴリフォルダが存在しない | フォルダを作成または `init-tree --write` を再実行 |
+| `LARGE-FLAT-FILE` | フラットファイルがサイズしきい値を超えている | `analyze-tree` で再構成計画を立てる |
+| `BROKEN-RELATIVE-LINK` | 相対リンクが解決しない | リンクを更新するか欠落ファイルを作成 |
+| `MISSING-FEATURES-INDEX` | `features/` があるが `features/index.md` がない | `add-feature --write` を実行 |
+| `MISSING-FEATURE-OVERVIEW` | 機能フォルダに `overview.md` がない | ゴールと受け入れ基準を含む `overview.md` を追加 |
+
+## 関連ドキュメント
+
+- [intent の整理・保守](03-intents.md)
+- [Intent ナレッジツリーレイアウト (tree-v1)](03a-intent-tree-layout.md)
+- [packet 作成と issue 公開](04-packets-issues.md)

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -316,6 +316,8 @@ internal static class CommandRouter
                 ["init"] = IntentInitCommand.Execute,
                 ["init-tree"] = IntentInitTreeCommand.Execute,
                 ["add-feature"] = IntentAddFeatureCommand.Execute,
+                ["analyze-tree"] = IntentAnalyzeTreeCommand.Execute,
+                ["lint-layout"] = IntentLintLayoutCommand.Execute,
                 ["status"] = IntentStatusCommand.Execute,
                 ["search"] = IntentSearchCommand.Execute,
                 ["explain"] = IntentExplainCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/GuideIntentWorkSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideIntentWorkSetupCommand.cs
@@ -23,9 +23,10 @@ internal static class GuideIntentWorkSetupCommand
     private const string KindClarification = "clarification";
     private const string KindIntentShape = "intent-shape";
     private const string KindTreeLayout = "tree-layout";
+    private const string KindRestructure = "restructure";
 
     private const string UsageLine =
-        "Usage: intent-cli guide intent-work setup --kind <domain-organize|next-slice|packet-preload|clarification|intent-shape|tree-layout> "
+        "Usage: intent-cli guide intent-work setup --kind <domain-organize|next-slice|packet-preload|clarification|intent-shape|tree-layout|restructure> "
         + "--domain <domain> --target-repo <owner/repo> [--format markdown|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
@@ -69,13 +70,14 @@ internal static class GuideIntentWorkSetupCommand
             KindClarification => BuildClarification(domain!, targetRepo!),
             KindIntentShape => BuildIntentShape(domain!, targetRepo!),
             KindTreeLayout => BuildTreeLayout(domain!, targetRepo!),
+            KindRestructure => BuildRestructure(domain!, targetRepo!),
             _ => null
         };
 
         if (result is null)
         {
             writer.WriteLine(
-                $"--kind must be '{KindDomainOrganize}', '{KindNextSlice}', '{KindPacketPreload}', '{KindClarification}', '{KindIntentShape}', or '{KindTreeLayout}' (got '{kind}').");
+                $"--kind must be '{KindDomainOrganize}', '{KindNextSlice}', '{KindPacketPreload}', '{KindClarification}', '{KindIntentShape}', '{KindTreeLayout}', or '{KindRestructure}' (got '{kind}').");
             writer.WriteLine(UsageLine);
             return 1;
         }
@@ -537,6 +539,118 @@ Hard rules:
         };
     }
 
+    private static GuideIntentWorkSetupResult BuildRestructure(string domain, string targetRepo)
+    {
+        var prompt =
+$@"Design-AI-assisted flat-to-tree restructuring workflow for domain `{domain}` in `{targetRepo}`.
+
+## Roles and responsibilities
+
+| Actor | Responsibility |
+|---|---|
+| **intent-cli** | Deterministic analysis, proposed moves, reference maps, linting, validation, safety checks. Does NOT make semantic grouping decisions. |
+| **Host/design AI + operator** | Semantic grouping decisions, content reorganization, writing/moving content, committing the result for review. |
+
+## Step 1 — Analyze the flat domain (read-only)
+
+```bash
+intent-cli intent analyze-tree --domain {domain} --format markdown
+```
+
+Review the proposed restructuring plan and migration reference map. The plan shows:
+- Flat files analyzed
+- Suggested category destinations for each H2/H3 heading
+- Detected references: markdown links, heading anchors, execution-unit IDs, packet paths, GitHub issue/PR URLs
+
+## Step 2 — Run lint before restructuring
+
+```bash
+intent-cli intent lint-layout --domain {domain} --format markdown
+```
+
+Note all LARGE-FLAT-FILE, MISSING-MANIFEST, and BROKEN-RELATIVE-LINK warnings.
+
+## Step 3 — Design AI reorganizes with operator
+
+Using the analysis plan as input, the host/design AI (with operator supervision) should:
+1. Decide final category groupings for each heading/section (intent-cli suggestions are a starting point, not binding).
+2. Create tree-v1 folder structure if not already done: `intent-cli intent init-tree --domain {domain} --target-repo {targetRepo} --write`
+3. Add feature folders as needed: `intent-cli intent add-feature --domain {domain} --name <feature> --write`
+4. Move or copy content blocks from flat files into the suggested destinations.
+5. Update all markdown links and heading anchors to resolve correctly.
+6. Preserve original references: packet paths, GitHub issue/PR URLs, execution-unit IDs (e.g. G123) must remain findable.
+7. Keep a `.restructure-backup/` copy of original flat files (or rely on `--write` backup mode).
+
+## Step 4 — Optional: generate backup + stub files
+
+```bash
+intent-cli intent analyze-tree --domain {domain} --write
+```
+
+This creates:
+- `.restructure-backup/` copies of flat files (non-destructive)
+- Destination stub files with placeholders for content to be filled in
+
+## Step 5 — Lint after restructuring
+
+```bash
+intent-cli intent lint-layout --domain {domain} --format markdown
+```
+
+Verify:
+- BROKEN-RELATIVE-LINK count has not increased
+- MISSING-FEATURES-INDEX and MISSING-FEATURE-OVERVIEW resolved
+- No LARGE-FLAT-FILE warnings remain for moved files
+
+## Step 6 — Commit for review
+
+Commit the restructure as a normal reviewable change. The commit message should reference:
+- Source flat files reorganized
+- Categories created
+- Reference map: old heading paths → new tree paths
+- Verification: no source meaning lost, links updated, manifest/index updated, packet/GitHub references preserved
+
+Review checklist:
+- [ ] All original headings are traceable to a destination file
+- [ ] Markdown links updated and resolve correctly
+- [ ] Execution-unit IDs and GitHub URLs still present
+- [ ] manifest.yaml and features/index.md updated
+- [ ] Original flat files backed up or removed with confirmation
+
+Hard rules:
+- intent-cli owns analysis, safety checks, linting, and validation only.
+- Semantic grouping belongs to host/design AI + operator, not intent-cli.
+- The restructure result MUST be committed as a normal change and reviewed before merging.
+- Do not delete original flat files without backup or operator confirmation.
+- Do not publish GitHub issues in this wake.";
+
+        return new GuideIntentWorkSetupResult
+        {
+            Kind = KindRestructure,
+            Domain = domain,
+            TargetRepo = targetRepo,
+            Prompt = prompt,
+            FirstCalls = new[]
+            {
+                "intent-cli guide model --format json",
+                "intent-cli guide onboarding --format json",
+                "intent-cli guide commands list --format json",
+                "intent-cli automation summary --format json",
+                $"intent-cli intent analyze-tree --domain {domain} --format markdown",
+                $"intent-cli intent lint-layout --domain {domain} --format markdown"
+            },
+            ForbiddenSources = new[]
+            {
+                "intents/rules/**",
+                "local skill files",
+                "copied prompt files"
+            },
+            ClarificationFormat = "background, question, options, pros/cons, and recommendation",
+            IssuePublishBoundary = "Do not publish a GitHub issue in this wake. Restructuring is a host-side structural step.",
+            WorktreeFriendly = "The prompt names the parent host repo worktree root as cwd and references domain/target-repo from arguments; no operator-specific paths are hard-coded."
+        };
+    }
+
     private static void WriteMarkdown(TextWriter writer, GuideIntentWorkSetupResult result)
     {
         writer.WriteLine($"# Guide intent-work setup — {result.Kind}");
@@ -685,6 +799,7 @@ Hard rules:
         writer.WriteLine($"- {KindClarification}   (--domain, --target-repo required)");
         writer.WriteLine($"- {KindIntentShape}     (--domain, --target-repo required)");
         writer.WriteLine($"- {KindTreeLayout}      (--domain, --target-repo required)");
+        writer.WriteLine($"- {KindRestructure}    (--domain, --target-repo required)");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/src/IntentSystem.Cli/Commands/IntentAnalyzeTreeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentAnalyzeTreeCommand.cs
@@ -1,0 +1,575 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G405: <c>intent-cli intent analyze-tree</c> — analyze a flat intent domain and
+/// produce a proposed tree-v1 restructuring plan with a reference map.
+///
+/// <para>Reads all Markdown files directly under <c>intents/&lt;domain&gt;/</c>
+/// (flat files — not inside sub-folders). For each file it:</para>
+/// <list type="bullet">
+///   <item>Extracts H2/H3 headings as content blocks to relocate.</item>
+///   <item>Suggests a tree-v1 destination path per heading based on keyword heuristics.</item>
+///   <item>Detects references: markdown links, heading anchors, execution-unit IDs (e.g. G123),
+///         packet paths, and GitHub issue/PR URLs.</item>
+///   <item>Produces a migration reference map from old path + heading to proposed new path.</item>
+/// </list>
+///
+/// <para>Without <c>--write</c> the command is a dry-run (analysis only, no file changes).</para>
+/// <para>With <c>--write</c> the command writes a <c>.restructure-backup/</c> copy of the
+/// analyzed flat files and creates the proposed destination files. Existing files are preserved
+/// (not overwritten).</para>
+///
+/// <para>Refuses to run inside an automation child worktree.</para>
+/// </summary>
+internal static class IntentAnalyzeTreeCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli intent analyze-tree --domain <name> [--write] [--format markdown|json]";
+
+    /// <summary>Maximum flat-file size (bytes) before the file is flagged as large.</summary>
+    internal const int LargeFlatFileBytesThreshold = 8_192;
+
+    private static readonly (string[] Keywords, string Category, string Subfolder)[] CategoryHeuristics =
+    [
+        (["mission", "vision", "value", "principle", "glossary", "term"], "identity", "identity/"),
+        (["feature", "auth", "login", "signup", "dashboard", "search", "notification", "payment"], "features", "features/"),
+        (["architecture", "technology", "stack", "library", "framework", "language", "database", "cloud", "security", "deploy", "pipeline", "observ", "infra"], "technology", "technology/"),
+        (["product", "user", "journey", "persona", "goal", "non-goal", "scope"], "product", "product/"),
+        (["operation", "loop", "release", "runbook", "recovery", "incident"], "operations", "operations/"),
+        (["decision", "adr", "chose", "trade", "rationale"], "decisions", "decisions/"),
+        (["question", "clarif", "open", "unresolved", "blocking"], "clarifications", "clarifications/"),
+        (["packet", "execution", "unit", "wave", "backlog", "roadmap"], "packets", "packets/"),
+        (["link", "reference", "related", "external"], "links", "links/")
+    ];
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(UsageLine);
+            writer.WriteLine("Analyzes a flat intent domain and produces a proposed tree-v1 restructuring plan.");
+            writer.WriteLine();
+            writer.WriteLine("Without --write: dry-run analysis only (no file changes).");
+            writer.WriteLine("With --write:    creates backup copies and proposed destination files (non-destructive).");
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var request, out var parseError))
+        {
+            writer.WriteLine(parseError);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        try
+        {
+            var result = ExecuteCore(context.RepoRoot, request);
+            WriteOutput(writer, request.Format, result);
+            return 0;
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IntentAnalyzeTreeResult ExecuteCore(string hostRepoRoot, IntentAnalyzeTreeRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostRepoRoot);
+        ArgumentNullException.ThrowIfNull(request);
+
+        EnsureNotChildWorktree(hostRepoRoot);
+
+        var domainRoot = Path.Combine(hostRepoRoot, "intents", request.Domain);
+        var flatFiles = DiscoverFlatFiles(domainRoot);
+
+        var proposals = new List<RestructureProposal>();
+        var referenceMap = new List<ReferenceMapEntry>();
+        var detectedRefs = new List<DetectedReference>();
+        var backups = new List<string>();
+        var written = new List<string>();
+
+        foreach (var flatFile in flatFiles)
+        {
+            var relativeFlatPath = MakeRelative(hostRepoRoot, flatFile);
+            var content = File.ReadAllText(flatFile);
+
+            // Extract references from this file
+            var fileRefs = ExtractReferences(content, relativeFlatPath);
+            detectedRefs.AddRange(fileRefs);
+
+            // Extract headings and produce proposals
+            var headings = ExtractHeadings(content);
+            foreach (var heading in headings)
+            {
+                var destination = SuggestDestination(request.Domain, heading);
+                var destRelative = $"intents/{request.Domain}/{destination}";
+                proposals.Add(new RestructureProposal(
+                    SourceFile: relativeFlatPath,
+                    Heading: heading.Text,
+                    HeadingLevel: heading.Level,
+                    SuggestedDestination: destRelative,
+                    Category: destination.Split('/')[0]
+                ));
+                referenceMap.Add(new ReferenceMapEntry(
+                    OldReference: $"{relativeFlatPath}#{SlugifyHeading(heading.Text)}",
+                    NewReference: $"{destRelative}#{SlugifyHeading(heading.Text)}"
+                ));
+            }
+
+            // Backup + write if requested
+            if (request.Write)
+            {
+                var backupPath = Path.Combine(
+                    domainRoot, ".restructure-backup",
+                    Path.GetFileName(flatFile));
+                Directory.CreateDirectory(Path.GetDirectoryName(backupPath)!);
+                if (!File.Exists(backupPath))
+                {
+                    File.Copy(flatFile, backupPath);
+                    backups.Add(MakeRelative(hostRepoRoot, backupPath));
+                }
+
+                // Write destination stub files (non-destructive)
+                foreach (var proposal in proposals.Where(p =>
+                    string.Equals(p.SourceFile, relativeFlatPath, StringComparison.Ordinal)))
+                {
+                    var absDestination = Path.Combine(
+                        hostRepoRoot, proposal.SuggestedDestination.Replace('/', Path.DirectorySeparatorChar));
+                    if (!File.Exists(absDestination))
+                    {
+                        Directory.CreateDirectory(Path.GetDirectoryName(absDestination)!);
+                        File.WriteAllText(absDestination, RenderDestinationStub(proposal, request.Domain));
+                        written.Add(proposal.SuggestedDestination);
+                    }
+                }
+            }
+        }
+
+        var nextSteps = BuildNextSteps(request, flatFiles, proposals, backups.Count, written.Count);
+
+        return new IntentAnalyzeTreeResult
+        {
+            Domain = request.Domain,
+            WriteApplied = request.Write,
+            FlatFilesAnalyzed = flatFiles.Select(f => MakeRelative(hostRepoRoot, f)).ToList(),
+            Proposals = proposals,
+            ReferenceMap = referenceMap,
+            DetectedReferences = detectedRefs,
+            BackupPaths = backups,
+            WrittenPaths = written,
+            NextSteps = nextSteps
+        };
+    }
+
+    // ── Discovery ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Finds Markdown files directly under <paramref name="domainRoot"/> (not in sub-folders).
+    /// Also flags files above the <see cref="LargeFlatFileBytesThreshold"/> threshold.
+    /// </summary>
+    internal static IReadOnlyList<string> DiscoverFlatFiles(string domainRoot)
+    {
+        if (!Directory.Exists(domainRoot))
+        {
+            return [];
+        }
+
+        return Directory
+            .GetFiles(domainRoot, "*.md", SearchOption.TopDirectoryOnly)
+            .Where(f => !string.Equals(Path.GetFileName(f), "README.md", StringComparison.OrdinalIgnoreCase))
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    // ── Heading extraction ────────────────────────────────────────────────────
+
+    internal sealed record HeadingInfo(string Text, int Level, int LineIndex);
+
+    internal static IReadOnlyList<HeadingInfo> ExtractHeadings(string content)
+    {
+        var result = new List<HeadingInfo>();
+        var lines = content.Split('\n');
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].TrimEnd();
+            if (line.StartsWith("## ", StringComparison.Ordinal))
+            {
+                result.Add(new HeadingInfo(line[3..].Trim(), 2, i));
+            }
+            else if (line.StartsWith("### ", StringComparison.Ordinal))
+            {
+                result.Add(new HeadingInfo(line[4..].Trim(), 3, i));
+            }
+        }
+        return result;
+    }
+
+    // ── Destination suggestion ────────────────────────────────────────────────
+
+    internal static string SuggestDestination(string domain, HeadingInfo heading)
+    {
+        var lower = heading.Text.ToLowerInvariant();
+        foreach (var (keywords, _, subfolder) in CategoryHeuristics)
+        {
+            if (keywords.Any(k => lower.Contains(k, StringComparison.Ordinal)))
+            {
+                var slug = SlugifyHeading(heading.Text);
+                return $"{subfolder}{slug}.md";
+            }
+        }
+        // Default: identity
+        var defaultSlug = SlugifyHeading(heading.Text);
+        return $"identity/{defaultSlug}.md";
+    }
+
+    // ── Reference detection ───────────────────────────────────────────────────
+
+    internal static IReadOnlyList<DetectedReference> ExtractReferences(string content, string sourcePath)
+    {
+        var refs = new List<DetectedReference>();
+
+        // Markdown links: [text](url)
+        foreach (Match m in Regex.Matches(content, @"\[([^\]]+)\]\(([^)]+)\)"))
+        {
+            refs.Add(new DetectedReference(
+                Kind: "markdown-link",
+                Value: m.Groups[2].Value,
+                SourcePath: sourcePath));
+        }
+
+        // Heading anchors: # Heading (extract as #slug)
+        foreach (Match m in Regex.Matches(content, @"^#{1,6}\s+(.+)$", RegexOptions.Multiline))
+        {
+            refs.Add(new DetectedReference(
+                Kind: "heading-anchor",
+                Value: "#" + SlugifyHeading(m.Groups[1].Value.Trim()),
+                SourcePath: sourcePath));
+        }
+
+        // Execution-unit IDs: G123, G404, etc.
+        foreach (Match m in Regex.Matches(content, @"\bG\d{3,4}\b"))
+        {
+            refs.Add(new DetectedReference(
+                Kind: "execution-unit-id",
+                Value: m.Value,
+                SourcePath: sourcePath));
+        }
+
+        // Packet paths: intents/.../packets/...
+        foreach (Match m in Regex.Matches(content, @"intents/[^\s\)\]""]+"))
+        {
+            refs.Add(new DetectedReference(
+                Kind: "packet-path",
+                Value: m.Value,
+                SourcePath: sourcePath));
+        }
+
+        // GitHub issue/PR URLs
+        foreach (Match m in Regex.Matches(content, @"https://github\.com/[^\s\)\]""]+/(issues|pull)/\d+"))
+        {
+            refs.Add(new DetectedReference(
+                Kind: "github-url",
+                Value: m.Value,
+                SourcePath: sourcePath));
+        }
+
+        return refs;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    internal static string SlugifyHeading(string heading)
+    {
+        var lower = heading.ToLowerInvariant();
+        var result = new System.Text.StringBuilder();
+        foreach (var c in lower)
+        {
+            if (char.IsLetterOrDigit(c))
+            {
+                result.Append(c);
+            }
+            else if (c == ' ' || c == '-' || c == '_')
+            {
+                if (result.Length > 0 && result[^1] != '-')
+                {
+                    result.Append('-');
+                }
+            }
+        }
+        return result.ToString().Trim('-');
+    }
+
+    private static string RenderDestinationStub(RestructureProposal proposal, string domain)
+    {
+        return $"""
+        # {proposal.Heading}
+
+        > **Restructured from:** `{proposal.SourceFile}`
+        > Run `intent-cli guide intent-work setup --kind restructure --domain {domain} --format markdown`
+        > for the design-AI-assisted restructuring workflow.
+
+        _[Paste or move the content from the source section here. Verify all links and references.]_
+        """;
+    }
+
+    private static IReadOnlyList<string> BuildNextSteps(
+        IntentAnalyzeTreeRequest request,
+        IReadOnlyList<string> flatFiles,
+        IReadOnlyList<RestructureProposal> proposals,
+        int backupCount,
+        int writtenCount)
+    {
+        var steps = new List<string>();
+
+        if (flatFiles.Count == 0)
+        {
+            steps.Add($"No flat files found in intents/{request.Domain}/. Domain may already be tree-structured.");
+            return steps;
+        }
+
+        steps.Add($"Analyzed {flatFiles.Count} flat file(s); proposed {proposals.Count} relocation(s).");
+
+        if (!request.Write)
+        {
+            steps.Add($"Re-run with --write to create backup copies and destination stubs: "
+                + $"intent-cli intent analyze-tree --domain {request.Domain} --write");
+        }
+        else
+        {
+            steps.Add($"Backed up {backupCount} file(s) to intents/{request.Domain}/.restructure-backup/.");
+            steps.Add($"Created {writtenCount} destination stub file(s). Fill in content from the source sections.");
+        }
+
+        steps.Add($"Run `intent-cli guide intent-work setup --kind restructure --domain {request.Domain} "
+            + "--target-repo <owner/repo> --format markdown` for the design-AI-assisted workflow.");
+        steps.Add($"Run `intent-cli intent lint-layout --domain {request.Domain}` to check the result after restructuring.");
+        return steps;
+    }
+
+    private static void EnsureNotChildWorktree(string hostRepoRoot)
+    {
+        var normalized = Path.GetFullPath(hostRepoRoot).Replace('\\', '/');
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = 0; i + 1 < segments.Length; i++)
+        {
+            if (string.Equals(segments[i], ".intent-cli", StringComparison.Ordinal)
+                && string.Equals(segments[i + 1], "worktrees", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Refusing to run 'intent analyze-tree' inside an automation child worktree at '{hostRepoRoot}'. "
+                    + "Run this command from the parent host repository.");
+            }
+        }
+    }
+
+    private static string MakeRelative(string repoRoot, string absolutePath)
+    {
+        var normalized = Path.GetFullPath(absolutePath);
+        var root = Path.GetFullPath(repoRoot);
+        if (normalized.StartsWith(root, StringComparison.Ordinal))
+        {
+            return normalized[(root.Length + 1)..].Replace(Path.DirectorySeparatorChar, '/');
+        }
+        return normalized.Replace(Path.DirectorySeparatorChar, '/');
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out IntentAnalyzeTreeRequest request,
+        out string error)
+    {
+        request = default!;
+        error = string.Empty;
+
+        string? domain = null;
+        var write = false;
+        var format = FormatMarkdown;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--domain":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--domain'.";
+                        return false;
+                    }
+                    domain = args[++i].Trim();
+                    break;
+                case "--write":
+                    write = true;
+                    break;
+                case "--format":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--format'.";
+                        return false;
+                    }
+                    var fmt = args[++i].Trim();
+                    if (!string.Equals(fmt, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(fmt, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{fmt}').";
+                        return false;
+                    }
+                    format = fmt;
+                    break;
+                default:
+                    error = $"Unknown option '{args[i]}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            error = "intent analyze-tree requires '--domain <name>'.";
+            return false;
+        }
+
+        if (!IntentInitTreeCommand.IsValidSlug(domain))
+        {
+            error = $"intent analyze-tree '--domain' value '{domain}' must be a slug (letters, digits, '-', '_').";
+            return false;
+        }
+
+        request = new IntentAnalyzeTreeRequest
+        {
+            Domain = domain!,
+            Write = write,
+            Format = format
+        };
+        return true;
+    }
+
+    private static void WriteOutput(TextWriter writer, string format, IntentAnalyzeTreeResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        WriteMarkdown(writer, result);
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IntentAnalyzeTreeResult result)
+    {
+        var mode = result.WriteApplied ? "write" : "dry-run";
+        writer.WriteLine($"# intent analyze-tree — {result.Domain} ({mode})");
+        writer.WriteLine();
+        writer.WriteLine($"- write-applied: {result.WriteApplied}");
+        writer.WriteLine($"- flat-files-analyzed: {result.FlatFilesAnalyzed.Count}");
+        writer.WriteLine($"- proposals: {result.Proposals.Count}");
+        writer.WriteLine($"- detected-references: {result.DetectedReferences.Count}");
+        writer.WriteLine();
+
+        if (result.Proposals.Count > 0)
+        {
+            writer.WriteLine("## Proposed relocations");
+            writer.WriteLine();
+            foreach (var p in result.Proposals)
+            {
+                writer.WriteLine($"- `{p.SourceFile}` → `{p.SuggestedDestination}` (heading: {p.Heading})");
+            }
+            writer.WriteLine();
+        }
+
+        if (result.ReferenceMap.Count > 0)
+        {
+            writer.WriteLine("## Migration reference map");
+            writer.WriteLine();
+            foreach (var r in result.ReferenceMap)
+            {
+                writer.WriteLine($"- old: `{r.OldReference}` → new: `{r.NewReference}`");
+            }
+            writer.WriteLine();
+        }
+
+        if (result.BackupPaths.Count > 0)
+        {
+            writer.WriteLine("## Backups created");
+            writer.WriteLine();
+            foreach (var b in result.BackupPaths)
+            {
+                writer.WriteLine($"- {b}");
+            }
+            writer.WriteLine();
+        }
+
+        if (result.WrittenPaths.Count > 0)
+        {
+            writer.WriteLine("## Destination stubs created");
+            writer.WriteLine();
+            foreach (var w in result.WrittenPaths)
+            {
+                writer.WriteLine($"- {w}");
+            }
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Next steps");
+        writer.WriteLine();
+        foreach (var step in result.NextSteps)
+        {
+            writer.WriteLine($"- {step}");
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+    internal sealed record IntentAnalyzeTreeRequest
+    {
+        public required string Domain { get; init; }
+        public required bool Write { get; init; }
+        public required string Format { get; init; }
+    }
+}
+
+internal sealed record IntentAnalyzeTreeResult
+{
+    public required string Domain { get; init; }
+    public required bool WriteApplied { get; init; }
+    public required IReadOnlyList<string> FlatFilesAnalyzed { get; init; }
+    public required IReadOnlyList<RestructureProposal> Proposals { get; init; }
+    public required IReadOnlyList<ReferenceMapEntry> ReferenceMap { get; init; }
+    public required IReadOnlyList<DetectedReference> DetectedReferences { get; init; }
+    public required IReadOnlyList<string> BackupPaths { get; init; }
+    public required IReadOnlyList<string> WrittenPaths { get; init; }
+    public required IReadOnlyList<string> NextSteps { get; init; }
+}
+
+internal sealed record RestructureProposal(
+    string SourceFile,
+    string Heading,
+    int HeadingLevel,
+    string SuggestedDestination,
+    string Category);
+
+internal sealed record ReferenceMapEntry(
+    string OldReference,
+    string NewReference);
+
+internal sealed record DetectedReference(
+    string Kind,
+    string Value,
+    string SourcePath);

--- a/src/IntentSystem.Cli/Commands/IntentLintLayoutCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentLintLayoutCommand.cs
@@ -1,0 +1,436 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G405: <c>intent-cli intent lint-layout</c> — detect layout problems in an intent domain.
+///
+/// <para>Checks performed:</para>
+/// <list type="bullet">
+///   <item>Missing <c>manifest.yaml</c> (for tree-v1 domains).</item>
+///   <item>Missing category index files referenced in the manifest.</item>
+///   <item>Broken relative Markdown links within the domain tree.</item>
+///   <item>Overly large flat Markdown files (above threshold).</item>
+///   <item>Missing <c>features/index.md</c> when feature sub-folders exist.</item>
+///   <item>Feature sub-folders missing <c>overview.md</c>.</item>
+/// </list>
+///
+/// <para>Supports mixed flat/tree domains: a domain without a manifest is treated as flat
+/// and receives only the large-file and missing-feature-index checks.</para>
+///
+/// <para>Refuses to run inside an automation child worktree.</para>
+/// </summary>
+internal static class IntentLintLayoutCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli intent lint-layout --domain <name> [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(UsageLine);
+            writer.WriteLine("Lints an intent domain layout: missing manifest, broken links, large flat files, missing indexes.");
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var request, out var parseError))
+        {
+            writer.WriteLine(parseError);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        try
+        {
+            var result = ExecuteCore(context.RepoRoot, request);
+            WriteOutput(writer, request.Format, result);
+            return result.Warnings.Count > 0 ? 0 : 0; // always exit 0; warnings surfaced in output
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine(exception.Message);
+            return 1;
+        }
+    }
+
+    internal static IntentLintLayoutResult ExecuteCore(string hostRepoRoot, IntentLintLayoutRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(hostRepoRoot);
+        ArgumentNullException.ThrowIfNull(request);
+
+        EnsureNotChildWorktree(hostRepoRoot);
+
+        var domainRoot = Path.Combine(hostRepoRoot, "intents", request.Domain);
+        var warnings = new List<LintWarning>();
+
+        if (!Directory.Exists(domainRoot))
+        {
+            warnings.Add(new LintWarning(
+                Code: "MISSING-DOMAIN",
+                Message: $"Domain directory 'intents/{request.Domain}/' does not exist.",
+                Fix: $"Run `intent-cli intent init-tree --domain {request.Domain} --write` to initialize."));
+            return BuildResult(request, warnings, isTreeDomain: false);
+        }
+
+        // Determine if this is a tree-v1 domain
+        var manifestPath = Path.Combine(domainRoot, "manifest.yaml");
+        var isTreeDomain = File.Exists(manifestPath);
+
+        if (!isTreeDomain)
+        {
+            warnings.Add(new LintWarning(
+                Code: "MISSING-MANIFEST",
+                Message: $"No manifest.yaml found in 'intents/{request.Domain}/'. Domain is flat.",
+                Fix: $"Run `intent-cli intent init-tree --domain {request.Domain} --write` to add tree structure, "
+                    + "or `intent-cli intent analyze-tree --domain "
+                    + $"{request.Domain}` to plan a restructure."));
+        }
+        else
+        {
+            // Parse manifest for category paths
+            var manifestContent = File.ReadAllText(manifestPath);
+            var categories = ParseManifestCategories(manifestContent);
+            CheckMissingCategoryFolders(domainRoot, request.Domain, categories, warnings);
+        }
+
+        // Check for large flat files (both flat and tree domains)
+        CheckLargeFlatFiles(domainRoot, request.Domain, warnings);
+
+        // Check broken relative links in all markdown files
+        CheckBrokenRelativeLinks(domainRoot, request.Domain, warnings);
+
+        // Check features/index.md
+        CheckFeaturesIndex(domainRoot, request.Domain, warnings);
+
+        return BuildResult(request, warnings, isTreeDomain);
+    }
+
+    // ── Category checks ───────────────────────────────────────────────────────
+
+    private static Dictionary<string, string> ParseManifestCategories(string manifestContent)
+    {
+        var categories = new Dictionary<string, string>(StringComparer.Ordinal);
+        var inCategories = false;
+
+        foreach (var line in manifestContent.Split('\n'))
+        {
+            var trimmed = line.TrimEnd();
+            if (string.Equals(trimmed, "categories:", StringComparison.Ordinal))
+            {
+                inCategories = true;
+                continue;
+            }
+
+            if (inCategories)
+            {
+                if (trimmed.StartsWith("  ", StringComparison.Ordinal) && trimmed.Contains(':'))
+                {
+                    var colonIdx = trimmed.IndexOf(':', StringComparison.Ordinal);
+                    var key = trimmed[..colonIdx].Trim();
+                    var value = trimmed[(colonIdx + 1)..].Trim();
+                    categories[key] = value;
+                }
+                else if (!string.IsNullOrWhiteSpace(trimmed))
+                {
+                    inCategories = false;
+                }
+            }
+        }
+
+        return categories;
+    }
+
+    private static void CheckMissingCategoryFolders(
+        string domainRoot,
+        string domain,
+        Dictionary<string, string> categories,
+        List<LintWarning> warnings)
+    {
+        foreach (var (key, path) in categories)
+        {
+            var catDir = Path.Combine(domainRoot, path.TrimEnd('/').Replace('/', Path.DirectorySeparatorChar));
+            if (!Directory.Exists(catDir))
+            {
+                warnings.Add(new LintWarning(
+                    Code: "MISSING-CATEGORY-FOLDER",
+                    Message: $"Category '{key}' folder 'intents/{domain}/{path}' listed in manifest.yaml does not exist.",
+                    Fix: $"Create the folder or run `intent-cli intent init-tree --domain {domain} --write` to scaffold it."));
+            }
+        }
+    }
+
+    // ── Large flat file check ─────────────────────────────────────────────────
+
+    private static void CheckLargeFlatFiles(
+        string domainRoot,
+        string domain,
+        List<LintWarning> warnings)
+    {
+        var flatFiles = Directory
+            .GetFiles(domainRoot, "*.md", SearchOption.TopDirectoryOnly)
+            .Where(f => !string.Equals(Path.GetFileName(f), "README.md", StringComparison.OrdinalIgnoreCase));
+
+        foreach (var file in flatFiles)
+        {
+            var info = new FileInfo(file);
+            if (info.Length > IntentAnalyzeTreeCommand.LargeFlatFileBytesThreshold)
+            {
+                var rel = $"intents/{domain}/{Path.GetFileName(file)}";
+                warnings.Add(new LintWarning(
+                    Code: "LARGE-FLAT-FILE",
+                    Message: $"Flat file '{rel}' is {info.Length:N0} bytes (threshold: {IntentAnalyzeTreeCommand.LargeFlatFileBytesThreshold:N0} bytes).",
+                    Fix: $"Consider restructuring into tree-v1 categories. "
+                        + $"Run `intent-cli intent analyze-tree --domain {domain}` to see a proposed plan."));
+            }
+        }
+    }
+
+    // ── Broken link check ─────────────────────────────────────────────────────
+
+    private static void CheckBrokenRelativeLinks(
+        string domainRoot,
+        string domain,
+        List<LintWarning> warnings)
+    {
+        var allMarkdown = Directory.GetFiles(domainRoot, "*.md", SearchOption.AllDirectories);
+
+        foreach (var mdFile in allMarkdown)
+        {
+            var content = File.ReadAllText(mdFile);
+            var dir = Path.GetDirectoryName(mdFile)!;
+
+            foreach (Match m in Regex.Matches(content, @"\[([^\]]+)\]\(([^)#]+)(?:#[^)]*)?\)"))
+            {
+                var linkTarget = m.Groups[2].Value.Trim();
+
+                // Skip absolute URLs
+                if (linkTarget.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                    || linkTarget.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+                    || linkTarget.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Skip empty
+                if (string.IsNullOrWhiteSpace(linkTarget))
+                {
+                    continue;
+                }
+
+                var resolved = Path.GetFullPath(Path.Combine(dir, linkTarget));
+                if (!File.Exists(resolved) && !Directory.Exists(resolved))
+                {
+                    var relSource = $"intents/{domain}/" + Path.GetRelativePath(domainRoot, mdFile).Replace(Path.DirectorySeparatorChar, '/');
+                    warnings.Add(new LintWarning(
+                        Code: "BROKEN-RELATIVE-LINK",
+                        Message: $"Broken link in '{relSource}': '{linkTarget}' does not resolve.",
+                        Fix: "Update the link target or create the missing file."));
+                }
+            }
+        }
+    }
+
+    // ── Feature index check ───────────────────────────────────────────────────
+
+    private static void CheckFeaturesIndex(
+        string domainRoot,
+        string domain,
+        List<LintWarning> warnings)
+    {
+        var featuresDir = Path.Combine(domainRoot, "features");
+        if (!Directory.Exists(featuresDir))
+        {
+            return;
+        }
+
+        // Check for features/index.md
+        var indexPath = Path.Combine(featuresDir, "index.md");
+        if (!File.Exists(indexPath))
+        {
+            warnings.Add(new LintWarning(
+                Code: "MISSING-FEATURES-INDEX",
+                Message: $"'intents/{domain}/features/' exists but 'features/index.md' is missing.",
+                Fix: $"Run `intent-cli intent add-feature --domain {domain} --name <feature> --write` "
+                    + "to create the first feature and the index."));
+        }
+
+        // Check for feature sub-folders missing overview.md
+        foreach (var featureDir in Directory.GetDirectories(featuresDir))
+        {
+            var featureName = Path.GetFileName(featureDir);
+            var overviewPath = Path.Combine(featureDir, "overview.md");
+            if (!File.Exists(overviewPath))
+            {
+                warnings.Add(new LintWarning(
+                    Code: "MISSING-FEATURE-OVERVIEW",
+                    Message: $"Feature folder 'intents/{domain}/features/{featureName}/' is missing 'overview.md'.",
+                    Fix: $"Add 'intents/{domain}/features/{featureName}/overview.md' with goals and acceptance criteria."));
+            }
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static IntentLintLayoutResult BuildResult(
+        IntentLintLayoutRequest request,
+        List<LintWarning> warnings,
+        bool isTreeDomain) =>
+        new()
+        {
+            Domain = request.Domain,
+            IsTreeDomain = isTreeDomain,
+            Warnings = warnings,
+            Clean = warnings.Count == 0
+        };
+
+    private static void EnsureNotChildWorktree(string hostRepoRoot)
+    {
+        var normalized = Path.GetFullPath(hostRepoRoot).Replace('\\', '/');
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var i = 0; i + 1 < segments.Length; i++)
+        {
+            if (string.Equals(segments[i], ".intent-cli", StringComparison.Ordinal)
+                && string.Equals(segments[i + 1], "worktrees", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(
+                    $"Refusing to run 'intent lint-layout' inside an automation child worktree at '{hostRepoRoot}'. "
+                    + "Run this command from the parent host repository.");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out IntentLintLayoutRequest request,
+        out string error)
+    {
+        request = default!;
+        error = string.Empty;
+
+        string? domain = null;
+        var format = FormatMarkdown;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--domain":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--domain'.";
+                        return false;
+                    }
+                    domain = args[++i].Trim();
+                    break;
+                case "--format":
+                    if (i + 1 >= args.Length || string.IsNullOrWhiteSpace(args[i + 1]))
+                    {
+                        error = "Missing value for '--format'.";
+                        return false;
+                    }
+                    var fmt = args[++i].Trim();
+                    if (!string.Equals(fmt, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(fmt, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{fmt}').";
+                        return false;
+                    }
+                    format = fmt;
+                    break;
+                default:
+                    error = $"Unknown option '{args[i]}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            error = "intent lint-layout requires '--domain <name>'.";
+            return false;
+        }
+
+        if (!IntentInitTreeCommand.IsValidSlug(domain))
+        {
+            error = $"intent lint-layout '--domain' value '{domain}' must be a slug (letters, digits, '-', '_').";
+            return false;
+        }
+
+        request = new IntentLintLayoutRequest { Domain = domain!, Format = format };
+        return true;
+    }
+
+    private static void WriteOutput(TextWriter writer, string format, IntentLintLayoutResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        WriteMarkdown(writer, result);
+    }
+
+    private static void WriteMarkdown(TextWriter writer, IntentLintLayoutResult result)
+    {
+        var status = result.Clean ? "clean" : $"{result.Warnings.Count} warning(s)";
+        writer.WriteLine($"# intent lint-layout — {result.Domain} ({status})");
+        writer.WriteLine();
+        writer.WriteLine($"- domain: {result.Domain}");
+        writer.WriteLine($"- tree-domain: {result.IsTreeDomain}");
+        writer.WriteLine($"- warnings: {result.Warnings.Count}");
+        writer.WriteLine();
+
+        if (result.Clean)
+        {
+            writer.WriteLine("No layout problems detected.");
+            return;
+        }
+
+        writer.WriteLine("## Warnings");
+        writer.WriteLine();
+        foreach (var w in result.Warnings)
+        {
+            writer.WriteLine($"### [{w.Code}] {w.Message}");
+            writer.WriteLine();
+            writer.WriteLine($"**Fix:** {w.Fix}");
+            writer.WriteLine();
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
+    internal sealed record IntentLintLayoutRequest
+    {
+        public required string Domain { get; init; }
+        public required string Format { get; init; }
+    }
+}
+
+internal sealed record IntentLintLayoutResult
+{
+    public required string Domain { get; init; }
+    public required bool IsTreeDomain { get; init; }
+    public required bool Clean { get; init; }
+    public required IReadOnlyList<LintWarning> Warnings { get; init; }
+}
+
+internal sealed record LintWarning(
+    string Code,
+    string Message,
+    string Fix);

--- a/tests/IntentSystem.Cli.Tests/GuideIntentWorkSetupCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideIntentWorkSetupCommandTests.cs
@@ -697,6 +697,100 @@ public sealed class GuideIntentWorkSetupCommandTests
         Assert.Contains("tree-layout", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // ──────────────────────────────────────────────
+    // G405: restructure kind
+    // ──────────────────────────────────────────────
+
+    /// <summary>
+    /// G405: restructure kind must emit a prompt describing the design-AI-assisted workflow.
+    /// </summary>
+    [Fact]
+    public void Execute_RestructureKind_EmitsDesignAiWorkflowPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "restructure", "--domain", "auth", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var json = writer.ToString();
+        var result = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+        Assert.Equal("restructure", result.GetProperty("kind").GetString());
+    }
+
+    /// <summary>
+    /// G405: restructure prompt must mention intent-cli owns analysis / guardrails,
+    /// and host/design AI owns semantic grouping.
+    /// </summary>
+    [Fact]
+    public void Execute_RestructureKind_PromptStatesIntentCliOwnsAnalysis()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "restructure", "--domain", "auth", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        var result = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(writer.ToString());
+        var prompt = result.GetProperty("prompt").GetString() ?? string.Empty;
+        Assert.Contains("intent-cli", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("analysis", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("semantic", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G405: restructure prompt must include the analyze-tree and lint-layout commands.
+    /// </summary>
+    [Fact]
+    public void Execute_RestructureKind_PromptIncludesAnalyzeTreeAndLintLayoutCommands()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "restructure", "--domain", "auth", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        var result = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json: writer.ToString());
+        var prompt = result.GetProperty("prompt").GetString() ?? string.Empty;
+        Assert.Contains("analyze-tree", prompt, StringComparison.Ordinal);
+        Assert.Contains("lint-layout", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G405: restructure prompt must state that result is committed for review.
+    /// </summary>
+    [Fact]
+    public void Execute_RestructureKind_PromptInstructsCommitForReview()
+    {
+        using var writer = new StringWriter();
+        GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--kind", "restructure", "--domain", "auth", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        var result = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(writer.ToString());
+        var prompt = result.GetProperty("prompt").GetString() ?? string.Empty;
+        Assert.Contains("commit", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("review", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G405: restructure kind must appear in the help output.
+    /// </summary>
+    [Fact]
+    public void Execute_Help_IncludesRestructureKind()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideIntentWorkSetupCommand.Execute(
+            CreateContext(),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("restructure", writer.ToString(), StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/IntentAnalyzeTreeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentAnalyzeTreeCommandTests.cs
@@ -1,0 +1,402 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>G405 tests for <c>intent-cli intent analyze-tree</c>.</summary>
+public sealed class IntentAnalyzeTreeCommandTests
+{
+    // ──────────────────────────────────────────────
+    // Dry-run (no --write)
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithoutWrite_PerformsDryRun_AndCreatesNoFiles()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateFlatFile(hostRoot, "auth", "intent.md",
+            "# Auth intent\n\n## Mission\nWe auth.\n\n## Features\nLogin stuff.");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        // No destination files created
+        Assert.False(Directory.Exists(Path.Combine(hostRoot, "intents", "auth", "identity")));
+        Assert.False(Directory.Exists(Path.Combine(hostRoot, "intents", "auth", ".restructure-backup")));
+
+        var output = writer.ToString();
+        Assert.Contains("dry-run", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--write", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithoutWrite_OutputsProposals()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateFlatFile(hostRoot, "auth", "intent.md",
+            "# Auth\n\n## Mission\nWe auth.\n\n## Features\nLogin stuff.");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Proposed relocations", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Mission", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Write mode
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithWrite_CreatesBackupCopy()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateFlatFile(hostRoot, "auth", "intent.md",
+            "# Auth\n\n## Mission\nWe auth.");
+        using var writer = new StringWriter();
+
+        IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            writer);
+
+        var backupPath = Path.Combine(hostRoot, "intents", "auth", ".restructure-backup", "intent.md");
+        Assert.True(File.Exists(backupPath), "Backup copy should exist.");
+    }
+
+    [Fact]
+    public void Execute_WithWrite_CreatesDestinationStubFiles()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateFlatFile(hostRoot, "auth", "intent.md",
+            "# Auth\n\n## Mission\nWe auth.\n\n## Features\nLogin stuff.");
+        using var writer = new StringWriter();
+
+        IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            writer);
+
+        // At least one destination stub should have been written
+        var output = writer.ToString();
+        Assert.Contains("Destination stubs created", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithWrite_IsNonDestructive_OriginalFileUnchanged()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        const string originalContent = "# Auth\n\n## Mission\nOriginal content.";
+        CreateFlatFile(hostRoot, "auth", "intent.md", originalContent);
+
+        IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            TextWriter.Null);
+
+        var original = File.ReadAllText(Path.Combine(hostRoot, "intents", "auth", "intent.md"));
+        Assert.Equal(originalContent, original);
+    }
+
+    [Fact]
+    public void Execute_WithWrite_IdempotentBackup_DoesNotOverwriteExistingBackup()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateFlatFile(hostRoot, "auth", "intent.md", "# Auth\n\n## Mission\nV1.");
+
+        // First run: creates backup
+        IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            TextWriter.Null);
+
+        // Modify the source file
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "intent.md"),
+            "# Auth\n\n## Mission\nV2.");
+
+        // Second run: should NOT overwrite existing backup
+        IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            TextWriter.Null);
+
+        var backupContent = File.ReadAllText(
+            Path.Combine(hostRoot, "intents", "auth", ".restructure-backup", "intent.md"));
+        Assert.Contains("V1", backupContent, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Empty / missing domain
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_MissingDomainDirectory_ReturnsZeroAndReportsNoFiles()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "nonexistent"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("flat-files-analyzed: 0", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DomainWithNoFlatFiles_ReturnsZeroAndReportsNoProposals()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        // Create a tree-structured domain (no flat markdown files at top level)
+        Directory.CreateDirectory(Path.Combine(hostRoot, "intents", "auth", "identity"));
+        File.WriteAllText(Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"), "# Mission");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("proposals: 0", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Reference detection
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractReferences_DetectsMarkdownLinks()
+    {
+        var content = "See [overview](../product/overview.md) for details.";
+        var refs = IntentAnalyzeTreeCommand.ExtractReferences(content, "intents/auth/intent.md");
+        Assert.Contains(refs, r => r.Kind == "markdown-link" && r.Value.Contains("overview.md"));
+    }
+
+    [Fact]
+    public void ExtractReferences_DetectsExecutionUnitIds()
+    {
+        var content = "This implements G403 and G404 patterns.";
+        var refs = IntentAnalyzeTreeCommand.ExtractReferences(content, "intents/auth/intent.md");
+        Assert.Contains(refs, r => r.Kind == "execution-unit-id" && r.Value == "G403");
+        Assert.Contains(refs, r => r.Kind == "execution-unit-id" && r.Value == "G404");
+    }
+
+    [Fact]
+    public void ExtractReferences_DetectsGitHubUrls()
+    {
+        var content = "See https://github.com/J-Tech-Japan/intent-system/issues/909 for tracking.";
+        var refs = IntentAnalyzeTreeCommand.ExtractReferences(content, "intents/auth/intent.md");
+        Assert.Contains(refs, r => r.Kind == "github-url" && r.Value.Contains("/issues/909"));
+    }
+
+    [Fact]
+    public void ExtractReferences_DetectsHeadingAnchors()
+    {
+        var content = "# My Section\n## Sub Section";
+        var refs = IntentAnalyzeTreeCommand.ExtractReferences(content, "intents/auth/intent.md");
+        Assert.Contains(refs, r => r.Kind == "heading-anchor");
+    }
+
+    [Fact]
+    public void ExtractReferences_DetectsPacketPaths()
+    {
+        var content = "See intents/auth/packets/wave-1.md for details.";
+        var refs = IntentAnalyzeTreeCommand.ExtractReferences(content, "intents/auth/intent.md");
+        Assert.Contains(refs, r => r.Kind == "packet-path" && r.Value.Contains("packets/wave-1.md"));
+    }
+
+    // ──────────────────────────────────────────────
+    // Heading extraction
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void ExtractHeadings_ExtractsH2AndH3()
+    {
+        var content = "# Title\n\n## Section A\n\ntext\n\n### Sub B\n\nmore text\n\n## Section C";
+        var headings = IntentAnalyzeTreeCommand.ExtractHeadings(content);
+        Assert.Equal(3, headings.Count);
+        Assert.Equal("Section A", headings[0].Text);
+        Assert.Equal(2, headings[0].Level);
+        Assert.Equal("Sub B", headings[1].Text);
+        Assert.Equal(3, headings[1].Level);
+        Assert.Equal("Section C", headings[2].Text);
+    }
+
+    // ──────────────────────────────────────────────
+    // Category destination suggestion
+    // ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Mission statement", "identity/")]
+    [InlineData("Feature: Login", "features/")]
+    [InlineData("Technology stack", "technology/")]
+    [InlineData("Open questions", "clarifications/")]
+    [InlineData("Design decisions", "decisions/")]
+    public void SuggestDestination_ReturnsExpectedCategory(string heading, string expectedPrefix)
+    {
+        var headingInfo = new IntentAnalyzeTreeCommand.HeadingInfo(heading, 2, 0);
+        var destination = IntentAnalyzeTreeCommand.SuggestDestination("auth", headingInfo);
+        Assert.StartsWith(expectedPrefix, destination, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // SlugifyHeading
+    // ──────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Mission Statement", "mission-statement")]
+    [InlineData("Feature: Login", "feature-login")]
+    [InlineData("Open Q&A", "open-qa")]
+    public void SlugifyHeading_ProducesExpectedSlug(string input, string expected)
+    {
+        var slug = IntentAnalyzeTreeCommand.SlugifyHeading(input);
+        Assert.Equal(expected, slug);
+    }
+
+    // ──────────────────────────────────────────────
+    // JSON output
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_FormatJson_OutputIsValidJson()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateFlatFile(hostRoot, "auth", "intent.md", "# Auth\n\n## Mission\nWe auth.");
+        using var writer = new StringWriter();
+
+        IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--format", "json"],
+            writer);
+
+        var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(writer.ToString());
+        Assert.Equal("auth", element.GetProperty("domain").GetString());
+        Assert.False(element.GetProperty("write_applied").GetBoolean());
+    }
+
+    // ──────────────────────────────────────────────
+    // Argument validation
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_MissingDomain_ReturnsExitCode1()
+    {
+        using var tmp = new TemporaryDirectory();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(tmp.CreateDirectory("host")),
+            [],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--domain", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("../outside")]
+    [InlineData("auth domain")]
+    public void Execute_InvalidDomainSlug_ReturnsExitCode1(string badDomain)
+    {
+        using var tmp = new TemporaryDirectory();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(tmp.CreateDirectory("host")),
+            ["--domain", badDomain],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("slug", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ──────────────────────────────────────────────
+    // Child worktree refusal
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_InsideChildWorktree_ReturnsExitCode1()
+    {
+        using var tmp = new TemporaryDirectory();
+        var childRoot = tmp.CreateDirectory(".intent-cli/worktrees/some-branch");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(childRoot),
+            ["--domain", "auth"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("child worktree", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ──────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────
+
+    private static void CreateFlatFile(string hostRoot, string domain, string fileName, string content)
+    {
+        var dir = Path.Combine(hostRoot, "intents", domain);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, fileName), content);
+    }
+
+    private static CliContext CreateContext(string repoRoot) =>
+        new()
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "bootstrap",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath =
+            Directory.CreateTempSubdirectory("intent-cli-analyze-tree-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentLintLayoutCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentLintLayoutCommandTests.cs
@@ -1,0 +1,426 @@
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>G405 tests for <c>intent-cli intent lint-layout</c>.</summary>
+public sealed class IntentLintLayoutCommandTests
+{
+    // ──────────────────────────────────────────────
+    // Clean tree domain
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_CleanTreeDomain_ReportsNoWarnings()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentLintLayoutCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("clean", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("No layout problems detected", output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("[MISSING-", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("[LARGE-", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("[BROKEN-", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Missing manifest (flat domain)
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_FlatDomainWithNoManifest_ReportsMissingManifestWarning()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        Directory.CreateDirectory(Path.Combine(hostRoot, "intents", "auth"));
+        using var writer = new StringWriter();
+
+        var exitCode = IntentLintLayoutCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("MISSING-MANIFEST", output, StringComparison.Ordinal);
+        Assert.Contains("init-tree", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Missing domain directory
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_MissingDomainDirectory_ReportsMissingDomainWarning()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentLintLayoutCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "nonexistent"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("MISSING-DOMAIN", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Large flat file detection
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_LargeFlatFile_ReportsLargeFlatFileWarning()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        var domainDir = Path.Combine(hostRoot, "intents", "auth");
+        Directory.CreateDirectory(domainDir);
+
+        // Create a file larger than the threshold
+        var largeContent = new string('x', IntentAnalyzeTreeCommand.LargeFlatFileBytesThreshold + 1);
+        File.WriteAllText(Path.Combine(domainDir, "big-file.md"), largeContent);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("LARGE-FLAT-FILE", output, StringComparison.Ordinal);
+        Assert.Contains("analyze-tree", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_SmallFlatFile_DoesNotReportLargeFlatFileWarning()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+
+        // Add a small flat file (should not trigger warning)
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "small.md"),
+            "# Small\nJust a bit of text.");
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.DoesNotContain("LARGE-FLAT-FILE", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Broken relative link detection
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_BrokenRelativeLink_ReportsBrokenLinkWarning()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+
+        // Add a file with a broken relative link
+        var identityDir = Path.Combine(hostRoot, "intents", "auth", "identity");
+        Directory.CreateDirectory(identityDir);
+        File.WriteAllText(
+            Path.Combine(identityDir, "mission.md"),
+            "# Mission\nSee [requirements](../nonexistent/requirements.md) for details.");
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.Contains("BROKEN-RELATIVE-LINK", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ValidRelativeLink_DoesNotReportBrokenLink()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+
+        var identityDir = Path.Combine(hostRoot, "intents", "auth", "identity");
+        Directory.CreateDirectory(identityDir);
+        // Create target file
+        File.WriteAllText(Path.Combine(identityDir, "values.md"), "# Values");
+        // Create file linking to it with a valid relative link
+        File.WriteAllText(
+            Path.Combine(identityDir, "mission.md"),
+            "# Mission\nSee [values](values.md) for details.");
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.DoesNotContain("BROKEN-RELATIVE-LINK", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_AbsoluteHttpLink_DoesNotReportBrokenLink()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+
+        var identityDir = Path.Combine(hostRoot, "intents", "auth", "identity");
+        Directory.CreateDirectory(identityDir);
+        File.WriteAllText(
+            Path.Combine(identityDir, "mission.md"),
+            "# Mission\nSee [GitHub](https://github.com/J-Tech-Japan/intent-system) for details.");
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.DoesNotContain("BROKEN-RELATIVE-LINK", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Features index check
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_FeaturesDirectoryWithoutIndex_ReportsMissingFeaturesIndex()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+
+        // Create features dir without index
+        Directory.CreateDirectory(Path.Combine(hostRoot, "intents", "auth", "features"));
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.Contains("MISSING-FEATURES-INDEX", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_FeatureSubFolderWithoutOverview_ReportsMissingFeatureOverview()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+
+        // Create feature subfolder without overview.md
+        var featureDir = Path.Combine(hostRoot, "intents", "auth", "features", "login");
+        Directory.CreateDirectory(featureDir);
+        File.WriteAllText(Path.Combine(hostRoot, "intents", "auth", "features", "index.md"), "# Features");
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.Contains("MISSING-FEATURE-OVERVIEW", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_FeatureSubFolderWithOverview_DoesNotReportMissingOverview()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+
+        var featureDir = Path.Combine(hostRoot, "intents", "auth", "features", "login");
+        Directory.CreateDirectory(featureDir);
+        File.WriteAllText(Path.Combine(featureDir, "overview.md"), "# Login overview");
+        File.WriteAllText(Path.Combine(hostRoot, "intents", "auth", "features", "index.md"), "# Features");
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.DoesNotContain("MISSING-FEATURE-OVERVIEW", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Missing category folders
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_ManifestListsMissingCategoryFolder_ReportsWarning()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        var domainDir = Path.Combine(hostRoot, "intents", "auth");
+        Directory.CreateDirectory(domainDir);
+
+        // Manifest references a category folder that doesn't exist
+        File.WriteAllText(Path.Combine(domainDir, "manifest.yaml"),
+            "version: \"1\"\nlayout_version: tree-v1\nproject_type: product-app\ncategories:\n  identity: identity/\n  missing-cat: missing-cat/\n");
+
+        // Create identity folder but not missing-cat
+        Directory.CreateDirectory(Path.Combine(domainDir, "identity"));
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.Contains("MISSING-CATEGORY-FOLDER", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("missing-cat", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Mixed flat/tree compatibility
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_MixedFlatAndTreeDomain_LintsBothFlatAndTreeProblems()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+
+        // Add a large flat file alongside the tree
+        var largeContent = new string('x', IntentAnalyzeTreeCommand.LargeFlatFileBytesThreshold + 1);
+        File.WriteAllText(Path.Combine(hostRoot, "intents", "auth", "legacy.md"), largeContent);
+
+        // Add a feature folder without overview
+        Directory.CreateDirectory(Path.Combine(hostRoot, "intents", "auth", "features", "mfa"));
+        File.WriteAllText(Path.Combine(hostRoot, "intents", "auth", "features", "index.md"), "# Features");
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        var output = writer.ToString();
+        Assert.Contains("LARGE-FLAT-FILE", output, StringComparison.Ordinal);
+        Assert.Contains("MISSING-FEATURE-OVERVIEW", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // JSON output
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_FormatJson_OutputIsValidJson()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        using var writer = new StringWriter();
+
+        IntentLintLayoutCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--format", "json"],
+            writer);
+
+        var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(writer.ToString());
+        Assert.Equal("auth", element.GetProperty("domain").GetString());
+        Assert.True(element.GetProperty("is_tree_domain").GetBoolean());
+        Assert.True(element.GetProperty("clean").GetBoolean());
+    }
+
+    // ──────────────────────────────────────────────
+    // Argument validation
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_MissingDomain_ReturnsExitCode1()
+    {
+        using var tmp = new TemporaryDirectory();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentLintLayoutCommand.Execute(
+            CreateContext(tmp.CreateDirectory("host")),
+            [],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--domain", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("../outside")]
+    [InlineData("auth domain")]
+    public void Execute_InvalidDomainSlug_ReturnsExitCode1(string badDomain)
+    {
+        using var tmp = new TemporaryDirectory();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentLintLayoutCommand.Execute(
+            CreateContext(tmp.CreateDirectory("host")),
+            ["--domain", badDomain],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("slug", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ──────────────────────────────────────────────
+    // Child worktree refusal
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_InsideChildWorktree_ReturnsExitCode1()
+    {
+        using var tmp = new TemporaryDirectory();
+        var childRoot = tmp.CreateDirectory(".intent-cli/worktrees/some-branch");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentLintLayoutCommand.Execute(
+            CreateContext(childRoot),
+            ["--domain", "auth"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("child worktree", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ──────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────
+
+    private static void CreateMinimalTreeDomain(string hostRoot, string domain)
+    {
+        var domainDir = Path.Combine(hostRoot, "intents", domain);
+        Directory.CreateDirectory(domainDir);
+        File.WriteAllText(Path.Combine(domainDir, "manifest.yaml"),
+            "version: \"1\"\nlayout_version: tree-v1\nproject_type: product-app\ncategories:\n  identity: identity/\n");
+        Directory.CreateDirectory(Path.Combine(domainDir, "identity"));
+    }
+
+    private static CliContext CreateContext(string repoRoot) =>
+        new()
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "bootstrap",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        private readonly string rootPath =
+            Directory.CreateTempSubdirectory("intent-cli-lint-layout-tests-").FullName;
+
+        public string CreateDirectory(string relativePath)
+        {
+            var fullPath = Path.Combine(rootPath, relativePath);
+            Directory.CreateDirectory(fullPath);
+            return fullPath;
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli intent analyze-tree` — reads flat domain files, extracts headings, suggests tree-v1 destinations, detects references (markdown links, heading anchors, execution-unit IDs, packet paths, GitHub URLs), produces migration reference map. With `--write`: creates `.restructure-backup/` copies and destination stubs (non-destructive).
- Adds `intent-cli intent lint-layout` — detects 7 lint codes (MISSING-DOMAIN, MISSING-MANIFEST, MISSING-CATEGORY-FOLDER, LARGE-FLAT-FILE, BROKEN-RELATIVE-LINK, MISSING-FEATURES-INDEX, MISSING-FEATURE-OVERVIEW) with actionable fix guidance. Supports mixed flat/tree domains.
- Adds `guide intent-work setup --kind restructure` — documented design-AI-assisted workflow: intent-cli owns analysis/linting/validation, host/design AI + operator own semantic grouping, result committed as a normal reviewable change.
- Bilingual docs (en/ja) with step-by-step workflow and lint code reference.
- 50 new tests covering dry-run, write guard, non-destructive backup, reference detection, lint warnings, mixed flat/tree, slug validation, child-worktree refusal.

Closes #911

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~IntentAnalyzeTreeCommand|FullyQualifiedName~IntentLintLayoutCommand|..."` — 50 passed
- [x] Build succeeds with 0 errors
- [x] `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)