### PR TITLE
G406: Prepare v0.3.0 GitHub Release and bump nextVersion to 0.3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,10 @@ jobs:
           fi
           VERSION="${RAW#v}"
           if [ -z "${VERSION}" ]; then
-            VERSION="0.2.0-dryrun.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+            # G406: derive the dry-run default from the repository version
+            # policy so the dry-run version stays in sync with nextVersion.
+            NEXT_VERSION="$(python3 -c "import json; data=json.load(open('eng/version.json')); print(data['nextVersion'])" 2>/dev/null || echo "0.3.1")"
+            VERSION="${NEXT_VERSION}-dryrun.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
           fi
           echo "version=${VERSION}" | tee -a "${GITHUB_OUTPUT}"
 

--- a/docs/en/release-notes-v0.3.0.md
+++ b/docs/en/release-notes-v0.3.0.md
@@ -1,0 +1,158 @@
+# Release Notes — intent-cli v0.3.0
+
+> **Release checklist for maintainers:** see [Creating the v0.3.0 GitHub Release](#creating-the-v030-github-release).
+
+## What's in v0.3.0
+
+v0.3.0 is the first OSS-oriented stable release of `intent-cli`. It ships the
+full set of commands that support the intent-driven development workflow on top
+of GitHub, plus the first public NuGet and self-contained binary distribution.
+
+### New commands in this release
+
+| Command group | Commands added |
+|---|---|
+| `intent-cli intent` | `init-tree`, `add-feature`, `analyze-tree`, `lint-layout` |
+| `intent-cli guide intent-work setup` | `--kind restructure` |
+
+### Intent knowledge tree (G403/G404/G405)
+
+- **`intent init-tree`** — bootstrap a domain into the `tree-v1` layout
+  (`manifest.yaml` + category folders). Supports four project types:
+  `product-app`, `library-tool`, `infrastructure`, `research-prototype`.
+- **`intent add-feature`** — add a feature folder with seven starter files
+  and auto-update `features/index.md`.
+- **`intent analyze-tree`** — dry-run or write-mode analysis of flat
+  intent files: heading extraction, keyword-based category suggestions,
+  reference detection (markdown links, anchors, execution-unit IDs, packet
+  paths, GitHub URLs), migration reference map, and `.restructure-backup/`
+  copies.
+- **`intent lint-layout`** — layout health check for flat and tree-v1
+  domains. Emits seven lint codes (`MISSING-DOMAIN`, `MISSING-MANIFEST`,
+  `MISSING-CATEGORY-FOLDER`, `LARGE-FLAT-FILE`, `BROKEN-RELATIVE-LINK`,
+  `MISSING-FEATURES-INDEX`, `MISSING-FEATURE-OVERVIEW`) in Markdown or JSON.
+- **`guide intent-work setup --kind restructure`** — emits a design-AI
+  prompt that drives the flat-to-tree redesign workflow, asking `intent-cli`
+  for the deterministic analysis and leaving semantic grouping to the
+  operator + AI pair.
+
+### Distribution (G386/G387)
+
+- NuGet stable package: `intent-cli` on NuGet.org (Apache-2.0).
+- Self-contained binaries attached to the GitHub Release:
+  `osx-arm64`, `win-x64`, `linux-x64`.
+- Preview/main builds continue using `nextVersion` from `eng/version.json`
+  (now `0.3.1-preview.*` post-release).
+
+---
+
+## Install / update
+
+### With the .NET SDK (recommended)
+
+```bash
+# New install
+dotnet tool install -g intent-cli
+
+# Upgrade from an older version
+dotnet tool update -g intent-cli
+```
+
+Requires **.NET 10 SDK** (`dotnet --version` → `10.x`).
+
+### Without the .NET SDK (self-contained binary)
+
+Download the archive for your platform from the
+[v0.3.0 GitHub Release assets](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.0),
+extract, and place the `intent-cli` binary somewhere on your `PATH`.
+
+| Platform | Archive name |
+|---|---|
+| macOS (Apple Silicon) | `intent-cli-0.3.0-osx-arm64.tar.gz` |
+| Windows (x64) | `intent-cli-0.3.0-win-x64.zip` |
+| Linux (x64) | `intent-cli-0.3.0-linux-x64.tar.gz` |
+
+Verify with `sha256sum` against the matching `.sha256` sidecar file.
+
+### Verify the install
+
+```bash
+intent-cli --version
+# Expected: 0.3.0
+```
+
+---
+
+## License
+
+Apache-2.0 — see [LICENSE](../../LICENSE) in the repository root.
+
+---
+
+## Creating the v0.3.0 GitHub Release
+
+> **For maintainers only.** This checklist is the authoritative sequence for
+> cutting a stable release. Publishing the GitHub Release automatically triggers
+> the release workflow, which builds and attaches the NuGet package and
+> self-contained binaries.
+
+### Pre-release checklist
+
+- [ ] All intended PRs for this release are merged into `main`.
+- [ ] `eng/version.json` has `"stableVersion": "0.3.0"` and
+  `"nextVersion": "0.3.1"` (the post-release bump is already committed as
+  part of G406 — do **not** change it before tagging; it represents the
+  next development line, not this release).
+- [ ] The release workflow (`release.yml`) is correct on `main`:
+  - Derives the stable version from the release tag (not `eng/version.json`).
+  - Does not set `PrivatePreview*` or expiry properties for the stable pack step.
+  - Binaries dry-run version falls back to `nextVersion` from `eng/version.json`.
+- [ ] `intent-cli --version` reports the expected version after a local build.
+- [ ] `git diff --check` passes (no whitespace errors).
+- [ ] CI is green on `main`.
+
+### Release steps
+
+1. **Create a GitHub Release** from the GitHub UI (or `gh release create`):
+   - Tag: `v0.3.0` (create from `main`).
+   - Title: `intent-cli v0.3.0 — first OSS-oriented stable release`.
+   - Body: paste the content of this file from "What's in v0.3.0" through
+     "License" (omit this checklist section).
+   - **Publish** (not draft) — publishing triggers the release workflow.
+
+2. **Monitor the release workflow** in the Actions tab:
+   - `nupkg` job: builds `intent-cli.0.3.0.nupkg` and pushes to NuGet.org
+     (if `NUGET_API_KEY` is set); attaches `.nupkg` + `.sha256` to the release.
+   - `binaries` jobs (3×): build `osx-arm64`, `win-x64`, `linux-x64`
+     self-contained archives; smoke-test `intent-cli --version`; attach to the
+     release.
+
+3. **Verify the release assets** on the GitHub Release page:
+   - `intent-cli.0.3.0.nupkg` + `.sha256`
+   - `intent-cli-0.3.0-osx-arm64.tar.gz` + `.sha256`
+   - `intent-cli-0.3.0-win-x64.zip` + `.sha256`
+   - `intent-cli-0.3.0-linux-x64.tar.gz` + `.sha256`
+
+4. **Verify NuGet.org** (allow up to 15 minutes for indexing):
+   ```bash
+   dotnet tool install -g intent-cli --version 0.3.0
+   intent-cli --version
+   # Expected: 0.3.0
+   ```
+
+5. **Announce** if applicable (e.g., update internal docs, notify teams).
+
+### Post-release version policy
+
+After the `v0.3.0` release, `main` preview builds derive their version from
+`eng/version.json`'s `nextVersion`, which is now `0.3.1`. Preview builds will
+appear as `0.3.1-preview.<build>.<commit>`.
+
+When preparing the next stable release (`v0.3.1` or higher), update
+`eng/version.json` **in the release-prep PR** (just like this G406 PR did),
+setting `stableVersion` to the new stable version and `nextVersion` to the
+following patch line.
+
+> **Rule:** never leave `nextVersion` equal to the just-published stable
+> version after a release. The version bump in `eng/version.json` is the
+> commit evidence that the release boundary was crossed.

--- a/docs/ja/release-notes-v0.3.0.md
+++ b/docs/ja/release-notes-v0.3.0.md
@@ -1,0 +1,122 @@
+# リリースノート — intent-cli v0.3.0
+
+> **メンテナー向けリリースチェックリスト:** [v0.3.0 GitHub Release の作成](#v030-github-release-の作成) を参照してください。
+
+## v0.3.0 の内容
+
+v0.3.0 は `intent-cli` の最初の OSS 向け安定リリースです。GitHub 上のインテント駆動開発ワークフローをサポートするコマンド一式と、初の公開 NuGet およびセルフコンテインドバイナリ配布が含まれています。
+
+### このリリースの新コマンド
+
+| コマンドグループ | 追加コマンド |
+|---|---|
+| `intent-cli intent` | `init-tree`, `add-feature`, `analyze-tree`, `lint-layout` |
+| `intent-cli guide intent-work setup` | `--kind restructure` |
+
+### Intent ナレッジツリー (G403/G404/G405)
+
+- **`intent init-tree`** — ドメインを `tree-v1` レイアウト (`manifest.yaml` + カテゴリフォルダ) に初期化。4つのプロジェクトタイプに対応: `product-app`, `library-tool`, `infrastructure`, `research-prototype`。
+- **`intent add-feature`** — 7つのスターターファイルとともに機能フォルダを追加し、`features/index.md` を自動更新。
+- **`intent analyze-tree`** — フラットな intent ファイルのドライランまたは書き込みモードによる分析: 見出し抽出、キーワードベースのカテゴリ提案、参照検出 (Markdown リンク、アンカー、実行ユニット ID、パケットパス、GitHub URL)、移行参照マップ、`.restructure-backup/` コピー。
+- **`intent lint-layout`** — フラットおよび tree-v1 ドメインのレイアウト健全性チェック。7つの lint コードを Markdown または JSON で出力 (`MISSING-DOMAIN`, `MISSING-MANIFEST`, `MISSING-CATEGORY-FOLDER`, `LARGE-FLAT-FILE`, `BROKEN-RELATIVE-LINK`, `MISSING-FEATURES-INDEX`, `MISSING-FEATURE-OVERVIEW`)。
+- **`guide intent-work setup --kind restructure`** — デザイン AI プロンプトを出力し、フラットからツリーへの再設計ワークフローを駆動。`intent-cli` が決定論的分析を担い、セマンティックなグループ化はオペレーター + AI ペアが担当。
+
+### 配布 (G386/G387)
+
+- NuGet 安定版パッケージ: NuGet.org の `intent-cli` (Apache-2.0)。
+- GitHub Release に添付されるセルフコンテインドバイナリ: `osx-arm64`, `win-x64`, `linux-x64`。
+- Preview/main ビルドは引き続き `eng/version.json` の `nextVersion` を使用 (リリース後は `0.3.1-preview.*`)。
+
+---
+
+## インストール / アップデート
+
+### .NET SDK を使用 (推奨)
+
+```bash
+# 新規インストール
+dotnet tool install -g intent-cli
+
+# 旧バージョンからのアップグレード
+dotnet tool update -g intent-cli
+```
+
+**.NET 10 SDK** が必要です (`dotnet --version` → `10.x`)。
+
+### .NET SDK なし (セルフコンテインドバイナリ)
+
+[v0.3.0 GitHub Release アセット](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.0) からプラットフォームに合ったアーカイブをダウンロードし、展開して `intent-cli` バイナリを `PATH` に追加してください。
+
+| プラットフォーム | アーカイブ名 |
+|---|---|
+| macOS (Apple Silicon) | `intent-cli-0.3.0-osx-arm64.tar.gz` |
+| Windows (x64) | `intent-cli-0.3.0-win-x64.zip` |
+| Linux (x64) | `intent-cli-0.3.0-linux-x64.tar.gz` |
+
+対応する `.sha256` サイドカーファイルで `sha256sum` を使って検証してください。
+
+### インストール確認
+
+```bash
+intent-cli --version
+# 期待値: 0.3.0
+```
+
+---
+
+## ライセンス
+
+Apache-2.0 — リポジトリルートの [LICENSE](../../LICENSE) を参照してください。
+
+---
+
+## v0.3.0 GitHub Release の作成
+
+> **メンテナー専用。** 安定リリースを切るための正式な手順です。GitHub Release を公開すると、リリースワークフローが自動的にトリガーされ、NuGet パッケージとセルフコンテインドバイナリがビルドされて添付されます。
+
+### リリース前チェックリスト
+
+- [ ] このリリースで意図した全 PR が `main` にマージ済みであること。
+- [ ] `eng/version.json` に `"stableVersion": "0.3.0"` および `"nextVersion": "0.3.1"` が設定されていること (リリース後のバンプは G406 の一部としてすでにコミット済み — タグ付け前に変更しないこと。これは次の開発ラインを示すものであり、このリリース自体を示すものではない)。
+- [ ] リリースワークフロー (`release.yml`) が `main` 上で正しいこと:
+  - 安定バージョンをリリースタグから導出している (`eng/version.json` からではない)。
+  - 安定パック手順で `PrivatePreview*` や有効期限プロパティを設定していない。
+  - バイナリのドライランバージョンが `eng/version.json` の `nextVersion` にフォールバックしている。
+- [ ] ローカルビルド後に `intent-cli --version` が期待するバージョンを報告すること。
+- [ ] `git diff --check` が通ること (空白エラーなし)。
+- [ ] `main` で CI がグリーンであること。
+
+### リリース手順
+
+1. **GitHub Release を作成** (GitHub UI または `gh release create`):
+   - タグ: `v0.3.0` (`main` から作成)。
+   - タイトル: `intent-cli v0.3.0 — first OSS-oriented stable release`。
+   - 本文: 「v0.3.0 の内容」から「ライセンス」までの内容を貼り付ける (このチェックリストセクションは除く)。
+   - **公開** (ドラフトではない) — 公開するとリリースワークフローがトリガーされる。
+
+2. **リリースワークフローを監視** (Actions タブ):
+   - `nupkg` ジョブ: `intent-cli.0.3.0.nupkg` をビルドし NuGet.org にプッシュ (`NUGET_API_KEY` が設定されている場合)。`.nupkg` + `.sha256` をリリースに添付。
+   - `binaries` ジョブ (3×): `osx-arm64`, `win-x64`, `linux-x64` のセルフコンテインドアーカイブをビルド。`intent-cli --version` のスモークテスト後にリリースへ添付。
+
+3. **GitHub Release ページでリリースアセットを確認**:
+   - `intent-cli.0.3.0.nupkg` + `.sha256`
+   - `intent-cli-0.3.0-osx-arm64.tar.gz` + `.sha256`
+   - `intent-cli-0.3.0-win-x64.zip` + `.sha256`
+   - `intent-cli-0.3.0-linux-x64.tar.gz` + `.sha256`
+
+4. **NuGet.org を確認** (インデックス化に最大 15 分かかる場合あり):
+   ```bash
+   dotnet tool install -g intent-cli --version 0.3.0
+   intent-cli --version
+   # 期待値: 0.3.0
+   ```
+
+5. **必要に応じてアナウンス** (内部ドキュメントの更新、チームへの通知など)。
+
+### リリース後のバージョンポリシー
+
+`v0.3.0` リリース後、`main` の preview ビルドは `eng/version.json` の `nextVersion` からバージョンを導出します (現在は `0.3.1`)。Preview ビルドは `0.3.1-preview.<build>.<commit>` の形式になります。
+
+次の安定リリース (`v0.3.1` 以降) の準備時には、この G406 PR と同様に、**リリース準備 PR 内で** `eng/version.json` を更新し、`stableVersion` を新しい安定バージョンに、`nextVersion` を次のパッチラインに設定してください。
+
+> **ルール:** リリース後に `nextVersion` を公開済みの安定バージョンと同じ値のまま放置しないこと。`eng/version.json` のバンプがリリース境界を越えたことを示すコミット上の証拠となります。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.2.0",
-  "nextVersion": "0.3.0"
+  "stableVersion": "0.3.0",
+  "nextVersion": "0.3.1"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,7 +124,8 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.0 as the next OSS release.
+        // be parseable and must point to 0.3.1 as the next development line
+        // (post-v0.3.0 release bump, see G406).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -134,8 +135,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.0", policy.NextVersion);
-        Assert.Equal("0.2.0", policy.StableVersion);
+        Assert.Equal("0.3.1", policy.NextVersion);
+        Assert.Equal("0.3.0", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

- **`eng/version.json`**: `stableVersion` `0.2.0`→`0.3.0`, `nextVersion` `0.3.0`→`0.3.1` — post-release boundary; `main` preview builds will be `0.3.1-preview.*`
- **`.github/workflows/release.yml`**: fix `binaries` job dry-run fallback version to read `nextVersion` from `eng/version.json` (was hardcoded `0.2.0`)
- **`docs/en/release-notes-v0.3.0.md`**: release notes + maintainer checklist for the v0.3.0 GitHub Release (install/update paths, NuGet, self-contained binaries, version policy)
- **`docs/ja/release-notes-v0.3.0.md`**: Japanese equivalent
- **`tests/VersionPolicyTests.cs`**: update smoke-test assertions to expect `nextVersion=0.3.1` / `stableVersion=0.3.0`

## Version policy clarification

Stable releases are driven by the GitHub Release tag (`v0.3.0`). The `nextVersion` field in `eng/version.json` represents the **next development line**, not the just-published release. After this PR merges, `main` preview builds will be `0.3.1-preview.*`, clearly separated from the `0.3.0` stable line.

## Test plan

- [x] `VersionPolicyTests` — all 9 pass with updated assertions
- [x] `git diff --check` — no whitespace errors
- [x] Build succeeds
- [ ] (Post-merge) Create `v0.3.0` GitHub Release — follow the checklist in `docs/en/release-notes-v0.3.0.md`

Closes #913

🤖 Generated with [Claude Code](https://claude.com/claude-code)