### PR TITLE
G408: Add repeated-stall recovery guidance for automation loops

### DIFF
--- a/docs/en/07-recovery.md
+++ b/docs/en/07-recovery.md
@@ -29,6 +29,42 @@ you whether a child-loop-owned repair exists. Host-owned categories surface as
 > `intent-cli automation doctor`, and only apply a repair the CLI says is safe
 > and in scope. Don't hand-edit labels or metadata.
 
+## Repeated-stall recovery (G408)
+
+When an automation loop selects the same target and hits the same blocker for
+**two or more consecutive wakes** without making progress, it should self-recover
+rather than reporting the same stop indefinitely.
+
+**Recovery flow — re-read guidance first:**
+
+```bash
+intent-cli guide model --format json
+intent-cli guide onboarding --format json
+intent-cli guide commands list --format json
+intent-cli automation summary --domain <domain> --format json
+
+# Child loop: run the matching preflight for the stuck target
+intent-cli worker issue-preflight     --repo <owner>/<repo> --issue <n> --format json
+intent-cli worker pr-comment-preflight --repo <owner>/<repo> --pr    <n> --format json
+
+# Host loop: check freshness and state
+intent-cli automation doctor --format json
+```
+
+**What to do with the result:**
+
+| Result | Action |
+|--------|--------|
+| `safe_repair_category: child-selector-label-gap` | Apply the one repair `intent-cli` marks safe; retry once. |
+| `host-artifact-repair-required` | Stop. Report a structured operator stop. Do not hand-fix. |
+| `clarification-required` | Stop. Report what is ambiguous; wait for operator input. |
+| Stall persists after one repair | Escalate to operator stop — do not retry indefinitely. |
+
+**Hard limits:**
+- Apply at most **one guided repair** per recovery cycle.
+- Never invent workarounds or raw `gh label` mutations as recovery.
+- Never bypass `intent-cli worker` / `intent-cli automation` transition ownership.
+
 ## Metadata / label safety
 
 - Recovery never means hand-editing `queue-state.json` or labels; the preflight

--- a/docs/ja/07-recovery.md
+++ b/docs/ja/07-recovery.md
@@ -28,6 +28,41 @@ child-loop 所有の修復が存在するかを示す。host 所有のカテゴ�
 > `intent-cli worker …-preflight` と `intent-cli automation doctor` を実行し、CLI が
 > 安全かつ scope 内と判断した修復のみ適用する。label/metadata を手編集しない。
 
+## 繰り返しストール回復（G408）
+
+自動化ループが同じターゲットで同じブロッカーに **2 回以上連続** してヒットし、
+進捗なしのまま繰り返す場合は、同じ停止を報告し続けるのではなく自己回復する。
+
+**回復フロー — まずガイダンスを再読する:**
+
+```bash
+intent-cli guide model --format json
+intent-cli guide onboarding --format json
+intent-cli guide commands list --format json
+intent-cli automation summary --domain <domain> --format json
+
+# child ループ: 詰まったターゲットに対応する preflight を実行
+intent-cli worker issue-preflight     --repo <owner>/<repo> --issue <n> --format json
+intent-cli worker pr-comment-preflight --repo <owner>/<repo> --pr    <n> --format json
+
+# host ループ: 鮮度と状態を確認
+intent-cli automation doctor --format json
+```
+
+**結果に応じた対応:**
+
+| 結果 | 対応 |
+|------|------|
+| `safe_repair_category: child-selector-label-gap` | `intent-cli` が安全と判断した修復を 1 回適用し、リトライ。 |
+| `host-artifact-repair-required` | 停止。構造化された operator stop を報告する。手修正しない。 |
+| `clarification-required` | 停止。何が曖昧かを報告し、operator の入力を待つ。 |
+| 1 回修復してもストール継続 | operator stop へエスカレートする。無限リトライしない。 |
+
+**制限事項:**
+- 1 回復サイクルあたり最大 **1 件** のガイド済み修復のみ適用する。
+- 回復として raw `gh label` 操作や手動ワークアラウンドを発明しない。
+- `intent-cli worker` / `intent-cli automation` のトランジション所有権を回避しない。
+
 ## metadata / label の安全境界
 
 - 復旧は `queue-state.json` や label の手編集を意味しない。preflight サーフェスは

--- a/src/IntentSystem.Cli/Commands/GuideOneshotCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOneshotCommand.cs
@@ -253,6 +253,15 @@ Workflow:
 12. If clarification is required, stop and report: background, question, options, pros/cons, and recommendation. Publish ownership disambiguation is NOT a valid clarification reason; proceed through `intent-cli` even when a concurrent publisher is observed.
 13. Commit and push parent host changes directly to `main` per `AGENTS.md`. Do not create a PR.
 
+Repeated-stall recovery (G408):
+- If the same PR or issue has returned to the host loop without progress for two or more consecutive wakes, do not retry without first re-reading intent-cli guidance:
+  1. `intent-cli guide model --format json`
+  2. `intent-cli automation summary --format text`
+  3. `intent-cli automation doctor --format json`
+- Apply only the safe current-lane repair that intent-cli explicitly marks as owned by the host loop (e.g. stale label cleanup via `intent-cli automation` commands).
+- If the gap requires operator judgment, is an unsafe metadata state, or requires durable state changes outside intent-cli transition commands, stop and report a structured operator stop rather than silently bypassing safety gates.
+- Apply at most one guided repair per recovery cycle. If the stall persists after one repair, escalate to the operator.
+
 Final report must include:
 - selected issue / PR or none
 - label transitions applied
@@ -296,6 +305,15 @@ Workflow:
 11. If next-slice is clear and WIP cap is empty, create/publish exactly one child issue and preload future packets only when they satisfy the Child Issue Contract. If a concurrent or prior publisher is observed in the host state (e.g. another automation has recently published), treat that as informational context only — do NOT ask the operator whether to proceed or who should own the publish step. Publish ownership follows `intent-cli` as the single source of truth; it is never a question for the operator chat.
 12. If clarification is required, stop and report: background, question, options, pros/cons, and recommendation. Publish ownership disambiguation is NOT a valid clarification reason; proceed through `intent-cli` even when a concurrent publisher is observed.
 13. Commit and push parent host changes directly to `main` per `AGENTS.md`. Do not create a PR.
+
+Repeated-stall recovery (G408):
+- If the same PR or issue has returned to the host loop without progress for two or more consecutive wakes, do not retry without first re-reading intent-cli guidance:
+  1. `intent-cli guide model --format json`
+  2. `intent-cli automation summary --format text`
+  3. `intent-cli automation doctor --format json`
+- Apply only the safe current-lane repair that intent-cli explicitly marks as owned by the host loop (e.g. stale label cleanup via `intent-cli automation` commands).
+- If the gap requires operator judgment, is an unsafe metadata state, or requires durable state changes outside intent-cli transition commands, stop and report a structured operator stop rather than silently bypassing safety gates.
+- Apply at most one guided repair per recovery cycle. If the stall persists after one repair, escalate to the operator.
 
 Final report must include:
 - selected issue / PR or none
@@ -375,6 +393,16 @@ Clarification / failure:
 - If clarification is needed, stop and report: background, question, options, pros/cons, and recommendation.
 - Do not create a second issue or PR in the same wake.
 - Do not continue to another target after success or failure.
+
+Repeated-stall recovery (G408):
+- If the same issue or PR has been selected and stalled without progress for two or more consecutive wakes, do not retry without first re-reading intent-cli guidance:
+  1. `intent-cli guide model --format json`
+  2. `intent-cli guide onboarding --format json`
+  3. `intent-cli guide commands list --format json`
+  4. `intent-cli automation summary --domain <DOMAIN> --format json`
+  5. Run the relevant preflight: `intent-cli worker issue-preflight --repo <OWNER>/<REPO> --issue <n> --format json` or `intent-cli worker pr-comment-preflight --repo <OWNER>/<REPO> --pr <n> --format json`.
+- Apply only the safe current-lane repair that intent-cli explicitly marks as owned by the child loop (`child-selector-label-gap` category). All other categories are host-owned or operator-owned and must be reported as structured operator stops.
+- Apply at most one guided repair per recovery cycle. If the stall persists after one repair, stop and report to the operator.
 
 Final report must include:
 - selected action

--- a/src/IntentSystem.Cli/Commands/GuideWorkerIssueToPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerIssueToPrCommand.cs
@@ -113,7 +113,18 @@ Hard rules:
 - Do not call `intent-cli run`. `run` is for integration smoke/replay/dogfooding, not the chat-first implementation path.
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
-- If the issue body is a thin stub or points only to parent breadcrumbs for the real contract, decline before creating any branch.";
+- If the issue body is a thin stub or points only to parent breadcrumbs for the real contract, decline before creating any branch.
+
+Repeated-stall recovery (G408: when the same issue has stalled without progress for two or more consecutive wakes):
+1. Do not retry the same action again without first re-reading the installed guidance:
+   - `intent-cli guide model --format json`
+   - `intent-cli guide onboarding --format json`
+   - `intent-cli guide commands list --format json`
+   - `intent-cli automation summary --domain {domainPlaceholder} --format json`
+   - `intent-cli worker issue-preflight --repo <OWNER>/<REPO> --issue <n> --format json`
+2. Determine whether the stall was caused by prior noncompliance with intent-cli guidance (e.g. missing worker claim, wrong branch base, missing `Closes #<n>` in PR body, host-owned label applied from child loop). If yes, apply the one safe current-lane repair that `intent-cli` explicitly marks as owned by the child loop (`child-selector-label-gap` category).
+3. If the stall is caused by a host-owned or operator-owned gap (`host-artifact-repair-required`, `ambiguous-contract`, unsafe durable state, or operator policy decision), stop and emit a structured operator stop. Do not silently bypass or invent workarounds.
+4. Apply at most one guided repair per recovery cycle. If the stall persists after the repair, escalate to an operator stop rather than retrying indefinitely.";
 
         return new GuideWorkerIssueToPrResult
         {
@@ -127,6 +138,21 @@ Hard rules:
                 "intent-cli guide onboarding --format json",
                 "intent-cli guide commands list --format json",
                 $"intent-cli automation summary --domain {domainPlaceholder} --format json"
+            },
+            RepeatedStallRecovery = new RepeatedStallRecoveryGuidance
+            {
+                Trigger = "Same issue stalled without progress for two or more consecutive wakes.",
+                ReReadGuidance = new[]
+                {
+                    "intent-cli guide model --format json",
+                    "intent-cli guide onboarding --format json",
+                    "intent-cli guide commands list --format json",
+                    $"intent-cli automation summary --domain {domainPlaceholder} --format json",
+                    "intent-cli worker issue-preflight --repo <OWNER>/<REPO> --issue <n> --format json"
+                },
+                SafeRepairCategory = "child-selector-label-gap",
+                OperatorStopCategories = new[] { "host-artifact-repair-required", "ambiguous-contract", "unsafe-durable-state", "operator-policy-decision" },
+                MaxRepairsPerCycle = 1
             },
             ContractGateSections = new[]
             {
@@ -207,6 +233,20 @@ Hard rules:
         writer.WriteLine(result.WorktreeFriendly);
         writer.WriteLine();
 
+        writer.WriteLine("## Repeated-stall recovery (G408)");
+        writer.WriteLine();
+        writer.WriteLine($"Trigger: {result.RepeatedStallRecovery.Trigger}");
+        writer.WriteLine();
+        writer.WriteLine("Re-read guidance:");
+        foreach (var call in result.RepeatedStallRecovery.ReReadGuidance)
+        {
+            writer.WriteLine($"- `{call}`");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"Safe repair category: `{result.RepeatedStallRecovery.SafeRepairCategory}`");
+        writer.WriteLine($"Operator stop categories: {string.Join(", ", result.RepeatedStallRecovery.OperatorStopCategories.Select(c => $"`{c}`"))}");
+        writer.WriteLine($"Max repairs per cycle: {result.RepeatedStallRecovery.MaxRepairsPerCycle}");
+        writer.WriteLine();
         writer.WriteLine("## Prompt");
         writer.WriteLine();
         writer.WriteLine("```text");
@@ -330,4 +370,28 @@ internal sealed record GuideWorkerIssueToPrResult
 
     [JsonPropertyName("worktree_friendly")]
     public required string WorktreeFriendly { get; init; }
+
+    [JsonPropertyName("repeated_stall_recovery")]
+    public required RepeatedStallRecoveryGuidance RepeatedStallRecovery { get; init; }
+}
+
+/// <summary>
+/// G408: Structured repeated-stall recovery guidance emitted by worker guide commands.
+/// </summary>
+internal sealed record RepeatedStallRecoveryGuidance
+{
+    [JsonPropertyName("trigger")]
+    public required string Trigger { get; init; }
+
+    [JsonPropertyName("re_read_guidance")]
+    public required IReadOnlyList<string> ReReadGuidance { get; init; }
+
+    [JsonPropertyName("safe_repair_category")]
+    public required string SafeRepairCategory { get; init; }
+
+    [JsonPropertyName("operator_stop_categories")]
+    public required IReadOnlyList<string> OperatorStopCategories { get; init; }
+
+    [JsonPropertyName("max_repairs_per_cycle")]
+    public required int MaxRepairsPerCycle { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
@@ -110,7 +110,18 @@ Hard rules:
 - Do not add `intent-pr-created` to the PR; it is an issue-side completion marker.
 - Do not edit `queue-state.json`, `linked_issue`, or `linked_pr`; those are host-owned durable bookkeeping and must not be touched during a PR comment fix turn.
 - Do not edit `.intent-cli/**` or `intents/**` paths. These are host-owned metadata artifacts (packet files, publish artifacts, clarifications, queue state, runs). If a comment requests such changes, stop with outcome `host-artifact-repair-required` — the host repair agent must handle them, not the child implementation worker.
-- Do not run `intent-cli automation issue-publish`; that command is for publishing child issues, not for resolving PR comment repairs.";
+- Do not run `intent-cli automation issue-publish`; that command is for publishing child issues, not for resolving PR comment repairs.
+
+Repeated-stall recovery (G408: when the same PR has cycled without progress for two or more consecutive wakes):
+1. Do not retry the same repair without first re-reading the installed guidance:
+   - `intent-cli guide model --format json`
+   - `intent-cli guide onboarding --format json`
+   - `intent-cli guide commands list --format json`
+   - `intent-cli automation summary --domain {domainPlaceholder} --format json`
+   - `intent-cli worker pr-comment-preflight --repo <OWNER>/<REPO> --pr <n> --format json`
+2. Determine whether the stall was caused by prior noncompliance with intent-cli guidance (e.g. new branch created instead of checking out the existing one, force-push when not requested, host metadata path edited by child worker, claim/complete handoff skipped). If yes, apply the one safe current-lane repair that `intent-cli` explicitly marks as owned by the child loop.
+3. If the stall is caused by a host-owned or operator-owned gap (`host-artifact-repair-required`, `clarification-required`, unsafe durable state, or operator policy decision), stop and emit a structured operator stop. Do not silently bypass or invent workarounds.
+4. Apply at most one guided repair per recovery cycle. If the stall persists after the repair, escalate to an operator stop rather than retrying indefinitely.";
 
         return new GuideWorkerPrCommentFixResult
         {
@@ -124,6 +135,21 @@ Hard rules:
                 "intent-cli guide onboarding --format json",
                 "intent-cli guide commands list --format json",
                 $"intent-cli automation summary --domain {domainPlaceholder} --format json"
+            },
+            RepeatedStallRecovery = new RepeatedStallRecoveryGuidance
+            {
+                Trigger = "Same PR has cycled without progress for two or more consecutive wakes.",
+                ReReadGuidance = new[]
+                {
+                    "intent-cli guide model --format json",
+                    "intent-cli guide onboarding --format json",
+                    "intent-cli guide commands list --format json",
+                    $"intent-cli automation summary --domain {domainPlaceholder} --format json",
+                    "intent-cli worker pr-comment-preflight --repo <OWNER>/<REPO> --pr <n> --format json"
+                },
+                SafeRepairCategory = "child-selector-label-gap",
+                OperatorStopCategories = new[] { "host-artifact-repair-required", "clarification-required", "unsafe-durable-state", "operator-policy-decision" },
+                MaxRepairsPerCycle = 1
             },
             OutcomeClassification = new Dictionary<string, string>(StringComparer.Ordinal)
             {
@@ -185,6 +211,20 @@ Hard rules:
         writer.WriteLine(result.WorktreeFriendly);
         writer.WriteLine();
 
+        writer.WriteLine("## Repeated-stall recovery (G408)");
+        writer.WriteLine();
+        writer.WriteLine($"Trigger: {result.RepeatedStallRecovery.Trigger}");
+        writer.WriteLine();
+        writer.WriteLine("Re-read guidance:");
+        foreach (var call in result.RepeatedStallRecovery.ReReadGuidance)
+        {
+            writer.WriteLine($"- `{call}`");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"Safe repair category: `{result.RepeatedStallRecovery.SafeRepairCategory}`");
+        writer.WriteLine($"Operator stop categories: {string.Join(", ", result.RepeatedStallRecovery.OperatorStopCategories.Select(c => $"`{c}`"))}");
+        writer.WriteLine($"Max repairs per cycle: {result.RepeatedStallRecovery.MaxRepairsPerCycle}");
+        writer.WriteLine();
         writer.WriteLine("## Prompt");
         writer.WriteLine();
         writer.WriteLine("```text");
@@ -305,4 +345,7 @@ internal sealed record GuideWorkerPrCommentFixResult
 
     [JsonPropertyName("worktree_friendly")]
     public required string WorktreeFriendly { get; init; }
+
+    [JsonPropertyName("repeated_stall_recovery")]
+    public required RepeatedStallRecoveryGuidance RepeatedStallRecovery { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerPrCommentFixCommand.cs
@@ -119,7 +119,7 @@ Repeated-stall recovery (G408: when the same PR has cycled without progress for 
    - `intent-cli guide commands list --format json`
    - `intent-cli automation summary --domain {domainPlaceholder} --format json`
    - `intent-cli worker pr-comment-preflight --repo <OWNER>/<REPO> --pr <n> --format json`
-2. Determine whether the stall was caused by prior noncompliance with intent-cli guidance (e.g. new branch created instead of checking out the existing one, force-push when not requested, host metadata path edited by child worker, claim/complete handoff skipped). If yes, apply the one safe current-lane repair that `intent-cli` explicitly marks as owned by the child loop.
+2. Determine whether the stall was caused by prior noncompliance with intent-cli guidance (e.g. new branch created instead of checking out the existing one, force-push when not requested, host metadata path edited by child worker, claim/complete handoff skipped). If yes, apply the one safe current-lane repair that `intent-cli` explicitly marks as owned by the child loop (`child-selector-label-gap` category).
 3. If the stall is caused by a host-owned or operator-owned gap (`host-artifact-repair-required`, `clarification-required`, unsafe durable state, or operator policy decision), stop and emit a structured operator stop. Do not silently bypass or invent workarounds.
 4. Apply at most one guided repair per recovery cycle. If the stall persists after the repair, escalate to an operator stop rather than retrying indefinitely.";
 

--- a/tests/IntentSystem.Cli.Tests/GuideOneshotCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOneshotCommandTests.cs
@@ -281,6 +281,105 @@ public sealed class GuideOneshotCommandTests
             StringComparison.Ordinal);
     }
 
+    // ── G408 repeated-stall recovery ─────────────────────────────────────────
+
+    /// <summary>
+    /// G408: the host intent-cli oneshot prompt must contain repeated-stall
+    /// recovery guidance that triggers after two or more consecutive identical stalls.
+    /// </summary>
+    [Fact]
+    public void HostIntentCliPrompt_ContainsRepeatedStallRecoveryGuidance()
+    {
+        Assert.Contains("Repeated-stall recovery", GuideOneshotCommand.HostIntentCliPrompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("two or more consecutive", GuideOneshotCommand.HostIntentCliPrompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli automation doctor", GuideOneshotCommand.HostIntentCliPrompt, StringComparison.Ordinal);
+        Assert.Contains("operator stop", GuideOneshotCommand.HostIntentCliPrompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G408: the host intent-cli prompt must distinguish safe host-loop-owned repairs
+    /// from operator-escalation stops.
+    /// </summary>
+    [Fact]
+    public void HostIntentCliPrompt_DistinguishesSafeRepairFromOperatorStop()
+    {
+        Assert.Contains("intent-cli automation", GuideOneshotCommand.HostIntentCliPrompt, StringComparison.Ordinal);
+        Assert.Contains("operator", GuideOneshotCommand.HostIntentCliPrompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("structured operator stop", GuideOneshotCommand.HostIntentCliPrompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G408: the sekiban-as-a-service host prompt must also contain repeated-stall recovery.
+    /// </summary>
+    [Fact]
+    public void HostSekibanAsAServicePrompt_ContainsRepeatedStallRecoveryGuidance()
+    {
+        Assert.Contains("Repeated-stall recovery", GuideOneshotCommand.HostSekibanAsAServicePrompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("two or more consecutive", GuideOneshotCommand.HostSekibanAsAServicePrompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli automation doctor", GuideOneshotCommand.HostSekibanAsAServicePrompt, StringComparison.Ordinal);
+        Assert.Contains("structured operator stop", GuideOneshotCommand.HostSekibanAsAServicePrompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G408: the child implement-or-update oneshot prompt must contain repeated-stall
+    /// recovery guidance specific to the child loop.
+    /// </summary>
+    [Fact]
+    public void ChildPromptBody_ContainsRepeatedStallRecoveryGuidance()
+    {
+        Assert.Contains("Repeated-stall recovery", GuideOneshotCommand.ChildPromptBody, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("two or more consecutive", GuideOneshotCommand.ChildPromptBody, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli worker issue-preflight", GuideOneshotCommand.ChildPromptBody, StringComparison.Ordinal);
+        Assert.Contains("intent-cli worker pr-comment-preflight", GuideOneshotCommand.ChildPromptBody, StringComparison.Ordinal);
+        Assert.Contains("child-selector-label-gap", GuideOneshotCommand.ChildPromptBody, StringComparison.Ordinal);
+        Assert.Contains("structured operator stop", GuideOneshotCommand.ChildPromptBody, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G408: the child oneshot prompt must limit recovery to at most one repair per cycle.
+    /// </summary>
+    [Fact]
+    public void ChildPromptBody_LimitsRecoveryToOneRepairPerCycle()
+    {
+        Assert.Contains("at most one guided repair", GuideOneshotCommand.ChildPromptBody, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G408: executing the child implement-or-update prompt must emit the recovery guidance.
+    /// </summary>
+    [Fact]
+    public void Execute_ChildImplementOrUpdate_EmitsRepeatedStallRecoveryGuidance()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOneshotCommand.Execute(
+            CreateContext(),
+            ["--kind", "child-implement-or-update", "--repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Repeated-stall recovery", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("child-selector-label-gap", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G408: executing the host review prompt must emit the recovery guidance.
+    /// </summary>
+    [Fact]
+    public void Execute_HostReviewNextSlice_IntentCli_EmitsRepeatedStallRecoveryGuidance()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOneshotCommand.Execute(
+            CreateContext(),
+            ["--kind", "host-review-next-slice", "--domain", "intent-cli", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Repeated-stall recovery", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("structured operator stop", output, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/GuideWorkerIssueToPrCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkerIssueToPrCommandTests.cs
@@ -268,6 +268,94 @@ public sealed class GuideWorkerIssueToPrCommandTests
         Assert.Contains("intents/rules/**", output, StringComparison.Ordinal);
     }
 
+    // ── G408 repeated-stall recovery ─────────────────────────────────────────
+
+    /// <summary>
+    /// G408: the issue-to-pr prompt must contain repeated-stall recovery guidance
+    /// that triggers after two or more consecutive identical stalls.
+    /// </summary>
+    [Fact]
+    public void Execute_Json_PromptContainsRepeatedStallRecoverySection()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Repeated-stall recovery", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("two or more consecutive", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli guide model", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide onboarding", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide commands list", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli worker issue-preflight", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G408: recovery must identify safe child-loop-owned repairs vs host/operator stops.
+    /// </summary>
+    [Fact]
+    public void Execute_Json_PromptDistinguishesSafeRepairFromOperatorStop()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("child-selector-label-gap", prompt, StringComparison.Ordinal);
+        Assert.Contains("host-artifact-repair-required", prompt, StringComparison.Ordinal);
+        Assert.Contains("operator stop", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G408: the JSON output must include a structured repeated_stall_recovery field.
+    /// </summary>
+    [Fact]
+    public void Execute_Json_EmitsRepeatedStallRecoveryStructuredField()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("repeated_stall_recovery", out var recovery));
+        Assert.False(string.IsNullOrWhiteSpace(recovery.GetProperty("trigger").GetString()));
+        Assert.True(recovery.GetProperty("re_read_guidance").GetArrayLength() >= 5);
+        Assert.Equal("child-selector-label-gap", recovery.GetProperty("safe_repair_category").GetString());
+        Assert.True(recovery.GetProperty("operator_stop_categories").GetArrayLength() >= 3);
+        Assert.Equal(1, recovery.GetProperty("max_repairs_per_cycle").GetInt32());
+    }
+
+    /// <summary>
+    /// G408: the markdown output must include a repeated-stall recovery section.
+    /// </summary>
+    [Fact]
+    public void Execute_Markdown_ContainsRepeatedStallRecoverySection()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerIssueToPrCommand.Execute(
+            CreateContext(),
+            ["--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("## Repeated-stall recovery", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("child-selector-label-gap", output, StringComparison.Ordinal);
+        Assert.Contains("max repairs per cycle: 1", output, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/GuideWorkerPrCommentFixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkerPrCommentFixCommandTests.cs
@@ -401,6 +401,93 @@ public sealed class GuideWorkerPrCommentFixCommandTests
         Assert.True(occurrences >= 2, $"Expected ≥2 occurrences of '{search}' in prompt, found {occurrences}.");
     }
 
+    // ── G408 repeated-stall recovery ─────────────────────────────────────────
+
+    /// <summary>
+    /// G408: the pr-comment-fix prompt must contain repeated-stall recovery guidance
+    /// that triggers after two or more consecutive wakes on the same PR without progress.
+    /// </summary>
+    [Fact]
+    public void Execute_Json_PromptContainsRepeatedStallRecoverySection()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Repeated-stall recovery", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("two or more consecutive", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli guide model", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide onboarding", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide commands list", prompt, StringComparison.Ordinal);
+        Assert.Contains("intent-cli worker pr-comment-preflight", prompt, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G408: recovery must identify safe child-loop-owned repairs vs host/operator stops.
+    /// </summary>
+    [Fact]
+    public void Execute_Json_PromptDistinguishesSafeRepairFromOperatorStop()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("child-selector-label-gap", prompt, StringComparison.Ordinal);
+        Assert.Contains("operator stop", prompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// G408: the JSON output must include a structured repeated_stall_recovery field.
+    /// </summary>
+    [Fact]
+    public void Execute_Json_EmitsRepeatedStallRecoveryStructuredField()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("repeated_stall_recovery", out var recovery));
+        Assert.False(string.IsNullOrWhiteSpace(recovery.GetProperty("trigger").GetString()));
+        Assert.True(recovery.GetProperty("re_read_guidance").GetArrayLength() >= 5);
+        Assert.Equal("child-selector-label-gap", recovery.GetProperty("safe_repair_category").GetString());
+        Assert.True(recovery.GetProperty("operator_stop_categories").GetArrayLength() >= 3);
+        Assert.Equal(1, recovery.GetProperty("max_repairs_per_cycle").GetInt32());
+    }
+
+    /// <summary>
+    /// G408: the markdown output must include a repeated-stall recovery section.
+    /// </summary>
+    [Fact]
+    public void Execute_Markdown_ContainsRepeatedStallRecoverySection()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkerPrCommentFixCommand.Execute(
+            CreateContext(),
+            ["--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("## Repeated-stall recovery", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("child-selector-label-gap", output, StringComparison.Ordinal);
+        Assert.Contains("max repairs per cycle: 1", output, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext


### PR DESCRIPTION
## Summary

- **`GuideWorkerIssueToPrCommand`**: add `Repeated-stall recovery (G408)` section to prompt text; add structured `repeated_stall_recovery` JSON field (`trigger`, `re_read_guidance`, `safe_repair_category`, `operator_stop_categories`, `max_repairs_per_cycle`); add `RepeatedStallRecoveryGuidance` record shared with pr-comment-fix.
- **`GuideWorkerPrCommentFixCommand`**: same structured additions for the pr-comment-fix path; `re_read_guidance` uses `pr-comment-preflight` instead of `issue-preflight`.
- **`GuideOneshotCommand`**: add `Repeated-stall recovery (G408)` section to both host prompts (`intent-cli`, `sekiban-as-a-service`) and `ChildPromptBody`; host recovery re-reads `automation doctor`; child recovery re-reads both preflight surfaces; limits to one guided repair per cycle.
- **`docs/en/07-recovery.md`** and **`docs/ja/07-recovery.md`**: add a new G408 section with table of safe vs operator-stop outcomes and hard limits.
- **Tests**: 12 new tests across `GuideWorkerIssueToPrCommandTests`, `GuideWorkerPrCommentFixCommandTests`, `GuideOneshotCommandTests` — covering prompt text, structured JSON field, markdown rendering.

## Key distinction

Safe repair (child loop): `child-selector-label-gap` — the one category `intent-cli` marks as child-loop-owned.  
Operator stop: `host-artifact-repair-required`, `clarification-required`, unsafe durable state, operator policy decision — never silently bypassed.

## Test plan

- [x] `GuideWorkerIssueToPrCommandTests` — 4 new G408 tests pass
- [x] `GuideWorkerPrCommentFixCommandTests` — 4 new G408 tests pass
- [x] `GuideOneshotCommandTests` — 4 new G408 tests pass (+ all prior tests still pass)
- [x] 56 focused guide/worker/oneshot tests pass total
- [x] `git diff --check` — clean

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)