### PR TITLE
G409: Fix release checksum sidecars to use basename for user-friendly verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,10 +242,14 @@ jobs:
             ASSET="dist/${NAME}.tar.gz"
             tar -czf "${ASSET}" -C stage "intent-cli"
           fi
+          # G409: cd into dist so the sidecar records only the basename, not
+          # the dist/ path prefix, allowing users to verify from the download
+          # directory without recreating the CI folder layout.
+          BASENAME="$(basename "${ASSET}")"
           if command -v sha256sum >/dev/null 2>&1; then
-            sha256sum "${ASSET}" > "${ASSET}.sha256"
+            (cd dist && sha256sum "${BASENAME}" > "${BASENAME}.sha256")
           else
-            shasum -a 256 "${ASSET}" > "${ASSET}.sha256"
+            (cd dist && shasum -a 256 "${BASENAME}" > "${BASENAME}.sha256")
           fi
           echo "asset=${ASSET}" | tee -a "${GITHUB_OUTPUT}"
           cat "${ASSET}.sha256"

--- a/README.md
+++ b/README.md
@@ -198,10 +198,13 @@ SDK is required).
 | Windows (x64) | `intent-cli-<version>-win-x64.zip` |
 | Linux (x64) | `intent-cli-<version>-linux-x64.tar.gz` |
 
-Each archive ships with a `.sha256` sidecar; verify it before use.
+Each archive ships with a `.sha256` sidecar; download both files into the same
+directory and verify before use.
+
+**macOS:**
 
 ```bash
-# 1. Verify the checksum (run from the folder containing both files).
+# 1. Verify (run from the folder containing both files).
 shasum -a 256 -c intent-cli-<version>-osx-arm64.tar.gz.sha256
 
 # 2. Extract and place the binary on your PATH.
@@ -213,8 +216,25 @@ sudo mv intent-cli /usr/local/bin/
 intent-cli --version
 ```
 
-On Windows, verify with `CertUtil -hashfile intent-cli-<version>-win-x64.zip SHA256`,
-unzip, and place `intent-cli.exe` on your `PATH`.
+**Linux:**
+
+```bash
+# 1. Verify (run from the folder containing both files).
+sha256sum -c intent-cli-<version>-linux-x64.tar.gz.sha256
+
+# 2. Extract and place the binary on your PATH.
+tar -xzf intent-cli-<version>-linux-x64.tar.gz
+chmod +x intent-cli
+sudo mv intent-cli /usr/local/bin/
+
+# 3. Confirm.
+intent-cli --version
+```
+
+**Windows:** Download `intent-cli-<version>-win-x64.zip` and its `.sha256` sidecar.
+Compare the hash from `CertUtil -hashfile intent-cli-<version>-win-x64.zip SHA256`
+against the first field in the `.sha256` file, unzip, and place `intent-cli.exe`
+on your `PATH`.
 
 Release binaries and OSS preview CI artifacts carry no build-time expiry.
 

--- a/eng/verify-checksum-basename.sh
+++ b/eng/verify-checksum-basename.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# G409: Static verification that .github/workflows/release.yml generates
+# checksum sidecars using the archive basename, not the dist/-prefixed path.
+#
+# Usage (from repo root):
+#   bash eng/verify-checksum-basename.sh
+#
+# Exit 0 = PASS, exit 1 = FAIL, exit 2 = workflow file not found.
+set -euo pipefail
+
+WORKFLOW="${1:-.github/workflows/release.yml}"
+
+if [ ! -f "$WORKFLOW" ]; then
+  echo "ERROR: $WORKFLOW not found (run from repo root)" >&2
+  exit 2
+fi
+
+fail=0
+
+check_present() {
+  local pattern="$1"
+  local desc="$2"
+  if ! grep -qF "$pattern" "$WORKFLOW"; then
+    echo "FAIL: $desc"
+    echo "      pattern '$pattern' not found in $WORKFLOW"
+    fail=1
+  fi
+}
+
+check_absent() {
+  local pattern="$1"
+  local desc="$2"
+  if grep -qF "$pattern" "$WORKFLOW"; then
+    echo "FAIL: $desc"
+    echo "      pattern '$pattern' found in $WORKFLOW (must be absent)"
+    fail=1
+  fi
+}
+
+check_present 'BASENAME=' \
+  'BASENAME variable must be set before hashing'
+check_present 'cd dist' \
+  'hasher must run inside dist/ so the sidecar records only the basename'
+
+# Regression guards: the old path-based form must not be present.
+check_absent 'sha256sum "${ASSET}"' \
+  'dist/-prefixed ASSET form must not be passed to sha256sum'
+check_absent 'shasum -a 256 "${ASSET}"' \
+  'dist/-prefixed ASSET form must not be passed to shasum'
+
+if [ "$fail" -eq 0 ]; then
+  echo "PASS: $WORKFLOW generates checksum sidecars with basename (no dist/ prefix)"
+fi
+exit "$fail"

--- a/tests/IntentSystem.Cli.Tests/ReleaseWorkflowContractTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseWorkflowContractTests.cs
@@ -74,6 +74,25 @@ public sealed class ReleaseWorkflowContractTests
         Assert.DoesNotContain("PrivatePreviewExpiresAt", workflow, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ReleaseWorkflow_ChecksumSidecarsUseBasenameNotDistPath()
+    {
+        // G409: sidecar files must record only the archive basename so users can
+        // verify from a plain download directory without recreating dist/.
+        // The fix is to cd into dist before running sha256sum/shasum, which means
+        // the checksum command must NOT pass the full dist/ path to the hasher.
+        var workflow = File.ReadAllText(LocateReleaseWorkflow());
+
+        // The fix pattern: cd into dist, then hash the BASENAME variable (not ASSET).
+        Assert.Contains("cd dist", workflow, StringComparison.Ordinal);
+        Assert.Contains("BASENAME", workflow, StringComparison.Ordinal);
+
+        // Regression guard: the hasher must not receive the dist/-prefixed ASSET path.
+        // sha256sum "${ASSET}" or shasum -a 256 "${ASSET}" would reintroduce dist/ prefix.
+        Assert.DoesNotContain("sha256sum \"${ASSET}\"", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("shasum -a 256 \"${ASSET}\"", workflow, StringComparison.Ordinal);
+    }
+
     private static string LocateReleaseWorkflow()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
## Summary

- Fix \`.github/workflows/release.yml\`: \`Archive + checksum\` step now \`cd\`s into \`dist/\` before running \`sha256sum\`/\`shasum\`, so sidecar files record only the archive basename (e.g. \`intent-cli-0.3.0-osx-arm64.tar.gz\`) instead of the CI-internal \`dist/intent-cli-0.3.0-osx-arm64.tar.gz\`.
- Update \`README.md\`: Add Linux (\`sha256sum -c\`) verification steps and clarify Windows CertUtil comparison flow for all platforms.
- Add \`ReleaseWorkflow_ChecksumSidecarsUseBasenameNotDistPath\` test in \`ReleaseWorkflowContractTests.cs\` to prevent reintroducing the \`dist/\` prefix.
- Add \`eng/verify-checksum-basename.sh\`: standalone static verification script (no .NET required) runnable directly from repo root.

## Focused static verification (no dotnet required)

\`\`\`bash
bash eng/verify-checksum-basename.sh
# => PASS: .github/workflows/release.yml generates checksum sidecars with basename (no dist/ prefix)
\`\`\`

## .NET focused test (requires solution-level restore)

The test project references sibling projects and must be built via the solution:

\`\`\`bash
dotnet restore IntentSystem.sln
dotnet build IntentSystem.sln --configuration Release --no-restore
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
  --configuration Release --no-build \
  --filter "FullyQualifiedName~ReleaseWorkflowContractTests"
# => Passed! - Failed: 0, Passed: 6, Skipped: 0, Total: 6
\`\`\`

Note: running the test project directly from a temp directory without a prior
solution restore fails to resolve sibling project references — this is an
expected environment-setup constraint. Use the solution restore path above.

## Test plan

- [x] \`bash eng/verify-checksum-basename.sh\` passes (standalone, no .NET needed).
- [x] \`dotnet test --filter FullyQualifiedName~ReleaseWorkflowContractTests\` passes 6/6 after solution restore.
- [x] \`git diff --check\` clean.
- [ ] After release workflow runs: download archive and \`.sha256\` to same directory; \`shasum -a 256 -c\` / \`sha256sum -c\` succeeds without creating a \`dist/\` folder.

Closes #919

🤖 Generated with [Claude Code](https://claude.com/claude-code)