### PR TITLE
G411: Add OSS community files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [J-Tech-Japan]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Report a bug in intent-cli
+labels: bug
+---
+
+## Summary
+
+A short description of the bug.
+
+## intent-cli version
+
+```
+intent-cli --version
+```
+
+## Operating system and install method
+
+<!-- e.g. macOS 14, installed via dotnet tool install -->
+
+## Command that failed
+
+```
+intent-cli <exact command here>
+```
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include the full error output if available.
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Additional context
+
+Any other information that might help (config files, environment variables, etc.).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,6 +38,11 @@ What actually happened. Include the full error output if available.
 2.
 3.
 
+## Did you ask intent-cli for guidance first?
+
+<!-- Run: intent-cli guide help -->
+<!-- If yes, paste the relevant output. If no, please try that first — it resolves most common questions. -->
+
 ## Additional context
 
 Any other information that might help (config files, environment variables, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,21 @@ about: Suggest a new feature or improvement for intent-cli
 labels: enhancement
 ---
 
+## Did you ask intent-cli for guidance first?
+
+<!-- Run: intent-cli guide help -->
+<!-- If yes, paste the relevant output. If no, please try that first before opening a request. -->
+
+## intent-cli version
+
+```
+intent-cli --version
+```
+
+## Operating system and install method
+
+<!-- e.g. macOS 14, installed via dotnet tool install -->
+
 ## Problem
 
 Describe the problem you are trying to solve. Why does the current behavior fall short?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement for intent-cli
+labels: enhancement
+---
+
+## Problem
+
+Describe the problem you are trying to solve. Why does the current behavior fall short?
+
+## Proposed solution
+
+What would you like to see? Describe the change or new capability.
+
+## Alternatives considered
+
+Other approaches you have thought about, and why you prefer this one.
+
+## Additional context
+
+Any other information, links, or examples that support this request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR do and why is it needed? -->
+
+## Related issue
+
+Closes #
+
+## Changes
+
+<!-- Bullet points describing what changed -->
+
+## Test plan
+
+<!-- How did you verify this works? -->
+
+## Checklist
+
+- [ ] Tests added or updated for new behavior
+- [ ] `dotnet test IntentSystem.sln --configuration Release` passes
+- [ ] PR is based on `main`
+- [ ] PR description explains **why** the change is needed

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,7 @@ Closes #
 
 ## Checklist
 
+- [ ] I asked `intent-cli` for current guidance before touching workflow labels, packets, automation state, or intent metadata (`intent-cli guide help`)
 - [ ] Tests added or updated for new behavior
 - [ ] `dotnet test IntentSystem.sln --configuration Release` passes
 - [ ] PR is based on `main`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,33 @@
+# Code of Conduct
+
+## Our pledge
+
+We are committed to making participation in this project a welcoming experience
+for everyone, regardless of experience level, background, or identity.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive feedback
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- Harassment of any kind
+- Trolling, insulting comments, or personal attacks
+- Publishing others' private information without permission
+- Other conduct that is reasonably considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by opening a GitHub issue or
+contacting the maintainers through the channels listed in [SUPPORT.md](SUPPORT.md).
+All reports will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This code of conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to intent-cli
+
+Thank you for your interest in contributing. This guide covers how to report
+bugs, suggest features, improve documentation, and submit pull requests.
+
+## Ask intent-cli first
+
+**This is the core operating rule.** Before you change workflow labels, packet
+metadata, automation state, or host artifacts — ask `intent-cli` for the current
+guidance rather than editing things by hand. The CLI exists so you never have to
+guess at the label/metadata contract.
+
+```bash
+intent-cli guide help
+intent-cli guide commands list --format json
+```
+
+If you are contributing as an AI agent: read the GitHub issue body as your
+standalone contract. Do not read or mutate the parent host's queue-state, packet
+directories, or intent tree. Use `intent-cli worker` commands for all label
+transitions; never use raw `gh ... edit --add-label`.
+
+## Ways to contribute
+
+- **Bug reports** — open a GitHub issue using the Bug Report template. Include
+  your `intent-cli --version`, operating system, install method, and the exact
+  command that failed.
+- **Feature suggestions** — open a GitHub issue using the Feature Request
+  template. Describe the problem you are trying to solve, not just the solution.
+- **Documentation improvements** — edit files under `docs/` and open a PR. Run
+  `git diff --check` before submitting.
+- **Code contributions** — see the sections below.
+
+## Setting up the development environment
+
+Requirements:
+- .NET 10 SDK (`dotnet --version` should report `10.x`)
+- Git
+
+```bash
+git clone https://github.com/J-Tech-Japan/intent-system.git
+cd intent-system
+dotnet restore IntentSystem.sln
+dotnet build IntentSystem.sln --configuration Release
+dotnet test IntentSystem.sln --configuration Release
+```
+
+## Pull request expectations
+
+- Base your PR on `main`.
+- Keep each PR focused on one change. Smaller PRs are reviewed faster.
+- Include tests for new behavior. The test suite lives under `tests/`.
+- Run `git diff --check` to catch whitespace errors before submitting.
+- Write a clear PR description explaining **why** the change is needed, not just
+  what it does.
+- Add a closing reference to the related issue (`Closes #N`) in the PR body.
+
+## Coding conventions
+
+- Language: C# / .NET 10
+- No comments unless the reason is non-obvious (a hidden constraint, a subtle
+  invariant, a workaround for a specific bug).
+- Do not introduce Node/TypeScript toolchain; this project is .NET-only.
+- Do not add features beyond the issue scope.
+
+## Tests
+
+Run the full test suite from the repo root:
+
+```bash
+dotnet test IntentSystem.sln --configuration Release
+```
+
+To run a focused set:
+
+```bash
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
+  --configuration Release \
+  --filter "FullyQualifiedName~YourTestClass"
+```
+
+Note: the test project references sibling projects and requires
+`dotnet restore IntentSystem.sln` before running in isolation.
+
+## Code of conduct
+
+Please read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). We expect all
+participants to adhere to it.
+
+## License
+
+By contributing, you agree your contributions will be licensed under the
+[Apache-2.0 license](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release of intent-cli receives security fixes.
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Send a report to the maintainers via GitHub's
+[private vulnerability reporting](https://github.com/J-Tech-Japan/intent-system/security/advisories/new).
+
+Include:
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Any suggested mitigations, if known
+
+We will acknowledge receipt within 5 business days and aim to release a fix
+within 30 days for confirmed critical issues.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,33 @@
+# Support
+
+## Ask intent-cli first
+
+Before opening a support request, run:
+
+```bash
+intent-cli guide help
+intent-cli guide commands list --format json
+```
+
+The CLI surfaces current guidance for most common questions without requiring
+human intervention.
+
+## Bug reports
+
+Open a GitHub issue using the **Bug Report** template. Include your
+`intent-cli --version`, operating system, install method, and the exact command
+that failed.
+
+## Feature requests
+
+Open a GitHub issue using the **Feature Request** template. Describe the
+problem you are trying to solve.
+
+## Questions
+
+For general questions, open a GitHub Discussion or a GitHub issue with the
+question label.
+
+## Security issues
+
+See [SECURITY.md](SECURITY.md) for how to report vulnerabilities privately.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with ask-intent-cli-first rule, dev setup instructions, PR expectations, and coding conventions
- Add `CODE_OF_CONDUCT.md` based on Contributor Covenant v2.1
- Add `SECURITY.md` with private vulnerability reporting instructions
- Add `SUPPORT.md` pointing users to intent-cli guidance and issue templates
- Add `.github/FUNDING.yml` with GitHub Sponsors set to J-Tech-Japan
- Add `.github/ISSUE_TEMPLATE/bug_report.md` and `feature_request.md`
- Add `.github/PULL_REQUEST_TEMPLATE.md`

## Related issue

Closes #923

## Test plan

- All files are static markdown/YAML — no code changes, no test changes needed
- Verified all required sections present per issue acceptance criteria

🤖 Generated with [Claude Code](https://claude.ai/claude-code)