### PR TITLE
G412: Add OSS readiness checklist and fix stale private-preview references

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ install` output prints the exact line to add (commonly `~/.dotnet/tools` on
 macOS/Linux, `%USERPROFILE%\.dotnet\tools` on Windows).
 
 > No .NET SDK? Use the self-contained binary instead — see
-> [Install without a .NET SDK](#install-without-a-net-sdk). Need the internal
-> testing channel? See [Preview install](#preview-install).
+> [Install without a .NET SDK](#install-without-a-net-sdk). Need the preview
+> channel? See [Preview install](#preview-install).
 
 ### 2. Verify
 

--- a/docs/en/01-install.md
+++ b/docs/en/01-install.md
@@ -26,8 +26,8 @@ not on your `PATH`, the install output prints the line to add.
 the runtime is bundled. Verify the `.sha256` sidecar before use. See the
 [root README](../../README.md#install-without-a-net-sdk) for the full steps.
 
-**Internal testers** consuming the `private-preview-pack` artifact: see the
-[root README private-preview section](../../README.md#private-preview-install).
+**Preview channel users** consuming the `preview-pack` artifact: see the
+[root README preview section](../../README.md#preview-install).
 
 ## Next
 

--- a/docs/ja/01-install.md
+++ b/docs/ja/01-install.md
@@ -25,8 +25,8 @@ intent-cli --version
 から取得（ランタイム同梱）。使用前に `.sha256` を検証する。手順は
 [ルート README](../../README.md#install-without-a-net-sdk) を参照。
 
-**社内テスター**（`private-preview-pack` アーティファクト利用）は
-[ルート README の private-preview セクション](../../README.md#private-preview-install)
+**プレビューチャンネルユーザー**（`preview-pack` アーティファクト利用）は
+[ルート README のプレビューセクション](../../README.md#preview-install)
 を参照。
 
 ## 次へ

--- a/docs/oss-readiness-checklist.md
+++ b/docs/oss-readiness-checklist.md
@@ -20,7 +20,7 @@ Run this checklist before promoting a branch or release to public OSS audiences.
 
 ## Private-preview and expiry language
 
-- [ ] No user-facing "private-preview", "internal tester", or "social内テスター" wording in docs
+- [ ] No user-facing "private-preview", "internal tester", or "社内テスター" wording in docs
   ```bash
   grep -rni "private.preview\|internal tester\|社内テスター" docs/ README.md
   ```

--- a/docs/oss-readiness-checklist.md
+++ b/docs/oss-readiness-checklist.md
@@ -1,0 +1,65 @@
+# OSS Readiness Checklist
+
+Run this checklist before promoting a branch or release to public OSS audiences.
+
+## Secrets and credentials
+
+- [ ] No private tokens, API keys, or passwords in tracked files
+  ```bash
+  grep -rn "token\|secret\|password\|api.key" --include="*.md" --include="*.yml" docs/ .github/ README.md
+  ```
+- [ ] Workflow secrets are accessed only via `${{ secrets.* }}` and guarded with `if [ -z "${VAR:-}" ]` skips
+
+## Personal and internal paths
+
+- [ ] No personal machine paths (e.g. `/Users/<name>/`, `/home/<name>/`) in user-facing docs or source
+  ```bash
+  grep -rn "/Users/\|/home/" --include="*.md" docs/ README.md
+  ```
+- [ ] Test fixtures using local paths are isolated to test files and not referenced from docs
+
+## Private-preview and expiry language
+
+- [ ] No user-facing "private-preview", "internal tester", or "social内テスター" wording in docs
+  ```bash
+  grep -rni "private.preview\|internal tester\|社内テスター" docs/ README.md
+  ```
+- [ ] No stale expiry or build-time gating claims in user-facing docs
+- [ ] Preview channel docs link to `#preview-install` (not `#private-preview-install`)
+
+## Install and first-use docs
+
+- [ ] README leads with NuGet install (`dotnet tool install -g JTechJapan.IntentSystem.Cli`)
+- [ ] README includes self-contained binary install instructions with checksum verification
+- [ ] `docs/en/01-install.md` and `docs/ja/01-install.md` are reachable from the docs index
+- [ ] `intent-cli --version` is documented as a post-install verification step
+- [ ] `intent-cli guide start` is recommended before first workflow use
+
+## Community files
+
+- [ ] `README.md` exists and is public-audience-friendly
+- [ ] `CONTRIBUTING.md` exists with ask-intent-cli-first rule and dev setup
+- [ ] `CODE_OF_CONDUCT.md` exists
+- [ ] `SECURITY.md` exists with private reporting instructions
+- [ ] `SUPPORT.md` exists
+- [ ] `.github/ISSUE_TEMPLATE/` contains bug report and feature request templates
+- [ ] `.github/PULL_REQUEST_TEMPLATE.md` exists
+
+## Release docs
+
+- [ ] Released version `0.3.0` release notes exist and are accurate
+- [ ] `eng/version.json` `nextVersion` reflects the correct post-release version
+- [ ] No stale release candidate version strings in user-facing docs
+
+## Static checks
+
+- [ ] `git diff --check` passes (no trailing whitespace or mixed line endings)
+- [ ] `dotnet test IntentSystem.sln --configuration Release` passes
+
+## Source code
+
+- [ ] No hardcoded private tokens or credentials in source
+- [ ] `PrivatePreviewExpiryGate` is wired only in non-OSS build paths (check `#if` or build props)
+  ```bash
+  grep -rn "PrivatePreviewExpiryGate\|private.preview" src/ --include="*.cs"
+  ```

--- a/src/IntentSystem.Cli/Infrastructure/PrivatePreviewExpiryGate.cs
+++ b/src/IntentSystem.Cli/Infrastructure/PrivatePreviewExpiryGate.cs
@@ -114,10 +114,10 @@ internal static class PrivatePreviewExpiryGate
                 ? "  commit: <unknown>"
                 : $"  commit: {metadata.SourceCommit}",
             string.Empty,
-            "Download a newer artifact from a more recent `private-preview-pack` workflow run on `main` and reinstall:",
+            "Download a newer artifact from a more recent `preview-pack` workflow run on `main` and reinstall:",
             "  dotnet tool update --global --add-source <downloaded-folder> --version <newer-version> JTechJapan.IntentSystem.Cli",
             string.Empty,
-            "Source-only builds (no preview metadata) are unaffected; see README.md \"Private-preview install\" for the full flow.",
+            "Source-only builds (no preview metadata) are unaffected; see README.md \"Preview install\" for the full flow.",
         });
     }
 


### PR DESCRIPTION
## Summary

- Add `docs/oss-readiness-checklist.md` with a runnable maintainer checklist for pre-promotion OSS audit (secrets, personal paths, internal language, install docs, community files, static checks)
- Fix broken anchor links in `docs/en/01-install.md` and `docs/ja/01-install.md`: `#private-preview-install` → `#preview-install`, artifact name `private-preview-pack` → `preview-pack`, wording "Internal testers" → "Preview channel users" / "社内テスター" → "プレビューチャンネルユーザー"
- Fix stale `PrivatePreviewExpiryGate.BuildExpiredMessage` text: update `private-preview-pack` → `preview-pack` and README section name to "Preview install" for expired old-artifact messages

## Related issue

Closes #925

## Test plan

- `dotnet test IntentSystem.sln --configuration Release --filter "FullyQualifiedName~PrivatePreviewExpiryGate"` — 8 tests pass
- `git diff --check` — no whitespace errors
- Manually verified anchor `#preview-install` exists in README.md

🤖 Generated with [Claude Code](https://claude.ai/claude-code)