### PR TITLE
G413: Prepare 0.3.1 version source and release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ uploads a self-contained install bundle as a workflow artifact named
 | `INSTALL.md` | Per-build install / update / verify / uninstall guide with this build's exact version and commit pre-filled. |
 
 The package version pattern is `<nextVersion>-preview.<run_number>.<run_attempt>`
-(e.g. `0.3.0-preview.42.1`), where `nextVersion` comes from `eng/version.json`.
+(e.g. `0.3.1-preview.42.1`), where `nextVersion` comes from `eng/version.json`.
 Every CI run produces a distinct version. No PAT, source checkout, or public
 NuGet feed is required — only a compatible .NET SDK / runtime and the unzipped
 bundle. **OSS preview packages carry no expiry; they remain runnable indefinitely.**
@@ -356,7 +356,7 @@ dotnet tool uninstall --global JTechJapan.IntentSystem.Cli
 The installed binary exposes the preview metadata via `intent-cli --version`:
 
 ```text
-intent-cli 0.3.0-preview.42.1-<short-sha>-G<unit>
+intent-cli 0.3.1-preview.42.1-<short-sha>-G<unit>
 channel=preview built=<iso-utc> commit=<full-sha>
 ```
 
@@ -372,29 +372,29 @@ The repository version policy lives in `eng/version.json`:
 
 ```json
 {
-  "stableVersion": "0.2.0",
-  "nextVersion": "0.3.0"
+  "stableVersion": "0.3.0",
+  "nextVersion": "0.3.1"
 }
 ```
 
 | Stage | Version form | How it is derived |
 | --- | --- | --- |
-| Main CI preview | `0.3.0-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.0-rc.N` | Tag `v0.3.0-rc.N` triggers release workflow |
-| Stable release | `0.3.0` | Tag `v0.3.0` triggers release workflow |
+| Main CI preview | `0.3.1-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.1-rc.N` | Tag `v0.3.1-rc.N` triggers release workflow |
+| Stable release | `0.3.1` | Tag `v0.3.1` triggers release workflow |
 | Post-release main builds | `0.4.0-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.4.0` |
 
-**After releasing `v0.3.0`**, bump both fields in `eng/version.json`:
+**After releasing `v0.3.1`**, bump both fields in `eng/version.json`:
 
 ```json
 {
-  "stableVersion": "0.3.0",
+  "stableVersion": "0.3.1",
   "nextVersion": "0.4.0"
 }
 ```
 
 This ensures the next main-branch CI build immediately produces
-`0.4.0-preview.<run>.<attempt>` rather than continuing to emit `0.3.0-preview`
+`0.4.0-preview.<run>.<attempt>` rather than continuing to emit `0.3.1-preview`
 (which would collide with the stable release version).
 
 ---

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ The CLI is packaged as a .NET tool (package id `JTechJapan.IntentSystem.Cli`,
 command `intent-cli`). To smoke-test a locally built package:
 
 ```bash
-export INTENT_CLI_LOCAL_VERSION="0.2.0-local.$(date -u +%Y%m%d%H%M%S)"
+export INTENT_CLI_LOCAL_VERSION="0.3.1-local.$(date -u +%Y%m%d%H%M%S)"
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
   -p:Version="$INTENT_CLI_LOCAL_VERSION" \
   -o .artifacts/packages

--- a/docs/en/release-notes-v0.3.1.md
+++ b/docs/en/release-notes-v0.3.1.md
@@ -1,0 +1,71 @@
+# Release Notes — intent-cli v0.3.1
+
+> **Release checklist for maintainers:** see [Creating the v0.3.1 GitHub Release](#creating-the-v031-github-release).
+
+## What's in v0.3.1
+
+v0.3.1 is the first OSS-hardened follow-up to v0.3.0. It ships release
+packaging improvements, repository cleanup, community files, and an OSS
+readiness checklist. No new product commands are added.
+
+### Release packaging (G409)
+
+- Release workflow checksum sidecars now use the bare filename
+  (`intent-cli-linux-x64.tar.gz.sha256`) instead of the full
+  distribution-relative path, so `sha256sum -c` and `CertUtil -hashfile`
+  work directly from the download directory without extracting the archive
+  first.
+- README verification instructions updated with per-platform
+  (Linux / macOS / Windows) sections.
+
+### Repository cleanup (G410)
+
+- Removed `.takt/` runtime trace directory and its `.gitignore`.
+- Moved `ops/` automation notes to `docs/automation-templates/` and
+  `eng/`; deleted stale historical ops notes.
+- `GuideRulesCommand` source reference updated from `ops/` to
+  `docs/automation-templates/`.
+
+### OSS community files (G411)
+
+- Added `CONTRIBUTING.md` with ask-intent-cli-first rule, dev setup,
+  PR expectations, and coding conventions.
+- Added `CODE_OF_CONDUCT.md` (Contributor Covenant v2.1).
+- Added `SECURITY.md` with private vulnerability reporting instructions.
+- Added `SUPPORT.md`.
+- Added `.github/FUNDING.yml`, issue templates, and PR template — all
+  including intent-cli guidance prompts.
+
+### OSS readiness (G412)
+
+- Added `docs/oss-readiness-checklist.md` for pre-promotion audit.
+- Fixed stale "internal testing channel" / "private-preview-install"
+  wording in install docs and error messages.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.1
+```
+
+Or download the self-contained binary from the
+[v0.3.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.1).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.0
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.1
+```
+
+There are no breaking changes from v0.3.0.
+
+## Creating the v0.3.1 GitHub Release
+
+1. Tag the release commit: `git tag v0.3.1 && git push origin v0.3.1`
+2. The `release.yml` workflow fires and builds binaries, `.nupkg`, and
+   checksums. Wait for it to complete.
+3. The workflow creates the GitHub Release draft. Review it, paste the
+   content of this file as the release body, and publish.
+4. Verify `dotnet tool install -g JTechJapan.IntentSystem.Cli` resolves
+   the new version from NuGet.org within a few minutes of publish.

--- a/docs/ja/release-notes-v0.3.1.md
+++ b/docs/ja/release-notes-v0.3.1.md
@@ -1,0 +1,65 @@
+# リリースノート — intent-cli v0.3.1
+
+> **メンテナー向けリリースチェックリスト:** [v0.3.1 GitHub Release の作成](#v031-github-release-の作成) を参照。
+
+## v0.3.1 の内容
+
+v0.3.1 は v0.3.0 に続く最初の OSS 対応強化リリースです。リリースパッケージングの改善、リポジトリクリーンアップ、コミュニティファイルの追加、および OSS レディネスチェックリストを含みます。新しいプロダクトコマンドはありません。
+
+### リリースパッケージング (G409)
+
+- リリースワークフローのチェックサムサイドカーが、配布物相対パスではなくベアファイル名
+  (`intent-cli-linux-x64.tar.gz.sha256`) を使用するように変更。
+  ダウンロードディレクトリから `sha256sum -c` / `CertUtil -hashfile` が
+  アーカイブ展開なしで直接動作します。
+- README の検証手順をプラットフォーム別（Linux / macOS / Windows）のセクションに更新。
+
+### リポジトリクリーンアップ (G410)
+
+- `.takt/` ランタイムトレースディレクトリとその `.gitignore` を削除。
+- `ops/` 内の自動化ノートを `docs/automation-templates/` および `eng/` に移動。
+  古い履歴 ops ノートを削除。
+- `GuideRulesCommand` のソース参照を `ops/` から `docs/automation-templates/` に更新。
+
+### OSS コミュニティファイル (G411)
+
+- `CONTRIBUTING.md` を追加（ask-intent-cli-first ルール、開発環境セットアップ、
+  PR の期待事項、コーディング規約を含む）。
+- `CODE_OF_CONDUCT.md` を追加（Contributor Covenant v2.1 ベース）。
+- `SECURITY.md` を追加（脆弱性のプライベート報告手順）。
+- `SUPPORT.md` を追加。
+- `.github/FUNDING.yml`、issue テンプレート、PR テンプレートを追加
+  （いずれも intent-cli ガイダンスプロンプトを含む）。
+
+### OSS レディネス (G412)
+
+- `docs/oss-readiness-checklist.md` を追加（公開前の監査チェックリスト）。
+- インストールドキュメントおよびエラーメッセージ内の古い「internal testing channel」/
+  「private-preview-install」表現を修正。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.1
+```
+
+または [v0.3.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.1)
+から self-contained バイナリをダウンロード。使用前に `.sha256` を検証してください。
+
+## v0.3.0 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.1
+```
+
+v0.3.0 からの破壊的変更はありません。
+
+## v0.3.1 GitHub Release の作成
+
+1. リリースコミットにタグを付ける: `git tag v0.3.1 && git push origin v0.3.1`
+2. `release.yml` ワークフローが起動し、バイナリ、`.nupkg`、チェックサムをビルドします。
+   完了を待ちます。
+3. ワークフローが GitHub Release ドラフトを作成します。内容を確認し、
+   このファイルの内容をリリース本文として貼り付けて公開します。
+4. 公開後数分以内に `dotnet tool install -g JTechJapan.IntentSystem.Cli` で
+   新バージョンが NuGet.org から解決できることを確認します。

--- a/eng/refresh-host-local-intent-cli.sh
+++ b/eng/refresh-host-local-intent-cli.sh
@@ -34,10 +34,10 @@ fi
 
 CHILD_SHA="$(git -C "$CHILD_INTENT_SYSTEM" rev-parse --short=12 HEAD)"
 LOCAL_STAMP="$(date -u +%Y%m%d%H%M%S)"
-INTENT_CLI_LOCAL_VERSION="${INTENT_CLI_LOCAL_VERSION:-0.2.0-local.$LOCAL_STAMP.$$.g$CHILD_SHA}"
+INTENT_CLI_LOCAL_VERSION="${INTENT_CLI_LOCAL_VERSION:-0.3.1-local.$LOCAL_STAMP.$$.g$CHILD_SHA}"
 
-if [[ "$INTENT_CLI_LOCAL_VERSION" == "0.2.0" ]]; then
-  echo "INTENT_CLI_LOCAL_VERSION must not be the fixed package version 0.2.0." >&2
+if [[ "$INTENT_CLI_LOCAL_VERSION" == "0.3.1" ]]; then
+  echo "INTENT_CLI_LOCAL_VERSION must not be the fixed package version 0.3.1." >&2
   exit 1
 fi
 

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -15,7 +15,7 @@
     -->
     <ToolCommandName>intent-cli</ToolCommandName>
     <PackageId>JTechJapan.IntentSystem.Cli</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.1</Version>
     <Authors>J-Tech-Japan</Authors>
     <Description>Intent System CLI — deterministic support tooling for intent-driven development on GitHub. Install: dotnet tool install -g JTechJapan.IntentSystem.Cli. Command: intent-cli.</Description>
     <PackageTags>intent-cli;dotnet-tool;intent-system</PackageTags>

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -152,7 +152,7 @@ public sealed class PackagedInvocationSmokeTests
 
         Assert.Contains("mkdir -p .artifacts/smoke-repo/.intent-cli", readme, StringComparison.Ordinal);
         Assert.Contains("cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'", readme, StringComparison.Ordinal);
-        Assert.Contains("export INTENT_CLI_LOCAL_VERSION=\"0.2.0-local.$(date -u +%Y%m%d%H%M%S)\"", readme, StringComparison.Ordinal);
+        Assert.Contains("export INTENT_CLI_LOCAL_VERSION=\"0.3.1-local.$(date -u +%Y%m%d%H%M%S)\"", readme, StringComparison.Ordinal);
         // G407: package id is JTechJapan.IntentSystem.Cli; dotnet tool exec / dnx uses the
         // package id to locate the nupkg. The installed command remains intent-cli.
         Assert.Contains("(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version \"$INTENT_CLI_LOCAL_VERSION\" JTechJapan.IntentSystem.Cli project status)", readme, StringComparison.Ordinal);
@@ -162,9 +162,9 @@ public sealed class PackagedInvocationSmokeTests
     [Fact]
     public void HostRefreshScript_UsesUniqueLocalVersionAndVerifiesAutomationSurface()
     {
-        var script = File.ReadAllText(Path.Combine(GetSolutionRoot(), "ops", "refresh-host-local-intent-cli.sh"));
+        var script = File.ReadAllText(Path.Combine(GetSolutionRoot(), "eng", "refresh-host-local-intent-cli.sh"));
 
-        Assert.Contains("0.2.0-local.$LOCAL_STAMP.$$.g$CHILD_SHA", script, StringComparison.Ordinal);
+        Assert.Contains("0.3.1-local.$LOCAL_STAMP.$$.g$CHILD_SHA", script, StringComparison.Ordinal);
         Assert.Contains("-p:Version=\"$INTENT_CLI_LOCAL_VERSION\"", script, StringComparison.Ordinal);
         Assert.Contains("--version \"\\$INTENT_CLI_LOCAL_VERSION\"", script, StringComparison.Ordinal);
         Assert.Contains("find \"$PACKAGES_DIR\" -maxdepth 1 -type f -name 'JTechJapan.IntentSystem.Cli.*.nupkg' -delete", script, StringComparison.Ordinal);
@@ -224,7 +224,7 @@ public sealed class PackagedInvocationSmokeTests
 
     private static string CreateLocalPackageVersion()
     {
-        return $"0.2.0-local.{Guid.NewGuid():N}";
+        return $"0.3.1-local.{Guid.NewGuid():N}";
     }
 
     private sealed record ProcessResult(int ExitCode);


### PR DESCRIPTION
## Summary

- Update `src/IntentSystem.Cli/IntentSystem.Cli.csproj` Version `0.2.0` → `0.3.1` so binary and NuGet package report 0.3.1
- Update README local smoke-test example from `0.2.0-local` to `0.3.1-local`
- Update `eng/refresh-host-local-intent-cli.sh` default local version to `0.3.1-local`
- Fix `PackagedInvocationSmokeTests`: update broken `ops/` path to `eng/` (G410 followup) and update version assertions to `0.3.1-local`
- Add `docs/en/release-notes-v0.3.1.md` and `docs/ja/release-notes-v0.3.1.md` covering G409–G412 changes

## Related issue

Closes #927

## Test plan

- `dotnet test IntentSystem.sln --configuration Release --filter "FullyQualifiedName~PackagedInvocationSmokeTests"` — 5 tests pass (was 4 pass, 1 fail before this fix)
- Local self-contained publish: `./IntentSystem.Cli --version` reports `intent-cli 0.3.1-...`
- Local `dotnet pack` produces `JTechJapan.IntentSystem.Cli.0.3.1.nupkg`
- `git diff --check` — no whitespace errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)