### PR TITLE
G417: Document host repository and metadata branch topology choices

### DIFF
--- a/docs/en/02-project-start.md
+++ b/docs/en/02-project-start.md
@@ -33,6 +33,62 @@ intent-cli guide intent-work --format json
 - Canonical state lives in the host repo's `.intent-cli/`; read it through
   intent-cli surfaces, don't edit `queue-state.json` directly.
 
+## Repository topology choices
+
+Before initializing, choose how you want to store host metadata. Two topologies
+are fully supported.
+
+### Topology A — separate host repository
+
+The host orchestration repository is a dedicated repo (e.g. `myorg/my-project-host`).
+Child implementation work happens in one or more separate target repos
+(e.g. `myorg/my-project`).
+
+```
+myorg/my-project-host      ← host repo
+  .intent-cli/             ← queue-state, config, intent tree
+  intents/
+  AGENTS.md
+
+myorg/my-project           ← child implementation repo
+  <source code>
+  (no .intent-cli/)
+```
+
+- `intent-cli intent init` is run from the **host repo** checkout.
+- The host agent invokes `intent-cli automation` and `intent-cli review` commands
+  from the host checkout.
+- Child implementation agents clone or work from the implementation repo; they
+  never access the host repo.
+
+### Topology B — same repository with a metadata branch
+
+The host and child implementation live in **the same repository**. Host metadata
+is kept on a dedicated branch (commonly `main-metadata`) so that implementation
+PRs target the implementation base branch (`main`) without carrying metadata.
+
+```
+myorg/my-project           ← single repo
+  branch: main             ← implementation code, child PRs target here
+  branch: main-metadata    ← .intent-cli/, intents/, AGENTS.md (host-only)
+```
+
+- `intent-cli intent init` is run from a **metadata branch checkout**.
+- Implementation PRs target `main`; metadata stays on `main-metadata`.
+- Child implementation agents are **GitHub-contract-only** in both topologies:
+  they do not read or modify the metadata branch.
+
+### Which topology to prefer
+
+| Consideration | Separate host repo | Same repo + metadata branch |
+|---|---|---|
+| Team keeps intent orchestration and implementation clearly separated | ✓ natural boundary | more discipline required |
+| Fewer repositories to manage | more repos | ✓ single repo |
+| Open-source project where contributors only see implementation | ✓ host repo can stay private | metadata branch is visible to all |
+| Existing single repo that you want to add intent-cli to | migration cost | ✓ lower cost |
+
+Both topologies are valid. Pick whichever fits your team's existing conventions.
+
 ## Next
 
 [Organize & maintain intents](03-intents.md).

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -42,3 +42,8 @@ Child implementation agents are **GitHub-contract-only**: they must not read or
 mutate host `.intent-cli/`, queue-state, metadata branches, or `intents/**`.
 Host/review agents may operate on metadata, but ask `intent-cli` for the current
 command first and prefer its transitions over hand edits.
+
+The host can live in a **separate host repository** or in the **same repository
+on a dedicated metadata branch** (e.g. `main-metadata`). Both topologies are
+fully supported. See [Start a project → Repository topology choices](02-project-start.md#repository-topology-choices)
+for guidance on which to choose.

--- a/docs/ja/02-project-start.md
+++ b/docs/ja/02-project-start.md
@@ -32,6 +32,57 @@ intent-cli guide intent-work --format json
 - 正本の状態は host repo の `.intent-cli/` にある。intent-cli のサーフェス経由で読み、
   `queue-state.json` を直接編集しない。
 
+## リポジトリトポロジーの選択
+
+初期化の前に、host metadata をどこに置くかを選択します。2 つのトポロジーが完全にサポートされています。
+
+### トポロジー A — 別の host リポジトリ
+
+host のオーケストレーションリポジトリを専用リポジトリ（例: `myorg/my-project-host`）として用意します。
+child 実装作業は 1 つ以上の別のターゲットリポジトリ（例: `myorg/my-project`）で行います。
+
+```
+myorg/my-project-host      ← host リポジトリ
+  .intent-cli/             ← queue-state、config、intent tree
+  intents/
+  AGENTS.md
+
+myorg/my-project           ← child 実装リポジトリ
+  <ソースコード>
+  (.intent-cli/ なし)
+```
+
+- `intent-cli intent init` は **host リポジトリ** のチェックアウトから実行します。
+- host agent は host チェックアウトから `intent-cli automation` と `intent-cli review` コマンドを呼び出します。
+- child 実装 agent は実装リポジトリをクローンまたは使用します。host リポジトリへはアクセスしません。
+
+### トポロジー B — metadata ブランチを使う同一リポジトリ
+
+host と child 実装が **同じリポジトリ** に共存します。host metadata は専用ブランチ（一般的に `main-metadata`）に置き、
+実装 PR が実装ベースブランチ（`main`）を対象にしながら metadata を含まないようにします。
+
+```
+myorg/my-project           ← 単一リポジトリ
+  branch: main             ← 実装コード、child の PR はここを対象
+  branch: main-metadata    ← .intent-cli/、intents/、AGENTS.md（host 専用）
+```
+
+- `intent-cli intent init` は **metadata ブランチのチェックアウト** から実行します。
+- 実装 PR は `main` を対象にします。metadata は `main-metadata` に留まります。
+- child 実装 agent は両方のトポロジーで **GitHub-contract-only** です。
+  metadata ブランチを読んだり変更したりしません。
+
+### どちらのトポロジーを選ぶか
+
+| 考慮点 | 別の host リポジトリ | 同一リポジトリ + metadata ブランチ |
+|---|---|---|
+| チームが intent オーケストレーションと実装を明確に分離したい | ✓ 自然な境界 | より多くの規律が必要 |
+| 管理するリポジトリ数を減らしたい | リポジトリが増える | ✓ 単一リポジトリ |
+| コントリビューターに実装のみ見せたい OSS プロジェクト | ✓ host リポジトリを非公開にできる | metadata ブランチは全員に見える |
+| すでに単一リポジトリがあり intent-cli を追加したい | 移行コストが発生 | ✓ 移行コストが低い |
+
+どちらのトポロジーも有効です。チームの既存の慣習に合う方を選んでください。
+
 ## 次へ
 
 [intent の整理・保守](03-intents.md)。

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -40,3 +40,8 @@ Child implementation agent は **GitHub-contract-only**: host の `.intent-cli/`
 queue-state、metadata branch、`intents/**` を読んだり変更したりしない。
 Host/review agent は metadata を扱ってよいが、手編集の前に `intent-cli` へ現在の
 コマンドを尋ね、その遷移を優先する。
+
+host は **別の host リポジトリ** に置くこともできますし、**同じリポジトリの専用 metadata ブランチ**
+（例: `main-metadata`）に置くこともできます。どちらのトポロジーも完全にサポートされています。
+どちらを選ぶかは [プロジェクト開始 → リポジトリトポロジーの選択](02-project-start.md#リポジトリトポロジーの選択)
+を参照してください。


### PR DESCRIPTION
Closes #935

## Summary

- Added **Repository topology choices** section to `docs/en/02-project-start.md` and `docs/ja/02-project-start.md`
- Documents both supported topologies: separate host repository and same repository with a dedicated metadata branch (e.g. `main-metadata`)
- Includes comparison table to help users choose the right topology for their project
- Updated `docs/en/index.md` and `docs/ja/index.md` to reference the topology guidance and note that both layouts are fully supported

## Test plan

- [x] `git diff --check` passes (no whitespace errors)
- [x] Topology terms (`topology`, `metadata branch`, `main-metadata`) are discoverable in docs (20+ occurrences)
- [x] Both English and Japanese docs updated
- [x] AC verified: separate host repo and same-repo metadata branch both described, child implementation agents noted as GitHub-contract-only in both topologies

🤖 Generated with [Claude Code](https://claude.com/claude-code)