### PR TITLE
G418: Reframe docs around design-thread ask-intent-cli prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,16 @@ recover when a loop looks wrong — all through explicit, inspectable commands.
 
 ## Quickstart (public / OSS)
 
-New to `intent-cli`? Follow this path top to bottom. Every step has a
-`intent-cli ...` command that tells you what to do next, so you rarely need to
-memorize anything.
+New to `intent-cli`? The typical path is:
 
-1. [Install](#1-install)
-2. [Verify](#2-verify)
-3. [Ask intent-cli first](#3-ask-intent-cli-first) ← the core habit
-4. [Start a project](#4-start-a-project)
-5. [Organize intents](#5-organize-intents)
-6. [Create packets / publish GitHub issues](#6-create-packets--publish-github-issues)
-7. [Set up implementation & review loops](#7-set-up-implementation--review-loops)
-8. [Recover when a loop looks wrong](#8-recover-when-a-loop-looks-wrong)
+1. [Install](#1-install) — one-time setup.
+2. [Verify](#2-verify) — confirm `intent-cli` is on your PATH.
+3. [Open a design thread and paste a prompt](#3-open-a-design-thread-and-paste-a-prompt) — the AI agent does the rest.
+
+After install, you do not need to memorize `intent-cli` commands. Open a Claude,
+Codex, or Copilot-style chat with repository access and paste one of the
+[ready-made prompts](#design-thread-prompt-examples) below. The AI agent will
+run `intent-cli` internally and bring questions or results back to you.
 
 ### 1. Install
 
@@ -64,33 +62,109 @@ A released build prints just the version line. (OSS preview CI builds add a
 `channel=preview built=… commit=…` trailer — see
 [Preview install](#preview-install).)
 
-### 3. Ask intent-cli first
+### 3. Open a design thread and paste a prompt
 
-**This is the operating rule of the whole system.** Before you edit metadata,
-move a workflow label, hand-write a packet, or tweak an automation prompt — ask
-`intent-cli` for the current guidance and let it own the transition. Guessing at
-label/metadata behavior is the most common cause of broken automation; the CLI
-exists so you never have to guess.
+Open a capable AI coding agent (Claude, Codex, Copilot, etc.) with access to
+your repository. Paste one of the prompts below. The agent will run
+`intent-cli` commands internally and bring back questions or results — you
+focus on intent, priorities, and approval decisions.
 
-Copy-paste starting points:
+**Start or continue a project:**
+
+> I want to work on `<owner>/<repo>` with intent-cli.
+> Please run `intent-cli guide start` and `intent-cli intent status`, then
+> tell me which phase we're in and what I should decide next.
+
+**Design/clarify intents before cutting work:**
+
+> Ask intent-cli about the current design phase for `<owner>/<repo>` domain `<name>`.
+> Run `intent-cli guide workflow --format json` and `intent-cli interview next-question`.
+> Report back: what questions remain open and what is the recommended next action?
+
+**Create a packet and publish GitHub issues:**
+
+> For domain `<name>` in `<owner>/<repo>`, ask intent-cli to help me
+> scaffold the next packet and publish a reviewed Child Issue Contract.
+> Run `intent-cli guide workflow --format json`, then follow the packet
+> and issue-publish workflow. Apply all labels through intent-cli; never
+> hand-apply `intent-target`.
+
+**Start an implementation loop (child agent):**
+
+> Set up a child implementation loop for `<owner>/<repo>`.
+> Run `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`
+> and follow the guidance. Use `intent-cli worker` commands for all label
+> transitions; never run raw `gh ... edit --add-label`.
+
+**Start a review / next-slice loop (host agent):**
+
+> Set up the host review and next-slice loop for `<owner>/<repo>`.
+> Run `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`
+> and follow the guidance. Use `intent-cli automation` commands for all
+> host-side label transitions.
+
+**Recover when something looks wrong:**
+
+> Something looks wrong with `<owner>/<repo>`.
+> Run `intent-cli automation doctor --format json` and
+> `intent-cli worker issue-preflight --repo <owner>/<repo> --issue <n> --format json`.
+> Classify the gap and apply only the safe, in-scope repair intent-cli recommends.
+
+---
+
+## Command reference (agent-facing / power users)
+
+The commands below are what the AI agent runs on your behalf. You do not need
+to run them directly for routine use; they are documented here for transparency,
+advanced troubleshooting, and power-user automation.
+
+### Project setup
 
 ```bash
-# What can intent-cli do, and which command owns which transition?
-intent-cli guide help
-intent-cli guide commands list --format json
-
-# The exact step-by-step prompt for a given loop/role:
-intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>
-intent-cli guide oneshot --kind host-review-next-slice    --repo <owner>/<repo>
-
-# The provider-neutral automation/label contract for your domain:
-intent-cli automation summary --domain <domain> --format json
-
-# Any command's current flags:
-intent-cli <group> <command> --help
+intent-cli intent init --domain <name> [--target-repo <owner>/<repo>] --write
+intent-cli intent status
+intent-cli guide intent-work --format json
 ```
 
-Rules of thumb the docs and guidance enforce:
+### Design / intents
+
+```bash
+intent-cli interview next-question
+intent-cli interview record-answer ...
+intent-cli interview compile
+intent-cli guide workflow
+```
+
+### Packets / issues
+
+```bash
+intent-cli packet ...
+intent-cli issue validate-body ...
+intent-cli issue prepare ...
+intent-cli issue publish-reviewed ...
+```
+
+### Implementation & review loops
+
+```bash
+# Fetch the complete loop prompt for an AI agent:
+intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>
+intent-cli guide oneshot --kind host-review-next-slice    --repo <owner>/<repo>
+```
+
+Operator-dogfooding prompt templates that wire these loops entirely through the
+deterministic worker/metadata commands live under
+[`docs/automation-templates/`](./docs/automation-templates/README.md).
+
+### Recovery
+
+```bash
+intent-cli worker issue-preflight       --repo <owner>/<repo> --issue <n> --format json
+intent-cli worker pr-comment-preflight  --repo <owner>/<repo> --pr <n>    --format json
+intent-cli automation doctor --format json
+```
+
+### Rules of thumb
 
 - **Use `intent-cli` transition commands, not raw edits.** Do not directly edit
   queue-state, workflow labels, packet publish metadata, or other host artifacts
@@ -99,74 +173,9 @@ Rules of thumb the docs and guidance enforce:
   --add-label`.
 - **Ask, don't read-and-guess.** Prefer `intent-cli guide ...` over reading
   local rule files; the guidance reflects the installed CLI's current contract.
-- **Never ask `intent-cli` to launch an AI provider.** Drive work through
-  `intent-cli guide`, `worker`, and `automation` commands; these are the
-  supported chat-first workflow surfaces.
-
-### 4. Start a project
-
-Initialize a host domain and inspect its state (read-only without `--write`):
-
-```bash
-intent-cli intent init --domain <name> [--target-repo <owner>/<repo>] --write
-intent-cli intent status
-intent-cli guide intent-work --format json   # what the work surfaces expect
-```
-
-### 5. Organize intents
-
-Capture and compile durable intent before cutting work:
-
-```bash
-intent-cli interview next-question        # durable per-domain Q/A
-intent-cli interview record-answer ...
-intent-cli interview compile
-intent-cli guide workflow                 # suggested end-to-end flow
-```
-
-### 6. Create packets / publish GitHub issues
-
-Scaffold the canonical packet (read-only without `--write`) and publish a
-reviewed Child Issue Contract. The publish boundary applies host labels through
-`intent-cli` — you never hand-apply `intent-target`:
-
-```bash
-intent-cli packet ...                     # packet.yaml / implementation.md / review-context.md / github-body.md
-intent-cli issue validate-body ...        # enforce the Standalone Child Issue Contract
-intent-cli issue prepare ...
-intent-cli issue publish-reviewed ...     # reviewed-issue publish boundary
-```
-
-### 7. Set up implementation & review loops
-
-Two cooperating loops, each with a ready-made prompt from
-`intent-cli guide oneshot`:
-
-- **Child implementation loop** (`--kind child-implement-or-update`): selects one
-  GitHub target via `intent-cli worker next-action`, claims it, implements the
-  smallest change, opens a ready-for-review PR (with a mandatory
-  `Closes #<issue>` reference), and records the outcome via
-  `intent-cli worker result-summary` + `intent-cli worker complete`.
-- **Host review / next-slice loop** (`--kind host-review-next-slice`): reviews PRs
-  against the packet/intent contract, requests updates, approves/merges, and cuts
-  the next slice.
-
-Operator-dogfooding prompt templates that wire these loops entirely through the
-deterministic worker/metadata commands live under
-[`docs/automation-templates/`](./docs/automation-templates/README.md).
-
-### 8. Recover when a loop looks wrong
-
-Don't hand-fix state — ask the CLI to classify and (where safe) repair:
-
-```bash
-intent-cli worker issue-preflight       --repo <owner>/<repo> --issue <n> --format json
-intent-cli worker pr-comment-preflight  --repo <owner>/<repo> --pr <n>    --format json
-intent-cli automation doctor --format json      # CLI freshness / host-state resolution
-```
-
-These read-only surfaces tell you whether a safe, in-scope repair is available
-and which command owns it, instead of guessing.
+- **`intent-cli` does not launch AI providers.** It emits deterministic
+  guidance, validates contracts, and performs bounded GitHub/metadata
+  transitions. The AI agent stays in the driver's seat.
 
 ---
 

--- a/docs/en/02-project-start.md
+++ b/docs/en/02-project-start.md
@@ -1,12 +1,22 @@
 # Start a project
 
-> **Ask intent-cli first:** `intent-cli guide start` → then the
-> `design-and-intent` / project-start guidance it points at. ← [docs index](index.md)
+> ← [docs index](index.md)
 
-This is **host/design** work (you may touch metadata, but ask intent-cli for the
-current command before hand-editing it).
+This is **host/design** work. Paste the prompt below into your AI agent
+design thread; the agent will run the intent-cli commands and bring back
+questions or results.
 
-## Initialize and inspect
+## Design-thread prompt
+
+Paste this into your AI agent (Claude, Codex, Copilot, etc.):
+
+> I want to start or continue the project on `<owner>/<repo>`, domain `<name>`.
+> Please run `intent-cli guide start` and `intent-cli intent status` from the
+> host repo root. Tell me which phase I'm in and what decisions I need to make
+> next. Use intent-cli transitions for any label or metadata change — never
+> hand-edit files or apply GitHub labels directly.
+
+## What the agent will run (reference)
 
 ```bash
 # Initialize a host domain (read-only without --write)
@@ -18,13 +28,6 @@ intent-cli intent status
 # Ask what the work surfaces expect
 intent-cli guide intent-work --format json
 ```
-
-## Ask-intent-cli prompt template
-
-> Before starting on `<owner>/<repo>` domain `<name>`, run
-> `intent-cli guide start` and `intent-cli intent status`, then follow the
-> guide command for the phase I'm in. Use intent-cli transitions for any
-> label/metadata change; never hand-edit.
 
 ## Metadata / label safety
 

--- a/docs/en/05-implementation-loop.md
+++ b/docs/en/05-implementation-loop.md
@@ -1,7 +1,5 @@
 # Implementation loop setup
 
-> **Ask intent-cli first:** `intent-cli guide start` →
-> `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`.
 > ← [docs index](index.md)
 
 This is **child-implementation** work and is **GitHub-contract-only &
@@ -9,9 +7,18 @@ metadata-free**: the issue/PR and repo-local code are the only source of truth.
 Never read or mutate host `.intent-cli/`, queue-state, metadata branches, or
 `intents/**`.
 
-## The loop (one action per wake)
+## Design-thread prompt
 
-The oneshot prompt is authoritative; in outline:
+Paste this into your AI agent (Claude, Codex, Copilot, etc.):
+
+> Run the child implementation loop for `<owner>/<repo>` from this worktree.
+> Get the full loop prompt via:
+> `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`
+> and follow it exactly. Select work only via `intent-cli worker next-action`;
+> process at most one action per wake. All label transitions go through
+> `intent-cli worker` — never raw `gh ... --add-label`.
+
+## What the agent will run (reference)
 
 ```bash
 # 1. Select exactly one target (no manual label-walking)
@@ -26,13 +33,6 @@ intent-cli worker complete --kind issue --number <n> --repo <owner>/<repo> --git
 
 `pr-comment-fix` targets follow the same claim → repair → result-summary →
 complete shape on the existing PR branch.
-
-## Ask-intent-cli prompt template
-
-> Run the child implementation loop for `<owner>/<repo>` from this worktree.
-> Get the prompt via `intent-cli guide oneshot --kind child-implement-or-update`.
-> Select work only via `intent-cli worker next-action`; process at most one
-> action; all label transitions through intent-cli worker, never raw `gh`.
 
 ## Metadata / label safety
 

--- a/docs/en/06-review-next-slice-loop.md
+++ b/docs/en/06-review-next-slice-loop.md
@@ -1,12 +1,23 @@
 # Review / next-slice loop setup
 
-> **Ask intent-cli first:** `intent-cli guide start` →
-> `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`.
 > ← [docs index](index.md)
 
 This is **host/review** work. It reviews PRs against the packet/intent contract,
 requests updates, approves/merges, and cuts the next slice. It may operate on
 host metadata, but always via `intent-cli`-supported transitions.
+
+## Design-thread prompt
+
+Paste this into your AI agent (Claude, Codex, Copilot, etc.):
+
+> Run the host review / next-slice loop for domain `<name>` / `<owner>/<repo>`.
+> Get the full loop prompt via:
+> `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`
+> and follow it exactly. Apply every label transition via `intent-cli automation`
+> — never hand-apply labels. Tie approvals to packet/intent evidence, not just
+> green tests.
+
+## What the agent will run (reference)
 
 ```bash
 # Get the authoritative review/next-slice prompt
@@ -18,14 +29,6 @@ intent-cli guide review --pr <n> --repo <owner>/<repo> --format json
 # Label transitions (review-start, request-update, approve, …) — never by hand
 intent-cli automation pr-transition --transition <name> --write --format json
 ```
-
-## Ask-intent-cli prompt template
-
-> Run the host review / next-slice loop for domain `<name>` / `<owner>/<repo>`.
-> Use `intent-cli guide oneshot --kind host-review-next-slice` and
-> `intent-cli guide review --pr <n>`. Apply every label transition via
-> `intent-cli automation`, and tie approvals to packet/intent evidence, not just
-> green tests.
 
 ## Metadata / label safety
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -7,19 +7,33 @@ development workflow on top of GitHub. These pages give a little more structure
 than the [root README](../../README.md) without requiring you to read the
 internal design notes.
 
-## The one rule: ask intent-cli first
+## How to use intent-cli
 
-Before any intent / packet / issue / review / implementation-loop work, run:
+`intent-cli` is designed to be driven by an AI agent — Claude, Codex,
+Copilot, or any capable coding assistant with repository access. You do not
+need to memorize or run its commands directly.
 
-```bash
-intent-cli guide start
-```
+**The typical human path:**
 
-It points you at the exact `intent-cli guide …` command for your phase. Don't
-start from memory, copied prompts, or ordinary GitHub habits, and don't
-hand-edit metadata or labels when an `intent-cli` command owns the transition.
-Every page below repeats this rule because it is the difference between a smooth
-loop and a broken one.
+1. Install `intent-cli` and verify with `intent-cli --version`.
+2. Open a design thread in your AI agent.
+3. Paste a prompt such as:
+
+> Ask intent-cli what phase I'm in for `<owner>/<repo>` domain `<name>`.
+> Run `intent-cli guide start` and `intent-cli intent status`, then tell me
+> what I should decide next.
+
+The agent runs `intent-cli` internally and brings back questions or results.
+You focus on intent, priorities, and approval decisions — not on memorizing
+command sequences.
+
+**The one rule behind the prompts:** before any label/metadata change, the AI
+agent should run the appropriate `intent-cli` command rather than editing files
+or applying GitHub labels by hand. Every guide and automation page below
+enforces this rule.
+
+See the [README command reference](../../README.md#command-reference-agent-facing--power-users)
+for the full list of commands the agent will use on your behalf.
 
 ## Pages
 

--- a/docs/ja/02-project-start.md
+++ b/docs/ja/02-project-start.md
@@ -1,12 +1,21 @@
 # プロジェクト開始
 
-> **まず intent-cli に聞く:** `intent-cli guide start` → 案内される
-> `design-and-intent` / プロジェクト開始ガイド。 ← [ドキュメント索引](index.md)
+> ← [ドキュメント索引](index.md)
 
-これは **host/design** 作業（metadata を触ってよいが、手編集の前に intent-cli へ
-現在のコマンドを尋ねる）。
+これは **host/design** 作業です。以下のプロンプトを AI agent のデザインスレッドに
+貼り付けてください。agent が intent-cli コマンドを実行し、質問や結果を返します。
 
-## 初期化と確認
+## デザインスレッドプロンプト
+
+AI agent（Claude、Codex、Copilot など）に貼り付けてください:
+
+> `<owner>/<repo>` の domain `<name>` のプロジェクトを開始または継続したいです。
+> host リポジトリのルートから `intent-cli guide start` と `intent-cli intent status`
+> を実行してください。現在のフェーズと、私が次に決断すべきことを教えてください。
+> label や metadata の変更は intent-cli の遷移を使い、ファイルを手編集したり
+> GitHub label を直接適用したりしないでください。
+
+## agent が実行するコマンド（リファレンス）
 
 ```bash
 # host domain を初期化（--write なしは read-only）
@@ -18,12 +27,6 @@ intent-cli intent status
 # 作業サーフェスが期待する内容を尋ねる
 intent-cli guide intent-work --format json
 ```
-
-## ask-intent-cli プロンプトテンプレート
-
-> `<owner>/<repo>` の domain `<name>` を始める前に、`intent-cli guide start` と
-> `intent-cli intent status` を実行し、フェーズに対応する guide コマンドに従う。
-> label/metadata の変更は intent-cli の遷移を使い、手編集しない。
 
 ## metadata / label の安全境界
 

--- a/docs/ja/05-implementation-loop.md
+++ b/docs/ja/05-implementation-loop.md
@@ -1,7 +1,5 @@
 # 実装ループの設定
 
-> **まず intent-cli に聞く:** `intent-cli guide start` →
-> `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`。
 > ← [ドキュメント索引](index.md)
 
 これは **child-implementation** 作業で、**GitHub-contract-only かつ
@@ -9,9 +7,17 @@ metadata-free**: issue/PR と repo ローカルのコードのみが source of t
 host の `.intent-cli/`、queue-state、metadata branch、`intents/**` を読んだり
 変更したりしない。
 
-## ループ（1 wake で 1 アクション）
+## デザインスレッドプロンプト
 
-oneshot prompt が正本。概要:
+AI agent（Claude、Codex、Copilot など）に貼り付けてください:
+
+> このワークツリーから `<owner>/<repo>` の child implementation ループを回してください。
+> まず以下を実行してフルループの prompt を取得し、そのとおりに従ってください:
+> `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`
+> 作業の選択は `intent-cli worker next-action` のみ。1 wake で最大 1 アクション。
+> label 遷移はすべて `intent-cli worker` 経由で — raw `gh ... --add-label` は使わない。
+
+## agent が実行するコマンド（リファレンス）
 
 ```bash
 # 1. 対象を 1 つだけ選ぶ（手動の label-walking はしない）
@@ -26,13 +32,6 @@ intent-cli worker complete --kind issue --number <n> --repo <owner>/<repo> --git
 
 `pr-comment-fix` の対象も、既存 PR ブランチ上で claim → 修正 → result-summary →
 complete という同じ形に従う。
-
-## ask-intent-cli プロンプトテンプレート
-
-> このワークツリーから `<owner>/<repo>` の child implementation ループを回す。
-> prompt は `intent-cli guide oneshot --kind child-implement-or-update` で取得。
-> 作業の選択は `intent-cli worker next-action` のみ。1 wake で最大 1 アクション。
-> label 遷移はすべて intent-cli worker 経由で、raw `gh` は使わない。
 
 ## metadata / label の安全境界
 

--- a/docs/ja/06-review-next-slice-loop.md
+++ b/docs/ja/06-review-next-slice-loop.md
@@ -1,12 +1,22 @@
 # レビュー / next-slice ループの設定
 
-> **まず intent-cli に聞く:** `intent-cli guide start` →
-> `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`。
 > ← [ドキュメント索引](index.md)
 
 これは **host/review** 作業。PR を packet/intent 契約に照らしてレビューし、更新を
 要求し、approve/merge し、next slice を切り出す。host metadata を扱ってよいが、
 常に `intent-cli` がサポートする遷移を使う。
+
+## デザインスレッドプロンプト
+
+AI agent（Claude、Codex、Copilot など）に貼り付けてください:
+
+> domain `<name>` / `<owner>/<repo>` の host review / next-slice ループを回してください。
+> まず以下を実行してフルループの prompt を取得し、そのとおりに従ってください:
+> `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`
+> label 遷移はすべて `intent-cli automation` 経由で行い、手動で label を付けないでください。
+> approve は green テストだけでなく packet/intent の証跡に紐づけてください。
+
+## agent が実行するコマンド（リファレンス）
 
 ```bash
 # レビュー / next-slice の正本 prompt を取得
@@ -18,14 +28,6 @@ intent-cli guide review --pr <n> --repo <owner>/<repo> --format json
 # label 遷移（review-start、request-update、approve …）— 手作業では行わない
 intent-cli automation pr-transition --transition <name> --write --format json
 ```
-
-## ask-intent-cli プロンプトテンプレート
-
-> domain `<name>` / `<owner>/<repo>` の host review / next-slice ループを回す。
-> `intent-cli guide oneshot --kind host-review-next-slice` と
-> `intent-cli guide review --pr <n>` を使う。label 遷移はすべて
-> `intent-cli automation` 経由で、approve は green テストだけでなく
-> packet/intent の証跡に紐づける。
 
 ## metadata / label の安全境界
 

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -6,18 +6,34 @@
 **決定論的なサポートツール** です。これらのページは、内部設計ノートを全部読まなくても
 [ルート README](../../README.md) より少しだけ構造化された案内を提供します。
 
-## 唯一のルール: まず intent-cli に聞く
+## intent-cli の使い方
 
-intent / packet / issue / review / implementation-loop の作業を始める前に、まず実行する:
+`intent-cli` は AI agent — Claude、Codex、Copilot など、リポジトリアクセスを持つ
+有能なコーディングアシスタント — に動かしてもらうことを前提に設計されています。
+コマンドを自分で記憶・実行する必要はありません。
 
-```bash
-intent-cli guide start
-```
+**人間の典型的な操作手順:**
 
-現在のフェーズに対応する `intent-cli guide …` コマンドを案内してくれます。記憶や
-コピーした prompt、通常の GitHub 操作の感覚から始めない。`intent-cli` のコマンドが
-遷移を所有している label / metadata は手編集しない。以下の各ページがこのルールを
-繰り返すのは、これがループの成否を分けるからです。
+1. `intent-cli` をインストールし、`intent-cli --version` で確認する。
+2. AI agent のデザインスレッドを開く。
+3. 次のようなプロンプトを貼り付ける:
+
+> `<owner>/<repo>` の domain `<name>` について、intent-cli に現在のフェーズを
+> 聞いてください。`intent-cli guide start` と `intent-cli intent status` を実行し、
+> 次に私が決断すべきことを教えてください。
+
+agent が内部で `intent-cli` を実行し、質問や結果を返します。
+あなたは意図・優先度・承認の判断に集中するだけです。コマンドシーケンスを
+記憶する必要はありません。
+
+**プロンプトの背後にある唯一のルール:** label/metadata を変更する前に、AI agent は
+ファイルを手編集したり GitHub label を手動で適用したりするのではなく、適切な
+`intent-cli` コマンドを実行すべきです。以下のすべてのガイドと自動化ページが
+このルールを強制しています。
+
+agent が代わりに使うコマンドの全リストは
+[README コマンドリファレンス](../../README.md#command-reference-agent-facing--power-users)
+を参照してください。
 
 ## ページ一覧
 

--- a/src/IntentSystem.Cli/Commands/GuideStartCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideStartCommand.cs
@@ -74,8 +74,9 @@ internal static class GuideStartCommand
                     + "`intent-cli worker` command owns that transition.",
                 "Detailed, drift-prone rules stay in intent-cli guidance output — not copied into repo files or "
                     + "agent prompts. Re-ask the guide command when you resume work; it reflects the installed CLI.",
-                "intent-cli never launches Claude, Codex, or any AI provider, and `intent-cli run` is not the "
-                    + "production orchestrator.",
+                "You can ask an AI agent (Claude, Codex, Copilot, etc.) to run intent-cli commands on your behalf "
+                    + "— intent-cli is deterministic, provider-free tooling the agent invokes internally; it does not "
+                    + "launch AI providers itself. `intent-cli run` is not the production orchestrator.",
             },
             WorkflowPhases = new[]
             {
@@ -159,8 +160,10 @@ internal static class GuideStartCommand
                     "Stand up a new host project / domain with `intent-cli guide workflow task init-host --format json`; "
                     + "for the zero-local-rules first-call sequence run `intent-cli guide onboarding --format json`.",
                 AskIntentCliFirst =
-                    "After install, ask intent-cli — not memory or copied prompts — for each next step: re-run "
-                    + "`intent-cli guide start` whenever you resume, and use the per-phase guide command it points at.",
+                    "After install, ask intent-cli for each next step — either by pasting a design-thread prompt "
+                    + "to an AI agent (Claude, Codex, Copilot, etc.) that runs intent-cli internally, or by running "
+                    + "`intent-cli guide start` yourself. Either way: re-ask the per-phase guide command when you resume; "
+                    + "it reflects the installed CLI, not memory or copied prompts.",
             },
             AskIntentCliTemplates = new[]
             {

--- a/tests/IntentSystem.Cli.Tests/GuideStartCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideStartCommandTests.cs
@@ -223,6 +223,46 @@ public sealed class GuideStartCommandTests
     }
 
     [Fact]
+    public void Execute_Json_GuideFirstRuleStatesUserCanAskAiAgentToRunIntentCli()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var rules = document.RootElement.GetProperty("guide_first_rule").EnumerateArray()
+            .Select(r => r.GetString()!)
+            .ToArray();
+
+        // G418 AC#4: help/guide wording says user can ask an AI agent to run intent-cli,
+        // while intent-cli remains deterministic tooling and does not launch providers.
+        var designThreadRule = rules.FirstOrDefault(r =>
+            r.Contains("AI agent", StringComparison.OrdinalIgnoreCase) &&
+            r.Contains("intent-cli", StringComparison.Ordinal));
+        Assert.NotNull(designThreadRule);
+        Assert.Contains("does not launch AI providers", designThreadRule, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("deterministic", designThreadRule, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Json_OnboardingGuidanceDescribesDesignThreadPath()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideStartCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var askFirst = document.RootElement
+            .GetProperty("onboarding_guidance")
+            .GetProperty("ask_intent_cli_first")
+            .GetString()!;
+
+        // G418 AC#4: onboarding says user can use an AI agent that runs intent-cli internally.
+        Assert.Contains("AI agent", askFirst, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli guide start", askFirst, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownArgument_ReturnsUsageError()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
Closes #937

## Summary

- Rewrote README Quickstart so the primary beginner path is: install → `intent-cli --version` → paste a design-thread prompt into an AI agent
- Moved all `intent-cli` command sequences to a **"Command reference (agent-facing / power users)"** section — reference-only, not required beginner steps
- Updated `docs/en/index.md` and `docs/ja/index.md` with a "How to use intent-cli" section explaining the design-thread model
- Added paste-ready design-thread prompts to `docs/en/02-project-start.md`, `docs/ja/02-project-start.md`, `docs/en/05-implementation-loop.md`, `docs/ja/05-implementation-loop.md`, `docs/en/06-review-next-slice-loop.md`, `docs/ja/06-review-next-slice-loop.md`
- Renamed "Ask-intent-cli prompt template" sections to "Design-thread prompt" (human-facing) and "What the agent will run" (reference)

## Test plan

- [x] `git diff --check` passes
- [x] README contains no required direct `intent-cli` command steps beyond `intent-cli --version` in the beginner path
- [x] All changed docs include paste-ready design-thread prompts in both English and Japanese
- [x] Command references are preserved as agent-facing/power-user sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)