### PR TITLE
G419: Add J-Tech Japan Discord community link to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,16 @@ This ensures the next main-branch CI build immediately produces
 
 ---
 
+## Community
+
+Join the [J-Tech Japan Discord](https://discord.gg/kMdv978X) for community
+discussion, questions, and lightweight support. Discord is for general chat;
+for reproducible bugs or actionable feature requests, please open a
+[GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) instead.
+Security-sensitive reports go to [SECURITY.md](./SECURITY.md), not Discord.
+
+---
+
 ## License
 
 This project is licensed under the Apache License, Version 2.0 — see the

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -23,10 +23,14 @@ that failed.
 Open a GitHub issue using the **Feature Request** template. Describe the
 problem you are trying to solve.
 
-## Questions
+## Questions and community discussion
 
-For general questions, open a GitHub Discussion or a GitHub issue with the
-question label.
+For general questions, join the [J-Tech Japan Discord](https://discord.gg/kMdv978X)
+for community discussion and lightweight support, or open a GitHub Discussion.
+Discord is not a formal support channel and carries no SLA.
+
+Reproducible bugs and actionable feature requests should still be filed as
+GitHub issues, not Discord messages.
 
 ## Security issues
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -61,3 +61,10 @@ The host can live in a **separate host repository** or in the **same repository
 on a dedicated metadata branch** (e.g. `main-metadata`). Both topologies are
 fully supported. See [Start a project → Repository topology choices](02-project-start.md#repository-topology-choices)
 for guidance on which to choose.
+
+## Community
+
+Join the [J-Tech Japan Discord](https://discord.gg/kMdv978X) for community
+discussion and questions. For bugs or actionable feature requests, open a
+[GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) instead.
+Security reports go to [SECURITY.md](../../SECURITY.md), not Discord.

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -61,3 +61,12 @@ host は **別の host リポジトリ** に置くこともできますし、**�
 （例: `main-metadata`）に置くこともできます。どちらのトポロジーも完全にサポートされています。
 どちらを選ぶかは [プロジェクト開始 → リポジトリトポロジーの選択](02-project-start.md#リポジトリトポロジーの選択)
 を参照してください。
+
+## コミュニティ
+
+コミュニティのディスカッションや質問には [J-Tech Japan Discord](https://discord.gg/kMdv978X)
+にご参加ください。Discord はカジュアルなサポート窓口であり、正式なサポート SLA はありません。
+
+再現可能なバグやアクションにつながる機能要望は Discord ではなく
+[GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) として報告してください。
+セキュリティに関する報告は Discord ではなく [SECURITY.md](../../SECURITY.md) へ。


### PR DESCRIPTION
Closes #939

## Summary

- Added J-Tech Japan Discord community link (`https://discord.gg/kMdv978X`) to `README.md`, `SUPPORT.md`, `docs/en/index.md`, and `docs/ja/index.md`
- Discord is scoped to community discussion; security reports remain directed to `SECURITY.md` and bugs to GitHub issues
- No SLA or private support implied in the wording

## Changes

- `README.md`: New `## Community` section before `## License`
- `SUPPORT.md`: Updated `## Questions` to `## Questions and community discussion` with Discord link
- `docs/en/index.md`: New `## Community` section at end of page
- `docs/ja/index.md`: New `## コミュニティ` section at end of page