### PR TITLE
G420: Put Japanese docs and Japanese-first guidance near the top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ recover when a loop looks wrong — all through explicit, inspectable commands.
 - License: [Apache-2.0](#license)
 - Repository: <https://github.com/J-Tech-Japan/intent-system>
 
+**ドキュメント / Documentation:**
+[日本語](./docs/ja/index.md) | [English](./docs/en/index.md)
+
+> **はじめての方へ:** インストール後、`intent-cli --version` で動作確認し、
+> Claude・Codex・Copilot などの AI エージェントのチャットで
+> `intent-cli に聞いて...` と伝えるだけで始められます。
+> 詳しくは[日本語ドキュメント](./docs/ja/index.md)をご覧ください。
+
 ---
 
 ## Quickstart (public / OSS)


### PR DESCRIPTION
Closes #941

## Summary

- Added bilingual documentation section near the top of `README.md` (after package info, before first `---` separator)
- Japanese users arriving from GitHub or NuGet now immediately see links to `docs/ja/index.md` and `docs/en/index.md`
- Includes Japanese-language note: install → `intent-cli --version` → ask AI agent with `intent-cli に聞いて...`
- README remains valid as NuGet `PackageReadmeFile` content

## Changes

- `README.md`: Added 8 lines — bilingual docs links and Japanese onboarding note