### PR TITLE
G422: Simplify README and move command/developer reference to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,41 +24,22 @@ recover when a loop looks wrong — all through explicit, inspectable commands.
 
 ---
 
-## Quickstart (public / OSS)
-
-New to `intent-cli`? The typical path is:
-
-1. [Install](#1-install) — one-time setup.
-2. [Verify](#2-verify) — confirm `intent-cli` is on your PATH.
-3. [Open a design thread and paste a prompt](#3-open-a-design-thread-and-paste-a-prompt) — the AI agent does the rest.
-
-After install, you do not need to memorize `intent-cli` commands. Open a Claude,
-Codex, or Copilot-style chat with repository access and paste one of the
-[ready-made prompts](#design-thread-prompt-examples) below. The AI agent will
-run `intent-cli` internally and bring questions or results back to you.
+## Quickstart
 
 ### 1. Install
 
-The basic path is the .NET global tool from NuGet.org. You need a **.NET 10
-SDK** (`dotnet --version` should report `10.x`).
-
-**macOS, Windows, and Linux (same commands):**
+You need a **.NET 10 SDK** (`dotnet --version` should report `10.x`).
 
 ```bash
-# Install (NuGet package id: JTechJapan.IntentSystem.Cli; command: intent-cli)
 dotnet tool install -g JTechJapan.IntentSystem.Cli
-
-# Later, upgrade in place
-dotnet tool update -g JTechJapan.IntentSystem.Cli
 ```
 
-If the global tools directory is not yet on your `PATH`, the `dotnet tool
-install` output prints the exact line to add (commonly `~/.dotnet/tools` on
-macOS/Linux, `%USERPROFILE%\.dotnet\tools` on Windows).
+If `intent-cli` is not found after install, add `~/.dotnet/tools` (macOS/Linux)
+or `%USERPROFILE%\.dotnet\tools` (Windows) to your `PATH`.
 
-> No .NET SDK? Use the self-contained binary instead — see
-> [Install without a .NET SDK](#install-without-a-net-sdk). Need the preview
-> channel? See [Preview install](#preview-install).
+> No .NET SDK? See **[Install without a .NET SDK](./docs/en/01-install.md#install-without-a-net-sdk)**
+> for self-contained binaries. Need the preview channel? See the
+> **[developer reference](./docs/en/09-developer-reference.md#preview-install)**.
 
 ### 2. Verify
 
@@ -66,16 +47,10 @@ macOS/Linux, `%USERPROFILE%\.dotnet\tools` on Windows).
 intent-cli --version
 ```
 
-A released build prints just the version line. (OSS preview CI builds add a
-`channel=preview built=… commit=…` trailer — see
-[Preview install](#preview-install).)
+### 3. Ask an AI agent
 
-### 3. Open a design thread and paste a prompt
-
-Open a capable AI coding agent (Claude, Codex, Copilot, etc.) with access to
-your repository. Paste one of the prompts below. The agent will run
-`intent-cli` commands internally and bring back questions or results — you
-focus on intent, priorities, and approval decisions.
+Open Claude, Codex, Copilot, or another coding assistant with access to your
+repository and paste one of these prompts:
 
 **Start or continue a project:**
 
@@ -83,329 +58,26 @@ focus on intent, priorities, and approval decisions.
 > Please run `intent-cli guide start` and `intent-cli intent status`, then
 > tell me which phase we're in and what I should decide next.
 
-**Design/clarify intents before cutting work:**
-
-> Ask intent-cli about the current design phase for `<owner>/<repo>` domain `<name>`.
-> Run `intent-cli guide workflow --format json` and `intent-cli interview next-question`.
-> Report back: what questions remain open and what is the recommended next action?
-
-**Create a packet and publish GitHub issues:**
-
-> For domain `<name>` in `<owner>/<repo>`, ask intent-cli to help me
-> scaffold the next packet and publish a reviewed Child Issue Contract.
-> Run `intent-cli guide workflow --format json`, then follow the packet
-> and issue-publish workflow. Apply all labels through intent-cli; never
-> hand-apply `intent-target`.
-
-**Start an implementation loop (child agent):**
+**Start an implementation loop:**
 
 > Set up a child implementation loop for `<owner>/<repo>`.
 > Run `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`
-> and follow the guidance. Use `intent-cli worker` commands for all label
-> transitions; never run raw `gh ... edit --add-label`.
+> and follow the guidance.
 
-**Start a review / next-slice loop (host agent):**
-
-> Set up the host review and next-slice loop for `<owner>/<repo>`.
-> Run `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`
-> and follow the guidance. Use `intent-cli automation` commands for all
-> host-side label transitions.
-
-**Recover when something looks wrong:**
-
-> Something looks wrong with `<owner>/<repo>`.
-> Run `intent-cli automation doctor --format json` and
-> `intent-cli worker issue-preflight --repo <owner>/<repo> --issue <n> --format json`.
-> Classify the gap and apply only the safe, in-scope repair intent-cli recommends.
-
----
-
-## Command reference (agent-facing / power users)
-
-The commands below are what the AI agent runs on your behalf. You do not need
-to run them directly for routine use; they are documented here for transparency,
-advanced troubleshooting, and power-user automation.
-
-### Project setup
-
-```bash
-intent-cli intent init --domain <name> [--target-repo <owner>/<repo>] --write
-intent-cli intent status
-intent-cli guide intent-work --format json
-```
-
-### Design / intents
-
-```bash
-intent-cli interview next-question
-intent-cli interview record-answer ...
-intent-cli interview compile
-intent-cli guide workflow
-```
-
-### Packets / issues
-
-```bash
-intent-cli packet ...
-intent-cli issue validate-body ...
-intent-cli issue prepare ...
-intent-cli issue publish-reviewed ...
-```
-
-### Implementation & review loops
-
-```bash
-# Fetch the complete loop prompt for an AI agent:
-intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>
-intent-cli guide oneshot --kind host-review-next-slice    --repo <owner>/<repo>
-```
-
-Operator-dogfooding prompt templates that wire these loops entirely through the
-deterministic worker/metadata commands live under
-[`docs/automation-templates/`](./docs/automation-templates/README.md).
-
-### Recovery
-
-```bash
-intent-cli worker issue-preflight       --repo <owner>/<repo> --issue <n> --format json
-intent-cli worker pr-comment-preflight  --repo <owner>/<repo> --pr <n>    --format json
-intent-cli automation doctor --format json
-```
-
-### Rules of thumb
-
-- **Use `intent-cli` transition commands, not raw edits.** Do not directly edit
-  queue-state, workflow labels, packet publish metadata, or other host artifacts
-  when an `intent-cli automation` / `intent-cli worker` command owns that
-  transition. Apply labels through those commands, never `gh ... edit
-  --add-label`.
-- **Ask, don't read-and-guess.** Prefer `intent-cli guide ...` over reading
-  local rule files; the guidance reflects the installed CLI's current contract.
-- **`intent-cli` does not launch AI providers.** It emits deterministic
-  guidance, validates contracts, and performs bounded GitHub/metadata
-  transitions. The AI agent stays in the driver's seat.
-
----
-
-## Host agents vs. child implementation agents
-
-The workflow distinguishes two agent roles, and the docs/guidance keep them
-separate on purpose:
-
-| Agent | Source of truth | Owns |
-| --- | --- | --- |
-| **Host / review agent** | parent host `.intent-cli/` state + intent tree | publishing issues, applying `intent-target`, review/approve/merge, next-slice planning, label transitions via `intent-cli automation` |
-| **Child implementation agent** | the **GitHub issue/PR + repo-local code** (NOT host metadata) | implementing the issue contract, opening/updating the PR, recording outcomes via `intent-cli worker` |
-
-Child implementation agents operate GitHub-contract-only: they must not read or
-mutate the parent host's queue-state, runs logs, packet directories, or intent
-tree, and they treat the GitHub issue body as the standalone contract.
-
----
-
-## Install without a .NET SDK
-
-Each [GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/latest)
-attaches SDK-free, self-contained binaries (the .NET runtime is bundled, so no
-SDK is required).
-
-| Platform | Asset |
-| --- | --- |
-| macOS (Apple Silicon) | `intent-cli-<version>-osx-arm64.tar.gz` |
-| Windows (x64) | `intent-cli-<version>-win-x64.zip` |
-| Linux (x64) | `intent-cli-<version>-linux-x64.tar.gz` |
-
-Each archive ships with a `.sha256` sidecar; download both files into the same
-directory and verify before use.
-
-**macOS:**
-
-```bash
-# 1. Verify (run from the folder containing both files).
-shasum -a 256 -c intent-cli-<version>-osx-arm64.tar.gz.sha256
-
-# 2. Extract and place the binary on your PATH.
-tar -xzf intent-cli-<version>-osx-arm64.tar.gz
-chmod +x intent-cli
-sudo mv intent-cli /usr/local/bin/
-
-# 3. Confirm.
-intent-cli --version
-```
-
-**Linux:**
-
-```bash
-# 1. Verify (run from the folder containing both files).
-sha256sum -c intent-cli-<version>-linux-x64.tar.gz.sha256
-
-# 2. Extract and place the binary on your PATH.
-tar -xzf intent-cli-<version>-linux-x64.tar.gz
-chmod +x intent-cli
-sudo mv intent-cli /usr/local/bin/
-
-# 3. Confirm.
-intent-cli --version
-```
-
-**Windows:** Download `intent-cli-<version>-win-x64.zip` and its `.sha256` sidecar.
-Compare the hash from `CertUtil -hashfile intent-cli-<version>-win-x64.zip SHA256`
-against the first field in the `.sha256` file, unzip, and place `intent-cli.exe`
-on your `PATH`.
-
-Release binaries and OSS preview CI artifacts carry no build-time expiry.
+The agent runs `intent-cli` commands internally and brings back questions or
+results. You focus on intent, priorities, and approval decisions.
 
 ---
 
 ## Documentation
 
-- Bilingual onboarding docs (installation, project start, intent organization,
-  packet/issue creation, implementation & review loop setup, recovery) —
-  **English: [`docs/en/`](./docs/en/index.md)**, **日本語: [`docs/ja/`](./docs/ja/index.md)**.
-- Local coding-automation prompt templates:
-  [`docs/automation-templates/`](./docs/automation-templates/README.md).
-
----
-
-## Packaged invocation (local smoke)
-
-The CLI is packaged as a .NET tool (package id `JTechJapan.IntentSystem.Cli`,
-command `intent-cli`). To smoke-test a locally built package:
-
-```bash
-export INTENT_CLI_LOCAL_VERSION="0.3.1-local.$(date -u +%Y%m%d%H%M%S)"
-dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
-  -p:Version="$INTENT_CLI_LOCAL_VERSION" \
-  -o .artifacts/packages
-mkdir -p .artifacts/smoke-repo/.intent-cli
-cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'
-default_domain = "intent-cli"
-artifact_root = ".intent-cli"
-worktree_root = ".intent-cli/worktrees"
-EOF
-(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" JTechJapan.IntentSystem.Cli project status)
-```
-
-Equivalent `dnx` path:
-
-```bash
-(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" JTechJapan.IntentSystem.Cli project status)
-```
-
----
-
-## CLI command roles
-
-The accepted production automation boundary lives in the parent host-side
-review/next-slice loop, which uses provider-neutral GitHub labels
-(`intent-target`, `intent-pr-reviewing`, `intent-pr-request-update`, etc.),
-durable parent state, and explicit handoff artifacts. The child CLI is a tasking
-companion to that loop, not a replacement.
-
-| Surface | Role |
-|---------|------|
-| `intent-cli guide …` | Ask-first guidance: command roles, oneshot prompts, review/worker/workflow help |
-| `intent-cli status brief` / `context collect` | Compact / richer AI-thread inputs |
-| `intent-cli clarify draft` / `clarify record` | Owner clarification flow |
-| `intent-cli issue validate-body` | Standalone Child Issue Contract enforcement |
-| `intent-cli issue prepare` / `issue publish-reviewed` | Reviewed issue body publish boundary (never applies `intent-target`) |
-| `intent-cli worker next-action` / `claim` / `result-summary` / `complete` | Child implementation loop selector + bounded label transitions |
-| `intent-cli automation summary` | Provider-neutral label-driven automation contract emitter |
-| `intent-cli safety nested-provider-handoff` | Artifact-only nested-provider safety guard (never spawns providers) |
-
-For ongoing production automation, drive work through the host-side
-review/next-slice loop and the provider-neutral label set described by
-`intent-cli automation summary`. For nested-provider handoff steps, use
-`intent-cli safety nested-provider-handoff` to emit a deterministic artifact.
-
----
-
-## Preview install
-
-> OSS preview channel. Public users should use the
-> [Quickstart install](#1-install) (stable NuGet) or a
-> [Release binary](#release-binary) above. This section is for users who want
-> the latest merged changes before a stable release.
-
-The `preview-pack` GitHub Actions workflow runs on every merge to `main` and
-uploads a self-contained install bundle as a workflow artifact named
-`intent-cli-preview-<version>`. The bundle contains:
-
-| File | Purpose |
-| --- | --- |
-| `JTechJapan.IntentSystem.Cli.<version>.nupkg` | The NuGet package consumed by `dotnet tool install`. |
-| `JTechJapan.IntentSystem.Cli.<version>.nupkg.sha256` | SHA-256 checksum sidecar; verify before installing. |
-| `preview-metadata.json` | Machine-readable build provenance (channel, version, build timestamp, commit, CI run identifiers). |
-| `INSTALL.md` | Per-build install / update / verify / uninstall guide with this build's exact version and commit pre-filled. |
-
-The package version pattern is `<nextVersion>-preview.<run_number>.<run_attempt>`
-(e.g. `0.3.1-preview.42.1`), where `nextVersion` comes from `eng/version.json`.
-Every CI run produces a distinct version. No PAT, source checkout, or public
-NuGet feed is required — only a compatible .NET SDK / runtime and the unzipped
-bundle. **OSS preview packages carry no expiry; they remain runnable indefinitely.**
-
-```bash
-# 1. Download and unzip the workflow artifact, then cd into it.
-cd ./intent-cli-preview-0.3.1-preview.42.1
-
-# 2. Verify the checksum (macOS: shasum; Linux: sha256sum). Prints
-#    `JTechJapan.IntentSystem.Cli.<version>.nupkg: OK` on success. Do not install if it fails.
-shasum -a 256 -c JTechJapan.IntentSystem.Cli.*.nupkg.sha256
-
-# 3. Install (or update) the .NET tool from this local folder:
-dotnet tool install --global --add-source . \
-  --version 0.3.1-preview.42.1 JTechJapan.IntentSystem.Cli
-# Upgrade-in-place:
-dotnet tool update --global --add-source . \
-  --version 0.3.1-preview.42.1 JTechJapan.IntentSystem.Cli
-
-# Uninstall:
-dotnet tool uninstall --global JTechJapan.IntentSystem.Cli
-```
-
-The installed binary exposes the preview metadata via `intent-cli --version`:
-
-```text
-intent-cli 0.3.1-preview.42.1-<short-sha>-G<unit>
-channel=preview built=<iso-utc> commit=<full-sha>
-```
-
-The `channel=preview` trailer confirms the embedded preview metadata loaded
-successfully. Source builds (`dotnet pack` without the CI properties) produce no
-trailer and remain unrestricted.
-
----
-
-## Version flow
-
-The repository version policy lives in `eng/version.json`:
-
-```json
-{
-  "stableVersion": "0.3.0",
-  "nextVersion": "0.3.1"
-}
-```
-
-| Stage | Version form | How it is derived |
-| --- | --- | --- |
-| Main CI preview | `0.3.1-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.1-rc.N` | Tag `v0.3.1-rc.N` triggers release workflow |
-| Stable release | `0.3.1` | Tag `v0.3.1` triggers release workflow |
-| Post-release main builds | `0.4.0-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.4.0` |
-
-**After releasing `v0.3.1`**, bump both fields in `eng/version.json`:
-
-```json
-{
-  "stableVersion": "0.3.1",
-  "nextVersion": "0.4.0"
-}
-```
-
-This ensures the next main-branch CI build immediately produces
-`0.4.0-preview.<run>.<attempt>` rather than continuing to emit `0.3.1-preview`
-(which would collide with the stable release version).
+- **English:** [`docs/en/`](./docs/en/index.md) — install, project start, intent
+  organization, packet/issue creation, implementation & review loop setup, recovery.
+- **日本語:** [`docs/ja/`](./docs/ja/index.md) — 同上のドキュメント日本語版。
+- **Command reference:** [`docs/en/08-command-reference.md`](./docs/en/08-command-reference.md)
+  — agent-facing and power-user command surfaces.
+- **Developer reference:** [`docs/en/09-developer-reference.md`](./docs/en/09-developer-reference.md)
+  — packaged invocation smoke test, preview channel, version flow.
 
 ---
 

--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -1,0 +1,108 @@
+# Command reference (agent-facing / power users)
+
+> English version. 日本語版: [`../ja/08-command-reference.md`](../ja/08-command-reference.md)
+
+This page lists the `intent-cli` command surfaces that AI agents and power users
+run on your behalf. You do not need to memorize these for routine use; the
+[root README](../../README.md) Quickstart and `intent-cli guide start` cover the
+typical path.
+
+The commands below are what the AI agent runs internally. Run
+`intent-cli guide commands list --format json` for the authoritative live catalog.
+
+---
+
+## Two agent roles
+
+| Agent | Source of truth | Owns |
+| --- | --- | --- |
+| **Host / review agent** | parent host `.intent-cli/` state + intent tree | publishing issues, applying `intent-target`, review/approve/merge, next-slice planning, label transitions via `intent-cli automation` |
+| **Child implementation agent** | the **GitHub issue/PR + repo-local code** (NOT host metadata) | implementing the issue contract, opening/updating the PR, recording outcomes via `intent-cli worker` |
+
+Child implementation agents are **GitHub-contract-only**: they must not read or
+mutate the parent host's queue-state, runs logs, packet directories, or intent
+tree, and they treat the GitHub issue body as the standalone contract.
+
+The host can live in a **separate host repository** or in the **same repository
+on a dedicated metadata branch** (e.g. `main-metadata`). Both topologies are
+fully supported — see [Start a project](02-project-start.md#repository-topology-choices).
+
+---
+
+## Project setup
+
+```bash
+intent-cli intent init --domain <name> [--target-repo <owner>/<repo>] --write
+intent-cli intent status
+intent-cli guide intent-work setup --format json
+```
+
+## Design / intents
+
+```bash
+intent-cli interview next-question
+intent-cli interview record-answer ...
+intent-cli interview compile
+intent-cli guide workflow
+```
+
+## Packets / issues
+
+```bash
+intent-cli packet ...
+intent-cli issue validate-body ...
+intent-cli issue prepare ...
+intent-cli issue publish-reviewed ...
+intent-cli issue publish-flow <id> --repo <owner>/<repo> --write --format json
+intent-cli automation issue-publish --write
+```
+
+## Implementation & review loops
+
+```bash
+# Fetch the complete loop prompt for an AI agent:
+intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>
+intent-cli guide oneshot --kind host-review-next-slice    --domain <name>
+```
+
+Operator-dogfooding prompt templates that wire these loops entirely through the
+deterministic worker/metadata commands live under
+[`docs/automation-templates/`](../automation-templates/README.md).
+
+## Recovery
+
+```bash
+intent-cli worker issue-preflight       --repo <owner>/<repo> --issue <n> --format json
+intent-cli worker pr-comment-preflight  --repo <owner>/<repo> --pr <n>    --format json
+intent-cli automation doctor --format json
+```
+
+---
+
+## Command group overview
+
+| Surface | Role |
+|---------|------|
+| `intent-cli guide …` | Ask-first guidance: collaboration model, workflow, prompt-template catalog, one-shot prompts |
+| `intent-cli status brief` | Compact AI-thread context input |
+| `intent-cli clarify draft` / `clarify record` | Owner clarification flow |
+| `intent-cli issue validate-body` | Standalone Child Issue Contract enforcement |
+| `intent-cli issue prepare` / `issue publish-reviewed` | Reviewed issue body publish boundary (never applies `intent-target`) |
+| `intent-cli worker next-action` / `claim` / `result-summary` / `complete` | Child implementation loop selector + bounded label transitions |
+| `intent-cli automation summary` | Provider-neutral label-driven automation contract emitter |
+| `intent-cli safety nested-provider-handoff` | Artifact-only nested-provider safety guard (never spawns providers) |
+
+---
+
+## Rules of thumb
+
+- **Use `intent-cli` transition commands, not raw edits.** Do not directly edit
+  queue-state, workflow labels, packet publish metadata, or other host artifacts
+  when an `intent-cli automation` / `intent-cli worker` command owns that
+  transition. Apply labels through those commands, never `gh ... edit
+  --add-label`.
+- **Ask, don't read-and-guess.** Prefer `intent-cli guide ...` over reading
+  local rule files; the guidance reflects the installed CLI's current contract.
+- **`intent-cli` does not launch AI providers.** It emits deterministic
+  guidance, validates contracts, and performs bounded GitHub/metadata
+  transitions. The AI agent stays in the driver's seat.

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1,0 +1,172 @@
+# Developer reference
+
+> English version. 日本語版: [`../ja/09-developer-reference.md`](../ja/09-developer-reference.md)
+
+This page covers install options, packaged invocation smoke testing, the preview
+channel, and the version policy. It is aimed at maintainers, contributors, and
+power users — not at beginners following the [Quickstart](../../README.md#quickstart).
+
+---
+
+## Install without a .NET SDK
+
+Each [GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/latest)
+attaches SDK-free, self-contained binaries (the .NET runtime is bundled, so no
+SDK is required).
+
+| Platform | Asset |
+| --- | --- |
+| macOS (Apple Silicon) | `intent-cli-<version>-osx-arm64.tar.gz` |
+| Windows (x64) | `intent-cli-<version>-win-x64.zip` |
+| Linux (x64) | `intent-cli-<version>-linux-x64.tar.gz` |
+
+Each archive ships with a `.sha256` sidecar; download both files into the same
+directory and verify before use.
+
+**macOS:**
+
+```bash
+# 1. Verify (run from the folder containing both files).
+shasum -a 256 -c intent-cli-<version>-osx-arm64.tar.gz.sha256
+
+# 2. Extract and place the binary on your PATH.
+tar -xzf intent-cli-<version>-osx-arm64.tar.gz
+chmod +x intent-cli
+sudo mv intent-cli /usr/local/bin/
+
+# 3. Confirm.
+intent-cli --version
+```
+
+**Linux:**
+
+```bash
+# 1. Verify.
+sha256sum -c intent-cli-<version>-linux-x64.tar.gz.sha256
+
+# 2. Extract and place on PATH.
+tar -xzf intent-cli-<version>-linux-x64.tar.gz
+chmod +x intent-cli
+sudo mv intent-cli /usr/local/bin/
+
+# 3. Confirm.
+intent-cli --version
+```
+
+**Windows:** Download `intent-cli-<version>-win-x64.zip` and its `.sha256` sidecar.
+Compare the hash from `CertUtil -hashfile intent-cli-<version>-win-x64.zip SHA256`
+against the first field in the `.sha256` file, unzip, and place `intent-cli.exe`
+on your `PATH`.
+
+Release binaries and OSS preview CI artifacts carry no build-time expiry.
+
+---
+
+## Packaged invocation (local smoke)
+
+The CLI is packaged as a .NET tool (package id `JTechJapan.IntentSystem.Cli`,
+command `intent-cli`). To smoke-test a locally built package:
+
+```bash
+export INTENT_CLI_LOCAL_VERSION="0.3.1-local.$(date -u +%Y%m%d%H%M%S)"
+dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
+  -p:Version="$INTENT_CLI_LOCAL_VERSION" \
+  -o .artifacts/packages
+mkdir -p .artifacts/smoke-repo/.intent-cli
+cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'
+default_domain = "intent-cli"
+artifact_root = ".intent-cli"
+worktree_root = ".intent-cli/worktrees"
+EOF
+(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" JTechJapan.IntentSystem.Cli project status)
+```
+
+Equivalent `dnx` path:
+
+```bash
+(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" JTechJapan.IntentSystem.Cli project status)
+```
+
+---
+
+## Preview install
+
+> OSS preview channel. Public users should use the stable NuGet install
+> (`dotnet tool install -g JTechJapan.IntentSystem.Cli`) or a release binary
+> above. This section is for users who want the latest merged changes before a
+> stable release.
+
+The `preview-pack` GitHub Actions workflow runs on every merge to `main` and
+uploads a self-contained install bundle as a workflow artifact named
+`intent-cli-preview-<version>`. The bundle contains:
+
+| File | Purpose |
+| --- | --- |
+| `JTechJapan.IntentSystem.Cli.<version>.nupkg` | The NuGet package consumed by `dotnet tool install`. |
+| `JTechJapan.IntentSystem.Cli.<version>.nupkg.sha256` | SHA-256 checksum sidecar; verify before installing. |
+| `preview-metadata.json` | Machine-readable build provenance (channel, version, build timestamp, commit, CI run identifiers). |
+| `INSTALL.md` | Per-build install / update / verify / uninstall guide with this build's exact version and commit pre-filled. |
+
+The package version pattern is `<nextVersion>-preview.<run_number>.<run_attempt>`
+(e.g. `0.3.1-preview.42.1`).
+
+```bash
+# 1. Download and unzip the workflow artifact, then cd into it.
+cd ./intent-cli-preview-0.3.1-preview.42.1
+
+# 2. Verify the checksum (macOS: shasum; Linux: sha256sum).
+shasum -a 256 -c JTechJapan.IntentSystem.Cli.*.nupkg.sha256
+
+# 3. Install (or update) the .NET tool from this local folder:
+dotnet tool install --global --add-source . \
+  --version 0.3.1-preview.42.1 JTechJapan.IntentSystem.Cli
+# Upgrade-in-place:
+dotnet tool update --global --add-source . \
+  --version 0.3.1-preview.42.1 JTechJapan.IntentSystem.Cli
+
+# Uninstall:
+dotnet tool uninstall --global JTechJapan.IntentSystem.Cli
+```
+
+The installed binary exposes the preview metadata via `intent-cli --version`:
+
+```text
+intent-cli 0.3.1-preview.42.1-<short-sha>-G<unit>
+channel=preview built=<iso-utc> commit=<full-sha>
+```
+
+The `channel=preview` trailer confirms the embedded preview metadata loaded
+successfully. **OSS preview packages carry no expiry; they remain runnable indefinitely.**
+
+---
+
+## Version flow
+
+The repository version policy lives in `eng/version.json`:
+
+```json
+{
+  "stableVersion": "0.3.0",
+  "nextVersion": "0.3.1"
+}
+```
+
+| Stage | Version form | How it is derived |
+| --- | --- | --- |
+| Main CI preview | `0.3.1-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.1-rc.N` | Tag `v0.3.1-rc.N` triggers release workflow |
+| Stable release | `0.3.1` | Tag `v0.3.1` triggers release workflow |
+| Post-release main builds | `0.4.0-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.4.0` |
+
+**After releasing `v0.3.1`**, bump both fields in `eng/version.json`:
+
+```json
+{
+  "stableVersion": "0.3.1",
+  "nextVersion": "0.4.0"
+}
+```
+
+This ensures the next main-branch CI build immediately produces
+`0.4.0-preview.<run>.<attempt>` rather than continuing to emit `0.3.1-preview`
+(which would collide with the stable release version).

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -32,7 +32,7 @@ agent should run the appropriate `intent-cli` command rather than editing files
 or applying GitHub labels by hand. Every guide and automation page below
 enforces this rule.
 
-See the [README command reference](../../README.md#command-reference-agent-facing--power-users)
+See the [command reference](08-command-reference.md)
 for the full list of commands the agent will use on your behalf.
 
 ## Pages
@@ -44,6 +44,8 @@ for the full list of commands the agent will use on your behalf.
 5. [Implementation loop setup](05-implementation-loop.md)
 6. [Review / next-slice loop setup](06-review-next-slice-loop.md)
 7. [Recover when a loop looks wrong](07-recovery.md)
+8. [Command reference](08-command-reference.md) — agent-facing and power-user command surfaces
+9. [Developer reference](09-developer-reference.md) — packaged invocation, preview channel, version flow
 
 ## Two agent roles (read this once)
 

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -1,0 +1,104 @@
+# コマンドリファレンス（agent 向け / パワーユーザー向け）
+
+> 日本語版。English version: [`../en/08-command-reference.md`](../en/08-command-reference.md)
+
+このページは AI agent やパワーユーザーが代理で実行する `intent-cli` コマンド群を示します。
+通常の利用では記憶する必要はありません。
+[ルート README](../../README.md) のクイックスタートと `intent-cli guide start` が
+典型的なパスをカバーします。
+
+以下のコマンドは AI agent が内部で実行するものです。現在の全カタログは
+`intent-cli guide commands list --format json` を実行してください。
+
+---
+
+## 2 つの agent ロール
+
+| ロール | source of truth | 責務 |
+| --- | --- | --- |
+| **Host / review agent** | 親 host の `.intent-cli/` 状態 + intent tree | issue 公開、`intent-target` 付与、review/approve/merge、next slice 切り出し、`intent-cli automation` 経由の label 遷移 |
+| **Child implementation agent** | **GitHub の issue/PR + repo ローカルのコード**（host metadata ではない） | issue 契約の実装、PR の作成/更新、`intent-cli worker` での結果記録 |
+
+Child implementation agent は **GitHub-contract-only** です: host の `.intent-cli/`、
+queue-state、metadata branch、`intents/**` を読んだり変更したりしません。
+
+host は **別の host リポジトリ** にも、**同じリポジトリの専用 metadata ブランチ**
+（例: `main-metadata`）にも置くことができます。
+詳しくは [プロジェクト開始 → リポジトリトポロジーの選択](02-project-start.md#リポジトリトポロジーの選択) を参照してください。
+
+---
+
+## プロジェクトセットアップ
+
+```bash
+intent-cli intent init --domain <name> [--target-repo <owner>/<repo>] --write
+intent-cli intent status
+intent-cli guide intent-work setup --format json
+```
+
+## デザイン / intent
+
+```bash
+intent-cli interview next-question
+intent-cli interview record-answer ...
+intent-cli interview compile
+intent-cli guide workflow
+```
+
+## Packet / issue
+
+```bash
+intent-cli packet ...
+intent-cli issue validate-body ...
+intent-cli issue prepare ...
+intent-cli issue publish-reviewed ...
+intent-cli issue publish-flow <id> --repo <owner>/<repo> --write --format json
+intent-cli automation issue-publish --write
+```
+
+## 実装・レビューループ
+
+```bash
+# AI agent 向けループプロンプトを取得:
+intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>
+intent-cli guide oneshot --kind host-review-next-slice    --domain <name>
+```
+
+worker/metadata コマンドだけでループを回す operator dogfooding 向けプロンプトテンプレートは
+[`docs/automation-templates/`](../automation-templates/README.md) にあります。
+
+## 復旧
+
+```bash
+intent-cli worker issue-preflight       --repo <owner>/<repo> --issue <n> --format json
+intent-cli worker pr-comment-preflight  --repo <owner>/<repo> --pr <n>    --format json
+intent-cli automation doctor --format json
+```
+
+---
+
+## コマンドグループ概要
+
+| Surface | 役割 |
+|---------|------|
+| `intent-cli guide …` | Ask-first ガイダンス: コラボレーションモデル、ワークフロー、プロンプトテンプレートカタログ、one-shot プロンプト |
+| `intent-cli status brief` | コンパクトな AI スレッドコンテキスト入力 |
+| `intent-cli clarify draft` / `clarify record` | オーナー clarification フロー |
+| `intent-cli issue validate-body` | Child Issue Contract 単独強制 |
+| `intent-cli issue prepare` / `issue publish-reviewed` | レビュー済み issue body 公開境界（`intent-target` は付与しない） |
+| `intent-cli worker next-action` / `claim` / `result-summary` / `complete` | Child 実装ループセレクター + 境界付き label 遷移 |
+| `intent-cli automation summary` | プロバイダー中立 label 駆動自動化コントラクトエミッター |
+| `intent-cli safety nested-provider-handoff` | アーティファクトのみのネストされたプロバイダー安全ガード（プロバイダーを起動しない） |
+
+---
+
+## ルール
+
+- **`intent-cli` 遷移コマンドを使い、直接編集はしない。** `intent-cli automation` /
+  `intent-cli worker` が所有する遷移（queue-state、ワークフロー label、
+  packet publish metadata など）は手編集しない。label は必ずこれらのコマンド経由で付与し、
+  `gh ... edit --add-label` を直接使わない。
+- **読んで推測するより聞く。** ローカルのルールファイルを読むより `intent-cli guide ...`
+  を優先する; ガイダンスはインストール済み CLI の現行コントラクトを反映している。
+- **`intent-cli` は AI プロバイダーを起動しない。** 決定論的なガイダンスを出力し、
+  コントラクトを検証し、bounded な GitHub/metadata 遷移を行うだけ。AI agent がドライバーシートに留まる。

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1,0 +1,162 @@
+# 開発者リファレンス
+
+> 日本語版。English version: [`../en/09-developer-reference.md`](../en/09-developer-reference.md)
+
+このページはインストールオプション、パッケージ化された実行によるスモークテスト、
+preview チャンネル、バージョンポリシーについて説明します。
+メンテナー、コントリビューター、パワーユーザー向けです。
+[クイックスタート](../../README.md#quickstart) に従う初心者向けではありません。
+
+---
+
+## .NET SDK なしでインストール
+
+各 [GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/latest) には
+SDK フリーの自己完結型バイナリが添付されています（.NET ランタイムが同梱されており、
+SDK は不要です）。
+
+| Platform | Asset |
+| --- | --- |
+| macOS (Apple Silicon) | `intent-cli-<version>-osx-arm64.tar.gz` |
+| Windows (x64) | `intent-cli-<version>-win-x64.zip` |
+| Linux (x64) | `intent-cli-<version>-linux-x64.tar.gz` |
+
+各アーカイブには `.sha256` サイドカーが同梱されています。
+使用前に両ファイルを同じディレクトリにダウンロードして確認してください。
+
+**macOS:**
+
+```bash
+# 1. 確認（両ファイルがあるフォルダで実行）。
+shasum -a 256 -c intent-cli-<version>-osx-arm64.tar.gz.sha256
+
+# 2. 展開して PATH に配置。
+tar -xzf intent-cli-<version>-osx-arm64.tar.gz
+chmod +x intent-cli
+sudo mv intent-cli /usr/local/bin/
+
+# 3. 確認。
+intent-cli --version
+```
+
+**Linux:**
+
+```bash
+# 1. 確認。
+sha256sum -c intent-cli-<version>-linux-x64.tar.gz.sha256
+
+# 2. 展開して PATH に配置。
+tar -xzf intent-cli-<version>-linux-x64.tar.gz
+chmod +x intent-cli
+sudo mv intent-cli /usr/local/bin/
+
+# 3. 確認。
+intent-cli --version
+```
+
+**Windows:** `intent-cli-<version>-win-x64.zip` と `.sha256` サイドカーをダウンロード。
+`CertUtil -hashfile intent-cli-<version>-win-x64.zip SHA256` のハッシュを
+`.sha256` ファイルの最初のフィールドと比較し、解凍後 `intent-cli.exe` を PATH に配置してください。
+
+リリースバイナリと OSS preview CI アーティファクトにはビルド時の有効期限はありません。
+
+---
+
+## パッケージ化された実行（ローカルスモークテスト）
+
+CLI は .NET ツールとしてパッケージ化されています（パッケージ id `JTechJapan.IntentSystem.Cli`、
+コマンド `intent-cli`）。ローカルビルドパッケージのスモークテスト:
+
+```bash
+export INTENT_CLI_LOCAL_VERSION="0.3.1-local.$(date -u +%Y%m%d%H%M%S)"
+dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
+  -p:Version="$INTENT_CLI_LOCAL_VERSION" \
+  -o .artifacts/packages
+mkdir -p .artifacts/smoke-repo/.intent-cli
+cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'
+default_domain = "intent-cli"
+artifact_root = ".intent-cli"
+worktree_root = ".intent-cli/worktrees"
+EOF
+(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" JTechJapan.IntentSystem.Cli project status)
+```
+
+等価な `dnx` パス:
+
+```bash
+(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" JTechJapan.IntentSystem.Cli project status)
+```
+
+---
+
+## Preview インストール
+
+> OSS preview チャンネル。公開ユーザーは安定版 NuGet
+> (`dotnet tool install -g JTechJapan.IntentSystem.Cli`) または上記のリリースバイナリを
+> 使用してください。このセクションは stable リリース前の最新変更が必要なユーザー向けです。
+
+`preview-pack` GitHub Actions ワークフローは `main` へのマージごとに実行され、
+ワークフローアーティファクトとして `intent-cli-preview-<version>` という名前の
+自己完結型インストールバンドルをアップロードします。
+
+パッケージバージョンパターン: `<nextVersion>-preview.<run_number>.<run_attempt>`
+（例: `0.3.1-preview.42.1`）。
+
+```bash
+# 1. ワークフローアーティファクトをダウンロードして解凍、そのディレクトリに cd。
+cd ./intent-cli-preview-0.3.1-preview.42.1
+
+# 2. チェックサムを確認（macOS: shasum; Linux: sha256sum）。
+shasum -a 256 -c JTechJapan.IntentSystem.Cli.*.nupkg.sha256
+
+# 3. .NET ツールをこのローカルフォルダからインストール（または更新）:
+dotnet tool install --global --add-source . \
+  --version 0.3.1-preview.42.1 JTechJapan.IntentSystem.Cli
+# アップグレード:
+dotnet tool update --global --add-source . \
+  --version 0.3.1-preview.42.1 JTechJapan.IntentSystem.Cli
+
+# アンインストール:
+dotnet tool uninstall --global JTechJapan.IntentSystem.Cli
+```
+
+インストール済みバイナリは `intent-cli --version` で preview メタデータを表示します:
+
+```text
+intent-cli 0.3.1-preview.42.1-<short-sha>-G<unit>
+channel=preview built=<iso-utc> commit=<full-sha>
+```
+
+**OSS preview パッケージには有効期限はなく、無期限で実行可能です。**
+
+---
+
+## バージョンフロー
+
+リポジトリのバージョンポリシーは `eng/version.json` に記載されています:
+
+```json
+{
+  "stableVersion": "0.3.0",
+  "nextVersion": "0.3.1"
+}
+```
+
+| ステージ | バージョン形式 | 導出方法 |
+| --- | --- | --- |
+| Main CI preview | `0.3.1-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.3.1-rc.N` | タグ `v0.3.1-rc.N` がリリースワークフローをトリガー |
+| 安定版リリース | `0.3.1` | タグ `v0.3.1` がリリースワークフローをトリガー |
+| リリース後の main ビルド | `0.4.0-preview.<run>.<attempt>` | `nextVersion` を `0.4.0` にバンプ後 |
+
+**`v0.3.1` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+
+```json
+{
+  "stableVersion": "0.3.1",
+  "nextVersion": "0.4.0"
+}
+```
+
+これにより次の main ブランチ CI ビルドが `0.4.0-preview.<run>.<attempt>` を生成し、
+`0.3.1-preview`（安定版リリースバージョンと衝突）の出力が継続されなくなります。

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -32,7 +32,7 @@ agent が内部で `intent-cli` を実行し、質問や結果を返します。
 このルールを強制しています。
 
 agent が代わりに使うコマンドの全リストは
-[README コマンドリファレンス](../../README.md#command-reference-agent-facing--power-users)
+[コマンドリファレンス](08-command-reference.md)
 を参照してください。
 
 ## ページ一覧
@@ -44,6 +44,8 @@ agent が代わりに使うコマンドの全リストは
 5. [実装ループの設定](05-implementation-loop.md)
 6. [レビュー / next-slice ループの設定](06-review-next-slice-loop.md)
 7. [ループがおかしいときの復旧](07-recovery.md)
+8. [コマンドリファレンス](08-command-reference.md) — agent 向け・パワーユーザー向けコマンド一覧
+9. [開発者リファレンス](09-developer-reference.md) — パッケージ化された実行、preview チャンネル、バージョンフロー
 
 ## 2 つの agent ロール（最初に一度だけ読む）
 

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -148,15 +148,18 @@ public sealed class PackagedInvocationSmokeTests
     [Fact]
     public void Readme_DocumentsHermeticPackagedInvocationPaths()
     {
-        var readme = File.ReadAllText(Path.Combine(GetSolutionRoot(), "README.md"));
+        // G422: packaged invocation smoke guidance moved from README.md to
+        // docs/en/09-developer-reference.md. Verify the new canonical location.
+        var devRef = File.ReadAllText(
+            Path.Combine(GetSolutionRoot(), "docs", "en", "09-developer-reference.md"));
 
-        Assert.Contains("mkdir -p .artifacts/smoke-repo/.intent-cli", readme, StringComparison.Ordinal);
-        Assert.Contains("cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'", readme, StringComparison.Ordinal);
-        Assert.Contains("export INTENT_CLI_LOCAL_VERSION=\"0.3.1-local.$(date -u +%Y%m%d%H%M%S)\"", readme, StringComparison.Ordinal);
+        Assert.Contains("mkdir -p .artifacts/smoke-repo/.intent-cli", devRef, StringComparison.Ordinal);
+        Assert.Contains("cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'", devRef, StringComparison.Ordinal);
+        Assert.Contains("export INTENT_CLI_LOCAL_VERSION=\"0.3.1-local.$(date -u +%Y%m%d%H%M%S)\"", devRef, StringComparison.Ordinal);
         // G407: package id is JTechJapan.IntentSystem.Cli; dotnet tool exec / dnx uses the
         // package id to locate the nupkg. The installed command remains intent-cli.
-        Assert.Contains("(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version \"$INTENT_CLI_LOCAL_VERSION\" JTechJapan.IntentSystem.Cli project status)", readme, StringComparison.Ordinal);
-        Assert.Contains("(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version \"$INTENT_CLI_LOCAL_VERSION\" JTechJapan.IntentSystem.Cli project status)", readme, StringComparison.Ordinal);
+        Assert.Contains("(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version \"$INTENT_CLI_LOCAL_VERSION\" JTechJapan.IntentSystem.Cli project status)", devRef, StringComparison.Ordinal);
+        Assert.Contains("(cd .artifacts/smoke-repo && dnx --yes --source ../packages --version \"$INTENT_CLI_LOCAL_VERSION\" JTechJapan.IntentSystem.Cli project status)", devRef, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- README is now a minimal GitHub/NuGet landing page: what intent-cli is, docs links, install, `--version`, two starter prompts, and community/license
- Long command catalog, host/child agent roles, CLI command roles table, packaged invocation smoke test, preview install, and version flow all moved to dedicated docs pages
- New pages: `docs/en/08-command-reference.md`, `docs/en/09-developer-reference.md`, `docs/ja/08-command-reference.md`, `docs/ja/09-developer-reference.md`
- Both docs index files updated with links to new pages
- Stale README anchor references in `docs/en/index.md` and `docs/ja/index.md` replaced with direct links to `08-command-reference.md`
- All documented commands verified against current `intent-cli --help` and `intent-cli guide commands list --format json` output

## Test plan

- [x] `git diff --check` clean
- [x] Full test suite: same 6 pre-existing failures, no new failures introduced
- [x] All documented commands cross-checked against live CLI output
- [x] Japanese and English docs consistent about new reference page locations

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)