### PR TITLE
G423: Polish docs prompts to minimal natural-language ask-intent-cli form

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,12 @@ repository and paste one of these prompts:
 **Start or continue a project:**
 
 > I want to work on `<owner>/<repo>` with intent-cli.
-> Please run `intent-cli guide start` and `intent-cli intent status`, then
-> tell me which phase we're in and what I should decide next.
+> Ask intent-cli what phase I'm in and what I should decide next.
 
 **Start an implementation loop:**
 
 > Set up a child implementation loop for `<owner>/<repo>`.
-> Run `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`
-> and follow the guidance.
+> Ask intent-cli for the next step.
 
 The agent runs `intent-cli` commands internally and brings back questions or
 results. You focus on intent, priorities, and approval decisions.

--- a/docs/en/01-install.md
+++ b/docs/en/01-install.md
@@ -1,7 +1,7 @@
 # Install
 
-> **Ask intent-cli first.** After installing, run `intent-cli guide start` before
-> doing any workflow work. ← [docs index](index.md)
+> **Ask intent-cli first.** After installing, ask intent-cli what to do next before
+> starting any workflow work. ← [docs index](index.md)
 
 The basic path is the .NET global tool from NuGet.org (requires a **.NET 10
 SDK**; check with `dotnet --version`). The same commands work on macOS, Windows,
@@ -32,4 +32,4 @@ the runtime is bundled. Verify the `.sha256` sidecar before use. See the
 ## Next
 
 Confirmed `intent-cli --version`? Continue to
-[Start a project](02-project-start.md) — but run `intent-cli guide start` first.
+[Start a project](02-project-start.md).

--- a/docs/en/02-project-start.md
+++ b/docs/en/02-project-start.md
@@ -11,10 +11,7 @@ questions or results.
 Paste this into your AI agent (Claude, Codex, Copilot, etc.):
 
 > I want to start or continue the project on `<owner>/<repo>`, domain `<name>`.
-> Please run `intent-cli guide start` and `intent-cli intent status` from the
-> host repo root. Tell me which phase I'm in and what decisions I need to make
-> next. Use intent-cli transitions for any label or metadata change — never
-> hand-edit files or apply GitHub labels directly.
+> Ask intent-cli what phase I'm in and what I should decide next.
 
 ## What the agent will run (reference)
 

--- a/docs/en/03-intents.md
+++ b/docs/en/03-intents.md
@@ -1,7 +1,6 @@
 # Organize & maintain intents
 
-> **Ask intent-cli first:** `intent-cli guide start` →
-> `intent-cli guide workflow task intent-interview --format json`. ← [docs index](index.md)
+> **Ask intent-cli first.** ← [docs index](index.md)
 
 **Host/design** work: capture and compile durable intent before cutting any
 slice.
@@ -19,9 +18,7 @@ intent-cli intent status --format json
 
 ## Ask-intent-cli prompt template
 
-> I'm organizing intents for domain `<name>`. Run `intent-cli guide start` then
-> the `intent-interview` workflow guide, and use `intent-cli interview …` to
-> record answers. Don't invent rules — ask intent-cli for current guidance.
+> I'm organizing intents for domain `<name>`. Ask intent-cli what I should do next.
 
 ## Metadata / label safety
 

--- a/docs/en/04-packets-issues.md
+++ b/docs/en/04-packets-issues.md
@@ -1,8 +1,6 @@
 # Create packets & publish issues
 
-> **Ask intent-cli first:** `intent-cli guide start` →
-> `intent-cli guide workflow task packet-draft --format json` and
-> `… task issue-publish --format json`. ← [docs index](index.md)
+> **Ask intent-cli first.** ← [docs index](index.md)
 
 **Host/design** work. A packet scaffolds the canonical files; the publish
 boundary turns a reviewed Standalone Child Issue Contract into a GitHub issue.
@@ -19,9 +17,8 @@ intent-cli automation issue-publish --issue <n> --write --format json
 
 ## Ask-intent-cli prompt template
 
-> I'm drafting packet `<id>` and publishing its issue to `<owner>/<repo>`. Run
-> `intent-cli guide start`, then the `packet-draft` and `issue-publish` workflow
-> guides, and apply `intent-target` only via the publish/automation command.
+> I'm drafting packet `<id>` and publishing its issue to `<owner>/<repo>`.
+> Ask intent-cli what I should do next.
 
 ## Metadata / label safety
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -19,9 +19,8 @@ need to memorize or run its commands directly.
 2. Open a design thread in your AI agent.
 3. Paste a prompt such as:
 
-> Ask intent-cli what phase I'm in for `<owner>/<repo>` domain `<name>`.
-> Run `intent-cli guide start` and `intent-cli intent status`, then tell me
-> what I should decide next.
+> I want to work on `<owner>/<repo>` with intent-cli.
+> Ask intent-cli what phase I'm in and what I should decide next.
 
 The agent runs `intent-cli` internally and brings back questions or results.
 You focus on intent, priorities, and approval decisions — not on memorizing

--- a/docs/ja/01-install.md
+++ b/docs/ja/01-install.md
@@ -1,7 +1,7 @@
 # インストール
 
 > **まず intent-cli に聞く。** インストール後、ワークフロー作業の前に
-> `intent-cli guide start` を実行する。 ← [ドキュメント索引](index.md)
+> intent-cli に次に行うべきことを聞く。 ← [ドキュメント索引](index.md)
 
 基本ルートは NuGet.org の .NET グローバルツール（**.NET 10 SDK** が必要。
 `dotnet --version` で確認）。macOS / Windows / Linux で同じコマンド:
@@ -32,4 +32,3 @@ intent-cli --version
 ## 次へ
 
 `intent-cli --version` を確認したら [プロジェクト開始](02-project-start.md) へ。
-ただし先に `intent-cli guide start` を実行する。

--- a/docs/ja/02-project-start.md
+++ b/docs/ja/02-project-start.md
@@ -10,10 +10,7 @@
 AI agent（Claude、Codex、Copilot など）に貼り付けてください:
 
 > `<owner>/<repo>` の domain `<name>` のプロジェクトを開始または継続したいです。
-> host リポジトリのルートから `intent-cli guide start` と `intent-cli intent status`
-> を実行してください。現在のフェーズと、私が次に決断すべきことを教えてください。
-> label や metadata の変更は intent-cli の遷移を使い、ファイルを手編集したり
-> GitHub label を直接適用したりしないでください。
+> intent-cli に現在のフェーズと次に決断すべきことを聞いてください。
 
 ## agent が実行するコマンド（リファレンス）
 

--- a/docs/ja/03-intents.md
+++ b/docs/ja/03-intents.md
@@ -1,7 +1,6 @@
 # intent の整理・保守
 
-> **まず intent-cli に聞く:** `intent-cli guide start` →
-> `intent-cli guide workflow task intent-interview --format json`。 ← [ドキュメント索引](index.md)
+> **まず intent-cli に聞く。** ← [ドキュメント索引](index.md)
 
 **host/design** 作業: slice を切り出す前に、永続的な intent を収集・コンパイルする。
 
@@ -18,9 +17,7 @@ intent-cli intent status --format json
 
 ## ask-intent-cli プロンプトテンプレート
 
-> domain `<name>` の intent を整理する。`intent-cli guide start` の後に
-> `intent-interview` ワークフローガイドを実行し、`intent-cli interview …` で
-> 回答を記録する。ルールを発明せず、現在のガイドを intent-cli に尋ねる。
+> domain `<name>` の intent を整理する。intent-cli に次に行うべきことを聞いてください。
 
 ## metadata / label の安全境界
 

--- a/docs/ja/04-packets-issues.md
+++ b/docs/ja/04-packets-issues.md
@@ -1,8 +1,6 @@
 # packet 作成と issue 公開
 
-> **まず intent-cli に聞く:** `intent-cli guide start` →
-> `intent-cli guide workflow task packet-draft --format json` と
-> `… task issue-publish --format json`。 ← [ドキュメント索引](index.md)
+> **まず intent-cli に聞く。** ← [ドキュメント索引](index.md)
 
 **host/design** 作業。packet が正本ファイルを scaffold し、公開境界がレビュー済みの
 Standalone Child Issue Contract を GitHub issue にする。
@@ -20,8 +18,7 @@ intent-cli automation issue-publish --issue <n> --write --format json
 ## ask-intent-cli プロンプトテンプレート
 
 > packet `<id>` を作成し、その issue を `<owner>/<repo>` に公開する。
-> `intent-cli guide start` の後に `packet-draft` と `issue-publish` のワークフロー
-> ガイドを実行し、`intent-target` は公開/automation コマンド経由でのみ付与する。
+> intent-cli に次に行うべきことを聞いてください。
 
 ## metadata / label の安全境界
 

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -18,9 +18,8 @@
 2. AI agent のデザインスレッドを開く。
 3. 次のようなプロンプトを貼り付ける:
 
-> `<owner>/<repo>` の domain `<name>` について、intent-cli に現在のフェーズを
-> 聞いてください。`intent-cli guide start` と `intent-cli intent status` を実行し、
-> 次に私が決断すべきことを教えてください。
+> `<owner>/<repo>` で intent-cli を使い始めたいです。
+> intent-cli に現在のフェーズと次に決断すべきことを聞いてください。
 
 agent が内部で `intent-cli` を実行し、質問や結果を返します。
 あなたは意図・優先度・承認の判断に集中するだけです。コマンドシーケンスを


### PR DESCRIPTION
## Summary

- Replace all beginner-facing prompts that hardcoded `intent-cli guide start`, `intent-cli intent status`, and other internal command sequences with minimal natural-language equivalents
- English: `Ask intent-cli what I should do next.` / `Ask intent-cli what phase I'm in and what I should decide next.`
- Japanese: `intent-cli に現在のフェーズと次に決断すべきことを聞いてください。` / `intent-cli に次に行うべきことを聞いてください。`
- Command sequences retained only in `## What the agent will run (reference)` blocks
- Affects: README.md, docs/en/{index,01-install,02-project-start,03-intents,04-packets-issues}.md, docs/ja/{index,01-install,02-project-start,03-intents,04-packets-issues}.md

Closes #947

## Test plan

- [ ] All changed files contain no `intent-cli guide start` in beginner-facing prompt blockquotes
- [ ] Reference sections still contain full command sequences for agent use
- [ ] CI passes (docs-only change, no .NET code modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)