### PR TITLE
G426: Rewrite loop setup docs with design-thread prompt model and folder separation

### DIFF
--- a/docs/en/05-implementation-loop.md
+++ b/docs/en/05-implementation-loop.md
@@ -1,47 +1,79 @@
 # Implementation loop setup
 
-> ← [docs index](index.md)
+← [docs index](index.md) | → [Review / next-slice loop setup](06-review-next-slice-loop.md)
 
-This is **child-implementation** work and is **GitHub-contract-only &
-metadata-free**: the issue/PR and repo-local code are the only source of truth.
-Never read or mutate host `.intent-cli/`, queue-state, metadata branches, or
-`intents/**`.
+Do not copy the steps from this page directly to create an implementation loop.
+The authoritative conditions come from installed intent-cli guidance.
+Ask the AI agent in your design thread to generate the current loop creation prompt.
 
-## Design-thread prompt
+## Folder separation (understand this first)
 
-Paste this into your AI agent (Claude, Codex, Copilot, etc.):
+Before starting an implementation loop, understand the three folder roles:
 
-> Run the child implementation loop for `<owner>/<repo>` from this worktree.
-> Get the full loop prompt via:
-> `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`
-> and follow it exactly. Select work only via `intent-cli worker next-action`;
-> process at most one action per wake. All label transitions go through
-> `intent-cli worker` — never raw `gh ... --add-label`.
+| Folder | Role |
+|---|---|
+| **Design/host folder** | Stores intent metadata and packets. The design thread runs here. |
+| **Implementation folder** | The child implementation loop edits code and creates/updates PRs here. |
+| **Review folder** | The host review/next-slice loop reviews PRs and publishes the next issue here. |
 
-## What the agent will run (reference)
+> **Warning — wrong cwd is a common failure mode.**
+> Starting an implementation loop from the design/host folder, or a review loop
+> from an implementation folder, causes misbehavior. Always verify your working
+> directory before starting a loop.
+
+**Same-repository metadata topology** (using a `main-metadata` branch): even when
+all three roles target the same repository, run each loop from a **separate
+folder, clone, or worktree**. Sharing a folder across roles causes branch
+operations and metadata changes to interfere with each other.
+
+## How to create a loop
+
+1. **In the design thread**, ask the AI agent to ask intent-cli for the current implementation loop creation prompt.
+2. Provide the domain, target repo, **path to the implementation folder**, and the PR base branch.
+3. Paste the generated prompt into a separate thread opened in the **implementation folder**.
+
+## Design-thread prompt (to request a loop creation prompt)
+
+Paste this into your design thread (the AI agent running in the design/host folder):
+
+> Ask intent-cli to generate the prompt I need to create a child implementation loop
+> for `<owner>/<repo>` using Claude Code `/loop 5m`.
+> The domain is `<domain>`, the working folder is `<implementation-folder>`,
+> and the implementation PR base branch is `<branch>`.
+> The generated prompt should delegate detailed conditions to intent-cli guidance.
+
+Paste the generated prompt into a **separate thread opened in the implementation folder**.
+The loop's detailed conditions come from intent-cli guidance — you do not need to
+copy a long loop body from this document.
+
+## Child implementation loop principles
+
+- **GitHub-contract-only and metadata-free**: the issue/PR and repo-local code are the only source of truth
+- Never read or mutate host `.intent-cli/`, queue-state, metadata branches, or `intents/**`
+- Select work only via `intent-cli worker next-action`; process at most one action per wake
+- All label transitions go through `intent-cli worker` — never raw `gh ... --add-label`
+
+## Metadata / label safety
+
+- A child agent never applies `intent-target` (host-owned) or `intent-pr-created` (issue-side marker) to a PR
+- `linked_pr_synced: false` from `worker complete` is the expected child-cwd warning — record it and move on
+
+## Command reference (for agents, maintainers, and troubleshooting)
+
+> **Note:** The commands below are run by the AI agent internally. The authoritative
+> loop conditions come from `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`.
+> You do not normally need to run these commands manually.
 
 ```bash
-# 1. Select exactly one target (no manual label-walking)
+# Select exactly one target (no manual label-walking)
 intent-cli worker next-action --repo <owner>/<repo> --github-only --format json
 
-# 2. issue-to-pr: claim, implement smallest change, open ready-for-review PR
+# issue-to-pr: claim, implement smallest change, open ready-for-review PR
 intent-cli worker claim --kind issue --number <n> --repo <owner>/<repo> --github-only --write --format json
 #    PR body MUST contain `Closes #<n>`; start from origin/main.
 intent-cli worker result-summary --kind issue-to-pr --repo <owner>/<repo> --issue <n> --pr <pr> --outcome <outcome> --format json
 intent-cli worker complete --kind issue --number <n> --repo <owner>/<repo> --github-only --outcome <outcome> --pr <pr> --write --format json
 ```
-
-`pr-comment-fix` targets follow the same claim → repair → result-summary →
-complete shape on the existing PR branch.
-
-## Metadata / label safety
-
-- All workflow-label transitions go through `intent-cli worker` — no raw
-  `gh ... --add-label`.
-- A child agent never applies `intent-target` (host-owned) or `intent-pr-created`
-  (issue-side marker) to a PR.
-- `linked_pr_synced: false` from `worker complete` is the expected child-cwd
-  warning — record it and move on.
 
 ## Next
 

--- a/docs/en/05-implementation-loop.md
+++ b/docs/en/05-implementation-loop.md
@@ -1,7 +1,5 @@
 # Implementation loop setup
 
-← [docs index](index.md) | → [Review / next-slice loop setup](06-review-next-slice-loop.md)
-
 Do not copy the steps from this page directly to create an implementation loop.
 The authoritative conditions come from installed intent-cli guidance.
 Ask the AI agent in your design thread to generate the current loop creation prompt.
@@ -77,4 +75,4 @@ intent-cli worker complete --kind issue --number <n> --repo <owner>/<repo> --git
 
 ## Next
 
-[Review / next-slice loop setup](06-review-next-slice-loop.md).
+[Review / next-slice loop setup](06-review-next-slice-loop.md) | [docs index](index.md)

--- a/docs/en/06-review-next-slice-loop.md
+++ b/docs/en/06-review-next-slice-loop.md
@@ -1,23 +1,69 @@
 # Review / next-slice loop setup
 
-> ← [docs index](index.md)
+← [Implementation loop setup](05-implementation-loop.md) | → [Recover when a loop looks wrong](07-recovery.md)
 
-This is **host/review** work. It reviews PRs against the packet/intent contract,
-requests updates, approves/merges, and cuts the next slice. It may operate on
-host metadata, but always via `intent-cli`-supported transitions.
+Do not copy the steps from this page directly to create a review/next-slice loop.
+The authoritative conditions come from installed intent-cli guidance.
+Ask the AI agent in your design thread to generate the current loop creation prompt.
 
-## Design-thread prompt
+## Folder separation (understand this first)
 
-Paste this into your AI agent (Claude, Codex, Copilot, etc.):
+Run the review loop from a **dedicated review folder**.
+Do not share a folder with the implementation loop or the design thread.
 
-> Run the host review / next-slice loop for domain `<name>` / `<owner>/<repo>`.
-> Get the full loop prompt via:
-> `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`
-> and follow it exactly. Apply every label transition via `intent-cli automation`
-> — never hand-apply labels. Tie approvals to packet/intent evidence, not just
-> green tests.
+| Folder | Role |
+|---|---|
+| **Design/host folder** | Stores intent metadata and packets. The design thread runs here. |
+| **Implementation folder** | The child implementation loop edits code and creates/updates PRs here. |
+| **Review folder** | The host review/next-slice loop reviews PRs and publishes the next issue here. |
 
-## What the agent will run (reference)
+> **Note:** The review folder is not optional in normal operation.
+> It exists so review/next-slice automation can pull and mutate host metadata
+> without interfering with the design thread or the implementation worker checkout.
+
+**Same-repository metadata topology** (using a `main-metadata` branch): even when
+all three roles target the same repository, run each loop from a **separate
+folder, clone, or worktree**.
+
+## How to create a loop
+
+1. **In the design thread**, ask the AI agent to ask intent-cli for the current review/next-slice loop creation prompt.
+2. Provide the domain, target repo, **path to the review folder**, and the PR base branch.
+3. Paste the generated prompt into a separate thread opened in the **review folder**.
+
+## Design-thread prompt (to request a loop creation prompt)
+
+Paste this into your design thread (the AI agent running in the design/host folder):
+
+> Ask intent-cli to generate the prompt I need to create a host review / next-slice loop
+> for `<owner>/<repo>` using Codex 5m automation.
+> The domain is `<domain>`, the working folder is `<review-folder>`,
+> and the implementation PR base branch is `<branch>`.
+> The review targets, next issue, workflow labels, and durable metadata
+> should all defer to intent-cli guidance as the source of truth.
+
+Paste the generated prompt into a **separate thread opened in the review folder**.
+The loop's detailed conditions come from intent-cli guidance — you do not need to
+copy a long loop body from this document.
+
+## Host review / next-slice loop principles
+
+- This is **host/review** work: review PRs against the packet/intent contract, request updates, approve/merge, and cut the next slice
+- It may operate on host metadata, but always via `intent-cli`-supported transitions
+- Tie approvals to packet/intent evidence, not just green tests
+- All label transitions go through `intent-cli automation` — never apply labels by hand
+
+## Metadata / label safety
+
+- Review label transitions (`intent-pr-reviewing`, `intent-pr-request-update`, `intent-pr-approved`, …) are applied by `intent-cli automation`, never by hand
+- Passing tests is **necessary but not sufficient** — approval requires packet/intent conformance evidence (see `guide review`)
+- Current-PR acceptance-criterion blockers get a durable PR comment before completing as request-update/clarification (see [recovery](07-recovery.md))
+
+## Command reference (for agents, maintainers, and troubleshooting)
+
+> **Note:** The commands below are run by the AI agent internally. The authoritative
+> loop conditions come from `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`.
+> You do not normally need to run these commands manually.
 
 ```bash
 # Get the authoritative review/next-slice prompt
@@ -29,15 +75,6 @@ intent-cli guide review --pr <n> --repo <owner>/<repo> --format json
 # Label transitions (review-start, request-update, approve, …) — never by hand
 intent-cli automation pr-transition --transition <name> --write --format json
 ```
-
-## Metadata / label safety
-
-- Review label transitions (`intent-pr-reviewing`, `intent-pr-request-update`,
-  `intent-pr-approved`, …) are applied by `intent-cli automation`, never by hand.
-- Passing tests is **necessary but not sufficient** — approval requires
-  packet/intent conformance evidence (see `guide review`).
-- Current-PR acceptance-criterion blockers get a durable PR comment before
-  completing as request-update/clarification (see [recovery](07-recovery.md)).
 
 ## Next
 

--- a/docs/en/06-review-next-slice-loop.md
+++ b/docs/en/06-review-next-slice-loop.md
@@ -1,7 +1,5 @@
 # Review / next-slice loop setup
 
-← [Implementation loop setup](05-implementation-loop.md) | → [Recover when a loop looks wrong](07-recovery.md)
-
 Do not copy the steps from this page directly to create a review/next-slice loop.
 The authoritative conditions come from installed intent-cli guidance.
 Ask the AI agent in your design thread to generate the current loop creation prompt.
@@ -78,4 +76,4 @@ intent-cli automation pr-transition --transition <name> --write --format json
 
 ## Next
 
-[Recover when a loop looks wrong](07-recovery.md).
+[Recover when a loop looks wrong](07-recovery.md) | [Implementation loop setup](05-implementation-loop.md) | [docs index](index.md)

--- a/docs/ja/05-implementation-loop.md
+++ b/docs/ja/05-implementation-loop.md
@@ -1,7 +1,5 @@
 # 実装ループの設定
 
-← [ドキュメント索引](index.md) | → [レビュー / next-slice ループの設定](06-review-next-slice-loop.md)
-
 実装ループは、このページの手順を直接コピーして作るものではありません。
 正確な条件は installed intent-cli guidance が source of truth です。
 設計スレッドで AI agent に依頼し、現在のループ作成プロンプトを生成してもらいます。
@@ -76,4 +74,4 @@ intent-cli worker complete --kind issue --number <n> --repo <owner>/<repo> --git
 
 ## 次へ
 
-[レビュー / next-slice ループの設定](06-review-next-slice-loop.md)。
+[レビュー / next-slice ループの設定](06-review-next-slice-loop.md) | [ドキュメント索引](index.md)

--- a/docs/ja/05-implementation-loop.md
+++ b/docs/ja/05-implementation-loop.md
@@ -1,46 +1,78 @@
 # 実装ループの設定
 
-> ← [ドキュメント索引](index.md)
+← [ドキュメント索引](index.md) | → [レビュー / next-slice ループの設定](06-review-next-slice-loop.md)
 
-これは **child-implementation** 作業で、**GitHub-contract-only かつ
-metadata-free**: issue/PR と repo ローカルのコードのみが source of truth。
-host の `.intent-cli/`、queue-state、metadata branch、`intents/**` を読んだり
-変更したりしない。
+実装ループは、このページの手順を直接コピーして作るものではありません。
+正確な条件は installed intent-cli guidance が source of truth です。
+設計スレッドで AI agent に依頼し、現在のループ作成プロンプトを生成してもらいます。
 
-## デザインスレッドプロンプト
+## フォルダー分離（最初に理解する）
 
-AI agent（Claude、Codex、Copilot など）に貼り付けてください:
+実装ループを始める前に、3 つのフォルダーの役割を理解してください:
 
-> このワークツリーから `<owner>/<repo>` の child implementation ループを回してください。
-> まず以下を実行してフルループの prompt を取得し、そのとおりに従ってください:
+| フォルダー | 役割 |
+|---|---|
+| **設計/host フォルダー** | intent metadata・packet を保管。設計スレッドがここで動く |
+| **実装フォルダー** | child implementation ループがコードを編集し PR を作成/更新する |
+| **レビューフォルダー** | host review/next-slice ループが PR をレビューし次の issue を公開する |
+
+> **注意 — cwd の誤りはよくある失敗パターンです。**
+> 実装ループを設計/host フォルダーで起動したり、レビューループを実装フォルダーで起動したりすると
+> 誤動作します。ループを開始する前に作業ディレクトリを必ず確認してください。
+
+**同一リポジトリ metadata トポロジー**（`main-metadata` ブランチ使用）の場合も、
+設計・実装・レビューの各ループは**同じリポジトリの別フォルダー/クローン/ワークツリー**
+で動かすことを強く推奨します。3 つのロールが同じフォルダーを共有すると、
+互いのブランチ操作や metadata 変更が干渉します。
+
+## ループ作成の手順
+
+1. **設計スレッドで** AI agent に intent-cli への問い合わせを依頼し、実装ループ作成プロンプトを生成する
+2. domain、target repo、**実装フォルダーのパス**、PR の base branch を伝える
+3. 生成されたプロンプトを **実装フォルダー** で開いた別スレッドに貼り付ける
+
+## 設計スレッドプロンプト（ループ作成依頼用）
+
+設計スレッド（設計/host フォルダーで動いている AI agent）に貼り付けてください:
+
+> intent-cli に聞いて、`<owner>/<repo>` の child implementation loop を
+> Claude Code の `/loop 5m` で作成するための依頼文を作ってください。
+> domain は `<domain>`、作業場所は `<implementation-folder>`、
+> 実装 PR の base は `<branch>` です。
+> 詳細条件は intent-cli guidance に従う形にしてください。
+
+生成されたプロンプトを**実装フォルダーを開いた別スレッド**に貼り付けます。
+ループの詳細条件は intent-cli guidance から取得されるため、
+このドキュメントに長いループ本体をコピーする必要はありません。
+
+## child implementation ループの原則
+
+- **GitHub-contract-only かつ metadata-free**: issue/PR とリポジトリローカルのコードのみが source of truth
+- host の `.intent-cli/`、queue-state、metadata branch、`intents/**` を読んだり変更したりしない
+- 作業の選択は `intent-cli worker next-action` のみ。1 wake で最大 1 アクション
+- label 遷移はすべて `intent-cli worker` 経由 — raw `gh ... --add-label` は使わない
+
+## metadata / label の安全境界
+
+- child agent は PR に `intent-target`（host 所有）や `intent-pr-created`（issue 側マーカー）を付けない
+- `worker complete` の `linked_pr_synced: false` は child-cwd で想定される警告 — 記録して先に進む
+
+## コマンドリファレンス（agent・メンテナ・トラブルシューティング向け）
+
+> **注意:** 以下のコマンドは AI agent が内部で実行します。ループの詳細条件は
 > `intent-cli guide oneshot --kind child-implement-or-update --repo <owner>/<repo>`
-> 作業の選択は `intent-cli worker next-action` のみ。1 wake で最大 1 アクション。
-> label 遷移はすべて `intent-cli worker` 経由で — raw `gh ... --add-label` は使わない。
-
-## agent が実行するコマンド（リファレンス）
+> が source of truth です。通常、ユーザーが直接実行する必要はありません。
 
 ```bash
-# 1. 対象を 1 つだけ選ぶ（手動の label-walking はしない）
+# 対象を 1 つだけ選ぶ（手動の label-walking はしない）
 intent-cli worker next-action --repo <owner>/<repo> --github-only --format json
 
-# 2. issue-to-pr: claim → 最小実装 → ready-for-review の PR を作成
+# issue-to-pr: claim → 最小実装 → ready-for-review の PR を作成
 intent-cli worker claim --kind issue --number <n> --repo <owner>/<repo> --github-only --write --format json
 #    PR 本文に `Closes #<n>` を必ず含める。origin/main から開始する。
 intent-cli worker result-summary --kind issue-to-pr --repo <owner>/<repo> --issue <n> --pr <pr> --outcome <outcome> --format json
 intent-cli worker complete --kind issue --number <n> --repo <owner>/<repo> --github-only --outcome <outcome> --pr <pr> --write --format json
 ```
-
-`pr-comment-fix` の対象も、既存 PR ブランチ上で claim → 修正 → result-summary →
-complete という同じ形に従う。
-
-## metadata / label の安全境界
-
-- ワークフロー label 遷移はすべて `intent-cli worker` 経由 — raw `gh ... --add-label`
-  は使わない。
-- child agent は PR に `intent-target`（host 所有）や `intent-pr-created`
-  （issue 側マーカー）を付けない。
-- `worker complete` の `linked_pr_synced: false` は child-cwd で想定される警告 —
-  記録して先に進む。
 
 ## 次へ
 

--- a/docs/ja/06-review-next-slice-loop.md
+++ b/docs/ja/06-review-next-slice-loop.md
@@ -1,7 +1,5 @@
 # レビュー / next-slice ループの設定
 
-← [実装ループの設定](05-implementation-loop.md) | → [ループがおかしいときの復旧](07-recovery.md)
-
 レビュー/next-slice ループも、このページの手順を直接コピーして作るものではありません。
 正確な条件は installed intent-cli guidance が source of truth です。
 設計スレッドで AI agent に依頼し、現在のループ作成プロンプトを生成してもらいます。
@@ -77,4 +75,4 @@ intent-cli automation pr-transition --transition <name> --write --format json
 
 ## 次へ
 
-[ループがおかしいときの復旧](07-recovery.md)。
+[ループがおかしいときの復旧](07-recovery.md) | [実装ループの設定](05-implementation-loop.md) | [ドキュメント索引](index.md)

--- a/docs/ja/06-review-next-slice-loop.md
+++ b/docs/ja/06-review-next-slice-loop.md
@@ -1,22 +1,68 @@
 # レビュー / next-slice ループの設定
 
-> ← [ドキュメント索引](index.md)
+← [実装ループの設定](05-implementation-loop.md) | → [ループがおかしいときの復旧](07-recovery.md)
 
-これは **host/review** 作業。PR を packet/intent 契約に照らしてレビューし、更新を
-要求し、approve/merge し、next slice を切り出す。host metadata を扱ってよいが、
-常に `intent-cli` がサポートする遷移を使う。
+レビュー/next-slice ループも、このページの手順を直接コピーして作るものではありません。
+正確な条件は installed intent-cli guidance が source of truth です。
+設計スレッドで AI agent に依頼し、現在のループ作成プロンプトを生成してもらいます。
 
-## デザインスレッドプロンプト
+## フォルダー分離（最初に理解する）
 
-AI agent（Claude、Codex、Copilot など）に貼り付けてください:
+レビューループは**レビュー専用フォルダー**で動かします。
+実装ループや設計スレッドと同じフォルダーを共有しないでください。
 
-> domain `<name>` / `<owner>/<repo>` の host review / next-slice ループを回してください。
-> まず以下を実行してフルループの prompt を取得し、そのとおりに従ってください:
+| フォルダー | 役割 |
+|---|---|
+| **設計/host フォルダー** | intent metadata・packet を保管。設計スレッドがここで動く |
+| **実装フォルダー** | child implementation ループがコードを編集し PR を作成/更新する |
+| **レビューフォルダー** | host review/next-slice ループが PR をレビューし次の issue を公開する |
+
+> **注意:** レビューフォルダーは通常運用では必須です。
+> レビュー/next-slice 自動化が host metadata を取得・変更するとき、
+> 設計スレッドや実装ワーカーのチェックアウトに干渉しないようにするためです。
+
+**同一リポジトリ metadata トポロジー**（`main-metadata` ブランチ使用）の場合も、
+設計・実装・レビューの各ループは同じリポジトリの**別フォルダー/クローン/ワークツリー**
+で動かすことを強く推奨します。
+
+## ループ作成の手順
+
+1. **設計スレッドで** AI agent に intent-cli への問い合わせを依頼し、レビューループ作成プロンプトを生成する
+2. domain、target repo、**レビューフォルダーのパス**、実装 PR の base branch を伝える
+3. 生成されたプロンプトを **レビューフォルダー** で開いた別スレッドに貼り付ける
+
+## 設計スレッドプロンプト（ループ作成依頼用）
+
+設計スレッド（設計/host フォルダーで動いている AI agent）に貼り付けてください:
+
+> intent-cli に聞いて、`<owner>/<repo>` の host review / next-slice loop を
+> Codex の 5m automation で作成するための依頼文を作ってください。
+> domain は `<domain>`、作業場所は `<review-folder>`、実装 PR の base は `<branch>` です。
+> レビュー対象、next issue、workflow label、durable metadata は
+> intent-cli guidance を source of truth にしてください。
+
+生成されたプロンプトを**レビューフォルダーを開いた別スレッド**に貼り付けます。
+ループの詳細条件は intent-cli guidance から取得されるため、
+このドキュメントに長いループ本体をコピーする必要はありません。
+
+## host review / next-slice ループの原則
+
+- これは **host/review** 作業: PR を packet/intent 契約に照らしてレビューし、更新を要求し、approve/merge し、next slice を切り出す
+- host metadata を扱ってよいが、常に `intent-cli` がサポートする遷移を使う
+- approve はテスト通過だけでなく packet/intent の証跡に紐づける
+- label 遷移はすべて `intent-cli automation` 経由 — 手作業では行わない
+
+## metadata / label の安全境界
+
+- レビュー label 遷移（`intent-pr-reviewing`、`intent-pr-request-update`、`intent-pr-approved` …）は `intent-cli automation` が付与する。手作業では行わない
+- テスト通過は **必要だが十分ではない** — approve には packet/intent への適合証跡が必要（`guide review` 参照）
+- 現在 PR の受け入れ基準ブロッカーは、request-update/clarification として完了する前に永続的な PR コメントを残す（[復旧](07-recovery.md) 参照）
+
+## コマンドリファレンス（agent・メンテナ・トラブルシューティング向け）
+
+> **注意:** 以下のコマンドは AI agent が内部で実行します。ループの詳細条件は
 > `intent-cli guide oneshot --kind host-review-next-slice --repo <owner>/<repo>`
-> label 遷移はすべて `intent-cli automation` 経由で行い、手動で label を付けないでください。
-> approve は green テストだけでなく packet/intent の証跡に紐づけてください。
-
-## agent が実行するコマンド（リファレンス）
+> が source of truth です。通常、ユーザーが直接実行する必要はありません。
 
 ```bash
 # レビュー / next-slice の正本 prompt を取得
@@ -28,15 +74,6 @@ intent-cli guide review --pr <n> --repo <owner>/<repo> --format json
 # label 遷移（review-start、request-update、approve …）— 手作業では行わない
 intent-cli automation pr-transition --transition <name> --write --format json
 ```
-
-## metadata / label の安全境界
-
-- レビュー label 遷移（`intent-pr-reviewing`、`intent-pr-request-update`、
-  `intent-pr-approved` …）は `intent-cli automation` が付与する。手作業では行わない。
-- テスト通過は **必要だが十分ではない** — approve には packet/intent への
-  適合証跡が必要（`guide review` 参照）。
-- 現在 PR の受け入れ基準ブロッカーは、request-update/clarification として完了する前に
-  永続的な PR コメントを残す（[復旧](07-recovery.md) 参照）。
 
 ## 次へ
 


### PR DESCRIPTION
## Summary

- Replace vague `← ドキュメント索引` callouts and long static loop bodies in implementation and review/next-slice loop docs
- Add folder separation model (design/host, implementation, review) with explicit warning that wrong cwd is a primary failure mode
- Add design-thread prompts (ja + en) that ask intent-cli to generate the current loop creation prompt
- Explain that same-repo metadata topology (`main-metadata`) still requires separate folders/clones/worktrees for design, implementation, and review
- Move command blocks to clearly labeled reference sections at the bottom
- Affected pages: `docs/ja/05-implementation-loop.md`, `docs/en/05-implementation-loop.md`, `docs/ja/06-review-next-slice-loop.md`, `docs/en/06-review-next-slice-loop.md`

Closes #953

## Test plan

- [ ] All loop docs explain folder separation clearly before any examples
- [ ] Design-thread prompt examples are short and delegate detailed conditions to intent-cli guidance
- [ ] No long static loop body copied into docs
- [ ] Command blocks are labeled as reference/troubleshooting only

🤖 Generated with [Claude Code](https://claude.com/claude-code)