### PR TITLE
G428: Add workflow label documentation explaining GitHub label meanings for all users

### DIFF
--- a/docs/en/04-packets-issues.md
+++ b/docs/en/04-packets-issues.md
@@ -1,6 +1,6 @@
 # Create packets & publish issues
 
-← [docs index](index.md) | → [Implementation loop setup](05-implementation-loop.md)
+← [docs index](index.md) | → [GitHub workflow labels](04a-workflow-labels.md) | → [Implementation loop setup](05-implementation-loop.md)
 
 This is **host/design** work. When your intent is clear enough to act on, the design thread splits it into **packets** — focused implementation units — and publishes one at a time as a GitHub Issue for a child implementation agent to pick up.
 

--- a/docs/en/04a-workflow-labels.md
+++ b/docs/en/04a-workflow-labels.md
@@ -1,0 +1,50 @@
+# GitHub workflow labels and what they mean
+
+When a packet becomes a GitHub Issue, the Intent System's workflow state becomes visible
+through GitHub labels. Labels are the canonical visible state that humans use to understand
+what is waiting on whom. **You do not manually add or remove workflow labels in normal operation.**
+Label transitions are managed by intent-cli and automation commands.
+
+## Core label reference
+
+| Label | Meaning |
+|---|---|
+| `intent-target` | This item is selected as the current workflow target |
+| `intent-issue-in-progress` | An implementation worker has claimed the issue and is working on it |
+| `intent-pr-created` | The issue has produced a PR (applied to the issue, not the PR) |
+| `intent-pr-reviewing` | The host review loop is actively reviewing the PR |
+| `intent-pr-request-update` | The reviewer has requested changes |
+| `intent-pr-update-in-progress` | An implementation worker has claimed the PR update |
+| `intent-pr-rereview-ready` | A fix has been pushed; the review loop should run again |
+| `intent-pr-approved` | The host review has approved the PR — waiting for merge or closeout |
+
+## Reading label combinations
+
+```text
+intent-target + intent-issue-in-progress
+→ This issue is the active implementation target; a worker is working on it.
+
+intent-target + intent-pr-created (on the issue)
+→ A PR has been created; waiting for the review loop to pick it up.
+
+intent-target + intent-pr-reviewing (on the PR)
+→ The host review loop is actively reviewing the PR.
+
+intent-target + intent-pr-request-update (on the PR)
+→ The PR has a change request; waiting for the implementation worker to respond.
+
+intent-target + intent-pr-rereview-ready (on the PR)
+→ A fix has been pushed; the review loop should re-review.
+
+intent-target + intent-pr-approved (on the PR)
+→ The PR is approved and waiting for merge.
+```
+
+## Important notes about labels
+
+- **Do not manually add or remove workflow labels**: in normal operation, workflow labels are managed by intent-cli/automation. Manual changes can cause loops to enter incorrect states.
+- **If the state looks wrong**: do not hand-fix labels. Describe the symptom to your AI agent and ask it to consult intent-cli for the safe repair path (see [Recover when a loop looks wrong](07-recovery.md)).
+
+## Next
+
+[Implementation loop setup](05-implementation-loop.md) | [Create packets & publish issues](04-packets-issues.md) | [docs index](index.md)

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -60,6 +60,7 @@ for the full list of commands the agent will use on your behalf.
 2. [Start a project](02-project-start.md)
 3. [Organize & maintain intents](03-intents.md)
 4. [Create packets & publish issues](04-packets-issues.md)
+4a. [GitHub workflow labels and what they mean](04a-workflow-labels.md) — label meanings and how to read them
 5. [Implementation loop setup](05-implementation-loop.md)
 6. [Review / next-slice loop setup](06-review-next-slice-loop.md)
 7. [Recover when a loop looks wrong](07-recovery.md)

--- a/docs/ja/04-packets-issues.md
+++ b/docs/ja/04-packets-issues.md
@@ -1,6 +1,6 @@
 # packet 作成と issue 公開
 
-← [ドキュメント索引](index.md) | → [実装ループの設定](05-implementation-loop.md)
+← [ドキュメント索引](index.md) | → [GitHub ワークフローラベル](04a-workflow-labels.md) | → [実装ループの設定](05-implementation-loop.md)
 
 これは **host/design** 作業です。intent が十分に固まったら、デザインスレッドがそれを **packet**（実行可能な実装単位）に分割し、1つずつ GitHub Issue として公開します。child implementation agent がその issue を受け取って実装します。
 

--- a/docs/ja/04a-workflow-labels.md
+++ b/docs/ja/04a-workflow-labels.md
@@ -1,0 +1,49 @@
+# GitHub ワークフローラベルで見る現在地
+
+packet が GitHub Issue になると、Intent System の状態は GitHub ラベルとして見えるようになります。
+ラベルは人間が現在地を把握するための可視状態です。**通常は手で付け外ししません。**
+workflow label の変更は intent-cli と automation が行います。
+
+## コアラベル一覧
+
+| ラベル | 意味 |
+|---|---|
+| `intent-target` | この item は現在のワークフロー対象として選択されている |
+| `intent-issue-in-progress` | 実装 worker が issue を claim して作業中 |
+| `intent-pr-created` | issue が PR を生み出した（issue 側に付く） |
+| `intent-pr-reviewing` | host review loop が PR をレビュー中 |
+| `intent-pr-request-update` | レビュアーが変更を要求した |
+| `intent-pr-update-in-progress` | 実装 worker が PR の修正を claim して作業中 |
+| `intent-pr-rereview-ready` | 修正が push 済みで、review loop の再レビュー待ち |
+| `intent-pr-approved` | host review が PR を承認した。マージまたは closeout を待つ |
+
+## ラベルの組み合わせで読む現在地
+
+```text
+intent-target + intent-issue-in-progress
+→ この issue は現在の実装対象で、実装 worker が作業中です。
+
+intent-target + intent-pr-created（issue 側）
+→ PR が作成済みで、review loop が拾うのを待っています。
+
+intent-target + intent-pr-reviewing（PR 側）
+→ host review loop が PR をレビュー中です。
+
+intent-target + intent-pr-request-update（PR 側）
+→ PR に修正依頼があり、実装 worker の再対応待ちです。
+
+intent-target + intent-pr-rereview-ready（PR 側）
+→ 修正が push 済みで、review loop の再レビュー待ちです。
+
+intent-target + intent-pr-approved（PR 側）
+→ PR が承認済みで、マージを待っています。
+```
+
+## ラベルについての注意
+
+- **手でラベルを付け外ししない**: 通常の運用では、workflow label は intent-cli/automation が管理します。手動で変更すると、ループが誤った状態に入る可能性があります。
+- **状態がおかしいと感じたら**: ラベルを手で直すのではなく、AI agent に症状を伝えて intent-cli への修復依頼を任せてください（[ループがおかしいときの復旧](07-recovery.md) を参照）。
+
+## 次へ
+
+[実装ループの設定](05-implementation-loop.md) | [packet 作成と issue 公開](04-packets-issues.md) | [ドキュメント索引](index.md)

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -64,6 +64,7 @@ agent が代わりに使うコマンドの全リストは
 2. [プロジェクト開始](02-project-start.md)
 3. [intent の整理・保守](03-intents.md)
 4. [packet 作成と issue 公開](04-packets-issues.md)
+4a. [GitHub ワークフローラベルで見る現在地](04a-workflow-labels.md) — ラベルの意味と読み方
 5. [実装ループの設定](05-implementation-loop.md)
 6. [レビュー / next-slice ループの設定](06-review-next-slice-loop.md)
 7. [ループがおかしいときの復旧](07-recovery.md)


### PR DESCRIPTION
## Summary

- Add new `docs/ja/04a-workflow-labels.md` and `docs/en/04a-workflow-labels.md` explaining core workflow labels and their human meaning
- Include label combination examples (from issue AC) showing how to interpret what is waiting on whom
- Note that workflow labels must not be manually mutated in normal operation
- Link to recovery docs when state looks wrong
- Update `docs/ja/index.md` and `docs/en/index.md` to include the new pages
- Update navigation in `04-packets-issues.md` to link through to the new label page

Closes #957

## Test plan

- [ ] Core labels (`intent-target`, `intent-issue-in-progress`, `intent-pr-reviewing`, etc.) all explained
- [ ] Label combination examples are present in Japanese docs (AC requirement)
- [ ] Docs explicitly state users should not manually mutate workflow labels
- [ ] Pages are discoverable from index and from `04-packets-issues.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)