### PR TITLE
G429: Rework docs index as landing page and align terminology with Intent Storming

### DIFF
--- a/docs/en/03-intents.md
+++ b/docs/en/03-intents.md
@@ -1,14 +1,16 @@
-# Organize & maintain intents
+# Intent Storming & organize intents
 
 ← [docs index](index.md) | → [Create packets & publish issues](04-packets-issues.md)
 
-This page covers **host/design** work. Before cutting packets, deepen your product and technical intent in a design thread with an AI agent.
+This page covers **host/design** work. Before cutting packets, run Intent Storming with an AI agent in a design thread to clarify your product and technical intent.
 
-## What is intent deepening?
+## What is Intent Storming?
 
-"Intent deepening" is the process of working with an AI agent to clarify what you want to build and why.
+**Intent Storming** is the practice of working with an AI agent before coding to clarify what you want to build and why — capturing the result in a structured intent tree.
 
 You start with a rough description. The AI agent uses intent-cli guidance to ask structured questions with background, options, pros/cons, and a recommendation. As you answer, the project direction, technical choices, and open questions become clear. The results are organized into an **intent tree** — a discoverable folder structure that feeds packets and GitHub issues.
+
+See also the [Intent-Driven Development Intent Storming proposal](https://www.intent-driven-development.com/jp/our-proposals/intent-storming).
 
 You do not need deep technical expertise. If you do not know the best technical choice, ask the AI agent to suggest options and explain tradeoffs.
 

--- a/docs/en/03a-intent-tree-layout.md
+++ b/docs/en/03a-intent-tree-layout.md
@@ -6,9 +6,9 @@ This page describes the **tree-v1** flexible intent knowledge-tree layout for ne
 domains. Existing flat-file domains do not need to migrate immediately — tree-v1
 is a recommended default for new domains, not a hard requirement for existing ones.
 
-## How the intent-deepening conversation maps to the tree
+## How the Intent Storming conversation maps to the tree
 
-Answers from the [intent-deepening conversation](03-intents.md#what-is-intent-deepening)
+Answers from the [Intent Storming conversation](03-intents.md#what-is-intent-storming)
 are organized into the folders below.
 
 | Conversation content | Tree location |
@@ -22,7 +22,7 @@ are organized into the folders below.
 | Implementation/review loop policy, release policy | `operations/` |
 | Executable slices | `packets/` → GitHub issue |
 
-Not all folders need to be populated in one conversation. Intent deepening can be repeated
+Not all folders need to be populated in one conversation. Intent Storming can be repeated
 as the project evolves.
 
 ## Why tree-v1

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -2,63 +2,20 @@
 
 > 日本語版は [`../ja/index.md`](../ja/index.md) を参照してください.
 
-`intent-cli` is **deterministic support tooling** for an intent-driven
-development workflow on top of GitHub. These pages give a little more structure
-than the [root README](../../README.md) without requiring you to read the
-internal design notes.
+`intent-cli` is **deterministic support tooling** for an intent-driven development workflow on top of GitHub.
 
-## How to use intent-cli
-
-`intent-cli` is designed to be driven by an AI agent — Claude, Codex,
-Copilot, or any capable coding assistant with repository access. You do not
-need to memorize or run its commands directly.
-
-**The typical human path:**
-
-1. Install `intent-cli` and verify with `intent-cli --version`.
-2. Open a design thread in your AI agent.
-3. Paste a prompt such as:
+Once installed, open a design thread in your AI agent and paste a prompt like:
 
 > I want to work on `<owner>/<repo>` with intent-cli.
 > Ask intent-cli what phase I'm in and what I should decide next.
 
-The agent runs `intent-cli` internally and brings back questions or results.
-You focus on intent, priorities, and approval decisions — not on memorizing
-command sequences.
-
-## What is intent deepening?
-
-**Intent deepening** is the process of working with an AI agent to clarify what you want to build and why.
-
-For a new product or domain, paste a prompt like this:
-
-> Ask intent-cli to help organize the intent for this project.
->
-> I want to build `<product or feature>`.
-> The important direction is `<user value, business goal, quality bar, operational policy>`.
-> Technically, I am considering `<language, cloud, architecture>`.
-> Some decisions are still unclear, so ask me structured questions with background, options, pros/cons, and a recommendation with reasons.
-> Organize the result into an intent tree that can lead to packets and GitHub issues.
-
-The AI agent uses intent-cli guidance to ask structured questions — background, options, pros/cons, and a recommendation. Your answers are organized into an **intent tree** (a discoverable folder structure) that feeds packets and GitHub issues.
-
-You do not need deep technical expertise. If you do not know the best technical choice, ask the AI agent to suggest options and explain tradeoffs.
-
-See [Organize & maintain intents](03-intents.md) for the full explanation.
-
-**The one rule behind the prompts:** before any label/metadata change, the AI
-agent should run the appropriate `intent-cli` command rather than editing files
-or applying GitHub labels by hand. Every guide and automation page below
-enforces this rule.
-
-See the [command reference](08-command-reference.md)
-for the full list of commands the agent will use on your behalf.
+The agent runs `intent-cli` internally and brings back questions or results. You do not need to memorize commands.
 
 ## Pages
 
 1. [Install](01-install.md)
 2. [Start a project](02-project-start.md)
-3. [Organize & maintain intents](03-intents.md)
+3. [Intent Storming & organize intents](03-intents.md)
 4. [Create packets & publish issues](04-packets-issues.md)
 4a. [GitHub workflow labels and what they mean](04a-workflow-labels.md) — label meanings and how to read them
 5. [Implementation loop setup](05-implementation-loop.md)
@@ -67,6 +24,14 @@ for the full list of commands the agent will use on your behalf.
 8. [Command reference](08-command-reference.md) — agent-facing and power-user command surfaces
 9. [Developer reference](09-developer-reference.md) — packaged invocation, preview channel, version flow
 
+## What is Intent Storming?
+
+**Intent Storming** is the practice of working with an AI agent before coding to clarify what you want to build and why — capturing the result in a structured intent tree. The AI agent asks structured questions with background, options, pros/cons, and a recommendation. Your answers are organized into an **intent tree** that feeds packets and GitHub issues.
+
+See [Intent Storming & organize intents](03-intents.md) for the full guide.
+
+**The one rule behind the prompts:** before any label/metadata change, the AI agent should run the appropriate `intent-cli` command rather than editing files or applying GitHub labels by hand. See the [command reference](08-command-reference.md).
+
 ## Two agent roles (read this once)
 
 | Role | Source of truth | Responsibilities |
@@ -74,19 +39,10 @@ for the full list of commands the agent will use on your behalf.
 | **Host / review agent** | parent host `.intent-cli/` state + intent tree | publish issues, apply `intent-target`, review/approve/merge, cut next slices, label transitions via `intent-cli automation` |
 | **Child implementation agent** | the **GitHub issue/PR + repo-local code** (not host metadata) | implement the issue contract, open/update the PR, record outcomes via `intent-cli worker` |
 
-Child implementation agents are **GitHub-contract-only**: they must not read or
-mutate host `.intent-cli/`, queue-state, metadata branches, or `intents/**`.
-Host/review agents may operate on metadata, but ask `intent-cli` for the current
-command first and prefer its transitions over hand edits.
+Child implementation agents are **GitHub-contract-only**: they must not read or mutate host `.intent-cli/`, queue-state, metadata branches, or `intents/**`.
 
-The host can live in a **separate host repository** or in the **same repository
-on a dedicated metadata branch** (e.g. `main-metadata`). Both topologies are
-fully supported. See [Start a project → Repository topology choices](02-project-start.md#repository-topology-choices)
-for guidance on which to choose.
+The host can live in a **separate host repository** or in the **same repository on a dedicated metadata branch** (e.g. `main-metadata`). See [Start a project → Repository topology choices](02-project-start.md#repository-topology-choices) for guidance.
 
 ## Community
 
-Join the [J-Tech Japan Discord](https://discord.gg/kMdv978X) for community
-discussion and questions. For bugs or actionable feature requests, open a
-[GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) instead.
-Security reports go to [SECURITY.md](../../SECURITY.md), not Discord.
+Join the [J-Tech Japan Discord](https://discord.gg/kMdv978X) for community discussion and questions. For bugs or actionable feature requests, open a [GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) instead. Security reports go to [SECURITY.md](../../SECURITY.md), not Discord.

--- a/docs/ja/03-intents.md
+++ b/docs/ja/03-intents.md
@@ -1,14 +1,16 @@
-# intent の整理・保守
+# Intent Storming と intent の整理
 
 ← [ドキュメント索引](index.md) | → [packet 作成と issue 公開](04-packets-issues.md)
 
-このページは **host/design** 作業です。packet を切り出す前に、AI agent とのデザインスレッドでプロダクト・技術の intent を深化させます。
+このページは **host/design** 作業です。packet を切り出す前に、AI agent とのデザインスレッドでプロダクト・技術の intent を整理します。
 
-## intent deepening とは
+## Intent Storming とは
 
-「intent deepening（意図の深化）」とは、AI agent と一緒に「何を作りたいか・なぜ作るか」を整理していくプロセスです。
+**Intent Storming** は、コードを書く前に「何を作るか・なぜ作るか・どの制約を受け入れるか」を AI agent と整理し、構造化された intent tree に残す作業です。
 
 最初は大まかな説明から始まります。AI agent は intent-cli のガイダンスを使って、背景・選択肢・メリット/デメリット・推奨理由つきで構造化された質問を投げかけます。あなたが答えるたびに、プロジェクトの方向性・技術的選択・未解決の課題が明確になっていきます。その結果は **intent tree** という発見しやすいフォルダ構造に整理され、packet（実装タスク）と GitHub issue の土台になります。
+
+詳細は [Intent-Driven Development サイトの Intent Storming 提案](https://www.intent-driven-development.com/jp/our-proposals/intent-storming) も参照してください。
 
 技術的な専門知識がなくても始められます。どの選択肢がよいか分からない場合は、AI agent に提案を求めてトレードオフを比較しながら決められます。
 

--- a/docs/ja/03a-intent-tree-layout.md
+++ b/docs/ja/03a-intent-tree-layout.md
@@ -5,9 +5,9 @@
 このページでは、新規ドメイン向けの **tree-v1** フレキシブル intent ナレッジツリーレイアウトについて説明します。
 既存のフラットファイルドメインはすぐに移行する必要はありません。tree-v1 は新規ドメインへの推奨デフォルトであり、既存ドメインへの強制要件ではありません。
 
-## intent deepening の会話とツリーの関係
+## Intent Storming の会話とツリーの関係
 
-[intent deepening の会話](03-intents.md#intent-deepening-とは)で得られた回答は、このツリーの各フォルダに整理されます。
+[Intent Storming の会話](03-intents.md#intent-storming-とは)で得られた回答は、このツリーの各フォルダに整理されます。
 
 | 会話で決まった内容 | ツリーの格納先 |
 |---|---|
@@ -20,7 +20,7 @@
 | 実装ループ・リリース方針 | `operations/` |
 | 実行可能スライス | `packets/` → GitHub issue |
 
-1回の会話ですべてのフォルダが埋まる必要はありません。intent deepening は何度でも繰り返せます。
+1回の会話ですべてのフォルダが埋まる必要はありません。Intent Storming は何度でも繰り返せます。
 
 ## なぜ tree-v1 か
 

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -2,67 +2,20 @@
 
 > English version: [`../en/index.md`](../en/index.md)
 
-`intent-cli` は、GitHub 上で intent 駆動の開発ワークフローを回すための
-**決定論的なサポートツール** です。これらのページは、内部設計ノートを全部読まなくても
-[ルート README](../../README.md) より少しだけ構造化された案内を提供します。
+`intent-cli` は、AI agent に Intent System の正規手順を確認させながら Intent-Driven Development を進めるための **決定論的なサポートツール** です。
 
-## intent-cli の使い方
-
-`intent-cli` は AI agent — Claude、Codex、Copilot など、リポジトリアクセスを持つ
-有能なコーディングアシスタント — に動かしてもらうことを前提に設計されています。
-コマンドを自分で記憶・実行する必要はありません。
-
-**人間の典型的な操作手順:**
-
-1. `intent-cli` をインストールし、`intent-cli --version` で確認する。
-2. AI agent のデザインスレッドを開く。
-3. 次のようなプロンプトを貼り付ける:
+`intent-cli` をインストールしたら、AI agent のデザインスレッドで次のように依頼します:
 
 > `<owner>/<repo>` で intent-cli を使い始めたいです。
 > intent-cli に現在のフェーズと次に決断すべきことを聞いてください。
 
-agent が内部で `intent-cli` を実行し、質問や結果を返します。
-あなたは意図・優先度・承認の判断に集中するだけです。コマンドシーケンスを
-記憶する必要はありません。
-
-## intent deepening とは
-
-**intent deepening（意図の深化）** は、AI agent と一緒に「何を作りたいか・なぜ作るか」を整理していくプロセスです。
-
-チャット文脈があるときは一文でも始められます:
-
-> `<やりたいこと>`。intent-cli に聞いて正規の仕方で扱って。
-
-新しいプロダクトやドメインを始めるときは、もう少し詳しいプロンプトを貼るとより充実した質問が得られます:
-
-> intent-cli に聞いて、このプロジェクトの intent を一緒に整理してください。
->
-> やりたいことは、`<作りたいプロダクトや機能>` です。
-> 大事にしたい方向性は、`<ユーザー価値、事業目的、品質、運用方針>` です。
-> 技術的には、`<使いたい言語、クラウド、アーキテクチャ>` を考えています。
-> まだ決めきれていない点もあるので、背景・選択肢・メリット/デメリット・推奨理由つきで質問してください。
-> 最終的に intent tree と packet に進められる形に整理してください。
-
-AI agent は intent-cli のガイダンスを使い、背景・選択肢・メリット/デメリット・推奨理由つきの構造化された質問を投げかけます。あなたの回答は **intent tree**（発見しやすいフォルダ構造）に整理され、packet（実装タスク）と GitHub issue の土台になります。
-
-技術的な専門知識がなくても始められます。どの選択肢がよいか分からない場合は、AI agent に提案を求めてトレードオフを比較しながら決められます。
-
-詳細は [intent の整理・保守](03-intents.md) を参照してください。
-
-**プロンプトの背後にある唯一のルール:** label/metadata を変更する前に、AI agent は
-ファイルを手編集したり GitHub label を手動で適用したりするのではなく、適切な
-`intent-cli` コマンドを実行すべきです。以下のすべてのガイドと自動化ページが
-このルールを強制しています。
-
-agent が代わりに使うコマンドの全リストは
-[コマンドリファレンス](08-command-reference.md)
-を参照してください。
+agent が内部で `intent-cli` を実行し、質問や結果を返します。コマンドを覚える必要はありません。
 
 ## ページ一覧
 
 1. [インストール](01-install.md)
 2. [プロジェクト開始](02-project-start.md)
-3. [intent の整理・保守](03-intents.md)
+3. [Intent Storming と intent の整理](03-intents.md)
 4. [packet 作成と issue 公開](04-packets-issues.md)
 4a. [GitHub ワークフローラベルで見る現在地](04a-workflow-labels.md) — ラベルの意味と読み方
 5. [実装ループの設定](05-implementation-loop.md)
@@ -71,6 +24,14 @@ agent が代わりに使うコマンドの全リストは
 8. [コマンドリファレンス](08-command-reference.md) — agent 向け・パワーユーザー向けコマンド一覧
 9. [開発者リファレンス](09-developer-reference.md) — パッケージ化された実行、preview チャンネル、バージョンフロー
 
+## Intent Storming とは
+
+**Intent Storming** は、コードを書く前に「何を作るか・なぜ作るか・どの制約を受け入れるか」を AI agent と整理し、構造化された intent tree に残す作業です。AI agent は背景・選択肢・メリット/デメリット・推奨理由つきで構造化された質問を投げかけ、あなたの回答を packet（実装タスク）と GitHub issue の土台となる intent tree に整理します。
+
+詳しくは [Intent Storming と intent の整理](03-intents.md) を参照してください。
+
+**プロンプトの背後にある唯一のルール:** label/metadata を変更する前に、AI agent は適切な `intent-cli` コマンドを実行すべきです。ファイルを手編集したり GitHub label を手動で適用しません。[コマンドリファレンス](08-command-reference.md) を参照してください。
+
 ## 2 つの agent ロール（最初に一度だけ読む）
 
 | ロール | source of truth | 責務 |
@@ -78,21 +39,12 @@ agent が代わりに使うコマンドの全リストは
 | **Host / review agent** | 親 host の `.intent-cli/` 状態 + intent tree | issue 公開、`intent-target` 付与、review/approve/merge、next slice 切り出し、`intent-cli automation` 経由の label 遷移 |
 | **Child implementation agent** | **GitHub の issue/PR + repo ローカルのコード**（host metadata ではない） | issue 契約の実装、PR の作成/更新、`intent-cli worker` での結果記録 |
 
-Child implementation agent は **GitHub-contract-only**: host の `.intent-cli/`、
-queue-state、metadata branch、`intents/**` を読んだり変更したりしない。
-Host/review agent は metadata を扱ってよいが、手編集の前に `intent-cli` へ現在の
-コマンドを尋ね、その遷移を優先する。
+Child implementation agent は **GitHub-contract-only**: host の `.intent-cli/`、queue-state、metadata branch、`intents/**` を読んだり変更したりしない。
 
-host は **別の host リポジトリ** に置くこともできますし、**同じリポジトリの専用 metadata ブランチ**
-（例: `main-metadata`）に置くこともできます。どちらのトポロジーも完全にサポートされています。
-どちらを選ぶかは [プロジェクト開始 → リポジトリトポロジーの選択](02-project-start.md#リポジトリトポロジーの選択)
-を参照してください。
+host は **別の host リポジトリ** に置くこともできますし、**同じリポジトリの専用 metadata ブランチ**（例: `main-metadata`）に置くこともできます。詳しくは [プロジェクト開始 → リポジトリトポロジーの選択](02-project-start.md#リポジトリトポロジーの選択) を参照してください。
 
 ## コミュニティ
 
-コミュニティのディスカッションや質問には [J-Tech Japan Discord](https://discord.gg/kMdv978X)
-にご参加ください。Discord はカジュアルなサポート窓口であり、正式なサポート SLA はありません。
+コミュニティのディスカッションや質問には [J-Tech Japan Discord](https://discord.gg/kMdv978X) にご参加ください。
 
-再現可能なバグやアクションにつながる機能要望は Discord ではなく
-[GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) として報告してください。
-セキュリティに関する報告は Discord ではなく [SECURITY.md](../../SECURITY.md) へ。
+再現可能なバグやアクションにつながる機能要望は [GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) として報告してください。セキュリティに関する報告は [SECURITY.md](../../SECURITY.md) へ。


### PR DESCRIPTION
## Summary

- Restructure `docs/ja/index.md` and `docs/en/index.md` as navigation-first landing pages: purpose → start prompt → page list → Intent Storming summary → agent roles → community
- Replace all `intent deepening` occurrences with `Intent Storming` in `03-intents.md`, `03a-intent-tree-layout.md` (both ja/en)
- Add link to the public [Intent Storming proposal](https://www.intent-driven-development.com/jp/our-proposals/intent-storming) in `03-intents.md`
- Page list entry for page 3 updated to "Intent Storming と intent の整理" / "Intent Storming & organize intents"

## Test plan

- [ ] Search docs for `intent deepening` — should return no matches
- [ ] Verify `docs/ja/index.md` and `docs/en/index.md` open with purpose + start prompt + page list before conceptual sections
- [ ] Verify `03-intents.md` section heading reads `Intent Storming とは` / `What is Intent Storming?`
- [ ] Verify anchor links in `03a-intent-tree-layout.md` point to updated headings
- [ ] Run `git diff --check` — no whitespace errors

Closes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)