### PR TITLE
G430: Add .NET SDK prerequisite section to install docs

### DIFF
--- a/docs/en/01-install.md
+++ b/docs/en/01-install.md
@@ -4,9 +4,25 @@
 
 Install `intent-cli` and verify it works. Once confirmed, continue to [Start a project](02-project-start.md).
 
+## If .NET is not installed
+
+Installing intent-cli as a NuGet global tool requires the .NET SDK.
+If the `dotnet` command is not yet available, install the .NET 10 SDK from the official Microsoft download page:
+
+- https://dotnet.microsoft.com/en-us/download
+
+After installing, confirm the SDK is available:
+
+```bash
+dotnet --version
+```
+
+Once a version number appears, you are ready for the next step.
+
+## Install
+
 The basic path is the .NET global tool from NuGet.org (requires a **.NET 10
-SDK**; check with `dotnet --version`). The same commands work on macOS, Windows,
-and Linux:
+SDK**). The same commands work on macOS, Windows, and Linux:
 
 ```bash
 # Install

--- a/docs/ja/01-install.md
+++ b/docs/ja/01-install.md
@@ -4,8 +4,24 @@
 
 `intent-cli` をインストールして動作確認します。インストールが終わったら [プロジェクト開始](02-project-start.md) に進んでください。
 
-基本ルートは NuGet.org の .NET グローバルツール（**.NET 10 SDK** が必要。
-`dotnet --version` で確認）。macOS / Windows / Linux で同じコマンド:
+## .NET SDK が入っていない場合
+
+NuGet global tool として intent-cli を入れるには .NET SDK が必要です。
+まだ `dotnet` コマンドが使えない場合は、Microsoft の公式ページから .NET 10 SDK をインストールしてください。
+
+- https://dotnet.microsoft.com/en-us/download
+
+インストール後、ターミナルで次を確認します。
+
+```bash
+dotnet --version
+```
+
+バージョンが表示されたら、次の手順に進めます。
+
+## インストール
+
+基本ルートは NuGet.org の .NET グローバルツール（**.NET 10 SDK** が必要）。macOS / Windows / Linux で同じコマンド:
 
 ```bash
 # インストール


### PR DESCRIPTION
## Summary

- Added `## If .NET is not installed` section to `docs/en/01-install.md` before the `dotnet tool install` command
- Added `## .NET SDK が入っていない場合` section to `docs/ja/01-install.md` before the `dotnet tool install` command
- Both sections link to the official .NET 10 download page and instruct users to verify with `dotnet --version`
- Removed inline `check with \`dotnet --version\`` note from the install intro since it is now covered in the new section

Closes #961

## Test plan

- [ ] Review rendered install docs — both language versions have clear prerequisite guidance before the install command
- [ ] Verify link to https://dotnet.microsoft.com/en-us/download is present in both files
- [ ] Confirm `dotnet --version` verification step appears in both files
- [ ] Confirm page remains install-focused (no workflow concepts added)
- [ ] Run `git diff --check` — no whitespace errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)