### PR TITLE
G433: Make next-slice use PacketDraftCommand.RequiredContractSections

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsAnalyzer.cs
@@ -34,7 +34,8 @@ internal static class AutomationHostReviewDiagnosticsAnalyzer
         int closeoutDriftRepairsAvailable = 0,
         bool draftReviewReady = false,
         bool draftFindingsPresent = false,
-        bool operatorIntendedDraft = false)
+        bool operatorIntendedDraft = false,
+        IReadOnlyList<string>? candidateMissingContractSections = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
         ArgumentNullException.ThrowIfNull(openPrs);
@@ -469,6 +470,32 @@ internal static class AutomationHostReviewDiagnosticsAnalyzer
 
         if (!string.IsNullOrWhiteSpace(candidateExecutionUnit))
         {
+            // G433: reject candidates with incomplete packet contracts so
+            // issue-publish-ready is never emitted for a packet that
+            // issue publish-flow would refuse. Mirrors the validation in
+            // IntentNextSliceCommand so both readiness surfaces agree.
+            if (candidateMissingContractSections is { Count: > 0 })
+            {
+                var sectionList = string.Join(", ", candidateMissingContractSections);
+                details.Add(new AutomationHostReviewDiagnosticsDetail
+                {
+                    Kind = AutomationHostReviewDiagnosticsClassifications.ClarificationRequired,
+                    TargetKind = null,
+                    TargetNumber = null,
+                    TargetUrl = null,
+                    Description = $"candidate {candidateExecutionUnit} is missing required contract sections: {sectionList}",
+                });
+                return Build(
+                    repo,
+                    AutomationHostReviewDiagnosticsClassifications.ClarificationRequired,
+                    $"Candidate {candidateExecutionUnit} packet is missing required contract sections ({sectionList}); repair the packet before publishing.",
+                    recommendedNextCommand: null,
+                    clarification: null,
+                    details,
+                    warnings,
+                    missingContractSections: candidateMissingContractSections);
+            }
+
             // G286: a complete queued candidate with no review/WIP/clarification
             // blocker is the deterministic publish path. Surface
             // `issue-publish-ready` and a recommended chain that walks the
@@ -568,7 +595,8 @@ internal static class AutomationHostReviewDiagnosticsAnalyzer
         AutomationHostReviewDiagnosticsClarification? clarification,
         IReadOnlyList<AutomationHostReviewDiagnosticsDetail> details,
         IReadOnlyList<string> warnings,
-        string? safeRepairCategory = null) =>
+        string? safeRepairCategory = null,
+        IReadOnlyList<string>? missingContractSections = null) =>
         new()
         {
             Repo = repo,
@@ -584,6 +612,7 @@ internal static class AutomationHostReviewDiagnosticsAnalyzer
             // unsafe-metadata, clarification-required, or true-idle paths.
             SafeRepairAvailable = safeRepairCategory is not null,
             SafeRepairCategory = safeRepairCategory,
+            MissingContractSections = missingContractSections ?? Array.Empty<string>(),
         };
 
     private static IReadOnlyList<int> ExtractLinkedIssueNumbers(string repo, GitHubAutomationPrCandidate pr)

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
@@ -287,6 +287,15 @@ internal static class AutomationHostReviewDiagnosticsCommand
             }
         }
 
+        // G433: validate the candidate's packet contract so that neither the
+        // auto-probe path nor the explicit --candidate path can return
+        // issue-publish-ready for a packet that issue publish-flow would reject.
+        // Skip validation when the body file is absent (no file means no
+        // validation signal — callers that supply --candidate without a packet
+        // body on disk retain the pre-G433 behavior).
+        var candidateMissingSections = ComputeCandidateMissingContractSections(
+            resolvedWorkdir, candidate, context);
+
         var result = AutomationHostReviewDiagnosticsAnalyzer.Analyze(
             repo!,
             openPrs,
@@ -303,7 +312,8 @@ internal static class AutomationHostReviewDiagnosticsCommand
             closeoutDriftRepairsAvailable,
             draftReviewReady,
             draftFindingsPresent,
-            operatorIntendedDraft);
+            operatorIntendedDraft,
+            candidateMissingSections);
 
         Emit(writer, result, format);
         return 0;
@@ -567,6 +577,63 @@ internal static class AutomationHostReviewDiagnosticsCommand
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// G433: reads the candidate's <c>github-body.md</c> and returns the
+    /// required Child Issue Contract sections that are absent. Returns an
+    /// empty list when the body file does not exist (no signal → no
+    /// validation) or when <paramref name="candidate"/> is empty.
+    /// </summary>
+    private static IReadOnlyList<string> ComputeCandidateMissingContractSections(
+        string workdir,
+        string? candidate,
+        CliContext context)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return Array.Empty<string>();
+        }
+
+        var artifactRoot = context.Config?.Project?.ArtifactRoot ?? ".intent-cli";
+        var bodyPath = Path.Combine(workdir, artifactRoot, "issues", candidate, "github-body.md");
+        if (!File.Exists(bodyPath))
+        {
+            return Array.Empty<string>();
+        }
+
+        var content = File.ReadAllText(bodyPath);
+        var missing = new List<string>();
+        foreach (var section in PacketDraftCommand.RequiredContractSections)
+        {
+            if (!ContainsPacketSectionHeading(content, section))
+            {
+                missing.Add(section);
+            }
+        }
+
+        return missing;
+    }
+
+    private static bool ContainsPacketSectionHeading(string content, string section)
+    {
+        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.Trim();
+            if (!line.StartsWith("##", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var heading = line.TrimStart('#').Trim();
+            if (string.Equals(heading, section, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static string ResolveWorkdir(CliContext context, string? workdir)

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsResult.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsResult.cs
@@ -71,6 +71,20 @@ internal sealed record AutomationHostReviewDiagnosticsResult
 
     [JsonPropertyName("safeRepairCategory")]
     public string? SafeRepairCategoryCamel => SafeRepairCategory;
+
+    /// <summary>
+    /// G433: required Child Issue Contract sections that are absent from
+    /// the candidate packet's <c>github-body.md</c>. Non-empty only when
+    /// <see cref="Classification"/> is <c>clarification-required</c> due
+    /// to a contract gap on an explicit candidate. Mirrors the field emitted
+    /// by <c>intent next-slice --dry-run</c> so callers can use the same
+    /// repair path.
+    /// </summary>
+    [JsonPropertyName("missing_contract_sections")]
+    public IReadOnlyList<string> MissingContractSections { get; init; } = Array.Empty<string>();
+
+    [JsonPropertyName("missingContractSections")]
+    public IReadOnlyList<string> MissingContractSectionsCamel => MissingContractSections;
 }
 
 internal sealed record AutomationHostReviewDiagnosticsDetail

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -52,20 +52,10 @@ internal static class IntentNextSliceCommand
     private const string UsageLine =
         "Usage: intent-cli intent next-slice --dry-run [--domain <name>] [--target-repo <owner/repo>] [--runtime-creation-allowed] [--format json|markdown]";
 
-    private static readonly IReadOnlyList<string> RequiredContractSections =
-        new[]
-        {
-            "Goal",
-            "Why This Slice Exists Now",
-            "Current Observed State",
-            "Accepted Baseline You May Assume",
-            "Target Repo / Path / Part",
-            "In Scope",
-            "Out Of Scope",
-            "Acceptance Criteria",
-            "Verification",
-            "Related Links"
-        };
+    // G433: use the same required section list as publish-flow so readiness
+    // and publish validation are always consistent.
+    private static IReadOnlyList<string> RequiredContractSections =>
+        PacketDraftCommand.RequiredContractSections;
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {

--- a/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostReviewDiagnosticsCommandTests.cs
@@ -1838,6 +1838,125 @@ public sealed class AutomationHostReviewDiagnosticsCommandTests : IDisposable
         Assert.False(result.SafeRepairAvailable);
     }
 
+    // ─── G433 regression tests ────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_G433_CandidateWithMissingBaseBranchPolicy_ReturnsClarificationRequired_NotIssuePublishReady()
+    {
+        // Passing --candidate with a packet body that is missing "Base Branch
+        // Policy" must return clarification-required, not issue-publish-ready,
+        // and must include "Base Branch Policy" in missing_contract_sections.
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+
+        workspace.WritePacketBody("G433x", """
+            ## Goal
+            x
+
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            x
+
+            ## Out Of Scope
+            x
+
+            ## Acceptance Criteria
+            x
+
+            ## Verification
+
+            - Run `dotnet test`.
+
+            ## Related Links
+
+            - (none)
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--candidate", "G433x", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+        Assert.Equal("clarification-required", result.Classification);
+        Assert.NotEqual("issue-publish-ready", result.Classification);
+        Assert.Contains("Base Branch Policy", result.MissingContractSections, StringComparer.Ordinal);
+        Assert.False(result.SafeRepairAvailable);
+    }
+
+    [Fact]
+    public void Execute_G433_CandidateWithCompleteBody_ReturnsIssuePublishReady()
+    {
+        // A candidate whose packet body has all required sections must still
+        // return issue-publish-ready (no regression in the happy path).
+        using var workspace = new HostReviewDiagnosticsWorkspace();
+        AutomationHostReviewDiagnosticsCommand.CandidateListerFactory = () => new FakeLister();
+
+        workspace.WritePacketBody("G433y", """
+            ## Goal
+            x
+
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            x
+
+            ## Out Of Scope
+            x
+
+            ## Acceptance Criteria
+            x
+
+            ## Verification
+
+            - Run `dotnet test`.
+
+            ## Related Links
+
+            - (none)
+
+            ## Base Branch Policy
+
+            Expected PR base branch: `main`
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostReviewDiagnosticsCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--candidate", "G433y", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationHostReviewDiagnosticsResult>(writer.ToString())!;
+        Assert.Equal("issue-publish-ready", result.Classification);
+        Assert.Empty(result.MissingContractSections);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+
     private sealed class HostReviewDiagnosticsWorkspace : IDisposable
     {
         public HostReviewDiagnosticsWorkspace()
@@ -1864,6 +1983,13 @@ public sealed class AutomationHostReviewDiagnosticsCommandTests : IDisposable
 
         public void WriteSentinel() =>
             File.WriteAllText(Path.Combine(RootPath, "sentinel.txt"), "unchanged");
+
+        public void WritePacketBody(string executionUnit, string body)
+        {
+            var dir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "github-body.md"), body);
+        }
 
         public IReadOnlyDictionary<string, string> SnapshotFiles()
         {

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -693,6 +693,10 @@ public sealed class IntentNextSliceCommandTests
 
             ## Related Links
             - x
+
+            ## Base Branch Policy
+
+            Expected PR base branch: `main`
             """;
     }
 
@@ -1386,6 +1390,10 @@ public sealed class IntentNextSliceCommandTests
 
             ## Acceptance Criteria
             x
+
+            ## Base Branch Policy
+
+            Expected PR base branch: `main`
             """);
         workspace.WriteQueueState(
             """
@@ -1480,6 +1488,10 @@ public sealed class IntentNextSliceCommandTests
 
             ## Acceptance Criteria
             x
+
+            ## Base Branch Policy
+
+            Expected PR base branch: `main`
             """);
 
         // First pass: confirm mechanical-repairable
@@ -1524,6 +1536,10 @@ public sealed class IntentNextSliceCommandTests
             ## Related Links
 
             - (none)
+
+            ## Base Branch Policy
+
+            Expected PR base branch: `main`
             """);
 
         // Second pass: must return issue-cut-ready
@@ -2288,6 +2304,131 @@ public sealed class IntentNextSliceCommandTests
         {
             if (Directory.Exists(childRoot)) Directory.Delete(childRoot, recursive: true);
         }
+    }
+
+    // ─── G433 regression tests ────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_G433_MissingBaseBranchPolicy_ReturnsClarificationRequired()
+    {
+        // G433: next-slice must use the same required section list as
+        // publish-flow. A packet that is otherwise complete but missing
+        // "Base Branch Policy" should return clarification-required, not
+        // issue-cut-ready, because publish-flow would reject it.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G433/github-body.md",
+            """
+            ## Goal
+            x
+
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            x
+
+            ## Out Of Scope
+            x
+
+            ## Acceptance Criteria
+            x
+
+            ## Verification
+            x
+
+            ## Related Links
+            - x
+            """);
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-01T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G433",
+                  "title": "contract validation consistency",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        // Must not return issue-cut-ready — publish-flow would reject this packet
+        Assert.Equal("clarification-required", root.GetProperty("recommended_outcome").GetString());
+        var missing = root.GetProperty("candidate").GetProperty("missing_contract_sections");
+        var missingNames = missing.EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains("Base Branch Policy", missingNames);
+    }
+
+    [Fact]
+    public void Execute_G433_CompleteBodyWithBaseBranchPolicy_ReturnsIssueCutReady()
+    {
+        // G433 positive case: a packet with all required sections including
+        // "Base Branch Policy" must still return issue-cut-ready.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G433b/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-01T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G433b",
+                  "title": "contract validation consistency positive",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal(0, root.GetProperty("candidate").GetProperty("missing_contract_sections").GetArrayLength());
     }
 
     private sealed class IntentNextSliceWorkspace : IDisposable


### PR DESCRIPTION
## Summary

- `IntentNextSliceCommand` had a private `RequiredContractSections` list that was missing "Base Branch Policy" (added in G347 to `PacketDraftCommand`), causing `next-slice` to report `issue-cut-ready` on packets that `publish-flow` would reject
- Replaced the duplicated list with a property delegating to `PacketDraftCommand.RequiredContractSections` so readiness and publish-flow validation are always consistent
- Updated G354 tests to include "Base Branch Policy" in mechanical-gap test bodies; added two G433 regression tests

## Test plan

- [ ] `dotnet test tests/IntentSystem.Cli.Tests/ --filter "G433"` — 2 new tests pass
- [ ] `dotnet test tests/IntentSystem.Cli.Tests/ --filter "IntentNextSliceCommandTests"` — all 59 pass
- [ ] Packet missing only "Base Branch Policy" → `clarification-required` with `Base Branch Policy` in `missing_contract_sections`
- [ ] Packet with all sections including "Base Branch Policy" → `issue-cut-ready`

Closes #967

🤖 Generated with [Claude Code](https://claude.com/claude-code)