### PR TITLE
G434: Bump version to 0.3.2 and set next development line to 0.3.3

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -68,7 +68,7 @@ The CLI is packaged as a .NET tool (package id `JTechJapan.IntentSystem.Cli`,
 command `intent-cli`). To smoke-test a locally built package:
 
 ```bash
-export INTENT_CLI_LOCAL_VERSION="0.3.1-local.$(date -u +%Y%m%d%H%M%S)"
+export INTENT_CLI_LOCAL_VERSION="0.3.2-local.$(date -u +%Y%m%d%H%M%S)"
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
   -p:Version="$INTENT_CLI_LOCAL_VERSION" \
   -o .artifacts/packages

--- a/docs/en/release-notes-v0.3.2.md
+++ b/docs/en/release-notes-v0.3.2.md
@@ -1,0 +1,63 @@
+# Release Notes — intent-cli v0.3.2
+
+> **Release checklist for maintainers:** see [Creating the v0.3.2 GitHub Release](#creating-the-v032-github-release).
+
+## What's in v0.3.2
+
+v0.3.2 is a documentation and packaging quality release focused on validating
+that all links on the NuGet.org package page resolve correctly after the
+absolute-URL cleanup introduced in G432. No new product commands are added.
+
+### NuGet package README absolute-link cleanup (G432)
+
+- All repository-relative links (`./docs/...`, `./SECURITY.md`, etc.) in
+  `README.md` converted to absolute GitHub blob URLs so they render correctly
+  on the NuGet.org package page.
+- Verified that install/upgrade commands, documentation links, community
+  links, and license/notice references all point to the correct stable paths.
+
+### Contract validation consistency (G433)
+
+- `intent next-slice --dry-run` now uses the same required Child Issue
+  Contract section list as `issue publish-flow`, eliminating a mismatch where
+  `next-slice` could report `issue-cut-ready` for a packet that `publish-flow`
+  would reject for missing sections (e.g. `Base Branch Policy`).
+- `automation host-review-diagnostics --candidate <unit>` now validates the
+  candidate's packet contract before reporting `issue-publish-ready`, and
+  emits `missing_contract_sections` in JSON output when sections are absent.
+- Regression tests added for both surfaces covering `Base Branch Policy`.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.2
+```
+
+Or download the self-contained binary from the
+[v0.3.2 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.2).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.1
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.2
+```
+
+There are no breaking changes from v0.3.1.
+
+## Creating the v0.3.2 GitHub Release
+
+1. Tag the release commit: `git tag v0.3.2 && git push origin v0.3.2`
+2. The `release.yml` workflow fires and builds binaries, `.nupkg`, and
+   checksums. Wait for it to complete.
+3. The workflow creates the GitHub Release draft. Review it, paste the
+   content of this file as the release body, and publish.
+4. Post-release verification checklist:
+   - [ ] NuGet.org package page links all resolve correctly (absolute URLs
+         from G432 are visible and functional).
+   - [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`)
+         are accessible.
+   - [ ] `.sha256` checksums match the downloaded artifacts.
+   - [ ] `intent-cli --version` reports `0.3.2`.
+   - [ ] Local preview/dry-run version metadata uses `0.3.3` as the next
+         development line.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -68,7 +68,7 @@ CLI は .NET ツールとしてパッケージ化されています（パッケ�
 コマンド `intent-cli`）。ローカルビルドパッケージのスモークテスト:
 
 ```bash
-export INTENT_CLI_LOCAL_VERSION="0.3.1-local.$(date -u +%Y%m%d%H%M%S)"
+export INTENT_CLI_LOCAL_VERSION="0.3.2-local.$(date -u +%Y%m%d%H%M%S)"
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
   -p:Version="$INTENT_CLI_LOCAL_VERSION" \
   -o .artifacts/packages

--- a/docs/ja/release-notes-v0.3.2.md
+++ b/docs/ja/release-notes-v0.3.2.md
@@ -1,0 +1,64 @@
+# リリースノート — intent-cli v0.3.2
+
+> **メンテナー向けリリースチェックリスト:** [v0.3.2 GitHub Release の作成](#v032-github-release-の作成) を参照。
+
+## v0.3.2 の内容
+
+v0.3.2 は、G432 で行った絶対 URL クリーンアップ後に NuGet.org パッケージページの
+すべてのリンクが正しく解決されることを検証することに重点を置いた、
+ドキュメントおよびパッケージング品質リリースです。新しいプロダクトコマンドはありません。
+
+### NuGet パッケージ README 絶対リンク化 (G432)
+
+- `README.md` 内のリポジトリ相対リンク（`./docs/...`、`./SECURITY.md` 等）を
+  すべて絶対 GitHub blob URL に変換し、NuGet.org パッケージページでも正しく
+  レンダリングされるようになりました。
+- インストール/アップグレードコマンド、ドキュメントリンク、コミュニティリンク、
+  ライセンス/通知リファレンスがすべて正しい安定パスを指していることを確認済みです。
+
+### コントラクト検証の一貫性 (G433)
+
+- `intent next-slice --dry-run` が `issue publish-flow` と同一の必須
+  Child Issue Contract セクションリストを使用するようになりました。
+  これにより、`next-slice` が `publish-flow` では拒否されるパケット
+  （例: `Base Branch Policy` が欠如しているもの）に対して `issue-cut-ready`
+  を報告するという不一致が解消されました。
+- `automation host-review-diagnostics --candidate <unit>` が
+  `issue-publish-ready` を報告する前に候補パケットの契約を検証するようになり、
+  セクションが欠如している場合は JSON 出力に `missing_contract_sections` を
+  含めるようになりました。
+- 両サーフェスに `Base Branch Policy` を対象とした回帰テストを追加。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.2
+```
+
+または [v0.3.2 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.2)
+から self-contained バイナリをダウンロード。使用前に `.sha256` を検証してください。
+
+## v0.3.1 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.2
+```
+
+v0.3.1 からの破壊的変更はありません。
+
+## v0.3.2 GitHub Release の作成
+
+1. リリースコミットにタグを付ける: `git tag v0.3.2 && git push origin v0.3.2`
+2. `release.yml` ワークフローが起動し、バイナリ、`.nupkg`、チェックサムをビルドします。
+   完了を待ちます。
+3. ワークフローが GitHub Release ドラフトを作成します。内容を確認し、
+   このファイルの内容をリリース本文として貼り付けて公開します。
+4. リリース後の確認チェックリスト:
+   - [ ] NuGet.org パッケージページのリンクがすべて正しく解決される（G432 の
+         絶対 URL が表示・機能する）。
+   - [ ] GitHub リリースアセットリンク（`.tar.gz`、`.zip`、`.exe`、`.nupkg`）
+         がアクセス可能。
+   - [ ] `.sha256` チェックサムがダウンロードしたアーティファクトと一致する。
+   - [ ] `intent-cli --version` が `0.3.2` を返す。
+   - [ ] ローカルプレビュー/dry-run バージョンメタデータが次の開発ラインとして
+         `0.3.3` を使用する。

--- a/eng/refresh-host-local-intent-cli.sh
+++ b/eng/refresh-host-local-intent-cli.sh
@@ -34,10 +34,10 @@ fi
 
 CHILD_SHA="$(git -C "$CHILD_INTENT_SYSTEM" rev-parse --short=12 HEAD)"
 LOCAL_STAMP="$(date -u +%Y%m%d%H%M%S)"
-INTENT_CLI_LOCAL_VERSION="${INTENT_CLI_LOCAL_VERSION:-0.3.1-local.$LOCAL_STAMP.$$.g$CHILD_SHA}"
+INTENT_CLI_LOCAL_VERSION="${INTENT_CLI_LOCAL_VERSION:-0.3.2-local.$LOCAL_STAMP.$$.g$CHILD_SHA}"
 
-if [[ "$INTENT_CLI_LOCAL_VERSION" == "0.3.1" ]]; then
-  echo "INTENT_CLI_LOCAL_VERSION must not be the fixed package version 0.3.1." >&2
+if [[ "$INTENT_CLI_LOCAL_VERSION" == "0.3.2" ]]; then
+  echo "INTENT_CLI_LOCAL_VERSION must not be the fixed package version 0.3.2." >&2
   exit 1
 fi
 

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.0",
-  "nextVersion": "0.3.1"
+  "stableVersion": "0.3.2",
+  "nextVersion": "0.3.3"
 }

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -15,7 +15,7 @@
     -->
     <ToolCommandName>intent-cli</ToolCommandName>
     <PackageId>JTechJapan.IntentSystem.Cli</PackageId>
-    <Version>0.3.1</Version>
+    <Version>0.3.2</Version>
     <Authors>J-Tech-Japan</Authors>
     <Description>Intent System CLI — deterministic support tooling for intent-driven development on GitHub. Install: dotnet tool install -g JTechJapan.IntentSystem.Cli. Command: intent-cli.</Description>
     <PackageTags>intent-cli;dotnet-tool;intent-system</PackageTags>

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -155,7 +155,7 @@ public sealed class PackagedInvocationSmokeTests
 
         Assert.Contains("mkdir -p .artifacts/smoke-repo/.intent-cli", devRef, StringComparison.Ordinal);
         Assert.Contains("cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'", devRef, StringComparison.Ordinal);
-        Assert.Contains("export INTENT_CLI_LOCAL_VERSION=\"0.3.1-local.$(date -u +%Y%m%d%H%M%S)\"", devRef, StringComparison.Ordinal);
+        Assert.Contains("export INTENT_CLI_LOCAL_VERSION=\"0.3.2-local.$(date -u +%Y%m%d%H%M%S)\"", devRef, StringComparison.Ordinal);
         // G407: package id is JTechJapan.IntentSystem.Cli; dotnet tool exec / dnx uses the
         // package id to locate the nupkg. The installed command remains intent-cli.
         Assert.Contains("(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version \"$INTENT_CLI_LOCAL_VERSION\" JTechJapan.IntentSystem.Cli project status)", devRef, StringComparison.Ordinal);
@@ -167,7 +167,7 @@ public sealed class PackagedInvocationSmokeTests
     {
         var script = File.ReadAllText(Path.Combine(GetSolutionRoot(), "eng", "refresh-host-local-intent-cli.sh"));
 
-        Assert.Contains("0.3.1-local.$LOCAL_STAMP.$$.g$CHILD_SHA", script, StringComparison.Ordinal);
+        Assert.Contains("0.3.2-local.$LOCAL_STAMP.$$.g$CHILD_SHA", script, StringComparison.Ordinal);
         Assert.Contains("-p:Version=\"$INTENT_CLI_LOCAL_VERSION\"", script, StringComparison.Ordinal);
         Assert.Contains("--version \"\\$INTENT_CLI_LOCAL_VERSION\"", script, StringComparison.Ordinal);
         Assert.Contains("find \"$PACKAGES_DIR\" -maxdepth 1 -type f -name 'JTechJapan.IntentSystem.Cli.*.nupkg' -delete", script, StringComparison.Ordinal);
@@ -227,7 +227,7 @@ public sealed class PackagedInvocationSmokeTests
 
     private static string CreateLocalPackageVersion()
     {
-        return $"0.3.1-local.{Guid.NewGuid():N}";
+        return $"0.3.2-local.{Guid.NewGuid():N}";
     }
 
     private sealed record ProcessResult(int ExitCode);

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,8 +124,8 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.1 as the next development line
-        // (post-v0.3.0 release bump, see G406).
+        // be parseable and must point to 0.3.3 as the next development line
+        // (post-v0.3.2 release bump, see G434).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -135,8 +135,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.1", policy.NextVersion);
-        Assert.Equal("0.3.0", policy.StableVersion);
+        Assert.Equal("0.3.3", policy.NextVersion);
+        Assert.Equal("0.3.2", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

- Bump `<Version>` in `IntentSystem.Cli.csproj` from `0.3.1` to `0.3.2`
- Update `eng/version.json`: `stableVersion=0.3.2`, `nextVersion=0.3.3`
- Update `eng/refresh-host-local-intent-cli.sh` local version stamp prefix to `0.3.2-local`
- Update developer reference docs (EN + JA) to use `0.3.2-local` examples
- Add `docs/en/release-notes-v0.3.2.md` and `docs/ja/release-notes-v0.3.2.md`
- Update `VersionPolicyTests.cs` smoke test to expect `stableVersion=0.3.2`, `nextVersion=0.3.3`
- Update `PackagedInvocationSmokeTests.cs` string assertions to match new `0.3.2-local` prefix

## Test plan

- [x] All 2820 tests pass (`dotnet test tests/IntentSystem.Cli.Tests/`)
- [x] `VersionPolicyTests.EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion` verifies actual `eng/version.json`
- [x] `HostRefreshScript_UsesUniqueLocalVersionAndVerifiesAutomationSurface` verifies refresh script version string
- [x] Release notes cover G432 (absolute link cleanup) and G433 (contract validation consistency)

Closes #969

🤖 Generated with [Claude Code](https://claude.com/claude-code)