### PR TITLE
G437: add docs/README.md with language navigation and automation-template explanation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,49 @@
+# intent-cli documentation
+
+Welcome to the intent-cli documentation.
+
+---
+
+## Choose your language
+
+| Language | Entry point |
+|---|---|
+| 日本語 (Japanese) | [`ja/README.md`](ja/README.md) |
+| English | [`en/README.md`](en/README.md) |
+
+---
+
+## Where to start
+
+If you are new to intent-cli, open a design thread in your AI agent and ask:
+
+> I want to work on `<owner>/<repo>` with intent-cli.
+> Ask intent-cli what phase I am in and what I should decide next.
+
+The agent runs `intent-cli` internally and returns questions or results.
+You do not need to memorize commands — intent-cli surfaces the right
+guidance for your current workflow state.
+
+---
+
+## About `automation-templates/`
+
+The [`automation-templates/`](automation-templates/) folder contains
+**reusable loop prompt templates** for operators and AI agents running
+automated coding loops.
+
+They are:
+
+- Intended for **operators** who are wiring up a local or cloud coding
+  automation loop (e.g. hooking Claude Code to an intent-cli worker
+  queue).
+- **Not** the first thing a beginner should copy.  Copying a template
+  without understanding the underlying workflow will produce commands
+  that do the right things mechanically but are hard to debug when
+  something unexpected happens.
+
+If you are just getting started, follow the beginner path in your
+language-specific README first.  When you reach the point of setting up
+automation, your AI agent can ask `intent-cli` for the current
+recommended prompt — the templates here serve as an up-to-date reference
+for that conversation.


### PR DESCRIPTION
## Summary

- Adds `docs/README.md` as the docs-folder landing page shown by GitHub when browsing `docs/`.
- Links clearly to `docs/ja/README.md` (Japanese) and `docs/en/README.md` (English) entry points.
- Explains that `automation-templates/` contains reusable loop prompt templates for operators/agents — not the first thing a beginner should copy — and directs beginners to the language-specific README first.
- Keeps the chat-first model: beginners ask their AI agent to run `intent-cli` for current guidance rather than copying commands manually.

## Verification

- `docs/README.md` renders as a useful landing page in GitHub's `docs/` folder view.
- Links to `docs/ja/README.md`, `docs/en/README.md`, and `docs/automation-templates/` are relative and valid.
- `git diff --check` passes (no whitespace errors).

Closes #975