### PR TITLE
G439: align next-slice with diagnostics for complete queued packets

### DIFF
--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -181,15 +181,23 @@ internal static class IntentNextSliceCommand
         // outcome instead of TryLoad so callers can distinguish
         // "no domain configured" (legacy fallback) from "domain
         // configured but bindings.md missing" and "bindings present
-        // but pattern invalid". When a domain IS supplied AND the
-        // bindings are missing or malformed, fail closed: refuse to
-        // surface ANY candidate (so a wrong-namespace packet cannot
-        // sneak through without verifying the domain boundary).
+        // but pattern invalid".
+        //
+        // G439: only fail closed on InvalidPattern (an explicitly
+        // broken regex the operator must fix). When bindings.md is
+        // absent/missing the namespace constraint simply isn't
+        // configured yet — treat it like a null regex (open filter,
+        // same as MatchesExecutionUnitRegex(null, …) = true) so a
+        // complete queued packet isn't blocked solely because
+        // bindings.md hasn't been authored. Domain/repo protection
+        // continues via MatchesDomainAndRepoFilter regardless.
         var bindingsResolution = NextSliceDomainBindingsExecutionUnitRegex.Resolve(context, domain);
         var executionUnitRegex = bindingsResolution.Regex;
         var bindingsFailedClosed = !string.IsNullOrWhiteSpace(domainOverride)
-            && bindingsResolution.Kind != ExecutionUnitRegexResolutionKind.Present;
-        if (bindingsFailedClosed)
+            && bindingsResolution.Kind == ExecutionUnitRegexResolutionKind.InvalidPattern;
+        if (bindingsFailedClosed
+            || (!string.IsNullOrWhiteSpace(domainOverride)
+                && bindingsResolution.Kind == ExecutionUnitRegexResolutionKind.MissingOrAbsent))
         {
             // Add a structured note so the operator can see the gap
             // (missing bindings.md, missing field, or invalid pattern).
@@ -203,8 +211,11 @@ internal static class IntentNextSliceCommand
                 $"domain `{domain}` bindings.md `{bindingsResolution.BindingsPath ?? "(unresolved)"}` "
                 + $"reported `{kindLabel}` "
                 + (bindingsResolution.Detail is { Length: > 0 } ? $"({bindingsResolution.Detail}); " : "; ")
-                + "next-slice refuses to surface a candidate without verifying the active "
-                + "domain boundary (PR #824 review repair #3).");
+                + (bindingsFailedClosed
+                    ? "next-slice refuses to surface a candidate without verifying the active "
+                      + "domain boundary (PR #824 review repair #3)."
+                    : "next-slice will surface candidates without an execution-unit namespace check; "
+                      + "add execution_unit_regex to bindings.md to restrict the domain boundary (G439)."));
         }
 
         var wip = new List<string>();
@@ -279,11 +290,13 @@ internal static class IntentNextSliceCommand
         // behave byte-identically.
 
         IntentNextSliceCandidate? candidate = null;
-        // PR #824 review repair #3: when the host requested a domain
-        // (--domain supplied) and the bindings.md is missing or
-        // malformed, refuse to surface ANY candidate. Otherwise a
-        // wrong-namespace packet could be accepted without verifying
-        // the domain boundary. The notes added above explain the gap.
+        // PR #824 review repair #3 / G439: only block candidate selection
+        // when bindings have an INVALID pattern (operator must fix the
+        // regex). When bindings.md is simply absent, domain/repo
+        // protection from MatchesDomainAndRepoFilter is still applied and
+        // the note added above informs the operator. This aligns
+        // next-slice with host-review-diagnostics which never gates on the
+        // execution_unit_regex.
         if (Directory.Exists(packetRoot) && !bindingsFailedClosed)
         {
             // Pick the first queued execution_unit in queue-state order whose packet

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -1998,14 +1998,14 @@ public sealed class IntentNextSliceCommandTests
     }
 
     [Fact]
-    public void Execute_G359_NoBindingsFile_FailsClosedWithDomainNote()
+    public void Execute_G439_NoBindingsFile_CompletePacket_ReturnsIssueCutReadyWithWarning()
     {
-        // PR #824 review repair #3: when `--domain` is supplied AND
-        // bindings.md is missing, next-slice MUST fail closed —
-        // accepting a candidate without verifying the active domain
-        // boundary defeats G361's safety contract. The previous fail-
-        // open behavior let a wrong-namespace packet slip into
-        // issue-cut-ready under a misconfigured host.
+        // G439: when `--domain` is supplied and bindings.md is MISSING
+        // (MissingOrAbsent) but the queued packet is complete, next-slice
+        // MUST surface the candidate as issue-cut-ready. Only an explicitly
+        // broken regex pattern (InvalidPattern) causes fail-closed behavior.
+        // A missing-domain-bindings note is still emitted as a warning so
+        // the operator knows to add execution_unit_regex to bindings.md.
         using var workspace = new IntentNextSliceWorkspace();
         // Delete the default permissive bindings the workspace
         // constructor seeded so we exercise the genuine "no
@@ -2024,8 +2024,14 @@ public sealed class IntentNextSliceCommandTests
         Assert.Equal(0, exitCode);
         using var document = JsonDocument.Parse(writer.ToString());
         var root = document.RootElement;
-        Assert.NotEqual("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
-        Assert.False(root.TryGetProperty("candidate", out _));
+        // G439: a complete packet MUST surface as issue-cut-ready even
+        // without a bindings.md — diagnostics would agree.
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.True(root.TryGetProperty("candidate", out var candidateEl));
+        Assert.Equal(
+            "G359",
+            candidateEl.GetProperty("execution_unit").GetString());
+        // The missing-domain-bindings warning note must still be present.
         var notes = root.GetProperty("notes");
         Assert.Contains(
             notes.EnumerateArray().Select(n => n.GetString() ?? string.Empty),
@@ -2066,6 +2072,60 @@ public sealed class IntentNextSliceCommandTests
         Assert.Contains(
             notes.EnumerateArray().Select(n => n.GetString() ?? string.Empty),
             n => n.Contains("invalid-domain-bindings", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_G439_Zero4RacerStyle_QueuedCompletePacket_NoBindings_ReturnsIssueCutReady()
+    {
+        // Regression for G439: Zero4Racer-style case where Z4R-G286 is
+        // queued, packet is complete, but bindings.md is absent from the
+        // zero4racer-mobile-revival domain. Previously next-slice returned
+        // design-needed; it must now return issue-cut-ready.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.DeleteAutomationBindings("intent-cli");
+        // Use a Z4R-prefixed packet name to simulate the Zero4Racer namespace
+        workspace.WriteFile(
+            ".intent-cli/issues/Z4R-G286/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-29T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "Z4R-G286",
+                  "title": "zero4racer queued complete packet",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": null,
+                  "linked_issue": null,
+                  "linked_pr": null
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.True(root.TryGetProperty("candidate", out var candidateEl));
+        Assert.Equal(
+            "Z4R-G286",
+            candidateEl.GetProperty("execution_unit").GetString());
+        // Warning note must still be present so operator can add bindings.md
+        var notes = root.GetProperty("notes");
+        Assert.Contains(
+            notes.EnumerateArray().Select(n => n.GetString() ?? string.Empty),
+            n => n.Contains("missing-domain-bindings", StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Fix `intent next-slice --dry-run` returning `design-needed` when a queued packet is complete but `bindings.md` is absent for the requested domain.
- Only `InvalidPattern` (explicitly broken `execution_unit_regex`) now fails closed; `MissingOrAbsent` bindings emit a warning note but no longer block candidate selection.
- Domain/repo protection via `MatchesDomainAndRepoFilter` remains in effect regardless.
- Aligns `next-slice` with `host-review-diagnostics` which never gated on `execution_unit_regex`.

## Test plan

- [ ] `Execute_G439_NoBindingsFile_CompletePacket_ReturnsIssueCutReadyWithWarning` — updated from the old fail-closed assertion; asserts `issue-cut-ready` outcome + `missing-domain-bindings` warning note
- [ ] `Execute_G439_Zero4RacerStyle_QueuedCompletePacket_NoBindings_ReturnsIssueCutReady` — regression for the Zero4Racer false-idle root cause
- [ ] `Execute_G359_InvalidBindingsRegex_FailsClosedWithDomainNote` — unchanged; invalid regex still fails closed
- [ ] Full suite: 2821 passed, 1 skipped (pre-existing), 0 failed

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)