### PR TITLE
G438: external artifact intake guidance — three-lane, metadata-required

### DIFF
--- a/docs/en/10-external-artifact-intake.md
+++ b/docs/en/10-external-artifact-intake.md
@@ -1,0 +1,109 @@
+# External artifact intake (G438)
+
+← [docs index](README.md) | → [Recovery](07-recovery.md)
+
+This page covers how AI agents and host operators handle **external GitHub issues and PRs** — artifacts that arrive from outside the normal intent-packet publish flow. The intended user experience is:
+
+> この外部 Issue / PR を intent-cli に聞いて、正規の方法で扱ってください。
+
+The AI agent asks intent-cli for guidance and follows the returned steps. Humans do not need to learn intent-cli commands directly.
+
+## Why metadata is required
+
+Simply commenting on an external artifact and applying a workflow label is **not** a valid import. The value of bringing an artifact into the intent workflow is durable traceability: the host must know *why* the artifact was accepted, *which intent* it supports, *which packets* it relates to, and *what review should verify*.
+
+Without this metadata, agents in subsequent loops cannot perform packet-aware review or closeout without manual repair.
+
+## Three lanes
+
+intent-cli distinguishes three intake scenarios:
+
+| Lane | Trigger | Key gate |
+|---|---|---|
+| `external-issue` | An external GitHub issue should enter the intent queue | Lightweight packet metadata before `intent-target` |
+| `external-pr-review` | An external PR should be reviewed as part of the intent workflow | Packet/review-context metadata + linked issue before review transitions |
+| `external-pr-adopt` | Host explicitly adopts an external PR into the intent workflow | Full provenance + shadow issue + explicit operator confirmation |
+
+## Ask-intent-cli prompt templates
+
+### External Issue intake
+
+> There is an external issue at `<url>`. Ask intent-cli how to properly bring it into the intent workflow.
+
+The AI agent will run:
+
+```
+intent-cli guide artifact-intake --lane external-issue --repo <owner/repo> --format markdown
+```
+
+and follow the returned guidance.
+
+### External PR review
+
+> There is an external PR at `<url>` that I want reviewed under the intent workflow. Ask intent-cli how to proceed.
+
+The AI agent will run:
+
+```
+intent-cli guide artifact-intake --lane external-pr-review --repo <owner/repo> --format markdown
+```
+
+### External PR adopt/import
+
+> I want to formally adopt PR `<url>` into the intent workflow. Ask intent-cli for the adoption steps.
+
+The AI agent will run:
+
+```
+intent-cli guide artifact-intake --lane external-pr-adopt --repo <owner/repo> --format markdown
+```
+
+## Metadata fields
+
+Each lane requires the host to record specific metadata before label mutations. The `artifact-intake` guide command returns the required fields for the requested lane. Key fields common to all lanes:
+
+- **source_artifact** — the external GitHub issue/PR URL and number
+- **relevant_intents** — links to existing intent documents this artifact supports
+- **related_packets** — execution units of any related packets
+- **expected_outcome** — what acceptance or implementation must achieve
+- **constraints** — scope, compatibility, or sequencing constraints
+
+PR-specific additional fields:
+
+- **linked_issue** — a suitable linked issue (or shadow issue) that anchors intent context
+- **review_focus** — what the host review should verify
+- **provenance** (adopt only) — original author, origin repo, prior discussion references
+- **operator_confirmation** (adopt only) — explicit host sign-off
+
+## Shadow issues
+
+When an external PR has no suitable linked issue, the host must create a **shadow issue** before any review transition or adoption step. The shadow issue:
+
+- Records the same metadata fields as the intake lane requires
+- Becomes the intent anchor for the PR in subsequent review/closeout steps
+- Must be created by the host operator (not automatically)
+
+If the PR raises unresolved product or technical questions, run the interview/clarification flow **before** creating the shadow issue:
+
+```
+intent-cli guide workflow task intent-interview --format markdown
+```
+
+## What contributors need to know
+
+Nothing. External contributors do not need to understand intent labels, queue-state, packet YAML, or closeout mechanics. The host agent handles all metadata creation and label transitions through intent-cli.
+
+## Guard rails
+
+- `intent-target` is never applied by comment or label alone
+- `intent-pr-reviewing` is never started before metadata and a linked issue exist
+- Ambiguous mappings stop for operator clarification rather than guessing
+- AI agents must not proceed past operator confirmation gates without an explicit decision
+
+## Command reference
+
+```
+intent-cli guide artifact-intake --lane external-issue [--repo <owner/repo>] [--format markdown|json]
+intent-cli guide artifact-intake --lane external-pr-review [--repo <owner/repo>] [--format markdown|json]
+intent-cli guide artifact-intake --lane external-pr-adopt [--repo <owner/repo>] [--format markdown|json]
+```

--- a/docs/ja/10-external-artifact-intake.md
+++ b/docs/ja/10-external-artifact-intake.md
@@ -1,0 +1,107 @@
+# 外部アーティファクト取り込み (G438)
+
+← [docs index](README.md) | → [リカバリー](07-recovery.md)
+
+このページでは、通常の intent-packet パブリッシュフロー以外から届く **外部 GitHub Issue や PR** を AI エージェントとホストオペレーターがどのように扱うかを説明します。想定するユーザー体験は次のとおりです：
+
+> この外部 Issue / PR を intent-cli に聞いて、正規の方法で扱ってください。
+
+AI エージェントが intent-cli にガイダンスを問い合わせ、返されたステップに従います。人間が intent-cli コマンドを直接覚える必要はありません。
+
+## なぜメタデータが必要か
+
+外部アーティファクトにコメントを付けてワークフローラベルを貼るだけでは**正規の取り込みになりません**。intent ワークフローに取り込む価値は永続的なトレーサビリティにあります。ホストは「なぜこのアーティファクトを受け入れたか」「どの intent を支えるか」「どのパケットと関連するか」「レビューで何を検証するか」を記録する必要があります。
+
+このメタデータがなければ、後続ループのエージェントはパケット対応のレビューやクローズアウトを手動修復なしに実行できません。
+
+## 3 つのレーン
+
+intent-cli は 3 つの取り込みシナリオを区別します：
+
+| レーン | トリガー | ゲート |
+|---|---|---|
+| `external-issue` | 外部 GitHub Issue を intent キューに追加したい | `intent-target` 適用前に軽量パケットメタデータが必要 |
+| `external-pr-review` | 外部 PR を intent ワークフローの一部としてレビューしたい | パケット/レビューコンテキストメタデータ + リンク Issue が必要 |
+| `external-pr-adopt` | 外部 PR をホストが正式に intent ワークフローに採用したい | 完全な来歴 + シャドウ Issue + オペレーターの明示的な確認が必要 |
+
+## intent-cli に聞くプロンプトテンプレート
+
+### 外部 Issue 取り込み
+
+> `<url>` にある外部 Issue を intent ワークフローに正式に取り込む方法を intent-cli に聞いてください。
+
+AI エージェントは次を実行します：
+
+```
+intent-cli guide artifact-intake --lane external-issue --repo <owner/repo> --format markdown
+```
+
+### 外部 PR レビュー
+
+> `<url>` にある外部 PR を intent ワークフローでレビューする方法を intent-cli に聞いてください。
+
+AI エージェントは次を実行します：
+
+```
+intent-cli guide artifact-intake --lane external-pr-review --repo <owner/repo> --format markdown
+```
+
+### 外部 PR 採用
+
+> `<url>` の PR を intent ワークフローに正式採用する手順を intent-cli に聞いてください。
+
+AI エージェントは次を実行します：
+
+```
+intent-cli guide artifact-intake --lane external-pr-adopt --repo <owner/repo> --format markdown
+```
+
+## メタデータフィールド
+
+各レーンでは、ラベル変更の前にホストが特定のメタデータを記録する必要があります。`artifact-intake` ガイドコマンドは要求レーンの必須フィールドを返します。全レーン共通の主要フィールド：
+
+- **source_artifact** — 外部 GitHub Issue/PR の URL と番号
+- **relevant_intents** — このアーティファクトが支える既存 intent ドキュメントへのリンク
+- **related_packets** — 関連パケットの実行ユニット
+- **expected_outcome** — 承認または実装が達成すべきこと
+- **constraints** — スコープ・互換性・順序の制約
+
+PR 固有の追加フィールド：
+
+- **linked_issue** — intent コンテキストを固定する適切なリンク Issue（またはシャドウ Issue）
+- **review_focus** — ホストレビューで検証すべきこと
+- **provenance**（採用のみ）— 元の作者、元リポジトリ、過去の議論への参照
+- **operator_confirmation**（採用のみ）— ホストオペレーターの明示的な承認
+
+## シャドウ Issue
+
+外部 PR に適切なリンク Issue がない場合、ホストはレビュートランジションや採用ステップの前に**シャドウ Issue** を作成する必要があります。シャドウ Issue は：
+
+- 取り込みレーンで必要なメタデータフィールドを記録する
+- 後続のレビュー/クローズアウトステップで PR の intent アンカーになる
+- ホストオペレーターが手動で作成する（自動作成禁止）
+
+PR に未解決のプロダクト質問や技術的な intent 質問がある場合は、シャドウ Issue を作成する**前**にインタビュー/クラリフィケーションフローを実行します：
+
+```
+intent-cli guide workflow task intent-interview --format markdown
+```
+
+## コントリビューターが知る必要があること
+
+何もありません。外部コントリビューターは intent ラベル、queue-state、パケット YAML、クローズアウトの仕組みを知る必要はありません。ホストエージェントが intent-cli を通じてすべてのメタデータ作成とラベルトランジションを処理します。
+
+## ガードレール
+
+- `intent-target` はコメントやラベル操作だけでは適用されない
+- `intent-pr-reviewing` はメタデータとリンク Issue が揃うまで開始されない
+- マッピングが曖昧な場合はオペレーターの確認待ちで停止し、推測しない
+- AI エージェントはオペレーター確認ゲートを明示的な意思決定なしに通過してはならない
+
+## コマンドリファレンス
+
+```
+intent-cli guide artifact-intake --lane external-issue [--repo <owner/repo>] [--format markdown|json]
+intent-cli guide artifact-intake --lane external-pr-review [--repo <owner/repo>] [--format markdown|json]
+intent-cli guide artifact-intake --lane external-pr-adopt [--repo <owner/repo>] [--format markdown|json]
+```

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -260,7 +260,9 @@ internal static class CommandRouter
                 // G326: role-scoped host ownership model.
                 ["host-ownership"] = GuideHostOwnershipCommand.Execute,
                 // G334: self-discovery help surface for external users.
-                ["help"] = GuideHelpCommand.Execute
+                ["help"] = GuideHelpCommand.Execute,
+                // G438: external artifact intake guidance (external issue / PR review / PR adopt).
+                ["artifact-intake"] = GuideArtifactIntakeCommand.Execute
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GuideArtifactIntakeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideArtifactIntakeCommand.cs
@@ -200,11 +200,11 @@ internal static class GuideArtifactIntakeCommand
     private static IReadOnlyList<string> SuggestedStepsExternalPrReview(string repo) =>
     [
         $"`gh pr view <n> --repo {repo}` — read the PR body, linked issues, and current labels.",
-        "Check if a suitable linked issue exists: `gh pr view <n> --repo {repo} --json closingIssuesReferences`.",
+        $"Check if a suitable linked issue exists: `gh pr view <n> --repo {repo} --json closingIssuesReferences`.",
         "If no linked issue and product questions are unresolved → run interview/clarification first:",
         "  `intent-cli guide workflow task intent-interview --format markdown`",
         "If no linked issue (and intent context is clear) → create a shadow issue with provenance:",
-        "  `gh issue create --repo {repo} --title \"[Shadow] <pr-title>\" --body \"<provenance + metadata>\"` (operator confirms)",
+        $"  `gh issue create --repo {repo} --title \"[Shadow] <pr-title>\" --body \"<provenance + metadata>\"` (operator confirms)",
         "Record review-context metadata: linked_issue, relevant_intents, review_focus, constraints, host_decision.",
         $"`intent-cli automation host-review-preflight --repo {repo} --format json` — verify review-start preconditions.",
         $"`intent-cli automation pr-transition --transition review-start --pr <n> --repo {repo} --write --format json` — start review after metadata is confirmed."
@@ -272,7 +272,7 @@ internal static class GuideArtifactIntakeCommand
         $"`gh pr view <n> --repo {repo}` — read the PR body, linked issues, provenance.",
         "Confirm operator explicitly intends adoption (not just review). If unclear, route to `external-pr-review`.",
         "If no suitable linked issue → create shadow issue with full provenance first:",
-        "  `gh issue create --repo {repo} --title \"[Adopt] <pr-title>\" --body \"<provenance + adoption rationale>\"` (operator confirms)",
+        $"  `gh issue create --repo {repo} --title \"[Adopt] <pr-title>\" --body \"<provenance + adoption rationale>\"` (operator confirms)",
         "Record adoption metadata: source_artifact, adoption_rationale, linked_issue, relevant_intents, provenance, expected_outcome, constraints, operator_confirmation.",
         $"`intent-cli intent search --domain <domain> --query <keyword> --format json` — verify intent linkage.",
         $"`intent-cli automation host-review-preflight --repo {repo} --format json` — verify review-start preconditions after metadata is complete.",

--- a/src/IntentSystem.Cli/Commands/GuideArtifactIntakeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideArtifactIntakeCommand.cs
@@ -1,0 +1,482 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G438: Read-only <c>intent-cli guide artifact-intake</c> command. Emits
+/// AI-agent-facing guidance for importing external GitHub issues and PRs
+/// into the intent workflow. Three lanes:
+/// <list type="bullet">
+///   <item><c>external-issue</c>: intake guidance before <c>intent-target</c>
+///     is applied to an external issue.</item>
+///   <item><c>external-pr-review</c>: intake guidance before normal review
+///     transitions are applied to an external PR.</item>
+///   <item><c>external-pr-adopt</c>: explicit adopt/import guidance for a
+///     rare host decision to formally incorporate an external PR.</item>
+/// </list>
+/// Every lane requires the host to create or link lightweight
+/// packet/review-context metadata before any label mutation. Never
+/// mutates state. Never launches an AI provider.
+/// </summary>
+internal static class GuideArtifactIntakeCommand
+{
+    internal const string LaneExternalIssue = "external-issue";
+    internal const string LaneExternalPrReview = "external-pr-review";
+    internal const string LaneExternalPrAdopt = "external-pr-adopt";
+
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide artifact-intake --lane external-issue|external-pr-review|external-pr-adopt [--repo <owner/repo>] [--format markdown|json]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var lane, out var repo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        if (lane is null
+            || (!string.Equals(lane, LaneExternalIssue, StringComparison.Ordinal)
+                && !string.Equals(lane, LaneExternalPrReview, StringComparison.Ordinal)
+                && !string.Equals(lane, LaneExternalPrAdopt, StringComparison.Ordinal)))
+        {
+            writer.WriteLine(
+                $"Unsupported --lane '{lane}'. Supported: {LaneExternalIssue}, {LaneExternalPrReview}, {LaneExternalPrAdopt}.");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var guidance = Build(lane, repo);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(guidance, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, guidance);
+        }
+
+        return 0;
+    }
+
+    internal static ArtifactIntakeGuidance Build(string lane, string? repo)
+    {
+        return lane switch
+        {
+            LaneExternalIssue => BuildExternalIssue(repo),
+            LaneExternalPrReview => BuildExternalPrReview(repo),
+            LaneExternalPrAdopt => BuildExternalPrAdopt(repo),
+            _ => throw new ArgumentException($"Unknown lane: {lane}", nameof(lane))
+        };
+    }
+
+    // ── Lane: external-issue ─────────────────────────────────────────────────
+
+    private static ArtifactIntakeGuidance BuildExternalIssue(string? repo)
+    {
+        var repoHint = repo ?? "<owner/repo>";
+        return new ArtifactIntakeGuidance
+        {
+            Lane = LaneExternalIssue,
+            Repo = repo,
+            Summary =
+                "External Issue intake — the host must create or link lightweight packet/review-context "
+                + "metadata that connects the issue to relevant intents, related packets, and expected "
+                + "outcome before applying `intent-target`. Comment-only or label-only handoff is not valid.",
+            MetadataRequirements = MetadataRequirementsExternalIssue,
+            GuardRails = GuardRailsExternalIssue,
+            SuggestedSteps = SuggestedStepsExternalIssue(repoHint),
+            ForbiddenActions = ForbiddenActionsIssue,
+            AmbiguityPolicy =
+                "When the mapping to an existing intent is ambiguous, stop and report `clarification-required` "
+                + "rather than guessing. Do not apply `intent-target` until the host operator has confirmed "
+                + "the intent linkage.",
+            ShadowIssueRequired = false,
+            OperatorConfirmationRequired = false
+        };
+    }
+
+    private static IReadOnlyList<string> MetadataRequirementsExternalIssue =>
+    [
+        "source_artifact: the external GitHub issue URL and number.",
+        "relevant_intents: links to one or more existing intent documents that this issue supports.",
+        "related_packets: execution units of any related prepared packets (may be empty if none exist).",
+        "expected_outcome: what a correct implementation must achieve, in terms the host can verify.",
+        "constraints: any scope, compatibility, or sequencing constraints that bound the work.",
+        "host_decision: explicit host-operator statement that this external issue is approved for intake."
+    ];
+
+    private static IReadOnlyList<string> GuardRailsExternalIssue =>
+    [
+        "Do not apply `intent-target` until packet/review-context metadata is created and approved.",
+        "Do not mutate queue-state or packet directories directly; use intent-cli commands.",
+        "Do not require external contributors to know about intent labels, queue-state, or packet YAML.",
+        "If relevant intents cannot be identified, run `intent search` before proceeding.",
+        "If the issue raises unresolved product questions, run interview/clarification before recording metadata."
+    ];
+
+    private static IReadOnlyList<string> SuggestedStepsExternalIssue(string repo) =>
+    [
+        $"`gh issue view <n> --repo {repo}` — read the external issue body and labels.",
+        $"`intent-cli intent search --domain <domain> --query <keyword> --format json` — find related intents.",
+        $"`intent-cli intent status --domain <domain> --format json` — confirm WIP cap and clarification state.",
+        "Create lightweight metadata: record source_artifact, relevant_intents, related_packets, expected_outcome, constraints, host_decision in a durable location (e.g. a linked comment on the issue, or a review-context file).",
+        "If unresolved product questions exist, run the interview/clarification flow first:",
+        "  `intent-cli guide workflow task intent-interview --format markdown`",
+        $"`intent-cli automation issue-publish --repo {repo} --issue <n> --write --format json` — apply `intent-target` after metadata is approved by the host operator."
+    ];
+
+    private static IReadOnlyList<string> ForbiddenActionsIssue =>
+    [
+        "Applying `intent-target` before lightweight metadata is recorded and approved.",
+        "Using raw `gh issue edit --add-label` to apply workflow labels.",
+        "Letting the AI agent decide the intent linkage without operator confirmation.",
+        "Moving the issue into the intent queue without a host decision."
+    ];
+
+    // ── Lane: external-pr-review ─────────────────────────────────────────────
+
+    private static ArtifactIntakeGuidance BuildExternalPrReview(string? repo)
+    {
+        var repoHint = repo ?? "<owner/repo>";
+        return new ArtifactIntakeGuidance
+        {
+            Lane = LaneExternalPrReview,
+            Repo = repo,
+            Summary =
+                "External PR review — the host must verify packet/review-context metadata exists and is "
+                + "linked before starting normal review transitions. If the PR has no suitable linked issue, "
+                + "a shadow issue must be created first. If unresolved product or technical intent questions "
+                + "exist, run interview/clarification before shadow issue creation.",
+            MetadataRequirements = MetadataRequirementsExternalPr,
+            GuardRails = GuardRailsExternalPrReview,
+            SuggestedSteps = SuggestedStepsExternalPrReview(repoHint),
+            ForbiddenActions = ForbiddenActionsPr,
+            AmbiguityPolicy =
+                "If the PR's intent context is ambiguous (no linked issue, unclear which intent it supports), "
+                + "do not start review transitions. Create the shadow issue and record metadata first, or stop "
+                + "with `clarification-required` if the host cannot resolve the mapping.",
+            ShadowIssueRequired = true,
+            OperatorConfirmationRequired = false
+        };
+    }
+
+    private static IReadOnlyList<string> MetadataRequirementsExternalPr =>
+    [
+        "source_artifact: the external GitHub PR URL and number.",
+        "linked_issue: a suitable linked issue (may be a shadow issue created by the host) that anchors intent context.",
+        "relevant_intents: links to one or more existing intent documents this PR relates to.",
+        "review_focus: what the host review should verify — behavior, compatibility, contract sections.",
+        "constraints: any scope or sequencing constraints on accepting the PR.",
+        "host_decision: explicit host-operator statement that this external PR is approved for review."
+    ];
+
+    private static IReadOnlyList<string> GuardRailsExternalPrReview =>
+    [
+        "Do not start `intent-pr-reviewing` transitions until metadata and a linked issue exist.",
+        "If the PR has no suitable linked issue, create a shadow issue before any review transition.",
+        "If unresolved product or technical questions exist, run interview/clarification BEFORE creating the shadow issue.",
+        "Do not require external contributors to understand intent workflow labels or packet mechanics.",
+        "Ambiguous PR → intent mapping must stop for operator clarification before any label mutation."
+    ];
+
+    private static IReadOnlyList<string> SuggestedStepsExternalPrReview(string repo) =>
+    [
+        $"`gh pr view <n> --repo {repo}` — read the PR body, linked issues, and current labels.",
+        "Check if a suitable linked issue exists: `gh pr view <n> --repo {repo} --json closingIssuesReferences`.",
+        "If no linked issue and product questions are unresolved → run interview/clarification first:",
+        "  `intent-cli guide workflow task intent-interview --format markdown`",
+        "If no linked issue (and intent context is clear) → create a shadow issue with provenance:",
+        "  `gh issue create --repo {repo} --title \"[Shadow] <pr-title>\" --body \"<provenance + metadata>\"` (operator confirms)",
+        "Record review-context metadata: linked_issue, relevant_intents, review_focus, constraints, host_decision.",
+        $"`intent-cli automation host-review-preflight --repo {repo} --format json` — verify review-start preconditions.",
+        $"`intent-cli automation pr-transition --transition review-start --pr <n> --repo {repo} --write --format json` — start review after metadata is confirmed."
+    ];
+
+    private static IReadOnlyList<string> ForbiddenActionsPr =>
+    [
+        "Starting `intent-pr-reviewing` before metadata and a linked issue exist.",
+        "Using raw `gh pr edit --add-label` to apply workflow labels.",
+        "Skipping shadow issue creation when the PR has no suitable linked issue.",
+        "Proceeding with review when unresolved product/technical questions exist."
+    ];
+
+    // ── Lane: external-pr-adopt ──────────────────────────────────────────────
+
+    private static ArtifactIntakeGuidance BuildExternalPrAdopt(string? repo)
+    {
+        var repoHint = repo ?? "<owner/repo>";
+        return new ArtifactIntakeGuidance
+        {
+            Lane = LaneExternalPrAdopt,
+            Repo = repo,
+            Summary =
+                "External PR adopt/import — a rare host decision to formally incorporate an external PR "
+                + "into the intent workflow. Requires explicit operator confirmation, full provenance "
+                + "recording, and a shadow issue if no suitable linked issue exists. This lane is NOT "
+                + "the default review path; use `external-pr-review` for normal external PR review.",
+            MetadataRequirements = MetadataRequirementsExternalPrAdopt,
+            GuardRails = GuardRailsExternalPrAdopt,
+            SuggestedSteps = SuggestedStepsExternalPrAdopt(repoHint),
+            ForbiddenActions = ForbiddenActionsAdopt,
+            AmbiguityPolicy =
+                "Adopt/import must never be the automatic path. If the operator has not explicitly stated "
+                + "adoption intent, route to `external-pr-review` instead. Ambiguous provenance must stop "
+                + "for operator confirmation before any label mutation.",
+            ShadowIssueRequired = true,
+            OperatorConfirmationRequired = true
+        };
+    }
+
+    private static IReadOnlyList<string> MetadataRequirementsExternalPrAdopt =>
+    [
+        "source_artifact: the external GitHub PR URL and number.",
+        "adoption_rationale: host-operator statement of WHY this PR is being adopted (not just reviewed).",
+        "linked_issue: a shadow or existing issue anchoring intent context (required before adoption).",
+        "relevant_intents: links to intent documents this adoption supports.",
+        "provenance: original author, origin repo (if fork/external), prior discussion references.",
+        "expected_outcome: what adoption achieves — merged behavior, contract sections it closes.",
+        "constraints: compatibility, sequencing, or license constraints on adoption.",
+        "operator_confirmation: explicit host-operator sign-off recorded in a durable location."
+    ];
+
+    private static IReadOnlyList<string> GuardRailsExternalPrAdopt =>
+    [
+        "Adoption is a rare explicit host decision; it must never be triggered automatically.",
+        "Operator confirmation must be recorded before any label mutation or queue-state change.",
+        "Shadow issue must exist before adoption proceeds if no suitable linked issue is present.",
+        "Provenance must be recorded so future agents can trace the artifact's origin.",
+        "Do not confuse adopt with review: adoption changes the PR's standing in the intent workflow permanently.",
+        "If the adoption rationale is unclear, stop and ask the operator for explicit confirmation."
+    ];
+
+    private static IReadOnlyList<string> SuggestedStepsExternalPrAdopt(string repo) =>
+    [
+        $"`gh pr view <n> --repo {repo}` — read the PR body, linked issues, provenance.",
+        "Confirm operator explicitly intends adoption (not just review). If unclear, route to `external-pr-review`.",
+        "If no suitable linked issue → create shadow issue with full provenance first:",
+        "  `gh issue create --repo {repo} --title \"[Adopt] <pr-title>\" --body \"<provenance + adoption rationale>\"` (operator confirms)",
+        "Record adoption metadata: source_artifact, adoption_rationale, linked_issue, relevant_intents, provenance, expected_outcome, constraints, operator_confirmation.",
+        $"`intent-cli intent search --domain <domain> --query <keyword> --format json` — verify intent linkage.",
+        $"`intent-cli automation host-review-preflight --repo {repo} --format json` — verify review-start preconditions after metadata is complete.",
+        $"`intent-cli automation pr-transition --transition review-start --pr <n> --repo {repo} --write --format json` — begin review after full adoption metadata is confirmed by operator."
+    ];
+
+    private static IReadOnlyList<string> ForbiddenActionsAdopt =>
+    [
+        "Automatically adopting PRs without explicit operator confirmation.",
+        "Adopting a PR without a shadow or linked issue.",
+        "Omitting provenance recording (origin author, prior discussion).",
+        "Using raw `gh pr edit --add-label` to apply workflow labels.",
+        "Treating adoption as the default path for external PRs (default is `external-pr-review`)."
+    ];
+
+    // ── Output ───────────────────────────────────────────────────────────────
+
+    private static void WriteMarkdown(TextWriter writer, ArtifactIntakeGuidance guidance)
+    {
+        writer.WriteLine($"# Guide artifact-intake — {guidance.Lane} (G438)");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(guidance.Repo))
+        {
+            writer.WriteLine($"- repo: {guidance.Repo}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine("## Summary");
+        writer.WriteLine();
+        writer.WriteLine(guidance.Summary);
+        writer.WriteLine();
+
+        writer.WriteLine("## Metadata requirements");
+        writer.WriteLine();
+        writer.WriteLine("The host must record all of the following before any label mutation:");
+        foreach (var req in guidance.MetadataRequirements)
+        {
+            writer.WriteLine($"- {req}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Guard rails");
+        foreach (var rail in guidance.GuardRails)
+        {
+            writer.WriteLine($"- {rail}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Suggested steps");
+        foreach (var step in guidance.SuggestedSteps)
+        {
+            writer.WriteLine($"- {step}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Forbidden actions");
+        foreach (var action in guidance.ForbiddenActions)
+        {
+            writer.WriteLine($"- {action}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Ambiguity policy");
+        writer.WriteLine();
+        writer.WriteLine(guidance.AmbiguityPolicy);
+        writer.WriteLine();
+
+        if (guidance.ShadowIssueRequired)
+        {
+            writer.WriteLine("## Shadow issue");
+            writer.WriteLine();
+            writer.WriteLine("A shadow issue is required when the PR has no suitable linked issue. Create it before any review transition or adoption step.");
+            writer.WriteLine();
+        }
+
+        if (guidance.OperatorConfirmationRequired)
+        {
+            writer.WriteLine("## Operator confirmation");
+            writer.WriteLine();
+            writer.WriteLine("Explicit operator confirmation must be recorded in a durable location (issue comment, metadata file) before this lane's mutations are applied. AI agents must not proceed past this point without confirmation.");
+            writer.WriteLine();
+        }
+    }
+
+    // ── Argument parsing ─────────────────────────────────────────────────────
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? lane,
+        out string? repo,
+        out string format,
+        out string error)
+    {
+        lane = null;
+        repo = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--lane":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--lane requires a value.";
+                        return false;
+                    }
+
+                    lane = args[index + 1];
+                    index++;
+                    break;
+
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value.";
+                        return false;
+                    }
+
+                    repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(lane))
+        {
+            error = "--lane is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide artifact-intake (G438)");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only AI-agent-facing guidance for importing external GitHub issues and PRs into the intent workflow.");
+        writer.WriteLine("Lanes: external-issue (issue intake), external-pr-review (PR review), external-pr-adopt (explicit adoption).");
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true
+    };
+}
+
+/// <summary>G438: structured guidance payload for external artifact intake.</summary>
+internal sealed record ArtifactIntakeGuidance
+{
+    [JsonPropertyName("lane")]
+    public required string Lane { get; init; }
+
+    [JsonPropertyName("repo")]
+    public string? Repo { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("metadata_requirements")]
+    public required IReadOnlyList<string> MetadataRequirements { get; init; }
+
+    [JsonPropertyName("guard_rails")]
+    public required IReadOnlyList<string> GuardRails { get; init; }
+
+    [JsonPropertyName("suggested_steps")]
+    public required IReadOnlyList<string> SuggestedSteps { get; init; }
+
+    [JsonPropertyName("forbidden_actions")]
+    public required IReadOnlyList<string> ForbiddenActions { get; init; }
+
+    [JsonPropertyName("ambiguity_policy")]
+    public required string AmbiguityPolicy { get; init; }
+
+    [JsonPropertyName("shadow_issue_required")]
+    public required bool ShadowIssueRequired { get; init; }
+
+    [JsonPropertyName("operator_confirmation_required")]
+    public required bool OperatorConfirmationRequired { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -244,6 +244,13 @@ internal static class GuideHelpCommand
             Name = "review-verification-policy",
             Purpose = "G383 deterministic route for visible/manual/runtime-gated verification ACs so the review loop never re-asks the operator: standing-policy-approve / implementation-finding (PR feedback) / review-policy-gap (durable host signal recorded once).",
             Example = "intent-cli guide review-verification-policy --standing-policy --evidence source-mapping --format json"
+        },
+        // G438: external artifact intake guidance.
+        new GuideSubcommandEntry
+        {
+            Name = "artifact-intake",
+            Purpose = "G438 AI-agent-facing guidance for importing external GitHub issues and PRs. Three lanes: external-issue (issue intake before intent-target), external-pr-review (PR review before transitions), external-pr-adopt (rare explicit host adoption). Each lane requires lightweight packet/review-context metadata before any label mutation.",
+            Example = "intent-cli guide artifact-intake --lane external-issue --repo <owner/repo> --format markdown"
         }
     };
 

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -155,7 +155,9 @@ internal static class Program
                 // routing inside CommandRouter, which also requires
                 // bootstrap-friendly entry from a child cwd).
                 || string.Equals(args[1], "help", StringComparison.Ordinal)
-                || string.Equals(args[1], "--help", StringComparison.Ordinal));
+                || string.Equals(args[1], "--help", StringComparison.Ordinal)
+                // G438: external artifact intake guidance — read-only, no host state required.
+                || string.Equals(args[1], "artifact-intake", StringComparison.Ordinal));
     }
 
     /// <summary>

--- a/tests/IntentSystem.Cli.Tests/GuideArtifactIntakeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideArtifactIntakeCommandTests.cs
@@ -307,6 +307,98 @@ public sealed class GuideArtifactIntakeCommandTests
         }
     }
 
+    // ── Repo interpolation regression (G438 review fix) ─────────────────────
+
+    [Fact]
+    public void Execute_ExternalPrReview_AllSuggestedSteps_SubstituteRepo()
+    {
+        // Every repo-bearing suggested step must contain the resolved repo,
+        // not a literal '{repo}' placeholder.
+        const string testRepo = "J-Tech-Japan/intent-system";
+        var guidance = GuideArtifactIntakeCommand.Build(
+            GuideArtifactIntakeCommand.LaneExternalPrReview,
+            testRepo);
+
+        foreach (var step in guidance.SuggestedSteps)
+        {
+            Assert.DoesNotContain("{repo}", step, StringComparison.Ordinal);
+            if (step.Contains("--repo", StringComparison.Ordinal))
+            {
+                Assert.Contains(testRepo, step, StringComparison.Ordinal);
+            }
+        }
+    }
+
+    [Fact]
+    public void Execute_ExternalPrAdopt_AllSuggestedSteps_SubstituteRepo()
+    {
+        // Every repo-bearing suggested step must contain the resolved repo,
+        // not a literal '{repo}' placeholder.
+        const string testRepo = "J-Tech-Japan/intent-system";
+        var guidance = GuideArtifactIntakeCommand.Build(
+            GuideArtifactIntakeCommand.LaneExternalPrAdopt,
+            testRepo);
+
+        foreach (var step in guidance.SuggestedSteps)
+        {
+            Assert.DoesNotContain("{repo}", step, StringComparison.Ordinal);
+            if (step.Contains("--repo", StringComparison.Ordinal))
+            {
+                Assert.Contains(testRepo, step, StringComparison.Ordinal);
+            }
+        }
+    }
+
+    [Fact]
+    public void Execute_ExternalIssue_AllSuggestedSteps_SubstituteRepo()
+    {
+        const string testRepo = "J-Tech-Japan/intent-system";
+        var guidance = GuideArtifactIntakeCommand.Build(
+            GuideArtifactIntakeCommand.LaneExternalIssue,
+            testRepo);
+
+        foreach (var step in guidance.SuggestedSteps)
+        {
+            Assert.DoesNotContain("{repo}", step, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Execute_ExternalPrReview_ShadowIssueStep_ContainsResolvedRepo()
+    {
+        // Specifically verify the shadow-issue gh command uses the resolved repo.
+        const string testRepo = "my-test-org/my-test-repo";
+        var guidance = GuideArtifactIntakeCommand.Build(
+            GuideArtifactIntakeCommand.LaneExternalPrReview,
+            testRepo);
+
+        var shadowStep = guidance.SuggestedSteps.FirstOrDefault(
+            s => s.Contains("Shadow", StringComparison.OrdinalIgnoreCase)
+              && s.Contains("gh issue create", StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotNull(shadowStep);
+        Assert.Contains(testRepo, shadowStep, StringComparison.Ordinal);
+        Assert.DoesNotContain("{repo}", shadowStep, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ExternalPrAdopt_ShadowIssueStep_ContainsResolvedRepo()
+    {
+        // Specifically verify the shadow-issue gh command uses the resolved repo.
+        const string testRepo = "my-test-org/my-test-repo";
+        var guidance = GuideArtifactIntakeCommand.Build(
+            GuideArtifactIntakeCommand.LaneExternalPrAdopt,
+            testRepo);
+
+        var shadowStep = guidance.SuggestedSteps.FirstOrDefault(
+            s => s.Contains("Adopt", StringComparison.OrdinalIgnoreCase)
+              && s.Contains("gh issue create", StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotNull(shadowStep);
+        Assert.Contains(testRepo, shadowStep, StringComparison.Ordinal);
+        Assert.DoesNotContain("{repo}", shadowStep, StringComparison.Ordinal);
+    }
+
     private static CliContext CreateContext(string domain)
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/GuideArtifactIntakeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideArtifactIntakeCommandTests.cs
@@ -1,0 +1,326 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideArtifactIntakeCommandTests
+{
+    // ── external-issue lane ──────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_ExternalIssue_Markdown_EmitsSummaryAndMetadataRequirements()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-issue", "--repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide artifact-intake — external-issue (G438)", output, StringComparison.Ordinal);
+        Assert.Contains("repo: J-Tech-Japan/intent-system", output, StringComparison.Ordinal);
+        Assert.Contains("## Summary", output, StringComparison.Ordinal);
+        Assert.Contains("## Metadata requirements", output, StringComparison.Ordinal);
+        Assert.Contains("source_artifact", output, StringComparison.Ordinal);
+        Assert.Contains("relevant_intents", output, StringComparison.Ordinal);
+        Assert.Contains("expected_outcome", output, StringComparison.Ordinal);
+        Assert.Contains("## Guard rails", output, StringComparison.Ordinal);
+        Assert.Contains("## Suggested steps", output, StringComparison.Ordinal);
+        Assert.Contains("## Forbidden actions", output, StringComparison.Ordinal);
+        Assert.Contains("## Ambiguity policy", output, StringComparison.Ordinal);
+        // intent-target must not be applied via comment/label alone
+        Assert.Contains("intent-target", output, StringComparison.Ordinal);
+        // automation issue-publish should appear in suggested steps
+        Assert.Contains("automation issue-publish", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ExternalIssue_Json_EmitsStructuredFields()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-issue", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("external-issue", root.GetProperty("lane").GetString());
+        Assert.True(root.GetProperty("metadata_requirements").GetArrayLength() >= 4);
+        Assert.True(root.GetProperty("guard_rails").GetArrayLength() >= 3);
+        Assert.True(root.GetProperty("suggested_steps").GetArrayLength() >= 3);
+        Assert.True(root.GetProperty("forbidden_actions").GetArrayLength() >= 3);
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("ambiguity_policy").GetString()));
+        Assert.False(root.GetProperty("shadow_issue_required").GetBoolean());
+        Assert.False(root.GetProperty("operator_confirmation_required").GetBoolean());
+    }
+
+    [Fact]
+    public void Execute_ExternalIssue_ForbiddenActions_DoNotIncludeCommentOnlyHandoff()
+    {
+        // G438: comment-only handoff must not be treated as imported/ready.
+        using var writer = new StringWriter();
+        GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-issue", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var forbiddenActions = document.RootElement
+            .GetProperty("forbidden_actions")
+            .EnumerateArray()
+            .Select(e => e.GetString() ?? string.Empty)
+            .ToList();
+
+        // Some forbidden action must mention label/comment-only behavior
+        Assert.Contains(
+            forbiddenActions,
+            a => a.Contains("intent-target", StringComparison.OrdinalIgnoreCase)
+                && (a.Contains("before", StringComparison.OrdinalIgnoreCase)
+                    || a.Contains("without", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    // ── external-pr-review lane ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_ExternalPrReview_Markdown_EmitsShadowIssueSection()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-pr-review", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide artifact-intake — external-pr-review (G438)", output, StringComparison.Ordinal);
+        Assert.Contains("## Shadow issue", output, StringComparison.Ordinal);
+        Assert.Contains("linked_issue", output, StringComparison.Ordinal);
+        Assert.Contains("review_focus", output, StringComparison.Ordinal);
+        Assert.Contains("interview/clarification", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ExternalPrReview_Json_ShadowIssueRequiredIsTrue()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-pr-review", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("external-pr-review", root.GetProperty("lane").GetString());
+        Assert.True(root.GetProperty("shadow_issue_required").GetBoolean());
+        Assert.False(root.GetProperty("operator_confirmation_required").GetBoolean());
+        Assert.True(root.GetProperty("metadata_requirements").GetArrayLength() >= 4);
+    }
+
+    [Fact]
+    public void Execute_ExternalPrReview_ForbiddenActions_DoNotSkipShadowIssue()
+    {
+        // G438: shadow issue must not be skipped for external PRs.
+        using var writer = new StringWriter();
+        GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-pr-review", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var forbiddenActions = document.RootElement
+            .GetProperty("forbidden_actions")
+            .EnumerateArray()
+            .Select(e => e.GetString() ?? string.Empty)
+            .ToList();
+
+        // Some forbidden action must mention shadow issue
+        Assert.Contains(
+            forbiddenActions,
+            a => a.Contains("shadow", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── external-pr-adopt lane ───────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_ExternalPrAdopt_Markdown_EmitsOperatorConfirmationSection()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-pr-adopt", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide artifact-intake — external-pr-adopt (G438)", output, StringComparison.Ordinal);
+        Assert.Contains("## Operator confirmation", output, StringComparison.Ordinal);
+        Assert.Contains("## Shadow issue", output, StringComparison.Ordinal);
+        Assert.Contains("adoption_rationale", output, StringComparison.Ordinal);
+        Assert.Contains("provenance", output, StringComparison.Ordinal);
+        Assert.Contains("operator_confirmation", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ExternalPrAdopt_Json_OperatorConfirmationAndShadowIssueRequired()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-pr-adopt", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("external-pr-adopt", root.GetProperty("lane").GetString());
+        Assert.True(root.GetProperty("shadow_issue_required").GetBoolean());
+        Assert.True(root.GetProperty("operator_confirmation_required").GetBoolean());
+        Assert.True(root.GetProperty("metadata_requirements").GetArrayLength() >= 6);
+    }
+
+    [Fact]
+    public void Execute_ExternalPrAdopt_ForbiddenActions_DoNotAutomaticallyAdopt()
+    {
+        // G438: adoption must never be automatic.
+        using var writer = new StringWriter();
+        GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-pr-adopt", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var forbiddenActions = document.RootElement
+            .GetProperty("forbidden_actions")
+            .EnumerateArray()
+            .Select(e => e.GetString() ?? string.Empty)
+            .ToList();
+
+        Assert.Contains(
+            forbiddenActions,
+            a => a.Contains("automatic", StringComparison.OrdinalIgnoreCase)
+                || a.Contains("automatically", StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── Validation ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_MissingLane_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--lane is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedLane_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "non-existent-lane"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unsupported --lane 'non-existent-lane'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnsupportedFormat_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-issue", "--format", "yaml"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ReturnsUsageError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-issue", "--surprise"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument '--surprise'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--help"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("guide artifact-intake", output, StringComparison.Ordinal);
+        Assert.Contains("G438", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RepoField_IsPreservedInJson()
+    {
+        using var writer = new StringWriter();
+        GuideArtifactIntakeCommand.Execute(
+            CreateContext("intent-cli"),
+            ["--lane", "external-issue", "--repo", "my-org/my-repo", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("my-org/my-repo", document.RootElement.GetProperty("repo").GetString());
+    }
+
+    [Fact]
+    public void Execute_AllLanes_DefaultFormatIsMarkdown()
+    {
+        foreach (var lane in new[] { "external-issue", "external-pr-review", "external-pr-adopt" })
+        {
+            using var writer = new StringWriter();
+            var exitCode = GuideArtifactIntakeCommand.Execute(
+                CreateContext("intent-cli"),
+                ["--lane", lane],
+                writer);
+
+            Assert.Equal(0, exitCode);
+            // Markdown output starts with #
+            var output = writer.ToString();
+            Assert.StartsWith("#", output.TrimStart(), StringComparison.Ordinal);
+        }
+    }
+
+    private static CliContext CreateContext(string domain)
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = domain,
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `intent-cli guide artifact-intake --lane <lane>` with three AI-agent-facing guidance lanes for importing external GitHub issues and PRs into the intent workflow.
- Each lane requires the host to create lightweight packet/review-context metadata before any label mutation — comment-only or label-only handoff is explicitly forbidden.
- Phrased for AI agents: humans ask an agent to ask intent-cli and follow the returned guidance.

**Lanes:**
- `external-issue`: issue intake guidance; requires metadata before `intent-target` is applied
- `external-pr-review`: PR review guidance; requires metadata + linked issue (shadow issue if none exists)
- `external-pr-adopt`: rare explicit adoption; requires full provenance, shadow issue, and explicit operator confirmation

## Test plan

- [ ] `GuideArtifactIntakeCommandTests` — 16 tests covering all three lanes (markdown + JSON output, metadata requirements, forbidden actions, guard rails, shadow issue / operator confirmation flags, validation errors)
- [ ] `CommandRouterTests.GuideHelpCommand_Subcommands_MatchRegisteredGuideHandlers` — catalog mirror test passes
- [ ] Full suite: 2837 passed, 1 skipped (pre-existing), 0 failed
- [ ] `git diff --check` — clean

Closes #979

🤖 Generated with [Claude Code](https://claude.com/claude-code)