### PR TITLE
G440: Link intent-driven-development.com from README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ recover when a loop looks wrong — all through explicit, inspectable commands.
 - Package id / command: `intent-cli`
 - License: [Apache-2.0](https://github.com/J-Tech-Japan/intent-system/blob/main/README.md#license)
 - Repository: <https://github.com/J-Tech-Japan/intent-system>
+- Official site: <https://www.intent-driven-development.com/> — the Intent-Driven Development concept & intent-system service site, operated by J-Tech Japan ([日本語](https://www.intent-driven-development.com/jp))
+
+> [intent-driven-development.com](https://www.intent-driven-development.com/) is
+> operated by J-Tech Japan and covers the broader Intent-Driven Development
+> concept and the intent-system service overview. This GitHub repository remains
+> the source for code, releases, installation, and detailed docs.
 
 **ドキュメント / Documentation:**
 [日本語](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/ja/README.md) | [English](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 Welcome to the intent-cli documentation.
 
+> **Official service site:** [intent-driven-development.com](https://www.intent-driven-development.com/) ([日本語](https://www.intent-driven-development.com/jp)) — the Intent-Driven Development concept & intent-system service site, operated by J-Tech Japan. These docs stay focused on installation, usage, and repository-specific guidance.
+
 ---
 
 ## Choose your language

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -2,6 +2,8 @@
 
 > 日本語版は [`../ja/README.md`](../ja/README.md) を参照してください.
 
+> **Official service site:** [intent-driven-development.com](https://www.intent-driven-development.com/) — the Intent-Driven Development concept & intent-system service site, operated by J-Tech Japan, covering the broader Intent-Driven Development concept and intent-system overview. This GitHub repository remains the source for code, releases, installation, and detailed docs.
+
 `intent-cli` is **deterministic support tooling** for an intent-driven development workflow on top of GitHub.
 
 Once installed, open a design thread in your AI agent and paste a prompt like:

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -2,6 +2,8 @@
 
 > English version: [`../en/README.md`](../en/README.md)
 
+> **公式サイト:** [intent-driven-development.com（日本語）](https://www.intent-driven-development.com/jp) — J-Tech Japan が運営する Intent-Driven Development のコンセプト・intent-system サービスサイトです。Intent-Driven Development の考え方や intent-system の概要を扱います。GitHub リポジトリは引き続きコード・リリース・インストール・詳細ドキュメントの提供元です。
+
 `intent-cli` は、AI agent に Intent System の正規手順を確認させながら Intent-Driven Development を進めるための **決定論的なサポートツール** です。
 
 `intent-cli` をインストールしたら、AI agent のデザインスレッドで次のように依頼します:


### PR DESCRIPTION
## Summary

Implements G440: link the official Intent-Driven Development / intent-system service site (https://www.intent-driven-development.com/, operated by J-Tech Japan) from the README and documentation entry points, without duplicating service-site content.

## Changes

- `README.md` — add an **Official site** bullet plus a short blurb clarifying the relationship (concept/service site vs. GitHub repo as code/releases/install/docs source). Links to `/` and the Japanese `/jp` landing page.
- `docs/README.md` — add an official-site callout on the language-neutral docs entry page (`/` + `/jp`).
- `docs/en/README.md` — link to `https://www.intent-driven-development.com/`.
- `docs/ja/README.md` — link to `https://www.intent-driven-development.com/jp`.

## Acceptance criteria

- [x] Root README links to `https://www.intent-driven-development.com/`.
- [x] Japanese docs link to `https://www.intent-driven-development.com/jp`.
- [x] English docs link to `https://www.intent-driven-development.com/`.
- [x] Link text identifies the site as the official IDD / intent-system service site operated by J-Tech Japan.
- [x] No large service-site content duplicated; GitHub docs stay focused on install/usage/repo guidance.

## Verification

- `grep -rn intent-driven-development.com` across README/docs confirms the new links and language-specific URLs.
- `git diff --check` is clean.

Closes #981