### PR TITLE
G442: Advance post-0.3.3 development version to 0.3.4

### DIFF
--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.2",
-  "nextVersion": "0.3.3"
+  "stableVersion": "0.3.3",
+  "nextVersion": "0.3.4"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,8 +124,8 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.3 as the next development line
-        // (post-v0.3.2 release bump, see G434).
+        // be parseable and must point to 0.3.4 as the next development line
+        // (post-v0.3.3 release bump, see G442).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -135,8 +135,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.3", policy.NextVersion);
-        Assert.Equal("0.3.2", policy.StableVersion);
+        Assert.Equal("0.3.4", policy.NextVersion);
+        Assert.Equal("0.3.3", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Implements G442: advance the repository's development version source from the `0.3.3` line to the `0.3.4` line after the corrected `v0.3.3` release, mirroring the post-`0.3.2` hygiene from G434.

## Change

- `eng/version.json` — `stableVersion` `0.3.2` → `0.3.3` (the released version), `nextVersion` `0.3.3` → `0.3.4` (next development line).
- `tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs` — update the `eng/version.json` smoke-test to expect `0.3.4` next / `0.3.3` stable.

Post-`v0.3.3` `main` builds now derive preview versions as `0.3.4-preview.<run>.<attempt>` (via `VersionPolicy.DerivePreviewPackageVersion`), i.e. **later than the released `0.3.3` and before a future `0.3.4` release**.

## Acceptance criteria

- [x] Repository no longer reports post-release dev builds as plain `0.3.3` (preview derives off `nextVersion` = `0.3.4`).
- [x] Version source indicates the next development line is `0.3.4`.
- [x] Package ID remains `JTechJapan.IntentSystem.Cli` (untouched).
- [x] Build/package metadata stays compatible with existing GitHub release + NuGet workflows (only the version-source JSON values changed).

Scope notes (per the issue's Out Of Scope): `v0.3.4` is **not** published here, the existing `v0.3.3` release is unchanged, and no release-notes stub is added — release notes are authored per published release (`docs/**/release-notes-vX.md`), and there is no canonical "unreleased/planning" location to update.

## Verification

- `VersionPolicyTests` = 9 pass (incl. the updated `eng/version.json` smoke-test).
- `grep 0.3.3` shows only intentional residue (`stableVersion: 0.3.3` and the stable-line assertion).
- `git diff --check` clean.

Closes #985