### PR TITLE
G444: Host-loop scheduler invariant + duplicate-publish guard

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -335,6 +335,10 @@ internal static class AutomationHostLoopNextActionCommand
             CloseoutDriftRepairsAvailable = closeoutDriftRepairsAvailable,
             NextSliceIssueCutReady = nextSliceIssueCutReady,
             PublishNextSliceExecutionUnit = publishNextSliceExecutionUnit,
+            // G444: when next-slice says issue-cut-ready, cross-check GitHub
+            // reality so a stale queue-state cannot drive a duplicate publish.
+            NextSliceUnitAlreadyOnGitHub = nextSliceIssueCutReady
+                && ExecutionUnitAlreadyOnGitHub(publishNextSliceExecutionUnit, openPrs, openIssues),
             OpenIntentTargetPrOrIssueExists = openIntentTargetExistsResolved,
             AnyChildWorkerLeaseHeld = anyLeaseHeld,
             HardClarificationOpen = hardClarificationOpen,
@@ -532,6 +536,32 @@ internal static class AutomationHostLoopNextActionCommand
             .Any(label => string.Equals(label.Name, WorkerNextActionConstants.Labels.IntentTarget, StringComparison.Ordinal));
         return openPrs.Any(pr => HasIntentTarget(pr.Labels))
             || openIssues.Any(issue => HasIntentTarget(issue.Labels));
+    }
+
+    /// <summary>
+    /// G444: deterministic GitHub-reality cross-check for the issue-cut-ready
+    /// execution unit. Returns true when an open issue or PR already names the
+    /// execution unit in its title (issues/PRs) or body (PRs) — the signal
+    /// that the unit is already published and the queue-state is stale. A
+    /// case-insensitive, word-boundary-aware substring match keeps the check
+    /// deterministic and avoids false positives on unrelated units.
+    /// </summary>
+    private static bool ExecutionUnitAlreadyOnGitHub(
+        string? executionUnit,
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
+        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues)
+    {
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            return false;
+        }
+
+        bool Names(string? text) =>
+            !string.IsNullOrEmpty(text)
+            && text.Contains(executionUnit, StringComparison.OrdinalIgnoreCase);
+
+        return openIssues.Any(issue => Names(issue.Title))
+            || openPrs.Any(pr => Names(pr.Title) || Names(pr.Body));
     }
 
     private static bool AnyChildWorkerLeaseHeld(

--- a/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostLoopNextActionCommand.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -541,10 +542,18 @@ internal static class AutomationHostLoopNextActionCommand
     /// <summary>
     /// G444: deterministic GitHub-reality cross-check for the issue-cut-ready
     /// execution unit. Returns true when an open issue or PR already names the
-    /// execution unit in its title (issues/PRs) or body (PRs) — the signal
-    /// that the unit is already published and the queue-state is stale. A
-    /// case-insensitive, word-boundary-aware substring match keeps the check
-    /// deterministic and avoids false positives on unrelated units.
+    /// execution unit as a standalone token in its title (issues/PRs) or body
+    /// (PRs) — the signal that the unit is already published and the
+    /// queue-state is stale.
+    ///
+    /// The match is TOKEN-BOUNDARY aware, not a plain substring: the
+    /// execution unit must be delimited by a non-identifier character (or
+    /// string start/end) on both sides, where identifier characters are
+    /// <c>[A-Za-z0-9-]</c>. This prevents a shorter candidate from
+    /// false-matching a longer adjacent id — e.g. `G44` must NOT match
+    /// `G444 ...` and `SKS-G67` must NOT match `SKS-G670 ...`, which would
+    /// otherwise wrongly suppress a legitimate publish. Exact ids such as
+    /// `Z4R-G329` still match `Z4R-G329 implement thing`.
     /// </summary>
     private static bool ExecutionUnitAlreadyOnGitHub(
         string? executionUnit,
@@ -556,9 +565,13 @@ internal static class AutomationHostLoopNextActionCommand
             return false;
         }
 
-        bool Names(string? text) =>
-            !string.IsNullOrEmpty(text)
-            && text.Contains(executionUnit, StringComparison.OrdinalIgnoreCase);
+        // (?<![A-Za-z0-9-]) <unit> (?![A-Za-z0-9-]) — the unit may itself
+        // contain '-', so identifier boundaries (not \b word boundaries)
+        // are required to reject adjacent longer ids.
+        var pattern = $"(?<![A-Za-z0-9-]){Regex.Escape(executionUnit)}(?![A-Za-z0-9-])";
+        var matcher = new Regex(pattern, RegexOptions.IgnoreCase | RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(200));
+
+        bool Names(string? text) => !string.IsNullOrEmpty(text) && matcher.IsMatch(text);
 
         return openIssues.Any(issue => Names(issue.Title))
             || openPrs.Any(pr => Names(pr.Title) || Names(pr.Body));

--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -386,8 +386,9 @@ $@"Frequency: {frequency} (operator-resolved). {schedulingHint}
     /// / disconnected monitor) so a fresh agent has no path to a
     /// non-local schedule.
     /// </summary>
-    private static string RenderLocalSchedulingContract(string resolvedAgent, string frequency) =>
-        resolvedAgent switch
+    private static string RenderLocalSchedulingContract(string resolvedAgent, string frequency)
+    {
+        var agentParagraph = resolvedAgent switch
         {
             AgentClaude =>
 $@"**Local scheduling contract (G314)**: this loop runs **same-thread** in the active Claude Code session via `/loop {frequency} <prompt>`. Each wake reuses this thread's local filesystem paths (host repo cwd, child worktree, `.intent-cli/` packages); a different thread / new chat / remote process cannot reach those paths. Do NOT create a new Claude Code thread, a separate chat, a remote/cloud scheduler, an external cron, an out-of-process monitor, or any automation that cannot exec the host's local `intent-cli` against the host repo. If `/loop` is unavailable in the current session, surface the gap to the operator instead of substituting a non-local schedule.",
@@ -396,6 +397,22 @@ $@"**Local scheduling contract (G314)**: this loop runs **current-thread** in th
             _ =>
 $@"**Local scheduling contract (G314)**: this loop runs in the **agent's current-thread / same-session** automation surface at {frequency}. Each wake reuses this thread's local filesystem paths (host repo cwd, child worktree, `.intent-cli/` packages); a different thread / new chat / remote process cannot reach those paths. Do NOT create a new thread / chat, a remote/cloud scheduler, an external cron, an out-of-process monitor, or any automation that cannot exec the host's local `intent-cli` against the host repo. If the agent has no same-thread loop primitive, surface the gap to the operator instead of substituting a non-local schedule."
         };
+
+        // G444: the safe scheduling invariant is "one active wake per host
+        // repo + domain", NOT "never use a short interval". A 5-minute
+        // same-thread sequential loop is acceptable because each wake runs to
+        // completion before the next fires (the runtime serializes wakes on
+        // the same thread). What is unsafe is two INDEPENDENT concurrent
+        // schedulers / threads / processes driving the same host repo+domain.
+        // Agents that previously stopped to ask the operator about "5m cron
+        // policy" should instead proceed when the runtime can satisfy the
+        // single-active-wake invariant, and only surface to the operator when
+        // it cannot be guaranteed.
+        var schedulerInvariant =
+$@"**Scheduler invariant (G444)**: the safe invariant is exactly ONE active wake per host repo + domain at a time. A {frequency} same-thread sequential loop satisfies this because each wake runs to completion before the next fires; what is forbidden is two independent concurrent schedulers (or threads/processes) driving the same host repo + domain. When the runtime can satisfy this invariant with a same-thread sequential loop, PROCEED and set it up — do NOT stop to ask the operator for scheduler-policy confirmation. Only surface to the operator when you cannot guarantee a single active wake (e.g. another loop already drives this repo + domain).";
+
+        return $"{agentParagraph}\n\n{schedulerInvariant}";
+    }
 
     private static string NormalizeAgent(string? agent)
     {

--- a/src/IntentSystem.Cli/Commands/HostLoopNextActionAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/HostLoopNextActionAnalyzer.cs
@@ -64,6 +64,19 @@ internal static class HostLoopNextActionAnalyzer
     public const string ClassificationApprovedPrMetadataBlocked = "approved-pr-metadata-blocked";
     public const string ClassificationRepairHostMetadata = "repair-host-metadata";
     public const string ClassificationPublishNextIssue = "publish-next-issue";
+
+    /// <summary>
+    /// G444: emitted when `next-slice --dry-run` reports `issue-cut-ready`
+    /// for an execution unit that GitHub reality shows is ALREADY published
+    /// (an open issue or PR already exists whose title/body names the unit).
+    /// This is a stale queue-state signal: publishing again would create a
+    /// duplicate issue. The host loop must reconcile queue-state with GitHub
+    /// instead of publishing, so this lane fires ABOVE
+    /// <see cref="ClassificationPublishNextIssue"/> and recommends
+    /// `automation reconcile` rather than the publish chain.
+    /// </summary>
+    public const string ClassificationStaleNextSliceReconcile = "stale-next-slice-reconcile";
+
     public const string ClassificationHardClarification = "hard-clarification";
     public const string ClassificationWipCapBlocked = "wip-cap-blocked";
     public const string ClassificationWaitForChild = "wait-for-child";
@@ -271,6 +284,25 @@ internal static class HostLoopNextActionAnalyzer
                 "Closeout drift (G358): linked_issue-only items have an inferred closing PR — run closeout-drift-check --write.");
         }
 
+        // 5b. G444 stale-next-slice reconcile: next-slice says issue-cut-ready
+        //     for a unit that GitHub already has an open issue/PR for. The
+        //     queue-state is stale; publishing would duplicate the issue.
+        //     Reconcile instead of publishing. Fires ABOVE publish-next-issue.
+        if (input.NextSliceIssueCutReady
+            && input.PublishNextSliceExecutionUnit is { } staleUnit
+            && input.NextSliceUnitAlreadyOnGitHub)
+        {
+            return Result(ClassificationStaleNextSliceReconcile, mutationAllowed: false,
+                $"intent-cli automation reconcile --repo {input.Repo} --lane next-slice --format json",
+                new[]
+                {
+                    $"intent next-slice --dry-run reports `issue-cut-ready` for execution unit `{staleUnit}`, but GitHub already has an open issue or PR for that unit.",
+                    "Queue-state is stale: publishing now would create a DUPLICATE issue. Run `automation reconcile --lane next-slice` to resync queue-state with GitHub reality, then re-run the wake.",
+                    "Do NOT run the publish chain (packet draft → issue publish-flow → automation issue-publish) while next-slice and GitHub disagree."
+                },
+                $"Stale next-slice (G444): `{staleUnit}` already on GitHub — reconcile, do not publish a duplicate.");
+        }
+
         // 6. publish next issue
         if (input.NextSliceIssueCutReady && input.PublishNextSliceExecutionUnit is { } unit && !input.OpenIntentTargetPrOrIssueExists)
         {
@@ -413,6 +445,15 @@ internal sealed record HostLoopNextActionInput
 
     /// <summary>Execution unit ready to publish (set when NextSliceIssueCutReady is true).</summary>
     public string? PublishNextSliceExecutionUnit { get; init; }
+
+    /// <summary>
+    /// G444: true when the issue-cut-ready execution unit
+    /// (<see cref="PublishNextSliceExecutionUnit"/>) already has an open
+    /// GitHub issue or PR naming it — i.e. queue-state is stale and a publish
+    /// would duplicate. Routes to <c>stale-next-slice-reconcile</c> instead of
+    /// <c>publish-next-issue</c>.
+    /// </summary>
+    public bool NextSliceUnitAlreadyOnGitHub { get; init; }
 
     /// <summary>True when any open intent-target PR or issue exists in the target repo.</summary>
     public bool OpenIntentTargetPrOrIssueExists { get; init; }

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -263,6 +263,68 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_NextSliceIssueCutReady_ButUnitAlreadyOnGitHub_ReconcilesInsteadOfDuplicatePublish_G444()
+    {
+        // G444 / Zero4Racer Z4R-G329: stale queue-state makes next-slice
+        // report `issue-cut-ready` even though GitHub already has an open
+        // issue (#661) and PR (#662) for the same execution unit. The host
+        // loop must NOT publish a duplicate; it must reconcile.
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: new[]
+            {
+                new GitHubAutomationPrCandidate
+                {
+                    Number = 662,
+                    Title = "Z4R-G329 implement thing",
+                    Url = "https://github.com/J-Tech-Japan/intent-system/pull/662",
+                    Body = "Closes #661",
+                    CreatedAt = "2026-06-01T00:00:00Z",
+                    UpdatedAt = "2026-06-01T00:00:00Z",
+                    Labels = Array.Empty<GitHubAutomationLabel>(),
+                    ClosingIssuesReferences = new[] { new GitHubPrClosingIssueReference { Number = 661 } },
+                    State = "OPEN",
+                    IsDraft = false
+                }
+            },
+            issues: new[]
+            {
+                new GitHubAutomationIssueCandidate
+                {
+                    Number = 661,
+                    Title = "Z4R-G329 implement thing",
+                    Url = "https://github.com/J-Tech-Japan/intent-system/issues/661",
+                    CreatedAt = "2026-06-01T00:00:00Z",
+                    Labels = new[]
+                    {
+                        new GitHubAutomationLabel { Name = "intent-target" },
+                        new GitHubAutomationLabel { Name = "intent-pr-created" }
+                    },
+                    State = "OPEN"
+                }
+            });
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "Z4R-G329" });
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/intent-system",
+             "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("stale-next-slice-reconcile", root.GetProperty("classification").GetString());
+        Assert.False(root.GetProperty("mutation_allowed").GetBoolean());
+        var recommended = root.GetProperty("recommended_command").GetString()!;
+        Assert.Contains("automation reconcile", recommended, StringComparison.Ordinal);
+        Assert.Contains("--lane next-slice", recommended, StringComparison.Ordinal);
+        // Must NOT recommend the publish chain.
+        Assert.DoesNotContain("packet draft", recommended, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_NextSliceProbeReturnsNoActionableItem_FallsThroughToTrueIdle()
     {
         // G318 acceptance: when next-slice has no candidate AND no other

--- a/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostLoopNextActionCommandTests.cs
@@ -325,6 +325,49 @@ public sealed class AutomationHostLoopNextActionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_NextSliceIssueCutReady_AdjacentLongerIdOnGitHub_DoesNotFalseMatch_StillPublishes_G444()
+    {
+        // G444 review fix: the duplicate guard must be token-boundary aware,
+        // not a plain substring. A candidate `SKS-G67` must NOT be treated as
+        // already-published just because an unrelated open issue is titled
+        // `SKS-G670 ...`. The guard must fall through to the normal publish
+        // lane (no real duplicate, no open intent-target work).
+        AutomationHostLoopNextActionCommand.CandidateListerFactory = () => new FakeLister(
+            prs: Array.Empty<GitHubAutomationPrCandidate>(),
+            issues: new[]
+            {
+                new GitHubAutomationIssueCandidate
+                {
+                    Number = 700,
+                    Title = "SKS-G670 a different, longer execution unit",
+                    Url = "https://github.com/J-Tech-Japan/SekibanAsAService/issues/700",
+                    CreatedAt = "2026-06-01T00:00:00Z",
+                    // No intent-target label: unrelated open issue, must not
+                    // block the WIP cap either.
+                    Labels = Array.Empty<GitHubAutomationLabel>(),
+                    State = "OPEN"
+                }
+            });
+        AutomationHostLoopNextActionCommand.NextSliceDryRunProbeFactory = _ => new FakeNextSliceProbe(
+            new NextSliceProbeResult { RecommendedOutcome = "issue-cut-ready", ExecutionUnit = "SKS-G67" });
+
+        using var writer = new StringWriter();
+        var exit = AutomationHostLoopNextActionCommand.Execute(
+            CreateContext(),
+            ["--repo", "J-Tech-Japan/SekibanAsAService",
+             "--domain", "sekiban-as-a-service", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        // Adjacent longer id must NOT trigger the stale-reconcile guard.
+        Assert.NotEqual("stale-next-slice-reconcile", root.GetProperty("classification").GetString());
+        Assert.Equal("publish-next-issue", root.GetProperty("classification").GetString());
+        Assert.Contains("--execution-unit SKS-G67", root.GetProperty("recommended_command").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_NextSliceProbeReturnsNoActionableItem_FallsThroughToTrueIdle()
     {
         // G318 acceptance: when next-slice has no candidate AND no other

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -942,6 +942,29 @@ public sealed class GuidePromptMatrixCommandTests
     }
 
     [Fact]
+    public void Execute_HostLoopPrompt_StatesSchedulerInvariantAndAllows5mSequential_G444()
+    {
+        // G444: the host-loop prompt must state the safe scheduling invariant
+        // (one active wake per host repo+domain), allow a 5m same-thread
+        // sequential loop, forbid independent concurrent schedulers, and tell
+        // the agent NOT to stop for scheduler-policy confirmation when the
+        // invariant is satisfiable.
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", "host-loop", "--domain", "intent-system", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude", "--frequency", "5m", "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+        Assert.Contains("Scheduler invariant (G444)", prompt, StringComparison.Ordinal);
+        Assert.Contains("ONE active wake per host repo + domain", prompt, StringComparison.Ordinal);
+        Assert.Contains("5m same-thread sequential loop", prompt, StringComparison.Ordinal);
+        Assert.Contains("two independent concurrent schedulers", prompt, StringComparison.Ordinal);
+        Assert.Contains("do NOT stop to ask the operator for scheduler-policy confirmation", prompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_ChildLoopPrompt_AgentCodex_IncludesLocalSchedulingContract_G314()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Implements G444 — two host-loop safety improvements observed in a Zero4Racer host-loop wake.

### Part 1 — scheduler invariant guidance
`GuidePromptMatrixCommand.RenderLocalSchedulingContract` now appends an explicit **Scheduler invariant (G444)** paragraph to every agent variant (claude/codex/generic) and to the unresolved-frequency path:
- The safe invariant is **exactly one active wake per host repo + domain**.
- A `5m` same-thread sequential loop **satisfies** it (each wake runs to completion before the next fires); two **independent concurrent** schedulers/threads/processes do not.
- Agents should **proceed** and set up the loop when the runtime can satisfy the invariant — **not** stop to ask the operator for scheduler-policy confirmation; surface to the operator only when single-active-wake cannot be guaranteed.

### Part 2 — duplicate-publish guard
When `next-slice --dry-run` reports `issue-cut-ready` for an execution unit that GitHub already has an open issue/PR for, the queue-state is stale and publishing would create a duplicate. New `stale-next-slice-reconcile` classification in `HostLoopNextActionAnalyzer` fires **above** `publish-next-issue` and recommends `automation reconcile --lane next-slice` (read-only, `mutation_allowed=false`) instead of the publish chain. `AutomationHostLoopNextActionCommand` cross-checks the issue-cut-ready unit against open issues/PRs (title/body match) via the existing `CandidateLister` seam and sets the new `NextSliceUnitAlreadyOnGitHub` input.

intent-cli still does not launch or own AI providers / external schedulers — this only defines the safe invariant and a deterministic diagnostic.

## Acceptance criteria

- [x] Host-loop guide states the scheduling invariant: one active wake per host repo/domain.
- [x] Guidance allows 5m same-thread sequential loops and forbids independent concurrent schedulers for the same domain/repo.
- [x] Agents are instructed not to stop for scheduler clarification when the invariant can be satisfied.
- [x] If `next-slice` reports `issue-cut-ready` but GitHub already has an issue/PR for that execution unit, the loop must not publish a duplicate (routed to `stale-next-slice-reconcile`, mutation disallowed).
- [x] `host-loop-next-action` surfaces a recovery/reconcile path for stale queue-state instead of `true-idle` / `publish-next-issue`.
- [x] Tests cover the stale queue-state + existing GitHub issue/PR scenario.
- [x] intent-cli does not launch/own AI providers or schedulers (unchanged).

## Verification

- `GuidePromptMatrixCommandTests` + `AutomationHostLoopNextActionCommandTests` + `HostLoopNextАction*` = 209 pass; `GuideWorkflowTask*` / `GuideHelp` / `GuideAutomation*` = 265 pass.
- E2E: `guide prompt-matrix --mode host-loop --agent claude --frequency 5m` emits the G444 invariant paragraph.
- New host-loop-next-action test reproduces Z4R-G329 (open issue #661 + PR #662) and asserts `stale-next-slice-reconcile` with `automation reconcile --lane next-slice`, not the publish chain.
- `git diff --check` clean.

Closes #989