### PR TITLE
G445: Standing policy for device-gated review evidence gaps

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
@@ -123,6 +123,25 @@ internal static class GuideReviewCommand
         "Tests-only failure mode (\"tests pass but evidence missing\") is itself an implementation-finding when the PR cannot show packet/intent conformance — request the implementer to add the missing evidence (test names mapped to AC, comments tying changes to packet clauses, etc.)."
     };
 
+    // G445: standing policy for device/operator/hardware-gated acceptance
+    // criteria. AI review loops cannot always operate physical devices or
+    // produce real hardware evidence; without a stable rule they stall,
+    // asking the operator the same policy question on every such packet.
+    // This surfaces the standing policy so the agent applies it
+    // deterministically: approve-with-recorded-gap for ordinary device gaps
+    // when code conformance is otherwise verified, hard-block for primary /
+    // high-risk device evidence, and never claim evidence that was not
+    // collected.
+    private static readonly IReadOnlyList<string> DeviceGatedEvidencePolicy = new[]
+    {
+        "Definition: a `device-gap` is an acceptance criterion whose ONLY missing evidence is real physical-device / operator / hardware proof that this automation cannot generate (e.g. a real two-finger touch gesture), while source, log, unit-test, and simulator evidence for the same criterion IS available and passes.",
+        "Approve-with-recorded-gap (NOT an operator stop) when ALL hold: (a) code/packet conformance is verified by available source/log/unit/simulator evidence; (b) the missing evidence is purely a device/automation limitation; (c) the gap is explicitly recorded as a `device-gap` in the approval summary AND a durable follow-up (PR comment / closeout note / follow-up issue) tracks collecting the real-device evidence.",
+        "HARD-BLOCK (request-update or operator stop, never approve) when the device-gated evidence IS the primary deliverable of the slice, OR is safety / security / data-loss / payment / other high-risk proof. These are not eligible for approve-with-gap.",
+        "NEVER claim physical evidence was collected when it was not. State plainly: \"real-device evidence for <criterion> was NOT collected (device-gap); verified by <source/log/unit/simulator> instead\" — fabricating or implying device evidence is a false-claim violation.",
+        "Do NOT re-ask the standing-policy question once a device-gap policy is established for this domain/wave; apply the same rule to subsequent packets with equivalent device gaps and only escalate genuinely new high-risk gates.",
+        "Record every accepted device-gap durably (closeout note / PR comment / follow-up issue) so the deferred real-device verification is tracked and not silently lost."
+    };
+
     private static readonly IReadOnlyList<string> DefaultValidationSuggestions = new[]
     {
         "Run focused tests named in the packet's Verification section.",
@@ -263,6 +282,7 @@ internal static class GuideReviewCommand
             ReviewBoundaries = ReviewBoundaries,
             ApprovalSummaryRequirements = ApprovalSummaryRequirements,
             RequestUpdateRequirements = RequestUpdateRequirements,
+            DeviceGatedEvidencePolicy = DeviceGatedEvidencePolicy,
             ReviewBlockerProtocol = ReviewBlockerProtocol.ProtocolRules,
             PrBlockerCommentTemplate = ReviewBlockerProtocol.BlockerCommentTemplateSections,
             ReviewBlockerRoutingExamples = BuildBlockerRoutingExamples(),
@@ -508,6 +528,14 @@ internal static class GuideReviewCommand
         }
         writer.WriteLine();
 
+        // G445: standing policy for device/operator/hardware-gated evidence gaps.
+        writer.WriteLine("## Device-gated evidence policy (G445)");
+        foreach (var item in result.DeviceGatedEvidencePolicy)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
         // G394: durable blocker protocol + PR blocker comment template +
         // worked routing examples. Record current-PR blockers on the PR, not
         // only in chat, before completing as request-update / clarification.
@@ -735,6 +763,15 @@ internal sealed record GuideReviewResult
     /// </summary>
     [JsonPropertyName("request_update_requirements")]
     public required IReadOnlyList<string> RequestUpdateRequirements { get; init; }
+
+    /// <summary>
+    /// G445: standing policy for device/operator/hardware-gated evidence
+    /// gaps — when to approve-with-recorded-gap vs hard-block, the
+    /// no-false-claim rule, durable follow-up tracking, and not re-asking the
+    /// standing-policy question per packet.
+    /// </summary>
+    [JsonPropertyName("device_gated_evidence_policy")]
+    public required IReadOnlyList<string> DeviceGatedEvidencePolicy { get; init; }
 
     /// <summary>
     /// G394: durable-routing rules for review clarification stops — record

--- a/tests/IntentSystem.Cli.Tests/GuideReviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideReviewCommandTests.cs
@@ -8,6 +8,58 @@ namespace IntentSystem.Cli.Tests;
 public sealed class GuideReviewCommandTests
 {
     [Fact]
+    public void Execute_EmitsDeviceGatedEvidencePolicy_WithApproveWithGapAndHardBlockRules_G445()
+    {
+        using var workspace = new GuideReviewWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G248", "review", title: "guide review", linkedPr: "598"));
+        workspace.WriteFile(".intent-cli/issues/G248/packet.yaml", "x");
+
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "598", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var policy = document.RootElement.GetProperty("device_gated_evidence_policy")
+            .EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.NotEmpty(policy);
+        // Distinguishes ordinary device-gap (approve-with-recorded-gap) from hard blockers.
+        Assert.Contains(policy, p => p.Contains("device-gap", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(policy, p => p.Contains("Approve-with-recorded-gap", StringComparison.Ordinal)
+            && p.Contains("source/log/unit/simulator", StringComparison.Ordinal));
+        Assert.Contains(policy, p => p.Contains("HARD-BLOCK", StringComparison.Ordinal)
+            && p.Contains("primary deliverable", StringComparison.Ordinal));
+        // No-false-claim rule.
+        Assert.Contains(policy, p => p.Contains("NEVER claim", StringComparison.Ordinal)
+            && p.Contains("NOT collected", StringComparison.Ordinal));
+        // Durable follow-up tracking required.
+        Assert.Contains(policy, p => p.Contains("follow-up", StringComparison.OrdinalIgnoreCase));
+        // Do not re-ask the standing-policy question per packet.
+        Assert.Contains(policy, p => p.Contains("Do NOT re-ask", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_Markdown_IncludesDeviceGatedEvidencePolicySection_G445()
+    {
+        using var workspace = new GuideReviewWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G248", "review", title: "guide review", linkedPr: "598"));
+        workspace.WriteFile(".intent-cli/issues/G248/packet.yaml", "x");
+
+        using var writer = new StringWriter();
+        GuideReviewCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "598", "--format", "markdown"],
+            writer);
+
+        var output = writer.ToString();
+        Assert.Contains("## Device-gated evidence policy (G445)", output, StringComparison.Ordinal);
+        Assert.Contains("Approve-with-recorded-gap", output, StringComparison.Ordinal);
+        Assert.Contains("HARD-BLOCK", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenQueueMatchAndReviewContext_EmitsReadyTrueWithExcerpt()
     {
         using var workspace = new GuideReviewWorkspace();


### PR DESCRIPTION
## Summary

Implements G445 — a standing review policy for device/operator/hardware-gated acceptance criteria, so autonomous review loops stop re-asking the operator the same policy question when automation cannot physically generate the required device evidence.

`GuideReviewCommand` now emits a `device_gated_evidence_policy` list (JSON) and a **## Device-gated evidence policy (G445)** markdown section:
- Defines a `device-gap` (only-missing evidence is real device/operator/hardware proof; source/log/unit/simulator evidence for the same criterion is available and passes).
- **Approve-with-recorded-gap** (not an operator stop) when code/packet conformance is otherwise verified, the gap is purely a device/automation limitation, and it is explicitly recorded as a `device-gap` with durable follow-up tracking.
- **Hard-block** when the device evidence is the slice's primary deliverable or safety/security/data-loss/payment/high-risk proof.
- **Never claim** physical evidence that was not collected (false-claim violation) — state the device-gap and what verified it instead.
- **Do not re-ask** the standing-policy question once a domain/wave policy is established; record every accepted gap durably.

## Acceptance criteria

- [x] Review guidance distinguishes ordinary device/operator-gated gaps from hard blockers.
- [x] Agents may proceed with approval when conformance is verified by available source/log/unit/simulator evidence and the missing physical evidence is recorded as a `device-gap`.
- [x] Agents must block when the missing device evidence is the slice's primary deliverable or high-risk critical evidence.
- [x] Approval summaries cannot claim physical evidence that was not collected.
- [x] Closeout/review comments include durable follow-up tracking for accepted device gaps.
- [x] Guidance tells agents not to ask the same standing-policy question repeatedly.

## Verification

- `GuideReviewCommandTests` = 21 pass, incl. two new G445 tests asserting the policy in JSON (approve-with-gap, hard-block, no-false-claim, follow-up, don't-re-ask) and the markdown section.
- `git diff --check` clean.

Scope: the canonical review-guidance surface is `intent-cli guide review` (what the host review loop instructs reviewers to run); the standing policy lives there. No merge-mechanics or label-transition semantics changed; no physical device automation added (out of scope).

Closes #991