### PR TITLE
G446: Release-readiness notes + operator gate for intent-cli v0.3.4

### DIFF
--- a/docs/en/release-notes-v0.3.4.md
+++ b/docs/en/release-notes-v0.3.4.md
@@ -1,0 +1,119 @@
+# Release Notes — intent-cli v0.3.4
+
+> **Release checklist for maintainers:** see [Creating the v0.3.4 GitHub Release](#creating-the-v034-github-release).
+> **Do NOT tag until the [release-readiness gate](#release-readiness-gate-g446) passes.**
+
+## What's in v0.3.4
+
+v0.3.4 is a reliability and host-loop-guidance release. It collects the
+release-blocking first-run and CI fixes plus the host-loop / review policy
+hardening completed after the corrected `v0.3.3` release. No package id,
+license, or workflow-semantics changes. The package id remains
+`JTechJapan.IntentSystem.Cli`.
+
+### First-run host initialization deadlock fix (G441)
+
+- `intent init-tree --write` now scaffolds `intents/<domain>/automation/bindings.md`
+  with a recognized `execution_unit_regex` (and `child_repo` when known), so a
+  freshly initialized host is recognized by `next-slice`, `host-check`, and
+  `automation summary` without hand-authoring.
+- `intent init --write` now scaffolds the durable-state skeletons
+  `.intent-cli/queue-state.json` (empty, schema 1) and `.intent-cli/runs.jsonl`,
+  so `host-check` reports `ok` instead of `partially-initialized` on a brand-new
+  host.
+- First-run docs steer agents to ask intent-cli for the next action rather than
+  read source or hand-author `bindings.md`.
+
+### Release CI stabilization (G443)
+
+- The installed-CLI surface probe (`AutomationInstalledCliSurfaceProbe`) now
+  retries on the Linux `Text file busy` (ETXTBSY) exec race and degrades a
+  persistent failure to a `missing` surface instead of crashing the command —
+  fixing the two flaky tests that blocked the earlier `v0.3.3` release CI.
+- Release/CI/preview workflows write uniquely named `*.trx` (`LogFilePrefix`)
+  so per-project results no longer overwrite one shared file.
+
+### Host-loop scheduler invariant + duplicate-publish guard (G444)
+
+- `guide prompt-matrix` host-loop guidance states the safe scheduling invariant:
+  exactly one active wake per host repo + domain. A 5-minute same-thread
+  sequential loop is allowed; independent concurrent schedulers are not. Agents
+  proceed instead of stopping for scheduler-policy confirmation when the
+  invariant is satisfiable.
+- `automation host-loop-next-action` adds `stale-next-slice-reconcile`: when
+  `next-slice` reports `issue-cut-ready` for an execution unit that GitHub
+  already has an open issue/PR for (token-boundary matched), it routes to
+  `automation reconcile --lane next-slice` instead of publishing a duplicate.
+
+### Device-gated review evidence policy (G445)
+
+- `guide review` emits a standing `device_gated_evidence_policy`: when to
+  approve-with-recorded-gap vs hard-block for device/operator/hardware-gated
+  acceptance criteria, the no-false-claim rule, durable follow-up tracking, and
+  not re-asking the standing-policy question per packet.
+
+> Version metadata note: G442 advanced the development version source to the
+> 0.3.4 line (`eng/version.json` `stableVersion: 0.3.3`, `nextVersion: 0.3.4`);
+> G446 (this packet) is the release-readiness gate.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.4
+```
+
+Or download the self-contained binary from the
+[v0.3.4 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.4).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.3
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.4
+```
+
+There are no breaking changes from v0.3.3.
+
+## Release-readiness gate (G446)
+
+Do not create the `v0.3.4` tag/release until ALL of the following hold
+(this gate fails closed — if any item is unmet, stop and do not tag):
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G441, G443, G444, G445 (and G442 version bump, G446 this prep). Confirm
+      on the host/review side via the host queue-state / GitHub PR state — the
+      child implementation loop must not read parent queue-state, so this is a
+      host-owned precondition.
+- [ ] `eng/version.json` `nextVersion` is `0.3.4` (the intended release version)
+      and matches the tag to be created (`v0.3.4`). The release workflow derives
+      the package version from the tag; `-p:Version=` overrides the static
+      `<Version>` in `src/IntentSystem.Cli/IntentSystem.Cli.csproj`.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+
+## Creating the v0.3.4 GitHub Release
+
+1. Confirm the [release-readiness gate](#release-readiness-gate-g446) — do not
+   proceed if any item is unmet.
+2. Tag the release commit: `git tag v0.3.4 && git push origin v0.3.4`.
+3. The `release.yml` workflow fires and builds binaries, `.nupkg`, and
+   checksums (version derived from the tag). Wait for it to complete green.
+4. The workflow creates the GitHub Release draft. Review it, paste the content
+   of this file as the release body, and publish.
+5. Confirm the NuGet publish step pushed `JTechJapan.IntentSystem.Cli 0.3.4`.
+6. Post-release verification checklist:
+   - [ ] NuGet.org package page links all resolve correctly.
+   - [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+         accessible.
+   - [ ] `.sha256` checksums match the downloaded artifacts.
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` then
+         `intent-cli --version` reports `0.3.4`.
+   - [ ] Local preview/dry-run version metadata uses the next development line
+         after `0.3.4` (bump `eng/version.json` per the post-release step in
+         [Version flow](09-developer-reference.md#version-flow)).

--- a/docs/ja/release-notes-v0.3.4.md
+++ b/docs/ja/release-notes-v0.3.4.md
@@ -1,0 +1,116 @@
+# リリースノート — intent-cli v0.3.4
+
+> **メンテナ向けリリースチェックリスト:** [v0.3.4 GitHub リリースの作成](#v034-github-リリースの作成) を参照。
+> **[リリース準備ゲート](#リリース準備ゲート-g446) を通過するまでタグを打たないこと。**
+
+## v0.3.4 の内容
+
+v0.3.4 は信頼性と host-loop ガイダンスのリリースです。修正済みの `v0.3.3`
+リリース後に完了した、初回セットアップ/CI のリリースブロッカー修正と
+host-loop / レビューポリシーの強化をまとめています。package id・ライセンス・
+ワークフロー semantics の変更はありません。package id は
+`JTechJapan.IntentSystem.Cli` のままです。
+
+### 初回 host 初期化デッドロック修正 (G441)
+
+- `intent init-tree --write` が `intents/<domain>/automation/bindings.md`
+  （認識される `execution_unit_regex`、判明時は `child_repo` 付き）を生成し、
+  初回ホストが手書きなしで `next-slice` / `host-check` / `automation summary`
+  に認識される。
+- `intent init --write` が durable-state スケルトン
+  `.intent-cli/queue-state.json`（空・schema 1）と `.intent-cli/runs.jsonl`
+  を生成し、新規ホストで `host-check` が `partially-initialized` ではなく
+  `ok` を返す。
+- 初回ドキュメントは、ソースを読んだり `bindings.md` を手書きせず intent-cli
+  に次アクションを尋ねるよう誘導。
+
+### リリース CI 安定化 (G443)
+
+- installed-CLI surface probe が Linux の `Text file busy`（ETXTBSY）exec
+  レースをリトライし、永続失敗時はコマンドをクラッシュさせず `missing` に
+  degrade。以前 `v0.3.3` リリース CI をブロックした2つの flaky テストを解消。
+- release/CI/preview ワークフローが一意名の `*.trx`（`LogFilePrefix`）を出力し、
+  プロジェクトごとの結果が同一ファイルを上書きしない。
+
+### host-loop scheduler invariant + 重複 publish ガード (G444)
+
+- `guide prompt-matrix` の host-loop ガイダンスが安全な scheduling invariant
+  （host repo + domain ごとに 1 active wake）を明記。5分の同一スレッド逐次
+  ループは可、独立並走は不可。invariant を満たせる場合 agent は確認で止まらず
+  進む。
+- `automation host-loop-next-action` に `stale-next-slice-reconcile` を追加:
+  `next-slice` が `issue-cut-ready` でも同一 execution unit に GitHub
+  issue/PR が既存（token 境界一致）なら、重複 publish せず
+  `automation reconcile --lane next-slice` へ誘導。
+
+### device-gated レビュー証跡ポリシー (G445)
+
+- `guide review` が standing `device_gated_evidence_policy` を出力:
+  device/operator/hardware-gated な受け入れ基準で approve-with-recorded-gap
+  か hard-block か、no-false-claim、durable follow-up tracking、同一ポリシーを
+  パケットごとに再質問しないことを明文化。
+
+> バージョンメタデータ注記: G442 が開発版ソースを 0.3.4 ライン
+> （`eng/version.json` `stableVersion: 0.3.3`, `nextVersion: 0.3.4`）へ前進。
+> G446（本パケット）はリリース準備ゲート。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.4
+```
+
+または
+[v0.3.4 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.4)
+から self-contained バイナリをダウンロード。使用前に `.sha256` を検証。
+
+## v0.3.3 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.4
+```
+
+v0.3.3 からの破壊的変更はありません。
+
+## リリース準備ゲート (G446)
+
+以下がすべて満たされるまで `v0.3.4` タグ/リリースを作成しないこと
+（このゲートは fail-closed — 未達があれば停止しタグを打たない）:
+
+- [ ] リリース対象パケットがすべて **完了し PR が `main` にマージ済み**:
+      G441, G443, G444, G445（および G442 version bump、G446 本準備）。
+      host/review 側の queue-state / GitHub PR 状態で確認すること — child
+      実装ループは parent queue-state を読まないため、これは host-owned
+      の前提条件。
+- [ ] `eng/version.json` の `nextVersion` が `0.3.4`（意図するリリース版）で、
+      作成するタグ（`v0.3.4`）と一致。リリースワークフローはタグから package
+      version を導出し、`-p:Version=` が
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` の静的 `<Version>` を上書き。
+- [ ] package メタデータが正しい: `PackageId = JTechJapan.IntentSystem.Cli`、
+      `RepositoryUrl` / `PackageProjectUrl` が
+      `https://github.com/J-Tech-Japan/intent-system`、
+      `PackageLicenseExpression = Apache-2.0`、README/docs リンクが解決し、
+      公式サイト `https://www.intent-driven-development.com/` が README から
+      リンクされている。
+- [ ] リリースコミットで **main CI が green**（`Build and test (source contract)`）、
+      かつ **preview-pack** ワークフローが green。
+
+## v0.3.4 GitHub リリースの作成
+
+1. [リリース準備ゲート](#リリース準備ゲート-g446) を確認 — 未達があれば進めない。
+2. リリースコミットにタグ: `git tag v0.3.4 && git push origin v0.3.4`。
+3. `release.yml` ワークフローが発火し、バイナリ・`.nupkg`・チェックサムを
+   ビルド（version はタグ由来）。green 完了まで待つ。
+4. ワークフローが GitHub Release ドラフトを作成。レビューし、本ファイルの内容を
+   リリース本文に貼り付けて公開。
+5. NuGet publish ステップが `JTechJapan.IntentSystem.Cli 0.3.4` を push したか確認。
+6. リリース後検証チェックリスト:
+   - [ ] NuGet.org パッケージページのリンクがすべて解決する。
+   - [ ] GitHub リリースのアセットリンク（`.tar.gz`, `.zip`, `.exe`, `.nupkg`）が
+         アクセス可能。
+   - [ ] `.sha256` チェックサムがダウンロード成果物と一致。
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` 後に
+         `intent-cli --version` が `0.3.4` を報告。
+   - [ ] ローカル preview/dry-run のバージョンメタデータが `0.3.4` の次の開発
+         ラインを使う（[Version flow](09-developer-reference.md#version-flow)
+         のリリース後手順に従って `eng/version.json` を bump）。


### PR DESCRIPTION
## Summary

Implements G446 — the release-readiness gate for the next intent-cli release (`v0.3.4`), **without** creating the release or publishing to NuGet (out of scope). Adds `docs/en|ja/release-notes-v0.3.4.md`.

## What it does

- **Release notes** summarizing the release train: G441 (first-run host init deadlock), G443 (release CI ETXTBSY + trx stabilization), G444 (host-loop scheduler invariant + duplicate-publish guard), G445 (device-gated review evidence policy). Notes that G442 advanced the version source to the 0.3.4 line.
- **Version coherence**: next release `0.3.4` matches `eng/version.json` `nextVersion`; documents that `release.yml` derives the package version from the git tag (`-p:Version=` overrides the static `<Version>` in the CLI csproj), so the static dev value is not the release version.
- **Package-metadata verification**: `PackageId = JTechJapan.IntentSystem.Cli`, `RepositoryUrl`/`PackageProjectUrl` → `github.com/J-Tech-Japan/intent-system`, `Apache-2.0`, README links incl. the official `intent-driven-development.com` site.
- **Fail-closed release-readiness gate** + operator checklist (tag/release creation, NuGet publish confirmation, artifact verification, post-release global-tool update verification).

## Acceptance criteria

- [x] Release preparation fails closed if any required packet remains incomplete — documented as an explicit gate precondition (all release-bound PRs merged + CI green) that must hold before tagging.
- [x] Next release version explicitly identified (`0.3.4`) and matches the repository version source (`eng/version.json`).
- [x] Release notes exist for the intended release and include G441, G443, G444, G445 (and note G442).
- [x] Package metadata points to the correct repo, license, README/docs, and official service site.
- [x] Release workflow runs only after CI/preview-pack are green on main — stated in the gate.
- [x] Concise operator checklist for tag/release, NuGet publish confirmation, artifact verification, and post-release global-tool update verification.

Scope note: the "all packets complete" check reads host queue-state, which is **host-owned**; this child implementation loop is GitHub-contract-only and does not read parent queue-state, so the gate documents it as a host-side precondition rather than reading it here. No GitHub release / NuGet publish / package-id change is performed (all out of scope).

## Verification

- `eng/version.json` confirmed `nextVersion: 0.3.4`; `release.yml` confirmed to derive version from the tag / version.json.
- Package metadata confirmed in `src/IntentSystem.Cli/IntentSystem.Cli.csproj`; README confirmed to link the official site.
- Docs-only; no source changed. `git diff --check` clean.

Closes #993