### PR TITLE
G447: Advance post-v0.3.4 development version to 0.3.5

### DIFF
--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.3",
-  "nextVersion": "0.3.4"
+  "stableVersion": "0.3.4",
+  "nextVersion": "0.3.5"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,8 +124,8 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.4 as the next development line
-        // (post-v0.3.3 release bump, see G442).
+        // be parseable and must point to 0.3.5 as the next development line
+        // (post-v0.3.4 release bump, see G447).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -135,8 +135,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.4", policy.NextVersion);
-        Assert.Equal("0.3.3", policy.StableVersion);
+        Assert.Equal("0.3.5", policy.NextVersion);
+        Assert.Equal("0.3.4", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Implements G447: advance the repository version source from the `0.3.4` line to `0.3.5` now that the `v0.3.4` release exists and its release workflow completed (mirrors the post-`0.3.2`/`0.3.3` hygiene from G442).

## Change

- `eng/version.json` — `stableVersion` `0.3.3` → `0.3.4` (the released version), `nextVersion` `0.3.4` → `0.3.5` (next development line).
- `tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs` — update the `eng/version.json` smoke-test to expect `0.3.5` next / `0.3.4` stable.

Post-`v0.3.4` `main` builds now derive preview versions as `0.3.5-preview.<run>.<attempt>`, sorting after the released `0.3.4`.

## Acceptance criteria

- [x] `eng/version.json` reports `stableVersion 0.3.4` and `nextVersion 0.3.5`.
- [x] Version policy tests updated for the new stable/next pair (9 pass).
- [x] No docs/checklists imply `0.3.4` is still the unreleased next train (only `eng/version.json` carried the next pointer; release notes for v0.3.4 are release docs and remain correct).
- [x] Package id remains `JTechJapan.IntentSystem.Cli` (untouched).
- [x] Local version/preview derivation remains parseable and sorts after `v0.3.4`.

Scope: `v0.3.5` is not published, the `v0.3.4` release is unchanged, and package id/license/NuGet credentials are untouched (all out of scope).

## Verification

- `VersionPolicyTests` = 9 pass (incl. updated smoke-test).
- `grep 0.3.4` shows only intentional residue (`stableVersion: 0.3.4`, stable assertion, comment).
- `git diff --check` clean.

Closes #995