### PR TITLE
G448: unified state doctor + fail-closed safe repair for host metadata drift

### DIFF
--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.3",
-  "nextVersion": "0.3.4"
+  "stableVersion": "0.3.4",
+  "nextVersion": "0.3.5"
 }

--- a/src/IntentSystem.Cli/Commands/AutomationStateDoctorAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStateDoctorAnalyzer.cs
@@ -1,0 +1,270 @@
+using System.Globalization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G448: Pure analyzer for the unified host-metadata state doctor. Given a
+/// snapshot of queue-state items, publish-artifact evidence, and GitHub PRs
+/// (open + merged), it reports deterministic, forward-only drift categories
+/// with evidence and confidence, and classifies ambiguous cases as unsafe
+/// (no repair). It NEVER reads files, mutates GitHub or local state, or
+/// launches an AI provider — the command layer wraps it with I/O and the
+/// fail-closed <c>--write</c> path.
+///
+/// Backward-compat invariant: the analyzer only proposes repairs that FILL a
+/// missing field or advance a lifecycle state. It never proposes clearing,
+/// rewriting, or downgrading existing host data, so applying high-confidence
+/// repairs to an old host is always safe and non-destructive.
+/// </summary>
+internal static class AutomationStateDoctorAnalyzer
+{
+    public static AutomationStateDoctorAnalysis Analyze(
+        string repo,
+        IReadOnlyList<StateDoctorQueueItem> queueItems,
+        IReadOnlyList<StateDoctorPublishEvidence> publishEvidence,
+        IReadOnlyList<StateDoctorPr> pullRequests)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(queueItems);
+        ArgumentNullException.ThrowIfNull(publishEvidence);
+        ArgumentNullException.ThrowIfNull(pullRequests);
+
+        var findings = new List<AutomationStateDoctorFinding>();
+        var unsafeFindings = new List<AutomationStateDoctorUnsafe>();
+
+        // Index PRs by the issue numbers they close (only same-repo numbers are
+        // supplied by the command projection). A given issue may be closed by
+        // more than one PR — that is the ambiguous case.
+        var prsByClosingIssue = new Dictionary<int, List<StateDoctorPr>>();
+        foreach (var pr in pullRequests)
+        {
+            foreach (var issueNumber in pr.ClosingIssueNumbers.Distinct())
+            {
+                if (!prsByClosingIssue.TryGetValue(issueNumber, out var list))
+                {
+                    list = new List<StateDoctorPr>();
+                    prsByClosingIssue[issueNumber] = list;
+                }
+                if (list.All(existing => existing.Number != pr.Number))
+                {
+                    list.Add(pr);
+                }
+            }
+        }
+
+        // ---- duplicate-issue-evidence (unsafe, fail-closed) ----------------
+        // More than one queue item that resolves to the SAME source issue, or
+        // more than one publish artifact recording the same created issue, is
+        // ambiguous: the doctor cannot decide which row owns the linkage.
+        var ambiguousIssueNumbers = new HashSet<int>();
+
+        var queueItemsByIssue = queueItems
+            .Where(item => item.LinkedIssueNumber is int && SameRepo(item.LinkedIssueRepo, repo))
+            .GroupBy(item => item.LinkedIssueNumber!.Value);
+        foreach (var group in queueItemsByIssue)
+        {
+            var units = group.Select(g => g.ExecutionUnit).Distinct().ToArray();
+            if (units.Length > 1)
+            {
+                ambiguousIssueNumbers.Add(group.Key);
+                unsafeFindings.Add(new AutomationStateDoctorUnsafe
+                {
+                    Kind = AutomationStateDoctorUnsafeKinds.DuplicateIssueEvidence,
+                    ExecutionUnit = null,
+                    IssueNumber = group.Key,
+                    Reason = $"{units.Length.ToString(CultureInfo.InvariantCulture)} queue items reference source issue #{group.Key.ToString(CultureInfo.InvariantCulture)} ({string.Join(", ", units.Select(u => "'" + u + "'"))}); cannot deterministically pick the owning row.",
+                    MissingEvidence =
+                    [
+                        "operator must dedupe queue-state so exactly one item owns the source issue before the doctor can repair its linkage",
+                    ],
+                });
+            }
+        }
+
+        var publishByIssue = publishEvidence
+            .Where(evidence => SameRepo(evidence.IssueRepo, repo))
+            .GroupBy(evidence => evidence.IssueNumber);
+        foreach (var group in publishByIssue)
+        {
+            var units = group.Select(g => g.ExecutionUnit).Distinct().ToArray();
+            if (units.Length > 1)
+            {
+                ambiguousIssueNumbers.Add(group.Key);
+                unsafeFindings.Add(new AutomationStateDoctorUnsafe
+                {
+                    Kind = AutomationStateDoctorUnsafeKinds.AmbiguousPublishEvidence,
+                    ExecutionUnit = null,
+                    IssueNumber = group.Key,
+                    Reason = $"{units.Length.ToString(CultureInfo.InvariantCulture)} publish artifacts record created issue #{group.Key.ToString(CultureInfo.InvariantCulture)} for different execution units ({string.Join(", ", units.Select(u => "'" + u + "'"))}); duplicate publish evidence is ambiguous.",
+                    MissingEvidence =
+                    [
+                        "operator must remove the duplicate publish artifact before the doctor can fill linked_issue",
+                    ],
+                });
+            }
+        }
+
+        // Index publish evidence by execution unit (after dedup, one issue per unit).
+        var publishByUnit = publishEvidence
+            .Where(evidence => SameRepo(evidence.IssueRepo, repo))
+            .GroupBy(evidence => evidence.ExecutionUnit, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.Ordinal);
+
+        foreach (var queueItem in queueItems)
+        {
+            var item = queueItem;
+            var hasLinkedIssue = item.LinkedIssueNumber is int && SameRepo(item.LinkedIssueRepo, repo);
+            var hasLinkedPr = !string.IsNullOrWhiteSpace(item.LinkedPrUrl);
+
+            // ---- missing-linked-issue (high: fill from publish artifact) ----
+            if (!hasLinkedIssue
+                && publishByUnit.TryGetValue(item.ExecutionUnit, out var evidenceForUnit))
+            {
+                var distinctIssues = evidenceForUnit
+                    .Select(e => e.IssueNumber)
+                    .Distinct()
+                    .ToArray();
+                if (distinctIssues.Length == 1 && !ambiguousIssueNumbers.Contains(distinctIssues[0]))
+                {
+                    var evidence = evidenceForUnit[0];
+                    findings.Add(new AutomationStateDoctorFinding
+                    {
+                        Category = AutomationStateDoctorCategories.MissingLinkedIssue,
+                        ExecutionUnit = item.ExecutionUnit,
+                        RepairKind = AutomationStateDoctorRepairKinds.SetQueueLinkedIssue,
+                        IssueNumber = evidence.IssueNumber,
+                        IssueUrl = evidence.IssueUrl,
+                        IssueRepo = evidence.IssueRepo,
+                        PrNumber = null,
+                        PrUrl = null,
+                        Confidence = AutomationStateDoctorConfidence.High,
+                        Applied = false,
+                        Evidence =
+                        [
+                            $"publish artifact for '{item.ExecutionUnit}' records created_issue_number = #{evidence.IssueNumber.ToString(CultureInfo.InvariantCulture)} in {evidence.IssueRepo}",
+                            $"queue item '{item.ExecutionUnit}' has linked_issue = null",
+                        ],
+                        Summary = $"Fill linked_issue for '{item.ExecutionUnit}' from publish artifact (#{evidence.IssueNumber.ToString(CultureInfo.InvariantCulture)}).",
+                    });
+
+                    // The unit now (post-repair) resolves to this issue; continue
+                    // so missing-linked-pr / merged checks can also key off it.
+                    hasLinkedIssue = true;
+                    item = item with
+                    {
+                        LinkedIssueRepo = evidence.IssueRepo,
+                        LinkedIssueNumber = evidence.IssueNumber,
+                        LinkedIssueUrl = evidence.IssueUrl,
+                    };
+                }
+            }
+
+            if (!hasLinkedIssue || item.LinkedIssueNumber is not int issueNo)
+            {
+                continue;
+            }
+
+            if (ambiguousIssueNumbers.Contains(issueNo))
+            {
+                continue; // already surfaced as unsafe; do not also propose a repair
+            }
+
+            var closingPrs = prsByClosingIssue.TryGetValue(issueNo, out var prs)
+                ? prs
+                : new List<StateDoctorPr>();
+
+            // ---- missing-linked-pr -----------------------------------------
+            if (!hasLinkedPr)
+            {
+                if (closingPrs.Count == 1)
+                {
+                    var pr = closingPrs[0];
+                    findings.Add(new AutomationStateDoctorFinding
+                    {
+                        Category = AutomationStateDoctorCategories.MissingLinkedPr,
+                        ExecutionUnit = item.ExecutionUnit,
+                        RepairKind = AutomationStateDoctorRepairKinds.SetQueueLinkedPr,
+                        IssueNumber = issueNo,
+                        IssueUrl = item.LinkedIssueUrl,
+                        IssueRepo = item.LinkedIssueRepo,
+                        PrNumber = pr.Number,
+                        PrUrl = pr.Url,
+                        Confidence = AutomationStateDoctorConfidence.High,
+                        Applied = false,
+                        Evidence =
+                        [
+                            $"PR #{pr.Number.ToString(CultureInfo.InvariantCulture)} uniquely closes source issue #{issueNo.ToString(CultureInfo.InvariantCulture)}",
+                            $"queue item '{item.ExecutionUnit}' has linked_pr = null",
+                        ],
+                        Summary = $"Fill linked_pr for '{item.ExecutionUnit}' (source issue #{issueNo.ToString(CultureInfo.InvariantCulture)}) with PR #{pr.Number.ToString(CultureInfo.InvariantCulture)}.",
+                    });
+                    hasLinkedPr = true;
+                }
+                else if (closingPrs.Count > 1)
+                {
+                    unsafeFindings.Add(new AutomationStateDoctorUnsafe
+                    {
+                        Kind = AutomationStateDoctorUnsafeKinds.AmbiguousPrLinkage,
+                        ExecutionUnit = item.ExecutionUnit,
+                        IssueNumber = issueNo,
+                        Reason = $"{closingPrs.Count.ToString(CultureInfo.InvariantCulture)} PRs close source issue #{issueNo.ToString(CultureInfo.InvariantCulture)} ({string.Join(", ", closingPrs.Select(p => "#" + p.Number.ToString(CultureInfo.InvariantCulture)))}); cannot deterministically pick linked_pr.",
+                        MissingEvidence =
+                        [
+                            "operator must close or retarget the duplicate PRs so exactly one closes the issue",
+                        ],
+                    });
+                    continue;
+                }
+            }
+
+            // ---- merged-pr-not-completed -----------------------------------
+            if (!item.Completed)
+            {
+                var mergedClosingPrs = closingPrs.Where(pr => pr.Merged).ToArray();
+                if (mergedClosingPrs.Length == 1)
+                {
+                    var pr = mergedClosingPrs[0];
+                    findings.Add(new AutomationStateDoctorFinding
+                    {
+                        Category = AutomationStateDoctorCategories.MergedPrNotCompleted,
+                        ExecutionUnit = item.ExecutionUnit,
+                        RepairKind = AutomationStateDoctorRepairKinds.MarkQueueCompleted,
+                        IssueNumber = issueNo,
+                        IssueUrl = item.LinkedIssueUrl,
+                        IssueRepo = item.LinkedIssueRepo,
+                        PrNumber = pr.Number,
+                        PrUrl = pr.Url,
+                        Confidence = AutomationStateDoctorConfidence.High,
+                        Applied = false,
+                        Evidence =
+                        [
+                            $"PR #{pr.Number.ToString(CultureInfo.InvariantCulture)} is MERGED and closes source issue #{issueNo.ToString(CultureInfo.InvariantCulture)}",
+                            $"queue item '{item.ExecutionUnit}' state is not completed",
+                        ],
+                        Summary = $"Advance queue item '{item.ExecutionUnit}' to completed (merged PR #{pr.Number.ToString(CultureInfo.InvariantCulture)} closed source issue #{issueNo.ToString(CultureInfo.InvariantCulture)}).",
+                    });
+                }
+                else if (mergedClosingPrs.Length > 1)
+                {
+                    unsafeFindings.Add(new AutomationStateDoctorUnsafe
+                    {
+                        Kind = AutomationStateDoctorUnsafeKinds.AmbiguousPrLinkage,
+                        ExecutionUnit = item.ExecutionUnit,
+                        IssueNumber = issueNo,
+                        Reason = $"{mergedClosingPrs.Length.ToString(CultureInfo.InvariantCulture)} merged PRs close source issue #{issueNo.ToString(CultureInfo.InvariantCulture)}; cannot deterministically confirm completion provenance.",
+                        MissingEvidence =
+                        [
+                            "operator must confirm which merged PR represents the completed work",
+                        ],
+                    });
+                }
+            }
+        }
+
+        return new AutomationStateDoctorAnalysis(findings, unsafeFindings);
+    }
+
+    private static bool SameRepo(string? candidate, string repo) =>
+        !string.IsNullOrWhiteSpace(candidate)
+        && string.Equals(candidate, repo, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
@@ -75,6 +75,19 @@ internal static class AutomationStateDoctorCommand
         }
 
         var resolvedWorkdir = ResolveWorkdir(context, workdir);
+
+        // G448 (review fix): --workdir must consistently drive the HOST context
+        // used for every read/write — queue-state, publish artifacts, and the
+        // run log — not just repo inference. Otherwise
+        // `state-doctor --workdir /path/to/host --repo other/repo --write` could
+        // mutate the caller cwd's `.intent-cli` state while inferring/reporting a
+        // different target host, risking corruption of the wrong host metadata.
+        // Rebind the context to the resolved workdir so all I/O targets that one
+        // host root (fail-closed host-data safety).
+        var hostContext = string.Equals(resolvedWorkdir, context.RepoRoot, StringComparison.Ordinal)
+            ? context
+            : context with { RepoRoot = resolvedWorkdir };
+
         if (string.IsNullOrWhiteSpace(repo)
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
         {
@@ -82,7 +95,7 @@ internal static class AutomationStateDoctorCommand
             return 1;
         }
 
-        var surfaceReport = AutomationInstalledCliSurfaceProbe.Check(context);
+        var surfaceReport = AutomationInstalledCliSurfaceProbe.Check(hostContext);
         if (!surfaceReport.Available)
         {
             var stale = BuildSingleUnsafe(
@@ -96,9 +109,9 @@ internal static class AutomationStateDoctorCommand
         }
 
         // ---- gather queue-state (forward-compat: missing/old files are fine) ----
-        QueueState? queueState = TryReadQueueState(context);
+        QueueState? queueState = TryReadQueueState(hostContext);
         var queueItems = ProjectQueueItems(queueState);
-        var publishEvidence = ProjectPublishEvidence(context, queueState, repo!);
+        var publishEvidence = ProjectPublishEvidence(hostContext, queueState, repo!);
 
         IGitHubAutomationCandidateLister lister;
         try
@@ -129,7 +142,7 @@ internal static class AutomationStateDoctorCommand
         var warnings = new List<string>();
         if (string.Equals(mode, AutomationStateDoctorModes.Write, StringComparison.Ordinal))
         {
-            findings = ApplyHighConfidenceRepairs(context, findings, warnings);
+            findings = ApplyHighConfidenceRepairs(hostContext, findings, warnings);
         }
 
         var result = new AutomationStateDoctorResult

--- a/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
@@ -1,0 +1,632 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G448: Unified, OSS-safe host-metadata state doctor. Read-only by default —
+/// it surveys queue-state, publish artifacts, and GitHub PRs (open + merged)
+/// and reports deterministic drift categories (missing linked_issue, missing
+/// linked_pr, merged-PR-not-completed) with evidence and confidence, plus
+/// ambiguous cases as fail-closed unsafe findings. <c>--write</c> applies ONLY
+/// high-confidence, forward-only queue-state repairs and appends an
+/// append-only <c>runs.jsonl</c> event per applied repair; it never clears,
+/// rewrites, or downgrades existing host data, and never migrates old hosts.
+///
+/// Host-only by policy: child implementation loops must not invoke it
+/// (<c>--child-loop-context</c> exits with code 2 for a testable prohibition).
+/// The command never reads <c>intents/rules/**</c> and never launches an AI
+/// provider.
+/// </summary>
+internal static class AutomationStateDoctorCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private const string OptRepo = "--repo";
+    private const string OptWorkdir = "--workdir";
+    private const string OptReadOnly = "--read-only";
+    private const string OptWrite = "--write";
+    private const string OptFormat = "--format";
+    private const string OptChildLoopContext = "--child-loop-context";
+    private const string OptHelp = "--help";
+
+    private const string RunEventName = "state-doctor-repair";
+
+    public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], OptHelp, StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var repo, out var workdir, out var mode, out var format, out var childLoopContext, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        if (childLoopContext)
+        {
+            var rejected = BuildSingleUnsafe(
+                repo ?? string.Empty,
+                mode,
+                AutomationStateDoctorUnsafeKinds.ChildLoopProhibited,
+                "automation state-doctor is host-only; child implementation loops must not invoke it.",
+                "child-loop prohibited: automation state-doctor is host-only.");
+            Emit(writer, rejected, format);
+            return 2;
+        }
+
+        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        if (string.IsNullOrWhiteSpace(repo)
+            && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var surfaceReport = AutomationInstalledCliSurfaceProbe.Check(context);
+        if (!surfaceReport.Available)
+        {
+            var stale = BuildSingleUnsafe(
+                repo!,
+                mode,
+                AutomationStateDoctorUnsafeKinds.StaleHostCli,
+                $"installed CLI at {surfaceReport.InstalledCliPath} is missing or stale for required automation surfaces; refresh the installed CLI before running state-doctor.",
+                "stale-host-cli: installed automation surface is incomplete.");
+            Emit(writer, stale, format);
+            return 1;
+        }
+
+        // ---- gather queue-state (forward-compat: missing/old files are fine) ----
+        QueueState? queueState = TryReadQueueState(context);
+        var queueItems = ProjectQueueItems(queueState);
+        var publishEvidence = ProjectPublishEvidence(context, queueState, repo!);
+
+        IGitHubAutomationCandidateLister lister;
+        try
+        {
+            lister = CandidateListerFactory?.Invoke()
+                ?? new GhCliGitHubAutomationCandidateLister();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub lister: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<StateDoctorPr> pullRequests;
+        try
+        {
+            pullRequests = ProjectPullRequests(repo!, lister);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to list state-doctor candidates for {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var analysis = AutomationStateDoctorAnalyzer.Analyze(repo!, queueItems, publishEvidence, pullRequests);
+
+        var findings = analysis.Findings;
+        var warnings = new List<string>();
+        if (string.Equals(mode, AutomationStateDoctorModes.Write, StringComparison.Ordinal))
+        {
+            findings = ApplyHighConfidenceRepairs(context, findings, warnings);
+        }
+
+        var result = new AutomationStateDoctorResult
+        {
+            Repo = repo!,
+            Mode = mode,
+            HostOnly = true,
+            Findings = findings,
+            UnsafeFindings = analysis.UnsafeFindings,
+            Warnings = warnings,
+            Summary = BuildSummary(analysis.Findings, analysis.UnsafeFindings, mode),
+        };
+
+        Emit(writer, result, format);
+        return 0;
+    }
+
+    private static IReadOnlyList<AutomationStateDoctorFinding> ApplyHighConfidenceRepairs(
+        CliContext context,
+        IReadOnlyList<AutomationStateDoctorFinding> findings,
+        List<string> warnings)
+    {
+        var highConfidence = findings
+            .Where(f => string.Equals(f.Confidence, AutomationStateDoctorConfidence.High, StringComparison.Ordinal))
+            .ToArray();
+        if (highConfidence.Length == 0)
+        {
+            return findings;
+        }
+
+        var queueStatePath = context.GetQueueStatePath();
+        if (!File.Exists(queueStatePath))
+        {
+            warnings.Add($"queue-state.json not found at {queueStatePath}; no forward-only repairs applied.");
+            return findings;
+        }
+
+        QueueState queueState;
+        try
+        {
+            queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+        {
+            warnings.Add($"failed to read queue-state.json for repair: {exception.Message}");
+            return findings;
+        }
+
+        var items = queueState.Items.ToArray();
+        var appliedById = new Dictionary<string, AutomationStateDoctorFinding>(StringComparer.Ordinal);
+        var appliedEvents = new List<RunEvent>();
+        var mutated = false;
+
+        foreach (var finding in highConfidence)
+        {
+            var index = Array.FindIndex(items, item => string.Equals(item.ExecutionUnit, finding.ExecutionUnit, StringComparison.Ordinal));
+            if (index < 0)
+            {
+                warnings.Add($"queue-state has no item with execution_unit '{finding.ExecutionUnit}'; skipped {finding.Category}.");
+                continue;
+            }
+
+            var existing = items[index];
+            QueueItem updated = existing;
+            string? linkedIssueForEvent = null;
+            string? linkedPrForEvent = null;
+
+            switch (finding.RepairKind)
+            {
+                case AutomationStateDoctorRepairKinds.SetQueueLinkedIssue:
+                    // Forward-only: only fill when currently empty.
+                    if (existing.LinkedIssue is { Number: { } }) { continue; }
+                    updated = existing with
+                    {
+                        LinkedIssue = new LinkedIssue
+                        {
+                            Repo = finding.IssueRepo ?? string.Empty,
+                            Number = finding.IssueNumber,
+                            Url = finding.IssueUrl,
+                        },
+                    };
+                    linkedIssueForEvent = finding.IssueUrl
+                        ?? (finding.IssueNumber is { } n ? $"https://github.com/{finding.IssueRepo}/issues/{n.ToString(CultureInfo.InvariantCulture)}" : null);
+                    break;
+
+                case AutomationStateDoctorRepairKinds.SetQueueLinkedPr:
+                    if (!string.IsNullOrWhiteSpace(existing.LinkedPr)) { continue; }
+                    updated = existing with { LinkedPr = finding.PrUrl };
+                    linkedPrForEvent = finding.PrUrl;
+                    break;
+
+                case AutomationStateDoctorRepairKinds.MarkQueueCompleted:
+                    if (existing.State == QueueItemState.Completed) { continue; }
+                    updated = existing with { State = QueueItemState.Completed };
+                    linkedPrForEvent = finding.PrUrl;
+                    break;
+
+                default:
+                    continue;
+            }
+
+            items[index] = updated;
+            mutated = true;
+            appliedById[finding.ExecutionUnit + "|" + finding.Category] = finding;
+            appliedEvents.Add(new RunEvent
+            {
+                Ts = DateTimeOffset.UtcNow,
+                ExecutionUnit = finding.ExecutionUnit,
+                Event = RunEventName,
+                By = "automation state-doctor (G448)",
+                LinkedIssue = linkedIssueForEvent,
+                LinkedPr = linkedPrForEvent,
+                Reason = finding.Summary,
+                Repo = finding.IssueRepo,
+                Pr = finding.PrNumber,
+            });
+        }
+
+        if (mutated)
+        {
+            try
+            {
+                var updatedState = queueState with { Items = items, UpdatedAt = DateTimeOffset.UtcNow };
+                File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+                AppendRunEvents(context, appliedEvents);
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+            {
+                warnings.Add($"failed to persist queue-state repairs: {exception.Message}");
+                return findings;
+            }
+        }
+
+        return findings
+            .Select(f => appliedById.ContainsKey(f.ExecutionUnit + "|" + f.Category) ? f with { Applied = true } : f)
+            .ToArray();
+    }
+
+    private static void AppendRunEvents(CliContext context, IReadOnlyList<RunEvent> events)
+    {
+        if (events.Count == 0)
+        {
+            return;
+        }
+
+        var runsPath = context.GetRunLogPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(runsPath)!);
+        var builder = new System.Text.StringBuilder();
+        foreach (var runEvent in events)
+        {
+            builder.Append(RunLogSerializer.SerializeLine(runEvent)).Append('\n');
+        }
+        File.AppendAllText(runsPath, builder.ToString());
+    }
+
+    private static QueueState? TryReadQueueState(CliContext context)
+    {
+        var path = context.GetQueueStatePath();
+        if (!File.Exists(path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return QueueStateSerializer.Deserialize(File.ReadAllText(path));
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static IReadOnlyList<StateDoctorQueueItem> ProjectQueueItems(QueueState? queueState)
+    {
+        if (queueState is null)
+        {
+            return Array.Empty<StateDoctorQueueItem>();
+        }
+
+        return queueState.Items
+            .Select(item => new StateDoctorQueueItem
+            {
+                ExecutionUnit = item.ExecutionUnit,
+                LinkedIssueRepo = item.LinkedIssue?.Repo,
+                LinkedIssueNumber = item.LinkedIssue?.Number,
+                LinkedIssueUrl = item.LinkedIssue?.Url,
+                LinkedPrUrl = item.LinkedPr,
+                Completed = item.State == QueueItemState.Completed,
+            })
+            .ToArray();
+    }
+
+    private static IReadOnlyList<StateDoctorPublishEvidence> ProjectPublishEvidence(
+        CliContext context,
+        QueueState? queueState,
+        string repo)
+    {
+        if (queueState is null)
+        {
+            return Array.Empty<StateDoctorPublishEvidence>();
+        }
+
+        var evidence = new List<StateDoctorPublishEvidence>();
+        foreach (var item in queueState.Items)
+        {
+            var publishPath = Path.Combine(
+                context.RepoRoot,
+                IssuePublishArtifactPathResolver.Resolve(item.ExecutionUnit).Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(publishPath))
+            {
+                continue;
+            }
+
+            IssuePublishArtifact artifact;
+            try
+            {
+                artifact = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(publishPath));
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                continue;
+            }
+
+            if (artifact.CreatedIssueNumber is not { } issueNumber)
+            {
+                continue;
+            }
+
+            var issueRepo = TryParseRepoFromIssueUrl(artifact.CreatedIssueUrl) ?? repo;
+            evidence.Add(new StateDoctorPublishEvidence
+            {
+                ExecutionUnit = item.ExecutionUnit,
+                IssueRepo = issueRepo,
+                IssueNumber = issueNumber,
+                IssueUrl = artifact.CreatedIssueUrl,
+            });
+        }
+        return evidence;
+    }
+
+    private static string? TryParseRepoFromIssueUrl(string? url)
+    {
+        // https://github.com/<owner>/<repo>/issues/<n>
+        if (string.IsNullOrWhiteSpace(url)
+            || !Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            return null;
+        }
+
+        var segments = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length >= 2 ? $"{segments[0]}/{segments[1]}" : null;
+    }
+
+    private static IReadOnlyList<StateDoctorPr> ProjectPullRequests(string repo, IGitHubAutomationCandidateLister lister)
+    {
+        var byNumber = new Dictionary<int, StateDoctorPr>();
+
+        void Ingest(IReadOnlyList<GitHubAutomationPrCandidate> candidates, bool forceMerged)
+        {
+            foreach (var candidate in candidates)
+            {
+                var closing = candidate.ClosingIssuesReferences
+                    .Where(reference => reference.Number > 0 && ReferenceMatchesRepo(reference, repo))
+                    .Select(reference => reference.Number)
+                    .Distinct()
+                    .ToArray();
+                var merged = forceMerged
+                    || string.Equals(candidate.State, "MERGED", StringComparison.OrdinalIgnoreCase);
+                byNumber[candidate.Number] = new StateDoctorPr
+                {
+                    Number = candidate.Number,
+                    Url = candidate.Url,
+                    Merged = merged,
+                    ClosingIssueNumbers = closing,
+                };
+            }
+        }
+
+        Ingest(lister.ListPullRequests(repo, Array.Empty<string>()), forceMerged: false);
+        Ingest(lister.ListMergedPullRequests(repo, Array.Empty<string>()), forceMerged: true);
+
+        return byNumber.Values.ToArray();
+    }
+
+    private static bool ReferenceMatchesRepo(GitHubPrClosingIssueReference reference, string repo)
+    {
+        if (reference.Repository is { Name.Length: > 0, Owner.Login.Length: > 0 } repository)
+        {
+            return string.Equals($"{repository.Owner.Login}/{repository.Name}", repo, StringComparison.OrdinalIgnoreCase);
+        }
+
+        // No repository descriptor → assume same-repo reference (gh omits the
+        // descriptor for same-repo closing references).
+        return true;
+    }
+
+    private static AutomationStateDoctorResult BuildSingleUnsafe(
+        string repo,
+        string mode,
+        string kind,
+        string reason,
+        string summary) =>
+        new()
+        {
+            Repo = repo,
+            Mode = mode,
+            HostOnly = true,
+            Findings = Array.Empty<AutomationStateDoctorFinding>(),
+            UnsafeFindings =
+            [
+                new AutomationStateDoctorUnsafe
+                {
+                    Kind = kind,
+                    ExecutionUnit = null,
+                    IssueNumber = null,
+                    Reason = reason,
+                    MissingEvidence = Array.Empty<string>(),
+                }
+            ],
+            Warnings = Array.Empty<string>(),
+            Summary = summary,
+        };
+
+    private static string BuildSummary(
+        IReadOnlyList<AutomationStateDoctorFinding> findings,
+        IReadOnlyList<AutomationStateDoctorUnsafe> unsafeFindings,
+        string mode)
+    {
+        var high = findings.Count(f => string.Equals(f.Confidence, AutomationStateDoctorConfidence.High, StringComparison.Ordinal));
+        var advisory = findings.Count - high;
+        if (high == 0 && advisory == 0 && unsafeFindings.Count == 0)
+        {
+            return $"no host-metadata drift detected; {mode} mode produced no findings.";
+        }
+
+        return $"state-doctor {mode}: {high.ToString(CultureInfo.InvariantCulture)} high-confidence repair(s), {advisory.ToString(CultureInfo.InvariantCulture)} advisory finding(s), {unsafeFindings.Count.ToString(CultureInfo.InvariantCulture)} unsafe finding(s).";
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? workdir,
+        out string mode,
+        out string format,
+        out bool childLoopContext,
+        out string error)
+    {
+        repo = null;
+        workdir = null;
+        mode = AutomationStateDoctorModes.ReadOnly;
+        format = FormatText;
+        childLoopContext = false;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case OptRepo:
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (e.g. owner/repo).";
+                        return false;
+                    }
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case OptWorkdir:
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--workdir requires a value.";
+                        return false;
+                    }
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+
+                case OptReadOnly:
+                    mode = AutomationStateDoctorModes.ReadOnly;
+                    break;
+
+                case OptWrite:
+                    mode = AutomationStateDoctorModes.Write;
+                    break;
+
+                case OptFormat:
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (text or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+
+                case OptChildLoopContext:
+                    childLoopContext = true;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: [--repo <owner/repo>] [--workdir <path>] [--read-only] [--write] [--child-loop-context] [--format text|json].";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static string ResolveWorkdir(CliContext context, string? workdir)
+    {
+        if (string.IsNullOrWhiteSpace(workdir))
+        {
+            return context.RepoRoot;
+        }
+
+        return Path.IsPathRooted(workdir)
+            ? workdir
+            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
+    }
+
+    private static void Emit(TextWriter writer, AutomationStateDoctorResult result, string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+    }
+
+    private static void WriteText(TextWriter writer, AutomationStateDoctorResult result)
+    {
+        writer.WriteLine($"# Automation state-doctor for {result.Repo}");
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- host_only: {result.HostOnly.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"- {result.Summary}");
+        writer.WriteLine();
+        writer.WriteLine("## Findings");
+        if (result.Findings.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        foreach (var finding in result.Findings)
+        {
+            writer.WriteLine($"- {finding.Category} ({finding.Confidence}, applied={finding.Applied.ToString().ToLowerInvariant()})");
+            writer.WriteLine($"  execution_unit: {finding.ExecutionUnit}");
+            writer.WriteLine($"  repair_kind: {finding.RepairKind}");
+            writer.WriteLine($"  summary: {finding.Summary}");
+            foreach (var line in finding.Evidence)
+            {
+                writer.WriteLine($"  evidence: {line}");
+            }
+        }
+        writer.WriteLine();
+        writer.WriteLine("## Unsafe findings");
+        if (result.UnsafeFindings.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        foreach (var entry in result.UnsafeFindings)
+        {
+            writer.WriteLine($"- {entry.Kind}: {entry.Reason}");
+            foreach (var line in entry.MissingEvidence)
+            {
+                writer.WriteLine($"  missing_evidence: {line}");
+            }
+        }
+        if (result.Warnings.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Warnings");
+            foreach (var warning in result.Warnings)
+            {
+                writer.WriteLine($"- {warning}");
+            }
+        }
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("automation state-doctor");
+        writer.WriteLine("Usage: intent-cli automation state-doctor [--repo <owner/repo>] [--workdir <path>] [--read-only] [--write] [--format text|json]");
+        writer.WriteLine("Unified, OSS-safe diagnostic for host-metadata drift (queue-state / publish artifacts / GitHub PRs).");
+        writer.WriteLine("Read-only by default. --write applies ONLY high-confidence, forward-only queue-state repairs and appends runs.jsonl events.");
+        writer.WriteLine("Ambiguous drift is reported as unsafe findings and never mutated (fail-closed). Existing/old hosts are never migrated.");
+        writer.WriteLine("Host-only: child implementation loops must not invoke this command. --child-loop-context exits with code 2.");
+    }
+}

--- a/src/IntentSystem.Cli/Commands/AutomationStateDoctorResult.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStateDoctorResult.cs
@@ -1,0 +1,223 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G448: Result of <c>intent-cli automation state-doctor</c> — a unified,
+/// OSS-safe diagnostic over host metadata drift among queue-state, publish
+/// artifacts, GitHub issues, and GitHub PRs. Read-only by default
+/// (<c>mode = read-only</c>); <c>--write</c> applies ONLY high-confidence,
+/// forward-only queue-state repairs and appends an append-only
+/// <c>runs.jsonl</c> event per applied repair. Ambiguous drift is reported as
+/// an <see cref="UnsafeFindings"/> entry and never mutated (fail-closed).
+/// Host-only by policy — never produced from a child implementation loop.
+/// </summary>
+internal sealed record AutomationStateDoctorResult
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("host_only")]
+    public required bool HostOnly { get; init; }
+
+    [JsonPropertyName("hostOnly")]
+    public bool HostOnlyCamel => HostOnly;
+
+    /// <summary>
+    /// Deterministic drift findings. <see cref="AutomationStateDoctorFinding.Confidence"/>
+    /// <c>= high</c> entries are the only ones applied in <c>--write</c> mode;
+    /// <c>advisory</c> entries are reported with evidence but never auto-mutated.
+    /// </summary>
+    [JsonPropertyName("findings")]
+    public required IReadOnlyList<AutomationStateDoctorFinding> Findings { get; init; }
+
+    /// <summary>
+    /// Drift the doctor refuses to repair because the evidence is ambiguous
+    /// (e.g. duplicate issue evidence, more than one PR closing the same
+    /// issue). These require operator clarification and produce NO writes.
+    /// </summary>
+    [JsonPropertyName("unsafe_findings")]
+    public required IReadOnlyList<AutomationStateDoctorUnsafe> UnsafeFindings { get; init; }
+
+    [JsonPropertyName("unsafeFindings")]
+    public IReadOnlyList<AutomationStateDoctorUnsafe> UnsafeFindingsCamel => UnsafeFindings;
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}
+
+/// <summary>
+/// G448: one deterministic drift finding. Forward-only by construction — the
+/// repair only ever FILLS a missing metadata field or advances a lifecycle
+/// state; it never clears, rewrites, or downgrades existing host data.
+/// </summary>
+internal sealed record AutomationStateDoctorFinding
+{
+    [JsonPropertyName("category")]
+    public required string Category { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("executionUnit")]
+    public string ExecutionUnitCamel => ExecutionUnit;
+
+    [JsonPropertyName("repair_kind")]
+    public required string RepairKind { get; init; }
+
+    [JsonPropertyName("repairKind")]
+    public string RepairKindCamel => RepairKind;
+
+    [JsonPropertyName("issue_number")]
+    public int? IssueNumber { get; init; }
+
+    [JsonPropertyName("issueNumber")]
+    public int? IssueNumberCamel => IssueNumber;
+
+    [JsonPropertyName("issue_url")]
+    public string? IssueUrl { get; init; }
+
+    [JsonPropertyName("issueUrl")]
+    public string? IssueUrlCamel => IssueUrl;
+
+    [JsonPropertyName("issue_repo")]
+    public string? IssueRepo { get; init; }
+
+    [JsonPropertyName("issueRepo")]
+    public string? IssueRepoCamel => IssueRepo;
+
+    [JsonPropertyName("pr_number")]
+    public int? PrNumber { get; init; }
+
+    [JsonPropertyName("prNumber")]
+    public int? PrNumberCamel => PrNumber;
+
+    [JsonPropertyName("pr_url")]
+    public string? PrUrl { get; init; }
+
+    [JsonPropertyName("prUrl")]
+    public string? PrUrlCamel => PrUrl;
+
+    [JsonPropertyName("confidence")]
+    public required string Confidence { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("evidence")]
+    public required IReadOnlyList<string> Evidence { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}
+
+/// <summary>G448: ambiguous drift the doctor refuses to repair (fail-closed).</summary>
+internal sealed record AutomationStateDoctorUnsafe
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public string? ExecutionUnit { get; init; }
+
+    [JsonPropertyName("executionUnit")]
+    public string? ExecutionUnitCamel => ExecutionUnit;
+
+    [JsonPropertyName("issue_number")]
+    public int? IssueNumber { get; init; }
+
+    [JsonPropertyName("issueNumber")]
+    public int? IssueNumberCamel => IssueNumber;
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    [JsonPropertyName("missing_evidence")]
+    public required IReadOnlyList<string> MissingEvidence { get; init; }
+
+    [JsonPropertyName("missingEvidence")]
+    public IReadOnlyList<string> MissingEvidenceCamel => MissingEvidence;
+}
+
+internal static class AutomationStateDoctorModes
+{
+    public const string ReadOnly = "read-only";
+    public const string Write = "write";
+}
+
+internal static class AutomationStateDoctorConfidence
+{
+    public const string High = "high";
+    public const string Advisory = "advisory";
+}
+
+internal static class AutomationStateDoctorCategories
+{
+    public const string MissingLinkedPr = "missing-linked-pr";
+    public const string MissingLinkedIssue = "missing-linked-issue";
+    public const string MergedPrNotCompleted = "merged-pr-not-completed";
+}
+
+internal static class AutomationStateDoctorRepairKinds
+{
+    /// <summary>No deterministic write; advisory only.</summary>
+    public const string None = "none";
+    public const string SetQueueLinkedPr = "queue-state-linked-pr";
+    public const string SetQueueLinkedIssue = "queue-state-linked-issue";
+    public const string MarkQueueCompleted = "queue-state-completed";
+}
+
+internal static class AutomationStateDoctorUnsafeKinds
+{
+    public const string ChildLoopProhibited = "child-loop-prohibited";
+    public const string StaleHostCli = "stale-host-cli";
+    public const string DuplicateIssueEvidence = "duplicate-issue-evidence";
+    public const string AmbiguousPrLinkage = "ambiguous-pr-linkage";
+    public const string AmbiguousPublishEvidence = "ambiguous-publish-evidence";
+}
+
+/// <summary>
+/// G448: minimal queue-state projection the analyzer reads. Avoids tying the
+/// pure analyzer to the full QueueState model so test fakes supply only the
+/// fields the drift checks consume.
+/// </summary>
+internal sealed record StateDoctorQueueItem
+{
+    public required string ExecutionUnit { get; init; }
+    public string? LinkedIssueRepo { get; init; }
+    public int? LinkedIssueNumber { get; init; }
+    public string? LinkedIssueUrl { get; init; }
+    public string? LinkedPrUrl { get; init; }
+    public required bool Completed { get; init; }
+}
+
+/// <summary>
+/// G448: publish-artifact evidence projection (one created GitHub issue per
+/// execution unit, as recorded in <c>.intent-cli/issues/&lt;unit&gt;/publish.yaml</c>).
+/// </summary>
+internal sealed record StateDoctorPublishEvidence
+{
+    public required string ExecutionUnit { get; init; }
+    public required string IssueRepo { get; init; }
+    public required int IssueNumber { get; init; }
+    public string? IssueUrl { get; init; }
+}
+
+/// <summary>G448: PR projection (open or merged) with its closing-issue refs.</summary>
+internal sealed record StateDoctorPr
+{
+    public required int Number { get; init; }
+    public required string Url { get; init; }
+    public required bool Merged { get; init; }
+    public required IReadOnlyList<int> ClosingIssueNumbers { get; init; }
+}
+
+internal sealed record AutomationStateDoctorAnalysis(
+    IReadOnlyList<AutomationStateDoctorFinding> Findings,
+    IReadOnlyList<AutomationStateDoctorUnsafe> UnsafeFindings);

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -70,6 +70,7 @@ internal static class CommandRouter
         "automation publish-lifecycle-repair --repo <r> [--write]",
         "automation publish-recovery --repo <r> [--write]",
         "automation reconcile [--lane host-review|next-slice|all] [--write]",
+        "automation state-doctor [--repo <r>] [--read-only] [--write]",
         "automation summary",
         "automation workspace-guard --mode plan|begin|end [--write]"
     ];
@@ -181,6 +182,7 @@ internal static class CommandRouter
                 ["queue-seed-from-packet"] = AutomationQueueSeedFromPacketCommand.Execute,
                 ["reconcile"] = AutomationReconcileCommand.Execute,
                 ["same-repo-metadata-preflight"] = AutomationSameRepoMetadataPreflightCommand.Execute,
+                ["state-doctor"] = AutomationStateDoctorCommand.Execute,
                 ["summary"] = AutomationSummaryCommand.Execute,
                 ["workspace-guard"] = AutomationWorkspaceGuardCommand.Execute
             },

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -19,6 +19,17 @@ internal interface IGitHubAutomationCandidateLister
     IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
         string repo,
         IReadOnlyCollection<string> requiredLabels);
+
+    /// <summary>
+    /// G448: list MERGED pull requests (with closing-issue references) for the
+    /// unified state doctor's merged-PR-not-completed lane. Default returns an
+    /// empty list so existing fakes/implementations keep compiling; the
+    /// gh-backed lister overrides it with a <c>--state merged</c> query.
+    /// </summary>
+    IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(
+        string repo,
+        IReadOnlyCollection<string> requiredLabels)
+        => Array.Empty<GitHubAutomationPrCandidate>();
 }
 
 /// <summary>
@@ -163,6 +174,34 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
     /// <summary>
     /// G206: builds the <c>gh issue list</c> argument list.
     /// </summary>
+    /// <summary>
+    /// G448: builds the <c>gh pr list --state merged</c> argument list used by
+    /// the unified state doctor's merged-PR lane.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildMergedPrListArguments(
+        string repo,
+        IReadOnlyCollection<string> requiredLabels)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentNullException.ThrowIfNull(requiredLabels);
+
+        var args = new List<string>
+        {
+            "pr",
+            "list",
+            "--repo", repo,
+            "--state", "merged",
+            "--json", PrListJsonFields,
+            "--limit", "200"
+        };
+        foreach (var label in requiredLabels)
+        {
+            args.Add("--label");
+            args.Add(label);
+        }
+        return args;
+    }
+
     internal static IReadOnlyList<string> BuildIssueListArguments(
         string repo,
         IReadOnlyCollection<string> requiredLabels)
@@ -203,6 +242,15 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
         var args = BuildIssueListArguments(repo, requiredLabels);
         var stdout = RunGh(args, $"list issues in {repo}");
         return DeserializeList<GitHubAutomationIssueCandidate>(stdout, $"`gh issue list` for {repo}");
+    }
+
+    public IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(
+        string repo,
+        IReadOnlyCollection<string> requiredLabels)
+    {
+        var args = BuildMergedPrListArguments(repo, requiredLabels);
+        var stdout = RunGh(args, $"list merged PRs in {repo}");
+        return DeserializeList<GitHubAutomationPrCandidate>(stdout, $"`gh pr list --state merged` for {repo}");
     }
 
     private static string RunGh(IReadOnlyList<string> arguments, string description)

--- a/tests/IntentSystem.Cli.Tests/AutomationStateDoctorTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStateDoctorTests.cs
@@ -265,6 +265,68 @@ public sealed class AutomationStateDoctorTests : IDisposable
     }
 
     [Fact]
+    public void Execute_Write_WithNonDefaultWorkdir_MutatesOnlyThatHostRoot_NotCallerContext()
+    {
+        // G448 review fix: --workdir must drive the host context for ALL I/O.
+        // The caller context points at one root; --workdir points at a DIFFERENT
+        // host root that has the drift. Only the --workdir host may be read or
+        // written; the caller's `.intent-cli` state must be untouched.
+        using var caller = new DoctorWorkspace();
+        // Caller has its own queue-state with NO drift — it must stay byte-identical.
+        var callerQueueBefore = BuildQueue(("CALLER-UNIT", Li(111), $"https://github.com/{Repo}/pull/9", QueueItemState.Completed));
+        caller.WriteQueueState(callerQueueBefore);
+
+        // Separate host root (the --workdir target) with a repairable item.
+        var hostRoot = Directory.CreateTempSubdirectory("state-doctor-host-").FullName;
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(hostRoot, ".intent-cli"));
+            File.WriteAllText(
+                Path.Combine(hostRoot, ".intent-cli", "queue-state.json"),
+                BuildQueue(("HOST-UNIT", null, null, QueueItemState.Queued)));
+            var publishDir = Path.Combine(hostRoot, ".intent-cli", "issues", "HOST-UNIT");
+            Directory.CreateDirectory(publishDir);
+            var artifact = new IssuePublishArtifact
+            {
+                ExecutionUnit = "HOST-UNIT",
+                PublishStatus = "published",
+                PacketPath = ".intent-cli/issues/HOST-UNIT/packet.yaml",
+                IssueBodyPath = ".intent-cli/issues/HOST-UNIT/github-body.md",
+                CreatedIssueNumber = 777,
+                CreatedIssueUrl = $"https://github.com/{Repo}/issues/777",
+                PublishedLabelName = "intent-target",
+            };
+            File.WriteAllText(Path.Combine(publishDir, "publish.yaml"), IssuePublishArtifactYaml.Serialize(artifact));
+
+            AutomationStateDoctorCommand.CandidateListerFactory = () => new FakeLister(
+                open: new[] { Pr(778, merged: false, closes: 777) });
+
+            using var writer = new StringWriter();
+            var exit = AutomationStateDoctorCommand.Execute(
+                caller.Context,
+                ["--repo", Repo, "--workdir", hostRoot, "--write", "--format", "json"],
+                writer);
+
+            Assert.Equal(0, exit);
+
+            // The --workdir host root WAS repaired.
+            var hostAfter = QueueStateSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(hostRoot, ".intent-cli", "queue-state.json")));
+            Assert.Equal(777, hostAfter.Items[0].LinkedIssue!.Number);
+            Assert.Contains("/pull/778", hostAfter.Items[0].LinkedPr!, StringComparison.Ordinal);
+            Assert.True(File.Exists(Path.Combine(hostRoot, ".intent-cli", "runs.jsonl")));
+
+            // The CALLER context was NOT touched — same bytes, no run log.
+            Assert.Equal(callerQueueBefore, File.ReadAllText(caller.Context.GetQueueStatePath()));
+            Assert.False(File.Exists(caller.Context.GetRunLogPath()));
+        }
+        finally
+        {
+            Directory.Delete(hostRoot, recursive: true);
+        }
+    }
+
+    [Fact]
     public void Execute_ChildLoopContext_IsRejected_HostOnly()
     {
         using var workspace = new DoctorWorkspace();

--- a/tests/IntentSystem.Cli.Tests/AutomationStateDoctorTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStateDoctorTests.cs
@@ -1,0 +1,425 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G448: coverage for the unified host-metadata state doctor — the pure
+/// analyzer's four required drift categories plus the command's read-only
+/// vs fail-closed <c>--write</c> behavior and host-only prohibition.
+/// </summary>
+public sealed class AutomationStateDoctorTests : IDisposable
+{
+    private const string Repo = "J-Tech-Japan/intent-system";
+
+    public AutomationStateDoctorTests()
+    {
+        AutomationStateDoctorCommand.CandidateListerFactory = null;
+        AutomationInstalledCliSurfaceProbe.ProbeRunner = null;
+        AutomationInstalledCliSurfaceProbe.ExplicitInstalledCliPathReader = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationStateDoctorCommand.CandidateListerFactory = null;
+        AutomationInstalledCliSurfaceProbe.ProbeRunner = null;
+        AutomationInstalledCliSurfaceProbe.ExplicitInstalledCliPathReader = null;
+    }
+
+    // ---- Analyzer: required AC drift categories ------------------------------
+
+    [Fact]
+    public void Analyze_MissingLinkedPr_FromUniqueClosingPr_IsHighConfidence()
+    {
+        var queue = new[]
+        {
+            new StateDoctorQueueItem
+            {
+                ExecutionUnit = "G300",
+                LinkedIssueRepo = Repo,
+                LinkedIssueNumber = 703,
+                LinkedPrUrl = null,
+                Completed = false,
+            },
+        };
+        var prs = new[] { Pr(706, merged: false, closes: 703) };
+
+        var analysis = AutomationStateDoctorAnalyzer.Analyze(Repo, queue, Array.Empty<StateDoctorPublishEvidence>(), prs);
+
+        var finding = Assert.Single(analysis.Findings, f => f.Category == AutomationStateDoctorCategories.MissingLinkedPr);
+        Assert.Equal(AutomationStateDoctorConfidence.High, finding.Confidence);
+        Assert.Equal(AutomationStateDoctorRepairKinds.SetQueueLinkedPr, finding.RepairKind);
+        Assert.Equal(706, finding.PrNumber);
+        Assert.Empty(analysis.UnsafeFindings);
+    }
+
+    [Fact]
+    public void Analyze_MissingLinkedIssue_FromPublishArtifact_IsHighConfidence()
+    {
+        var queue = new[]
+        {
+            new StateDoctorQueueItem
+            {
+                ExecutionUnit = "G300",
+                LinkedIssueRepo = null,
+                LinkedIssueNumber = null,
+                LinkedPrUrl = null,
+                Completed = false,
+            },
+        };
+        var publish = new[]
+        {
+            new StateDoctorPublishEvidence
+            {
+                ExecutionUnit = "G300",
+                IssueRepo = Repo,
+                IssueNumber = 703,
+                IssueUrl = $"https://github.com/{Repo}/issues/703",
+            },
+        };
+
+        var analysis = AutomationStateDoctorAnalyzer.Analyze(Repo, queue, publish, Array.Empty<StateDoctorPr>());
+
+        var finding = Assert.Single(analysis.Findings, f => f.Category == AutomationStateDoctorCategories.MissingLinkedIssue);
+        Assert.Equal(AutomationStateDoctorConfidence.High, finding.Confidence);
+        Assert.Equal(AutomationStateDoctorRepairKinds.SetQueueLinkedIssue, finding.RepairKind);
+        Assert.Equal(703, finding.IssueNumber);
+        Assert.Empty(analysis.UnsafeFindings);
+    }
+
+    [Fact]
+    public void Analyze_MergedPrNotCompleted_IsHighConfidence()
+    {
+        var queue = new[]
+        {
+            new StateDoctorQueueItem
+            {
+                ExecutionUnit = "G300",
+                LinkedIssueRepo = Repo,
+                LinkedIssueNumber = 703,
+                LinkedPrUrl = $"https://github.com/{Repo}/pull/706",
+                Completed = false,
+            },
+        };
+        var prs = new[] { Pr(706, merged: true, closes: 703) };
+
+        var analysis = AutomationStateDoctorAnalyzer.Analyze(Repo, queue, Array.Empty<StateDoctorPublishEvidence>(), prs);
+
+        var finding = Assert.Single(analysis.Findings, f => f.Category == AutomationStateDoctorCategories.MergedPrNotCompleted);
+        Assert.Equal(AutomationStateDoctorConfidence.High, finding.Confidence);
+        Assert.Equal(AutomationStateDoctorRepairKinds.MarkQueueCompleted, finding.RepairKind);
+        Assert.Equal(706, finding.PrNumber);
+    }
+
+    [Fact]
+    public void Analyze_DuplicateIssueEvidence_IsUnsafe_NoRepair()
+    {
+        var queue = new[]
+        {
+            new StateDoctorQueueItem { ExecutionUnit = "G300", LinkedIssueRepo = Repo, LinkedIssueNumber = 703, LinkedPrUrl = null, Completed = false },
+            new StateDoctorQueueItem { ExecutionUnit = "G301", LinkedIssueRepo = Repo, LinkedIssueNumber = 703, LinkedPrUrl = null, Completed = false },
+        };
+        var prs = new[] { Pr(706, merged: false, closes: 703) };
+
+        var analysis = AutomationStateDoctorAnalyzer.Analyze(Repo, queue, Array.Empty<StateDoctorPublishEvidence>(), prs);
+
+        var unsafeEntry = Assert.Single(analysis.UnsafeFindings);
+        Assert.Equal(AutomationStateDoctorUnsafeKinds.DuplicateIssueEvidence, unsafeEntry.Kind);
+        // Fail-closed: the ambiguous issue must NOT also produce a linked_pr repair.
+        Assert.DoesNotContain(analysis.Findings, f => f.IssueNumber == 703);
+    }
+
+    [Fact]
+    public void Analyze_MultiplePrsCloseSameIssue_IsAmbiguous_NoLinkedPrRepair()
+    {
+        var queue = new[]
+        {
+            new StateDoctorQueueItem { ExecutionUnit = "G300", LinkedIssueRepo = Repo, LinkedIssueNumber = 703, LinkedPrUrl = null, Completed = false },
+        };
+        var prs = new[] { Pr(706, merged: false, closes: 703), Pr(707, merged: false, closes: 703) };
+
+        var analysis = AutomationStateDoctorAnalyzer.Analyze(Repo, queue, Array.Empty<StateDoctorPublishEvidence>(), prs);
+
+        Assert.DoesNotContain(analysis.Findings, f => f.Category == AutomationStateDoctorCategories.MissingLinkedPr);
+        Assert.Contains(analysis.UnsafeFindings, u => u.Kind == AutomationStateDoctorUnsafeKinds.AmbiguousPrLinkage);
+    }
+
+    [Fact]
+    public void Analyze_FullyLinkedCompletedItem_ProducesNoFindings()
+    {
+        var queue = new[]
+        {
+            new StateDoctorQueueItem
+            {
+                ExecutionUnit = "G300",
+                LinkedIssueRepo = Repo,
+                LinkedIssueNumber = 703,
+                LinkedPrUrl = $"https://github.com/{Repo}/pull/706",
+                Completed = true,
+            },
+        };
+        var prs = new[] { Pr(706, merged: true, closes: 703) };
+
+        var analysis = AutomationStateDoctorAnalyzer.Analyze(Repo, queue, Array.Empty<StateDoctorPublishEvidence>(), prs);
+
+        Assert.Empty(analysis.Findings);
+        Assert.Empty(analysis.UnsafeFindings);
+    }
+
+    // ---- Command: read-only vs fail-closed write ----------------------------
+
+    [Fact]
+    public void Execute_ReadOnly_ReportsDrift_ButDoesNotMutateQueueState()
+    {
+        using var workspace = new DoctorWorkspace();
+        workspace.WriteQueueState(BuildQueue(("G300", null, null, QueueItemState.Queued)));
+        workspace.WritePublishArtifact("G300", createdIssueNumber: 703);
+        AutomationStateDoctorCommand.CandidateListerFactory = () => new FakeLister(
+            open: new[] { Pr(706, merged: false, closes: 703) });
+
+        using var writer = new StringWriter();
+        var exit = AutomationStateDoctorCommand.Execute(workspace.Context, ["--repo", Repo, "--format", "json"], writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("read-only", doc.RootElement.GetProperty("mode").GetString());
+        Assert.True(doc.RootElement.GetProperty("findings").GetArrayLength() >= 1);
+        Assert.All(
+            doc.RootElement.GetProperty("findings").EnumerateArray(),
+            f => Assert.False(f.GetProperty("applied").GetBoolean()));
+
+        var after = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.Null(after.Items[0].LinkedIssue);
+        Assert.Null(after.Items[0].LinkedPr);
+        Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
+    }
+
+    [Fact]
+    public void Execute_Write_AppliesHighConfidenceForwardOnlyRepair_AndAppendsRunEvent()
+    {
+        using var workspace = new DoctorWorkspace();
+        workspace.WriteQueueState(BuildQueue(("G300", null, null, QueueItemState.Queued)));
+        workspace.WritePublishArtifact("G300", createdIssueNumber: 703);
+        AutomationStateDoctorCommand.CandidateListerFactory = () => new FakeLister(
+            open: new[] { Pr(706, merged: false, closes: 703) });
+
+        using var writer = new StringWriter();
+        var exit = AutomationStateDoctorCommand.Execute(workspace.Context, ["--repo", Repo, "--write", "--format", "json"], writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("write", doc.RootElement.GetProperty("mode").GetString());
+
+        var after = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        var item = after.Items[0];
+        Assert.NotNull(item.LinkedIssue);
+        Assert.Equal(703, item.LinkedIssue!.Number);
+        Assert.Contains("/pull/706", item.LinkedPr!, StringComparison.Ordinal);
+
+        var runs = File.ReadAllText(workspace.Context.GetRunLogPath());
+        Assert.Contains("state-doctor-repair", runs, StringComparison.Ordinal);
+        Assert.Contains("G300", runs, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Write_AmbiguousDrift_FailsClosed_NoMutation()
+    {
+        using var workspace = new DoctorWorkspace();
+        workspace.WriteQueueState(BuildQueue(
+            ("G300", Li(703), null, QueueItemState.Queued),
+            ("G301", Li(703), null, QueueItemState.Queued)));
+        AutomationStateDoctorCommand.CandidateListerFactory = () => new FakeLister(
+            open: new[] { Pr(706, merged: false, closes: 703) });
+
+        using var writer = new StringWriter();
+        var exit = AutomationStateDoctorCommand.Execute(workspace.Context, ["--repo", Repo, "--write", "--format", "json"], writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.True(doc.RootElement.GetProperty("unsafe_findings").GetArrayLength() >= 1);
+
+        var after = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.All(after.Items, item => Assert.Null(item.LinkedPr));
+        // Fail-closed write: no run log appended for an ambiguous-only result.
+        Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
+    }
+
+    [Fact]
+    public void Execute_OldHostWithNoQueueState_DoesNotCrash_AndReportsNoDrift()
+    {
+        using var workspace = new DoctorWorkspace();
+        // No queue-state.json written — simulates a brand-new / old host.
+        AutomationStateDoctorCommand.CandidateListerFactory = () => new FakeLister(open: Array.Empty<StateDoctorPr>());
+
+        using var writer = new StringWriter();
+        var exit = AutomationStateDoctorCommand.Execute(workspace.Context, ["--repo", Repo, "--format", "json"], writer);
+
+        Assert.Equal(0, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("findings").GetArrayLength());
+        Assert.Equal(0, doc.RootElement.GetProperty("unsafe_findings").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_ChildLoopContext_IsRejected_HostOnly()
+    {
+        using var workspace = new DoctorWorkspace();
+        using var writer = new StringWriter();
+        var exit = AutomationStateDoctorCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--child-loop-context", "--format", "json"],
+            writer);
+
+        Assert.Equal(2, exit);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(
+            AutomationStateDoctorUnsafeKinds.ChildLoopProhibited,
+            doc.RootElement.GetProperty("unsafe_findings")[0].GetProperty("kind").GetString());
+    }
+
+    // ---- builders / fakes ---------------------------------------------------
+
+    private static StateDoctorPr Pr(int number, bool merged, params int[] closes) =>
+        new()
+        {
+            Number = number,
+            Url = $"https://github.com/{Repo}/pull/{number}",
+            Merged = merged,
+            ClosingIssueNumbers = closes,
+        };
+
+    private static LinkedIssue Li(int number) =>
+        new() { Repo = Repo, Number = number, Url = $"https://github.com/{Repo}/issues/{number}" };
+
+    private static string BuildQueue(params (string Unit, LinkedIssue? Issue, string? Pr, QueueItemState State)[] items)
+    {
+        var state = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = new DateTimeOffset(2026, 6, 2, 0, 0, 0, TimeSpan.Zero),
+            Items = items.Select(i => new QueueItem
+            {
+                ExecutionUnit = i.Unit,
+                Title = $"{i.Unit} title",
+                State = i.State,
+                Dependencies = Array.Empty<string>(),
+                BlockedBy = Array.Empty<string>(),
+                ClarificationReturnPath = string.Empty,
+                PacketPaths = new PacketPaths
+                {
+                    Yaml = $".intent-cli/issues/{i.Unit}/packet.yaml",
+                    Implementation = $".intent-cli/issues/{i.Unit}/implementation.md",
+                    ReviewContext = $".intent-cli/issues/{i.Unit}/review-context.md",
+                },
+                LinkedIssue = i.Issue,
+                LinkedPr = i.Pr,
+                WorkerRole = "Claude",
+                ReviewRole = "Codex",
+                Priority = "normal",
+            }).ToArray(),
+        };
+        return QueueStateSerializer.Serialize(state);
+    }
+
+    private sealed class FakeLister : IGitHubAutomationCandidateLister
+    {
+        private readonly IReadOnlyList<StateDoctorPr> open;
+        private readonly IReadOnlyList<StateDoctorPr> merged;
+
+        public FakeLister(IReadOnlyList<StateDoctorPr> open, IReadOnlyList<StateDoctorPr>? merged = null)
+        {
+            this.open = open;
+            this.merged = merged ?? open.Where(p => p.Merged).ToArray();
+        }
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) =>
+            open.Select(ToCandidate).ToArray();
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) =>
+            Array.Empty<GitHubAutomationIssueCandidate>();
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) =>
+            merged.Select(ToCandidate).ToArray();
+
+        private static GitHubAutomationPrCandidate ToCandidate(StateDoctorPr pr) => new()
+        {
+            Number = pr.Number,
+            Url = pr.Url,
+            State = pr.Merged ? "MERGED" : "OPEN",
+            ClosingIssuesReferences = pr.ClosingIssueNumbers
+                .Select(n => new GitHubPrClosingIssueReference { Number = n })
+                .ToArray(),
+        };
+    }
+
+    private sealed class DoctorWorkspace : IDisposable
+    {
+        private readonly string installedCliPath;
+
+        public DoctorWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("state-doctor-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            installedCliPath = Path.Combine(RootPath, ".intent-cli", "installed-cli-stub");
+            File.WriteAllText(installedCliPath, "stub");
+
+            // Satisfy the installed-CLI surface probe deterministically without a
+            // real subprocess: a resolvable path + a stdout covering every
+            // required capability token.
+            AutomationInstalledCliSurfaceProbe.ExplicitInstalledCliPathReader = () => installedCliPath;
+            AutomationInstalledCliSurfaceProbe.ProbeRunner = (_, _) =>
+                new InstalledCliProbeResult(
+                    0,
+                    "automation summary host-review-preflight issue-publish pr-transition review-start request-update approved",
+                    string.Empty);
+
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                    },
+                },
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public void WriteQueueState(string serialized) =>
+            File.WriteAllText(Context.GetQueueStatePath(), serialized);
+
+        public void WritePublishArtifact(string executionUnit, int createdIssueNumber)
+        {
+            var dir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(dir);
+            var artifact = new IssuePublishArtifact
+            {
+                ExecutionUnit = executionUnit,
+                PublishStatus = "published",
+                PacketPath = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                IssueBodyPath = $".intent-cli/issues/{executionUnit}/github-body.md",
+                CreatedIssueNumber = createdIssueNumber,
+                CreatedIssueUrl = $"https://github.com/{Repo}/issues/{createdIssueNumber}",
+                PublishedLabelName = "intent-target",
+            };
+            File.WriteAllText(Path.Combine(dir, "publish.yaml"), IssuePublishArtifactYaml.Serialize(artifact));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,8 +124,8 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.4 as the next development line
-        // (post-v0.3.3 release bump, see G442).
+        // be parseable and must point to 0.3.5 as the next development line
+        // (post-v0.3.4 release bump, see G447).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -135,8 +135,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.4", policy.NextVersion);
-        Assert.Equal("0.3.3", policy.StableVersion);
+        Assert.Equal("0.3.5", policy.NextVersion);
+        Assert.Equal("0.3.4", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Adds `intent-cli automation state-doctor`: a unified, OSS-safe diagnostic and safe-repair entry point for host-metadata drift across queue-state, publish artifacts, and GitHub PRs (open + merged). Read-only by default; `--write` applies **only** high-confidence, forward-only queue-state repairs and appends an append-only `runs.jsonl` event per repair. Ambiguous drift is reported as fail-closed unsafe findings and never mutated. Existing/old hosts are never migrated.

## What changed

- **`AutomationStateDoctorAnalyzer`** (pure): detects the four required drift categories with evidence + confidence:
  - `missing-linked-pr` — queue item's linked issue uniquely closed by one PR, linked_pr empty → high.
  - `missing-linked-issue` — publish artifact records a created issue for a unit whose queue linked_issue is empty → high.
  - `merged-pr-not-completed` — a merged PR closes the linked issue but the queue item is not completed → high.
  - `duplicate-issue-evidence` / ambiguous PR/publish linkage → **unsafe**, no repair.
  Forward-only by construction: a repair only fills a missing field or advances a lifecycle state; it never clears, rewrites, or downgrades existing host data.
- **`AutomationStateDoctorResult`**: structured findings + unsafe findings (snake + camel JSON), confidence, evidence, applied flag.
- **`AutomationStateDoctorCommand`**: `--read-only` (default) / `--write`; host-only (`--child-loop-context` exits 2); stale-host-cli gate; text/JSON. `--write` persists high-confidence queue-state repairs and appends `runs.jsonl` events.
- **`IGitHubAutomationCandidateLister`**: non-breaking default `ListMergedPullRequests` (gh `--state merged`) so existing implementers/fakes keep compiling.
- Router registration + usage line.

## Acceptance criteria mapping

- Read-only doctor reports deterministic drift categories with evidence ✅
- Write repair mutates only high-confidence forward-only metadata and appends run events ✅
- Existing hosts with old/absent queue-state continue to work without migration ✅ (`Execute_OldHostWithNoQueueState_*`)
- Ambiguous cases return unsafe classifications and no writes ✅ (`Execute_Write_AmbiguousDrift_FailsClosed_NoMutation`)
- Tests cover missing linked_pr, missing linked_issue from publish artifact, merged-PR-not-completed, and duplicate issue evidence ✅

## Verification

- `dotnet test` — 11 new tests pass; full CLI suite green (one unrelated, pre-existing ETXTBSY probe flake passes in isolation).
- `git diff --check` clean.
- Read-only mode performs no writes; existing host data is not destructively migrated.

Closes #997