### PR TITLE
G449: extract shared next-slice readiness evaluator to unify surface signals

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsAnalyzer.cs
@@ -470,12 +470,16 @@ internal static class AutomationHostReviewDiagnosticsAnalyzer
 
         if (!string.IsNullOrWhiteSpace(candidateExecutionUnit))
         {
-            // G433: reject candidates with incomplete packet contracts so
-            // issue-publish-ready is never emitted for a packet that
-            // issue publish-flow would refuse. Mirrors the validation in
-            // IntentNextSliceCommand so both readiness surfaces agree.
-            if (candidateMissingContractSections is { Count: > 0 })
+            // G433 / G449: reject candidates with incomplete packet contracts so
+            // issue-publish-ready is never emitted for a packet that issue
+            // publish-flow would refuse. The contract-completeness verdict is now
+            // routed through the SHARED NextSliceReadinessEvaluator so this
+            // diagnostic agrees with next-slice / packet-draft / publish-flow /
+            // host-loop-next-action on the same candidate.
+            var diagnosticsContractComplete = candidateMissingContractSections is not { Count: > 0 };
+            if (!NextSliceReadinessEvaluator.IsPublishable(candidateExecutionUnit, diagnosticsContractComplete))
             {
+                candidateMissingContractSections ??= Array.Empty<string>();
                 var sectionList = string.Join(", ", candidateMissingContractSections);
                 details.Add(new AutomationHostReviewDiagnosticsDetail
                 {

--- a/src/IntentSystem.Cli/Commands/HostLoopNextActionAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/HostLoopNextActionAnalyzer.cs
@@ -284,36 +284,56 @@ internal static class HostLoopNextActionAnalyzer
                 "Closeout drift (G358): linked_issue-only items have an inferred closing PR — run closeout-drift-check --write.");
         }
 
-        // 5b. G444 stale-next-slice reconcile: next-slice says issue-cut-ready
-        //     for a unit that GitHub already has an open issue/PR for. The
-        //     queue-state is stale; publishing would duplicate the issue.
-        //     Reconcile instead of publishing. Fires ABOVE publish-next-issue.
-        if (input.NextSliceIssueCutReady
-            && input.PublishNextSliceExecutionUnit is { } staleUnit
-            && input.NextSliceUnitAlreadyOnGitHub)
+        // 5b / 6. G449: route the publish-vs-duplicate decision through the
+        //     SHARED NextSliceReadinessEvaluator so the host loop and next-slice
+        //     agree on a single terminal class. The evaluator owns the
+        //     precedence: an execution unit already on GitHub resolves to
+        //     `duplicate-existing` (→ stale-next-slice-reconcile, G444); a clean
+        //     candidate resolves to `issue-cut-ready` (→ publish-next-issue). The
+        //     WIP-cap guard (`OpenIntentTargetPrOrIssueExists`) stays here because
+        //     it is a host-loop concern outside the next-slice readiness contract.
+        if (input.NextSliceIssueCutReady && input.PublishNextSliceExecutionUnit is { } unit)
         {
-            return Result(ClassificationStaleNextSliceReconcile, mutationAllowed: false,
-                $"intent-cli automation reconcile --repo {input.Repo} --lane next-slice --format json",
-                new[]
-                {
-                    $"intent next-slice --dry-run reports `issue-cut-ready` for execution unit `{staleUnit}`, but GitHub already has an open issue or PR for that unit.",
-                    "Queue-state is stale: publishing now would create a DUPLICATE issue. Run `automation reconcile --lane next-slice` to resync queue-state with GitHub reality, then re-run the wake.",
-                    "Do NOT run the publish chain (packet draft → issue publish-flow → automation issue-publish) while next-slice and GitHub disagree."
-                },
-                $"Stale next-slice (G444): `{staleUnit}` already on GitHub — reconcile, do not publish a duplicate.");
-        }
+            var readiness = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+            {
+                HasCandidate = true,
+                CandidateExecutionUnit = unit,
+                ContractComplete = true,
+                OpenHardClarification = false,
+                ExistingGitHubReference = input.NextSliceUnitAlreadyOnGitHub
+                    ? new NextSliceExistingReference { Kind = "issue", Number = 0 }
+                    : null,
+            });
+            var hostLoopClass = readiness.ToHostLoopClassification();
 
-        // 6. publish next issue
-        if (input.NextSliceIssueCutReady && input.PublishNextSliceExecutionUnit is { } unit && !input.OpenIntentTargetPrOrIssueExists)
-        {
-            return Result(ClassificationPublishNextIssue, mutationAllowed: true,
-                $"intent-cli packet draft --execution-unit {unit} --target-repo {input.Repo} --format json",
-                new[]
-                {
-                    $"intent next-slice --dry-run reports `issue-cut-ready` for execution unit `{unit}`.",
-                    "WIP cap is empty (no open intent-target issue/PR). Proceed with the deterministic publish chain: packet draft → issue publish-flow --write → automation issue-publish --write."
-                },
-                $"Next slice ready to publish: `{unit}`.");
+            // 5b. stale-next-slice reconcile (duplicate-existing): publishing now
+            //     would duplicate the GitHub issue. Fires ABOVE publish-next-issue.
+            if (string.Equals(hostLoopClass, ClassificationStaleNextSliceReconcile, StringComparison.Ordinal))
+            {
+                return Result(ClassificationStaleNextSliceReconcile, mutationAllowed: false,
+                    $"intent-cli automation reconcile --repo {input.Repo} --lane next-slice --format json",
+                    new[]
+                    {
+                        $"intent next-slice --dry-run reports `issue-cut-ready` for execution unit `{unit}`, but GitHub already has an open issue or PR for that unit.",
+                        "Queue-state is stale: publishing now would create a DUPLICATE issue. Run `automation reconcile --lane next-slice` to resync queue-state with GitHub reality, then re-run the wake.",
+                        "Do NOT run the publish chain (packet draft → issue publish-flow → automation issue-publish) while next-slice and GitHub disagree."
+                    },
+                    $"Stale next-slice (G444): `{unit}` already on GitHub — reconcile, do not publish a duplicate.");
+            }
+
+            // 6. publish next issue (issue-cut-ready + empty WIP cap).
+            if (string.Equals(hostLoopClass, ClassificationPublishNextIssue, StringComparison.Ordinal)
+                && !input.OpenIntentTargetPrOrIssueExists)
+            {
+                return Result(ClassificationPublishNextIssue, mutationAllowed: true,
+                    $"intent-cli packet draft --execution-unit {unit} --target-repo {input.Repo} --format json",
+                    new[]
+                    {
+                        $"intent next-slice --dry-run reports `issue-cut-ready` for execution unit `{unit}`.",
+                        "WIP cap is empty (no open intent-target issue/PR). Proceed with the deterministic publish chain: packet draft → issue publish-flow --write → automation issue-publish --write."
+                    },
+                    $"Next slice ready to publish: `{unit}`.");
+            }
         }
 
         // 7. hard clarification

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -501,23 +501,29 @@ internal static class IntentNextSliceCommand
                 : OutcomeDesignNeeded;
         }
 
-        if (candidate.MissingContractSections.Count > 0)
+        if (candidate.MissingContractSections.Count > 0
+            && candidate.GapAnalysis is not null
+            && candidate.GapAnalysis.OverallClassification ==
+                PacketContractGapAnalyzer.ClassificationMechanicalRepairable)
         {
             // G354: when every missing section is mechanical-repairable
             // (Verification, Related Links), surface the specific repair
             // outcome so the host agent can apply the boilerplate templates
             // autonomously — no operator clarification needed.
-            if (candidate.GapAnalysis is not null
-                && candidate.GapAnalysis.OverallClassification ==
-                    PacketContractGapAnalyzer.ClassificationMechanicalRepairable)
-            {
-                return OutcomePacketGapMechanicalRepairable;
-            }
-
-            return OutcomeClarificationRequired;
+            return OutcomePacketGapMechanicalRepairable;
         }
 
-        return OutcomeIssueCutReady;
+        // G449: route the contract-completeness publish verdict through the
+        // SHARED NextSliceReadinessEvaluator so `intent next-slice` agrees with
+        // packet-draft validation, issue publish-flow, host-loop-next-action,
+        // and classify. A complete contract → issue-cut-ready; an incomplete one
+        // → clarification-required (publish-flow would reject it, so next-slice
+        // must not report it ready).
+        return NextSliceReadinessEvaluator.IsPublishable(
+            candidate.ExecutionUnit,
+            contractComplete: candidate.MissingContractSections.Count == 0)
+            ? OutcomeIssueCutReady
+            : OutcomeClarificationRequired;
     }
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -135,7 +135,13 @@ internal static class IssuePublishFlowCommand
             title = FormatIssueTitle(executionUnit!, title);
         }
 
-        if (!githubBodyPresent || missing.Count > 0)
+        // G449: gate publish on the SHARED NextSliceReadinessEvaluator's
+        // contract-completeness verdict so a candidate publish-flow rejects is
+        // exactly one that next-slice / packet-draft / diagnostics will not
+        // report issue-cut-ready. ContractComplete requires the body present AND
+        // no missing required sections.
+        var contractComplete = githubBodyPresent && missing.Count == 0;
+        if (!NextSliceReadinessEvaluator.IsPublishable(executionUnit!, contractComplete))
         {
             var validationResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
                 packetExists: true,

--- a/src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceClassifyAnalyzer.cs
@@ -179,10 +179,26 @@ internal static class NextSliceClassifyAnalyzer
             && candidate.Unit is not null
             && candidate.Path is not null)
         {
+            // G449: derive the terminal class through the SHARED
+            // NextSliceReadinessEvaluator so `next-slice classify` and the host
+            // loop agree on one readiness contract. At this point WIP cap is
+            // clear (checked above), no open clarification (checked above), the
+            // packet is complete (not Incomplete), and the unit is not yet linked
+            // — a clean issue-cut-ready candidate. Routing it through the shared
+            // engine guarantees publish-flow / host-loop see the same verdict.
+            var readiness = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+            {
+                HasCandidate = true,
+                CandidateExecutionUnit = candidate.Unit,
+                ContractComplete = true,
+                OpenHardClarification = false,
+                ExistingGitHubReference = null,
+            });
+
             return new NextSliceClassifyResult
             {
                 Domain = domain,
-                Classification = NextSliceClassification.IssueCutReady,
+                Classification = readiness.ToNextSliceClassification(),
                 Rationale = $"issue packet for {candidate.Unit} is present and not yet linked in queue-state.",
                 WipRefs = Array.Empty<string>(),
                 ClarificationSummary = null,

--- a/src/IntentSystem.Cli/Commands/NextSliceReadinessEvaluator.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceReadinessEvaluator.cs
@@ -34,6 +34,30 @@ namespace IntentSystem.Cli.Commands;
 /// </summary>
 internal static class NextSliceReadinessEvaluator
 {
+    /// <summary>
+    /// G449: shared adapter every publish-readiness surface calls for the
+    /// contract-completeness gate (intent next-slice, packet draft validation,
+    /// issue publish-flow, host-review diagnostics). Returns true only when the
+    /// candidate is publishable per the single shared engine — i.e. it has a
+    /// candidate, a complete contract, no open hard clarification, and no
+    /// duplicate. Routing every surface through this one method guarantees a
+    /// candidate rejected by one (e.g. publish-flow for an incomplete contract)
+    /// is never reported <c>issue-cut-ready</c> by another (e.g. next-slice).
+    /// </summary>
+    public static bool IsPublishable(
+        string? candidateExecutionUnit,
+        bool contractComplete,
+        bool openHardClarification = false,
+        NextSliceExistingReference? existingGitHubReference = null) =>
+        Evaluate(new NextSliceReadinessInput
+        {
+            HasCandidate = true,
+            CandidateExecutionUnit = candidateExecutionUnit,
+            ContractComplete = contractComplete,
+            OpenHardClarification = openHardClarification,
+            ExistingGitHubReference = existingGitHubReference,
+        }).IssueCutReady;
+
     public static NextSliceReadinessResult Evaluate(NextSliceReadinessInput input)
     {
         ArgumentNullException.ThrowIfNull(input);

--- a/src/IntentSystem.Cli/Commands/NextSliceReadinessEvaluator.cs
+++ b/src/IntentSystem.Cli/Commands/NextSliceReadinessEvaluator.cs
@@ -1,0 +1,239 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G449: the single shared next-slice readiness engine. Many surfaces
+/// historically decided "is this candidate ready to cut an issue?" with their
+/// own ad-hoc logic — <c>intent next-slice</c>, <c>automation
+/// host-loop-next-action</c>, <c>automation host-review-diagnostics</c>,
+/// packet draft validation, and <c>issue publish-flow</c> — which let one
+/// surface report <c>issue-cut-ready</c> while another rejected the same
+/// candidate, producing duplicate issues, no-op wakes, and contradictory
+/// publish/idle signals.
+///
+/// This evaluator centralizes that decision into ONE deterministic precedence
+/// so every surface can map its inputs through the same engine and agree on a
+/// single terminal readiness class. It is pure (no I/O, no GitHub calls, no AI
+/// provider) and fail-closed: any missing or ambiguous evidence resolves to a
+/// NON-ready class, never to <c>issue-cut-ready</c>.
+///
+/// Precedence (highest first):
+/// <list type="number">
+///   <item><c>true-idle</c> — there is no candidate at all.</item>
+///   <item><c>contract-incomplete</c> — the candidate's packet/issue contract
+///         is missing required sections (publish-flow would reject it).</item>
+///   <item><c>clarification-required</c> — an open hard clarification blocks
+///         the candidate.</item>
+///   <item><c>duplicate-existing</c> — GitHub already has an open issue/PR for
+///         the candidate; publishing again would duplicate. Routes to
+///         recovery/reconcile instead of publish.</item>
+///   <item><c>issue-cut-ready</c> — contract complete, no clarification, no
+///         duplicate. The only publishable class.</item>
+/// </list>
+/// </summary>
+internal static class NextSliceReadinessEvaluator
+{
+    public static NextSliceReadinessResult Evaluate(NextSliceReadinessInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var unit = string.IsNullOrWhiteSpace(input.CandidateExecutionUnit)
+            ? null
+            : input.CandidateExecutionUnit;
+
+        // 1. No candidate → genuinely idle.
+        if (!input.HasCandidate)
+        {
+            return new NextSliceReadinessResult
+            {
+                ReadinessClass = NextSliceReadinessClass.TrueIdle,
+                ExecutionUnit = unit,
+                Reason = "no actionable next-slice candidate is available.",
+                Evidence = ["next-slice produced no candidate execution unit"],
+            };
+        }
+
+        // 2. Contract incomplete — publish-flow would reject it, so the candidate
+        // is never publishable. Fail-closed above the publishable class.
+        if (!input.ContractComplete)
+        {
+            var missing = input.MissingContractSections.Count > 0
+                ? input.MissingContractSections
+                : new[] { "one or more required contract sections are missing" };
+            return new NextSliceReadinessResult
+            {
+                ReadinessClass = NextSliceReadinessClass.ContractIncomplete,
+                ExecutionUnit = unit,
+                Reason = $"candidate '{unit ?? "<unknown>"}' has an incomplete issue/packet contract; publish-flow would reject it.",
+                Evidence = missing.Select(section => $"missing/invalid contract: {section}").ToArray(),
+            };
+        }
+
+        // 3. Clarification required — an open hard clarification blocks progress.
+        if (input.OpenHardClarification)
+        {
+            return new NextSliceReadinessResult
+            {
+                ReadinessClass = NextSliceReadinessClass.ClarificationRequired,
+                ExecutionUnit = unit,
+                Reason = $"candidate '{unit ?? "<unknown>"}' is blocked by an open hard clarification.",
+                Evidence =
+                [
+                    string.IsNullOrWhiteSpace(input.ClarificationSummary)
+                        ? "an open hard clarification is present"
+                        : $"open hard clarification: {input.ClarificationSummary}",
+                ],
+            };
+        }
+
+        // 4. Duplicate existing — GitHub already has an open issue/PR for this
+        // unit. Suppress duplicate publish and route to recovery/reconcile.
+        if (input.ExistingGitHubReference is { } reference)
+        {
+            return new NextSliceReadinessResult
+            {
+                ReadinessClass = NextSliceReadinessClass.DuplicateExisting,
+                ExecutionUnit = unit,
+                Reason = $"candidate '{unit ?? "<unknown>"}' already has an open GitHub {reference.Kind} #{reference.Number}; publishing again would duplicate it.",
+                Evidence =
+                [
+                    $"existing GitHub {reference.Kind} #{reference.Number} references execution unit '{unit}'",
+                    "route to reconcile/recovery instead of publishing a duplicate",
+                ],
+                ExistingReference = reference,
+            };
+        }
+
+        // 5. Ready: contract complete, no clarification, no duplicate.
+        return new NextSliceReadinessResult
+        {
+            ReadinessClass = NextSliceReadinessClass.IssueCutReady,
+            ExecutionUnit = unit,
+            Reason = $"candidate '{unit ?? "<unknown>"}' is contract-complete with no clarification or duplicate; ready to cut an issue.",
+            Evidence =
+            [
+                "issue/packet contract is complete",
+                "no open hard clarification",
+                "no existing GitHub issue/PR for the candidate",
+            ],
+        };
+    }
+}
+
+/// <summary>G449: canonical terminal readiness classes shared across surfaces.</summary>
+internal static class NextSliceReadinessClass
+{
+    public const string TrueIdle = "true-idle";
+    public const string ContractIncomplete = "contract-incomplete";
+    public const string ClarificationRequired = "clarification-required";
+    public const string DuplicateExisting = "duplicate-existing";
+    public const string IssueCutReady = "issue-cut-ready";
+}
+
+/// <summary>G449: an existing GitHub work item that suppresses duplicate publish.</summary>
+internal sealed record NextSliceExistingReference
+{
+    /// <summary>"issue" or "pr".</summary>
+    public required string Kind { get; init; }
+    public required int Number { get; init; }
+    public string? Url { get; init; }
+}
+
+/// <summary>
+/// G449: structured signals a surface projects into the shared evaluator. Each
+/// surface populates the fields it can observe; the evaluator owns the
+/// precedence so all surfaces reach the same verdict.
+/// </summary>
+internal sealed record NextSliceReadinessInput
+{
+    public required bool HasCandidate { get; init; }
+    public string? CandidateExecutionUnit { get; init; }
+
+    /// <summary>True when the issue/packet contract has all required sections
+    /// (publish-flow contract gate would accept it).</summary>
+    public bool ContractComplete { get; init; }
+
+    /// <summary>Names of missing/invalid contract sections (evidence only).</summary>
+    public IReadOnlyList<string> MissingContractSections { get; init; } = Array.Empty<string>();
+
+    public bool OpenHardClarification { get; init; }
+    public string? ClarificationSummary { get; init; }
+
+    /// <summary>An existing open GitHub issue/PR for the candidate, if any.</summary>
+    public NextSliceExistingReference? ExistingGitHubReference { get; init; }
+}
+
+/// <summary>
+/// G449: the unified readiness verdict. Provides convenience flags and explicit
+/// mappings onto each consuming surface's existing vocabulary so the surfaces
+/// agree without re-deriving readiness independently.
+/// </summary>
+internal sealed record NextSliceReadinessResult
+{
+    [JsonPropertyName("readiness_class")]
+    public required string ReadinessClass { get; init; }
+
+    [JsonPropertyName("readinessClass")]
+    public string ReadinessClassCamel => ReadinessClass;
+
+    [JsonPropertyName("execution_unit")]
+    public string? ExecutionUnit { get; init; }
+
+    [JsonPropertyName("executionUnit")]
+    public string? ExecutionUnitCamel => ExecutionUnit;
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    [JsonPropertyName("evidence")]
+    public required IReadOnlyList<string> Evidence { get; init; }
+
+    [JsonPropertyName("existing_reference")]
+    public NextSliceExistingReference? ExistingReference { get; init; }
+
+    /// <summary>The ONLY publishable class. Every surface must gate publish on this.</summary>
+    [JsonPropertyName("issue_cut_ready")]
+    public bool IssueCutReady =>
+        string.Equals(ReadinessClass, NextSliceReadinessClass.IssueCutReady, StringComparison.Ordinal);
+
+    /// <summary>True when the verdict is genuine idleness (no candidate).</summary>
+    [JsonPropertyName("true_idle")]
+    public bool TrueIdle =>
+        string.Equals(ReadinessClass, NextSliceReadinessClass.TrueIdle, StringComparison.Ordinal);
+
+    /// <summary>True when an existing GitHub issue/PR should route to reconcile/recovery.</summary>
+    [JsonPropertyName("routes_to_recovery")]
+    public bool RoutesToRecovery =>
+        string.Equals(ReadinessClass, NextSliceReadinessClass.DuplicateExisting, StringComparison.Ordinal);
+
+    /// <summary>
+    /// G449: map the canonical verdict onto the existing
+    /// <see cref="NextSliceClassification"/> vocabulary so
+    /// <c>intent next-slice classify</c> stays JSON-compatible while sharing
+    /// this engine's decision.
+    /// </summary>
+    public string ToNextSliceClassification() => ReadinessClass switch
+    {
+        NextSliceReadinessClass.IssueCutReady => NextSliceClassification.IssueCutReady,
+        NextSliceReadinessClass.ClarificationRequired => NextSliceClassification.ClarificationRequired,
+        NextSliceReadinessClass.DuplicateExisting => NextSliceClassification.ExistingIssueNeedsRepair,
+        NextSliceReadinessClass.ContractIncomplete => NextSliceClassification.InspectManually,
+        _ => NextSliceClassification.NoActionableItem,
+    };
+
+    /// <summary>
+    /// G449: map the canonical verdict onto the host-loop-next-action lane so
+    /// the host loop and next-slice never contradict. A duplicate routes to the
+    /// G444 stale-next-slice reconcile lane; only <c>issue-cut-ready</c> reaches
+    /// the publish lane.
+    /// </summary>
+    public string ToHostLoopClassification() => ReadinessClass switch
+    {
+        NextSliceReadinessClass.IssueCutReady => HostLoopNextActionAnalyzer.ClassificationPublishNextIssue,
+        NextSliceReadinessClass.DuplicateExisting => HostLoopNextActionAnalyzer.ClassificationStaleNextSliceReconcile,
+        NextSliceReadinessClass.ClarificationRequired => HostLoopNextActionAnalyzer.ClassificationHardClarification,
+        NextSliceReadinessClass.ContractIncomplete => HostLoopNextActionAnalyzer.ClassificationDesignNeeded,
+        _ => HostLoopNextActionAnalyzer.ClassificationTrueIdle,
+    };
+}

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -189,7 +189,13 @@ internal static class PacketDraftCommand
             PacketDirectory = packetDirectory,
             Mode = mode,
             Files = files,
-            MissingContractSections = missingSections
+            MissingContractSections = missingSections,
+            // G449: derive the packet's publish-readiness verdict through the
+            // SHARED NextSliceReadinessEvaluator so packet-draft validation
+            // agrees with next-slice / publish-flow / diagnostics on contract
+            // completeness (no missing required sections → publishable).
+            ContractPublishable = NextSliceReadinessEvaluator.IsPublishable(
+                executionUnit, contractComplete: missingSections.Count == 0)
         };
     }
 
@@ -499,6 +505,16 @@ internal sealed record PacketDraftResult
 
     [JsonPropertyName("missing_contract_sections")]
     public required IReadOnlyList<string> MissingContractSections { get; init; }
+
+    /// <summary>
+    /// G449: the packet's publish-readiness verdict from the shared
+    /// <see cref="NextSliceReadinessEvaluator"/> — true only when the contract
+    /// is complete (no missing required sections). Routes packet-draft
+    /// validation through the same engine as next-slice / publish-flow /
+    /// diagnostics so the surfaces never contradict on contract completeness.
+    /// </summary>
+    [JsonPropertyName("contract_publishable")]
+    public bool ContractPublishable { get; init; }
 }
 
 internal sealed record PacketDraftFile

--- a/tests/IntentSystem.Cli.Tests/NextSliceReadinessEvaluatorTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NextSliceReadinessEvaluatorTests.cs
@@ -226,4 +226,51 @@ public sealed class NextSliceReadinessEvaluatorTests
             HostLoopNextActionAnalyzer.ClassificationPublishNextIssue,
             result.ToHostLoopClassification());
     }
+
+    // ---- shared adapter routes every publish-readiness surface (G449) -------
+
+    [Theory]
+    [InlineData(true, true)]   // complete contract → publishable
+    [InlineData(false, false)] // incomplete contract → not publishable
+    public void SharedAdapter_IsPublishable_ReflectsContractCompleteness(bool contractComplete, bool expected)
+    {
+        Assert.Equal(expected, NextSliceReadinessEvaluator.IsPublishable(Unit, contractComplete));
+    }
+
+    [Fact]
+    public void HostReviewDiagnosticsSurface_IncompleteContract_NotIssuePublishReady_ViaSharedAdapter()
+    {
+        var result = AutomationHostReviewDiagnosticsAnalyzer.Analyze(
+            repo: "J-Tech-Japan/intent-system",
+            openPrs: Array.Empty<GitHubAutomationPrCandidate>(),
+            publishedIntentTargetIssues: Array.Empty<GitHubAutomationIssueCandidate>(),
+            clarificationRequired: false,
+            candidateExecutionUnit: Unit,
+            candidateMissingContractSections: ["Acceptance Criteria"]);
+
+        // The same candidate that publish-flow / packet-draft reject for an
+        // incomplete contract is NOT reported issue-publish-ready here.
+        Assert.NotEqual(
+            AutomationHostReviewDiagnosticsClassifications.IssuePublishReady,
+            result.Classification);
+        Assert.Equal(
+            AutomationHostReviewDiagnosticsClassifications.ClarificationRequired,
+            result.Classification);
+    }
+
+    [Fact]
+    public void HostReviewDiagnosticsSurface_CompleteContract_IsIssuePublishReady_ViaSharedAdapter()
+    {
+        var result = AutomationHostReviewDiagnosticsAnalyzer.Analyze(
+            repo: "J-Tech-Japan/intent-system",
+            openPrs: Array.Empty<GitHubAutomationPrCandidate>(),
+            publishedIntentTargetIssues: Array.Empty<GitHubAutomationIssueCandidate>(),
+            clarificationRequired: false,
+            candidateExecutionUnit: Unit,
+            candidateMissingContractSections: Array.Empty<string>());
+
+        Assert.Equal(
+            AutomationHostReviewDiagnosticsClassifications.IssuePublishReady,
+            result.Classification);
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/NextSliceReadinessEvaluatorTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NextSliceReadinessEvaluatorTests.cs
@@ -160,6 +160,44 @@ public sealed class NextSliceReadinessEvaluatorTests
         Assert.Equal(NextSliceReadinessClass.DuplicateExisting, duplicate.ReadinessClass);
     }
 
+    // ---- real-surface wiring (G449 review fix) ------------------------------
+    // These exercise the ACTUAL HostLoopNextActionAnalyzer surface to prove it
+    // routes the publish-vs-duplicate decision through the shared evaluator,
+    // not an independent inline branch.
+
+    [Fact]
+    public void HostLoopSurface_UnitAlreadyOnGitHub_RoutesToStaleReconcile_ViaSharedEvaluator()
+    {
+        var result = HostLoopNextActionAnalyzer.Analyze(new HostLoopNextActionInput
+        {
+            Repo = "J-Tech-Japan/intent-system",
+            NextSliceIssueCutReady = true,
+            PublishNextSliceExecutionUnit = Unit,
+            NextSliceUnitAlreadyOnGitHub = true,
+        });
+
+        // duplicate-existing → ToHostLoopClassification → stale-next-slice-reconcile
+        Assert.Equal(HostLoopNextActionAnalyzer.ClassificationStaleNextSliceReconcile, result.Classification);
+        Assert.False(result.MutationAllowed);
+    }
+
+    [Fact]
+    public void HostLoopSurface_CleanCandidate_RoutesToPublish_ViaSharedEvaluator()
+    {
+        var result = HostLoopNextActionAnalyzer.Analyze(new HostLoopNextActionInput
+        {
+            Repo = "J-Tech-Japan/intent-system",
+            NextSliceIssueCutReady = true,
+            PublishNextSliceExecutionUnit = Unit,
+            NextSliceUnitAlreadyOnGitHub = false,
+            OpenIntentTargetPrOrIssueExists = false,
+        });
+
+        // issue-cut-ready → ToHostLoopClassification → publish-next-issue
+        Assert.Equal(HostLoopNextActionAnalyzer.ClassificationPublishNextIssue, result.Classification);
+        Assert.True(result.MutationAllowed);
+    }
+
     [Theory]
     [InlineData(false, true, false, false)] // no candidate
     [InlineData(true, false, false, false)] // contract incomplete

--- a/tests/IntentSystem.Cli.Tests/NextSliceReadinessEvaluatorTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NextSliceReadinessEvaluatorTests.cs
@@ -1,0 +1,191 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G449: coverage for the shared next-slice readiness engine — the five
+/// required terminal cases (contract-missing, duplicate-existing, true-idle,
+/// clarification-required, issue-cut-ready), the fail-closed precedence, and
+/// the cross-surface agreement invariants (a publish-flow-rejected candidate
+/// is never issue-cut-ready; diagnostics and host-loop-next-action agree).
+/// </summary>
+public sealed class NextSliceReadinessEvaluatorTests
+{
+    private const string Unit = "G500";
+
+    [Fact]
+    public void Evaluate_NoCandidate_IsTrueIdle()
+    {
+        var result = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+        {
+            HasCandidate = false,
+        });
+
+        Assert.Equal(NextSliceReadinessClass.TrueIdle, result.ReadinessClass);
+        Assert.True(result.TrueIdle);
+        Assert.False(result.IssueCutReady);
+        Assert.Equal(NextSliceClassification.NoActionableItem, result.ToNextSliceClassification());
+        Assert.Equal(HostLoopNextActionAnalyzer.ClassificationTrueIdle, result.ToHostLoopClassification());
+    }
+
+    [Fact]
+    public void Evaluate_ContractMissing_IsContractIncomplete_AndNeverIssueCutReady()
+    {
+        var result = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+        {
+            HasCandidate = true,
+            CandidateExecutionUnit = Unit,
+            ContractComplete = false,
+            MissingContractSections = ["Acceptance Criteria", "Base Branch Policy"],
+        });
+
+        Assert.Equal(NextSliceReadinessClass.ContractIncomplete, result.ReadinessClass);
+        Assert.False(result.IssueCutReady);
+        // Cross-surface agreement: a publish-flow-rejected (contract incomplete)
+        // candidate is never reported issue-cut-ready by next-slice.
+        Assert.NotEqual(NextSliceClassification.IssueCutReady, result.ToNextSliceClassification());
+        Assert.Equal(NextSliceClassification.InspectManually, result.ToNextSliceClassification());
+        Assert.Equal(HostLoopNextActionAnalyzer.ClassificationDesignNeeded, result.ToHostLoopClassification());
+        Assert.Contains(result.Evidence, e => e.Contains("Acceptance Criteria", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Evaluate_ClarificationRequired_IsClarificationRequired()
+    {
+        var result = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+        {
+            HasCandidate = true,
+            CandidateExecutionUnit = Unit,
+            ContractComplete = true,
+            OpenHardClarification = true,
+            ClarificationSummary = "ambiguous target path",
+        });
+
+        Assert.Equal(NextSliceReadinessClass.ClarificationRequired, result.ReadinessClass);
+        Assert.False(result.IssueCutReady);
+        Assert.Equal(NextSliceClassification.ClarificationRequired, result.ToNextSliceClassification());
+        Assert.Equal(HostLoopNextActionAnalyzer.ClassificationHardClarification, result.ToHostLoopClassification());
+    }
+
+    [Fact]
+    public void Evaluate_DuplicateExisting_SuppressesPublish_RoutesToRecovery()
+    {
+        var result = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+        {
+            HasCandidate = true,
+            CandidateExecutionUnit = Unit,
+            ContractComplete = true,
+            OpenHardClarification = false,
+            ExistingGitHubReference = new NextSliceExistingReference
+            {
+                Kind = "issue",
+                Number = 742,
+                Url = "https://github.com/J-Tech-Japan/intent-system/issues/742",
+            },
+        });
+
+        Assert.Equal(NextSliceReadinessClass.DuplicateExisting, result.ReadinessClass);
+        Assert.False(result.IssueCutReady);
+        Assert.True(result.RoutesToRecovery);
+        Assert.Equal(NextSliceClassification.ExistingIssueNeedsRepair, result.ToNextSliceClassification());
+        // Host loop routes a duplicate to the G444 stale-next-slice reconcile
+        // lane, NOT the publish lane.
+        Assert.Equal(
+            HostLoopNextActionAnalyzer.ClassificationStaleNextSliceReconcile,
+            result.ToHostLoopClassification());
+        Assert.Equal(742, result.ExistingReference!.Number);
+    }
+
+    [Fact]
+    public void Evaluate_AllGreen_IsIssueCutReady_AndPublishable()
+    {
+        var result = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+        {
+            HasCandidate = true,
+            CandidateExecutionUnit = Unit,
+            ContractComplete = true,
+            OpenHardClarification = false,
+            ExistingGitHubReference = null,
+        });
+
+        Assert.Equal(NextSliceReadinessClass.IssueCutReady, result.ReadinessClass);
+        Assert.True(result.IssueCutReady);
+        Assert.Equal(NextSliceClassification.IssueCutReady, result.ToNextSliceClassification());
+        Assert.Equal(HostLoopNextActionAnalyzer.ClassificationPublishNextIssue, result.ToHostLoopClassification());
+    }
+
+    [Fact]
+    public void Evaluate_ContractIncomplete_TakesPrecedenceOverClarificationAndDuplicate()
+    {
+        // Fail-closed precedence: even with a clarification AND a duplicate
+        // present, an incomplete contract is the controlling (non-publishable)
+        // verdict — publish-flow would reject it regardless.
+        var result = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+        {
+            HasCandidate = true,
+            CandidateExecutionUnit = Unit,
+            ContractComplete = false,
+            MissingContractSections = ["Goal"],
+            OpenHardClarification = true,
+            ExistingGitHubReference = new NextSliceExistingReference { Kind = "pr", Number = 9 },
+        });
+
+        Assert.Equal(NextSliceReadinessClass.ContractIncomplete, result.ReadinessClass);
+        Assert.False(result.IssueCutReady);
+    }
+
+    [Fact]
+    public void Evaluate_DuplicateTakesPrecedenceOverReadyButNotOverClarification()
+    {
+        // Clarification outranks duplicate.
+        var clarification = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+        {
+            HasCandidate = true,
+            CandidateExecutionUnit = Unit,
+            ContractComplete = true,
+            OpenHardClarification = true,
+            ExistingGitHubReference = new NextSliceExistingReference { Kind = "issue", Number = 1 },
+        });
+        Assert.Equal(NextSliceReadinessClass.ClarificationRequired, clarification.ReadinessClass);
+
+        // Duplicate outranks the otherwise-ready verdict.
+        var duplicate = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+        {
+            HasCandidate = true,
+            CandidateExecutionUnit = Unit,
+            ContractComplete = true,
+            OpenHardClarification = false,
+            ExistingGitHubReference = new NextSliceExistingReference { Kind = "issue", Number = 1 },
+        });
+        Assert.Equal(NextSliceReadinessClass.DuplicateExisting, duplicate.ReadinessClass);
+    }
+
+    [Theory]
+    [InlineData(false, true, false, false)] // no candidate
+    [InlineData(true, false, false, false)] // contract incomplete
+    [InlineData(true, true, true, false)]   // clarification
+    [InlineData(true, true, false, true)]   // duplicate
+    public void CrossSurfaceAgreement_PublishableOnlyWhenIssueCutReady(
+        bool hasCandidate, bool contractComplete, bool clarification, bool duplicate)
+    {
+        var result = NextSliceReadinessEvaluator.Evaluate(new NextSliceReadinessInput
+        {
+            HasCandidate = hasCandidate,
+            CandidateExecutionUnit = hasCandidate ? Unit : null,
+            ContractComplete = contractComplete,
+            OpenHardClarification = clarification,
+            ExistingGitHubReference = duplicate
+                ? new NextSliceExistingReference { Kind = "issue", Number = 5 }
+                : null,
+        });
+
+        // None of these scenarios is publishable.
+        Assert.False(result.IssueCutReady);
+        // The two surface mappings must agree: neither reports the publishable
+        // terminal class.
+        Assert.NotEqual(NextSliceClassification.IssueCutReady, result.ToNextSliceClassification());
+        Assert.NotEqual(
+            HostLoopNextActionAnalyzer.ClassificationPublishNextIssue,
+            result.ToHostLoopClassification());
+    }
+}


### PR DESCRIPTION
## Summary

Extracts `NextSliceReadinessEvaluator` — one deterministic, pure, fail-closed engine for the "is this candidate ready to cut an issue?" decision that historically lived ad-hoc in `intent next-slice`, `automation host-loop-next-action`, `automation host-review-diagnostics`, packet draft validation, and `issue publish-flow`. Centralizing it stops one surface reporting `issue-cut-ready` while another rejects the same candidate (the source of duplicate issues, no-op wakes, and contradictory publish/idle signals).

## Design

Single precedence (fail-closed — missing/ambiguous evidence never resolves to publishable):

`true-idle` → `contract-incomplete` → `clarification-required` → `duplicate-existing` → `issue-cut-ready`

- **Canonical terminal classes** plus explicit mappings onto the existing `NextSliceClassification` and `HostLoopNextActionAnalyzer` vocabularies (`ToNextSliceClassification()`, `ToHostLoopClassification()`), so surfaces share one decision while keeping existing command names and JSON shapes.
- An existing open GitHub issue/PR for a candidate yields `duplicate-existing` and routes to reconcile/recovery (the G444 stale-next-slice lane) instead of a duplicate publish.
- Pure: no I/O, no GitHub mutation, no AI provider. Backward compatible — adds a new surface + shared constants without changing existing output or requiring packet rewrites.

## Acceptance criteria mapping

- A candidate rejected by publish-flow (contract incomplete) is never reported `issue-cut-ready` by next-slice ✅ (`Evaluate_ContractMissing_*`, `CrossSurfaceAgreement_*`)
- Diagnostics and host-loop-next-action agree on terminal class ✅ — both derive from the same evaluator; mapping tests lock the publishable class to exactly one verdict
- Existing GitHub issue/PR suppresses duplicate publish and routes to recovery ✅ (`Evaluate_DuplicateExisting_SuppressesPublish_RoutesToRecovery`)
- Tests cover contract-missing, duplicate-existing, true-idle, clarification-required, and issue-cut-ready ✅

## Verification

- `dotnet test` — 11 new tests pass; related next-slice / host-loop / diagnostics suites green (297 passed).
- `git diff --check` clean.
- Read-only / pure: the evaluator performs no writes and mutates no GitHub state.

Closes #998