### PR TITLE
G455: recover linked_pr for non-default-base PRs from PR-body closing references

### DIFF
--- a/src/IntentSystem.Cli/Commands/PrBodyClosingReferenceFallbackAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PrBodyClosingReferenceFallbackAnalyzer.cs
@@ -1,0 +1,133 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G455: pure analyzer that resolves the effective closing-issue numbers for
+/// linkage recovery, falling back to the PR body's canonical
+/// <c>Closes</c>/<c>Fixes</c>/<c>Resolves</c> reference when GitHub's
+/// <c>closingIssuesReferences</c> API is empty.
+///
+/// The failure mode (observed on AIC PR #3750): a PR targeting a non-default
+/// base branch (<c>develop-v2</c>) was green, non-draft, mergeable, and
+/// contained <c>Closes #3749</c> — but GitHub's <c>closingIssuesReferences</c>
+/// came back EMPTY because the base is not the repository default branch. The
+/// host loop then stopped with <c>host-metadata-blocked</c> (no <c>linked_pr</c>
+/// for the queue item) even though the PR body carried deterministic evidence.
+/// The only way out was the manual
+/// <c>review closeout-plan --closing-issues 3749 --write-recovered-linkage</c>
+/// flag — knowledge a routine wake should not need.
+///
+/// This analyzer makes the recovery automatic and deterministic:
+/// <list type="bullet">
+///   <item>GitHub closing references present → use them (no change in behavior).</item>
+///   <item>GitHub empty + exactly ONE canonical same-repo body reference → use
+///   it as the closing issue (the <c>pr-body-fallback</c> source).</item>
+///   <item>GitHub empty + MULTIPLE distinct body references → ambiguous; refuse
+///   to guess (G455 out-of-scope).</item>
+///   <item>GitHub empty + no canonical reference (or only loose prose /
+///   cross-repo references) → no recovery; fall through to the existing
+///   host-metadata-blocked path.</item>
+/// </list>
+///
+/// Pure: no I/O, no GitHub, no process launch. Cross-repo references and loose
+/// prose are already excluded by
+/// <see cref="PrClosingReferenceAnalyzer.ExtractCanonicalReferences"/>.
+/// </summary>
+internal static class PrBodyClosingReferenceFallbackAnalyzer
+{
+    public const string SourceGitHub = "github-closing-references";
+    public const string SourcePrBodyFallback = "pr-body-fallback";
+
+    public const string ClassificationGitHub = "github-closing-references";
+    public const string ClassificationBodyFallback = "pr-body-fallback";
+    public const string ClassificationAmbiguousBody = "ambiguous-body-references";
+    public const string ClassificationNoReference = "no-closing-reference";
+
+    public static PrBodyClosingReferenceFallbackDecision Resolve(
+        IReadOnlyList<int>? githubClosingIssues,
+        string? prBody,
+        string repo)
+    {
+        ArgumentNullException.ThrowIfNull(repo);
+
+        var github = (githubClosingIssues ?? Array.Empty<int>())
+            .Where(n => n > 0)
+            .Distinct()
+            .ToArray();
+
+        // GitHub closing references are authoritative when present — no
+        // fallback needed. This preserves the existing (default-base) behavior
+        // exactly.
+        if (github.Length > 0)
+        {
+            return new PrBodyClosingReferenceFallbackDecision
+            {
+                Classification = ClassificationGitHub,
+                Source = SourceGitHub,
+                ResolvedClosingIssues = github,
+                Ambiguous = false,
+                Reason = $"GitHub closingIssuesReferences provided {github.Length} closing issue(s); PR-body fallback not needed.",
+            };
+        }
+
+        // GitHub empty → derive from canonical same-repo body references.
+        var bodyRefs = PrClosingReferenceAnalyzer.ExtractCanonicalReferences(prBody, repo);
+        var distinctIssues = bodyRefs
+            .Select(r => r.IssueNumber)
+            .Distinct()
+            .ToArray();
+
+        if (distinctIssues.Length == 0)
+        {
+            return new PrBodyClosingReferenceFallbackDecision
+            {
+                Classification = ClassificationNoReference,
+                Source = null,
+                ResolvedClosingIssues = Array.Empty<int>(),
+                Ambiguous = false,
+                Reason = "GitHub closingIssuesReferences is empty and the PR body has no canonical Closes/Fixes/Resolves reference in this repo (loose prose like `see #N` / `Linked Issue #N` and cross-repo references do not count).",
+            };
+        }
+
+        if (distinctIssues.Length > 1)
+        {
+            // Multiple distinct canonical references — refuse to guess.
+            return new PrBodyClosingReferenceFallbackDecision
+            {
+                Classification = ClassificationAmbiguousBody,
+                Source = null,
+                ResolvedClosingIssues = Array.Empty<int>(),
+                Ambiguous = true,
+                Reason = $"GitHub closingIssuesReferences is empty and the PR body has {distinctIssues.Length} distinct canonical closing references ({string.Join(", ", distinctIssues.Select(n => "#" + n))}); refusing to guess which is the source issue.",
+            };
+        }
+
+        return new PrBodyClosingReferenceFallbackDecision
+        {
+            Classification = ClassificationBodyFallback,
+            Source = SourcePrBodyFallback,
+            ResolvedClosingIssues = distinctIssues,
+            Ambiguous = false,
+            Reason = $"GitHub closingIssuesReferences is empty; recovered a single canonical body reference `Closes #{distinctIssues[0]}` in {repo} (typical of a non-default-base PR where GitHub does not populate closingIssuesReferences).",
+        };
+    }
+}
+
+/// <summary>
+/// G455: resolution of the effective closing-issue set for linkage recovery,
+/// plus the <see cref="Source"/> tag and an <see cref="Ambiguous"/> flag so the
+/// caller can surface a structured ambiguity gap instead of guessing.
+/// </summary>
+internal sealed record PrBodyClosingReferenceFallbackDecision
+{
+    public required string Classification { get; init; }
+
+    /// <summary>Provenance of the resolved issues; null when none resolved.</summary>
+    public string? Source { get; init; }
+
+    public required IReadOnlyList<int> ResolvedClosingIssues { get; init; }
+
+    /// <summary>True when the body had multiple distinct canonical references (refuse-to-guess).</summary>
+    public required bool Ambiguous { get; init; }
+
+    public required string Reason { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/PrClosingReferenceAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PrClosingReferenceAnalyzer.cs
@@ -126,6 +126,22 @@ internal static class PrClosingReferenceAnalyzer
         };
     }
 
+    /// <summary>
+    /// G455: public access to the canonical closing-reference parser so the
+    /// linkage-recovery fallback (<see cref="PrBodyClosingReferenceFallbackAnalyzer"/>)
+    /// can derive closing issues from a PR body when GitHub's
+    /// <c>closingIssuesReferences</c> API is empty (which happens for
+    /// non-default-base PRs). Returns only canonical references
+    /// (Close/Fix/Resolve forms) targeting <paramref name="repo"/>; loose
+    /// prose like <c>see #N</c> / <c>Linked Issue #N</c> and cross-repo
+    /// references are already excluded.
+    /// </summary>
+    public static IReadOnlyList<PrClosingReference> ExtractCanonicalReferences(string? prBody, string repo)
+    {
+        ArgumentNullException.ThrowIfNull(repo);
+        return ExtractReferences(prBody, repo);
+    }
+
     private static IReadOnlyList<PrClosingReference> ExtractReferences(string? prBody, string repo)
     {
         if (string.IsNullOrWhiteSpace(prBody))

--- a/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
@@ -47,6 +47,40 @@ internal sealed class GhCliPrClosingIssuesFetcher : IPrClosingIssuesFetcher
 }
 
 /// <summary>
+/// G455: read-only seam for fetching a PR's body so linkage recovery can fall
+/// back to a canonical <c>Closes #N</c> reference when GitHub's
+/// <c>closingIssuesReferences</c> API is empty (non-default-base PRs). The
+/// default production implementation reuses <see cref="GhCliGitHubPrLookup"/>;
+/// tests inject a deterministic fake. Returns <c>null</c> on any failure so the
+/// planner falls through to its existing host-metadata-blocked path.
+/// </summary>
+internal interface IPrBodyFetcher
+{
+    string? Fetch(string repo, int prNumber);
+}
+
+/// <summary>
+/// G455: default PR-body fetcher backed by the existing
+/// <see cref="GhCliGitHubPrLookup"/> shell adapter. Fail-soft: any GitHub error
+/// returns <c>null</c>.
+/// </summary>
+internal sealed class GhCliPrBodyFetcher : IPrBodyFetcher
+{
+    public string? Fetch(string repo, int prNumber)
+    {
+        try
+        {
+            var lookup = new GhCliGitHubPrLookup();
+            return lookup.Lookup(repo, prNumber).Body;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+}
+
+/// <summary>
 /// G247: Read-only <c>intent-cli review closeout-plan</c> command. Reports
 /// what a review-pass closeout would mutate before any merge or parent
 /// state write. Resolves the queue item via <c>linked_pr</c>, lists the
@@ -95,6 +129,14 @@ internal static class ReviewCloseoutPlanCommand
     /// <see cref="GhCliPrClosingIssuesFetcher"/>.
     /// </summary>
     public static Func<IPrClosingIssuesFetcher>? PrClosingIssuesFetcherFactory { get; set; }
+
+    /// <summary>
+    /// G455: test seam for the PR-body fetcher used by the canonical
+    /// closing-reference fallback (when GitHub <c>closingIssuesReferences</c>
+    /// is empty for a non-default-base PR). Production callers leave this null
+    /// and the planner uses <see cref="GhCliPrBodyFetcher"/>.
+    /// </summary>
+    public static Func<IPrBodyFetcher>? PrBodyFetcherFactory { get; set; }
 
     private const string FormatJson = "json";
     private const string FormatMarkdown = "markdown";
@@ -194,52 +236,86 @@ internal static class ReviewCloseoutPlanCommand
                     }
                 }
 
+                // G455: GitHub `closingIssuesReferences` comes back EMPTY for
+                // PRs targeting a non-default base branch (e.g. `develop-v2`),
+                // even when the PR body carries a deterministic `Closes #N`.
+                // Fall back to the canonical body reference: exactly ONE
+                // same-repo Close/Fix/Resolve reference recovers the closing
+                // issue; multiple distinct references surface as a structured
+                // ambiguity gap (no guessing). Only consult the body when the
+                // operator did not pass `--closing-issues` and GitHub provided
+                // none.
+                var bodyFallbackAmbiguous = false;
+                if (closingIssues.Count == 0)
+                {
+                    var bodyFetcher = PrBodyFetcherFactory?.Invoke() ?? new GhCliPrBodyFetcher();
+                    var prBody = bodyFetcher.Fetch(repo!, pr!.Value);
+                    var fallback = PrBodyClosingReferenceFallbackAnalyzer.Resolve(closingIssues, prBody, repo!);
+                    if (fallback.ResolvedClosingIssues.Count > 0)
+                    {
+                        closingIssues = fallback.ResolvedClosingIssues;
+                        closingIssuesSource = fallback.Source;
+                    }
+                    else if (fallback.Ambiguous)
+                    {
+                        bodyFallbackAmbiguous = true;
+                        gaps.Add(LinkageAmbiguousGap(
+                            $"linkage-ambiguous: {fallback.Reason}"));
+                    }
+                }
+
                 // G329: before classifying this as host-metadata-blocked,
                 // try to reconstruct the linkage from GitHub closing-issue
                 // facts. If exactly one queue item matches a closing issue,
                 // recover the linkage and treat that queue item as matched
                 // for the rest of planning. Multiple matches surface as a
                 // structured `linkage-ambiguous` gap (no guessing per G329
-                // out-of-scope).
-                var reconstruction = GitHubLinkageReconstructor.Reconstruct(closingIssues, queueState);
-                switch (reconstruction.Kind)
+                // out-of-scope). When the G455 body fallback already surfaced
+                // an ambiguity gap, skip reconstruction entirely so the wake
+                // reports a single structured ambiguity rather than a
+                // redundant host-metadata gap.
+                if (!bodyFallbackAmbiguous)
                 {
-                    case LinkageReconstructionKind.Deterministic:
-                        var candidate = reconstruction.Candidates[0];
-                        matchedItem = queueState.Items.First(item =>
-                            string.Equals(item.ExecutionUnit, candidate.ExecutionUnit, StringComparison.Ordinal));
-                        recoveredLinkage = new RecoveredLinkagePayload
-                        {
-                            ExecutionUnit = candidate.ExecutionUnit,
-                            LinkedPrNumber = pr!.Value,
-                            LinkedPrRepo = repo!,
-                            LinkedPrUrl = $"https://github.com/{repo}/pull/{pr}",
-                            LinkedIssueNumber = candidate.LinkedIssueNumber,
-                            LinkedIssueRepo = candidate.LinkedIssueRepo,
-                            LinkedIssueUrl = candidate.LinkedIssueUrl,
-                            RecoverySource = LinkageReconstructionConstants.RecoverySourceGitHubClosingReference
-                        };
-                        break;
+                    var reconstruction = GitHubLinkageReconstructor.Reconstruct(closingIssues, queueState);
+                    switch (reconstruction.Kind)
+                    {
+                        case LinkageReconstructionKind.Deterministic:
+                            var candidate = reconstruction.Candidates[0];
+                            matchedItem = queueState.Items.First(item =>
+                                string.Equals(item.ExecutionUnit, candidate.ExecutionUnit, StringComparison.Ordinal));
+                            recoveredLinkage = new RecoveredLinkagePayload
+                            {
+                                ExecutionUnit = candidate.ExecutionUnit,
+                                LinkedPrNumber = pr!.Value,
+                                LinkedPrRepo = repo!,
+                                LinkedPrUrl = $"https://github.com/{repo}/pull/{pr}",
+                                LinkedIssueNumber = candidate.LinkedIssueNumber,
+                                LinkedIssueRepo = candidate.LinkedIssueRepo,
+                                LinkedIssueUrl = candidate.LinkedIssueUrl,
+                                RecoverySource = LinkageReconstructionConstants.RecoverySourceGitHubClosingReference
+                            };
+                            break;
 
-                    case LinkageReconstructionKind.Ambiguous:
-                        ambiguousLinkage = new AmbiguousLinkagePayload
-                        {
-                            Candidates = reconstruction.Candidates,
-                            Reason = $"PR #{pr} closes {closingIssues.Count} issue(s) matching {reconstruction.Candidates.Count} queue items; cannot deterministically recover linkage."
-                        };
-                        gaps.Add(LinkageAmbiguousGap(
-                            $"linkage-ambiguous: PR #{pr} closing-issues match {reconstruction.Candidates.Count} queue items "
-                            + $"({string.Join(", ", reconstruction.Candidates.Select(c => c.ExecutionUnit))}); refusing to guess."));
-                        break;
+                        case LinkageReconstructionKind.Ambiguous:
+                            ambiguousLinkage = new AmbiguousLinkagePayload
+                            {
+                                Candidates = reconstruction.Candidates,
+                                Reason = $"PR #{pr} closes {closingIssues.Count} issue(s) matching {reconstruction.Candidates.Count} queue items; cannot deterministically recover linkage."
+                            };
+                            gaps.Add(LinkageAmbiguousGap(
+                                $"linkage-ambiguous: PR #{pr} closing-issues match {reconstruction.Candidates.Count} queue items "
+                                + $"({string.Join(", ", reconstruction.Candidates.Select(c => c.ExecutionUnit))}); refusing to guess."));
+                            break;
 
-                    case LinkageReconstructionKind.NoClosingReferences:
-                    case LinkageReconstructionKind.NoMatch:
-                    default:
-                        // G287: this is the PR #670-shaped gap — host metadata drift,
-                        // not an implementation defect. The host loop must run
-                        // `automation reconcile`, not request a child PR repair.
-                        gaps.Add(HostMetadataGap($"no queue item found with linked_pr matching #{pr}."));
-                        break;
+                        case LinkageReconstructionKind.NoClosingReferences:
+                        case LinkageReconstructionKind.NoMatch:
+                        default:
+                            // G287: this is the PR #670-shaped gap — host metadata drift,
+                            // not an implementation defect. The host loop must run
+                            // `automation reconcile`, not request a child PR repair.
+                            gaps.Add(HostMetadataGap($"no queue item found with linked_pr matching #{pr}."));
+                            break;
+                    }
                 }
             }
         }

--- a/tests/IntentSystem.Cli.Tests/PrBodyClosingReferenceFallbackAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PrBodyClosingReferenceFallbackAnalyzerTests.cs
@@ -1,0 +1,127 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G455: pure tests for the PR-body closing-reference fallback. The central
+/// regression fixture is AIC PR #3750: a PR targeting the non-default base
+/// `develop-v2`, green/non-draft/mergeable, containing `Closes #3749`, but with
+/// an EMPTY GitHub `closingIssuesReferences` (GitHub does not populate it for
+/// non-default-base PRs). The fallback must recover the single canonical body
+/// reference deterministically while refusing to guess on ambiguity.
+/// </summary>
+public sealed class PrBodyClosingReferenceFallbackAnalyzerTests
+{
+    private const string Repo = "J-Tech-Japan/intent-system";
+
+    [Fact]
+    public void Aic3750Fixture_EmptyGitHubRefs_SingleBodyCloses_RecoversIssue()
+    {
+        var decision = PrBodyClosingReferenceFallbackAnalyzer.Resolve(
+            githubClosingIssues: Array.Empty<int>(),
+            prBody: "Implements the develop-v2 work.\n\nCloses #3749\n",
+            repo: Repo);
+
+        Assert.Equal(PrBodyClosingReferenceFallbackAnalyzer.ClassificationBodyFallback, decision.Classification);
+        Assert.Equal(PrBodyClosingReferenceFallbackAnalyzer.SourcePrBodyFallback, decision.Source);
+        Assert.Equal(new[] { 3749 }, decision.ResolvedClosingIssues);
+        Assert.False(decision.Ambiguous);
+    }
+
+    [Fact]
+    public void GitHubRefsPresent_UsesGitHub_NoBodyFallback()
+    {
+        // When GitHub provides closing references, behavior is unchanged — the
+        // body is not even consulted.
+        var decision = PrBodyClosingReferenceFallbackAnalyzer.Resolve(
+            githubClosingIssues: new[] { 100 },
+            prBody: "Closes #999",
+            repo: Repo);
+
+        Assert.Equal(PrBodyClosingReferenceFallbackAnalyzer.ClassificationGitHub, decision.Classification);
+        Assert.Equal(PrBodyClosingReferenceFallbackAnalyzer.SourceGitHub, decision.Source);
+        Assert.Equal(new[] { 100 }, decision.ResolvedClosingIssues);
+    }
+
+    [Fact]
+    public void MultipleDistinctBodyReferences_IsAmbiguous_RefusesToGuess()
+    {
+        var decision = PrBodyClosingReferenceFallbackAnalyzer.Resolve(
+            githubClosingIssues: Array.Empty<int>(),
+            prBody: "Closes #10\nFixes #11\n",
+            repo: Repo);
+
+        Assert.Equal(PrBodyClosingReferenceFallbackAnalyzer.ClassificationAmbiguousBody, decision.Classification);
+        Assert.True(decision.Ambiguous);
+        Assert.Empty(decision.ResolvedClosingIssues);
+        Assert.Null(decision.Source);
+    }
+
+    [Fact]
+    public void SameIssueRepeatedAcrossKeywords_IsNotAmbiguous_DistinctSingle()
+    {
+        // `Closes #42` and `Fixes #42` reference the same issue — one distinct
+        // issue, so it is recoverable, not ambiguous.
+        var decision = PrBodyClosingReferenceFallbackAnalyzer.Resolve(
+            githubClosingIssues: Array.Empty<int>(),
+            prBody: "Closes #42\n... later ...\nFixes #42\n",
+            repo: Repo);
+
+        Assert.Equal(PrBodyClosingReferenceFallbackAnalyzer.ClassificationBodyFallback, decision.Classification);
+        Assert.Equal(new[] { 42 }, decision.ResolvedClosingIssues);
+    }
+
+    [Fact]
+    public void LongProseReference_DoesNotCount_NoReference()
+    {
+        // Loose prose like `see #N` / `Linked Issue #N` is not a canonical
+        // closing reference.
+        var decision = PrBodyClosingReferenceFallbackAnalyzer.Resolve(
+            githubClosingIssues: Array.Empty<int>(),
+            prBody: "Linked Issue #3749 — see #3749 for context.",
+            repo: Repo);
+
+        Assert.Equal(PrBodyClosingReferenceFallbackAnalyzer.ClassificationNoReference, decision.Classification);
+        Assert.Empty(decision.ResolvedClosingIssues);
+        Assert.Null(decision.Source);
+    }
+
+    [Fact]
+    public void CrossRepoReference_DoesNotCount_NoReference()
+    {
+        // A cross-repo `Closes other-org/other#42` does not close an issue in
+        // THIS repo, so it is excluded.
+        var decision = PrBodyClosingReferenceFallbackAnalyzer.Resolve(
+            githubClosingIssues: Array.Empty<int>(),
+            prBody: "Closes other-org/other-repo#42",
+            repo: Repo);
+
+        Assert.Equal(PrBodyClosingReferenceFallbackAnalyzer.ClassificationNoReference, decision.Classification);
+        Assert.Empty(decision.ResolvedClosingIssues);
+    }
+
+    [Fact]
+    public void SameRepoQualifiedReference_Counts()
+    {
+        // An explicit same-repo qualified reference `Closes owner/repo#N` is
+        // valid for this repo.
+        var decision = PrBodyClosingReferenceFallbackAnalyzer.Resolve(
+            githubClosingIssues: Array.Empty<int>(),
+            prBody: $"Resolves {Repo}#3749",
+            repo: Repo);
+
+        Assert.Equal(PrBodyClosingReferenceFallbackAnalyzer.ClassificationBodyFallback, decision.Classification);
+        Assert.Equal(new[] { 3749 }, decision.ResolvedClosingIssues);
+    }
+
+    [Fact]
+    public void EmptyBody_NoReference()
+    {
+        var decision = PrBodyClosingReferenceFallbackAnalyzer.Resolve(
+            githubClosingIssues: Array.Empty<int>(),
+            prBody: null,
+            repo: Repo);
+
+        Assert.Equal(PrBodyClosingReferenceFallbackAnalyzer.ClassificationNoReference, decision.Classification);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
@@ -15,11 +15,17 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         // returning the issue numbers they want to reconstruct.
         ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
             () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+        // G455: default the PR-body fetcher to an empty result so unit tests
+        // never shell out to live `gh`. Tests exercising the body fallback
+        // override this with a fake returning a `Closes #N` body.
+        ReviewCloseoutPlanCommand.PrBodyFetcherFactory =
+            () => new FakePrBodyFetcher(null);
     }
 
     public void Dispose()
     {
         ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory = null;
+        ReviewCloseoutPlanCommand.PrBodyFetcherFactory = null;
     }
 
     private sealed class FakePrClosingIssuesFetcher : IPrClosingIssuesFetcher
@@ -30,6 +36,13 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             this.closingIssues = closingIssues;
         }
         public IReadOnlyList<int> Fetch(string repo, int prNumber) => closingIssues;
+    }
+
+    private sealed class FakePrBodyFetcher : IPrBodyFetcher
+    {
+        private readonly string? body;
+        public FakePrBodyFetcher(string? body) => this.body = body;
+        public string? Fetch(string repo, int prNumber) => body;
     }
 
     [Fact]
@@ -249,6 +262,105 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         Assert.Contains("--pr 647", cmd, StringComparison.Ordinal);
         Assert.Contains("--write", cmd, StringComparison.Ordinal);
         Assert.Equal(cmd, root.GetProperty("recommended_recovery_command").GetString());
+    }
+
+    [Fact]
+    public void Execute_G455_EmptyGitHubRefs_BodyClosesRecoversLinkage_ReadyWithBodyFallbackSource()
+    {
+        // AIC #3750 shape: PR targets a non-default base, GitHub
+        // closingIssuesReferences is empty, but the PR body has `Closes #595`
+        // and a queue item carries linked_issue 595 with no linked_pr.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review", linkedPr: null,
+            linkedIssue: ("J-Tech-Japan/intent-system", 595, "https://github.com/J-Tech-Japan/intent-system/issues/595")));
+        workspace.WriteFile(".intent-cli/issues/G247/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G247/packet.yaml", "x");
+
+        // GitHub closing refs empty (non-default base); body carries Closes #595.
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+        ReviewCloseoutPlanCommand.PrBodyFetcherFactory =
+            () => new FakePrBodyFetcher("Implements develop-v2 work.\n\nCloses #595\n");
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.True(root.GetProperty("ready").GetBoolean());
+        Assert.Equal("G247", root.GetProperty("execution_unit").GetString());
+        // Provenance marks the body fallback recovery.
+        Assert.Equal("pr-body-fallback", root.GetProperty("closing_issues_source").GetString());
+        Assert.True(root.TryGetProperty("recovered_linkage", out var recovered), "expected recovered_linkage payload");
+        Assert.Equal(596, recovered.GetProperty("linked_pr_number").GetInt32());
+        Assert.Equal(595, recovered.GetProperty("linked_issue_number").GetInt32());
+    }
+
+    [Fact]
+    public void Execute_G455_EmptyGitHubRefs_MultipleBodyReferences_SurfacesLinkageAmbiguousGap()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review", linkedPr: null,
+            linkedIssue: ("J-Tech-Japan/intent-system", 595, null)));
+        workspace.WriteFile(".intent-cli/issues/G247/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G247/packet.yaml", "x");
+
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+        ReviewCloseoutPlanCommand.PrBodyFetcherFactory =
+            () => new FakePrBodyFetcher("Closes #595\nFixes #777\n");
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.False(root.GetProperty("ready").GetBoolean());
+        Assert.Equal("host-metadata-blocked", root.GetProperty("blocker_classification").GetString());
+        var gapClassifications = root.GetProperty("classified_gaps").EnumerateArray()
+            .Select(g => g.GetProperty("classification").GetString()).ToArray();
+        Assert.Contains("linkage-ambiguous", gapClassifications);
+        // The ambiguity must not also produce a redundant "no queue item found"
+        // host-metadata gap.
+        var gapDescriptions = root.GetProperty("gaps").EnumerateArray()
+            .Select(g => g.GetString()!).ToArray();
+        Assert.DoesNotContain(gapDescriptions, d => d.Contains("no queue item found with linked_pr", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_G455_GitHubRefsPresent_StillUsesGitHub_NotBodyFallback()
+    {
+        // Regression: when GitHub provides closing refs, the body fallback must
+        // not override them — provenance stays github-auto-fetch.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review", linkedPr: null,
+            linkedIssue: ("J-Tech-Japan/intent-system", 595, "https://github.com/J-Tech-Japan/intent-system/issues/595")));
+        workspace.WriteFile(".intent-cli/issues/G247/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G247/packet.yaml", "x");
+
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(new[] { 595 });
+        // Body references a DIFFERENT issue; it must be ignored because GitHub won.
+        ReviewCloseoutPlanCommand.PrBodyFetcherFactory =
+            () => new FakePrBodyFetcher("Closes #777");
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("github-auto-fetch", doc.RootElement.GetProperty("closing_issues_source").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements **G455** (#1011): make host review recover a missing `linked_pr` automatically from the PR body's canonical `Closes` / `Fixes` / `Resolves` reference when GitHub's `closingIssuesReferences` API is empty — which happens for PRs targeting a **non-default base branch** (e.g. `develop-v2`).

Reproduces the **AIC PR #3750** failure mode: a `develop-v2`-targeting PR was green/non-draft/mergeable with `Closes #3749`, but GitHub returned empty `closingIssuesReferences`, so `closeout-plan` / `guide review` stopped at `host-metadata-blocked` and only the manual `--closing-issues 3749 --write-recovered-linkage` flag recovered it.

## What changed

- **`PrBodyClosingReferenceFallbackAnalyzer`** (new, pure): when GitHub closing refs are empty, derive the closing issue from exactly **one** canonical same-repo body reference. Multiple distinct references → ambiguous (refuse to guess); loose prose (`see #N`, `Linked Issue #N`) and cross-repo references do not count.
- **`PrClosingReferenceAnalyzer.ExtractCanonicalReferences`** exposed for reuse (same regex/canonical rules as G311).
- **`review closeout-plan`** wires the fallback via a new fail-soft `IPrBodyFetcher` seam. Recovery is **automatic** (no `--closing-issues` flag needed) and records `closing_issues_source = pr-body-fallback`. Ambiguous body references surface a single `linkage-ambiguous` gap without a redundant host-metadata gap. GitHub-provided refs still win (unchanged default-base behavior).

## Acceptance criteria coverage

- ✅ Empty GitHub refs + single `Closes #N` body + unique queue/publish map → high-confidence writeable recovery
- ✅ Non-default-base scenario passes (recovery is base-agnostic; base policy continues to resolve via existing `ImplementationBaseBranchResolver` / config — `automation summary`, `base-branch-check`, `task review-pr` already honor the effective domain base)
- ✅ Unsafe for multiple refs / wrong-repo / loose prose (refuse to guess)
- ✅ After write recovery, `closeout-plan` returns ready
- ✅ Deterministic fallback recovers rather than stopping at advisory-only drift

## Verification

- New `PrBodyClosingReferenceFallbackAnalyzerTests` (AIC #3750 develop-v2 fixture, ambiguity/cross-repo/loose-prose negatives, GitHub-wins precedence) + `ReviewCloseoutPlanCommandTests` integration tests (body fallback recovers to ready with `pr-body-fallback` source; ambiguous → single `linkage-ambiguous` gap; GitHub-present precedence).
- Full `IntentSystem.Cli.Tests` suite: 2945 passed, 0 failed.
- `git diff --check`: clean.

## Base Branch Policy

Implementation PR base: `main` for `J-Tech-Japan/intent-system` (direct-main). The feature itself supports target projects whose effective implementation base is not `main` (e.g. AIC's `develop-v2`).

Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)