### PR TITLE
G456: add design-thread improve / realignment guide surface

### DIFF
--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -46,6 +46,36 @@ intent-cli interview compile
 intent-cli guide workflow
 ```
 
+## Design-thread improve / realignment
+
+A periodic reflection step for a design thread: step back and check whether
+recent work still aligns with the original mission, vision, values, ADR/design
+notes, and intent tree. In a design thread you can simply paste the
+natural-language request and let the agent run the guide internally:
+
+```text
+intent-cli で improve プロセスを実行してください。
+```
+
+The agent then fetches the current guidance and produces a structured report:
+
+```bash
+intent-cli guide improve --domain <domain> --format markdown
+```
+
+`guide improve` is a design-thread reflection process — **not** a scheduler, a
+provider launcher, or a routine host-loop / worker-loop recovery diagnostic.
+Operational metadata/label/queue repair stays in the existing operational
+surfaces (`automation reconcile`, `automation publish-recovery`,
+`review closeout-plan`). It inspects MVV, ADR/design notes, the intent tree,
+recent packet history, clarification history, and short-term-loop signals, and
+classifies the outcome as one of `aligned`,
+`intent-strengthening-recommended`, `clarification-recommended`,
+`corrective-packet-recommended`, `adr-update-recommended`,
+`short-term-loop-detected`, or `operator-policy-required`. Mutations are
+proposed first and applied only after operator agreement through supported
+intent-cli / repo paths.
+
 ## Packets / issues
 
 ```bash

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -45,6 +45,35 @@ intent-cli interview compile
 intent-cli guide workflow
 ```
 
+## デザインスレッド improve / 再整合
+
+デザインスレッドで定期的に一歩引いて、最近の作業が当初の mission / vision /
+values・ADR / design note・intent tree とまだ整合しているかを確認するための
+リフレクション工程です。デザインスレッドでは次の自然言語リクエストをそのまま
+貼り付ければ、agent が内部で guide を実行します:
+
+```text
+intent-cli で improve プロセスを実行してください。
+```
+
+agent は現在のガイダンスを取得し、構造化レポートを生成します:
+
+```bash
+intent-cli guide improve --domain <domain> --format markdown
+```
+
+`guide improve` はデザインスレッドのリフレクション工程であり、スケジューラでも
+provider 起動でも、host-loop / worker-loop の通常の復旧診断でもありません。
+metadata / label / queue の復旧は既存の運用サーフェス
+（`automation reconcile` / `automation publish-recovery` /
+`review closeout-plan`）に残します。MVV・ADR / design note・intent tree・直近の
+packet 履歴・clarification 履歴・短期ループの兆候を点検し、結果を `aligned` /
+`intent-strengthening-recommended` / `clarification-recommended` /
+`corrective-packet-recommended` / `adr-update-recommended` /
+`short-term-loop-detected` / `operator-policy-required` のいずれかに分類します。
+変更はまず提案し、operator の同意後にサポートされた intent-cli / repo 経路でのみ
+適用します。
+
 ## Packet / issue
 
 ```bash

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -246,6 +246,7 @@ internal static class CommandRouter
                 ["rules"] = GuideRulesCommand.Execute,
                 ["workflow"] = GuideWorkflowCommand.Execute,
                 ["model"] = GuideModelCommand.Execute,
+                ["improve"] = GuideImproveCommand.Execute,
                 ["commands"] = GuideCommandsCommand.Execute,
                 ["onboarding"] = GuideOnboardingCommand.Execute,
                 ["intent-work"] = GuideIntentWorkCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -139,6 +139,12 @@ internal static class GuideHelpCommand
         },
         new GuideSubcommandEntry
         {
+            Name = "improve",
+            Purpose = "Design-thread improve / realignment process (G456): periodically review MVV, ADR/design notes, intent tree, packet history, and clarification history for drift, short-term loops, and intent-strengthening opportunities. Run it by asking: `intent-cli で improve プロセスを実行してください。`. A reflection process, not a scheduler / provider launcher / loop-recovery diagnostic.",
+            Example = "intent-cli guide improve --domain <domain> --format markdown"
+        },
+        new GuideSubcommandEntry
+        {
             Name = "onboarding",
             Purpose = "First-call sequence for a fresh agent. Ordered list of guide / automation surfaces to read before any mutation.",
             Example = "intent-cli guide onboarding --format json"

--- a/src/IntentSystem.Cli/Commands/GuideImproveCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideImproveCommand.cs
@@ -1,0 +1,289 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G456: Read-only <c>intent-cli guide improve --domain &lt;domain&gt;</c>.
+/// Emits the canonical design-thread <em>improve / realignment</em> process so a
+/// design-thread AI agent can periodically step back and check whether recent
+/// work still aligns with the original mission, vision, values, ADR/design
+/// notes, and intent tree — reusing the accumulated intent artifacts instead of
+/// letting fast issue/PR automation drift into short-term local fixes.
+///
+/// The intended user experience is a single natural-language ask:
+/// <c>intent-cli で improve プロセスを実行してください。</c>
+/// The agent then runs this guide to fetch the current improve guidance and
+/// produces a structured design-thread report.
+///
+/// This is a DESIGN-THREAD periodic reflection process — NOT a scheduler, NOT a
+/// provider launcher, and NOT a routine host-loop/worker-loop recovery
+/// diagnostic. intent-cli owns deterministic guidance, discovery, artifact
+/// locations, the report shape, and mutation boundaries; the AI agent owns
+/// semantic analysis and conversation. Never mutates state. Never launches an
+/// AI provider.
+/// </summary>
+internal static class GuideImproveCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide improve [--domain <name>] [--format markdown|json]";
+
+    /// <summary>The shortest natural-language ask that triggers this process.</summary>
+    public const string ShortPrompt = "intent-cli で improve プロセスを実行してください。";
+
+    // Outcome classifications the design-thread report must use.
+    public const string OutcomeAligned = "aligned";
+    public const string OutcomeIntentStrengthening = "intent-strengthening-recommended";
+    public const string OutcomeClarification = "clarification-recommended";
+    public const string OutcomeCorrectivePacket = "corrective-packet-recommended";
+    public const string OutcomeAdrUpdate = "adr-update-recommended";
+    public const string OutcomeShortTermLoop = "short-term-loop-detected";
+    public const string OutcomeOperatorPolicy = "operator-policy-required";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domain, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildResult(domain);
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    internal static GuideImproveResult BuildResult(string? domain)
+    {
+        var domainToken = string.IsNullOrWhiteSpace(domain) ? "<domain>" : domain!;
+        return new GuideImproveResult
+        {
+            Process = "design-thread-improve",
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            ShortPrompt = ShortPrompt,
+            Summary =
+                "Design-thread improve / realignment: periodically step back and check whether recent work still aligns "
+                + "with the original mission, vision, values, ADR/design notes, and intent tree. Reuse the accumulated "
+                + "intent artifacts (MVV, ADRs, packet history, clarification history) rather than letting fast issue/PR "
+                + "automation drift into short-term local fixes.",
+            NotThis = new[]
+            {
+                "This is a DESIGN-THREAD periodic reflection process — run it on demand when the operator asks, not on a 5m/20m schedule.",
+                "intent-cli does NOT launch Claude/Codex/Copilot or any AI provider; the AI agent owns the semantic analysis and conversation.",
+                "This is NOT a scheduler and NOT a routine host-loop / worker-loop recovery diagnostic — operational metadata/label/queue recovery stays in the existing operational surfaces (`automation reconcile`, `automation publish-recovery`, `automation host-review-diagnostics`, `review closeout-plan`).",
+                "intent-cli does not make semantic product-direction decisions; it owns deterministic guidance, discovery, artifact locations, report shape, and mutation boundaries."
+            },
+            InspectionChecklist = new[]
+            {
+                $"Mission / Vision / Values and product goal — read `intents/{domainToken}/` MVV and product-goal artifacts; restate them in your own words and check recent work against them.",
+                $"ADR / design notes — review architecture decision records and design notes for decisions recent work may have silently violated or superseded.",
+                $"Intent tree structure — inspect `intents/{domainToken}/intent-tree/` for coherence: are new slices hanging off the right parent intents, or accreting as ad-hoc leaves?",
+                $"Recent packet history — review the last several execution-unit packets (`.intent-cli/issues/<unit>/`) for theme: are they advancing intents or repeatedly patching the same surface?",
+                $"Clarification history — review `intents/{domainToken}/clarifications/` for unresolved or repeatedly-reopened questions that signal an unsettled intent.",
+                "Short-term loop signals — look for repeated corrective packets on the same area, fixes that re-fix prior fixes, or automation that advanced while the underlying intent stayed ambiguous.",
+                "Intent strengthening opportunities — where an intent is implied by the work but never written down, note it as a candidate to make explicit."
+            },
+            ReportTemplate = new[]
+            {
+                "## Design-thread improve report",
+                "- domain: <domain>",
+                "- reviewed artifacts: <MVV / ADRs / intent-tree paths / packet units / clarification ids actually read>",
+                "## Alignment findings",
+                "- <finding> — <which MVV/ADR/intent it supports or contradicts, with the artifact path/clause cited>",
+                "## Short-term-loop signals",
+                "- <repeated-pattern observed, with the packet units / PRs that evidence it, or 'none observed'>",
+                "## Recommended outcome",
+                "- outcome: <one of the outcome classifications>",
+                "- rationale: <why, tied to the cited artifacts>",
+                "## Proposed next steps (propose first — apply only after operator agreement)",
+                "- <intent-strengthening edit / clarification to open / corrective packet to draft / ADR update>, each via a supported intent-cli or repo path"
+            },
+            OutcomeClassifications = new[]
+            {
+                new GuideImproveOutcome { Id = OutcomeAligned, Meaning = "Recent work aligns with MVV / ADRs / intent tree; no realignment action needed beyond recording the check." },
+                new GuideImproveOutcome { Id = OutcomeIntentStrengthening, Meaning = "An intent implied by recent work is not yet written down; propose making it explicit in the intent tree / specs." },
+                new GuideImproveOutcome { Id = OutcomeClarification, Meaning = "An ambiguous source-of-truth surfaced; propose opening a Hard Clarification via `intent-cli clarification` rather than guessing." },
+                new GuideImproveOutcome { Id = OutcomeCorrectivePacket, Meaning = "Recent work drifted from intent in a way that needs a corrective execution unit; propose drafting a packet through the normal next-slice/packet path." },
+                new GuideImproveOutcome { Id = OutcomeAdrUpdate, Meaning = "An architecture decision was superseded or violated; propose updating the ADR / design notes." },
+                new GuideImproveOutcome { Id = OutcomeShortTermLoop, Meaning = "A short-term local-fix loop is detected (repeated patches on the same surface); surface it so the operator can decide whether to invest in the underlying intent." },
+                new GuideImproveOutcome { Id = OutcomeOperatorPolicy, Meaning = "A product-direction or policy decision is required that only the operator can make; surface it as an operator decision, do not decide it in intent-cli or the agent." }
+            },
+            MutationBoundary = new[]
+            {
+                "Propose mutations first; apply them only after explicit operator agreement, and only through supported intent-cli / repo paths.",
+                "Intent strengthening / ADR updates land as ordinary repo edits the operator accepts; clarifications go through `intent-cli clarification`; corrective work goes through the normal packet / next-slice path.",
+                "Never hand-edit workflow labels, queue-state, or publish metadata from this process — that repair stays routed through the existing operational intent-cli surfaces."
+            }
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideImproveResult result)
+    {
+        writer.WriteLine("# Guide improve — design-thread realignment process");
+        writer.WriteLine();
+        writer.WriteLine($"_Run it by asking:_ **{result.ShortPrompt}**");
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+        writer.WriteLine();
+
+        writer.WriteLine("## What this is NOT");
+        foreach (var item in result.NotThis)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Inspection checklist");
+        foreach (var item in result.InspectionChecklist)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Structured report template");
+        writer.WriteLine();
+        foreach (var line in result.ReportTemplate)
+        {
+            writer.WriteLine(line);
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Outcome classifications");
+        foreach (var outcome in result.OutcomeClassifications)
+        {
+            writer.WriteLine($"- `{outcome.Id}` — {outcome.Meaning}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Mutation boundary");
+        foreach (var item in result.MutationBoundary)
+        {
+            writer.WriteLine($"- {item}");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string? domain, out string format, out string error)
+    {
+        domain = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide improve");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only design-thread improve / realignment process: review MVV, ADR/design notes, intent tree, packet history, and clarification history for drift and short-term loops. Run it by asking: " + ShortPrompt);
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}
+
+internal sealed record GuideImproveResult
+{
+    [JsonPropertyName("process")]
+    public required string Process { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("short_prompt")]
+    public required string ShortPrompt { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("not_this")]
+    public required IReadOnlyList<string> NotThis { get; init; }
+
+    [JsonPropertyName("inspection_checklist")]
+    public required IReadOnlyList<string> InspectionChecklist { get; init; }
+
+    [JsonPropertyName("report_template")]
+    public required IReadOnlyList<string> ReportTemplate { get; init; }
+
+    [JsonPropertyName("outcome_classifications")]
+    public required IReadOnlyList<GuideImproveOutcome> OutcomeClassifications { get; init; }
+
+    [JsonPropertyName("mutation_boundary")]
+    public required IReadOnlyList<string> MutationBoundary { get; init; }
+}
+
+internal sealed record GuideImproveOutcome
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("meaning")]
+    public required string Meaning { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -135,6 +135,8 @@ internal static class Program
                 || string.Equals(args[1], "rules", StringComparison.Ordinal)
                 || string.Equals(args[1], "workflow", StringComparison.Ordinal)
                 || string.Equals(args[1], "model", StringComparison.Ordinal)
+                // G456: design-thread improve / realignment guidance — read-only, no host state required.
+                || string.Equals(args[1], "improve", StringComparison.Ordinal)
                 || string.Equals(args[1], "commands", StringComparison.Ordinal)
                 || string.Equals(args[1], "onboarding", StringComparison.Ordinal)
                 || string.Equals(args[1], "prompt-matrix", StringComparison.Ordinal)

--- a/tests/IntentSystem.Cli.Tests/GuideImproveCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideImproveCommandTests.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G456: tests for the design-thread improve / realignment guide surface.
+/// </summary>
+public sealed class GuideImproveCommandTests
+{
+    [Fact]
+    public void Execute_DefaultMarkdown_EmitsShortPromptAndSections()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideImproveCommand.Execute(CreateContext(), [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide improve", output, StringComparison.Ordinal);
+        // AC: the short natural-language prompt is present verbatim.
+        Assert.Contains("intent-cli で improve プロセスを実行してください。", output, StringComparison.Ordinal);
+        // AC: states it is a reflection process, not a scheduler/provider/loop-recovery.
+        Assert.Contains("5m/20m schedule", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("NOT a scheduler", output, StringComparison.Ordinal);
+        Assert.Contains("does NOT launch", output, StringComparison.Ordinal);
+        // AC: inspection of MVV / ADR / intent tree / packet history / clarification / loops.
+        Assert.Contains("Mission / Vision / Values", output, StringComparison.Ordinal);
+        Assert.Contains("ADR", output, StringComparison.Ordinal);
+        Assert.Contains("Intent tree", output, StringComparison.Ordinal);
+        Assert.Contains("packet history", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Clarification history", output, StringComparison.Ordinal);
+        Assert.Contains("Short-term loop", output, StringComparison.Ordinal);
+        // AC: structured report template + mutation boundary.
+        Assert.Contains("Structured report template", output, StringComparison.Ordinal);
+        Assert.Contains("Mutation boundary", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_EmitsOutcomeClassificationsAndShortPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideImproveCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("design-thread-improve", root.GetProperty("process").GetString());
+        Assert.Equal("intent-cli で improve プロセスを実行してください。", root.GetProperty("short_prompt").GetString());
+
+        var outcomes = root.GetProperty("outcome_classifications").EnumerateArray()
+            .Select(o => o.GetProperty("id").GetString()).ToArray();
+        Assert.Equal(
+            new[]
+            {
+                "aligned",
+                "intent-strengthening-recommended",
+                "clarification-recommended",
+                "corrective-packet-recommended",
+                "adr-update-recommended",
+                "short-term-loop-detected",
+                "operator-policy-required",
+            },
+            outcomes);
+
+        // Mutation boundary keeps metadata/label/queue repair in operational surfaces.
+        var boundary = root.GetProperty("mutation_boundary").EnumerateArray()
+            .Select(e => e.GetString()!).ToArray();
+        Assert.Contains(boundary, b => b.Contains("Never hand-edit workflow labels", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_WithDomain_SubstitutesDomainInChecklistPaths()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideImproveCommand.Execute(CreateContext(), ["--domain", "aic", "--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("aic", root.GetProperty("domain").GetString());
+        var checklist = root.GetProperty("inspection_checklist").EnumerateArray()
+            .Select(e => e.GetString()!).ToArray();
+        Assert.Contains(checklist, c => c.Contains("intents/aic/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_UnknownFormat_ReturnsError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideImproveCommand.Execute(CreateContext(), ["--format", "yaml"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsageWithShortPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideImproveCommand.Execute(CreateContext(), ["--help"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("guide improve", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli で improve プロセスを実行してください。", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideHelp_ListsImproveSubcommand_ForDiscoverability()
+    {
+        // AC: improve is discoverable from the guide help surface.
+        using var writer = new StringWriter();
+        var exitCode = GuideHelpCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var names = doc.RootElement.GetProperty("subcommands").EnumerateArray()
+            .Select(s => s.GetProperty("name").GetString()).ToArray();
+        Assert.Contains("improve", names);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Implements **G456** (#1013): add a discoverable `intent-cli guide improve --domain <domain> --format markdown|json` design-thread reflection/realignment process. A design-thread AI agent runs it periodically to review MVV, ADR/design notes, intent tree, packet history, and clarification history for drift, short-term loops, and intent-strengthening opportunities — reusing accumulated intent artifacts instead of letting fast issue/PR automation drift into short-term local fixes.

The intended UX is a single natural-language ask:

```text
intent-cli で improve プロセスを実行してください。
```

## What changed

- **`GuideImproveCommand`** (new, read-only, markdown+json):
  - Carries the short prompt verbatim.
  - States explicitly it is a **design-thread reflection process — NOT** a scheduler, provider launcher, or routine host-loop/worker-loop recovery diagnostic.
  - Inspection checklist: MVV / product goal, ADR/design notes, intent tree, recent packet history, clarification history, short-term-loop signals, intent-strengthening opportunities.
  - Structured report template + outcome classifications: `aligned`, `intent-strengthening-recommended`, `clarification-recommended`, `corrective-packet-recommended`, `adr-update-recommended`, `short-term-loop-detected`, `operator-policy-required`.
  - Mutation boundary: propose first, apply only after operator agreement via supported intent-cli/repo paths; label/queue/metadata repair stays in existing operational surfaces.
- Registered in `CommandRouter` guide dispatch, `Program` guide-oneshot bootstrap allow-list (runs from a child cwd with no `.intent-cli/`), and `GuideHelpCommand` subcommand catalog (**discoverability**).
- Docs: design-thread improve section added to `docs/en/08-command-reference.md` and `docs/ja/08-command-reference.md`.

## Acceptance criteria coverage

- ✅ `guide improve --domain <domain> --format markdown` discoverable (CommandRouter + bootstrap + guide help)
- ✅ Help / guide-help discovery surface mentions improve
- ✅ Output includes the short prompt verbatim
- ✅ Output states it is a reflection process, not scheduler/provider/loop-recovery
- ✅ Output instructs inspection of MVV/ADR/intent-tree/packet-history/clarification/short-term-loop
- ✅ Structured report template + outcome classifications
- ✅ Docs mention improve as a natural-language request
- ✅ Metadata/label/queue repair stays routed through existing operational surfaces

## Verification

- New `GuideImproveCommandTests` (markdown sections, JSON outcome classifications, `--domain` substitution, `--help`, error path, guide-help discoverability).
- Full `IntentSystem.Cli.Tests` suite: 2951 passed, 0 failed.
- `git diff --check`: clean.

## Base Branch Policy

Implementation PR base: `main` for `J-Tech-Japan/intent-system` (direct-main).

Closes #1013

🤖 Generated with [Claude Code](https://claude.com/claude-code)