### PR TITLE
G457: make improve a first-class discoverable command and prevent recovery misrouting

### DIFF
--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -57,11 +57,20 @@ natural-language request and let the agent run the guide internally:
 intent-cli で improve プロセスを実行してください。
 ```
 
-The agent then fetches the current guidance and produces a structured report:
+The agent then fetches the current guidance and produces a structured report.
+`improve` is a first-class top-level command (with `guide improve` as the
+equivalent guide-namespaced form):
 
 ```bash
+intent-cli improve --domain <domain> --format markdown
 intent-cli guide improve --domain <domain> --format markdown
 ```
+
+Both forms return identical guidance and are discoverable via `intent-cli
+--help` and `intent-cli guide commands list`. If the installed CLI has no
+`improve` surface, report `improve guidance unavailable` and update the CLI —
+do **not** substitute `bug-to-intent-repair`, host-loop recovery,
+`state-doctor`, or dirty-state repair.
 
 `guide improve` is a design-thread reflection process — **not** a scheduler, a
 provider launcher, or a routine host-loop / worker-loop recovery diagnostic.

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -56,11 +56,20 @@ values・ADR / design note・intent tree とまだ整合しているかを確認
 intent-cli で improve プロセスを実行してください。
 ```
 
-agent は現在のガイダンスを取得し、構造化レポートを生成します:
+agent は現在のガイダンスを取得し、構造化レポートを生成します。`improve` は
+first-class の top-level コマンドで、`guide improve` も同等の guide 名前空間形式
+です:
 
 ```bash
+intent-cli improve --domain <domain> --format markdown
 intent-cli guide improve --domain <domain> --format markdown
 ```
+
+両形式は同一のガイダンスを返し、`intent-cli --help` と
+`intent-cli guide commands list` から discoverable です。installed CLI に
+`improve` サーフェスが無い場合は `improve guidance unavailable` を報告して CLI を
+更新します。`bug-to-intent-repair`・host-loop recovery・`state-doctor`・
+dirty-state repair で**代替しない**でください。
 
 `guide improve` はデザインスレッドのリフレクション工程であり、スケジューラでも
 provider 起動でも、host-loop / worker-loop の通常の復旧診断でもありません。

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -333,6 +333,21 @@ internal static class CommandRouter
             return TaskCommand.Execute(context, args[1..], writer);
         }
 
+        // G457: top-level `intent-cli improve` alias for the design-thread
+        // improve / realignment process. Without a first-class top-level
+        // surface, an agent given the short request "intent-cli で improve
+        // プロセスを実行してください" searches the CLI, fails to find an
+        // obvious improve command, and misroutes to bug-to-intent-repair /
+        // host-loop recovery / state-doctor. `improve` takes only flags
+        // (`--domain` / `--format` / `--help`), so it is intercepted here
+        // before group/subcommand dispatch (which would treat `--domain` as
+        // a subcommand) and delegated verbatim to the same guidance surface
+        // as `guide improve`.
+        if (string.Equals(args[0], "improve", StringComparison.Ordinal))
+        {
+            return GuideImproveCommand.Execute(context, args[1..], writer);
+        }
+
         // G334: per-group help routing. `intent-cli <group> --help` and
         // `intent-cli <group> help` must reach a useful surface before
         // we fall through to "group and subcommand required" / "not
@@ -559,7 +574,8 @@ internal static class CommandRouter
         "bug repair — `intent-cli guide worker pr-comment-fix --format json` (narrow PR-comment repair guidance).",
         "implementation-loop — `intent-cli guide workflow task implementation-loop --target-repo <r> --agent claude --frequency 5m --format markdown` (paste-ready child implementation-loop prompt with current label/claim/complete rules, G338).",
         "review-next-slice-loop — `intent-cli guide workflow task review-next-slice-loop --domain <d> --target-repo <r> --agent claude --frequency 20m --format markdown` (paste-ready host review / next-slice-loop prompt with current host-sync preflight + packet/issue lifecycle rules, G338).",
-        "bug-to-intent-repair — `intent-cli guide workflow task bug-to-intent-repair --format json` (report → triage → plan → intent-repair → implementation-repair chain; classifies implementation-mismatch / intent-gap / packet-gap / rule-gap / metadata-workflow-gap; recommends packet creation when the bug is in intent-cli rules/guidance, G339)."
+        "bug-to-intent-repair — `intent-cli guide workflow task bug-to-intent-repair --format json` (report → triage → plan → intent-repair → implementation-repair chain; classifies implementation-mismatch / intent-gap / packet-gap / rule-gap / metadata-workflow-gap; recommends packet creation when the bug is in intent-cli rules/guidance, G339).",
+        "improve (design-thread reflection) — `intent-cli improve --domain <d> --format markdown` (alias of `intent-cli guide improve`): periodic MVV / ADR / intent-tree / packet-history / clarification-history realignment review, G456/G457. NOT bug-to-intent-repair, host-loop recovery, state-doctor, or dirty-state repair."
     };
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -42,6 +42,14 @@ internal static class GuideCommandsListCommand
         },
         new CommandGroupEntry
         {
+            Name = "improve",
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Design-thread improve / realignment process (G456/G457): `intent-cli improve --domain <d>` (alias of `guide improve`) returns the periodic MVV / ADR / intent-tree / packet-history / clarification-history reflection review. A design-thread reflection process — NOT bug-to-intent-repair, host-loop recovery, state-doctor, dirty-state repair, or any operational diagnostic."
+        },
+        new CommandGroupEntry
+        {
             Name = "intent",
             Classification = ClassificationPrimary,
             Mutability = MutabilityMixed,

--- a/src/IntentSystem.Cli/Commands/GuideImproveCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideImproveCommand.cs
@@ -96,6 +96,14 @@ internal static class GuideImproveCommand
                 "This is NOT a scheduler and NOT a routine host-loop / worker-loop recovery diagnostic — operational metadata/label/queue recovery stays in the existing operational surfaces (`automation reconcile`, `automation publish-recovery`, `automation host-review-diagnostics`, `review closeout-plan`).",
                 "intent-cli does not make semantic product-direction decisions; it owns deterministic guidance, discovery, artifact locations, report shape, and mutation boundaries."
             },
+            DoNotSubstitute = new[]
+            {
+                "When the operator asks to run the improve process, run `intent-cli improve` (or `intent-cli guide improve`) — do NOT substitute an operational recovery workflow.",
+                "Do NOT route improve to `guide workflow task bug-to-intent-repair` — that is a bug → triage → intent/implementation-repair chain, not a design-thread realignment review.",
+                "Do NOT route improve to host-loop recovery (`automation host-loop-wake` / `automation host-review-diagnostics` / `automation reconcile`) — those advance or repair the operational queue, not the intent alignment.",
+                "Do NOT route improve to `automation state-doctor` or any dirty-state / workspace repair — improve never inspects or repairs queue-state, labels, or publish metadata.",
+                "If a first-class improve surface is not found in the installed CLI (e.g. `intent-cli improve --help` fails), report `improve guidance unavailable` and request a CLI update — do NOT silently choose another workflow."
+            },
             InspectionChecklist = new[]
             {
                 $"Mission / Vision / Values and product goal — read `intents/{domainToken}/` MVV and product-goal artifacts; restate them in your own words and check recent work against them.",
@@ -151,6 +159,13 @@ internal static class GuideImproveCommand
 
         writer.WriteLine("## What this is NOT");
         foreach (var item in result.NotThis)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Do not substitute another workflow");
+        foreach (var item in result.DoNotSubstitute)
         {
             writer.WriteLine($"- {item}");
         }
@@ -265,6 +280,9 @@ internal sealed record GuideImproveResult
 
     [JsonPropertyName("not_this")]
     public required IReadOnlyList<string> NotThis { get; init; }
+
+    [JsonPropertyName("do_not_substitute")]
+    public required IReadOnlyList<string> DoNotSubstitute { get; init; }
 
     [JsonPropertyName("inspection_checklist")]
     public required IReadOnlyList<string> InspectionChecklist { get; init; }

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -41,6 +41,7 @@ internal static class Program
             if (IsIntentInitCommand(args)
                 || IsAutomationWorktreeCommand(args)
                 || IsGuideOneshotCommand(args)
+                || IsImproveCommand(args)
                 || IsWorkerCommand(args)
                 || IsHelpCommand(args))
             {
@@ -160,6 +161,21 @@ internal static class Program
                 || string.Equals(args[1], "--help", StringComparison.Ordinal)
                 // G438: external artifact intake guidance — read-only, no host state required.
                 || string.Equals(args[1], "artifact-intake", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// G457: the top-level <c>intent-cli improve</c> alias is a read-only
+    /// design-thread reflection surface (delegates to
+    /// <c>GuideImproveCommand</c>). Like the <c>guide improve</c> form it
+    /// emits Markdown / JSON without touching parent durable state, so it
+    /// must bootstrap from any cwd — including a child implementation repo
+    /// with no <c>.intent-cli/</c> directory — rather than failing the
+    /// host-state gate and pushing the agent toward an operational recovery
+    /// command instead.
+    /// </summary>
+    private static bool IsImproveCommand(string[] args)
+    {
+        return args.Length >= 1 && string.Equals(args[0], "improve", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -51,6 +51,48 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_TopLevelImprove_DelegatesToGuideImprove_DesignThreadProcess()
+    {
+        // G457: `intent-cli improve` is a first-class top-level alias that
+        // delegates to the same design-thread guidance as `guide improve`.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["improve", "--domain", "intent-cli", "--format", "json"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        Assert.Equal("design-thread-improve", doc.RootElement.GetProperty("process").GetString());
+    }
+
+    [Fact]
+    public void Execute_TopLevelImproveHelp_ReachesImproveHelpSurface()
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["improve", "--help"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("guide improve", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DefaultHelp_ExposesImprovePointer()
+    {
+        // G457: improve is discoverable from `intent-cli --help`.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(Array.Empty<string>(), CreateContext("/tmp/intent-system"), writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("improve", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli improve", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenHelpAll_ListsEveryCommandGroup_AndGenerateFromCurrent()
     {
         // G379: `intent-cli --help --all` restores the full group catalog,

--- a/tests/IntentSystem.Cli.Tests/GuideImproveCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideImproveCommandTests.cs
@@ -121,6 +121,26 @@ public sealed class GuideImproveCommandTests
         Assert.Contains("improve", names);
     }
 
+    [Fact]
+    public void Execute_Json_EmitsDoNotSubstituteAntiMisroutingGuidance()
+    {
+        // G457: improve output must explicitly tell agents not to substitute
+        // operational recovery workflows.
+        using var writer = new StringWriter();
+        var exitCode = GuideImproveCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var doNotSubstitute = doc.RootElement.GetProperty("do_not_substitute").EnumerateArray()
+            .Select(e => e.GetString()!).ToArray();
+        Assert.Contains(doNotSubstitute, s => s.Contains("bug-to-intent-repair", StringComparison.Ordinal));
+        Assert.Contains(doNotSubstitute, s => s.Contains("host-loop", StringComparison.Ordinal));
+        Assert.Contains(doNotSubstitute, s => s.Contains("state-doctor", StringComparison.Ordinal));
+        Assert.Contains(doNotSubstitute, s => s.Contains("dirty-state", StringComparison.Ordinal));
+        // AC: missing improve surfaces `improve guidance unavailable`.
+        Assert.Contains(doNotSubstitute, s => s.Contains("improve guidance unavailable", StringComparison.Ordinal));
+    }
+
     private static CliContext CreateContext()
     {
         return new CliContext


### PR DESCRIPTION
## Summary

Implements **G457** (#1016): make `improve` a first-class discoverable command so an agent given the short request `intent-cli で improve プロセスを実行してください。` reliably runs the design-thread improve process instead of misrouting to `bug-to-intent-repair`, host-loop recovery, or `state-doctor`.

G456 added `intent-cli guide improve`; this slice adds the top-level surface, discoverability, and an explicit anti-misrouting contract.

## What changed

- **Top-level `intent-cli improve --domain <d> --format markdown`** alias in `CommandRouter` (intercepted before group/subcommand dispatch because it takes only flags), delegating to the same guidance as `guide improve`. `intent-cli improve --help` reaches the improve help surface.
- **Program bootstrap allow-list** (`IsImproveCommand`) — runs read-only from any cwd, including a child repo with no `.intent-cli/`.
- **Discoverability**: improve pointer in `intent-cli --help` (`WorkflowGuidePointersHelp`) and a top-level `improve` entry in `intent-cli guide commands list`.
- **Anti-misrouting** (`GuideImproveResult.do_not_substitute`): explicitly tells agents NOT to substitute `bug-to-intent-repair`, host-loop recovery, `state-doctor`, or dirty-state repair, and to report **`improve guidance unavailable`** (not silently choose another workflow) when the surface is missing.
- **Docs**: top-level alias + anti-misrouting + unavailable contract in `docs/en` and `docs/ja` command references.

## Acceptance criteria coverage

- ✅ `intent-cli improve --domain <d> --format markdown` succeeds (read-only alias)
- ✅ `intent-cli guide improve --domain <d> --format markdown` succeeds (unchanged, parity)
- ✅ Both outputs carry MVV / ADR / intent-tree / packet-history / clarification-history / drift / short-term-loop / intent-strengthening / corrective-packet axes
- ✅ `intent-cli --help` exposes improve
- ✅ `intent-cli guide commands list` exposes improve
- ✅ Prompt/workflow discovery exposes improve as a design-thread reflection pointer (top-level `--help` pointer)
- ✅ Output explicitly says not to substitute bug-to-intent-repair / host-loop recovery / state-doctor / dirty-state repair / operational diagnostics
- ✅ Missing improve surfaces `improve guidance unavailable` rather than silently choosing another workflow

## Verification

- New tests: top-level routing (`CommandRouterTests`), `--help` + commands-list discovery, `do_not_substitute` anti-misrouting (`GuideImproveCommandTests`).
- Full `IntentSystem.Cli.Tests` suite: 2955 passed, 0 failed (1 skipped). Note: this suite has a pre-existing parallel-execution flake where a test that deletes the process cwd can cascade `Interop.Sys.GetCwd` FileNotFound failures into unrelated tests; a clean serial/retry run is green and unrelated to this change.
- `git diff --check`: clean.

## Base Branch Policy

Implementation PR base: `main` for `J-Tech-Japan/intent-system` (direct-main).

Closes #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)