### PR TITLE
G462: prevent host-only packets from being published as child implementation issues

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
@@ -19,6 +19,16 @@ internal static class AutomationIssuePublishCommand
 
     public static Func<bool>? NestedProviderLauncher { get; set; }
 
+    /// <summary>
+    /// G462: test seam / optional issue-body source for the host-only publish
+    /// gate. When set (or in production, the default <c>gh</c>-backed lookup),
+    /// the command reads the issue body before applying <c>intent-target</c> and
+    /// refuses to publish a host-only packet (all target paths host-owned) as a
+    /// child implementation issue unless <c>--allow-host-only-override</c> is
+    /// passed. Tests inject a fake to avoid touching GitHub.
+    /// </summary>
+    public static Func<IGitHubIssueLookup>? IssueLookupFactory { get; set; }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
@@ -44,6 +54,7 @@ internal static class AutomationIssuePublishCommand
                 out var issue,
                 out var mode,
                 out var format,
+                out var allowHostOnlyOverride,
                 out var error))
         {
             writer.WriteLine(error);
@@ -89,6 +100,58 @@ internal static class AutomationIssuePublishCommand
             return 1;
         }
 
+        // G462: host-only publish gate. Read the issue body and refuse to
+        // publish a host-only packet (every declared target path is host-owned:
+        // intents/**, .intent-cli/**) as a child intent-target issue, unless the
+        // operator explicitly overrides. This stops the G458 / issue #1018
+        // mis-routing class at the publish boundary. The body fetch is fail-soft:
+        // a lookup error simply skips the gate (the existing behavior).
+        HostOnlyPacketVerdict? hostOnlyVerdict = null;
+        try
+        {
+            var lookup = IssueLookupFactory?.Invoke() ?? new GhCliGitHubIssueLookup();
+            var issuePayload = lookup.Lookup(repo!, issue!.Value);
+            hostOnlyVerdict = HostOnlyPacketClassifier.Classify(issuePayload.Body);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            hostOnlyVerdict = null;
+        }
+
+        if (hostOnlyVerdict is { IsHostOnly: true } && !allowHostOnlyOverride)
+        {
+            var refusal = new AutomationIssuePublishResult
+            {
+                Repo = repo!,
+                Issue = issue!.Value,
+                IssueUrl = BuildIssueUrl(repo!, issue.Value),
+                Mode = mode,
+                Applied = false,
+                Refused = true,
+                RefusalReason = "host-only packet: every declared target path is host/design-owned ("
+                    + string.Join(", ", hostOnlyVerdict.HostOwnedPaths)
+                    + "); a GitHub-contract-only child loop cannot edit host metadata, so this packet must not be published as a child intent-target issue. Retarget it to child-owned paths (src/**, tests/**, docs/**, README.md) or keep it in the host/design workflow. Pass --allow-host-only-override only if intent-target is genuinely intended here.",
+                AppliedLabel = AppliedLabel,
+                AddLabels = Array.Empty<string>(),
+                RemoveLabels = Array.Empty<string>(),
+                CurrentLabels = currentLabels,
+                PublishedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
+                Summary = $"Refused to publish issue #{issue.Value}: host-only packet (host-owned target paths only).",
+            };
+
+            if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+            {
+                writer.WriteLine(JsonSerializer.Serialize(refusal, JsonOptions));
+            }
+            else
+            {
+                writer.WriteLine(refusal.Summary);
+                writer.WriteLine($"refusal_reason: {refusal.RefusalReason}");
+            }
+
+            return 1;
+        }
+
         var applied = false;
         var publishedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow)
             .ToUniversalTime();
@@ -121,6 +184,8 @@ internal static class AutomationIssuePublishCommand
             IssueUrl = BuildIssueUrl(repo!, issue.Value),
             Mode = mode,
             Applied = applied,
+            Refused = false,
+            RefusalReason = null,
             AppliedLabel = AppliedLabel,
             AddLabels = [AppliedLabel],
             RemoveLabels = Array.Empty<string>(),
@@ -148,6 +213,7 @@ internal static class AutomationIssuePublishCommand
         out int? issue,
         out string mode,
         out string format,
+        out bool allowHostOnlyOverride,
         out string error)
     {
         repo = null;
@@ -155,6 +221,7 @@ internal static class AutomationIssuePublishCommand
         issue = null;
         mode = WorkerClaimCompleteConstants.Modes.DryRun;
         format = FormatText;
+        allowHostOnlyOverride = false;
         error = string.Empty;
 
         for (var index = 0; index < args.Length; index++)
@@ -197,6 +264,10 @@ internal static class AutomationIssuePublishCommand
 
                 case "--dry-run":
                     mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    break;
+
+                case "--allow-host-only-override":
+                    allowHostOnlyOverride = true;
                     break;
 
                 case "--format":
@@ -312,6 +383,13 @@ internal sealed record AutomationIssuePublishResult
 
     [JsonPropertyName("applied")]
     public required bool Applied { get; init; }
+
+    /// <summary>G462: true when publishing was refused because the issue is a host-only packet.</summary>
+    [JsonPropertyName("refused")]
+    public bool Refused { get; init; }
+
+    [JsonPropertyName("refusal_reason")]
+    public string? RefusalReason { get; init; }
 
     [JsonPropertyName("applied_label")]
     public required string AppliedLabel { get; init; }

--- a/src/IntentSystem.Cli/Commands/AutomationIssueReleaseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueReleaseCommand.cs
@@ -1,0 +1,308 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G462: host-owned issue RELEASE transition — the safe counterpart to
+/// <see cref="AutomationIssuePublishCommand"/>. Removes <c>intent-target</c>
+/// from an issue that was mistakenly published as a child implementation target
+/// (e.g. a host-only packet, the G458 / issue #1018 regression), and records
+/// why, WITHOUT raw <c>gh ... edit --remove-label</c>. Dry-run by default; with
+/// explicit <c>--write</c>, removes <c>intent-target</c> via the installed label
+/// mutator. Never adds labels, never edits parent durable state, never launches
+/// an AI provider.
+/// </summary>
+internal static class AutomationIssueReleaseCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+    private const string ReleasedLabel = WorkerNextActionConstants.Labels.IntentTarget;
+
+    public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
+
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(
+                args,
+                out var repo,
+                out var workdir,
+                out var issue,
+                out var reason,
+                out var mode,
+                out var format,
+                out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        if (string.IsNullOrWhiteSpace(repo)
+            && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubLabelMutator mutator;
+        try
+        {
+            mutator = MutatorFactory?.Invoke() ?? new GhCliGitHubLabelMutator();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub mutator: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<string> currentLabels;
+        try
+        {
+            currentLabels = mutator
+                .ReadLabels(repo!, GhCliGitHubLabelMutator.Kinds.Issue, issue!.Value)
+                .Select(label => label.Name)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .ToArray();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to read current labels for issue #{issue} in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var hasTarget = currentLabels.Contains(ReleasedLabel, StringComparer.Ordinal);
+        var applied = false;
+        var releasedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+
+        if (string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal) && hasTarget)
+        {
+            try
+            {
+                mutator.ApplyLabelTransitions(
+                    repo!,
+                    GhCliGitHubLabelMutator.Kinds.Issue,
+                    issue!.Value,
+                    Array.Empty<string>(),
+                    [ReleasedLabel]);
+                applied = true;
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or IOException)
+            {
+                writer.WriteLine($"failed to apply issue release transition on issue #{issue} in {repo}: {exception.Message}");
+                return 1;
+            }
+        }
+
+        var result = new AutomationIssueReleaseResult
+        {
+            Repo = repo!,
+            Issue = issue!.Value,
+            IssueUrl = BuildIssueUrl(repo!, issue.Value),
+            Mode = mode,
+            Applied = applied,
+            ReleasedLabel = ReleasedLabel,
+            HadTargetLabel = hasTarget,
+            Reason = reason,
+            AddLabels = Array.Empty<string>(),
+            RemoveLabels = [ReleasedLabel],
+            CurrentLabels = currentLabels,
+            ReleasedAt = releasedAt,
+            Summary = hasTarget
+                ? $"Would release issue #{issue.Value} by removing {ReleasedLabel}"
+                    + (string.IsNullOrWhiteSpace(reason) ? "." : $" (reason: {reason}).")
+                : $"Issue #{issue.Value} does not carry {ReleasedLabel}; nothing to release.",
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out string? workdir,
+        out int? issue,
+        out string? reason,
+        out string mode,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        workdir = null;
+        issue = null;
+        reason = null;
+        mode = WorkerClaimCompleteConstants.Modes.DryRun;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { error = "--repo requires a value (e.g. owner/repo)."; return false; }
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--workdir":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { error = "--workdir requires a value."; return false; }
+                    workdir = args[index + 1];
+                    index++;
+                    break;
+                case "--issue":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var issueNumber)
+                        || issueNumber <= 0)
+                    {
+                        error = "--issue requires a positive integer.";
+                        return false;
+                    }
+                    issue = issueNumber;
+                    index++;
+                    break;
+                case "--reason":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { error = "--reason requires a value."; return false; }
+                    reason = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--write":
+                    mode = WorkerClaimCompleteConstants.Modes.Write;
+                    break;
+                case "--dry-run":
+                    mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { error = "--format requires a value (text or json)."; return false; }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: [--repo <owner/repo>] [--workdir <path>] --issue <n> [--reason <text>] [--write] [--dry-run] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (issue is null)
+        {
+            error = "--issue is required.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string ResolveWorkdir(CliContext context, string? workdir)
+    {
+        if (string.IsNullOrWhiteSpace(workdir))
+        {
+            return context.RepoRoot;
+        }
+        return Path.IsPathRooted(workdir)
+            ? workdir
+            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
+    }
+
+    private static string BuildIssueUrl(string repo, int issue) =>
+        $"https://github.com/{repo}/issues/{issue.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+
+    private static void WriteText(TextWriter writer, AutomationIssueReleaseResult result)
+    {
+        writer.WriteLine(result.Summary);
+        writer.WriteLine($"mode: {result.Mode}");
+        writer.WriteLine($"repo: {result.Repo}");
+        writer.WriteLine($"issue: {result.Issue.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        writer.WriteLine($"issue_url: {result.IssueUrl}");
+        writer.WriteLine($"released_label: {result.ReleasedLabel}");
+        writer.WriteLine($"had_target_label: {result.HadTargetLabel.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"applied: {result.Applied.ToString().ToLowerInvariant()}");
+        if (!string.IsNullOrWhiteSpace(result.Reason))
+        {
+            writer.WriteLine($"reason: {result.Reason}");
+        }
+        writer.WriteLine($"released_at: {result.ReleasedAt:O}");
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("automation issue-release");
+        writer.WriteLine("Usage: intent-cli automation issue-release --repo <owner/repo> --issue <n> [--reason <text>] [--write] [--dry-run] [--format text|json]");
+        writer.WriteLine("Releases an issue that was mistakenly published as a child target by removing the host-owned intent-target label (G462). The safe counterpart to automation issue-publish; never uses raw gh label mutation.");
+    }
+}
+
+internal sealed record AutomationIssueReleaseResult
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("issue")]
+    public required int Issue { get; init; }
+
+    [JsonPropertyName("issue_url")]
+    public required string IssueUrl { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("released_label")]
+    public required string ReleasedLabel { get; init; }
+
+    [JsonPropertyName("had_target_label")]
+    public required bool HadTargetLabel { get; init; }
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+
+    [JsonPropertyName("add_labels")]
+    public required IReadOnlyList<string> AddLabels { get; init; }
+
+    [JsonPropertyName("remove_labels")]
+    public required IReadOnlyList<string> RemoveLabels { get; init; }
+
+    [JsonPropertyName("current_labels")]
+    public required IReadOnlyList<string> CurrentLabels { get; init; }
+
+    [JsonPropertyName("released_at")]
+    public required DateTimeOffset ReleasedAt { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -176,6 +176,7 @@ internal static class CommandRouter
                 ["host-sync-preflight"] = AutomationHostSyncPreflightCommand.Execute,
                 ["intent-target-gap-recovery"] = AutomationIntentTargetGapRecoveryCommand.Execute,
                 ["issue-publish"] = AutomationIssuePublishCommand.Execute,
+                ["issue-release"] = AutomationIssueReleaseCommand.Execute,
                 ["label-palette-audit"] = AutomationLabelPaletteAuditCommand.Execute,
                 ["label-palette-sync"] = AutomationLabelPaletteSyncCommand.Execute,
                 ["pr-transition"] = AutomationPrTransitionCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/GuidanceProhibitions.cs
+++ b/src/IntentSystem.Cli/Commands/GuidanceProhibitions.cs
@@ -40,6 +40,7 @@ internal static class GuidanceProhibitionCatalog
     public const string ProviderLaunchForbidden = "provider-launch-forbidden";
     public const string IntentCliRunForbidden = "intent-cli-run-forbidden";
     public const string StaleMemoryFallbackForbidden = "stale-memory-fallback-forbidden";
+    public const string HostOnlyPacketChildPublishForbidden = "host-only-packet-child-publish-forbidden";
 
     /// <summary>
     /// G323: canonical prohibition list for setup contracts AND task
@@ -97,6 +98,11 @@ internal static class GuidanceProhibitionCatalog
         {
             Id = IntentCliRunForbidden,
             Description = "Do not call `intent-cli run` from chat-first loops; `run` is advanced runtime (integration smoke / replay / dogfooding) and is not part of the routine collaboration path."
+        },
+        new()
+        {
+            Id = HostOnlyPacketChildPublishForbidden,
+            Description = "Do not publish a host-only packet (all target paths host-owned: `intents/**`, `.intent-cli/**`) as a child `intent-target` issue; host/design packets stay in the host/design workflow unless retargeted to child-owned paths (`src/**`, `tests/**`, `docs/**`, `README.md`). If one was mis-published, release it via `intent-cli automation issue-release --write` (never raw `gh` label mutation)."
         }
     };
 }

--- a/src/IntentSystem.Cli/Commands/HostOnlyPacketClassifier.cs
+++ b/src/IntentSystem.Cli/Commands/HostOnlyPacketClassifier.cs
@@ -1,0 +1,183 @@
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G462: pure classifier that decides whether a packet / issue is
+/// <em>host-only</em> — i.e. its declared target paths point exclusively at
+/// host/design-owned metadata (<c>intents/**</c>, <c>.intent-cli/**</c>, and the
+/// host-owned root docs <c>AGENTS.md</c> / <c>CLAUDE.md</c>) with no
+/// child-owned implementation path (<c>src/**</c>, <c>tests/**</c>,
+/// <c>docs/**</c>, <c>README.md</c>, or any other target-repo source file).
+///
+/// The G458 / issue #1018 regression: a product-goal / intent-tree refresh
+/// packet targeting only <c>intents/intent-cli/**</c> was published as a child
+/// <c>intent-target</c> issue. The child implementation loop selected it every
+/// wake, but a GitHub-contract-only child repo cannot edit host-owned
+/// <c>intents/**</c> metadata, so every wake stopped with
+/// <c>host-artifact-repair-required</c> — and <c>worker issue-preflight</c>
+/// still classified it as <c>ready-to-implement</c>.
+///
+/// This classifier gives intent-cli a deterministic signal to (a) refuse
+/// publishing host-only packets as child issues, and (b) classify a
+/// host-only issue as non-actionable in <c>worker issue-preflight</c>.
+///
+/// Pure: no I/O, no GitHub, no process launch.
+/// </summary>
+internal static class HostOnlyPacketClassifier
+{
+    // Prefixes that identify host/design-owned metadata. Aligned with the
+    // host-path classification used by host-sync / durable-state preflight
+    // (intents/**, .intent-cli/**) plus the always-unsafe host root docs.
+    private static readonly string[] HostOwnedPrefixes =
+    {
+        "intents/",
+        ".intent-cli/",
+    };
+
+    private static readonly string[] HostOwnedExactPaths =
+    {
+        "agents.md",
+        "claude.md",
+    };
+
+    // Matches the `Target paths: ...` line in the issue body's
+    // `## Target Repo / Path / Part` section. Captures everything after the
+    // colon on that line. Tolerant of leading `-`/`*` bullets and backticks.
+    private static readonly Regex TargetPathsLineRegex = new(
+        @"(?im)^\s*[-*]?\s*Target\s*paths?\s*:\s*(?<paths>.+)$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// True when <paramref name="path"/> is a host/design-owned path the child
+    /// implementation loop must not edit.
+    /// </summary>
+    public static bool IsHostOwnedPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return false;
+        }
+
+        var normalized = path.Replace('\\', '/').Trim().Trim('`').TrimStart('/');
+        if (normalized.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var prefix in HostOwnedPrefixes)
+        {
+            if (normalized.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        foreach (var exact in HostOwnedExactPaths)
+        {
+            if (string.Equals(normalized, exact, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Split a `Target paths:` value into individual paths. Handles
+    /// comma-separated and/or whitespace-separated lists and strips surrounding
+    /// backticks/quotes.
+    /// </summary>
+    public static IReadOnlyList<string> SplitTargetPaths(string? targetPathsValue)
+    {
+        if (string.IsNullOrWhiteSpace(targetPathsValue))
+        {
+            return Array.Empty<string>();
+        }
+
+        return targetPathsValue
+            .Split(new[] { ',', ' ', '\t', '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries)
+            // Strip surrounding backticks/quotes only — NEVER trim '.', which
+            // would corrupt host-owned `.intent-cli/...` paths into `intent-cli/...`.
+            .Select(p => p.Trim().Trim('`', '"', '\''))
+            .Where(p => p.Length > 0)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Extract the `Target paths:` list from a packet / issue body's
+    /// `## Target Repo / Path / Part` section. Returns the individual paths in
+    /// document order (deduplicated, order-preserving). Empty when no
+    /// `Target paths:` line is present.
+    /// </summary>
+    public static IReadOnlyList<string> ExtractTargetPaths(string? body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return Array.Empty<string>();
+        }
+
+        var all = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (Match match in TargetPathsLineRegex.Matches(body))
+        {
+            foreach (var path in SplitTargetPaths(match.Groups["paths"].Value))
+            {
+                if (seen.Add(path))
+                {
+                    all.Add(path);
+                }
+            }
+        }
+
+        return all;
+    }
+
+    /// <summary>
+    /// Classify whether the supplied target paths are host-only: at least one
+    /// path is present AND every path is host-owned. Returns false when the set
+    /// is empty (no evidence) or when any child-owned path is present.
+    /// </summary>
+    public static bool AllPathsAreHostOwned(IReadOnlyList<string> paths)
+    {
+        ArgumentNullException.ThrowIfNull(paths);
+        var nonEmpty = paths.Where(p => !string.IsNullOrWhiteSpace(p)).ToArray();
+        return nonEmpty.Length > 0 && nonEmpty.All(IsHostOwnedPath);
+    }
+
+    /// <summary>
+    /// Convenience: parse a packet / issue body and decide if it is a host-only
+    /// packet (all declared target paths are host-owned). Returns a structured
+    /// verdict so callers can surface the offending paths.
+    /// </summary>
+    public static HostOnlyPacketVerdict Classify(string? body)
+    {
+        var paths = ExtractTargetPaths(body);
+        var hostOwned = paths.Where(IsHostOwnedPath).ToArray();
+        var childOwned = paths.Where(p => !IsHostOwnedPath(p)).ToArray();
+        var isHostOnly = paths.Count > 0 && childOwned.Length == 0;
+        return new HostOnlyPacketVerdict
+        {
+            IsHostOnly = isHostOnly,
+            TargetPaths = paths,
+            HostOwnedPaths = hostOwned,
+            ChildOwnedPaths = childOwned,
+        };
+    }
+}
+
+/// <summary>
+/// G462: structured result of <see cref="HostOnlyPacketClassifier.Classify"/>.
+/// </summary>
+internal sealed record HostOnlyPacketVerdict
+{
+    /// <summary>True when target paths are present and ALL are host-owned.</summary>
+    public required bool IsHostOnly { get; init; }
+
+    public required IReadOnlyList<string> TargetPaths { get; init; }
+
+    public required IReadOnlyList<string> HostOwnedPaths { get; init; }
+
+    public required IReadOnlyList<string> ChildOwnedPaths { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/WorkerIssuePreflightAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerIssuePreflightAnalyzer.cs
@@ -107,6 +107,37 @@ internal static class WorkerIssuePreflightAnalyzer
                 WorkerIssuePreflightConstants.RecommendedActions.DeclineWithSummary);
         }
 
+        // Step 4.5: host-only-packet (G462). The issue carries intent-target
+        // (passed step 4) but its declared `Target paths:` are exclusively
+        // host/design-owned (intents/**, .intent-cli/**). A GitHub-contract-only
+        // child loop must not edit host metadata, so this is NOT a child
+        // implementation issue — it must be released from the child target (or
+        // retargeted to child-owned paths) on the host/design side. Checked
+        // BEFORE target-mismatch so the more specific host-only signal wins over
+        // the generic mismatch heuristics. (G458 / issue #1018 regression.)
+        var hostOnlyVerdict = HostOnlyPacketClassifier.Classify(body);
+        if (hostOnlyVerdict.IsHostOnly)
+        {
+            return Build(
+                lookup,
+                repo,
+                issueNumber,
+                title,
+                state,
+                labels,
+                WorkerIssuePreflightConstants.Classifications.HostOnlyPacket,
+                new[]
+                {
+                    "issue is a host-only packet: every declared target path is host/design-owned ("
+                        + string.Join(", ", hostOnlyVerdict.HostOwnedPaths)
+                        + ") with no child-owned implementation path (src/**, tests/**, docs/**, README.md, ...).",
+                    "a GitHub-contract-only child loop must not edit host metadata (intents/**, .intent-cli/**); host/design packets stay in the host/design workflow unless retargeted to child-owned paths.",
+                    $"release this issue from the child target via `intent-cli automation issue-release --repo {repo} --issue {issueNumber} --write` (never raw gh label mutation), or retarget the packet to child-owned paths.",
+                },
+                actionable: false,
+                WorkerIssuePreflightConstants.RecommendedActions.ReleaseFromTarget);
+        }
+
         // Step 5: target-mismatch.
         var mismatchReasons = DetectTargetMismatch(body, repo, workdir);
         if (mismatchReasons.Count > 0)

--- a/src/IntentSystem.Cli/Commands/WorkerIssuePreflightResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerIssuePreflightResult.cs
@@ -70,6 +70,17 @@ internal static class WorkerIssuePreflightConstants
         public const string ContractIncomplete = "contract-incomplete";
         public const string TargetMismatch = "target-mismatch";
         public const string NonActionable = "non-actionable";
+
+        /// <summary>
+        /// G462: the issue carries <c>intent-target</c> but its declared target
+        /// paths are exclusively host/design-owned (<c>intents/**</c>,
+        /// <c>.intent-cli/**</c>). A GitHub-contract-only child loop cannot edit
+        /// host metadata, so the issue is NOT actionable as a child
+        /// implementation issue; it should be released from the child target
+        /// (or retargeted to child-owned paths) on the host/design side. This is
+        /// the G458 / issue #1018 regression class.
+        /// </summary>
+        public const string HostOnlyPacket = "host-only-packet";
     }
 
     public static class RecommendedActions
@@ -79,6 +90,14 @@ internal static class WorkerIssuePreflightConstants
         public const string WaitForClarification = "wait-for-clarification";
         public const string SwitchRepo = "switch-repo";
         public const string NoAction = "no-action";
+
+        /// <summary>
+        /// G462: release the mistakenly-targeted host-only issue from the child
+        /// target via <c>intent-cli automation issue-release --write</c> (never
+        /// raw <c>gh</c> label mutation), or retarget it to child-owned paths on
+        /// the host/design side.
+        /// </summary>
+        public const string ReleaseFromTarget = "release-from-target";
     }
 
     public static class Labels

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -101,6 +101,7 @@ internal static class Program
                 || string.Equals(args[1], "host-review-diagnostics", StringComparison.Ordinal)
                 || string.Equals(args[1], "host-sync-preflight", StringComparison.Ordinal)
                 || string.Equals(args[1], "issue-publish", StringComparison.Ordinal)
+                || string.Equals(args[1], "issue-release", StringComparison.Ordinal)
                 || string.Equals(args[1], "label-palette-audit", StringComparison.Ordinal)
                 || string.Equals(args[1], "label-palette-sync", StringComparison.Ordinal)
                 || string.Equals(args[1], "pr-transition", StringComparison.Ordinal)

--- a/tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
@@ -15,6 +15,10 @@ public sealed class AutomationIssuePublishCommandTests : IDisposable
         AutomationIssuePublishCommand.MutatorFactory = null;
         AutomationIssuePublishCommand.UtcNowFactory = () => FixedNow;
         AutomationIssuePublishCommand.NestedProviderLauncher = null;
+        // G462: default the host-only gate's issue-body lookup to a child-path
+        // fake so existing publish tests neither hit live `gh` nor get refused.
+        AutomationIssuePublishCommand.IssueLookupFactory =
+            () => new FakeIssueLookup("Target paths: `src/Foo`, `docs`, `README.md`");
     }
 
     public void Dispose()
@@ -22,6 +26,57 @@ public sealed class AutomationIssuePublishCommandTests : IDisposable
         AutomationIssuePublishCommand.MutatorFactory = null;
         AutomationIssuePublishCommand.UtcNowFactory = null;
         AutomationIssuePublishCommand.NestedProviderLauncher = null;
+        AutomationIssuePublishCommand.IssueLookupFactory = null;
+    }
+
+    [Fact]
+    public void Execute_HostOnlyPacket_RefusesPublish_NonZero()
+    {
+        // G462 / G458 regression: a packet whose target paths are all
+        // host-owned must NOT be published as a child intent-target issue.
+        using var workspace = new AutomationIssuePublishWorkspace();
+        var mutator = new FakeMutator();
+        AutomationIssuePublishCommand.MutatorFactory = () => mutator;
+        AutomationIssuePublishCommand.IssueLookupFactory = () => new FakeIssueLookup(
+            "Target paths: `intents/intent-cli/intent-tree/purpose/04-product-goal.md`, `.intent-cli/issues/G458`");
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1018", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssuePublishResult>(writer.ToString())!;
+        Assert.True(result.Refused);
+        Assert.False(result.Applied);
+        Assert.NotNull(result.RefusalReason);
+        Assert.Contains("host-only packet", result.RefusalReason!, StringComparison.Ordinal);
+        // The label was NEVER applied.
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_HostOnlyPacket_WithOverride_StillPublishes()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+        var mutator = new FakeMutator();
+        AutomationIssuePublishCommand.MutatorFactory = () => mutator;
+        AutomationIssuePublishCommand.IssueLookupFactory = () => new FakeIssueLookup(
+            "Target paths: `intents/intent-cli/x.md`");
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1018", "--write",
+             "--allow-host-only-override", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssuePublishResult>(writer.ToString())!;
+        Assert.False(result.Refused);
+        Assert.True(result.Applied);
+        Assert.Single(mutator.AppliedTransitions);
     }
 
     [Fact]
@@ -206,6 +261,14 @@ public sealed class AutomationIssuePublishCommandTests : IDisposable
 
         Assert.False(launcherInvoked,
             "AutomationIssuePublishCommand must never invoke NestedProviderLauncher.");
+    }
+
+    private sealed class FakeIssueLookup : IGitHubIssueLookup
+    {
+        private readonly string body;
+        public FakeIssueLookup(string body) => this.body = body;
+        public GitHubIssueLookupResult Lookup(string repo, int issueNumber) =>
+            new() { Number = issueNumber, State = "OPEN", Body = body };
     }
 
     private sealed class FakeMutator : IGitHubLabelMutator

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueReleaseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueReleaseCommandTests.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G462: tests for the safe issue RELEASE transition that removes
+/// <c>intent-target</c> from a mistakenly-targeted issue without raw gh label
+/// mutation.
+/// </summary>
+public sealed class AutomationIssueReleaseCommandTests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 6, 4, 19, 0, 0, TimeSpan.Zero);
+
+    public AutomationIssueReleaseCommandTests()
+    {
+        AutomationIssueReleaseCommand.MutatorFactory = null;
+        AutomationIssueReleaseCommand.UtcNowFactory = () => FixedNow;
+    }
+
+    public void Dispose()
+    {
+        AutomationIssueReleaseCommand.MutatorFactory = null;
+        AutomationIssueReleaseCommand.UtcNowFactory = null;
+    }
+
+    [Fact]
+    public void Execute_Write_RemovesIntentTargetFromIssue()
+    {
+        using var workspace = new Workspace();
+        var mutator = new FakeMutator(new[] { "intent-target" });
+        AutomationIssueReleaseCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueReleaseCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1018",
+             "--reason", "host-only packet (G458)", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueReleaseResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.True(result.HadTargetLabel);
+        Assert.Contains("intent-target", result.RemoveLabels);
+        Assert.Empty(result.AddLabels);
+        Assert.Equal("host-only packet (G458)", result.Reason);
+
+        var transition = Assert.Single(mutator.Transitions);
+        Assert.Equal("issue", transition.Kind);
+        Assert.Equal(1018, transition.Number);
+        Assert.Contains("intent-target", transition.RemoveLabels);
+        Assert.Empty(transition.AddLabels);
+    }
+
+    [Fact]
+    public void Execute_DryRun_DoesNotMutate()
+    {
+        using var workspace = new Workspace();
+        var mutator = new FakeMutator(new[] { "intent-target" });
+        AutomationIssueReleaseCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueReleaseCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1018", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueReleaseResult>(writer.ToString())!;
+        Assert.False(result.Applied);
+        Assert.True(result.HadTargetLabel);
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void Execute_IssueWithoutTarget_NothingToRelease()
+    {
+        using var workspace = new Workspace();
+        var mutator = new FakeMutator(Array.Empty<string>());
+        AutomationIssueReleaseCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueReleaseCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1018", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueReleaseResult>(writer.ToString())!;
+        Assert.False(result.HadTargetLabel);
+        Assert.False(result.Applied);
+        Assert.Empty(mutator.Transitions);
+        Assert.Contains("nothing to release", result.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CommandRouter_RegistersAutomationIssueRelease()
+    {
+        using var workspace = new Workspace();
+        AutomationIssueReleaseCommand.MutatorFactory = () => new FakeMutator(new[] { "intent-target" });
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["automation", "issue-release", "--repo", "J-Tech-Japan/intent-system", "--issue", "1018", "--format", "json"],
+            workspace.Context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueReleaseResult>(writer.ToString())!;
+        Assert.Equal(1018, result.Issue);
+    }
+
+    private sealed class FakeMutator : IGitHubLabelMutator
+    {
+        private readonly IReadOnlyList<string> labels;
+        public List<Transition> Transitions { get; } = new();
+        public FakeMutator(IReadOnlyList<string> labels) => this.labels = labels;
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+
+        public void ApplyLabelTransitions(string repo, string kind, int number,
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
+            Transitions.Add(new Transition(kind, number, addLabels.ToArray(), removeLabels.ToArray()));
+
+        public void ApplyReconcileTransitions(string repo, string kind, int number,
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed record Transition(string Kind, int Number, IReadOnlyList<string> AddLabels, IReadOnlyList<string> RemoveLabels);
+
+    private sealed class Workspace : IDisposable
+    {
+        public Workspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("automation-issue-release-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig { Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" } }
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/HostOnlyPacketClassifierTests.cs
+++ b/tests/IntentSystem.Cli.Tests/HostOnlyPacketClassifierTests.cs
@@ -1,0 +1,99 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G462: pure tests for the host-only packet classifier. The central
+/// regression is G458 / issue #1018: a product-goal / intent-tree refresh
+/// targeting only `intents/intent-cli/**` was mis-published as a child
+/// implementation issue.
+/// </summary>
+public sealed class HostOnlyPacketClassifierTests
+{
+    private const string Aic1018Body = """
+## Target Repo / Path / Part
+
+- Target repo: `J-Tech-Japan/intent-system`
+- Target paths: `intents/intent-cli/intent-tree/purpose/04-product-goal.md`, `intents/intent-cli/intent-tree/00-map.md`, `intents/intent-cli/README.md`
+- Target part: canonical product goal
+""";
+
+    private const string MixedBody = """
+## Target Repo / Path / Part
+
+- Target paths: `intents/intent-cli/intent-tree/00-map.md`, `docs`, `README.md`
+""";
+
+    private const string ChildBody = """
+## Target Repo / Path / Part
+
+- Target paths: `src/IntentSystem.Cli/Commands`, `tests/IntentSystem.Cli.Tests`, `docs`
+""";
+
+    [Fact]
+    public void Issue1018Regression_AllHostOwnedPaths_ClassifiesHostOnly()
+    {
+        var verdict = HostOnlyPacketClassifier.Classify(Aic1018Body);
+
+        Assert.True(verdict.IsHostOnly);
+        Assert.Empty(verdict.ChildOwnedPaths);
+        Assert.Equal(3, verdict.TargetPaths.Count);
+        Assert.All(verdict.HostOwnedPaths, p => Assert.StartsWith("intents/", p));
+    }
+
+    [Fact]
+    public void MixedPaths_WithDocsAndReadme_IsNotHostOnly()
+    {
+        var verdict = HostOnlyPacketClassifier.Classify(MixedBody);
+
+        Assert.False(verdict.IsHostOnly);
+        Assert.Contains("docs", verdict.ChildOwnedPaths);
+        Assert.Contains("README.md", verdict.ChildOwnedPaths);
+    }
+
+    [Fact]
+    public void ChildOnlyPaths_IsNotHostOnly()
+    {
+        var verdict = HostOnlyPacketClassifier.Classify(ChildBody);
+
+        Assert.False(verdict.IsHostOnly);
+        Assert.Empty(verdict.HostOwnedPaths);
+    }
+
+    [Fact]
+    public void NoTargetPathsLine_IsNotHostOnly()
+    {
+        var verdict = HostOnlyPacketClassifier.Classify("# An issue\n\nNo target paths section here.");
+
+        Assert.False(verdict.IsHostOnly);
+        Assert.Empty(verdict.TargetPaths);
+    }
+
+    [Fact]
+    public void DotIntentCliPaths_AreHostOwned()
+    {
+        Assert.True(HostOnlyPacketClassifier.IsHostOwnedPath(".intent-cli/queue-state.json"));
+        Assert.True(HostOnlyPacketClassifier.IsHostOwnedPath("intents/intent-cli/specs/05.md"));
+        Assert.True(HostOnlyPacketClassifier.IsHostOwnedPath("`intents/x`"));
+        Assert.True(HostOnlyPacketClassifier.IsHostOwnedPath("AGENTS.md"));
+        Assert.False(HostOnlyPacketClassifier.IsHostOwnedPath("src/Foo.cs"));
+        Assert.False(HostOnlyPacketClassifier.IsHostOwnedPath("docs/en/01.md"));
+        Assert.False(HostOnlyPacketClassifier.IsHostOwnedPath("README.md"));
+    }
+
+    [Fact]
+    public void AllPathsHostOwned_RequiresNonEmpty()
+    {
+        Assert.False(HostOnlyPacketClassifier.AllPathsAreHostOwned(System.Array.Empty<string>()));
+        Assert.True(HostOnlyPacketClassifier.AllPathsAreHostOwned(new[] { "intents/x", ".intent-cli/y" }));
+        Assert.False(HostOnlyPacketClassifier.AllPathsAreHostOwned(new[] { "intents/x", "src/y" }));
+    }
+
+    [Fact]
+    public void ExtractTargetPaths_DeduplicatesAndPreservesOrder()
+    {
+        var paths = HostOnlyPacketClassifier.ExtractTargetPaths(
+            "Target paths: `a/b`, `a/b`, `c/d`");
+        Assert.Equal(new[] { "a/b", "c/d" }, paths);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerIssuePreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerIssuePreflightCommandTests.cs
@@ -123,6 +123,64 @@ public sealed class WorkerIssuePreflightCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenHostOnlyPacket_ClassifiesAsHostOnlyPacket_NonActionable()
+    {
+        // G462 regression (G458 / issue #1018): an intent-target issue whose
+        // declared Target paths are all host-owned (intents/**) must NOT be
+        // reported as ready-to-implement.
+        using var workspace = new WorkerIssuePreflightWorkspace();
+        var hostOnlyBody = ValidBody("J-Tech-Japan/intent-system")
+            + "\n\nTarget paths: `intents/intent-cli/intent-tree/purpose/04-product-goal.md`, `intents/intent-cli/intent-tree/00-map.md`, `.intent-cli/issues/G458`\n";
+        WorkerIssuePreflightCommand.IssueLookupFactory = () => new FakeLookup(BuildIssue(
+            number: 1018,
+            state: "OPEN",
+            title: "G458 Refresh canonical product goal",
+            body: hostOnlyBody,
+            labelNames: new[] { "intent-target" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerIssuePreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--issue", "1018", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerIssuePreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerIssuePreflightConstants.Classifications.HostOnlyPacket, result.Classification);
+        Assert.False(result.Actionable);
+        Assert.Equal(WorkerIssuePreflightConstants.RecommendedActions.ReleaseFromTarget, result.RecommendedAction);
+        Assert.Contains(result.Reasons, r => r.Contains("issue-release", StringComparison.Ordinal));
+        Assert.Contains(result.Reasons, r => r.Contains("host-only packet", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenIntentTargetWithChildPaths_StaysReadyToImplement()
+    {
+        // A child-implementable intent-target issue (target paths include
+        // src/** / docs / README.md) must still classify ready-to-implement.
+        using var workspace = new WorkerIssuePreflightWorkspace();
+        var childBody = ValidBody("J-Tech-Japan/intent-system")
+            + "\n\nTarget paths: `intents/intent-cli/specs/14.md`, `src/IntentSystem.Cli/Commands`, `tests/IntentSystem.Cli.Tests`\n";
+        WorkerIssuePreflightCommand.IssueLookupFactory = () => new FakeLookup(BuildIssue(
+            number: 1019,
+            state: "OPEN",
+            title: "G462 child-implementable",
+            body: childBody,
+            labelNames: new[] { "intent-target" }));
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerIssuePreflightCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--issue", "1019", "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerIssuePreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerIssuePreflightConstants.Classifications.ReadyToImplement, result.Classification);
+        Assert.True(result.Actionable);
+    }
+
+    [Fact]
     public void Execute_GivenContractIncompleteBody_ClassifiesAsContractIncomplete()
     {
         using var workspace = new WorkerIssuePreflightWorkspace();


### PR DESCRIPTION
## Summary

Implements **G462** (#1019): prevent host/design-only packets from being published as child implementation issues with `intent-target`, and add a safe intent-cli-backed way to release a mistakenly-targeted issue.

Fixes the **G458 / issue #1018** regression directly: a product-goal / intent-tree refresh packet targeting only `intents/intent-cli/**` was published as a child `intent-target` issue. The child implementation loop selected it every wake but cannot edit host-owned `intents/**` metadata, so every wake stopped with `host-artifact-repair-required` — and `worker issue-preflight` still classified it as `ready-to-implement`.

## What changed

- **`HostOnlyPacketClassifier`** (new, pure): parses a packet/issue body's `## Target Repo / Path / Part` → `Target paths:` list and classifies it **host-only** when every declared path is host-owned (`intents/**`, `.intent-cli/**`, `AGENTS.md`, `CLAUDE.md`) with no child-owned path (`src/**`, `tests/**`, `docs/**`, `README.md`, ...).
- **`worker issue-preflight`**: new precedence step (before target-mismatch) classifies a host-only `intent-target` issue as **`host-only-packet`** (non-actionable, recommended action `release-from-target`) — the exact gap that let #1018 loop.
- **`automation issue-publish`**: a **host-only publish gate** refuses to apply `intent-target` to a host-only packet (fail-soft issue-body lookup; `refused` / `refusal_reason` result fields; `--allow-host-only-override` escape for intentional cases).
- **`automation issue-release`** (new command): safely **removes `intent-target`** from a mistakenly-targeted issue via the installed label mutator (never raw `gh`), recording a reason. Registered in `CommandRouter` + `Program` bootstrap allow-list.
- **Guidance**: new `GuidanceProhibitionCatalog` entry `host-only-packet-child-publish-forbidden` (advertised by every guidance contract).

## Acceptance criteria coverage

- ✅ Packets targeting only `intents/**` / `.intent-cli/**` are not published as child `intent-target` issues by default (publish gate)
- ✅ A G458/#1018-style issue is not reported as `ready-to-implement` by worker preflight (`host-only-packet` classification)
- ✅ Supported command to release a mistakenly targeted issue without raw GitHub label mutation (`automation issue-release`)
- ✅ Valid child implementation issues still publish and route normally (child-paths-stay-ready test; publish passes with child paths)
- ✅ Guide text explains the host/design packet vs child implementation issue boundary (prohibition entry)

## Verification

- New `HostOnlyPacketClassifierTests` (#1018 regression fixture, mixed/child/empty bodies, `.intent-cli` dot-path), `WorkerIssuePreflightCommandTests` (host-only classification + child-paths-stay-ready), `AutomationIssuePublishCommandTests` (host-only refusal + override), `AutomationIssueReleaseCommandTests` (write/dry-run/no-target/router).
- Full `IntentSystem.Cli.Tests` suite: 2970 passed, 0 failed (two clean runs). Note: this suite has a pre-existing parallel-execution flake (a test mutating the process cwd can cascade `Interop.Sys.GetCwd` failures into unrelated tests); a clean re-run is green and unrelated to this change.
- `git diff --check`: clean.

## Base Branch Policy

Implementation PR base: `main` for `J-Tech-Japan/intent-system` (direct-main).

Closes #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)