### PR TITLE
G460: make improve default to implementation-aware reflection with optional light mode

### DIFF
--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -72,6 +72,21 @@ Both forms return identical guidance and are discoverable via `intent-cli
 do **not** substitute `bug-to-intent-repair`, host-loop recovery,
 `state-doctor`, or dirty-state repair.
 
+By default `improve` is **implementation-aware**: when evidence is available it
+also inspects related GitHub issues/PRs, implementation diffs, tests, review
+findings, and product evidence to find the current top blocker and propose a
+corrective backlog (`Implementation Reality Check`, `Blocker Cluster Analysis`,
+`Corrective Backlog Candidates`) — intent-tree cleanup alone is not enough when
+packet history suggests an unresolved product blocker. Pass `--light` for a
+quick intent-only reflection:
+
+```bash
+intent-cli improve --domain <domain> --light --format markdown
+```
+
+After operator approval the agent may create the proposed corrective packets and
+publish **at most one** first GitHub issue unless asked for more.
+
 `guide improve` is a design-thread reflection process — **not** a scheduler, a
 provider launcher, or a routine host-loop / worker-loop recovery diagnostic.
 Operational metadata/label/queue repair stays in the existing operational

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -71,6 +71,21 @@ intent-cli guide improve --domain <domain> --format markdown
 更新します。`bug-to-intent-repair`・host-loop recovery・`state-doctor`・
 dirty-state repair で**代替しない**でください。
 
+`improve` はデフォルトで **implementation-aware** です。evidence が利用可能なら
+関連 GitHub issue/PR・実装 diff・テスト・レビュー所見・product evidence も点検し、
+現在の最上位 blocker を特定して corrective backlog を提案します
+（`Implementation Reality Check` / `Blocker Cluster Analysis` /
+`Corrective Backlog Candidates`）。packet 履歴が未解決の product blocker を示す場合、
+intent-tree の整理だけでは不十分です。素早い intent-only リフレクションには
+`--light` を付けます:
+
+```bash
+intent-cli improve --domain <domain> --light --format markdown
+```
+
+operator 承認後、agent は提案した corrective packet を作成し、最初の GitHub issue を
+**最大1件**だけ publish できます（明示的に依頼された場合を除く）。
+
 `guide improve` はデザインスレッドのリフレクション工程であり、スケジューラでも
 provider 起動でも、host-loop / worker-loop の通常の復旧診断でもありません。
 metadata / label / queue の復旧は既存の運用サーフェス

--- a/src/IntentSystem.Cli/Commands/GuideImproveCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideImproveCommand.cs
@@ -29,10 +29,18 @@ internal static class GuideImproveCommand
     private const string FormatMarkdown = "markdown";
 
     private const string UsageLine =
-        "Usage: intent-cli guide improve [--domain <name>] [--format markdown|json]";
+        "Usage: intent-cli guide improve [--domain <name>] [--light] [--format markdown|json]";
 
     /// <summary>The shortest natural-language ask that triggers this process.</summary>
     public const string ShortPrompt = "intent-cli で improve プロセスを実行してください。";
+
+    // G460: improve modes. The DEFAULT path is implementation-aware: when
+    // implementation evidence (issues/PRs/diffs/tests/reviews/product evidence)
+    // is available, improve must inspect it and produce a corrective backlog,
+    // not merely reorganize the intent tree. `--light` runs a quick
+    // intent-only reflection (the pre-G460 shallow shape) for fast checks.
+    public const string ModeImplementationAware = "implementation-aware";
+    public const string ModeLight = "light";
 
     // Outcome classifications the design-thread report must use.
     public const string OutcomeAligned = "aligned";
@@ -55,14 +63,14 @@ internal static class GuideImproveCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var domain, out var format, out var error))
+        if (!TryParseArguments(args, out var domain, out var light, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
             return 1;
         }
 
-        var result = BuildResult(domain);
+        var result = BuildResult(domain, light);
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
             writer.Write(JsonSerializer.Serialize(result, JsonOptions));
@@ -76,19 +84,77 @@ internal static class GuideImproveCommand
         return 0;
     }
 
-    internal static GuideImproveResult BuildResult(string? domain)
+    internal static GuideImproveResult BuildResult(string? domain) => BuildResult(domain, light: false);
+
+    internal static GuideImproveResult BuildResult(string? domain, bool light)
     {
         var domainToken = string.IsNullOrWhiteSpace(domain) ? "<domain>" : domain!;
+        var mode = light ? ModeLight : ModeImplementationAware;
+
+        // G460: in the DEFAULT (implementation-aware) mode, improve inspects
+        // implementation reality and produces a corrective backlog. The
+        // checklist, report template, and contrast examples below add the deep
+        // sections; `--light` keeps only the quick intent-only reflection.
+        var checklist = new List<string>
+        {
+            $"Mission / Vision / Values and product goal — read `intents/{domainToken}/` MVV and product-goal artifacts; restate them in your own words and check recent work against them.",
+            $"ADR / design notes — review architecture decision records and design notes for decisions recent work may have silently violated or superseded.",
+            $"Intent tree structure — inspect `intents/{domainToken}/intent-tree/` for coherence: are new slices hanging off the right parent intents, or accreting as ad-hoc leaves?",
+            $"Recent packet history — review the last several execution-unit packets (`.intent-cli/issues/<unit>/`) for theme: are they advancing intents or repeatedly patching the same surface?",
+            $"Clarification history — review `intents/{domainToken}/clarifications/` for unresolved or repeatedly-reopened questions that signal an unsettled intent.",
+            "Short-term loop signals — look for repeated corrective packets on the same area, fixes that re-fix prior fixes, or automation that advanced while the underlying intent stayed ambiguous.",
+            "Intent strengthening opportunities — where an intent is implied by the work but never written down, note it as a candidate to make explicit."
+        };
+
+        var reportTemplate = new List<string>
+        {
+            "## Design-thread improve report",
+            "- domain: <domain>",
+            $"- mode: {mode}",
+            "- reviewed artifacts: <MVV / ADRs / intent-tree paths / packet units / clarification ids actually read>",
+            "## Alignment findings",
+            "- <finding> — <which MVV/ADR/intent it supports or contradicts, with the artifact path/clause cited>",
+            "## Short-term-loop signals",
+            "- <repeated-pattern observed, with the packet units / PRs that evidence it, or 'none observed'>"
+        };
+
+        if (!light)
+        {
+            // Implementation-reality inspection sources (default mode).
+            checklist.Add("Implementation reality — when evidence is available, inspect related GitHub issues and PRs, the actual implementation diffs, tests, and review findings against the packet/intent claims. Intent-tree cleanup alone is NOT sufficient when packet history suggests an unresolved product blocker.");
+            checklist.Add("Product blocker / target-repo evidence — read product-goal recovery artifacts and target-repo evidence to identify the CURRENT top product blocker, not just documentation gaps.");
+            checklist.Add("Blocker reduction — for the top blocker cluster, propose corrective packets that REDUCE it, rather than merely adding evidence or cleaning up docs.");
+
+            // Deep report sections (default mode), inserted before the outcome.
+            reportTemplate.Add("## Implementation Reality Check");
+            reportTemplate.Add("- <for the reviewed packets/intents, what the implementation diffs / tests / reviews actually show vs what the packets claim; cite issue/PR numbers and test/review evidence, or 'no implementation evidence available — running light reflection'>");
+            reportTemplate.Add("## Blocker Cluster Analysis");
+            reportTemplate.Add("- <the current top product blocker cluster, the packets/PRs that touch it, and whether recent work actually reduced it or repeatedly patched around it>");
+            reportTemplate.Add("## Corrective Backlog Candidates");
+            reportTemplate.Add("- <ordered corrective packet candidates that reduce the top blocker, each tied to the evidence above; propose first, create only after operator approval>");
+        }
+
+        reportTemplate.Add("## Recommended outcome");
+        reportTemplate.Add("- outcome: <one of the outcome classifications>");
+        reportTemplate.Add("- rationale: <why, tied to the cited artifacts" + (light ? string.Empty : " and implementation evidence") + ">");
+        reportTemplate.Add("## Proposed next steps (propose first — apply only after operator agreement)");
+        reportTemplate.Add("- <intent-strengthening edit / clarification to open / corrective packet to draft / ADR update>, each via a supported intent-cli or repo path");
+
         return new GuideImproveResult
         {
             Process = "design-thread-improve",
+            Mode = mode,
             Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
             ShortPrompt = ShortPrompt,
-            Summary =
-                "Design-thread improve / realignment: periodically step back and check whether recent work still aligns "
-                + "with the original mission, vision, values, ADR/design notes, and intent tree. Reuse the accumulated "
-                + "intent artifacts (MVV, ADRs, packet history, clarification history) rather than letting fast issue/PR "
-                + "automation drift into short-term local fixes.",
+            Summary = light
+                ? "Design-thread improve (LIGHT / intent-only): a quick reflection over MVV, ADR/design notes, intent tree, "
+                    + "packet history, and clarification history for drift and short-term loops, without deep implementation "
+                    + "analysis. Use `--light` for a fast check; the DEFAULT improve is implementation-aware (see below)."
+                : "Design-thread improve / realignment (DEFAULT: implementation-aware): step back and check whether recent work "
+                    + "still aligns with mission, vision, values, ADR/design notes, and intent tree — AND, when implementation "
+                    + "evidence is available, inspect related issues/PRs/diffs/tests/reviews/product evidence to find the current "
+                    + "top product blocker and propose a corrective backlog. Intent-tree strengthening alone is insufficient when "
+                    + "packet history suggests an unresolved product blocker. Run `--light` for a quick intent-only reflection.",
             NotThis = new[]
             {
                 "This is a DESIGN-THREAD periodic reflection process — run it on demand when the operator asks, not on a 5m/20m schedule.",
@@ -104,31 +170,23 @@ internal static class GuideImproveCommand
                 "Do NOT route improve to `automation state-doctor` or any dirty-state / workspace repair — improve never inspects or repairs queue-state, labels, or publish metadata.",
                 "If a first-class improve surface is not found in the installed CLI (e.g. `intent-cli improve --help` fails), report `improve guidance unavailable` and request a CLI update — do NOT silently choose another workflow."
             },
-            InspectionChecklist = new[]
-            {
-                $"Mission / Vision / Values and product goal — read `intents/{domainToken}/` MVV and product-goal artifacts; restate them in your own words and check recent work against them.",
-                $"ADR / design notes — review architecture decision records and design notes for decisions recent work may have silently violated or superseded.",
-                $"Intent tree structure — inspect `intents/{domainToken}/intent-tree/` for coherence: are new slices hanging off the right parent intents, or accreting as ad-hoc leaves?",
-                $"Recent packet history — review the last several execution-unit packets (`.intent-cli/issues/<unit>/`) for theme: are they advancing intents or repeatedly patching the same surface?",
-                $"Clarification history — review `intents/{domainToken}/clarifications/` for unresolved or repeatedly-reopened questions that signal an unsettled intent.",
-                "Short-term loop signals — look for repeated corrective packets on the same area, fixes that re-fix prior fixes, or automation that advanced while the underlying intent stayed ambiguous.",
-                "Intent strengthening opportunities — where an intent is implied by the work but never written down, note it as a candidate to make explicit."
-            },
-            ReportTemplate = new[]
-            {
-                "## Design-thread improve report",
-                "- domain: <domain>",
-                "- reviewed artifacts: <MVV / ADRs / intent-tree paths / packet units / clarification ids actually read>",
-                "## Alignment findings",
-                "- <finding> — <which MVV/ADR/intent it supports or contradicts, with the artifact path/clause cited>",
-                "## Short-term-loop signals",
-                "- <repeated-pattern observed, with the packet units / PRs that evidence it, or 'none observed'>",
-                "## Recommended outcome",
-                "- outcome: <one of the outcome classifications>",
-                "- rationale: <why, tied to the cited artifacts>",
-                "## Proposed next steps (propose first — apply only after operator agreement)",
-                "- <intent-strengthening edit / clarification to open / corrective packet to draft / ADR update>, each via a supported intent-cli or repo path"
-            },
+            InspectionChecklist = checklist,
+            ReportTemplate = reportTemplate,
+            ContrastExamples = light
+                ? Array.Empty<GuideImproveContrastExample>()
+                : new[]
+                {
+                    new GuideImproveContrastExample
+                    {
+                        Label = "shallow (intent-only) — AIC observed run",
+                        Description = "Read AIC intent artifacts and AIC-G29..G39 packet history, found the intent-tree lagged behind packet history, and updated `intents/aic/intent-tree/00-map.md`. It mostly stopped at intent organization — it did NOT deeply inspect related PRs, diffs, tests, or review findings, and produced no corrective backlog from implementation reality. This is the behavior to move PAST."
+                    },
+                    new GuideImproveContrastExample
+                    {
+                        Label = "target (implementation-aware) — SekibanAsAService observed run",
+                        Description = "Read product-goal recovery artifacts, recent SKS-G699..G715 packets, AND target-repo evidence; classified the current local-backend usability blocker cluster; created ordered corrective packets SKS-G716..G721; and published ONE first GitHub issue (#1551) after operator approval. This is the DEFAULT improve behavior to aim for — driven by guidance, not agent luck."
+                    }
+                },
             OutcomeClassifications = new[]
             {
                 new GuideImproveOutcome { Id = OutcomeAligned, Meaning = "Recent work aligns with MVV / ADRs / intent tree; no realignment action needed beyond recording the check." },
@@ -143,6 +201,8 @@ internal static class GuideImproveCommand
             {
                 "Propose mutations first; apply them only after explicit operator agreement, and only through supported intent-cli / repo paths.",
                 "Intent strengthening / ADR updates land as ordinary repo edits the operator accepts; clarifications go through `intent-cli clarification`; corrective work goes through the normal packet / next-slice path.",
+                "After operator approval you may create the proposed corrective packets and publish AT MOST ONE first GitHub issue unless the operator explicitly asks for more — do not publish the whole corrective chain at once.",
+                "Do not force expensive repository/test analysis or run expensive tests by default; inspect implementation evidence that is already available and note when deeper analysis would require operator-approved cost.",
                 "Never hand-edit workflow labels, queue-state, or publish metadata from this process — that repair stays routed through the existing operational intent-cli surfaces."
             }
         };
@@ -153,6 +213,8 @@ internal static class GuideImproveCommand
         writer.WriteLine("# Guide improve — design-thread realignment process");
         writer.WriteLine();
         writer.WriteLine($"_Run it by asking:_ **{result.ShortPrompt}**");
+        writer.WriteLine();
+        writer.WriteLine($"_mode: {result.Mode}_ (default is implementation-aware; pass `--light` for a quick intent-only reflection)");
         writer.WriteLine();
         writer.WriteLine(result.Summary);
         writer.WriteLine();
@@ -193,6 +255,16 @@ internal static class GuideImproveCommand
         }
         writer.WriteLine();
 
+        if (result.ContrastExamples.Count > 0)
+        {
+            writer.WriteLine("## Shallow vs target behavior (contrast examples)");
+            foreach (var example in result.ContrastExamples)
+            {
+                writer.WriteLine($"- **{example.Label}**: {example.Description}");
+            }
+            writer.WriteLine();
+        }
+
         writer.WriteLine("## Mutation boundary");
         foreach (var item in result.MutationBoundary)
         {
@@ -200,9 +272,10 @@ internal static class GuideImproveCommand
         }
     }
 
-    private static bool TryParseArguments(string[] args, out string? domain, out string format, out string error)
+    private static bool TryParseArguments(string[] args, out string? domain, out bool light, out string format, out string error)
     {
         domain = null;
+        light = false;
         format = FormatMarkdown;
         error = string.Empty;
 
@@ -219,6 +292,10 @@ internal static class GuideImproveCommand
                     }
                     domain = args[index + 1].Trim();
                     index++;
+                    break;
+
+                case "--light":
+                    light = true;
                     break;
 
                 case "--format":
@@ -253,7 +330,7 @@ internal static class GuideImproveCommand
     {
         writer.WriteLine("guide improve");
         writer.WriteLine(UsageLine);
-        writer.WriteLine("Read-only design-thread improve / realignment process: review MVV, ADR/design notes, intent tree, packet history, and clarification history for drift and short-term loops. Run it by asking: " + ShortPrompt);
+        writer.WriteLine("Read-only design-thread improve / realignment process. DEFAULT is implementation-aware: when evidence is available, inspect related issues/PRs/diffs/tests/reviews/product evidence and propose a corrective backlog. Pass `--light` for a quick intent-only reflection (MVV / ADR / intent-tree / packet / clarification). Run it by asking: " + ShortPrompt);
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -268,6 +345,10 @@ internal sealed record GuideImproveResult
 {
     [JsonPropertyName("process")]
     public required string Process { get; init; }
+
+    /// <summary>G460: `implementation-aware` (default) or `light`.</summary>
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
 
     [JsonPropertyName("domain")]
     public string? Domain { get; init; }
@@ -293,8 +374,21 @@ internal sealed record GuideImproveResult
     [JsonPropertyName("outcome_classifications")]
     public required IReadOnlyList<GuideImproveOutcome> OutcomeClassifications { get; init; }
 
+    /// <summary>G460: shallow-vs-target contrast examples (default mode only; empty in light mode).</summary>
+    [JsonPropertyName("contrast_examples")]
+    public required IReadOnlyList<GuideImproveContrastExample> ContrastExamples { get; init; }
+
     [JsonPropertyName("mutation_boundary")]
     public required IReadOnlyList<string> MutationBoundary { get; init; }
+}
+
+internal sealed record GuideImproveContrastExample
+{
+    [JsonPropertyName("label")]
+    public required string Label { get; init; }
+
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
 }
 
 internal sealed record GuideImproveOutcome

--- a/tests/IntentSystem.Cli.Tests/GuideImproveCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideImproveCommandTests.cs
@@ -38,6 +38,57 @@ public sealed class GuideImproveCommandTests
     }
 
     [Fact]
+    public void Execute_DefaultJson_IsImplementationAware_WithDeepSections()
+    {
+        // G460: the DEFAULT improve path is implementation-aware with the three
+        // deep report sections and shallow-vs-target contrast examples.
+        using var writer = new StringWriter();
+        var exitCode = GuideImproveCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("implementation-aware", root.GetProperty("mode").GetString());
+
+        var report = string.Join("\n", root.GetProperty("report_template").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("Implementation Reality Check", report, StringComparison.Ordinal);
+        Assert.Contains("Blocker Cluster Analysis", report, StringComparison.Ordinal);
+        Assert.Contains("Corrective Backlog Candidates", report, StringComparison.Ordinal);
+
+        var checklist = root.GetProperty("inspection_checklist").EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(checklist, c => c.Contains("Implementation reality", StringComparison.Ordinal));
+        Assert.Contains(checklist, c => c.Contains("top product blocker", StringComparison.Ordinal));
+
+        // Contrast examples (AIC shallow vs Sekiban target) present in default mode.
+        var labels = root.GetProperty("contrast_examples").EnumerateArray()
+            .Select(e => e.GetProperty("label").GetString()!).ToArray();
+        Assert.Contains(labels, l => l.Contains("AIC", StringComparison.Ordinal));
+        Assert.Contains(labels, l => l.Contains("SekibanAsAService", StringComparison.Ordinal));
+
+        // Mutation boundary: at most one first issue after approval.
+        var boundary = root.GetProperty("mutation_boundary").EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains(boundary, b => b.Contains("AT MOST ONE first GitHub issue", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_LightMode_IsIntentOnly_NoDeepSections()
+    {
+        // G460: --light keeps the quick intent-only reflection (no deep sections).
+        using var writer = new StringWriter();
+        var exitCode = GuideImproveCommand.Execute(CreateContext(), ["--light", "--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("light", root.GetProperty("mode").GetString());
+
+        var report = string.Join("\n", root.GetProperty("report_template").EnumerateArray().Select(e => e.GetString()));
+        Assert.DoesNotContain("Implementation Reality Check", report, StringComparison.Ordinal);
+        Assert.DoesNotContain("Corrective Backlog Candidates", report, StringComparison.Ordinal);
+        Assert.Empty(root.GetProperty("contrast_examples").EnumerateArray());
+    }
+
+    [Fact]
     public void Execute_Json_EmitsOutcomeClassificationsAndShortPrompt()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Implements **G460** (#1022): make the default `improve` process implementation-aware. Agents should inspect intent artifacts **plus** related issues, PRs, implementation diffs, tests, review history, and product blockers when evidence is available — while still allowing an explicit `--light` mode for quick intent-tree reflection.

Moves improve from `packet history → intent-tree cleanup` to `intent + packet history + implementation reality + tests/reviews/evidence → corrective backlog` by default. (Extends the `GuideImproveCommand` added in G456.)

## What changed

- **`GuideImproveCommand` gains a `mode`**: `implementation-aware` (default) or `light`.
- **Default (implementation-aware)** adds:
  - inspection sources for implementation reality (related issues/PRs, diffs, tests, review findings, product/target-repo evidence) and a current-top-blocker focus;
  - three report sections: **`Implementation Reality Check`**, **`Blocker Cluster Analysis`**, **`Corrective Backlog Candidates`**;
  - guidance that intent-tree strengthening alone is insufficient when packet history suggests an unresolved product blocker;
  - shallow-vs-target **contrast examples** (AIC intent-only run vs SekibanAsAService implementation-aware run).
- **`--light`** keeps the quick intent-only reflection (no deep sections).
- **Mutation boundary**: after operator approval, create corrective packets and publish **at most one** first GitHub issue unless asked for more; do not force expensive repo/test analysis or run expensive tests by default.
- **Docs** (en/ja) document the implementation-aware default + `--light` option; the main natural-language prompt stays simple.

## Acceptance criteria coverage

- ✅ `improve` / `guide improve` documents implementation-aware default + explicit light/quick option
- ✅ Default guidance tells agents to inspect issue/PR history, diffs, tests, review findings, product evidence, target-repo artifacts when available
- ✅ Default report template includes the three deep sections
- ✅ Guidance: intent-tree strengthening alone is insufficient when packets suggest unresolved blockers
- ✅ After approval, at most one first GitHub issue
- ✅ AIC and SekibanAsAService examples reflected as contrast cases
- ✅ Mutation boundary remains explicit

## Verification

- `GuideImproveCommandTests`: default deep sections + contrast examples + at-most-one-issue boundary; light-mode intent-only behavior; plus existing markdown/json/discovery tests.
- Full `IntentSystem.Cli.Tests` suite: 2972 passed, 0 failed (clean re-run; the one intermittent failure is the known parallel-cwd-deletion flake in an unrelated `ProgramTests`, green in isolation).
- `git diff --check`: clean.

## Base Branch Policy

Implementation PR base: `main` for `J-Tech-Japan/intent-system` (direct-main).

Closes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)