### PR TITLE
G461 Add optional packet-time intent maintenance metadata

### DIFF
--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -87,6 +87,15 @@ intent-cli improve --domain <domain> --light --format markdown
 After operator approval the agent may create the proposed corrective packets and
 publish **at most one** first GitHub issue unless asked for more.
 
+`improve` is a **safety net**, not the first line of defense. The normal path is
+**packet-time intent maintenance** (G461): when a packet is drafted, the agent is
+already prompted to consider intent placement, ADR candidates, diagram candidates,
+docs updates, and closeout knowledge writeback — see `intent-cli guide workflow task
+packet-draft`. That metadata is optional and backward-compatible (legacy packets
+without it stay valid), but capturing it while the design context is fresh keeps the
+intent tree, ADRs, and diagrams from drifting behind packet history in the first
+place. `improve` then catches whatever the packet-time check missed.
+
 `guide improve` is a design-thread reflection process — **not** a scheduler, a
 provider launcher, or a routine host-loop / worker-loop recovery diagnostic.
 Operational metadata/label/queue repair stays in the existing operational

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -86,6 +86,15 @@ intent-cli improve --domain <domain> --light --format markdown
 operator 承認後、agent は提案した corrective packet を作成し、最初の GitHub issue を
 **最大1件**だけ publish できます（明示的に依頼された場合を除く）。
 
+`improve` は first line of defense ではなく **safety net** です。通常パスは
+**packet-time intent maintenance**（G461）です。packet draft 時点で agent は intent
+placement・ADR candidate・diagram candidate・docs update・closeout knowledge writeback
+を検討するよう促されます（`intent-cli guide workflow task packet-draft` 参照）。この
+metadata は optional かつ backward-compatible で（metadata を持たない legacy packet も
+有効のまま）、設計コンテキストが新鮮なうちに記録することで intent tree・ADR・diagram が
+packet 履歴から遅れて drift するのを最初の段階で防ぎます。`improve` は packet-time
+チェックが見逃した drift を後から拾います。
+
 `guide improve` はデザインスレッドのリフレクション工程であり、スケジューラでも
 provider 起動でも、host-loop / worker-loop の通常の復旧診断でもありません。
 metadata / label / queue の復旧は既存の運用サーフェス

--- a/src/IntentSystem.Cli/Commands/GuideCloseoutRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCloseoutRunCommand.cs
@@ -107,6 +107,11 @@ Stage 5 — apply queue/runs state (write):
    - If the result has an `error` field, stop and report the error.
    - Confirm: mode is `write`, queue_state_after is `completed`.
 
+Stage 5b — knowledge writeback check (G461; read-only):
+1. If the packet carried optional `closeout_learning` metadata with `write_back_required: true`, confirm the expected intent-tree / ADR / diagram / docs writeback either landed in the merged PR or was captured as a follow-up packet.
+2. If the writeback was expected but neither landed nor captured, report `knowledge-writeback-pending` with the named `write_back_targets` so the design thread can open a follow-up packet. Do not block the closeout queue write on this.
+3. If the packet declined knowledge maintenance (or carried no such metadata — legacy packets), this stage is a no-op. Packet-time intent maintenance is the normal path; `improve` (G456 / G460) remains the later safety net.
+
 Stage 6 — parent commit/push checklist (required last step):
 1. Stage parent durable state: `git add .intent-cli/queue-state.json .intent-cli/runs.jsonl submodules/<child-repo-name>`.
 2. Commit: `git commit -m ""closeout: PR #{targetRepoPlaceholder}#<n> — <execution-unit>""`.

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskPacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskPacketDraftCommand.cs
@@ -78,6 +78,24 @@ internal static class GuideWorkflowTaskPacketDraftCommand
     };
 
     /// <summary>
+    /// G461: packet-time intent-maintenance prompts. A packet draft is the
+    /// earliest, cheapest moment to capture design knowledge (intent placement,
+    /// ADR / diagram / docs candidates, closeout writeback) while the design
+    /// context is fresh. These prompts are OPTIONAL and backward-compatible —
+    /// the agent may explicitly decline each one — but they make the
+    /// `improve` reflection process (G456 / G460) the safety net rather than
+    /// the only place this knowledge is considered. Tests pin each id.
+    /// </summary>
+    internal static readonly IReadOnlyList<IntentMaintenancePrompt> IntentMaintenancePrompts = new[]
+    {
+        new IntentMaintenancePrompt { Id = "intent-placement", Prompt = "Which intent node does this slice support? Name the primary intent path (and any supporting intents). If no existing node fits, flag `new_intent_needed: true` with a one-line placement rationale instead of leaving the design knowledge trapped in packet history." },
+        new IntentMaintenancePrompt { Id = "adr-candidate", Prompt = "Does this slice make an ADR-worthy decision (a hard-to-reverse choice, a rejected alternative, a new constraint)? If so, name the decision title and target ADR path; otherwise explicitly decline (`adr.required: false`). ADRs are not required for every packet." },
+        new IntentMaintenancePrompt { Id = "diagram-candidate", Prompt = "Does a concept / workflow / topology / state diagram need to change because of this slice? Name the diagram type and target path, or decline (`diagram.required: false`)." },
+        new IntentMaintenancePrompt { Id = "docs-update", Prompt = "Which user-facing docs must change so the documented behavior matches this slice once it lands? List target doc paths, or decline (`docs.required: false`)." },
+        new IntentMaintenancePrompt { Id = "closeout-learning", Prompt = "What knowledge should be written back AFTER this slice lands (intent tree, ADR, diagram, docs)? Set `closeout_learning.write_back_required` and name the write-back targets so review / closeout can verify it happened or open a follow-up packet." }
+    };
+
+    /// <summary>
     /// G337: the canonical commands an external agent runs to produce
     /// a packet draft. Tests pin every flag against the corresponding
     /// command source file (regression for the G336 PR #776 finding).
@@ -112,7 +130,8 @@ internal static class GuideWorkflowTaskPacketDraftCommand
         "Packet ownership is design-side; runtime-created packets carry an explicit `runtime-created` flag in `packet.yaml`. The review-runtime workspace MUST NOT silently edit the four files; it goes through `packet draft --write` with the runtime ownership label (G326).",
         "Prefer intent-cli-backed metadata mutation over hand-editing. Ask `intent-cli guide commands list --format json` or `intent-cli automation summary --domain <d> --format json` which command performs the transition, run that command, then validate the result.",
         "Child implementation loops MUST NOT inspect or mutate parent host queue-state, runs logs, packet directories, intent tree, review-runtime state, local rules, or local skills (G300 / G330 / G333). The packet directory is host-owned; child agents see only the rendered GitHub issue body.",
-        "Never launch AI providers (Claude / Codex / any LLM) from intent-cli. The chat-first model has the human agent driving the conversation; intent-cli emits text the agent acts on."
+        "Never launch AI providers (Claude / Codex / any LLM) from intent-cli. The chat-first model has the human agent driving the conversation; intent-cli emits text the agent acts on.",
+        "Packet-time intent maintenance is the NORMAL path: every packet draft considers intent placement, ADR / diagram / docs candidates, and closeout writeback while the design context is fresh (G461). The `improve` reflection process (G456 / G460) is the later SAFETY NET that catches drift the packet-time check missed — it is not a substitute for thinking about knowledge maintenance when the packet is written. This metadata is OPTIONAL and backward-compatible: legacy packets without it stay valid, and the agent may explicitly decline each prompt."
     };
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
@@ -135,6 +154,7 @@ internal static class GuideWorkflowTaskPacketDraftCommand
                 Usage = UsageLine,
                 PacketFiles = PacketFiles,
                 IssueContractSections = IssueContractSections,
+                IntentMaintenancePrompts = IntentMaintenancePrompts,
                 Commands = Commands,
                 StopConditions = StopConditions,
                 Invariants = Invariants
@@ -176,6 +196,16 @@ internal static class GuideWorkflowTaskPacketDraftCommand
         foreach (var section in IssueContractSections)
         {
             writer.WriteLine($"- **{section.Section}** — {section.Purpose}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Packet-time intent maintenance (optional, normal path)");
+        writer.WriteLine();
+        writer.WriteLine("A packet draft is the earliest, cheapest moment to capture design knowledge while the context is fresh. Consider — and explicitly answer or decline — each prompt. The metadata is optional and backward-compatible; `improve` (G456 / G460) is the later safety net, not a substitute:");
+        writer.WriteLine();
+        foreach (var prompt in IntentMaintenancePrompts)
+        {
+            writer.WriteLine($"- **{prompt.Id}** — {prompt.Prompt}");
         }
         writer.WriteLine();
 
@@ -272,6 +302,19 @@ internal sealed record IssueContractSection
 }
 
 /// <summary>
+/// G461: one packet-time intent-maintenance prompt the agent should answer
+/// or explicitly decline while the design context is fresh.
+/// </summary>
+internal sealed record IntentMaintenancePrompt
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+}
+
+/// <summary>
 /// G337: full JSON payload for <c>guide workflow task packet-draft</c>.
 /// </summary>
 internal sealed record PacketDraftGuidance
@@ -284,6 +327,9 @@ internal sealed record PacketDraftGuidance
 
     [JsonPropertyName("issue_contract_sections")]
     public required IReadOnlyList<IssueContractSection> IssueContractSections { get; init; }
+
+    [JsonPropertyName("intent_maintenance_prompts")]
+    public required IReadOnlyList<IntentMaintenancePrompt> IntentMaintenancePrompts { get; init; }
 
     [JsonPropertyName("commands")]
     public required IReadOnlyList<string> Commands { get; init; }

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -216,6 +216,37 @@ internal static class PacketDraftCommand
               intent_references: []
               acceptance_criteria:
                 - "TODO: at least one acceptance criterion"
+
+            # G461: optional packet-time intent-maintenance metadata. OPTIONAL and
+            # backward-compatible — packets that omit this whole block stay valid.
+            # Fill it in or explicitly decline each part while the design context is
+            # fresh; `improve` (G456 / G460) is the later safety net, not a substitute.
+            intent_placement:
+              primary_intent: <intents/{domain}/intent-tree/...>
+              supporting_intents: []
+              new_intent_needed: false
+              placement_rationale: ""
+            knowledge_updates:
+              intent_tree:
+                required: false
+                target_paths: []
+                summary: ""
+              adr:
+                required: false
+                target_paths: []
+                decision_title: ""
+              diagram:
+                required: false
+                target_paths: []
+                diagram_type: none
+              docs:
+                required: false
+                target_paths: []
+                summary: ""
+            closeout_learning:
+              expected: ""
+              write_back_required: false
+              write_back_targets: []
             """;
     }
 
@@ -243,6 +274,18 @@ internal static class PacketDraftCommand
             ## Verification
 
             TODO: focused tests and `git diff --check`.
+
+            ## Knowledge Maintenance (G461, optional)
+
+            Captured while the design context is fresh. Answer or explicitly decline:
+
+            - Intent placement: TODO which intent node this supports / whether a new node is needed.
+            - ADR candidate: TODO ADR-worthy decision + path, or decline.
+            - Diagram candidate: TODO concept/workflow/topology/state diagram update, or decline.
+            - Docs update: TODO user-facing docs to change, or decline.
+            - Closeout learning: TODO knowledge to write back after landing + whether `write_back_required`.
+
+            `improve` (G456 / G460) is the later safety net; packet-time maintenance is the normal path.
             """;
     }
 
@@ -259,6 +302,13 @@ internal static class PacketDraftCommand
             - launches AI providers from `intent-cli`;
             - mutates GitHub or parent state when the issue is read-only;
             - skips required contract sections.
+
+            ## Knowledge Writeback Expectation (G461)
+
+            If the packet's `closeout_learning.write_back_required` is `true`, confirm the
+            expected intent-tree / ADR / diagram / docs writeback landed in this PR or was
+            captured as a follow-up packet. If the packet declined all knowledge maintenance,
+            that is acceptable — note it rather than blocking.
             """;
     }
 
@@ -313,6 +363,17 @@ internal static class PacketDraftCommand
             ## Related Links
 
             - TODO
+
+            ## Knowledge Maintenance
+
+            Optional (G461). Tells the implementer/reviewer whether intent / ADR / diagram / docs
+            writeback is expected for this slice. Answer or explicitly decline:
+
+            - Intent placement: TODO / none
+            - ADR candidate: TODO / none
+            - Diagram candidate: TODO / none
+            - Docs update: TODO / none
+            - Closeout writeback expected: no
 
             ## Base Branch Policy
 

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
@@ -99,6 +99,50 @@ public sealed class GuideWorkflowTaskPacketDraftCommandTests
     }
 
     [Fact]
+    public void Execute_EmitsPacketTimeIntentMaintenancePrompts()
+    {
+        // G461 AC: new packet draft guidance includes intent placement, ADR
+        // candidate, diagram candidate, docs update, and closeout learning prompts.
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowTaskPacketDraftCommand.Execute(
+            CreateContext(), new[] { "--format", "json" }, writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.TryGetProperty("intent_maintenance_prompts", out var prompts));
+        var ids = prompts.EnumerateArray().Select(p => p.GetProperty("id").GetString()).ToArray();
+        Assert.Equal(
+            new[] { "intent-placement", "adr-candidate", "diagram-candidate", "docs-update", "closeout-learning" },
+            ids);
+        // Each prompt carries actionable text.
+        foreach (var p in prompts.EnumerateArray())
+        {
+            Assert.False(string.IsNullOrWhiteSpace(p.GetProperty("prompt").GetString()));
+        }
+    }
+
+    [Fact]
+    public void Execute_Markdown_DescribesPacketTimeMaintenanceAsNormalPathAndImproveAsSafetyNet()
+    {
+        // G461 AC: docs/guide text explains packet-time intent maintenance is the
+        // normal path, while improve catches missed drift later.
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowTaskPacketDraftCommand.Execute(
+            CreateContext(), Array.Empty<string>(), writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Packet-time intent maintenance", output, StringComparison.Ordinal);
+        Assert.Contains("safety net", output, StringComparison.OrdinalIgnoreCase);
+        // The five prompt ids surface in the markdown too.
+        foreach (var id in new[] { "intent-placement", "adr-candidate", "diagram-candidate", "docs-update", "closeout-learning" })
+        {
+            Assert.Contains(id, output, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
     public void Invariants_IncludeIntentTargetFinalBoundaryWarning()
     {
         // Acceptance criterion: "The guide warns that intent-target

--- a/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
@@ -232,6 +232,43 @@ public sealed class PacketDraftCommandTests
         Assert.Contains("Expected PR base branch: `main`", githubBody, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_GeneratesOptionalIntentMaintenanceMetadata_WithoutAddingRequiredSections()
+    {
+        // G461 AC: new generated packet templates include the optional intent
+        // maintenance sections/fields by default, but the metadata is OPTIONAL —
+        // it must NOT be added to the required standalone-contract sections.
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G461", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G461");
+
+        var packetYaml = File.ReadAllText(Path.Combine(packetDir, "packet.yaml"));
+        foreach (var key in new[] { "intent_placement:", "knowledge_updates:", "adr:", "diagram:", "closeout_learning:", "write_back_required:" })
+        {
+            Assert.Contains(key, packetYaml, StringComparison.Ordinal);
+        }
+
+        var implementation = File.ReadAllText(Path.Combine(packetDir, "implementation.md"));
+        Assert.Contains("Knowledge Maintenance", implementation, StringComparison.Ordinal);
+
+        var githubBody = File.ReadAllText(Path.Combine(packetDir, "github-body.md"));
+        Assert.Contains("## Knowledge Maintenance", githubBody, StringComparison.Ordinal);
+
+        var reviewContext = File.ReadAllText(Path.Combine(packetDir, "review-context.md"));
+        Assert.Contains("Knowledge Writeback Expectation", reviewContext, StringComparison.Ordinal);
+
+        // Backward-compat invariant: the optional metadata is NOT a required section.
+        Assert.DoesNotContain("Knowledge Maintenance", string.Join("\n", PacketDraftCommand.RequiredContractSections), StringComparison.Ordinal);
+        Assert.DoesNotContain("intent_placement", string.Join("\n", PacketDraftCommand.RequiredContractSections), StringComparison.Ordinal);
+    }
+
     private sealed class PacketDraftWorkspace : IDisposable
     {
         public PacketDraftWorkspace()

--- a/tests/IntentSystem.Projection.Tests/ProjectionPacketSerializerTests.cs
+++ b/tests/IntentSystem.Projection.Tests/ProjectionPacketSerializerTests.cs
@@ -73,6 +73,80 @@ public sealed class ProjectionPacketSerializerTests
     }
 
     [Fact]
+    public void Deserialize_GivenOptionalIntentMaintenanceMetadata_StillValidates()
+    {
+        // G461 regression: appending the optional packet-time intent-maintenance
+        // metadata (intent_placement / knowledge_updates / closeout_learning) must
+        // NOT break a packet that already satisfies the required contract. Legacy
+        // packets omit it entirely; new packets carry it. Both must deserialize.
+        var packet = ProjectionPacketSerializer.Deserialize(
+            """
+            implementation_issue_packet:
+              issue_title: "G461 Packet-time intent maintenance"
+              issue_kind: "feature"
+              source_execution_unit: "G461"
+              goal: "goal"
+              in_scope: []
+              out_of_scope: []
+              target_repo: "repo"
+              target_path: "."
+              target_part: "part"
+              dependencies: []
+              technical_baseline: []
+              project_local_guide: []
+              intent_baseline: []
+              intent_references: []
+              rules_and_specs: []
+              acceptance_criteria: []
+              verification_evidence: []
+              review_mode: "deterministic-review"
+              completion_action: "open-pr"
+              landing_policy: "merge-after-review"
+
+            review_context_packet:
+              source_execution_unit: "G461"
+              parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+              intent_references: []
+              rules_and_specs: []
+              acceptance_criteria: []
+              deterministic_review_checks: []
+              clarification_return_path: "path.md"
+
+            intent_placement:
+              primary_intent: "intents/intent-cli/intent-tree/00-map.md"
+              supporting_intents: []
+              new_intent_needed: false
+              placement_rationale: ""
+            knowledge_updates:
+              intent_tree:
+                required: false
+                target_paths: []
+                summary: ""
+              adr:
+                required: false
+                target_paths: []
+                decision_title: ""
+              diagram:
+                required: false
+                target_paths: []
+                diagram_type: none
+              docs:
+                required: false
+                target_paths: []
+                summary: ""
+            closeout_learning:
+              expected: ""
+              write_back_required: false
+              write_back_targets: []
+            """);
+
+        // The optional metadata is ignored by the required-field contract; the
+        // packet still deserializes to the same shape as a packet without it.
+        Assert.Equal("G461", packet.ImplementationIssuePacket.SourceExecutionUnit);
+        Assert.Equal("G461", packet.ReviewContextPacket.SourceExecutionUnit);
+    }
+
+    [Fact]
     public void Deserialize_GivenMissingRequiredField_ThrowsInvalidOperationException()
     {
         var exception = Assert.Throws<InvalidOperationException>(


### PR DESCRIPTION
## Summary

Implements #1024 (G461): make normal packet creation prompt agents to consider intent placement, ADR / diagram / docs candidates, and closeout knowledge writeback, while keeping the metadata **optional** and **backward-compatible**.

Packet-time intent maintenance becomes the **normal path**; `improve` (G456 / G460) stays the later **safety net**.

## Changes

- **`guide workflow task packet-draft`** — new packet-time intent-maintenance prompts (`intent-placement`, `adr-candidate`, `diagram-candidate`, `docs-update`, `closeout-learning`) in JSON + markdown, plus an invariant stating packet-time maintenance is the normal path and `improve` is the safety net.
- **Packet draft templates** — optional `intent_placement` / `knowledge_updates` / `closeout_learning` metadata in `packet.yaml`, a `Knowledge Maintenance` section in `implementation.md` and `github-body.md`, and a knowledge-writeback expectation note in `review-context.md`. **Not** added to the required standalone-contract sections.
- **`guide closeout run`** — Stage 5b knowledge-writeback check that surfaces `knowledge-writeback-pending` without blocking the closeout queue write; no-op for legacy/declined packets.
- **Docs (en/ja)** — explain packet-time intent maintenance is the normal path while `improve` catches missed drift later.

## Acceptance criteria

- [x] New packet draft guidance includes intent placement, ADR candidate, diagram candidate, docs update, and closeout learning prompts.
- [x] `packet.yaml` optional metadata shape is documented and accepted without breaking packets that omit it.
- [x] New generated packet templates include the sections / equivalent fields by default.
- [x] Review/closeout guidance can surface whether knowledge writeback was expected and completed.
- [x] Docs/guide text explain packet-time intent maintenance is the normal path; `improve` catches drift later.
- [x] Tests cover packet draft output with optional metadata + compatibility with packets that omit it.

## Verification

- `dotnet test` (CLI 2975 passed, Projection 59 passed). The one transient failure in the full CLI run was the known parallel cwd-deletion flake (`WorkerCompleteCommandTests.Execute_G347_...`), green on isolated re-run and on the determinism re-run — unrelated to this change.
- New regression: `ProjectionPacketSerializerTests.Deserialize_GivenOptionalIntentMaintenanceMetadata_StillValidates` proves a packet carrying the optional metadata still validates; legacy packets that omit it already validate.
- `git diff --check` clean.

Note: the issue lists host-owned `intents/intent-cli/specs/**` paths; those are host-side spec docs not present in the implementation repo, so this child PR delivers the equivalent guide/template/docs/test surfaces. All acceptance criteria are satisfied in child-owned code.

Closes #1024

🤖 Generated with [Claude Code](https://claude.com/claude-code)