### PR TITLE
G463 Add grill as persistent interview mode with open-question backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,16 @@ repository and paste one of these prompts:
 > Set up a child implementation loop for `<owner>/<repo>`.
 > Ask intent-cli for the next step.
 
+**Grill a topic (persistent interview mode):**
+
+> Grill `<topic>` with intent-cli.
+> Keep asking me one question at a time until the intent is packet-ready.
+
 The agent runs `intent-cli` commands internally and brings back questions or
-results. You focus on intent, priorities, and approval decisions.
+results. You focus on intent, priorities, and approval decisions. In **grill**
+mode (`intent-cli grill`) the thread stays persistent — it builds an
+open-question backlog and keeps asking one question at a time, continuing after
+each answer until a stop condition is reached.
 
 ---
 

--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -109,6 +109,34 @@ classifies the outcome as one of `aligned`,
 proposed first and applied only after operator agreement through supported
 intent-cli / repo paths.
 
+## Grill — persistent interview mode
+
+A user-facing **persistent interview mode** (G463). Once you ask to grill a
+topic, the design thread STAYS in grill mode: it generates an open-question
+backlog from the current intent context (intents, packets, ADR/design notes,
+docs, and relevant implementation evidence) and keeps asking **one question at a
+time**, continuing after each answer without you repeating `grill`, until a
+structured stop condition is reached.
+
+```bash
+intent-cli grill --domain <domain> --format markdown
+intent-cli guide grill --domain <domain> --format markdown
+```
+
+Both forms return identical guidance and are discoverable via `intent-cli
+--help` and `intent-cli guide commands list`. grill is built on the existing
+`interview` artifacts (it records answers through `intent-cli interview
+record-answer` and reads pending questions through `intent-cli interview
+next-question`); it is **not** `clarification` (blocker resolution) and **not**
+`improve` (retrospective realignment), and it never auto-publishes packets or
+issues.
+
+Stop conditions: `no-more-questions` (returns `今のところ追加質問はありません`
+only when the backlog is empty and rediscovery finds nothing), `packet-ready`,
+`intent-update-ready`, `clarification-needed`, `blocked-by-user-decision`, and
+`too-broad-split-needed`. Packet / issue / intent-update actions are proposed at
+a stop condition and applied only after explicit operator acceptance.
+
 ## Packets / issues
 
 ```bash

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -107,6 +107,34 @@ packet 履歴・clarification 履歴・短期ループの兆候を点検し、�
 変更はまず提案し、operator の同意後にサポートされた intent-cli / repo 経路でのみ
 適用します。
 
+## Grill — 永続インタビューモード
+
+ユーザー向けの**永続インタビューモード**（G463）です。トピックを grill する
+よう依頼すると、デザインスレッドは grill モードに留まり、現在の intent
+コンテキスト（intents・packets・ADR / design note・docs・関連する実装
+evidence）から open-question backlog を生成し、**一度に1つずつ質問**を続けます。
+各回答のあとも `grill` を再入力させることなく自動的に継続し、構造化された
+停止条件に達するまで質問します。
+
+```bash
+intent-cli grill --domain <domain> --format markdown
+intent-cli guide grill --domain <domain> --format markdown
+```
+
+両形式は同一のガイダンスを返し、`intent-cli --help` と
+`intent-cli guide commands list` から discoverable です。grill は既存の
+`interview` artifact の上に構築されており（回答は `intent-cli interview
+record-answer` で記録し、保留中の質問は `intent-cli interview next-question`
+で読み出します）、`clarification`（blocker 解決）でも `improve`（遡及的な
+再整合）でもなく、packet / issue を自動 publish しません。
+
+停止条件: `no-more-questions`（backlog が空で rediscovery でも新しい質問が
+見つからない場合にのみ `今のところ追加質問はありません` を返す）・
+`packet-ready`・`intent-update-ready`・`clarification-needed`・
+`blocked-by-user-decision`・`too-broad-split-needed`。packet / issue /
+intent-update のアクションは停止条件で提案し、operator の明示的な同意後にのみ
+適用します。
+
 ## Packet / issue
 
 ```bash

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -248,6 +248,7 @@ internal static class CommandRouter
                 ["workflow"] = GuideWorkflowCommand.Execute,
                 ["model"] = GuideModelCommand.Execute,
                 ["improve"] = GuideImproveCommand.Execute,
+                ["grill"] = GuideGrillCommand.Execute,
                 ["commands"] = GuideCommandsCommand.Execute,
                 ["onboarding"] = GuideOnboardingCommand.Execute,
                 ["intent-work"] = GuideIntentWorkCommand.Execute,
@@ -347,6 +348,17 @@ internal static class CommandRouter
         if (string.Equals(args[0], "improve", StringComparison.Ordinal))
         {
             return GuideImproveCommand.Execute(context, args[1..], writer);
+        }
+
+        // G463: top-level `intent-cli grill` alias for persistent interview
+        // mode. Like `improve`, it takes only flags (`--domain` / `--format` /
+        // `--help`), so it is intercepted here before group/subcommand dispatch
+        // and delegated verbatim to the same guidance surface as `guide grill`.
+        // A first-class top-level surface keeps an agent asked to "grill a
+        // topic" from misrouting to clarification or improve.
+        if (string.Equals(args[0], "grill", StringComparison.Ordinal))
+        {
+            return GuideGrillCommand.Execute(context, args[1..], writer);
         }
 
         // G334: per-group help routing. `intent-cli <group> --help` and
@@ -576,7 +588,8 @@ internal static class CommandRouter
         "implementation-loop — `intent-cli guide workflow task implementation-loop --target-repo <r> --agent claude --frequency 5m --format markdown` (paste-ready child implementation-loop prompt with current label/claim/complete rules, G338).",
         "review-next-slice-loop — `intent-cli guide workflow task review-next-slice-loop --domain <d> --target-repo <r> --agent claude --frequency 20m --format markdown` (paste-ready host review / next-slice-loop prompt with current host-sync preflight + packet/issue lifecycle rules, G338).",
         "bug-to-intent-repair — `intent-cli guide workflow task bug-to-intent-repair --format json` (report → triage → plan → intent-repair → implementation-repair chain; classifies implementation-mismatch / intent-gap / packet-gap / rule-gap / metadata-workflow-gap; recommends packet creation when the bug is in intent-cli rules/guidance, G339).",
-        "improve (design-thread reflection) — `intent-cli improve --domain <d> --format markdown` (alias of `intent-cli guide improve`): periodic MVV / ADR / intent-tree / packet-history / clarification-history realignment review, G456/G457. NOT bug-to-intent-repair, host-loop recovery, state-doctor, or dirty-state repair."
+        "improve (design-thread reflection) — `intent-cli improve --domain <d> --format markdown` (alias of `intent-cli guide improve`): periodic MVV / ADR / intent-tree / packet-history / clarification-history realignment review, G456/G457. NOT bug-to-intent-repair, host-loop recovery, state-doctor, or dirty-state repair.",
+        "grill (persistent interview mode) — `intent-cli grill --domain <d> --format markdown` (alias of `intent-cli guide grill`): once the user asks to grill a topic, stay in grill mode — generate an open-question backlog from current intents/packets/ADRs/docs, ask one question at a time, and continue after each answer until a stop condition holds, G463. Built on the interview artifacts; NOT clarification (blocker resolution) and NOT improve (retrospective realignment)."
     };
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/GuideGrillCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideGrillCommand.cs
@@ -1,0 +1,368 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G463: Read-only <c>intent-cli grill</c> / <c>intent-cli guide grill</c>.
+/// Emits the canonical <em>persistent interview mode</em> guidance: once the
+/// user asks to grill a topic, the design thread STAYS in grill mode and keeps
+/// asking one question at a time, generating an open-question backlog from the
+/// current intent context, until a structured stop condition is reached.
+///
+/// grill is the user-facing persistent mode BUILT ON the existing
+/// <c>interview</c> artifacts (it records answers through
+/// <c>interview record-answer</c> and reads pending questions through
+/// <c>interview next-question</c>); it does not introduce a new durable store.
+/// It is distinct from <c>clarification</c> (blocker resolution) and
+/// <c>improve</c> (retrospective realignment). Host-state-free: works from any
+/// cwd, never reads parent queue state, never launches an AI provider, and
+/// never auto-publishes packets or issues.
+/// </summary>
+internal static class GuideGrillCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli grill [--domain <name>] [--format markdown|json]  (alias: intent-cli guide grill)";
+
+    /// <summary>The shortest natural-language ask that starts persistent grill mode.</summary>
+    public const string ShortPrompt = "intent-cli で <topic> を grill してください。";
+
+    /// <summary>Returned only when the backlog is empty AND rediscovery finds no meaningful question.</summary>
+    public const string EmptyBacklogResponse = "今のところ追加質問はありません";
+
+    // Stop conditions the persistent grill loop recognizes (AC: all six required).
+    public const string StopNoMoreQuestions = "no-more-questions";
+    public const string StopPacketReady = "packet-ready";
+    public const string StopIntentUpdateReady = "intent-update-ready";
+    public const string StopClarificationNeeded = "clarification-needed";
+    public const string StopBlockedByUserDecision = "blocked-by-user-decision";
+    public const string StopTooBroadSplitNeeded = "too-broad-split-needed";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domain, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildResult(domain);
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    internal static GuideGrillResult BuildResult(string? domain)
+    {
+        var domainArg = string.IsNullOrWhiteSpace(domain) ? "<domain>" : domain!;
+
+        var prompt =
+$@"Enter persistent grill mode for `{domainArg}`: the user asked to grill a topic, so the thread STAYS in grill mode and keeps extracting intent one question at a time until a stop condition holds. You talk to the user in chat; you call intent-cli internally and never launch an AI provider.
+
+1. Research first: inspect current intents, recent packets, ADR / design notes, docs, and relevant implementation evidence BEFORE asking anything those artifacts already answer. Never make the user repeat known facts.
+2. Generate an open-question backlog: enumerate the open product / technical / operational / verification questions implied by the topic and the gaps you found. Order them by dependency (blocking decisions first).
+3. Ask exactly ONE question at a time and wait for the answer. Record each answer through the interview artifacts as it arrives.
+4. After each answer, CONTINUE automatically — re-derive the backlog (some answers open new questions, some close several) and ask the next one. Do NOT require the user to repeat `grill`.
+5. Stop only when a structured stop condition (below) holds. When the backlog is empty AND a fresh rediscovery pass finds no meaningful new question, return exactly: `{EmptyBacklogResponse}`.";
+
+        var inspectionSources = new[]
+        {
+            $"Current intents — `intents/{domainArg}/` MVV, product goal, and intent-tree nodes the topic touches.",
+            $"Recent packet history — `.intent-cli/issues/<unit>/` packets related to the topic, for decisions already made or still open.",
+            $"ADR / design notes — architecture decision records and design notes that constrain or inform the topic.",
+            "Docs — user-facing docs and README sections that describe current behavior for the topic.",
+            "Relevant implementation evidence — related code, tests, and GitHub issues/PRs, when available, so questions target real gaps rather than re-asking settled facts.",
+        };
+
+        var backlogGeneration = new[]
+        {
+            "Derive open questions across four intent dimensions: product (what/why/for-whom), technical (how/architecture/constraints), operational (rollout/ownership/failure modes), and verification (acceptance criteria / how it is proven).",
+            "Seed the backlog from the research gaps — every artifact that is missing, ambiguous, or contradicted by recent work becomes a candidate question.",
+            "Order by dependency: resolve blocking decisions before the decisions that depend on them; split a question that secretly bundles several decisions.",
+            "Keep the backlog visible: after each turn, restate what remains open so progress toward readiness is observable.",
+        };
+
+        var continuationBehavior = new[]
+        {
+            "grill is PERSISTENT: staying in grill mode after each answer is the default; the user does not re-issue `grill` to get the next question.",
+            "One decision per turn: ask a single focused question and wait — never batch multiple decisions into one turn.",
+            "Re-derive after every answer: an answer may close several backlog items or open new ones; recompute the backlog before asking the next question.",
+            $"Continue until a stop condition holds. Only when the backlog is empty and rediscovery finds nothing meaningful do you return `{EmptyBacklogResponse}`.",
+        };
+
+        var interviewIntegration = new[]
+        {
+            "grill is persistent interview mode built ON the existing interview artifacts — it reuses them internally rather than introducing a new durable session store.",
+            $"Read the pending question id: `intent-cli interview next-question --domain {domainArg} --format json`.",
+            $"Record each answer as it arrives: `intent-cli interview record-answer --domain {domainArg} --question-id <id> --answer \"<the user's decision>\"`.",
+            "The durable output is the interview decision record (resolved decisions + the answers that drove them), not a raw chat transcript.",
+            "See also `intent-cli guide interview-mode` for the per-turn question structure; grill is the persistent, backlog-driven wrapper over that protocol.",
+        };
+
+        var stopConditions = new[]
+        {
+            new GuideGrillStopCondition { Name = StopNoMoreQuestions, Meaning = $"The backlog is empty and a fresh rediscovery pass finds no meaningful new question; return exactly `{EmptyBacklogResponse}` and leave grill mode." },
+            new GuideGrillStopCondition { Name = StopPacketReady, Meaning = "Scope, constraints, acceptance criteria, and verification are resolved enough to draft the canonical packet; propose `intent-cli packet draft` (with operator acceptance). grill never auto-publishes." },
+            new GuideGrillStopCondition { Name = StopIntentUpdateReady, Meaning = "The answers establish an intent that should be written into the intent tree / specs; propose the intent update through the normal repo path before further questioning." },
+            new GuideGrillStopCondition { Name = StopClarificationNeeded, Meaning = "A blocking ambiguity surfaced that belongs in the clarification flow; stop grilling that thread and route it to `intent-cli clarification` rather than guessing." },
+            new GuideGrillStopCondition { Name = StopBlockedByUserDecision, Meaning = "Progress is gated on an explicit product-owner decision that has not been given; stop and name the exact decision needed." },
+            new GuideGrillStopCondition { Name = StopTooBroadSplitNeeded, Meaning = "The topic is too broad to grill as one thread; stop and propose splitting it into narrower sub-topics, then grill each in dependency order." },
+        };
+
+        return new GuideGrillResult
+        {
+            Process = "persistent-grill-interview",
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            ShortPrompt = ShortPrompt,
+            Summary =
+                "grill is the user-facing PERSISTENT interview mode. Once the user asks to grill a topic, the thread stays "
+                + "in grill mode: research the existing intents / packets / ADRs / docs / implementation evidence, generate an "
+                + "open-question backlog, ask one question at a time, and CONTINUE after each answer without the user repeating "
+                + "`grill` — until a structured stop condition holds. It is built on the existing interview artifacts; it is NOT "
+                + "clarification (blocker resolution) and NOT improve (retrospective realignment), and it never auto-publishes "
+                + "packets or issues.",
+            EmptyBacklogResponse = EmptyBacklogResponse,
+            NotThis = new[]
+            {
+                "grill does NOT auto-publish packets or issues — packet/issue creation stays an explicit, operator-accepted step at a stop condition.",
+                "grill does NOT replace `clarification` (blocker resolution) or `improve` (retrospective realignment) — it is forward extraction of intent before packets are cut.",
+                "intent-cli does NOT launch Claude/Codex/Copilot or any AI provider; the AI agent owns the semantic questioning and conversation.",
+                "grill is NOT a one-shot question — stopping after a single shallow answer while scope / constraints / acceptance / verification gaps remain is explicitly not enough.",
+            },
+            DoNotSubstitute = new[]
+            {
+                "When the user asks to grill a topic, run `intent-cli grill` (or `intent-cli guide grill`) and stay persistent — do NOT ask one question and drop out of grill mode.",
+                "Do NOT route grill to `clarification` for ordinary open questions — only an actual blocking ambiguity becomes `clarification-needed`.",
+                "Do NOT route grill to `improve` — improve is retrospective realignment of already-shipped work, not forward intent extraction.",
+                "If a first-class grill surface is not found in the installed CLI (e.g. `intent-cli grill --help` fails), report `grill guidance unavailable` and request a CLI update — do NOT silently substitute another workflow.",
+            },
+            InspectionSources = inspectionSources,
+            BacklogGeneration = backlogGeneration,
+            ContinuationBehavior = continuationBehavior,
+            InterviewIntegration = interviewIntegration,
+            StopConditions = stopConditions,
+            MutationBoundary = new[]
+            {
+                "Record answers through `intent-cli interview record-answer`; do not generate a packet from unrecorded answers.",
+                "Packet / issue / intent-update actions are proposed at a stop condition and applied only after explicit operator acceptance, through supported intent-cli / repo paths.",
+                "Never hand-edit workflow labels, queue-state, or publish metadata from grill — grill only reads context and records interview answers.",
+            },
+            Prompt = prompt,
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideGrillResult result)
+    {
+        writer.WriteLine("# Guide grill — persistent interview mode");
+        writer.WriteLine();
+        writer.WriteLine($"_Start it by asking:_ **{result.ShortPrompt}**");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: {result.Domain}");
+            writer.WriteLine();
+        }
+        writer.WriteLine(result.Summary);
+        writer.WriteLine();
+
+        writer.WriteLine("## Protocol");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+        writer.WriteLine();
+
+        writer.WriteLine("## What this is NOT");
+        foreach (var item in result.NotThis)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Do not substitute another workflow");
+        foreach (var item in result.DoNotSubstitute)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Inspect before asking");
+        foreach (var item in result.InspectionSources)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Open-question backlog generation");
+        foreach (var item in result.BacklogGeneration)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Continuation after each answer");
+        foreach (var item in result.ContinuationBehavior)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Interview integration");
+        foreach (var item in result.InterviewIntegration)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Stop conditions");
+        foreach (var condition in result.StopConditions)
+        {
+            writer.WriteLine($"- `{condition.Name}`: {condition.Meaning}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Mutation boundary");
+        foreach (var item in result.MutationBoundary)
+        {
+            writer.WriteLine($"- {item}");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string? domain, out string format, out string error)
+    {
+        domain = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("grill (alias: guide grill)");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only: persistent interview mode. Generates an open-question backlog from current intent context and keeps asking one question at a time, continuing after each answer until a stop condition holds. Built on the interview artifacts; never auto-publishes; never launches an AI provider.");
+        writer.WriteLine("Start it by asking: " + ShortPrompt);
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}
+
+internal sealed record GuideGrillResult
+{
+    [JsonPropertyName("process")]
+    public required string Process { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("short_prompt")]
+    public required string ShortPrompt { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("empty_backlog_response")]
+    public required string EmptyBacklogResponse { get; init; }
+
+    [JsonPropertyName("not_this")]
+    public required IReadOnlyList<string> NotThis { get; init; }
+
+    [JsonPropertyName("do_not_substitute")]
+    public required IReadOnlyList<string> DoNotSubstitute { get; init; }
+
+    [JsonPropertyName("inspection_sources")]
+    public required IReadOnlyList<string> InspectionSources { get; init; }
+
+    [JsonPropertyName("backlog_generation")]
+    public required IReadOnlyList<string> BacklogGeneration { get; init; }
+
+    [JsonPropertyName("continuation_behavior")]
+    public required IReadOnlyList<string> ContinuationBehavior { get; init; }
+
+    [JsonPropertyName("interview_integration")]
+    public required IReadOnlyList<string> InterviewIntegration { get; init; }
+
+    [JsonPropertyName("stop_conditions")]
+    public required IReadOnlyList<GuideGrillStopCondition> StopConditions { get; init; }
+
+    [JsonPropertyName("mutation_boundary")]
+    public required IReadOnlyList<string> MutationBoundary { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+}
+
+internal sealed record GuideGrillStopCondition
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("meaning")]
+    public required string Meaning { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -145,6 +145,12 @@ internal static class GuideHelpCommand
         },
         new GuideSubcommandEntry
         {
+            Name = "grill",
+            Purpose = "Persistent interview mode (G463): once the user asks to grill a topic, stay in grill mode — generate an open-question backlog from current intents/packets/ADRs/docs, ask one question at a time, and continue after each answer until a stop condition holds. Built on the interview artifacts; not clarification (blocker resolution) and not improve (retrospective realignment); never auto-publishes.",
+            Example = "intent-cli guide grill --domain <domain> --format markdown"
+        },
+        new GuideSubcommandEntry
+        {
             Name = "onboarding",
             Purpose = "First-call sequence for a fresh agent. Ordered list of guide / automation surfaces to read before any mutation.",
             Example = "intent-cli guide onboarding --format json"

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -42,6 +42,7 @@ internal static class Program
                 || IsAutomationWorktreeCommand(args)
                 || IsGuideOneshotCommand(args)
                 || IsImproveCommand(args)
+                || IsGrillCommand(args)
                 || IsWorkerCommand(args)
                 || IsHelpCommand(args))
             {
@@ -139,6 +140,8 @@ internal static class Program
                 || string.Equals(args[1], "model", StringComparison.Ordinal)
                 // G456: design-thread improve / realignment guidance — read-only, no host state required.
                 || string.Equals(args[1], "improve", StringComparison.Ordinal)
+                // G463: persistent grill interview-mode guidance — read-only, no host state required.
+                || string.Equals(args[1], "grill", StringComparison.Ordinal)
                 || string.Equals(args[1], "commands", StringComparison.Ordinal)
                 || string.Equals(args[1], "onboarding", StringComparison.Ordinal)
                 || string.Equals(args[1], "prompt-matrix", StringComparison.Ordinal)
@@ -177,6 +180,19 @@ internal static class Program
     private static bool IsImproveCommand(string[] args)
     {
         return args.Length >= 1 && string.Equals(args[0], "improve", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G463: the top-level <c>intent-cli grill</c> alias is a read-only
+    /// persistent-interview guidance surface (delegates to
+    /// <c>GuideGrillCommand</c>). Like <c>guide grill</c> it emits Markdown /
+    /// JSON without touching parent durable state, so it must bootstrap from
+    /// any cwd — including a child implementation repo with no
+    /// <c>.intent-cli/</c> directory.
+    /// </summary>
+    private static bool IsGrillCommand(string[] args)
+    {
+        return args.Length >= 1 && string.Equals(args[0], "grill", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -93,6 +93,49 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_TopLevelGrill_DelegatesToGuideGrill_PersistentInterviewMode()
+    {
+        // G463: `intent-cli grill` is a first-class top-level alias that
+        // delegates to the same persistent-interview guidance as `guide grill`.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["grill", "--domain", "intent-cli", "--format", "json"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        Assert.Equal("persistent-grill-interview", doc.RootElement.GetProperty("process").GetString());
+    }
+
+    [Fact]
+    public void Execute_GuideGrill_ReachesPersistentInterviewModeSurface()
+    {
+        // G463: the guide-namespaced form returns the same surface.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "grill", "--domain", "intent-cli", "--format", "json"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        Assert.Equal("persistent-grill-interview", doc.RootElement.GetProperty("process").GetString());
+    }
+
+    [Fact]
+    public void Execute_DefaultHelp_ExposesGrillPointer()
+    {
+        // G463: grill is discoverable from `intent-cli --help`.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(Array.Empty<string>(), CreateContext("/tmp/intent-system"), writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("intent-cli grill", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenHelpAll_ListsEveryCommandGroup_AndGenerateFromCurrent()
     {
         // G379: `intent-cli --help --all` restores the full group catalog,

--- a/tests/IntentSystem.Cli.Tests/GuideGrillCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideGrillCommandTests.cs
@@ -1,0 +1,151 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G463: tests for the persistent grill interview-mode guide surface.
+/// </summary>
+public sealed class GuideGrillCommandTests
+{
+    [Fact]
+    public void Execute_DefaultMarkdown_DescribesPersistentInterviewModeAndBacklog()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideGrillCommand.Execute(CreateContext(), [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide grill", output, StringComparison.Ordinal);
+        // AC: persistent interview mode using interview artifacts internally.
+        Assert.Contains("persistent", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("interview", output, StringComparison.OrdinalIgnoreCase);
+        // AC: open-question backlog generation + continuation-after-answer.
+        Assert.Contains("Open-question backlog generation", output, StringComparison.Ordinal);
+        Assert.Contains("Continuation after each answer", output, StringComparison.Ordinal);
+        // AC: one question at a time.
+        Assert.Contains("one question at a time", output, StringComparison.OrdinalIgnoreCase);
+        // AC: empty-backlog phrase only after backlog empty + rediscovery.
+        Assert.Contains("今のところ追加質問はありません", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasStableShapeAndAllRequiredStopConditions()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideGrillCommand.Execute(CreateContext(), ["--domain", "intent-cli", "--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("persistent-grill-interview", root.GetProperty("process").GetString());
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal("今のところ追加質問はありません", root.GetProperty("empty_backlog_response").GetString());
+
+        // AC: stop conditions include all six required names.
+        var stops = root.GetProperty("stop_conditions").EnumerateArray()
+            .Select(s => s.GetProperty("name").GetString()).ToArray();
+        foreach (var required in new[]
+                 {
+                     "no-more-questions", "packet-ready", "intent-update-ready",
+                     "clarification-needed", "blocked-by-user-decision", "too-broad-split-needed",
+                 })
+        {
+            Assert.Contains(required, stops);
+        }
+
+        // AC: backlog generation + continuation behavior present.
+        Assert.True(root.GetProperty("backlog_generation").GetArrayLength() > 0);
+        Assert.True(root.GetProperty("continuation_behavior").GetArrayLength() > 0);
+
+        // AC: built on interview artifacts — references the real interview commands.
+        var integration = string.Join("\n", root.GetProperty("interview_integration").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("interview next-question", integration, StringComparison.Ordinal);
+        Assert.Contains("interview record-answer", integration, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_DoesNotSubstituteClarificationOrImprove()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideGrillCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var doNotSubstitute = string.Join("\n", doc.RootElement.GetProperty("do_not_substitute").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("clarification", doNotSubstitute, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("improve", doNotSubstitute, StringComparison.Ordinal);
+        // AC: missing grill surface reports `grill guidance unavailable`.
+        Assert.Contains("grill guidance unavailable", doNotSubstitute, StringComparison.Ordinal);
+
+        // grill never auto-publishes.
+        var notThis = string.Join("\n", doc.RootElement.GetProperty("not_this").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("auto-publish", notThis, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_WithDomain_SubstitutesDomainInInspectionSources()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideGrillCommand.Execute(CreateContext(), ["--domain", "aic", "--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var sources = string.Join("\n", doc.RootElement.GetProperty("inspection_sources").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("intents/aic/", sources, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownFormat_ReturnsError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideGrillCommand.Execute(CreateContext(), ["--format", "yaml"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsageWithStartPrompt()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideGrillCommand.Execute(CreateContext(), ["--help"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("grill", output, StringComparison.Ordinal);
+        Assert.Contains("persistent interview mode", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GuideHelp_ListsGrillSubcommand_ForDiscoverability()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideHelpCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var names = doc.RootElement.GetProperty("subcommands").EnumerateArray()
+            .Select(s => s.GetProperty("name").GetString()).ToArray();
+        Assert.Contains("grill", names);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Implements #1026 (G463): add `intent-cli grill` and `intent-cli guide grill` as a user-facing **persistent interview mode**. Once the user asks to grill a topic, the thread STAYS in grill mode — it generates an open-question backlog from the current intent context and keeps asking one question at a time, continuing after each answer until a structured stop condition holds.

grill is built on the existing `interview` artifacts; it is **not** `clarification` (blocker resolution) and **not** `improve` (retrospective realignment), and it never auto-publishes packets or issues.

## Changes

- **`GuideGrillCommand`** — read-only guidance surface mirroring `guide improve` (G456). Emits `process=persistent-grill-interview` with summary, `not_this` / `do_not_substitute`, `inspection_sources`, `backlog_generation`, `continuation_behavior`, `interview_integration` (references the real `interview next-question` / `record-answer` commands), `stop_conditions`, `mutation_boundary`, and the empty-backlog response `今のところ追加質問はありません`. markdown + json.
- **CommandRouter** — top-level `grill` alias (intercepted before group dispatch), `guide grill` in the guide group, and a workflow guide pointer.
- **Program.cs** — `IsGrillCommand` bootstrap allow-list (top-level) + `guide grill` in the read-only guide allow-list, so grill works from a child cwd with no `.intent-cli/`.
- **GuideHelpCommand** — grill subcommand entry for discoverability.
- **docs (en/ja) + README** — grill persistent interview mode section.

## Acceptance criteria

- [x] `intent-cli grill --domain <d> --format markdown|json` and `intent-cli guide grill --domain <d> --format markdown|json` available.
- [x] Guide output states grill is persistent interview mode using interview artifacts internally.
- [x] Guide output includes open-question backlog generation and continuation-after-answer behavior.
- [x] Stop conditions include `no-more-questions`, `packet-ready`, `intent-update-ready`, `clarification-needed`, `blocked-by-user-decision`, and `too-broad-split-needed`.
- [x] Help / command catalog makes grill discoverable (`guide help`, `intent-cli --help`, top-level + guide-namespaced).

## Verification

- `dotnet test` CLI suite: 2985 passed / 1 skipped, green on two consecutive runs (determinism). +10 new grill/router tests.
- New tests: `GuideGrillCommandTests` (shape, all six stop conditions, interview integration, do-not-substitute clarification/improve, domain substitution, help) and `CommandRouterTests` top-level/guide/default-help discoverability.
- `git diff --check` clean.

Note: the issue lists host-owned `intents/intent-cli/specs/**` paths; those are host-side spec docs not present in the implementation repo, so this child PR delivers the equivalent command/guide/docs/test surfaces. All acceptance criteria are satisfied in child-owned code.

Closes #1026

🤖 Generated with [Claude Code](https://claude.com/claude-code)