### PR TITLE
G465 Add next advisor for choosing design-side action

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ repository and paste one of these prompts:
 > Stack the available packets for `<owner>/<repo>` with intent-cli.
 > Create the ready packets and publish only the first issue.
 
+**Ask what to do next:**
+
+> intent-cli に聞いて、次に何をしたらいいか教えてください。
+> (Ask intent-cli `next` to recommend the right design-side process.)
+
 The agent runs `intent-cli` commands internally and brings back questions or
 results. You focus on intent, priorities, and approval decisions. In **grill**
 mode (`intent-cli grill`) the thread stays persistent — it builds an

--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -137,6 +137,29 @@ only when the backlog is empty and rediscovery finds nothing), `packet-ready`,
 `too-broad-split-needed`. Packet / issue / intent-update actions are proposed at
 a stop condition and applied only after explicit operator acceptance.
 
+## Next — design-side action advisor
+
+The simplest design-thread question — "what should I do next?" — answered by
+`intent-cli next` (G465). It lays out the catalog of design-side processes and
+recommends one, so users do not have to remember every command name.
+
+```bash
+intent-cli next --domain <domain> --target-repo <owner/repo> --format markdown
+intent-cli guide next --domain <domain> --target-repo <owner/repo> --format markdown
+```
+
+Ask it in natural language: `intent-cli に聞いて、次に何をしたらいいか教えてくださ
+い。`. It checks the evidence (current intents, open questions, packet backlog,
+open PRs / review state, CLI / queue health) and recommends exactly one of
+**grill** (extract open questions), **stack** (create packet backlog + publish
+first issue), **improve** (retrospective realignment), **inspect** (read-only
+state), **issue-publish** (publish a ready packet), **review** (review an open
+PR), **recovery** (repair stale CLI / queue), or **idle** (nothing actionable).
+The output includes the recommended action, the reason, the evidence checked, a
+paste-ready suggested prompt, and the safety boundary. `next` is **read-only by
+default** and never auto-executes the chosen action — the user decides whether
+to run the suggested prompt.
+
 ## Stack — packet backlog creation + first issue publish
 
 A named **forward planning** process (G464). `stack` reads the current intents,

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -135,6 +135,28 @@ record-answer` で記録し、保留中の質問は `intent-cli interview next-q
 intent-update のアクションは停止条件で提案し、operator の明示的な同意後にのみ
 適用します。
 
+## Next — design-side アクションアドバイザー
+
+デザインスレッドで最もシンプルな問い「次に何をしたらいいか」に答えるのが
+`intent-cli next`（G465）です。design-side プロセスのカタログを提示し、その中から
+1つを推奨するので、ユーザーは全コマンド名を覚える必要がありません。
+
+```bash
+intent-cli next --domain <domain> --target-repo <owner/repo> --format markdown
+intent-cli guide next --domain <domain> --target-repo <owner/repo> --format markdown
+```
+
+自然言語で `intent-cli に聞いて、次に何をしたらいいか教えてください。` と尋ねれば、
+agent が evidence（現在の intents・open question・packet backlog・open PR / review
+状態・CLI / queue health）を確認し、**grill**（open question 抽出）・**stack**
+（packet backlog 作成 + 最初の issue publish）・**improve**（遡及的再整合）・
+**inspect**（read-only な状態確認）・**issue-publish**（ready な packet の publish）・
+**review**（open PR のレビュー）・**recovery**（stale CLI / queue の修復）・**idle**
+（着手可能な作業なし）のいずれか1つを推奨します。出力には recommended action・
+reason・確認した evidence・paste 可能な suggested prompt・safety boundary が含まれ
+ます。`next` はデフォルトで **read-only** で、選択したアクションを自動実行しません。
+実行するかはユーザーが判断します。
+
 ## Stack — packet backlog 作成 + 最初の issue publish
 
 名前付きの**前方計画**プロセス（G464）です。`stack` は現在の intents を読み、

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -250,6 +250,7 @@ internal static class CommandRouter
                 ["improve"] = GuideImproveCommand.Execute,
                 ["grill"] = GuideGrillCommand.Execute,
                 ["stack"] = GuideStackCommand.Execute,
+                ["next"] = GuideNextCommand.Execute,
                 ["commands"] = GuideCommandsCommand.Execute,
                 ["onboarding"] = GuideOnboardingCommand.Execute,
                 ["intent-work"] = GuideIntentWorkCommand.Execute,
@@ -373,6 +374,18 @@ internal static class CommandRouter
         if (string.Equals(args[0], "stack", StringComparison.Ordinal))
         {
             return GuideStackCommand.Execute(context, args[1..], writer);
+        }
+
+        // G465: top-level `intent-cli next` alias for the design-side action
+        // advisor. Like `improve` / `grill` / `stack`, it takes only flags
+        // (`--domain` / `--target-repo` / `--format` / `--help`), so it is
+        // intercepted here before group/subcommand dispatch and delegated
+        // verbatim to the same guidance surface as `guide next`. A first-class
+        // top-level surface is the answer to "intent-cli に聞いて、次に何を
+        // したらいいか教えてください。" without the agent guessing a process.
+        if (string.Equals(args[0], "next", StringComparison.Ordinal))
+        {
+            return GuideNextCommand.Execute(context, args[1..], writer);
         }
 
         // G334: per-group help routing. `intent-cli <group> --help` and
@@ -604,7 +617,8 @@ internal static class CommandRouter
         "bug-to-intent-repair — `intent-cli guide workflow task bug-to-intent-repair --format json` (report → triage → plan → intent-repair → implementation-repair chain; classifies implementation-mismatch / intent-gap / packet-gap / rule-gap / metadata-workflow-gap; recommends packet creation when the bug is in intent-cli rules/guidance, G339).",
         "improve (design-thread reflection) — `intent-cli improve --domain <d> --format markdown` (alias of `intent-cli guide improve`): periodic MVV / ADR / intent-tree / packet-history / clarification-history realignment review, G456/G457. NOT bug-to-intent-repair, host-loop recovery, state-doctor, or dirty-state repair.",
         "grill (persistent interview mode) — `intent-cli grill --domain <d> --format markdown` (alias of `intent-cli guide grill`): once the user asks to grill a topic, stay in grill mode — generate an open-question backlog from current intents/packets/ADRs/docs, ask one question at a time, and continue after each answer until a stop condition holds, G463. Built on the interview artifacts; NOT clarification (blocker resolution) and NOT improve (retrospective realignment).",
-        "stack (packet backlog creation) — `intent-cli stack --domain <d> --target-repo <r> --format markdown` (alias of `intent-cli guide stack`): forward planning — create an ordered packet backlog from the current intents (often ~10), commit/push durable state, and publish AT MOST the first GitHub issue by default, G464. Distinct from improve (retrospective realignment), grill (open-question interview), clarification (blocker resolution), and runtime queue transitions."
+        "stack (packet backlog creation) — `intent-cli stack --domain <d> --target-repo <r> --format markdown` (alias of `intent-cli guide stack`): forward planning — create an ordered packet backlog from the current intents (often ~10), commit/push durable state, and publish AT MOST the first GitHub issue by default, G464. Distinct from improve (retrospective realignment), grill (open-question interview), clarification (blocker resolution), and runtime queue transitions.",
+        "next (design-side action advisor) — `intent-cli next --domain <d> --target-repo <r> --format markdown` (alias of `intent-cli guide next`): answers \"what should I do next?\" by recommending ONE design-side process among grill / stack / improve / inspect / issue-publish / review / recovery / idle, with a paste-ready suggested prompt, G465. Read-only by default; never auto-executes."
     };
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -157,6 +157,12 @@ internal static class GuideHelpCommand
         },
         new GuideSubcommandEntry
         {
+            Name = "next",
+            Purpose = "Design-side action advisor (G465): answers 'what should I do next?' by recommending one design-side process among grill, stack, improve, inspect, issue-publish, review, recovery, and idle — with the evidence to check and a paste-ready suggested prompt. Read-only by default; never auto-executes; the user decides whether to run the recommendation.",
+            Example = "intent-cli guide next --domain <domain> --target-repo <owner/repo> --format markdown"
+        },
+        new GuideSubcommandEntry
+        {
             Name = "onboarding",
             Purpose = "First-call sequence for a fresh agent. Ordered list of guide / automation surfaces to read before any mutation.",
             Example = "intent-cli guide onboarding --format json"

--- a/src/IntentSystem.Cli/Commands/GuideNextCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideNextCommand.cs
@@ -1,0 +1,398 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G465: Read-only <c>intent-cli next</c> / <c>intent-cli guide next</c>.
+/// The design-side <em>action advisor</em>: answers "what should I do next?" by
+/// laying out the catalog of design-side processes (grill, stack, improve,
+/// inspect, issue-publish, review, recovery, idle), the evidence to check
+/// before choosing, and the recommendation output shape the agent fills in.
+///
+/// The intended user experience is a single natural-language ask:
+/// <c>intent-cli に聞いて、次に何をしたらいいか教えてください。</c>
+///
+/// next is READ-ONLY by default: it recommends a process, it does not secretly
+/// mutate packets, issues, labels, or queue state, and it never launches an AI
+/// provider. Host-state-free: works from any cwd.
+/// </summary>
+internal static class GuideNextCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli next [--domain <name>] [--target-repo <owner/repo>] [--format markdown|json]  (alias: intent-cli guide next)";
+
+    /// <summary>The shortest natural-language ask that triggers the advisor.</summary>
+    public const string ShortPrompt = "intent-cli に聞いて、次に何をしたらいいか教えてください。";
+
+    // Design-side actions in the decision set.
+    public const string ActionGrill = "grill";
+    public const string ActionStack = "stack";
+    public const string ActionImprove = "improve";
+    public const string ActionInspect = "inspect";
+    public const string ActionIssuePublish = "issue-publish";
+    public const string ActionReview = "review";
+    public const string ActionRecovery = "recovery";
+    public const string ActionIdle = "idle";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domain, out var targetRepo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildResult(domain, targetRepo);
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    internal static GuideNextResult BuildResult(string? domain, string? targetRepo)
+    {
+        var domainArg = string.IsNullOrWhiteSpace(domain) ? "<domain>" : domain!;
+        var repoArg = string.IsNullOrWhiteSpace(targetRepo) ? "<owner/repo>" : targetRepo!;
+
+        var prompt =
+$@"Advise the design thread on what to do next for `{domainArg}` ({repoArg}). This is READ-ONLY: recommend ONE design-side process, do not mutate packets / issues / labels / queue state, and never launch an AI provider.
+
+1. Check the evidence (below) — current intents, open questions, packet backlog, open PRs / review state, and CLI / queue health — before recommending.
+2. Match the situation to exactly one action in the decision set (grill / stack / improve / inspect / issue-publish / review / recovery / idle).
+3. Return the recommendation output shape: the recommended action, the reason tied to the evidence you actually checked, the evidence checked, a paste-ready suggested prompt for that action, and the safety boundary.
+4. Stop there — the user decides whether to run the suggested prompt. next never auto-executes the chosen action.";
+
+        var evidenceToCheck = new[]
+        {
+            $"Current intents — `intents/{domainArg}/` MVV / product goal / intent-tree: is the intent clear, or are there open questions to extract?",
+            $"Open questions / clarifications — `intents/{domainArg}/clarifications/`: unresolved blocking questions push toward grill or clarification.",
+            "Packet backlog — recent `.intent-cli/issues/<unit>/` packets: is there ready work to stack, or is the backlog already drafted?",
+            $"Open PRs and review state — `intent-cli guide review` inputs / GitHub PR labels for {repoArg}: a PR awaiting review pushes toward review; a request-update pushes toward recovery/comment-fix.",
+            "CLI / queue health — `intent-cli automation doctor`: a stale CLI or dirty queue pushes toward recovery before anything else.",
+            "Drift / short-term-loop signals — repeated corrective packets on the same surface push toward improve.",
+        };
+
+        var decisionSet = new[]
+        {
+            new GuideNextAction
+            {
+                Action = ActionGrill,
+                WhenToChoose = "The intent is still fuzzy — there are open product / technical / operational / verification questions to extract before any packet is cut. Persistent interview mode (G463).",
+                SuggestedPrompt = $"intent-cli で <topic> を grill してください。（`intent-cli grill --domain {domainArg} --format markdown`）",
+            },
+            new GuideNextAction
+            {
+                Action = ActionStack,
+                WhenToChoose = "The intent is clear and there is ready work to package — create an ordered packet backlog and publish the first issue. Forward planning (G464).",
+                SuggestedPrompt = $"intent-cli で stack を実行してください。（`intent-cli stack --domain {domainArg} --target-repo {repoArg} --format markdown`）",
+            },
+            new GuideNextAction
+            {
+                Action = ActionImprove,
+                WhenToChoose = "Recent work has drifted from MVV / ADR / intent tree, or a short-term-loop / repeated-patch pattern is showing. Retrospective realignment (G456).",
+                SuggestedPrompt = $"intent-cli で improve プロセスを実行してください。（`intent-cli improve --domain {domainArg} --format markdown`）",
+            },
+            new GuideNextAction
+            {
+                Action = ActionInspect,
+                WhenToChoose = "You need to understand the current state before deciding — read-only status of intents, packets, and the next planned slice.",
+                SuggestedPrompt = $"`intent-cli status brief --format json` / `intent-cli intent status` / `intent-cli intent next-slice --dry-run --domain {domainArg} --format json`",
+            },
+            new GuideNextAction
+            {
+                Action = ActionIssuePublish,
+                WhenToChoose = "A reviewed, contract-complete packet is ready to become a GitHub issue — publish through the normal boundary (host applies intent-target).",
+                SuggestedPrompt = $"`intent-cli issue publish-flow <id> --repo {repoArg} --write --format json` then `intent-cli automation issue-publish --write`",
+            },
+            new GuideNextAction
+            {
+                Action = ActionReview,
+                WhenToChoose = "An implementation PR is open and awaiting design/host review against its packet and intent.",
+                SuggestedPrompt = $"`intent-cli guide review --pr <n> --repo {repoArg} --domain {domainArg} --format json`",
+            },
+            new GuideNextAction
+            {
+                Action = ActionRecovery,
+                WhenToChoose = "The CLI is stale, the queue/labels are inconsistent, or a publish/closeout is stuck — repair operational state before design work.",
+                SuggestedPrompt = $"`intent-cli automation doctor --format json` then `intent-cli automation reconcile` / `intent-cli automation publish-recovery` as indicated.",
+            },
+            new GuideNextAction
+            {
+                Action = ActionIdle,
+                WhenToChoose = "Nothing is actionable on the design side right now — the backlog is drained, PRs are with the host, and no drift or open question is pending. Stop and wait.",
+                SuggestedPrompt = "（no action — report idle and wait for the next design input or host hand-off）",
+            },
+        };
+
+        return new GuideNextResult
+        {
+            Process = "design-action-next-advisor",
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            TargetRepo = string.IsNullOrWhiteSpace(targetRepo) ? null : targetRepo,
+            ShortPrompt = ShortPrompt,
+            ReadOnly = true,
+            Summary =
+                "next is the design-side action advisor: ask it what to do next and it lays out the catalog of design-side "
+                + "processes (grill, stack, improve, inspect, issue-publish, review, recovery, idle), the evidence to check first, "
+                + "and the recommendation output shape. It recommends ONE process tied to the evidence; it is read-only by default "
+                + "and never auto-executes the chosen action — the user decides whether to run the suggested prompt.",
+            NotThis = new[]
+            {
+                "next does NOT auto-execute the selected action — it recommends; the user runs the suggested prompt.",
+                "next is READ-ONLY by default — it does not mutate packets, issues, labels, or queue state.",
+                "next does NOT replace the host / review / worker loops — it advises the design thread, it does not drive operational automation.",
+                "intent-cli does NOT launch Claude/Codex/Copilot or any AI provider; the AI agent owns the semantic decision and conversation.",
+            },
+            DoNotSubstitute = new[]
+            {
+                "When the user asks what to do next, run `intent-cli next` (or `intent-cli guide next`) and recommend ONE design-side process — do NOT silently start one.",
+                "Do NOT turn next into a generic AI planner unrelated to intent-cli state — every recommendation must tie to the evidence checked.",
+                "If a first-class next surface is not found in the installed CLI (e.g. `intent-cli next --help` fails), report `next advisor unavailable` and request a CLI update — do NOT silently substitute another workflow.",
+            },
+            EvidenceToCheck = evidenceToCheck,
+            DecisionSet = decisionSet,
+            RecommendationOutputShape = new[]
+            {
+                new GuideNextOutputField { Field = "recommended_action", Meaning = "Exactly one action id from the decision set (grill / stack / improve / inspect / issue-publish / review / recovery / idle)." },
+                new GuideNextOutputField { Field = "reason", Meaning = "Why this action, tied to the specific evidence checked (cite the intent / packet / PR / health signal that drove it)." },
+                new GuideNextOutputField { Field = "evidence_checked", Meaning = "The evidence actually inspected this run, so the recommendation is auditable." },
+                new GuideNextOutputField { Field = "suggested_prompt", Meaning = "The paste-ready prompt / command for the recommended action that the user can run as-is." },
+                new GuideNextOutputField { Field = "safety_boundary", Meaning = "The read-only / no-auto-execute boundary: next recommended, the user decides whether to run it." },
+            },
+            SafetyBoundary = new[]
+            {
+                "Read-only by default: next inspects evidence and recommends; it does not mutate packets, issues, labels, or queue state.",
+                "No auto-execute: the recommended action runs only when the user chooses to run the suggested prompt.",
+                "Never hand-edit workflow labels, queue-state, or publish metadata from next — those stay in the operational intent-cli surfaces.",
+            },
+            Prompt = prompt,
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideNextResult result)
+    {
+        writer.WriteLine("# Guide next — design-side action advisor");
+        writer.WriteLine();
+        writer.WriteLine($"_Ask it:_ **{result.ShortPrompt}**");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: {result.Domain}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.TargetRepo))
+        {
+            writer.WriteLine($"- target repo: {result.TargetRepo}");
+        }
+        writer.WriteLine($"- read-only: {(result.ReadOnly ? "yes" : "no")}");
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+        writer.WriteLine();
+
+        writer.WriteLine("## Procedure");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+        writer.WriteLine();
+
+        writer.WriteLine("## What this is NOT");
+        foreach (var item in result.NotThis)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Do not substitute another workflow");
+        foreach (var item in result.DoNotSubstitute)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Evidence to check before recommending");
+        foreach (var item in result.EvidenceToCheck)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Decision set — when to choose each design-side process");
+        foreach (var action in result.DecisionSet)
+        {
+            writer.WriteLine($"- **{action.Action}** — {action.WhenToChoose}");
+            writer.WriteLine($"  - suggested prompt: {action.SuggestedPrompt}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Recommendation output shape");
+        foreach (var field in result.RecommendationOutputShape)
+        {
+            writer.WriteLine($"- `{field.Field}`: {field.Meaning}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Safety boundary");
+        foreach (var item in result.SafetyBoundary)
+        {
+            writer.WriteLine($"- {item}");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string? domain, out string? targetRepo, out string format, out string error)
+    {
+        domain = null;
+        targetRepo = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--target-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--target-repo requires a value.";
+                        return false;
+                    }
+                    targetRepo = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("next (alias: guide next)");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only: design-side action advisor. Lays out the design-side process catalog (grill / stack / improve / inspect / issue-publish / review / recovery / idle), the evidence to check, and the recommendation output shape so an AI agent can answer what to do next. Read-only by default; never auto-executes; never launches an AI provider.");
+        writer.WriteLine("Ask it: " + ShortPrompt);
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}
+
+internal sealed record GuideNextResult
+{
+    [JsonPropertyName("process")]
+    public required string Process { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("target_repo")]
+    public string? TargetRepo { get; init; }
+
+    [JsonPropertyName("short_prompt")]
+    public required string ShortPrompt { get; init; }
+
+    [JsonPropertyName("read_only")]
+    public required bool ReadOnly { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("not_this")]
+    public required IReadOnlyList<string> NotThis { get; init; }
+
+    [JsonPropertyName("do_not_substitute")]
+    public required IReadOnlyList<string> DoNotSubstitute { get; init; }
+
+    [JsonPropertyName("evidence_to_check")]
+    public required IReadOnlyList<string> EvidenceToCheck { get; init; }
+
+    [JsonPropertyName("decision_set")]
+    public required IReadOnlyList<GuideNextAction> DecisionSet { get; init; }
+
+    [JsonPropertyName("recommendation_output_shape")]
+    public required IReadOnlyList<GuideNextOutputField> RecommendationOutputShape { get; init; }
+
+    [JsonPropertyName("safety_boundary")]
+    public required IReadOnlyList<string> SafetyBoundary { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+}
+
+internal sealed record GuideNextAction
+{
+    [JsonPropertyName("action")]
+    public required string Action { get; init; }
+
+    [JsonPropertyName("when_to_choose")]
+    public required string WhenToChoose { get; init; }
+
+    [JsonPropertyName("suggested_prompt")]
+    public required string SuggestedPrompt { get; init; }
+}
+
+internal sealed record GuideNextOutputField
+{
+    [JsonPropertyName("field")]
+    public required string Field { get; init; }
+
+    [JsonPropertyName("meaning")]
+    public required string Meaning { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -44,6 +44,7 @@ internal static class Program
                 || IsImproveCommand(args)
                 || IsGrillCommand(args)
                 || IsStackCommand(args)
+                || IsNextCommand(args)
                 || IsWorkerCommand(args)
                 || IsHelpCommand(args))
             {
@@ -145,6 +146,8 @@ internal static class Program
                 || string.Equals(args[1], "grill", StringComparison.Ordinal)
                 // G464: stack packet-backlog-creation guidance — read-only, no host state required.
                 || string.Equals(args[1], "stack", StringComparison.Ordinal)
+                // G465: next design-side action advisor — read-only, no host state required.
+                || string.Equals(args[1], "next", StringComparison.Ordinal)
                 || string.Equals(args[1], "commands", StringComparison.Ordinal)
                 || string.Equals(args[1], "onboarding", StringComparison.Ordinal)
                 || string.Equals(args[1], "prompt-matrix", StringComparison.Ordinal)
@@ -209,6 +212,19 @@ internal static class Program
     private static bool IsStackCommand(string[] args)
     {
         return args.Length >= 1 && string.Equals(args[0], "stack", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G465: the top-level <c>intent-cli next</c> alias is a read-only
+    /// design-side action-advisor surface (delegates to
+    /// <c>GuideNextCommand</c>). Like <c>guide next</c> it emits Markdown /
+    /// JSON without touching parent durable state, so it must bootstrap from
+    /// any cwd — including a child implementation repo with no
+    /// <c>.intent-cli/</c> directory.
+    /// </summary>
+    private static bool IsNextCommand(string[] args)
+    {
+        return args.Length >= 1 && string.Equals(args[0], "next", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -179,6 +179,49 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_TopLevelNext_DelegatesToGuideNext_DesignActionAdvisor()
+    {
+        // G465: `intent-cli next` is a first-class top-level alias that
+        // delegates to the same design-side action-advisor guidance as `guide next`.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["next", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        Assert.Equal("design-action-next-advisor", doc.RootElement.GetProperty("process").GetString());
+    }
+
+    [Fact]
+    public void Execute_GuideNext_ReachesDesignActionAdvisorSurface()
+    {
+        // G465: the guide-namespaced form returns the same surface.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "next", "--domain", "intent-cli", "--format", "json"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        Assert.Equal("design-action-next-advisor", doc.RootElement.GetProperty("process").GetString());
+    }
+
+    [Fact]
+    public void Execute_DefaultHelp_ExposesNextPointer()
+    {
+        // G465: next is discoverable from `intent-cli --help`.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(Array.Empty<string>(), CreateContext("/tmp/intent-system"), writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("intent-cli next", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenHelpAll_ListsEveryCommandGroup_AndGenerateFromCurrent()
     {
         // G379: `intent-cli --help --all` restores the full group catalog,

--- a/tests/IntentSystem.Cli.Tests/GuideNextCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideNextCommandTests.cs
@@ -1,0 +1,154 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G465: tests for the design-side action advisor guide surface.
+/// </summary>
+public sealed class GuideNextCommandTests
+{
+    [Fact]
+    public void Execute_DefaultMarkdown_DescribesDecisionSetAndReadOnly()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideNextCommand.Execute(CreateContext(), [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide next", output, StringComparison.Ordinal);
+        // AC: the natural-language ask is present verbatim.
+        Assert.Contains("次に何をしたらいいか教えてください", output, StringComparison.Ordinal);
+        // AC: read-only by default.
+        Assert.Contains("read-only: yes", output, StringComparison.Ordinal);
+        // AC: decision set explains when to choose each process.
+        Assert.Contains("Decision set", output, StringComparison.Ordinal);
+        Assert.Contains("Recommendation output shape", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_IncludesAllEightDesignSideActions()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideNextCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("design-action-next-advisor", root.GetProperty("process").GetString());
+        Assert.True(root.GetProperty("read_only").GetBoolean());
+
+        // AC: decision set includes grill, stack, improve, inspect, issue-publish, review, recovery, idle.
+        var actions = root.GetProperty("decision_set").EnumerateArray()
+            .Select(a => a.GetProperty("action").GetString()).ToArray();
+        foreach (var required in new[]
+                 {
+                     "grill", "stack", "improve", "inspect",
+                     "issue-publish", "review", "recovery", "idle",
+                 })
+        {
+            Assert.Contains(required, actions);
+        }
+
+        // AC: every action carries a paste-ready suggested prompt.
+        foreach (var a in root.GetProperty("decision_set").EnumerateArray())
+        {
+            Assert.False(string.IsNullOrWhiteSpace(a.GetProperty("suggested_prompt").GetString()));
+        }
+    }
+
+    [Fact]
+    public void Execute_Json_RecommendationOutputShapeAndSafetyBoundaryPresent()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideNextCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+
+        // AC: output includes recommended action, reason, evidence, suggested prompt, safety boundary.
+        var fields = root.GetProperty("recommendation_output_shape").EnumerateArray()
+            .Select(f => f.GetProperty("field").GetString()).ToArray();
+        Assert.Equal(
+            new[] { "recommended_action", "reason", "evidence_checked", "suggested_prompt", "safety_boundary" },
+            fields);
+
+        // Read-only safety boundary present + do-not-substitute unavailable signal.
+        var safety = string.Join("\n", root.GetProperty("safety_boundary").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("Read-only", safety, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("No auto-execute", safety, StringComparison.OrdinalIgnoreCase);
+
+        var doNotSubstitute = string.Join("\n", root.GetProperty("do_not_substitute").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("next advisor unavailable", doNotSubstitute, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_WithDomain_SubstitutesDomainInEvidence()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideNextCommand.Execute(CreateContext(), ["--domain", "aic", "--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var evidence = string.Join("\n", doc.RootElement.GetProperty("evidence_to_check").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("intents/aic/", evidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownFormat_ReturnsError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideNextCommand.Execute(CreateContext(), ["--format", "yaml"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideNextCommand.Execute(CreateContext(), ["--help"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("next", output, StringComparison.Ordinal);
+        Assert.Contains("action advisor", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GuideHelp_ListsNextSubcommand_ForDiscoverability()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideHelpCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var names = doc.RootElement.GetProperty("subcommands").EnumerateArray()
+            .Select(s => s.GetProperty("name").GetString()).ToArray();
+        Assert.Contains("next", names);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Implements #1030 (G465): add `intent-cli next` and `intent-cli guide next` so a design-thread AI agent can answer "what should I do next?" by recommending **one** design-side process among grill, stack, improve, inspect, issue-publish, review, recovery, and idle.

The simplest user prompt — `intent-cli に聞いて、次に何をしたらいいか教えてください。` — now has a first-class surface instead of the agent guessing a process.

## Changes

- **`GuideNextCommand`** — read-only guidance surface mirroring `guide improve` (G456) / `grill` (G463) / `stack` (G464). Emits `process=design-action-next-advisor` with `read_only=true`, `evidence_to_check`, `decision_set` (all eight actions, each with when-to-choose + paste-ready `suggested_prompt`), `recommendation_output_shape` (recommended_action / reason / evidence_checked / suggested_prompt / safety_boundary), and `safety_boundary`. markdown + json.
- **CommandRouter** — top-level `next` alias (intercepted before group dispatch), `guide next` in the guide group, and a workflow guide pointer.
- **Program.cs** — `IsNextCommand` bootstrap allow-list (top-level) + `guide next` in the read-only guide allow-list, so next works from a child cwd with no `.intent-cli/`.
- **GuideHelpCommand** — next subcommand entry for discoverability.
- **docs (en/ja) + README** — next design-side action advisor section.

## Acceptance criteria

- [x] `intent-cli next --domain <d> --target-repo <r> --format markdown|json` and `intent-cli guide next ...` available.
- [x] Guide output explains when to choose grill, stack, improve, inspect, issue-publish, review, recovery, and idle.
- [x] Output includes a paste-ready suggested prompt for the recommended action (per action + in the output shape).
- [x] `intent-cli guide` / command catalog exposes the design-side process list (`guide help`, `intent-cli --help`).
- [x] `next` is read-only by default (`read_only=true`, safety boundary, no auto-execute).

## Verification

- `dotnet test` CLI suite (Release, CI-equivalent): 3006 passed / 1 skipped, green on two consecutive runs. +10 new next/router tests.
- New tests: `GuideNextCommandTests` (shape, all eight actions, output shape, read-only safety boundary, domain substitution, help) and `CommandRouterTests` top-level/guide/default-help discoverability.
- `git diff --check` clean.

Note: the issue lists host-owned `intents/intent-cli/specs/**` paths; those are host-side spec docs not present in the implementation repo, so this child PR delivers the equivalent command/guide/docs/test surfaces. All acceptance criteria are satisfied in child-owned code.

Closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)