### PR TITLE
G466 Add inspect process for evidence-backed observation and task generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ repository and paste one of these prompts:
 > intent-cli に聞いて、次に何をしたらいいか教えてください。
 > (Ask intent-cli `next` to recommend the right design-side process.)
 
+**Inspect the real product (evidence-backed observation):**
+
+> Inspect `<target>` with intent-cli.
+> Observe the real behavior, separate evidence from inference, and propose packet candidates.
+
 The agent runs `intent-cli` commands internally and brings back questions or
 results. You focus on intent, priorities, and approval decisions. In **grill**
 mode (`intent-cli grill`) the thread stays persistent — it builds an

--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -137,6 +137,28 @@ only when the backlog is empty and rediscovery finds nothing), `packet-ready`,
 `too-broad-split-needed`. Packet / issue / intent-update actions are proposed at
 a stop condition and applied only after explicit operator acceptance.
 
+## Inspect — evidence-backed observation
+
+A named process for **observing the real product** before cutting tasks (G466).
+`inspect` guides an agent to exercise the actual app / CLI / UI / logs / tests,
+strictly separate observed evidence from inference, compare against expected
+intent, and turn the gaps into packet candidates.
+
+```bash
+intent-cli inspect --domain <domain> --target-repo <owner/repo> --format markdown
+intent-cli guide inspect --domain <domain> --target-repo <owner/repo> --format markdown
+```
+
+The **Inspect Report** separates `observed_behavior`, `expected_intent`,
+`evidence`, `gaps`, `risk_severity`, `recommended_next_action`, and
+`packet_candidates`. The first pass is **read-only by default** — it never runs
+destructive interactions or auto-publishes — and it *guides how to use*
+browser / computer-use / log / test tooling rather than replacing it. Based on
+what it finds, an inspect pass routes to **stack** (package the gaps),
+**grill** (extract unclear intent), **improve** (systemic drift), **recovery**
+(broken operational state), or **no-action** (behavior matches intent). It is
+distinct from grill, stack, and improve.
+
 ## Next — design-side action advisor
 
 The simplest design-thread question — "what should I do next?" — answered by

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -135,6 +135,27 @@ record-answer` で記録し、保留中の質問は `intent-cli interview next-q
 intent-update のアクションは停止条件で提案し、operator の明示的な同意後にのみ
 適用します。
 
+## Inspect — evidence-backed 観測
+
+タスクを切る前に**実際のプロダクトを観測する**ための名前付きプロセスです（G466）。
+`inspect` は agent に、実際の app / CLI / UI / logs / tests を動かし、観測した
+evidence と inference を厳密に分離し、expected intent と比較し、その gap を packet
+candidate に変換するよう導きます。
+
+```bash
+intent-cli inspect --domain <domain> --target-repo <owner/repo> --format markdown
+intent-cli guide inspect --domain <domain> --target-repo <owner/repo> --format markdown
+```
+
+**Inspect Report** は `observed_behavior`・`expected_intent`・`evidence`・`gaps`・
+`risk_severity`・`recommended_next_action`・`packet_candidates` を分離します。最初の
+パスはデフォルトで **read-only** で、破壊的な操作や自動 publish を行わず、
+browser / computer-use / log / test ツールを**置き換えるのではなく使い方を導きます**。
+観測結果に応じて inspect パスは **stack**（gap を packet 化）・**grill**（不明確な
+intent を抽出）・**improve**（systemic drift）・**recovery**（壊れた運用状態）・
+**no-action**（intent と一致）へルーティングします。grill・stack・improve とは
+区別されます。
+
 ## Next — design-side アクションアドバイザー
 
 デザインスレッドで最もシンプルな問い「次に何をしたらいいか」に答えるのが

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -251,6 +251,7 @@ internal static class CommandRouter
                 ["grill"] = GuideGrillCommand.Execute,
                 ["stack"] = GuideStackCommand.Execute,
                 ["next"] = GuideNextCommand.Execute,
+                ["inspect"] = GuideInspectCommand.Execute,
                 ["commands"] = GuideCommandsCommand.Execute,
                 ["onboarding"] = GuideOnboardingCommand.Execute,
                 ["intent-work"] = GuideIntentWorkCommand.Execute,
@@ -386,6 +387,17 @@ internal static class CommandRouter
         if (string.Equals(args[0], "next", StringComparison.Ordinal))
         {
             return GuideNextCommand.Execute(context, args[1..], writer);
+        }
+
+        // G466: top-level `intent-cli inspect` alias for the evidence-backed
+        // observation process. Like `improve` / `grill` / `stack` / `next`, it
+        // takes only flags (`--domain` / `--target-repo` / `--format` /
+        // `--help`), so it is intercepted here before group/subcommand dispatch
+        // and delegated verbatim to the same guidance surface as
+        // `guide inspect`.
+        if (string.Equals(args[0], "inspect", StringComparison.Ordinal))
+        {
+            return GuideInspectCommand.Execute(context, args[1..], writer);
         }
 
         // G334: per-group help routing. `intent-cli <group> --help` and
@@ -618,7 +630,8 @@ internal static class CommandRouter
         "improve (design-thread reflection) — `intent-cli improve --domain <d> --format markdown` (alias of `intent-cli guide improve`): periodic MVV / ADR / intent-tree / packet-history / clarification-history realignment review, G456/G457. NOT bug-to-intent-repair, host-loop recovery, state-doctor, or dirty-state repair.",
         "grill (persistent interview mode) — `intent-cli grill --domain <d> --format markdown` (alias of `intent-cli guide grill`): once the user asks to grill a topic, stay in grill mode — generate an open-question backlog from current intents/packets/ADRs/docs, ask one question at a time, and continue after each answer until a stop condition holds, G463. Built on the interview artifacts; NOT clarification (blocker resolution) and NOT improve (retrospective realignment).",
         "stack (packet backlog creation) — `intent-cli stack --domain <d> --target-repo <r> --format markdown` (alias of `intent-cli guide stack`): forward planning — create an ordered packet backlog from the current intents (often ~10), commit/push durable state, and publish AT MOST the first GitHub issue by default, G464. Distinct from improve (retrospective realignment), grill (open-question interview), clarification (blocker resolution), and runtime queue transitions.",
-        "next (design-side action advisor) — `intent-cli next --domain <d> --target-repo <r> --format markdown` (alias of `intent-cli guide next`): answers \"what should I do next?\" by recommending ONE design-side process among grill / stack / improve / inspect / issue-publish / review / recovery / idle, with a paste-ready suggested prompt, G465. Read-only by default; never auto-executes."
+        "next (design-side action advisor) — `intent-cli next --domain <d> --target-repo <r> --format markdown` (alias of `intent-cli guide next`): answers \"what should I do next?\" by recommending ONE design-side process among grill / stack / improve / inspect / issue-publish / review / recovery / idle, with a paste-ready suggested prompt, G465. Read-only by default; never auto-executes.",
+        "inspect (evidence-backed observation) — `intent-cli inspect --domain <d> --target-repo <r> --format markdown` (alias of `intent-cli guide inspect`): observe the real app / CLI / UI / log / test behavior, separate observed evidence from inference, compare against expected intent, and turn gaps into packet candidates, G466. First pass read-only; routes to stack / grill / improve / recovery / no-action. Distinct from grill, stack, and improve."
     };
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -163,6 +163,12 @@ internal static class GuideHelpCommand
         },
         new GuideSubcommandEntry
         {
+            Name = "inspect",
+            Purpose = "Evidence-backed observation (G466): observe the real app/CLI/UI/log/test behavior, separate observed evidence from inference, compare against expected intent, and turn gaps into packet candidates. First pass read-only; routes to stack/grill/improve/recovery/no-action. Guides how to use browser/computer-use/log/test tooling rather than replacing it; distinct from grill, stack, and improve.",
+            Example = "intent-cli guide inspect --domain <domain> --target-repo <owner/repo> --format markdown"
+        },
+        new GuideSubcommandEntry
+        {
             Name = "onboarding",
             Purpose = "First-call sequence for a fresh agent. Ordered list of guide / automation surfaces to read before any mutation.",
             Example = "intent-cli guide onboarding --format json"

--- a/src/IntentSystem.Cli/Commands/GuideInspectCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideInspectCommand.cs
@@ -1,0 +1,380 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G466: Read-only <c>intent-cli inspect</c> / <c>intent-cli guide inspect</c>.
+/// The evidence-backed <em>observation</em> process: observe the REAL
+/// app / CLI / UI / log / test behavior with whatever tools are available,
+/// strictly separate observed evidence from inference, and convert the gaps
+/// between observed behavior and expected intent into packet candidates.
+///
+/// inspect is the named answer to "look at what the product actually does
+/// before cutting tasks", so agents stop inventing packets from stale
+/// assumptions. It is distinct from <c>grill</c> (open-question interview),
+/// <c>stack</c> (packet backlog creation), and <c>improve</c> (retrospective
+/// realignment).
+///
+/// The FIRST inspect pass is READ-ONLY by default: it observes and reports, it
+/// does not run destructive interactions, publish issues, or mutate state, and
+/// it never launches an AI provider. It guides how to use existing
+/// browser / computer-use / log / test tooling — it does not replace it.
+/// </summary>
+internal static class GuideInspectCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli inspect [--domain <name>] [--target-repo <owner/repo>] [--format markdown|json]  (alias: intent-cli guide inspect)";
+
+    /// <summary>The shortest natural-language ask that triggers the process.</summary>
+    public const string ShortPrompt = "intent-cli で <target> を inspect して、観測した挙動から packet candidate を出してください。";
+
+    // Where an inspect pass routes next.
+    public const string RouteStack = "stack";
+    public const string RouteGrill = "grill";
+    public const string RouteImprove = "improve";
+    public const string RouteRecovery = "recovery";
+    public const string RouteNoAction = "no-action";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domain, out var targetRepo, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var result = BuildResult(domain, targetRepo);
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    internal static GuideInspectResult BuildResult(string? domain, string? targetRepo)
+    {
+        var domainArg = string.IsNullOrWhiteSpace(domain) ? "<domain>" : domain!;
+        var repoArg = string.IsNullOrWhiteSpace(targetRepo) ? "<owner/repo>" : targetRepo!;
+
+        var prompt =
+$@"Run an evidence-backed inspect pass for `{domainArg}` ({repoArg}). The FIRST pass is READ-ONLY: observe the real behavior, do not run destructive interactions, do not publish issues, and never launch an AI provider.
+
+1. Observe the real product — exercise the app / CLI / UI / logs / tests with the tools you actually have (browser / computer-use / shell / test runner). Capture concrete, reproducible evidence (commands run, outputs, screenshots, log lines, test names).
+2. Separate observation from inference — write down ONLY what you observed as evidence; mark anything you are reasoning about as inference, never blur the two.
+3. Compare observed behavior against expected intent — read `intents/{domainArg}/` and recent packets for what the product is SUPPOSED to do, and identify the gaps.
+4. Rank gaps by risk / severity — note user impact and likelihood, so the most important gaps surface first.
+5. Convert gaps into packet candidates — concrete, cuttable slices, each tied to the evidence and the intent it restores. Do not publish them; propose them.
+6. Recommend the next action (below) — stack / grill / improve / recovery / no-action — and stop. The user decides.";
+
+        var observationVsInference = new[]
+        {
+            "Evidence is what you directly observed: a command you ran and its output, a log line, a screenshot, a failing test name — reproducible and attributable.",
+            "Inference is what you concluded from evidence: a suspected cause, a generalization, an expectation. Always label it as inference, never as observed fact.",
+            "Never promote inference to evidence: if you did not observe it this pass, it is not evidence — go observe it or mark the gap as 'unobserved'.",
+            "Every claimed gap must cite the specific evidence that shows it; a gap with no observed evidence is an open question for grill, not an inspect finding.",
+        };
+
+        var inspectionTargets = new[]
+        {
+            "App / UI behavior — exercise the running product with browser / computer-use tooling; capture what the user actually sees and does.",
+            "CLI behavior — run the real commands and capture exit codes and output; compare against documented behavior.",
+            "Logs — read runtime / build / CI logs for errors, warnings, and unexpected paths.",
+            "Tests — run the focused tests for the area and capture pass/fail + the concrete failure, not a summary.",
+            $"Intent baseline — `intents/{domainArg}/` and recent `.intent-cli/issues/<unit>/` packets for the expected behavior to compare against.",
+        };
+
+        var reportShape = new[]
+        {
+            new GuideInspectReportSection { Section = "observed_behavior", Meaning = "What the product actually did this pass — concrete and reproducible, no inference." },
+            new GuideInspectReportSection { Section = "expected_intent", Meaning = "What the product is supposed to do, per the intents / packets / docs, with the source cited." },
+            new GuideInspectReportSection { Section = "evidence", Meaning = "The raw evidence backing the observation: commands run, outputs, log lines, screenshots, test names." },
+            new GuideInspectReportSection { Section = "gaps", Meaning = "The differences between observed behavior and expected intent, each tied to the evidence above." },
+            new GuideInspectReportSection { Section = "risk_severity", Meaning = "User impact and likelihood for each gap, so the most important surface first." },
+            new GuideInspectReportSection { Section = "recommended_next_action", Meaning = "One of stack / grill / improve / recovery / no-action, with the reason." },
+            new GuideInspectReportSection { Section = "packet_candidates", Meaning = "Concrete, cuttable slices derived from the gaps — proposed, not published." },
+        };
+
+        var nextActionRouting = new[]
+        {
+            new GuideInspectRoute { Route = RouteStack, WhenToChoose = "The gaps are well understood and ready to package as work — hand the packet candidates to stack to create the backlog and publish the first issue." },
+            new GuideInspectRoute { Route = RouteGrill, WhenToChoose = "Inspection surfaced open questions the evidence cannot answer — the intent itself is unclear; grill to extract it before cutting packets." },
+            new GuideInspectRoute { Route = RouteImprove, WhenToChoose = "The gaps reveal systemic drift or a short-term-loop pattern, not a single fix — improve for retrospective realignment." },
+            new GuideInspectRoute { Route = RouteRecovery, WhenToChoose = "Inspection found broken operational state (stale CLI, dirty queue, stuck publish/closeout) — recover before more design work." },
+            new GuideInspectRoute { Route = RouteNoAction, WhenToChoose = "Observed behavior matches expected intent — no gap worth a packet; record the inspection and stop." },
+        };
+
+        return new GuideInspectResult
+        {
+            Process = "evidence-backed-inspect",
+            Domain = string.IsNullOrWhiteSpace(domain) ? null : domain,
+            TargetRepo = string.IsNullOrWhiteSpace(targetRepo) ? null : targetRepo,
+            ShortPrompt = ShortPrompt,
+            ReadOnly = true,
+            Summary =
+                "inspect is the evidence-backed observation process: observe the REAL app / CLI / UI / log / test behavior with the "
+                + "tools you have, strictly separate observed evidence from inference, compare against expected intent, and turn the "
+                + "gaps into packet candidates. The first pass is read-only by default; it never runs destructive interactions, never "
+                + "auto-publishes, and guides how to use existing browser / computer-use / log / test tooling rather than replacing it. "
+                + "It is distinct from grill (open-question interview), stack (packet backlog creation), and improve (retrospective "
+                + "realignment).",
+            NotThis = new[]
+            {
+                "inspect does NOT replace browser / computer-use / log / test tooling — it guides how to use that tooling and turn its output into evidence.",
+                "inspect does NOT run destructive interactions by default — the first pass is read-only observation.",
+                "inspect does NOT auto-publish issues — packet candidates are proposed; publishing is a separate, user-approved step (stack / issue-publish).",
+                "inspect does NOT do a broad retrospective intent rewrite — that is improve; inspect reports observed gaps and proposes cuttable slices.",
+                "intent-cli does NOT launch Claude/Codex/Copilot or any AI provider; the agent owns the observation and the semantic gap analysis.",
+            },
+            DoNotSubstitute = new[]
+            {
+                "When the work needs observing the real product before cutting tasks, run `intent-cli inspect` (or `intent-cli guide inspect`) — do NOT invent packets from stale assumptions.",
+                "Do NOT route inspect to grill for things you can directly observe — observe them and record evidence; only genuinely unobservable questions go to grill.",
+                "Do NOT route inspect to improve — improve is retrospective realignment, inspect is forward observation of real current behavior.",
+                "If a first-class inspect surface is not found in the installed CLI (e.g. `intent-cli inspect --help` fails), report `inspect guidance unavailable` and request a CLI update — do NOT silently substitute another workflow.",
+            },
+            ObservationVsInference = observationVsInference,
+            InspectionTargets = inspectionTargets,
+            ReportShape = reportShape,
+            NextActionRouting = nextActionRouting,
+            SafetyBoundary = new[]
+            {
+                "First inspect pass is read-only by default: observe and report, do not mutate product, packets, issues, labels, or queue state.",
+                "No destructive interactions by default: any state-changing interaction needs explicit user approval and is out of the first pass.",
+                "No auto-publish: packet candidates are proposed; the user decides whether to stack / publish them.",
+            },
+            Prompt = prompt,
+        };
+    }
+
+    private static void WriteMarkdown(TextWriter writer, GuideInspectResult result)
+    {
+        writer.WriteLine("# Guide inspect — evidence-backed observation");
+        writer.WriteLine();
+        writer.WriteLine($"_Run it by asking:_ **{result.ShortPrompt}**");
+        writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: {result.Domain}");
+        }
+        if (!string.IsNullOrWhiteSpace(result.TargetRepo))
+        {
+            writer.WriteLine($"- target repo: {result.TargetRepo}");
+        }
+        writer.WriteLine($"- read-only: {(result.ReadOnly ? "yes" : "no")}");
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+        writer.WriteLine();
+
+        writer.WriteLine("## Procedure");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(result.Prompt);
+        writer.WriteLine("```");
+        writer.WriteLine();
+
+        writer.WriteLine("## What this is NOT");
+        foreach (var item in result.NotThis)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Do not substitute another workflow");
+        foreach (var item in result.DoNotSubstitute)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Observation vs inference");
+        foreach (var item in result.ObservationVsInference)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Inspection targets");
+        foreach (var item in result.InspectionTargets)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Inspect Report sections");
+        foreach (var section in result.ReportShape)
+        {
+            writer.WriteLine($"- `{section.Section}`: {section.Meaning}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Where an inspect pass routes next");
+        foreach (var route in result.NextActionRouting)
+        {
+            writer.WriteLine($"- **{route.Route}** — {route.WhenToChoose}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Safety boundary");
+        foreach (var item in result.SafetyBoundary)
+        {
+            writer.WriteLine($"- {item}");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string? domain, out string? targetRepo, out string format, out string error)
+    {
+        domain = null;
+        targetRepo = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--target-repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--target-repo requires a value.";
+                        return false;
+                    }
+                    targetRepo = args[index + 1].Trim();
+                    index++;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[index + 1];
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    index++;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("inspect (alias: guide inspect)");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only: evidence-backed observation process. Observe the real app / CLI / UI / log / test behavior, separate observed evidence from inference, compare against expected intent, and turn gaps into packet candidates. First pass read-only; never runs destructive interactions; never auto-publishes; never launches an AI provider.");
+        writer.WriteLine("Run it by asking: " + ShortPrompt);
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+}
+
+internal sealed record GuideInspectResult
+{
+    [JsonPropertyName("process")]
+    public required string Process { get; init; }
+
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("target_repo")]
+    public string? TargetRepo { get; init; }
+
+    [JsonPropertyName("short_prompt")]
+    public required string ShortPrompt { get; init; }
+
+    [JsonPropertyName("read_only")]
+    public required bool ReadOnly { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("not_this")]
+    public required IReadOnlyList<string> NotThis { get; init; }
+
+    [JsonPropertyName("do_not_substitute")]
+    public required IReadOnlyList<string> DoNotSubstitute { get; init; }
+
+    [JsonPropertyName("observation_vs_inference")]
+    public required IReadOnlyList<string> ObservationVsInference { get; init; }
+
+    [JsonPropertyName("inspection_targets")]
+    public required IReadOnlyList<string> InspectionTargets { get; init; }
+
+    [JsonPropertyName("report_shape")]
+    public required IReadOnlyList<GuideInspectReportSection> ReportShape { get; init; }
+
+    [JsonPropertyName("next_action_routing")]
+    public required IReadOnlyList<GuideInspectRoute> NextActionRouting { get; init; }
+
+    [JsonPropertyName("safety_boundary")]
+    public required IReadOnlyList<string> SafetyBoundary { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+}
+
+internal sealed record GuideInspectReportSection
+{
+    [JsonPropertyName("section")]
+    public required string Section { get; init; }
+
+    [JsonPropertyName("meaning")]
+    public required string Meaning { get; init; }
+}
+
+internal sealed record GuideInspectRoute
+{
+    [JsonPropertyName("route")]
+    public required string Route { get; init; }
+
+    [JsonPropertyName("when_to_choose")]
+    public required string WhenToChoose { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -45,6 +45,7 @@ internal static class Program
                 || IsGrillCommand(args)
                 || IsStackCommand(args)
                 || IsNextCommand(args)
+                || IsInspectCommand(args)
                 || IsWorkerCommand(args)
                 || IsHelpCommand(args))
             {
@@ -148,6 +149,8 @@ internal static class Program
                 || string.Equals(args[1], "stack", StringComparison.Ordinal)
                 // G465: next design-side action advisor — read-only, no host state required.
                 || string.Equals(args[1], "next", StringComparison.Ordinal)
+                // G466: inspect evidence-backed observation guidance — read-only, no host state required.
+                || string.Equals(args[1], "inspect", StringComparison.Ordinal)
                 || string.Equals(args[1], "commands", StringComparison.Ordinal)
                 || string.Equals(args[1], "onboarding", StringComparison.Ordinal)
                 || string.Equals(args[1], "prompt-matrix", StringComparison.Ordinal)
@@ -225,6 +228,19 @@ internal static class Program
     private static bool IsNextCommand(string[] args)
     {
         return args.Length >= 1 && string.Equals(args[0], "next", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G466: the top-level <c>intent-cli inspect</c> alias is a read-only
+    /// evidence-backed observation guidance surface (delegates to
+    /// <c>GuideInspectCommand</c>). Like <c>guide inspect</c> it emits Markdown /
+    /// JSON without touching parent durable state, so it must bootstrap from
+    /// any cwd — including a child implementation repo with no
+    /// <c>.intent-cli/</c> directory.
+    /// </summary>
+    private static bool IsInspectCommand(string[] args)
+    {
+        return args.Length >= 1 && string.Equals(args[0], "inspect", StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CommandRouterTests.cs
@@ -222,6 +222,49 @@ public sealed class CommandRouterTests
     }
 
     [Fact]
+    public void Execute_TopLevelInspect_DelegatesToGuideInspect_EvidenceBackedObservation()
+    {
+        // G466: `intent-cli inspect` is a first-class top-level alias that
+        // delegates to the same evidence-backed observation guidance as `guide inspect`.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["inspect", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        Assert.Equal("evidence-backed-inspect", doc.RootElement.GetProperty("process").GetString());
+    }
+
+    [Fact]
+    public void Execute_GuideInspect_ReachesEvidenceBackedObservationSurface()
+    {
+        // G466: the guide-namespaced form returns the same surface.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "inspect", "--domain", "intent-cli", "--format", "json"],
+            CreateContext("/tmp/intent-system"),
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        Assert.Equal("evidence-backed-inspect", doc.RootElement.GetProperty("process").GetString());
+    }
+
+    [Fact]
+    public void Execute_DefaultHelp_ExposesInspectPointer()
+    {
+        // G466: inspect is discoverable from `intent-cli --help`.
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(Array.Empty<string>(), CreateContext("/tmp/intent-system"), writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("intent-cli inspect", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenHelpAll_ListsEveryCommandGroup_AndGenerateFromCurrent()
     {
         // G379: `intent-cli --help --all` restores the full group catalog,

--- a/tests/IntentSystem.Cli.Tests/GuideInspectCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideInspectCommandTests.cs
@@ -1,0 +1,151 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G466: tests for the evidence-backed inspect guide surface.
+/// </summary>
+public sealed class GuideInspectCommandTests
+{
+    [Fact]
+    public void Execute_DefaultMarkdown_DescribesObservationVsInferenceAndReadOnly()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideInspectCommand.Execute(CreateContext(), [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# Guide inspect", output, StringComparison.Ordinal);
+        // AC: observation vs inference rules.
+        Assert.Contains("Observation vs inference", output, StringComparison.Ordinal);
+        // AC: first pass read-only by default.
+        Assert.Contains("read-only: yes", output, StringComparison.Ordinal);
+        // AC: report sections + routing present.
+        Assert.Contains("Inspect Report sections", output, StringComparison.Ordinal);
+        Assert.Contains("routes next", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_IncludesAllReportSections()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideInspectCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("evidence-backed-inspect", root.GetProperty("process").GetString());
+        Assert.True(root.GetProperty("read_only").GetBoolean());
+
+        // AC: Inspect Report sections — observed behavior, expected intent, evidence,
+        // gaps, risk/severity, recommended next action, packet candidates.
+        var sections = root.GetProperty("report_shape").EnumerateArray()
+            .Select(s => s.GetProperty("section").GetString()).ToArray();
+        Assert.Equal(
+            new[]
+            {
+                "observed_behavior", "expected_intent", "evidence", "gaps",
+                "risk_severity", "recommended_next_action", "packet_candidates",
+            },
+            sections);
+
+        // AC: observation vs inference rules present.
+        Assert.True(root.GetProperty("observation_vs_inference").GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public void Execute_Json_RoutingCoversStackGrillImproveRecoveryNoAction()
+    {
+        // AC: explains when inspect should lead to stack, grill, improve, recovery, or no action.
+        using var writer = new StringWriter();
+        var exitCode = GuideInspectCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var routes = doc.RootElement.GetProperty("next_action_routing").EnumerateArray()
+            .Select(r => r.GetProperty("route").GetString()).ToArray();
+        foreach (var required in new[] { "stack", "grill", "improve", "recovery", "no-action" })
+        {
+            Assert.Contains(required, routes);
+        }
+
+        // do-not-substitute names the unavailable-surface signal.
+        var doNotSubstitute = string.Join("\n", doc.RootElement.GetProperty("do_not_substitute").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("inspect guidance unavailable", doNotSubstitute, StringComparison.Ordinal);
+
+        // Safety boundary: read-only first pass, no destructive interactions.
+        var safety = string.Join("\n", doc.RootElement.GetProperty("safety_boundary").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("read-only", safety, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("destructive", safety, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_WithDomain_SubstitutesDomainInInspectionTargets()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideInspectCommand.Execute(CreateContext(), ["--domain", "aic", "--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var targets = string.Join("\n", doc.RootElement.GetProperty("inspection_targets").EnumerateArray().Select(e => e.GetString()));
+        Assert.Contains("intents/aic/", targets, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownFormat_ReturnsError()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideInspectCommand.Execute(CreateContext(), ["--format", "yaml"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideInspectCommand.Execute(CreateContext(), ["--help"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("inspect", output, StringComparison.Ordinal);
+        Assert.Contains("evidence-backed", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GuideHelp_ListsInspectSubcommand_ForDiscoverability()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideHelpCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var names = doc.RootElement.GetProperty("subcommands").EnumerateArray()
+            .Select(s => s.GetProperty("name").GetString()).ToArray();
+        Assert.Contains("inspect", names);
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Implements #1032 (G466): add `intent-cli inspect` and `intent-cli guide inspect` so AI agents can observe the **real** app / CLI / UI / log / test behavior, strictly separate observed evidence from inference, compare against expected intent, and convert the gaps into packet candidates — instead of inventing packets from stale assumptions.

## Changes

- **`GuideInspectCommand`** — read-only guidance surface mirroring `guide improve` (G456) / `grill` (G463) / `stack` (G464) / `next` (G465). Emits `process=evidence-backed-inspect` with `read_only=true`, `observation_vs_inference` rules, `inspection_targets`, the seven-section `report_shape` (observed_behavior / expected_intent / evidence / gaps / risk_severity / recommended_next_action / packet_candidates), `next_action_routing` (stack / grill / improve / recovery / no-action), and `safety_boundary`. markdown + json.
- **CommandRouter** — top-level `inspect` alias (intercepted before group dispatch), `guide inspect` in the guide group, and a workflow guide pointer.
- **Program.cs** — `IsInspectCommand` bootstrap allow-list (top-level) + `guide inspect` in the read-only guide allow-list, so inspect works from a child cwd with no `.intent-cli/`.
- **GuideHelpCommand** — inspect subcommand entry for discoverability.
- **docs (en/ja) + README** — inspect evidence-backed observation section.

## Acceptance criteria

- [x] `intent-cli inspect --domain <d> --target-repo <r> --format markdown|json` and `intent-cli guide inspect ...` available.
- [x] Guide output includes observation vs inference rules.
- [x] Inspect Report sections: observed behavior, expected intent, evidence, gaps, risk/severity, recommended next action, packet candidates.
- [x] Guide output explains when inspect leads to stack, grill, improve, recovery, or no action.
- [x] First inspect pass is read-only by default (`read_only=true`, safety boundary).
- [x] Help / command catalog includes inspect.

## Verification

- `dotnet test` CLI suite (Release, CI-equivalent): 3016 passed / 1 skipped, green on two consecutive runs. +10 new inspect/router tests.
- New tests: `GuideInspectCommandTests` + `CommandRouterTests` top-level/guide/default-help discoverability.
- `git diff --check` clean.

Note: the issue lists host-owned `intents/intent-cli/specs/**` paths; those are host-side spec docs not present in the implementation repo, so this child PR delivers the equivalent command/guide/docs/test surfaces. All acceptance criteria are satisfied in child-owned code.

Closes #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)