### PR TITLE
G467 Complete guide catalogs for design, review, implementation, and loop prompt creation

### DIFF
--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -174,9 +174,11 @@ Ask it in natural language: `intent-cli に聞いて、次に何をしたらい�
 い。`. It checks the evidence (current intents, open questions, packet backlog,
 open PRs / review state, CLI / queue health) and recommends exactly one of
 **grill** (extract open questions), **stack** (create packet backlog + publish
-first issue), **improve** (retrospective realignment), **inspect** (read-only
-state), **issue-publish** (publish a ready packet), **review** (review an open
-PR), **recovery** (repair stale CLI / queue), or **idle** (nothing actionable).
+first issue), **improve** (retrospective realignment), **inspect**
+(evidence-backed observation of real app/CLI/UI/log/test behavior, not just
+status checking), **issue-publish** (publish a ready packet), **review** (review
+an open PR), **recovery** (repair stale CLI / queue), or **idle** (nothing
+actionable).
 The output includes the recommended action, the reason, the evidence checked, a
 paste-ready suggested prompt, and the safety boundary. `next` is **read-only by
 default** and never auto-executes the chosen action — the user decides whether
@@ -237,6 +239,16 @@ intent-cli automation doctor --format json
 ---
 
 ## Command group overview
+
+`intent-cli guide commands list` is a **role-based catalog** (G467): every
+command group carries an operator-role category — **design** (improve / grill /
+stack / next / inspect / intent / interview / packet / clarify), **host-review**
+(review / closeout / automation / issue), **child-implementation** (worker),
+**recovery-diagnostics** (automation doctor / metadata / queue), and
+**advanced-developer** (task) — alongside its `primary`/`support` lifecycle
+classification. `intent-cli guide help` explains the same role buckets and points
+to the loop-prompt generators (`guide workflow task implementation-loop` /
+`review-next-slice-loop`).
 
 | Surface | Role |
 |---------|------|

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -171,7 +171,7 @@ intent-cli guide next --domain <domain> --target-repo <owner/repo> --format mark
 agent が evidence（現在の intents・open question・packet backlog・open PR / review
 状態・CLI / queue health）を確認し、**grill**（open question 抽出）・**stack**
 （packet backlog 作成 + 最初の issue publish）・**improve**（遡及的再整合）・
-**inspect**（read-only な状態確認）・**issue-publish**（ready な packet の publish）・
+**inspect**（実際の app/CLI/UI/log/test 挙動の evidence-backed 観測。単なる status 確認ではない）・**issue-publish**（ready な packet の publish）・
 **review**（open PR のレビュー）・**recovery**（stale CLI / queue の修復）・**idle**
 （着手可能な作業なし）のいずれか1つを推奨します。出力には recommended action・
 reason・確認した evidence・paste 可能な suggested prompt・safety boundary が含まれ
@@ -231,6 +231,16 @@ intent-cli automation doctor --format json
 ---
 
 ## コマンドグループ概要
+
+`intent-cli guide commands list` は **role ベースのカタログ**（G467）です。各
+command group が operator-role カテゴリ — **design**（improve / grill / stack /
+next / inspect / intent / interview / packet / clarify）・**host-review**（review /
+closeout / automation / issue）・**child-implementation**（worker）・
+**recovery-diagnostics**（automation doctor / metadata / queue）・
+**advanced-developer**（task）— を `primary`/`support` lifecycle classification
+とともに持ちます。`intent-cli guide help` も同じ role バケットを説明し、loop-prompt
+生成（`guide workflow task implementation-loop` / `review-next-slice-loop`）を案内
+します。
 
 | Surface | 役割 |
 |---------|------|

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -27,6 +27,14 @@ internal static class GuideCommandsListCommand
     private const string CallerHostLoop = "host-loop";
     private const string CallerOperator = "operator";
 
+    // G467: operator-role categories so an unfamiliar AI agent can find the
+    // right surface by role, not just by lifecycle classification.
+    private const string RoleDesign = "design";                       // design-side planning (host design thread)
+    private const string RoleHostReview = "host-review";              // host review / next-slice / publish
+    private const string RoleChildImplementation = "child-implementation"; // child implementation loop
+    private const string RoleRecoveryDiagnostics = "recovery-diagnostics"; // operational recovery / diagnostics
+    private const string RoleAdvancedDeveloper = "advanced-developer";     // advanced / developer / dogfooding
+
     private const string UsageLine =
         "Usage: intent-cli guide commands list [--format markdown|json]";
 
@@ -35,14 +43,16 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "guide",
+            Role = RoleDesign,
             Classification = ClassificationPrimary,
             Mutability = MutabilityReadOnly,
             RecommendedCaller = CallerChatAgent,
-            Purpose = "Operator-facing guidance: collaboration model, rules-by-topic, workflow suggestion, prompt-template catalog, one-shot/automation/review prompts."
+            Purpose = "Operator-facing guidance: collaboration model, rules-by-topic, workflow suggestion, prompt-template catalog, one-shot/automation/review prompts. The single entry point an unfamiliar AI agent reads first."
         },
         new CommandGroupEntry
         {
             Name = "improve",
+            Role = RoleDesign,
             Classification = ClassificationPrimary,
             Mutability = MutabilityReadOnly,
             RecommendedCaller = CallerChatAgent,
@@ -50,7 +60,44 @@ internal static class GuideCommandsListCommand
         },
         new CommandGroupEntry
         {
+            Name = "grill",
+            Role = RoleDesign,
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Persistent interview mode (G463): `intent-cli grill --domain <d>` (alias of `guide grill`) stays in grill mode, generates an open-question backlog from current intents, and asks one question at a time until a stop condition. Built on the interview artifacts; not clarification, not improve."
+        },
+        new CommandGroupEntry
+        {
+            Name = "stack",
+            Role = RoleDesign,
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Packet backlog creation (G464): `intent-cli stack --domain <d> --target-repo <r>` (alias of `guide stack`) creates an ordered packet backlog from current intents, commits/pushes durable state, and publishes at most the first GitHub issue by default. Forward planning — not improve, grill, clarification, or a queue transition."
+        },
+        new CommandGroupEntry
+        {
+            Name = "next",
+            Role = RoleDesign,
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Design-side action advisor (G465): `intent-cli next --domain <d> --target-repo <r>` (alias of `guide next`) recommends ONE design-side process — grill / stack / improve / inspect / issue-publish / review / recovery / idle — with a paste-ready suggested prompt. Read-only; never auto-executes."
+        },
+        new CommandGroupEntry
+        {
+            Name = "inspect",
+            Role = RoleDesign,
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Evidence-backed observation (G466): `intent-cli inspect --domain <d> --target-repo <r>` (alias of `guide inspect`) observes real app/CLI/UI/log/test behavior, separates observed evidence from inference, and turns gaps into packet candidates. NOT status / next-slice checking; routes to stack / grill / improve / recovery / no-action."
+        },
+        new CommandGroupEntry
+        {
             Name = "intent",
+            Role = RoleDesign,
             Classification = ClassificationPrimary,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerChatAgent,
@@ -59,14 +106,16 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "interview",
+            Role = RoleDesign,
             Classification = ClassificationPrimary,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerChatAgent,
-            Purpose = "Durable per-domain Q/A artifact: next-question/record-answer/compile (older start/answer/resume retained)."
+            Purpose = "Durable per-domain Q/A artifact: next-question/record-answer/compile (older start/answer/resume retained). grill is the persistent wrapper over this surface."
         },
         new CommandGroupEntry
         {
             Name = "packet",
+            Role = RoleDesign,
             Classification = ClassificationPrimary,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerChatAgent,
@@ -75,22 +124,25 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "worker",
+            Role = RoleChildImplementation,
             Classification = ClassificationPrimary,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerImplementationLoop,
-            Purpose = "Child implementation loop selector: next-action / claim / complete / result-summary."
+            Purpose = "Child implementation loop selector: next-action / claim / complete / result-summary / issue-preflight / pr-comment-preflight. GitHub-contract-only with --github-only."
         },
         new CommandGroupEntry
         {
             Name = "automation",
+            Role = RoleHostReview,
             Classification = ClassificationSupport,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerHostLoop,
-            Purpose = "Host-side label transitions and capability JSON: summary / doctor / host-review-preflight / issue-publish / pr-transition / check / complete / clarification-stop."
+            Purpose = "Host-side label transitions and capability JSON: summary / doctor / host-review-preflight / issue-publish / pr-transition / check / complete / clarification-stop. doctor / reconcile / publish-recovery are the recovery-diagnostics subset."
         },
         new CommandGroupEntry
         {
             Name = "metadata",
+            Role = RoleRecoveryDiagnostics,
             Classification = ClassificationSupport,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerHostLoop,
@@ -99,6 +151,7 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "review",
+            Role = RoleHostReview,
             Classification = ClassificationSupport,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerHostLoop,
@@ -107,6 +160,7 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "closeout",
+            Role = RoleHostReview,
             Classification = ClassificationSupport,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerHostLoop,
@@ -115,6 +169,7 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "issue",
+            Role = RoleHostReview,
             Classification = ClassificationSupport,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerOperator,
@@ -123,6 +178,7 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "queue",
+            Role = RoleRecoveryDiagnostics,
             Classification = ClassificationSupport,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerOperator,
@@ -131,6 +187,7 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "status",
+            Role = RoleDesign,
             Classification = ClassificationSupport,
             Mutability = MutabilityReadOnly,
             RecommendedCaller = CallerChatAgent,
@@ -139,6 +196,7 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "context",
+            Role = RoleDesign,
             Classification = ClassificationSupport,
             Mutability = MutabilityReadOnly,
             RecommendedCaller = CallerChatAgent,
@@ -147,6 +205,7 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "clarify",
+            Role = RoleDesign,
             Classification = ClassificationSupport,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerOperator,
@@ -155,6 +214,7 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "next-slice",
+            Role = RoleDesign,
             Classification = ClassificationSupport,
             Mutability = MutabilityReadOnly,
             RecommendedCaller = CallerOperator,
@@ -163,10 +223,38 @@ internal static class GuideCommandsListCommand
         new CommandGroupEntry
         {
             Name = "task",
+            Role = RoleAdvancedDeveloper,
             Classification = ClassificationSupport,
             Mutability = MutabilityReadOnly,
             RecommendedCaller = CallerOperator,
             Purpose = "G317 explicit one-shot task planners (issue-to-pr / review-pr / fix-pr-comments / publish-next-issue). Returns a bounded executable contract — preconditions, steps, label transitions, abort conditions — for controllers that already know the target. Read-only: never calls gh, never mutates state, never launches AI providers."
+        },
+        new CommandGroupEntry
+        {
+            Name = "guide prompt-template",
+            Role = RoleDesign,
+            Classification = ClassificationSupport,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Loop-prompt creation: `intent-cli guide prompt-template` + `intent-cli guide prompt-matrix` are the canonical catalog of paste-ready prompts. The short way to turn a minimal user ask (`intent-cli に聞いて...`) into a fixed-condition loop prompt."
+        },
+        new CommandGroupEntry
+        {
+            Name = "guide workflow task implementation-loop",
+            Role = RoleChildImplementation,
+            Classification = ClassificationSupport,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Canonical child implementation-loop prompt generator: `intent-cli guide workflow task implementation-loop --target-repo <r> --agent claude --frequency 5m --format markdown` emits the paste-ready loop prompt with current claim/complete/label rules (G338)."
+        },
+        new CommandGroupEntry
+        {
+            Name = "guide workflow task review-next-slice-loop",
+            Role = RoleHostReview,
+            Classification = ClassificationSupport,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Canonical host review / next-slice-loop prompt generator: `intent-cli guide workflow task review-next-slice-loop --domain <d> --target-repo <r> --agent claude --frequency 20m --format markdown` emits the paste-ready host loop prompt with current preflight + packet/issue lifecycle rules (G338)."
         },
     };
 
@@ -207,13 +295,17 @@ internal static class GuideCommandsListCommand
     {
         writer.WriteLine("# Guide commands — top-level groups");
         writer.WriteLine();
+        writer.WriteLine("Operator-role categories (G467): `design` (design-side planning — improve / grill / stack / next / inspect / intent / interview / packet / clarify), `host-review` (host review / next-slice / publish — review / closeout / automation / issue), `child-implementation` (child loop — worker), `recovery-diagnostics` (operational recovery — automation doctor / metadata / queue), `advanced-developer` (one-shot planners / dogfooding — task).");
+        writer.WriteLine();
         writer.WriteLine("Lifecycle classification: `primary` (chat-agent's first calls), `support` (used inside the same flow).");
         writer.WriteLine();
-        writer.WriteLine("| group | classification | mutability | caller | purpose |");
-        writer.WriteLine("|-------|----------------|------------|--------|---------|");
+        writer.WriteLine("Loop-prompt creation: ask for a loop prompt with a minimal user request — `intent-cli guide prompt-template` / `prompt-matrix` catalog them, and `intent-cli guide workflow task implementation-loop` / `review-next-slice-loop` emit the paste-ready prompt with current fixed conditions.");
+        writer.WriteLine();
+        writer.WriteLine("| group | role | classification | mutability | caller | purpose |");
+        writer.WriteLine("|-------|------|----------------|------------|--------|---------|");
         foreach (var group in Groups)
         {
-            writer.WriteLine($"| {group.Name} | {group.Classification} | {group.Mutability} | {group.RecommendedCaller} | {group.Purpose} |");
+            writer.WriteLine($"| {group.Name} | {group.Role} | {group.Classification} | {group.Mutability} | {group.RecommendedCaller} | {group.Purpose} |");
         }
     }
 
@@ -259,7 +351,7 @@ internal static class GuideCommandsListCommand
     {
         writer.WriteLine("guide commands list");
         writer.WriteLine(UsageLine);
-        writer.WriteLine("Read-only listing of intent-cli command groups with primary/support/advanced/experimental classification.");
+        writer.WriteLine("Read-only role-based catalog of intent-cli command groups: each entry carries an operator-role category (design / host-review / child-implementation / recovery-diagnostics / advanced-developer) and a primary/support lifecycle classification.");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -273,6 +365,10 @@ internal sealed record CommandGroupEntry
 {
     [JsonPropertyName("name")]
     public required string Name { get; init; }
+
+    /// <summary>G467: operator-role category (design / host-review / child-implementation / recovery-diagnostics / advanced-developer).</summary>
+    [JsonPropertyName("role")]
+    public required string Role { get; init; }
 
     [JsonPropertyName("classification")]
     public required string Classification { get; init; }

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -236,7 +236,16 @@ internal static class GuideCommandsListCommand
             Classification = ClassificationSupport,
             Mutability = MutabilityReadOnly,
             RecommendedCaller = CallerChatAgent,
-            Purpose = "Loop-prompt creation: `intent-cli guide prompt-template` + `intent-cli guide prompt-matrix` are the canonical catalog of paste-ready prompts. The short way to turn a minimal user ask (`intent-cli に聞いて...`) into a fixed-condition loop prompt."
+            Purpose = "Loop-prompt creation: `intent-cli guide prompt-template` returns a single paste-ready prompt by name. The short way to turn a minimal user ask (`intent-cli に聞いて...`) into a fixed-condition prompt."
+        },
+        new CommandGroupEntry
+        {
+            Name = "guide prompt-matrix",
+            Role = RoleDesign,
+            Classification = ClassificationSupport,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Loop-prompt creation: `intent-cli guide prompt-matrix` is the catalog of available prompt templates (design / host-review / child-implementation / recovery) so an agent can discover which loop or one-shot prompt to request."
         },
         new CommandGroupEntry
         {

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -338,6 +338,17 @@ internal static class GuideHelpCommand
         writer.WriteLine("`guide` is the read-only entry surface. Every subcommand returns Markdown by default and JSON via `--format json`. None of the guide subcommands mutate state or launch AI providers.");
         writer.WriteLine();
 
+        writer.WriteLine("## Surfaces by operator role (G467)");
+        writer.WriteLine();
+        writer.WriteLine("Pick the surface by what you are trying to do. `intent-cli guide commands list` carries the same `role` category on every command group.");
+        writer.WriteLine();
+        writer.WriteLine("- **Design-side planning** — shape intent and cut work: `intent-cli improve` (realignment), `intent-cli grill` (persistent interview), `intent-cli stack` (packet backlog + first issue), `intent-cli inspect` (evidence-backed observation), `intent-cli next` (which of these to run), plus `intent` / `interview` / `packet` / `clarify`.");
+        writer.WriteLine("- **Host review / next-slice** — review PRs and plan the next slice: `intent-cli guide review`, `intent-cli review closeout-plan`, `intent-cli automation host-review-preflight`, `intent-cli closeout pr`, `intent-cli issue publish-flow`, and the `guide workflow task review-next-slice-loop` prompt generator.");
+        writer.WriteLine("- **Child implementation** — implement an issue into a PR: `intent-cli worker next-action / claim / complete / result-summary` (GitHub-contract-only with `--github-only`), and the `guide workflow task implementation-loop` prompt generator.");
+        writer.WriteLine("- **Recovery / diagnostics** — repair operational state: `intent-cli automation doctor`, `intent-cli automation reconcile`, `intent-cli automation publish-recovery`, plus `metadata` / `queue` inspection.");
+        writer.WriteLine("- **Loop-prompt creation** — turn a minimal user ask into a paste-ready loop prompt: `intent-cli guide prompt-template` / `prompt-matrix` (catalog) and `intent-cli guide workflow task implementation-loop|review-next-slice-loop` (generators with current fixed conditions).");
+        writer.WriteLine();
+
         writer.WriteLine("## Subcommands");
         writer.WriteLine();
         writer.WriteLine("| subcommand | purpose | example |");

--- a/src/IntentSystem.Cli/Commands/GuideNextCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideNextCommand.cs
@@ -117,8 +117,8 @@ $@"Advise the design thread on what to do next for `{domainArg}` ({repoArg}). Th
             new GuideNextAction
             {
                 Action = ActionInspect,
-                WhenToChoose = "You need to understand the current state before deciding — read-only status of intents, packets, and the next planned slice.",
-                SuggestedPrompt = $"`intent-cli status brief --format json` / `intent-cli intent status` / `intent-cli intent next-slice --dry-run --domain {domainArg} --format json`",
+                WhenToChoose = "You need to observe what the product ACTUALLY does before deciding — evidence-backed observation of real app / CLI / UI / log / test behavior, separating observed evidence from inference and turning gaps into packet candidates (G466). This is NOT status / next-slice checking; for a quick read-only state summary use `intent-cli status brief` / `intent intent status` directly.",
+                SuggestedPrompt = $"intent-cli で <target> を inspect してください。（`intent-cli inspect --domain {domainArg} --target-repo {repoArg} --format markdown`, alias `intent-cli guide inspect`）",
             },
             new GuideNextAction
             {

--- a/tests/IntentSystem.Cli.Tests/GuideCommandsListCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideCommandsListCommandTests.cs
@@ -19,11 +19,50 @@ public sealed class GuideCommandsListCommandTests
         Assert.Equal(0, exitCode);
         var output = writer.ToString();
         Assert.Contains("# Guide commands — top-level groups", output, StringComparison.Ordinal);
-        Assert.Contains("| group | classification | mutability | caller | purpose |", output, StringComparison.Ordinal);
-        foreach (var group in new[] { "guide", "intent", "interview", "packet", "worker", "automation", "metadata", "review", "closeout", "issue", "queue" })
+        // G467: the table now carries the operator-role column.
+        Assert.Contains("| group | role | classification | mutability | caller | purpose |", output, StringComparison.Ordinal);
+        Assert.Contains("Operator-role categories (G467)", output, StringComparison.Ordinal);
+        foreach (var group in new[] { "guide", "intent", "interview", "packet", "worker", "automation", "metadata", "review", "closeout", "issue", "queue", "grill", "stack", "next", "inspect" })
         {
             Assert.Contains(group, output, StringComparison.Ordinal);
         }
+    }
+
+    [Fact]
+    public void Execute_Json_IncludesRoleMetadataAndDesignSideCommands()
+    {
+        // G467: every entry carries an operator-role category, and the new
+        // design-side commands appear in the catalog.
+        using var writer = new StringWriter();
+        var exitCode = GuideCommandsListCommand.Execute(CreateContext(), ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var groups = document.RootElement.GetProperty("groups");
+        var byName = groups.EnumerateArray()
+            .ToDictionary(e => e.GetProperty("name").GetString()!, e => e);
+
+        // New design-side commands present and categorized as design.
+        foreach (var name in new[] { "grill", "stack", "next", "inspect", "improve" })
+        {
+            Assert.True(byName.ContainsKey(name), $"catalog missing '{name}'");
+            Assert.Equal("design", byName[name].GetProperty("role").GetString());
+        }
+
+        // Role coverage spans all five operator-role categories.
+        var roles = groups.EnumerateArray().Select(e => e.GetProperty("role").GetString()).ToHashSet();
+        foreach (var role in new[] { "design", "host-review", "child-implementation", "recovery-diagnostics", "advanced-developer" })
+        {
+            Assert.Contains(role, roles);
+        }
+
+        // worker is the child-implementation surface.
+        Assert.Equal("child-implementation", byName["worker"].GetProperty("role").GetString());
+
+        // Loop-prompt creation surfaces are discoverable in the catalog.
+        Assert.Contains("guide workflow task implementation-loop", byName.Keys);
+        Assert.Contains("guide workflow task review-next-slice-loop", byName.Keys);
+        Assert.Contains("guide prompt-template", byName.Keys);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/GuideCommandsListCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideCommandsListCommandTests.cs
@@ -59,10 +59,16 @@ public sealed class GuideCommandsListCommandTests
         // worker is the child-implementation surface.
         Assert.Equal("child-implementation", byName["worker"].GetProperty("role").GetString());
 
-        // Loop-prompt creation surfaces are discoverable in the catalog.
+        // Loop-prompt creation surfaces are discoverable in the catalog —
+        // prompt-template AND prompt-matrix each as their own role-categorized
+        // entry (G467 review: prompt-matrix must be a discoverable entry, not
+        // only mentioned inside prompt-template's purpose text).
         Assert.Contains("guide workflow task implementation-loop", byName.Keys);
         Assert.Contains("guide workflow task review-next-slice-loop", byName.Keys);
         Assert.Contains("guide prompt-template", byName.Keys);
+        Assert.Contains("guide prompt-matrix", byName.Keys);
+        Assert.Equal("design", byName["guide prompt-matrix"].GetProperty("role").GetString());
+        Assert.Equal("support", byName["guide prompt-matrix"].GetProperty("classification").GetString());
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/GuideHelpRoleCatalogTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideHelpRoleCatalogTests.cs
@@ -1,0 +1,58 @@
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G467: tests that `guide help` explains which surfaces are for design-side
+/// planning, host review/next-slice, child implementation, recovery, and
+/// loop-prompt creation.
+/// </summary>
+public sealed class GuideHelpRoleCatalogTests
+{
+    [Fact]
+    public void Execute_Markdown_ExplainsSurfacesByOperatorRole()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideHelpCommand.Execute(CreateContext(), [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+
+        Assert.Contains("Surfaces by operator role", output, StringComparison.Ordinal);
+        // AC: the four role buckets + loop-prompt creation are explained.
+        Assert.Contains("Design-side planning", output, StringComparison.Ordinal);
+        Assert.Contains("Host review / next-slice", output, StringComparison.Ordinal);
+        Assert.Contains("Child implementation", output, StringComparison.Ordinal);
+        Assert.Contains("Recovery / diagnostics", output, StringComparison.Ordinal);
+        Assert.Contains("Loop-prompt creation", output, StringComparison.Ordinal);
+
+        // AC: implementation-loop / review-next-slice-loop prompt generators are
+        // discoverable from guide help.
+        Assert.Contains("guide workflow task implementation-loop", output, StringComparison.Ordinal);
+        Assert.Contains("review-next-slice-loop", output, StringComparison.Ordinal);
+        // AC: the design-side commands are named in the role guidance.
+        foreach (var cmd in new[] { "intent-cli grill", "intent-cli stack", "intent-cli inspect", "intent-cli next", "intent-cli improve" })
+        {
+            Assert.Contains(cmd, output, StringComparison.Ordinal);
+        }
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideNextCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideNextCommandTests.cs
@@ -60,6 +60,13 @@ public sealed class GuideNextCommandTests
         {
             Assert.False(string.IsNullOrWhiteSpace(a.GetProperty("suggested_prompt").GetString()));
         }
+
+        // G467 AC: inspect routes to evidence-backed observation and points to
+        // `intent-cli inspect`, NOT to status / next-slice checking.
+        var inspect = root.GetProperty("decision_set").EnumerateArray()
+            .Single(a => a.GetProperty("action").GetString() == "inspect");
+        Assert.Contains("evidence-backed", inspect.GetProperty("when_to_choose").GetString()!, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli inspect", inspect.GetProperty("suggested_prompt").GetString()!, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Implements #1034 (G467): make the `intent-cli guide` surfaces classify commands by **operator role** and clearly teach an unfamiliar AI agent which surface to use for design, review, child implementation, recovery, or loop-prompt creation.

## Changes

- **`guide commands list`** — every catalog entry now carries an `role` operator-role category (**design** / **host-review** / **child-implementation** / **recovery-diagnostics** / **advanced-developer**) alongside its `primary`/`support` lifecycle classification. Added the new design-side commands **grill**, **stack**, **next**, **inspect** (improve was already present) and loop-prompt-creation entries (`guide prompt-template`, `guide workflow task implementation-loop` / `review-next-slice-loop`). The markdown table gains a role column + a role legend + a loop-prompt note.
- **`guide help`** — new **"Surfaces by operator role"** section explaining which surfaces are design-side planning, host review / next-slice, child implementation, recovery / diagnostics, and loop-prompt creation.
- **`guide next`** — the `inspect` action now routes to **evidence-backed observation** (G466) and points to `intent-cli inspect`, instead of looking like status / next-slice checking.
- **docs (en/ja)** — role-based catalog note in the command-group overview; fixed the stale "inspect = read-only state" wording in the next section.

## Acceptance criteria

- [x] `guide commands list --format markdown|json` includes the new design-side commands and role/category metadata.
- [x] `guide help --format markdown` explains which guide surfaces are for design-side planning, host review/next-slice, child implementation, and recovery.
- [x] `guide next --format markdown` routes inspect to evidence-backed observation and points to `intent-cli inspect` / `intent-cli guide inspect`.
- [x] `guide prompt-template` and `guide workflow task implementation-loop|review-next-slice-loop` are discoverable as the canonical loop-prompt creation path (catalog entries + guide help section).
- [x] Tests cover the role-based catalog and loop-prompt discoverability.

## Verification

- `dotnet test` CLI suite (Release, CI-equivalent): 3018 passed / 1 skipped, green on two consecutive runs. +2 new tests; updated the catalog markdown-header test for the new role column.
- New/updated tests: `GuideCommandsListCommandTests` (role metadata, design-side commands, loop-prompt entries), `GuideHelpRoleCatalogTests` (role buckets + loop generators), `GuideNextCommandTests` (inspect → evidence-backed observation).
- `git diff --check` clean.

Closes #1034

🤖 Generated with [Claude Code](https://claude.com/claude-code)