### PR TITLE
G468 Unify intent-cli package and display version sources for local pack and release artifacts

### DIFF
--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.4",
-  "nextVersion": "0.3.5"
+  "stableVersion": "0.3.5",
+  "nextVersion": "0.3.6"
 }

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -15,7 +15,32 @@
     -->
     <ToolCommandName>intent-cli</ToolCommandName>
     <PackageId>JTechJapan.IntentSystem.Cli</PackageId>
-    <Version>0.3.2</Version>
+    <!--
+      G468: the package version is derived from the repository version
+      policy (`eng/version.json` → `nextVersion`) instead of a stale
+      hard-coded literal. Previously this carried `<Version>0.3.2</Version>`,
+      so a plain local `dotnet pack` reported `0.3.2-<sha>-<G-unit>` long
+      after the source had moved on (the released line was already 0.3.5).
+
+      Resolution order:
+        * `-p:Version=<x>` (release tag-driven build, preview pack) is a
+          global property and always wins — those paths are unchanged.
+        * otherwise the local default is read from `eng/version.json`
+          `nextVersion` so local pack / install / the preview baseline pack
+          all track the in-development line from a single source of truth.
+        * a neutral `0.0.0-dev` last-resort fallback applies only if the
+          policy file is missing/unreadable — never a stale released number.
+
+      `IntentSystemNextVersionFromPolicy` is read with a nested
+      File.ReadAllText so the JSON (with its commas/quotes) is passed to the
+      regex as a real string argument rather than substituted into the
+      MSBuild argument parser. The version-policy guard test asserts this
+      file never reintroduces a hard-coded `<Version>` literal.
+    -->
+    <IntentSystemVersionPolicyFile>$(MSBuildProjectDirectory)/../../eng/version.json</IntentSystemVersionPolicyFile>
+    <IntentSystemNextVersionFromPolicy Condition="Exists('$(IntentSystemVersionPolicyFile)')">$([System.Text.RegularExpressions.Regex]::Match($([System.IO.File]::ReadAllText($(IntentSystemVersionPolicyFile))), '"nextVersion"\s*:\s*"([^"]+)"').get_Groups().get_Item(1).get_Value())</IntentSystemNextVersionFromPolicy>
+    <Version Condition="'$(Version)' == '' AND '$(IntentSystemNextVersionFromPolicy)' != ''">$(IntentSystemNextVersionFromPolicy)</Version>
+    <Version Condition="'$(Version)' == ''">0.0.0-dev</Version>
     <Authors>J-Tech-Japan</Authors>
     <Description>Intent System CLI — deterministic support tooling for intent-driven development on GitHub. Install: dotnet tool install -g JTechJapan.IntentSystem.Cli. Command: intent-cli.</Description>
     <PackageTags>intent-cli;dotnet-tool;intent-system</PackageTags>

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,8 +124,10 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.5 as the next development line
-        // (post-v0.3.4 release bump, see G447).
+        // be parseable and must point to 0.3.6 as the next development line
+        // (post-v0.3.5 release bump, see G468 — the policy was stale at
+        // 0.3.4/0.3.5 after v0.3.5 shipped, which made local pack report a
+        // misleading version).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -135,8 +137,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.5", policy.NextVersion);
-        Assert.Equal("0.3.4", policy.StableVersion);
+        Assert.Equal("0.3.6", policy.NextVersion);
+        Assert.Equal("0.3.5", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()

--- a/tests/IntentSystem.Cli.Tests/VersionSourcePolicyGuardTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionSourcePolicyGuardTests.cs
@@ -1,0 +1,111 @@
+using System.Text.Json;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G468: guard tests that keep the package/display version derived from the
+/// repository version policy (`eng/version.json`) instead of a stale
+/// hard-coded csproj literal. These fail if `IntentSystem.Cli.csproj`
+/// reintroduces a `&lt;Version&gt;x.y.z&lt;/Version&gt;` literal that bypasses
+/// the policy, or if the policy file drifts from the csproj derivation.
+/// </summary>
+public sealed class VersionSourcePolicyGuardTests
+{
+    [Fact]
+    public void Csproj_DoesNotHardcodeAVersionLiteral_AndDerivesFromPolicy()
+    {
+        var raw = File.ReadAllText(CsprojPath());
+
+        // Strip XML comments first so documentation that *mentions* the old
+        // literal (e.g. explaining the fix) is not mistaken for a real
+        // hard-coded element.
+        var csproj = System.Text.RegularExpressions.Regex.Replace(
+            raw, "(?s)<!--.*?-->", string.Empty);
+
+        // AC: a stale hard-coded csproj Version must not recur. A literal
+        // semver `<Version>` element bypasses the policy and is exactly the
+        // bug this slice fixes.
+        var hardCodedVersion = System.Text.RegularExpressions.Regex.Match(
+            csproj, @"<Version>\s*\d+\.\d+\.\d+[^<]*</Version>");
+        Assert.False(
+            hardCodedVersion.Success,
+            $"IntentSystem.Cli.csproj contains a hard-coded <Version> literal ('{hardCodedVersion.Value}') that bypasses eng/version.json. Derive the version from the version policy instead.");
+
+        // AC: the version must be derived from eng/version.json (nextVersion).
+        Assert.Contains("eng/version.json", csproj, StringComparison.Ordinal);
+        Assert.Contains("IntentSystemNextVersionFromPolicy", csproj, StringComparison.Ordinal);
+        Assert.Contains("nextVersion", csproj, StringComparison.Ordinal);
+        // The explicit -p:Version override path (release/preview) is preserved:
+        // the derived default only applies when Version is empty.
+        Assert.Contains("'$(Version)' == ''", csproj, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VersionPolicyFile_IsCoherent_AndReadableByVersionPolicy()
+    {
+        var policyPath = Path.Combine(FindRepoRoot(), "eng", "version.json");
+        Assert.True(File.Exists(policyPath), $"eng/version.json missing at {policyPath}");
+
+        // The runtime VersionPolicy reader and the csproj derivation must
+        // agree on the same source of truth.
+        var policy = VersionPolicy.TryReadFromFile(policyPath);
+        Assert.NotNull(policy);
+
+        var stable = ParseVersion(policy!.StableVersion);
+        var next = ParseVersion(policy.NextVersion);
+
+        // Policy coherence: next is strictly ahead of stable so a local dev
+        // build never collides with the latest released stable line.
+        Assert.True(
+            Compare(next, stable) > 0,
+            $"eng/version.json nextVersion ({policy.NextVersion}) must be ahead of stableVersion ({policy.StableVersion}).");
+    }
+
+    [Fact]
+    public void Csproj_NextVersionRegex_ExtractsTheSameValueAsVersionPolicy()
+    {
+        // Mirror the MSBuild derivation regex against the live file so a
+        // change to the JSON shape that would silently break the csproj
+        // derivation is caught by a test.
+        var policyPath = Path.Combine(FindRepoRoot(), "eng", "version.json");
+        var json = File.ReadAllText(policyPath);
+
+        var match = System.Text.RegularExpressions.Regex.Match(json, "\"nextVersion\"\\s*:\\s*\"([^\"]+)\"");
+        Assert.True(match.Success, "csproj-style nextVersion regex failed to match eng/version.json");
+
+        var policy = VersionPolicy.TryReadFromFile(policyPath);
+        Assert.NotNull(policy);
+        Assert.Equal(policy!.NextVersion, match.Groups[1].Value);
+    }
+
+    private static (int Major, int Minor, int Patch) ParseVersion(string version)
+    {
+        // Tolerate prerelease suffixes (e.g. "0.3.6-preview.1.2").
+        var core = version.Split('-', 2)[0];
+        var parts = core.Split('.');
+        Assert.True(parts.Length >= 3, $"version '{version}' is not semver-shaped");
+        return (int.Parse(parts[0]), int.Parse(parts[1]), int.Parse(parts[2]));
+    }
+
+    private static int Compare((int Major, int Minor, int Patch) a, (int Major, int Minor, int Patch) b)
+    {
+        if (a.Major != b.Major) return a.Major.CompareTo(b.Major);
+        if (a.Minor != b.Minor) return a.Minor.CompareTo(b.Minor);
+        return a.Patch.CompareTo(b.Patch);
+    }
+
+    private static string CsprojPath() =>
+        Path.Combine(FindRepoRoot(), "src", "IntentSystem.Cli", "IntentSystem.Cli.csproj");
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !Directory.Exists(Path.Combine(dir, "src")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        Assert.NotNull(dir);
+        return dir!;
+    }
+}


### PR DESCRIPTION
## Summary

Implements #1036 (G468). Local `dotnet pack` reported `intent-cli 0.3.2-<sha>-<G-unit>` because `IntentSystem.Cli.csproj` carried a stale hard-coded `<Version>0.3.2</Version>` literal, while the released line had already moved to **v0.3.5**. Release builds override `-p:Version=<tag>` so they were correct, but local pack / install and the preview baseline pack derived a misleading version from the stale literal.

This makes local builds, local nupkg installs, NuGet packages, and self-contained binaries all derive the package version from a single source of truth (`eng/version.json`).

## Changes

- **`src/IntentSystem.Cli/IntentSystem.Cli.csproj`** — derive the default `<Version>` from `eng/version.json` (`nextVersion`) instead of the stale literal. Resolution order: `-p:Version=<x>` (release tag-driven / preview pack) is a global property and still **wins**; otherwise the policy `nextVersion` applies; a neutral `0.0.0-dev` last-resort fallback applies only if the policy file is unreadable (never a stale released number). The JSON is read via a nested `File.ReadAllText` so its commas/quotes don't break the MSBuild argument parser.
- **`eng/version.json`** — correct the stale policy: stable `0.3.4 → 0.3.5`, next `0.3.5 → 0.3.6`, so it agrees with the released v0.3.5 and a local dev build no longer collides with the latest stable line.
- **tests** — `VersionSourcePolicyGuardTests` fails if the csproj reintroduces a hard-coded `<Version>` literal (XML comments stripped first), asserts the policy derivation is present, checks policy coherence (next ahead of stable), and verifies the csproj-style `nextVersion` regex matches `VersionPolicy`. Updated the existing `eng/version.json` smoke test to the new 0.3.6/0.3.5 policy.

The release and binary-artifact workflows already use `fetch-depth: 0` and pass the same `-p:Version` to both the nupkg pack and the self-contained publish, so version / git short SHA / latest-G-unit stay coherent per commit. The preview **baseline** pack (which passes no `-p:Version`) now tracks the same policy default. No workflow change required.

## Acceptance criteria

- [x] Local pack from a checkout no longer produces `intent-cli 0.3.2-...` — it derives `nextVersion` (now 0.3.6) from `eng/version.json`.
- [x] Local install from the local nupkg reports the intended package version + git short SHA + latest G-unit.
- [x] Release workflow and binary-artifact workflow pass the same version/latest-unit properties (same `-p:Version`; SHA & G-unit auto-derived from the same `fetch-depth: 0` checkout).
- [x] `eng/version.json`, csproj default, release/preview workflows, and version tests agree on stable/next policy.
- [x] Tests fail if `IntentSystem.Cli.csproj` reintroduces a stale hard-coded `<Version>` that bypasses the policy.

## Verification

- Default local build/pack reports `0.3.6-<sha>-<G-unit>` (was `0.3.2-...`); `-p:Version=9.9.9` still overrides; `dotnet pack` produces `JTechJapan.IntentSystem.Cli.0.3.6.nupkg` (no stale 0.3.2).
- `dotnet test` full Release **solution**: all projects green on two consecutive runs (CLI 3021 passed / 1 skipped; +3 new guard tests).
- `git diff --check` clean.

Closes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)