### PR TITLE
G469 Prepare the next NuGet release version after version-source alignment

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -142,34 +142,90 @@ successfully. **OSS preview packages carry no expiry; they remain runnable indef
 
 ## Version flow
 
-The repository version policy lives in `eng/version.json`:
+The repository version policy lives in `eng/version.json` — the single source of
+truth for `stableVersion` (the latest published stable line) and `nextVersion`
+(the release being prepared / in-development line). Since G468 the local
+`dotnet pack` default `<Version>` is derived from this file, so a local pack and
+install report the in-development `nextVersion` rather than a stale csproj
+literal:
 
 ```json
 {
-  "stableVersion": "0.3.0",
-  "nextVersion": "0.3.1"
+  "stableVersion": "0.3.5",
+  "nextVersion": "0.3.6"
 }
 ```
 
 | Stage | Version form | How it is derived |
 | --- | --- | --- |
-| Main CI preview | `0.3.1-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.1-rc.N` | Tag `v0.3.1-rc.N` triggers release workflow |
-| Stable release | `0.3.1` | Tag `v0.3.1` triggers release workflow |
-| Post-release main builds | `0.4.0-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.4.0` |
+| Local pack / install | `0.3.6-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.3.6-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.6-rc.N` | Tag `v0.3.6-rc.N` triggers release workflow |
+| Stable release | `0.3.6` | Tag `v0.3.6` triggers release workflow (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.3.7-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.7` |
 
-**After releasing `v0.3.1`**, bump both fields in `eng/version.json`:
+**After releasing `v0.3.6`**, bump both fields in `eng/version.json`:
 
 ```json
 {
-  "stableVersion": "0.3.1",
-  "nextVersion": "0.4.0"
+  "stableVersion": "0.3.6",
+  "nextVersion": "0.3.7"
 }
 ```
 
-This ensures the next main-branch CI build immediately produces
-`0.4.0-preview.<run>.<attempt>` rather than continuing to emit `0.3.1-preview`
-(which would collide with the stable release version).
+This ensures the next main-branch CI build (and local pack) immediately produces
+`0.3.7-preview.<run>.<attempt>` / `0.3.7-<sha>-<G-unit>` rather than continuing to
+emit `0.3.6` (which would collide with the stable release version).
+
+### Next release readiness (v0.3.6)
+
+The repository is prepared for an explicit operator release of **`v0.3.6`** (the
+current `nextVersion`). The release itself is published by tagging — this packet
+does not cut the release.
+
+**User-visible changes since `v0.3.5`:**
+
+- **Design-side process family** — five named, discoverable design-thread
+  surfaces: `intent-cli improve` (G456, retrospective realignment),
+  `intent-cli grill` (G463, persistent open-question interview),
+  `intent-cli stack` (G464, packet backlog + first issue),
+  `intent-cli next` (G465, "what should I do next?" advisor), and
+  `intent-cli inspect` (G466, evidence-backed observation). Each has a
+  top-level alias and a `guide <name>` form.
+- **Guide catalog / role classification** (G467) — `intent-cli guide commands
+  list` is now a role-based catalog (design / host-review /
+  child-implementation / recovery-diagnostics / advanced-developer), and
+  `intent-cli guide help` explains which surfaces serve each role, including the
+  loop-prompt generators.
+- **Version-source alignment** (G468) — local pack/install, NuGet packages, and
+  self-contained release artifacts derive package version, git short SHA, and
+  latest G-unit from `eng/version.json` and git instead of a stale csproj
+  literal, so `intent-cli --version` is coherent across build paths.
+
+**Release-readiness verification (run before tagging `v0.3.6`):**
+
+```bash
+# 1. Confirm the version policy records the release-to-be-cut.
+cat eng/version.json   # stableVersion 0.3.5 (published), nextVersion 0.3.6 (to release)
+
+# 2. Build and confirm the display version identity (version + git SHA + G-unit).
+dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
+dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
+#   expected shape: intent-cli 0.3.6-<sha>-G46x   (NOT 0.3.2-...)
+
+# 3. Pack and confirm the NuGet package version matches the policy.
+dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.6.nupkg
+
+# 4. Confirm package metadata (id / command / license / project URL).
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
+  -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
+```
+
+The official release is then cut by publishing a GitHub Release tagged `v0.3.6`;
+the release workflow passes `-p:Version=0.3.6` (which wins over the local
+default). After the release publishes, apply the post-release `eng/version.json`
+bump above.
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -133,33 +133,76 @@ channel=preview built=<iso-utc> commit=<full-sha>
 
 ## バージョンフロー
 
-リポジトリのバージョンポリシーは `eng/version.json` に記載されています:
+リポジトリのバージョンポリシーは `eng/version.json` に記載されています。`stableVersion`
+（最新の公開済み安定版）と `nextVersion`（準備中 / 開発中のライン）の単一の source of
+truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Version>` はこのファイルから
+導出されるため、ローカル pack / install は stale な csproj リテラルではなく開発中の
+`nextVersion` を報告します:
 
 ```json
 {
-  "stableVersion": "0.3.0",
-  "nextVersion": "0.3.1"
+  "stableVersion": "0.3.5",
+  "nextVersion": "0.3.6"
 }
 ```
 
 | ステージ | バージョン形式 | 導出方法 |
 | --- | --- | --- |
-| Main CI preview | `0.3.1-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.1-rc.N` | タグ `v0.3.1-rc.N` がリリースワークフローをトリガー |
-| 安定版リリース | `0.3.1` | タグ `v0.3.1` がリリースワークフローをトリガー |
-| リリース後の main ビルド | `0.4.0-preview.<run>.<attempt>` | `nextVersion` を `0.4.0` にバンプ後 |
+| ローカル pack / install | `0.3.6-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.3.6-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.3.6-rc.N` | タグ `v0.3.6-rc.N` がリリースワークフローをトリガー |
+| 安定版リリース | `0.3.6` | タグ `v0.3.6` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.3.7-preview.<run>.<attempt>` | `nextVersion` を `0.3.7` にバンプ後 |
 
-**`v0.3.1` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+**`v0.3.6` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
 
 ```json
 {
-  "stableVersion": "0.3.1",
-  "nextVersion": "0.4.0"
+  "stableVersion": "0.3.6",
+  "nextVersion": "0.3.7"
 }
 ```
 
-これにより次の main ブランチ CI ビルドが `0.4.0-preview.<run>.<attempt>` を生成し、
-`0.3.1-preview`（安定版リリースバージョンと衝突）の出力が継続されなくなります。
+これにより次の main ブランチ CI ビルド（およびローカル pack）が
+`0.3.7-preview.<run>.<attempt>` / `0.3.7-<sha>-<G-unit>` を生成し、`0.3.6`（安定版
+リリースバージョンと衝突）の出力が継続されなくなります。
+
+### 次リリース準備（v0.3.6）
+
+リポジトリは operator による明示的な **`v0.3.6`** リリース（現在の `nextVersion`）の
+準備が整っています。リリース自体はタグ付けで publish され、このパケットはリリースを
+cut しません。
+
+**`v0.3.5` 以降のユーザー可視の変更:**
+
+- **design-side プロセスファミリー** — 名前付きで discoverable な5つの design-thread
+  surface: `intent-cli improve`（G456）・`intent-cli grill`（G463）・
+  `intent-cli stack`（G464）・`intent-cli next`（G465）・`intent-cli inspect`（G466）。
+  各々に top-level alias と `guide <name>` 形式があります。
+- **guide カタログ / role 分類**（G467）— `intent-cli guide commands list` が role
+  ベースのカタログ（design / host-review / child-implementation /
+  recovery-diagnostics / advanced-developer）になり、`intent-cli guide help` が各
+  role の surface を説明します。
+- **version-source 整合**（G468）— ローカル pack/install・NuGet パッケージ・
+  self-contained リリース artifact が package version・git short SHA・最新 G-unit を
+  stale な csproj リテラルではなく `eng/version.json` と git から導出します。
+
+**リリース準備の検証（`v0.3.6` タグ付け前に実行）:**
+
+```bash
+cat eng/version.json   # stableVersion 0.3.5（公開済み）, nextVersion 0.3.6（リリース対象）
+dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
+dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
+#   期待形: intent-cli 0.3.6-<sha>-G46x （0.3.2-... ではない）
+dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.6.nupkg
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
+  -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
+```
+
+公式リリースは `v0.3.6` タグの GitHub Release publish で cut され、リリースワークフローが
+`-p:Version=0.3.6` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
+`eng/version.json` バンプを適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/tests/IntentSystem.Cli.Tests/ReleasePackageMetadataTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleasePackageMetadataTests.cs
@@ -1,0 +1,91 @@
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G469: release-readiness guards for the next NuGet release after G468.
+/// These pin the package metadata that the public install/update docs depend
+/// on (package id, command name, license, project URL, README) and assert the
+/// version policy records a coherent release-to-be-cut, so an operator can cut
+/// the release with confidence and `intent-cli --version` stays trustworthy.
+/// </summary>
+public sealed class ReleasePackageMetadataTests
+{
+    [Fact]
+    public void Csproj_PinsPublicPackageMetadata()
+    {
+        var csproj = File.ReadAllText(CsprojPath());
+
+        // Out of scope to change these — guard them so a release never ships
+        // with a drifted id / command / license / URL that breaks install docs.
+        Assert.Contains("<PackageId>JTechJapan.IntentSystem.Cli</PackageId>", csproj, StringComparison.Ordinal);
+        Assert.Contains("<ToolCommandName>intent-cli</ToolCommandName>", csproj, StringComparison.Ordinal);
+        Assert.Contains("<PackAsTool>true</PackAsTool>", csproj, StringComparison.Ordinal);
+        Assert.Contains("<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>", csproj, StringComparison.Ordinal);
+        Assert.Contains("<PackageReadmeFile>README.md</PackageReadmeFile>", csproj, StringComparison.Ordinal);
+        Assert.Contains("https://github.com/J-Tech-Japan/intent-system", csproj, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void VersionPolicy_RecordsReleaseToBeCut_AheadOfPublishedStable()
+    {
+        var policy = VersionPolicy.TryReadFromRepo(FindRepoRoot());
+        Assert.NotNull(policy);
+
+        // The release-to-be-cut is nextVersion; it must be strictly ahead of the
+        // currently published stableVersion so the tagged release does not
+        // collide with the latest stable line.
+        var stable = ParseVersion(policy!.StableVersion);
+        var next = ParseVersion(policy.NextVersion);
+        Assert.True(
+            Compare(next, stable) > 0,
+            $"eng/version.json nextVersion ({policy.NextVersion}) must be ahead of stableVersion ({policy.StableVersion}) to be release-ready.");
+    }
+
+    [Fact]
+    public void DeveloperReference_DocumentsReleaseReadinessForNextVersion()
+    {
+        var policy = VersionPolicy.TryReadFromRepo(FindRepoRoot());
+        Assert.NotNull(policy);
+
+        var devRef = File.ReadAllText(Path.Combine(FindRepoRoot(), "docs", "en", "09-developer-reference.md"));
+
+        // The release-readiness section names the release-to-be-cut and points at
+        // this metadata test, so docs and the guard stay in lock-step.
+        Assert.Contains("Next release readiness", devRef, StringComparison.Ordinal);
+        Assert.Contains(policy!.NextVersion, devRef, StringComparison.Ordinal);
+        Assert.Contains("ReleasePackageMetadataTests", devRef, StringComparison.Ordinal);
+        // It must surface the version-identity verification (the G468 fix).
+        Assert.Contains("intent-cli", devRef, StringComparison.Ordinal);
+        Assert.Contains("--version", devRef, StringComparison.Ordinal);
+    }
+
+    private static (int Major, int Minor, int Patch) ParseVersion(string version)
+    {
+        var core = version.Split('-', 2)[0];
+        var parts = core.Split('.');
+        Assert.True(parts.Length >= 3, $"version '{version}' is not semver-shaped");
+        return (int.Parse(parts[0]), int.Parse(parts[1]), int.Parse(parts[2]));
+    }
+
+    private static int Compare((int Major, int Minor, int Patch) a, (int Major, int Minor, int Patch) b)
+    {
+        if (a.Major != b.Major) return a.Major.CompareTo(b.Major);
+        if (a.Minor != b.Minor) return a.Minor.CompareTo(b.Minor);
+        return a.Patch.CompareTo(b.Patch);
+    }
+
+    private static string CsprojPath() =>
+        Path.Combine(FindRepoRoot(), "src", "IntentSystem.Cli", "IntentSystem.Cli.csproj");
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !Directory.Exists(Path.Combine(dir, "src")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+        Assert.NotNull(dir);
+        return dir!;
+    }
+}


### PR DESCRIPTION
## Summary

Implements #1038 (G469). Prepares the repository for an explicit operator release of **`v0.3.6`** (the current `nextVersion`) after G468 aligned the version-source contract. **This packet does not publish the release** — it leaves the repo release-ready.

## Changes

- **docs (en/ja developer reference)** — refresh the stale Version-flow example (`0.3.0/0.3.1` → `0.3.5/0.3.6`) so it agrees with `eng/version.json` and the G468 local-pack derivation, and add a **"Next release readiness (v0.3.6)"** section:
  - **What's new since v0.3.5** — the design-side process family (`improve` G456, `grill` G463, `stack` G464, `next` G465, `inspect` G466), the guide catalog / role classification (G467), and the version-source alignment fix (G468).
  - **Release-readiness verification command sequence** — confirm `eng/version.json`, `intent-cli --version` (shows `0.3.6-<sha>-<G-unit>`, not `0.3.2-...`), the `0.3.6` nupkg, and package metadata before tagging.
  - **Post-release bump** (stable→0.3.6, next→0.3.7) for the operator to apply after tagging.
- **tests** — `ReleasePackageMetadataTests` pins the public package metadata install/update docs depend on (id `JTechJapan.IntentSystem.Cli`, command `intent-cli`, Apache-2.0, README, project URL), asserts the version policy records a coherent release-to-be-cut (next ahead of published stable), and asserts the developer reference documents release readiness for the next version and references this test.

`eng/version.json` is **intentionally unchanged**: G468 already set it to `stableVersion 0.3.5` (published) / `nextVersion 0.3.6` (release-to-cut), which correctly represents the release-to-be-cut. Bumping `stableVersion` to 0.3.6 would falsely assert 0.3.6 is already published — publishing is out of scope. The post-release bump is documented for the operator.

## Acceptance criteria

- [x] The repo clearly records the next NuGet version to release (`0.3.6`) and the post-release next dev version (`0.3.7`).
- [x] Release-ready docs summarize user-visible fixes since v0.3.5 (guide coverage G467, version-source alignment G468, design-side process family).
- [x] Local release-readiness verification shows package version, git SHA, and latest G-unit before creating a release.
- [x] NuGet metadata + install/update docs verified against package id `JTechJapan.IntentSystem.Cli` and command `intent-cli` (guard test).
- [x] The packet does not publish a release; it leaves the repo ready for an explicit operator release action.

## Verification

- Documented readiness sequence runs end-to-end: `--version` reports `intent-cli 0.3.6-21d669f-G468` (not `0.3.2-...`); `dotnet pack` → `JTechJapan.IntentSystem.Cli.0.3.6.nupkg`; `ReleasePackageMetadataTests` green.
- `dotnet test` full Release CLI suite: 3024 passed / 1 skipped, green on two consecutive runs (+3 new tests).
- `git diff --check` clean.

Closes #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)