### PR TITLE
G470 Bump version policy to 0.3.7 after v0.3.6 release

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -151,39 +151,40 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.3.5",
-  "nextVersion": "0.3.6"
-}
-```
-
-| Stage | Version form | How it is derived |
-| --- | --- | --- |
-| Local pack / install | `0.3.6-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.3.6-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.6-rc.N` | Tag `v0.3.6-rc.N` triggers release workflow |
-| Stable release | `0.3.6` | Tag `v0.3.6` triggers release workflow (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.3.7-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.7` |
-
-**After releasing `v0.3.6`**, bump both fields in `eng/version.json`:
-
-```json
-{
   "stableVersion": "0.3.6",
   "nextVersion": "0.3.7"
 }
 ```
 
+| Stage | Version form | How it is derived |
+| --- | --- | --- |
+| Local pack / install | `0.3.7-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.3.7-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.7-rc.N` | Tag `v0.3.7-rc.N` triggers release workflow |
+| Stable release | `0.3.7` | Tag `v0.3.7` triggers release workflow (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.3.8-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.8` |
+
+**After releasing `v0.3.7`**, bump both fields in `eng/version.json`:
+
+```json
+{
+  "stableVersion": "0.3.7",
+  "nextVersion": "0.3.8"
+}
+```
+
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.3.7-preview.<run>.<attempt>` / `0.3.7-<sha>-<G-unit>` rather than continuing to
-emit `0.3.6` (which would collide with the stable release version).
+`0.3.8-preview.<run>.<attempt>` / `0.3.8-<sha>-<G-unit>` rather than continuing to
+emit `0.3.7` (which would collide with the stable release version).
 
-### Next release readiness (v0.3.6)
+### Next release readiness (v0.3.7)
 
-The repository is prepared for an explicit operator release of **`v0.3.6`** (the
-current `nextVersion`). The release itself is published by tagging — this packet
-does not cut the release.
+**`v0.3.6` shipped** (GitHub Release + NuGet, 2026-06-05) and the version policy
+was bumped to the `0.3.7` development line (G470). The repository is now on the
+in-development **`0.3.7`** `nextVersion`; the next release is published by tagging
+`v0.3.7` once it is prepared — this bump does not cut a release.
 
-**User-visible changes since `v0.3.5`:**
+**Shipped in `v0.3.6` (changes since `v0.3.5`):**
 
 - **Design-side process family** — five named, discoverable design-thread
   surfaces: `intent-cli improve` (G456, retrospective realignment),
@@ -202,30 +203,30 @@ does not cut the release.
   latest G-unit from `eng/version.json` and git instead of a stale csproj
   literal, so `intent-cli --version` is coherent across build paths.
 
-**Release-readiness verification (run before tagging `v0.3.6`):**
+**Release-readiness verification (run before tagging the next `v0.3.7`):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.3.5 (published), nextVersion 0.3.6 (to release)
+cat eng/version.json   # stableVersion 0.3.6 (published), nextVersion 0.3.7 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.3.6-<sha>-G46x   (NOT 0.3.2-...)
+#   expected shape: intent-cli 0.3.7-<sha>-G47x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.6.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.7.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-The official release is then cut by publishing a GitHub Release tagged `v0.3.6`;
-the release workflow passes `-p:Version=0.3.6` (which wins over the local
+The official release is then cut by publishing a GitHub Release tagged `v0.3.7`;
+the release workflow passes `-p:Version=0.3.7` (which wins over the local
 default). After the release publishes, apply the post-release `eng/version.json`
-bump above.
+bump above (`stableVersion → 0.3.7`, `nextVersion → 0.3.8`).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -141,39 +141,40 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.3.5",
-  "nextVersion": "0.3.6"
-}
-```
-
-| ステージ | バージョン形式 | 導出方法 |
-| --- | --- | --- |
-| ローカル pack / install | `0.3.6-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.3.6-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.6-rc.N` | タグ `v0.3.6-rc.N` がリリースワークフローをトリガー |
-| 安定版リリース | `0.3.6` | タグ `v0.3.6` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.3.7-preview.<run>.<attempt>` | `nextVersion` を `0.3.7` にバンプ後 |
-
-**`v0.3.6` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
-
-```json
-{
   "stableVersion": "0.3.6",
   "nextVersion": "0.3.7"
 }
 ```
 
+| ステージ | バージョン形式 | 導出方法 |
+| --- | --- | --- |
+| ローカル pack / install | `0.3.7-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.3.7-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.3.7-rc.N` | タグ `v0.3.7-rc.N` がリリースワークフローをトリガー |
+| 安定版リリース | `0.3.7` | タグ `v0.3.7` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.3.8-preview.<run>.<attempt>` | `nextVersion` を `0.3.8` にバンプ後 |
+
+**`v0.3.7` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+
+```json
+{
+  "stableVersion": "0.3.7",
+  "nextVersion": "0.3.8"
+}
+```
+
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.3.7-preview.<run>.<attempt>` / `0.3.7-<sha>-<G-unit>` を生成し、`0.3.6`（安定版
+`0.3.8-preview.<run>.<attempt>` / `0.3.8-<sha>-<G-unit>` を生成し、`0.3.7`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備（v0.3.6）
+### 次リリース準備（v0.3.7）
 
-リポジトリは operator による明示的な **`v0.3.6`** リリース（現在の `nextVersion`）の
-準備が整っています。リリース自体はタグ付けで publish され、このパケットはリリースを
-cut しません。
+**`v0.3.6` は publish 済み**（GitHub Release + NuGet, 2026-06-05）で、バージョンポリシーは
+`0.3.7` 開発ラインにバンプされました（G470）。リポジトリは現在 in-development の **`0.3.7`**
+`nextVersion` 上にあります。次のリリースは準備完了後に `v0.3.7` タグ付けで publish され、
+このバンプはリリースを cut しません。
 
-**`v0.3.5` 以降のユーザー可視の変更:**
+**`v0.3.6` で出荷済み（`v0.3.5` 以降の変更）:**
 
 - **design-side プロセスファミリー** — 名前付きで discoverable な5つの design-thread
   surface: `intent-cli improve`（G456）・`intent-cli grill`（G463）・
@@ -187,22 +188,22 @@ cut しません。
   self-contained リリース artifact が package version・git short SHA・最新 G-unit を
   stale な csproj リテラルではなく `eng/version.json` と git から導出します。
 
-**リリース準備の検証（`v0.3.6` タグ付け前に実行）:**
+**リリース準備の検証（次の `v0.3.7` タグ付け前に実行）:**
 
 ```bash
-cat eng/version.json   # stableVersion 0.3.5（公開済み）, nextVersion 0.3.6（リリース対象）
+cat eng/version.json   # stableVersion 0.3.6（公開済み）, nextVersion 0.3.7（リリース対象）
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.3.6-<sha>-G46x （0.3.2-... ではない）
+#   期待形: intent-cli 0.3.7-<sha>-G47x （stale なリテラルではない）
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.6.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.7.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-公式リリースは `v0.3.6` タグの GitHub Release publish で cut され、リリースワークフローが
-`-p:Version=0.3.6` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
-`eng/version.json` バンプを適用します。
+公式リリースは `v0.3.7` タグの GitHub Release publish で cut され、リリースワークフローが
+`-p:Version=0.3.7` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
+`eng/version.json` バンプ（`stableVersion → 0.3.7`, `nextVersion → 0.3.8`）を適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.5",
-  "nextVersion": "0.3.6"
+  "stableVersion": "0.3.6",
+  "nextVersion": "0.3.7"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,10 +124,10 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.6 as the next development line
-        // (post-v0.3.5 release bump, see G468 — the policy was stale at
-        // 0.3.4/0.3.5 after v0.3.5 shipped, which made local pack report a
-        // misleading version).
+        // be parseable and must point to 0.3.7 as the next development line
+        // (post-v0.3.6 release bump, see G470 — v0.3.6 was published to
+        // GitHub Releases + NuGet, so the policy moves the development line
+        // forward to 0.3.7 while recording 0.3.6 as the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -137,8 +137,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.6", policy.NextVersion);
-        Assert.Equal("0.3.5", policy.StableVersion);
+        Assert.Equal("0.3.7", policy.NextVersion);
+        Assert.Equal("0.3.6", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

`v0.3.6` was published successfully — the GitHub Release `v0.3.6` (non-draft, 2026-06-05) carries all three platform binaries + sha256 sidecars + the nupkg, and `0.3.6` is the latest version on NuGet (`jtechjapan.intentsystem.cli`). With the release confirmed, this moves the version policy forward so future local/preview builds identify as the `0.3.7` development line.

## Changes

- **`eng/version.json`** — `stableVersion` `0.3.5 → 0.3.6` (now published), `nextVersion` `0.3.6 → 0.3.7` (in-development line).
- **Tests** — `VersionPolicyTests` now expects the `0.3.7`/`0.3.6` pair. The G468/G469 guards (no hard-coded csproj `<Version>` literal, policy coherence, package metadata, docs reference the current `nextVersion`) read policy/docs dynamically and continue to pass.
- **Docs (en/ja developer reference)** — refresh the Version-flow example/table to `0.3.6`/`0.3.7` (post-release bump example → `0.3.7`/`0.3.8`), and retarget the release-readiness section to `v0.3.7`, recording that `v0.3.6` shipped and `0.3.7` is the new development line.

## Verification

- Before mutation: confirmed `v0.3.6` GitHub Release + NuGet availability.
- After the bump, the local default build reports `intent-cli 0.3.7-<sha>-<G-unit>`.
- Focused version/release tests (31) and the full Release suite (3024 passed) are green on two consecutive runs.

## Out of scope (untouched)

Creating/publishing `v0.3.6` or `v0.3.7`, release-workflow semantics, CLI features.

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)