### PR TITLE
G473 Deprecate local automation rule docs as canonical loop prompt sources

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -552,6 +552,7 @@ Host metadata gaps surfaced by `worker complete` (e.g. `linked_pr_synced: false`
 
 Hard rules:
 - Do not read `intents/rules/**`, local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, etc.), or copied prompt files for routine collaboration. Use `intent-cli guide ...` instead.
+- **Installed-guidance-wins conflict rule (G473)**: for routine loop work, installed `intent-cli guide` / `automation` output is the canonical source of truth. Repository-local automation rule docs (`intents/rules/automations/*.md` such as `scheduling.md`, `setup-host-review-loop.md`, `child-implement-and-update-loop.md`) are historical/reference only — they are NOT canonical loop-prompt sources. Do NOT read `intents/rules/**` to compose routine prompts EVEN WHEN the operator names those files, unless the task is explicitly to maintain or migrate those historical docs. When a local rule doc conflicts with installed `intent-cli guide` output, the installed guide wins.
 - Do not call `intent-cli run` from this loop. `run` is advanced runtime (integration smoke / replay / dogfooding), not the chat-first path.
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
@@ -670,6 +671,7 @@ Loop body (single wake):
 Hard rules:
 - **Continuation contract (G454)**: workflow labels are state markers, not completion boundaries. `intent-pr-approved` is INTERMEDIATE — after approval the SAME wake MUST merge, verify `merged == true`, and run `closeout pr --write` unless a concrete gate (draft, failing CI, merge conflict, base-policy mismatch, missing linkage) blocks merge. A wake that stops at `intent-pr-approved` without merging or naming the blocking gate is INCOMPLETE. For a recoverable blocker, apply the named repair command and retry ONCE (resume from the named stage) before declaring the PR blocked; never loop the same repair, never escalate to raw label mutation. If the previous wake stopped after a partial step, run this wake as a rail-recovery wake: re-derive the PR's true state, match it to the `Host-loop continuation contract` stop classification, and run that classification's next command (for an approved-but-unmerged PR that is merge + `closeout pr`, NOT a re-review).
 - Do not read `intents/rules/**`, local skill files, or copied prompt files for routine review/closeout. Use `intent-cli guide ...` and `intent-cli automation ...` instead.
+- **Installed-guidance-wins conflict rule (G473)**: for routine loop work, installed `intent-cli guide` / `automation` output is the canonical source of truth. Repository-local automation rule docs (`intents/rules/automations/*.md` such as `scheduling.md`, `setup-host-review-loop.md`, `child-implement-and-update-loop.md`) are historical/reference only — they are NOT canonical loop-prompt sources. Do NOT read `intents/rules/**` to compose routine prompts EVEN WHEN the operator names those files, unless the task is explicitly to maintain or migrate those historical docs. When a local rule doc conflicts with installed `intent-cli guide` output, the installed guide wins.
 - Do not call `intent-cli run`. `run` is advanced runtime, not the host review/closeout path.
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
@@ -739,6 +741,7 @@ Host metadata gaps surfaced by `worker complete` (e.g. `linked_pr_synced: false`
 
 Hard rules:
 - Do not read `intents/rules/**`, local skill files (`gh-issue-to-pr`, `gh-fix-pr-comment`, etc.), or copied prompt files for routine collaboration. Use `intent-cli guide ...` instead.
+- **Installed-guidance-wins conflict rule (G473)**: for routine loop work, installed `intent-cli guide` / `automation` output is the canonical source of truth. Repository-local automation rule docs (`intents/rules/automations/*.md` such as `scheduling.md`, `setup-host-review-loop.md`, `child-implement-and-update-loop.md`) are historical/reference only — they are NOT canonical loop-prompt sources. Do NOT read `intents/rules/**` to compose routine prompts EVEN WHEN the operator names those files, unless the task is explicitly to maintain or migrate those historical docs. When a local rule doc conflicts with installed `intent-cli guide` output, the installed guide wins.
 - Do not call `intent-cli run` from this loop. `run` is advanced runtime (integration smoke / replay / dogfooding), not the chat-first path.
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.
@@ -838,6 +841,7 @@ Loop body (single wake only — do not repeat):
 
 Hard rules:
 - Do not read `intents/rules/**`, local skill files, or copied prompt files for routine review/closeout. Use `intent-cli guide ...` and `intent-cli automation ...` instead.
+- **Installed-guidance-wins conflict rule (G473)**: for routine loop work, installed `intent-cli guide` / `automation` output is the canonical source of truth. Repository-local automation rule docs (`intents/rules/automations/*.md` such as `scheduling.md`, `setup-host-review-loop.md`, `child-implement-and-update-loop.md`) are historical/reference only — they are NOT canonical loop-prompt sources. Do NOT read `intents/rules/**` to compose routine prompts EVEN WHEN the operator names those files, unless the task is explicitly to maintain or migrate those historical docs. When a local rule doc conflicts with installed `intent-cli guide` output, the installed guide wins.
 - Do not call `intent-cli run`. `run` is advanced runtime, not the host review/closeout path.
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -342,6 +342,60 @@ public sealed class GuidePromptMatrixCommandTests
         Assert.Contains("MUST NOT become a `request-update` comment", prompt, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("child-loop")]
+    [InlineData("host-loop")]
+    public void Execute_LoopJson_InstalledGuidanceWinsOverLocalRuleDocs(string mode)
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", mode, "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+
+        // G473: installed intent-cli guidance is canonical; local automation rule
+        // docs are historical/reference and must not be read to compose routine
+        // prompts even when the operator names them.
+        Assert.Contains("Installed-guidance-wins conflict rule", prompt, StringComparison.Ordinal);
+        Assert.Contains("intents/rules/automations/*.md", prompt, StringComparison.Ordinal);
+        Assert.Contains("the installed guide wins", prompt, StringComparison.Ordinal);
+        Assert.Contains("EVEN WHEN the operator names those files", prompt, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("child-loop")]
+    [InlineData("host-loop")]
+    public void Execute_LoopJson_DoesNotRecommendObsoleteDefaults(string mode)
+    {
+        using var writer = new StringWriter();
+        GuidePromptMatrixCommand.Execute(
+            CreateContext(),
+            ["--mode", mode, "--format", "json"],
+            writer);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompt = document.RootElement.GetProperty("prompt").GetString()!;
+
+        // G473: generated loop prompts must not reintroduce obsolete concepts as
+        // canonical defaults. The historical local rule docs surfaced these; the
+        // installed guide must not. (Lines that explicitly forbid an obsolete name
+        // are allowed; bare default recommendations are not.)
+        Assert.DoesNotContain("intent-next-slice skill", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("/schedule every 5 minutes", prompt, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("/loop 3m", prompt, StringComparison.OrdinalIgnoreCase);
+        // The obsolete closeout skill may only appear inside a forbidding sentence.
+        foreach (var line in prompt.Split('\n'))
+        {
+            if (line.Contains("intent-review-closeout", StringComparison.OrdinalIgnoreCase))
+            {
+                Assert.Contains("Do NOT invoke a local closeout skill", line, StringComparison.Ordinal);
+            }
+        }
+    }
+
     // ── child-oneshot tests ──────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Make routine loop-prompt creation unambiguously installed-intent-cli-driven (G473). Generated child-loop / host-loop (and one-shot) prompts now carry an **installed-guidance-wins conflict rule**: installed `intent-cli guide` / `automation` output is canonical; repository-local automation rule docs are historical/reference only and must not be read to compose routine prompts even when the operator names them; on any conflict the installed guide wins.

## Changes

- **`GuidePromptMatrixCommand`** — append the G473 conflict rule to the child-loop / child-oneshot and host-loop / host-oneshot hard-rules blocks. It names `intents/rules/automations/*.md` (e.g. `scheduling.md`, `setup-host-review-loop.md`, `child-implement-and-update-loop.md`) as non-canonical, instructs agents not to read `intents/rules/**` for routine prompts EVEN WHEN the operator names those files (unless explicitly maintaining/migrating them), and states the installed guide wins on conflict. The review-next-slice-loop workflow guide forwards `--mode host-loop`, so it inherits the rule.
- **Tests** — `Execute_LoopJson_InstalledGuidanceWinsOverLocalRuleDocs` (child-loop + host-loop) asserts the conflict rule is present; `Execute_LoopJson_DoesNotRecommendObsoleteDefaults` asserts the prompts do not recommend `intent-next-slice skill`, `/schedule every 5 minutes`, `/loop 3m`, or a non-forbidding `intent-review-closeout` mention.

## Verification

- `dotnet build src/IntentSystem.Cli` — 0 errors.
- `dotnet test tests/IntentSystem.Cli.Tests` — 3046 passed, 1 skipped, 0 failed.
- `git diff --check` — clean.

## Scope note

This repo (the intent-cli source) has no `intents/` tree. The `intents/rules/automations/*.md` legacy-banner work and the `intents/intent-cli/specs/19-...` / `design/decisions/004-...` docs named in the issue live in the **parent host intent repo** and are out of reach from the GitHub-contract-only child implementation loop. The installed-surface conflict rule and its regression tests — the part that actually controls what fresh loop-setup agents see — land here.

Closes #1047
