### PR TITLE
G475 Prepare v0.3.7 release after G471-G474 automation safety fixes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -181,27 +181,31 @@ emit `0.3.7` (which would collide with the stable release version).
 
 **`v0.3.6` shipped** (GitHub Release + NuGet, 2026-06-05) and the version policy
 was bumped to the `0.3.7` development line (G470). The repository is now on the
-in-development **`0.3.7`** `nextVersion`; the next release is published by tagging
-`v0.3.7` once it is prepared — this bump does not cut a release.
+in-development **`0.3.7`** `nextVersion`; G475 (this packet) prepares the
+`v0.3.7` release — the next release is published by tagging `v0.3.7` once the
+[release-readiness gate](release-notes-v0.3.7.md#release-readiness-gate-g475)
+passes. Preparing the release does not cut it. Full changelog and operator
+checklist: [release-notes-v0.3.7.md](release-notes-v0.3.7.md).
 
-**Shipped in `v0.3.6` (changes since `v0.3.5`):**
+**To ship in `v0.3.7` (changes since `v0.3.6`) — an automation-safety release:**
 
-- **Design-side process family** — five named, discoverable design-thread
-  surfaces: `intent-cli improve` (G456, retrospective realignment),
-  `intent-cli grill` (G463, persistent open-question interview),
-  `intent-cli stack` (G464, packet backlog + first issue),
-  `intent-cli next` (G465, "what should I do next?" advisor), and
-  `intent-cli inspect` (G466, evidence-backed observation). Each has a
-  top-level alias and a `guide <name>` form.
-- **Guide catalog / role classification** (G467) — `intent-cli guide commands
-  list` is now a role-based catalog (design / host-review /
-  child-implementation / recovery-diagnostics / advanced-developer), and
-  `intent-cli guide help` explains which surfaces serve each role, including the
-  loop-prompt generators.
-- **Version-source alignment** (G468) — local pack/install, NuGet packages, and
-  self-contained release artifacts derive package version, git short SHA, and
-  latest G-unit from `eng/version.json` and git instead of a stale csproj
-  literal, so `intent-cli --version` is coherent across build paths.
+- **Non-default implementation base branches** (G471) — loop-prompt prose and
+  review guidance treat a non-default implementation base branch as a
+  first-class case, so child loops pick the correct PR base without reading host
+  metadata and review no longer mis-flags a correctly-based PR.
+- **`issue-published` queue compatibility** (G472) — review-closeout parsing
+  tolerates queue-state rows in the `issue-published` state instead of aborting
+  the closeout read; host review loop guidance is skill-free and treats
+  CI-pending as a defer condition.
+- **Installed guide over local rule docs** (G473) — when generating loop
+  prompts, the installed `intent-cli guide` output is canonical over local
+  `intents/rules/automations/*.md`; the hard rule forbids reading the local rule
+  docs even when an operator names them.
+- **Absorbed packet retirement safety** (G474) — machine-readable packet
+  lifecycle retirement (`lifecycle.yaml` sidecar + `intent-cli packet retire`)
+  excludes absorbed/superseded/retired packets from `intent next-slice`
+  issue-cut-ready selection and flags stale human `STATUS: ABSORBED` markers for
+  repair, so an absorbed packet is never re-cut as a duplicate issue.
 
 **Release-readiness verification (run before tagging the next `v0.3.7`):**
 

--- a/docs/en/release-notes-v0.3.7.md
+++ b/docs/en/release-notes-v0.3.7.md
@@ -1,0 +1,132 @@
+# Release Notes — intent-cli v0.3.7
+
+> **Release checklist for maintainers:** see [Creating the v0.3.7 GitHub Release](#creating-the-v037-github-release).
+> **Do NOT tag until the [release-readiness gate](#release-readiness-gate-g475) passes.**
+
+## What's in v0.3.7
+
+v0.3.7 is an automation-safety release. It collects the loop-prompt /
+review-closeout / next-slice reliability fixes completed after `v0.3.6` that
+make automated implementation/review loops behave correctly on non-default base
+branches, stop a `issue-published` queue-state row from blocking review
+closeout, keep the installed `intent-cli guide` output authoritative over stale
+local rule docs, and prevent absorbed/superseded packets from being re-cut as
+duplicate issues. No package id, license, or workflow-semantics changes. The
+package id remains `JTechJapan.IntentSystem.Cli`.
+
+### Non-default implementation base branches are first-class in loop prompts (G471)
+
+- Loop-prompt prose and review guidance now treat a non-default implementation
+  base branch as a first-class case instead of assuming `main`. The generated
+  child/host loop prompts and the base-branch policy guidance carry the actual
+  configured base so a child implementation agent picks the correct PR base
+  without reading host metadata, and review guidance no longer mis-flags a
+  correctly-based PR.
+
+### `issue-published` queue rows no longer block review closeout (G472)
+
+- Review-closeout parsing tolerates queue-state rows whose state is
+  `issue-published`, so a published-but-not-yet-PR'd row no longer aborts the
+  closeout read. The host review loop guidance is skill-free (closeout routes
+  through installed `intent-cli` surfaces only) and treats a CI-pending result
+  as a defer condition rather than a stop.
+
+### Installed `intent-cli guide` is canonical over stale local rule docs (G473)
+
+- When generating loop prompts, the installed `intent-cli guide` output wins
+  over local `intents/rules/automations/*.md` rule docs. The hard rule is now
+  explicit in the child/host loop and one-shot guidance: do not read the local
+  rule docs even when an operator names them — the installed guide is the source
+  of truth, so a stale checked-in rule file can no longer silently override the
+  shipped guidance.
+
+### Absorbed / superseded packet lifecycle retirement safety (G474)
+
+- New machine-readable packet lifecycle retirement: a `lifecycle.yaml` sidecar
+  (`lifecycle: ready|absorbed|retired|superseded` plus optional `absorbed_by` /
+  `superseded_by` / `retired_reason` / `retired_at`) records that a packet
+  directory is design history, not a next-slice candidate.
+- New `intent-cli packet retire --execution-unit <id> (--absorbed-by <unit> |
+  --superseded-by <unit> | --retired) --reason <text> [--write]` records the
+  sidecar and appends a `packet-retired` run event. It is idempotent (re-running
+  the same retirement reports `already-retired` without rewriting the sidecar or
+  duplicating run events) and never deletes the packet files.
+- `intent-cli intent next-slice` excludes machine-retired packets from
+  issue-cut-ready selection in both scan passes; a packet carrying only a stale
+  human marker (e.g. `STATUS: ABSORBED`) is excluded and surfaced with a
+  `legacy-retirement-marker-needs-machine-metadata` warning and a repair note,
+  so an absorbed packet is never blindly published. Host loop guidance tells
+  agents to retire such packets through `intent-cli packet retire` rather than
+  asking the operator whether to publish.
+
+> Version metadata note: `eng/version.json` already records
+> `stableVersion: 0.3.6`, `nextVersion: 0.3.7`; G475 (this packet) is the
+> release-readiness preparation. The post-v0.3.7 metadata advancement
+> (`stableVersion → 0.3.7`, `nextVersion → 0.3.8`) is the operator's
+> post-release step and is out of scope for this packet.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.7
+```
+
+Or download the self-contained binary from the
+[v0.3.7 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.7).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.6
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.7
+```
+
+There are no breaking changes from v0.3.6.
+
+## Release-readiness gate (G475)
+
+Do not create the `v0.3.7` tag/release until ALL of the following hold
+(this gate fails closed — if any item is unmet, stop and do not tag):
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G471, G472, G473, G474 (and G475 this prep). Confirm on the host/review
+      side via the host queue-state / GitHub PR state — the child implementation
+      loop must not read parent queue-state, so this is a host-owned
+      precondition.
+- [ ] `eng/version.json` `nextVersion` is `0.3.7` (the intended release version)
+      and matches the tag to be created (`v0.3.7`). The release workflow derives
+      the package version from the tag; `-p:Version=` overrides the policy-derived
+      default in `src/IntentSystem.Cli/IntentSystem.Cli.csproj`.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+
+## Creating the v0.3.7 GitHub Release
+
+1. Confirm the [release-readiness gate](#release-readiness-gate-g475) — do not
+   proceed if any item is unmet.
+2. Tag the release commit: `git tag v0.3.7 && git push origin v0.3.7`.
+3. The `release.yml` workflow fires and builds binaries, `.nupkg`, and
+   checksums (version derived from the tag). Wait for it to complete green.
+4. The workflow creates the GitHub Release draft. Review it, paste the content
+   of this file as the release body, and publish.
+5. Confirm the NuGet publish step pushed `JTechJapan.IntentSystem.Cli 0.3.7`.
+6. Post-release verification checklist:
+   - [ ] NuGet.org package page links all resolve correctly.
+   - [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+         accessible.
+   - [ ] `.sha256` checksums match the downloaded artifacts.
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.7`)
+         then `intent-cli --version` reports `0.3.7`.
+   - [ ] Binary artifact smoke check: download the platform archive, verify its
+         `.sha256`, extract, and run `./intent-cli --version` → `0.3.7`.
+   - [ ] Local preview/dry-run version metadata uses the next development line
+         after `0.3.7` (bump `eng/version.json` per the post-release step in
+         [Version flow](09-developer-reference.md#version-flow)):
+         `stableVersion → 0.3.7`, `nextVersion → 0.3.8`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -171,22 +171,27 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 **`v0.3.6` は publish 済み**（GitHub Release + NuGet, 2026-06-05）で、バージョンポリシーは
 `0.3.7` 開発ラインにバンプされました（G470）。リポジトリは現在 in-development の **`0.3.7`**
-`nextVersion` 上にあります。次のリリースは準備完了後に `v0.3.7` タグ付けで publish され、
-このバンプはリリースを cut しません。
+`nextVersion` 上にあり、G475（本パケット）が `v0.3.7` リリースを準備します。次のリリースは
+[リリース準備ゲート](release-notes-v0.3.7.md#リリース準備ゲート-g475)を通過後に `v0.3.7`
+タグ付けで publish されます。準備はリリースを cut しません。完全な changelog と operator
+チェックリスト: [release-notes-v0.3.7.md](release-notes-v0.3.7.md)。
 
-**`v0.3.6` で出荷済み（`v0.3.5` 以降の変更）:**
+**`v0.3.7` で出荷予定（`v0.3.6` 以降の変更）— automation 安全性リリース:**
 
-- **design-side プロセスファミリー** — 名前付きで discoverable な5つの design-thread
-  surface: `intent-cli improve`（G456）・`intent-cli grill`（G463）・
-  `intent-cli stack`（G464）・`intent-cli next`（G465）・`intent-cli inspect`（G466）。
-  各々に top-level alias と `guide <name>` 形式があります。
-- **guide カタログ / role 分類**（G467）— `intent-cli guide commands list` が role
-  ベースのカタログ（design / host-review / child-implementation /
-  recovery-diagnostics / advanced-developer）になり、`intent-cli guide help` が各
-  role の surface を説明します。
-- **version-source 整合**（G468）— ローカル pack/install・NuGet パッケージ・
-  self-contained リリース artifact が package version・git short SHA・最新 G-unit を
-  stale な csproj リテラルではなく `eng/version.json` と git から導出します。
+- **非デフォルト実装 base branch**（G471）— loop-prompt 本文と review ガイダンスが非デフォルトの
+  実装 base branch を first-class として扱い、child loop は host メタデータを読まずに正しい PR
+  base を選択し、review は正しい base の PR を誤判定しません。
+- **`issue-published` queue 互換**（G472）— review-closeout parsing が `issue-published`
+  state の queue-state 行を許容し closeout 読み取りを中断しません。host review loop ガイダンスは
+  skill-free で CI-pending を defer 条件として扱います。
+- **installed guide を local rule docs より優先**（G473）— loop prompt 生成時、インストール済み
+  `intent-cli guide` の出力がローカル `intents/rules/automations/*.md` より正統です。hard rule は
+  operator が名指ししてもローカル rule docs を読むことを禁じます。
+- **absorbed パケット retirement の安全性**（G474）— machine-readable なパケット lifecycle
+  retirement（`lifecycle.yaml` サイドカー + `intent-cli packet retire`）が absorbed/superseded/
+  retired パケットを `intent next-slice` の issue-cut-ready 選択から除外し、古い human
+  `STATUS: ABSORBED` marker を修復対象として flag するため、absorbed パケットが重複 issue として
+  再 cut されることはありません。
 
 **リリース準備の検証（次の `v0.3.7` タグ付け前に実行）:**
 

--- a/docs/ja/release-notes-v0.3.7.md
+++ b/docs/ja/release-notes-v0.3.7.md
@@ -1,0 +1,124 @@
+# リリースノート — intent-cli v0.3.7
+
+> **メンテナ向けリリースチェックリスト:** [v0.3.7 GitHub リリースの作成](#v037-github-リリースの作成) を参照。
+> **[リリース準備ゲート](#リリース準備ゲート-g475) を通過するまでタグを打たないこと。**
+
+## v0.3.7 の内容
+
+v0.3.7 は automation 安全性のリリースです。`v0.3.6` 後に完了した loop-prompt /
+review-closeout / next-slice の信頼性修正をまとめ、非デフォルト base branch 上での
+実装/レビュー loop を正しく動作させ、`issue-published` の queue-state 行が review
+closeout を阻害しないようにし、インストール済み `intent-cli guide` の出力を古いローカル
+rule docs より優先させ、absorbed/superseded パケットが重複 issue として再発行されるのを
+防ぎます。package id・ライセンス・ワークフロー semantics の変更はありません。package id
+は `JTechJapan.IntentSystem.Cli` のままです。
+
+### 非デフォルト実装 base branch を loop prompt で first-class に (G471)
+
+- loop-prompt の本文と review ガイダンスが、`main` を前提とせず非デフォルトの実装 base
+  branch を first-class なケースとして扱うようになりました。生成される child/host loop
+  prompt と base-branch ポリシー ガイダンスが実際に設定された base を保持するため、child
+  実装エージェントは host メタデータを読まずに正しい PR base を選択でき、review ガイダンスも
+  正しい base の PR を誤判定しません。
+
+### `issue-published` の queue 行が review closeout を阻害しない (G472)
+
+- review-closeout の parsing が、state が `issue-published` の queue-state 行を許容する
+  ようになり、publish 済みで未 PR の行が closeout 読み取りを中断しなくなりました。host
+  review loop ガイダンスは skill-free（closeout はインストール済み `intent-cli` surface
+  のみを経由）で、CI-pending の結果は stop ではなく defer 条件として扱います。
+
+### インストール済み `intent-cli guide` を古いローカル rule docs より優先 (G473)
+
+- loop prompt 生成時、インストール済み `intent-cli guide` の出力がローカルの
+  `intents/rules/automations/*.md` rule docs より優先されます。child/host loop と
+  one-shot ガイダンスで hard rule が明示されました: operator がローカル rule docs を
+  名指ししても読まない — インストール済み guide が source of truth であり、古い
+  checked-in rule ファイルが出荷済みガイダンスを暗黙に上書きできなくなりました。
+
+### absorbed / superseded パケット lifecycle retirement の安全性 (G474)
+
+- 新しい machine-readable なパケット lifecycle retirement: `lifecycle.yaml` サイドカー
+  （`lifecycle: ready|absorbed|retired|superseded` と任意の `absorbed_by` /
+  `superseded_by` / `retired_reason` / `retired_at`）が、パケットディレクトリが
+  next-slice 候補ではなく design history であることを記録します。
+- 新 `intent-cli packet retire --execution-unit <id> (--absorbed-by <unit> |
+  --superseded-by <unit> | --retired) --reason <text> [--write]` がサイドカーを記録し
+  `packet-retired` run イベントを追加します。冪等（同じ retirement の再実行はサイドカーを
+  書き換えず run イベントを重複させず `already-retired` を報告）で、パケットファイルを削除
+  しません。
+- `intent-cli intent next-slice` は両方の scan pass で machine-retired パケットを
+  issue-cut-ready 選択から除外します。古い human marker（例: `STATUS: ABSORBED`）のみを
+  持つパケットは除外され、`legacy-retirement-marker-needs-machine-metadata` 警告と
+  修復ノートで surface されるため、absorbed パケットが盲目的に publish されることはありません。
+  host loop ガイダンスは、こうしたパケットを operator に publish 可否を尋ねるのではなく
+  `intent-cli packet retire` で retire するよう指示します。
+
+> バージョンメタデータ注記: `eng/version.json` は既に `stableVersion: 0.3.6`,
+> `nextVersion: 0.3.7` を記録しており、G475（本パケット）はリリース準備です。v0.3.7 後の
+> メタデータ前進（`stableVersion → 0.3.7`, `nextVersion → 0.3.8`）は operator のリリース後
+> 手順であり、本パケットの対象外です。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.7
+```
+
+または
+[v0.3.7 GitHub リリース](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.7)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを
+検証してください。
+
+## v0.3.6 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.7
+```
+
+v0.3.6 からの破壊的変更はありません。
+
+## リリース準備ゲート (G475)
+
+以下が **すべて** 満たされるまで `v0.3.7` タグ/リリースを作成しないこと
+（このゲートは fail-closed — 1 つでも未達なら停止しタグを打たない）:
+
+- [ ] リリース対象パケットがすべて **完了し PR が `main` にマージ済み**:
+      G471, G472, G473, G474（および本準備 G475）。host/review 側で host queue-state /
+      GitHub PR state により確認すること — child 実装 loop は親 queue-state を読まないため、
+      これは host 所有の前提条件です。
+- [ ] `eng/version.json` の `nextVersion` が `0.3.7`（意図したリリースバージョン）で、
+      作成するタグ（`v0.3.7`）と一致すること。release ワークフローはタグからパッケージ
+      バージョンを導出し、`-p:Version=` が
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` のポリシー導出デフォルトを上書きします。
+- [ ] パッケージメタデータが正しいこと: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` が
+      `https://github.com/J-Tech-Japan/intent-system` を指す,
+      `PackageLicenseExpression = Apache-2.0`, README/docs リンクが解決し,
+      公式サービスサイト `https://www.intent-driven-development.com/` が README から
+      リンクされていること。
+- [ ] release コミットで **main CI が green**（`Build and test (source contract)`）で、
+      **preview-pack** ワークフローが green であること。
+
+## v0.3.7 GitHub リリースの作成
+
+1. [リリース準備ゲート](#リリース準備ゲート-g475) を確認 — 未達項目があれば進めない。
+2. release コミットにタグ: `git tag v0.3.7 && git push origin v0.3.7`。
+3. `release.yml` ワークフローが発火し、バイナリ・`.nupkg`・チェックサムをビルド
+   （バージョンはタグから導出）。green 完了を待つ。
+4. ワークフローが GitHub Release draft を作成。確認し、本ファイルの内容を release body
+   として貼り付け、publish。
+5. NuGet publish ステップが `JTechJapan.IntentSystem.Cli 0.3.7` を push したことを確認。
+6. リリース後の検証チェックリスト:
+   - [ ] NuGet.org パッケージページのリンクがすべて正しく解決する。
+   - [ ] GitHub release アセットリンク（`.tar.gz`, `.zip`, `.exe`, `.nupkg`）が
+         アクセス可能。
+   - [ ] `.sha256` チェックサムがダウンロードしたアーティファクトと一致する。
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`（または
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.7`）の後、
+         `intent-cli --version` が `0.3.7` を報告する。
+   - [ ] バイナリアーティファクトの smoke check: プラットフォームアーカイブをダウンロードし、
+         `.sha256` を検証、展開して `./intent-cli --version` → `0.3.7`。
+   - [ ] ローカル preview/dry-run のバージョンメタデータが `0.3.7` 後の次の開発ラインを
+         使う（[Version flow](09-developer-reference.md#version-flow) のリリース後手順に
+         従い `eng/version.json` を bump）: `stableVersion → 0.3.7`, `nextVersion → 0.3.8`。

--- a/tests/IntentSystem.Cli.Tests/ReleasePackageMetadataTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleasePackageMetadataTests.cs
@@ -60,6 +60,31 @@ public sealed class ReleasePackageMetadataTests
         Assert.Contains("--version", devRef, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ReleaseNotes_ForNextVersion_ExistInEnAndJa_WithInstallVersionAndGate()
+    {
+        // G475: every release-to-be-cut must ship paste-ready release notes
+        // (en + ja) so the operator has a release body and a readiness gate.
+        // Derived from nextVersion so this guard stays correct across bumps.
+        var policy = VersionPolicy.TryReadFromRepo(FindRepoRoot());
+        Assert.NotNull(policy);
+        var version = policy!.NextVersion;
+        var fileName = $"release-notes-v{version}.md";
+
+        foreach (var lang in new[] { "en", "ja" })
+        {
+            var path = Path.Combine(FindRepoRoot(), "docs", lang, fileName);
+            Assert.True(File.Exists(path), $"missing release notes: docs/{lang}/{fileName}");
+
+            var notes = File.ReadAllText(path);
+            // The notes must name the package + the exact release version so an
+            // install/upgrade copy-paste lands the intended version.
+            Assert.Contains($"JTechJapan.IntentSystem.Cli --version {version}", notes, StringComparison.Ordinal);
+            // The notes must point at the matching GitHub Release tag (language-neutral).
+            Assert.Contains($"releases/tag/v{version}", notes, StringComparison.Ordinal);
+        }
+    }
+
     private static (int Major, int Minor, int Patch) ParseVersion(string version)
     {
         var core = version.Split('-', 2)[0];


### PR DESCRIPTION
## Summary

Prepare the repository for an explicit operator release of **v0.3.7** (the current `nextVersion`) containing the G471–G474 automation-safety fixes. This packet **does not publish** the release — release creation remains an operator/host action after merge (per Out Of Scope).

## Changes

- **`docs/{en,ja}/release-notes-v0.3.7.md`** (new) — paste-ready release notes covering the three user-visible fixes plus G474:
  - G471 non-default implementation base branch prompt reliability
  - G472 `issue-published` queue-state compatibility for review closeout
  - G473 installed `intent-cli guide` canonical over local rule docs
  - G474 absorbed/superseded packet lifecycle retirement safety

  Each includes install/upgrade commands pinned to `0.3.7`, a fail-closed **release-readiness gate (G475)**, and a **post-release operator verification checklist** (`dotnet tool update/install` → `intent-cli --version` → binary artifact smoke check with `.sha256`).
- **`docs/{en,ja}/09-developer-reference.md`** — retarget the "Next release readiness (v0.3.7)" section to the v0.3.7 changelog (G471–G474), link the release notes, and keep the post-release `eng/version.json` bump (`stableVersion → 0.3.7`, `nextVersion → 0.3.8`) documented as the operator step.
- **`tests/IntentSystem.Cli.Tests/ReleasePackageMetadataTests.cs`** — new guard that the release notes for the current `nextVersion` exist in en + ja, pin the package install version, and link the matching GitHub Release tag. Existing metadata/version-policy guards continue to pass.

## Version policy (intentionally unchanged)

`eng/version.json` stays `stableVersion 0.3.6` (published) / `nextVersion 0.3.7` (release-to-cut), which already represents the release-to-be-cut — exactly the G469 precedent. Bumping `stableVersion` to `0.3.7` now would falsely assert it is published. The release artifact version is **tag-driven** (`release.yml` passes `-p:Version=0.3.7`, which wins over the policy-derived local default); after tagging, the operator applies the documented post-release bump so dev/preview builds identify as `0.3.8-preview`, strictly newer than v0.3.7.

The release workflow is tag-driven and version-agnostic and already publishes NuGet plus `osx-arm64` / `win-x64` / `linux-x64` binaries with `.sha256` sidecars; no workflow change is required.

## Verification

- `intent-cli --version` → `intent-cli 0.3.7-a54c896-G474` (policy-derived, not a stale literal).
- Focused version/release tests: 16 passed (`ReleasePackageMetadataTests`, `VersionPolicyTests`, `VersionSourcePolicyGuardTests`).
- Full solution `dotnet test`: **3056 passed, 1 skipped, 0 failed**.
- `git diff --check` — clean.
- Confirmed G471, G472, G473, G474 are all merged to `main`.

## Acceptance criteria coverage

- v0.3.7 identified as the next GitHub/NuGet release containing G471–G474 ✓
- Release notes name the three user-visible fixes ✓
- Version sources produce v0.3.7 for release artifacts (tag-driven) and a strictly newer dev identifier after the documented post-release bump ✓
- Package id remains `JTechJapan.IntentSystem.Cli`; metadata links absolute/valid (guarded) ✓
- Short post-release verification checklist (tool update/install, `--version`, binary smoke check) ✓
- No open intent-system PR or WIP packet skipped — release prep is docs/test only ✓

Closes #1051
