### PR TITLE
G477 Auto-fallback closeout when linked_pr is missing but linked_issue is deterministic

### DIFF
--- a/docs/en/07-recovery.md
+++ b/docs/en/07-recovery.md
@@ -75,6 +75,20 @@ you whether a child-loop-owned repair exists. Host-owned categories surface as
 > but the host loop reports no host drift, re-run `pr-comment-preflight` and check those
 > two path lists to disambiguate the real edit target rather than looping silently.
 
+> **Missing `linked_pr` closeout is host-owned deterministic recovery (G477).** When
+> `intent-cli closeout pr --pr <n>` cannot match a queue item only because `linked_pr`
+> was never projected into host durable state, it auto-recovers from GitHub facts: a
+> merged PR whose closing references identify exactly one queue item (by `linked_issue`)
+> is completed without a manual `--issue <n>` rerun. The result reports
+> `recoverable_missing_linked_pr: true`, `inferred_issue`, and
+> `recovery_action: recover-linked-pr-from-github-closing-reference`, and the write
+> repairs the missing `linked_pr`. This is host-owned projection recovery, not an
+> operator policy question — do not treat the manual `--issue` rerun as required tribal
+> knowledge. Ambiguous evidence (closing references match more than one queue item)
+> fails closed with a `linkage-ambiguous` error; only then rerun with the correct
+> `--issue <n>`. Child `--github-only` loops never write `linked_pr`; this recovery
+> belongs to the host closeout surface.
+
 ### Repeated-stall recovery (G408)
 
 When an automation loop hits the same blocker on the same target for **two or more

--- a/docs/ja/07-recovery.md
+++ b/docs/ja/07-recovery.md
@@ -75,6 +75,19 @@ child-loop 所有の修復が存在するかを示す。host 所有のカテゴ�
 > と言うのに host ループが host drift なしと報告する場合は、黙ってループせず
 > `pr-comment-preflight` を再実行し、この 2 つの path リストで実際の編集対象を切り分ける。
 
+> **`linked_pr` 欠落の closeout は host 所有の deterministic recovery（G477）。**
+> `intent-cli closeout pr --pr <n>` が、`linked_pr` が host durable state に projection
+> されていないことだけを理由に queue item を照合できない場合、GitHub facts から自動回復する:
+> merged PR の closing references が（`linked_issue` 経由で）ちょうど1つの queue item を
+> 特定できれば、手動の `--issue <n>` 再実行なしで completed になる。結果は
+> `recoverable_missing_linked_pr: true` / `inferred_issue` /
+> `recovery_action: recover-linked-pr-from-github-closing-reference` を報告し、write 時に
+> 欠落していた `linked_pr` を修復する。これは host 所有の projection recovery であり、
+> operator の policy 判断ではない — 手動 `--issue` 再実行を必須の tribal knowledge として
+> 扱わないこと。曖昧な証拠（closing references が複数の queue item に一致）は
+> `linkage-ambiguous` エラーで fail closed する。その場合のみ正しい `--issue <n>` で再実行する。
+> child `--github-only` ループは `linked_pr` を書かない。この recovery は host closeout surface の責務。
+
 ### 繰り返しストール回復（G408）
 
 同じターゲットで同じブロッカーに **2 回以上連続** してヒットした場合は、

--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -30,10 +30,21 @@ internal static class CloseoutPrCommand
     private const string UsageLine =
         "Usage: intent-cli closeout pr --pr <n> --repo <owner/repo> [--issue <n>] [--domain <name>] [--pr-merged true|false] [--dry-run|--write] [--format json|markdown]";
 
+    private const string RecoveryActionRecoverLinkedPr = "recover-linked-pr-from-github-closing-reference";
+
     /// <summary>
     /// Test seam — replaces the default UTC timestamp source for runs events.
     /// </summary>
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    /// <summary>
+    /// G477: test seam for the PR closing-issues fetcher used by the
+    /// missing-<c>linked_pr</c> auto-recovery path. Production leaves this null
+    /// and falls back to <see cref="GhCliPrClosingIssuesFetcher"/> (which
+    /// fail-softs to an empty list on any <c>gh</c> error). Tests inject a
+    /// deterministic fake so closeout never shells out to live GitHub.
+    /// </summary>
+    public static Func<IPrClosingIssuesFetcher>? PrClosingIssuesFetcherFactory { get; set; }
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -140,11 +151,59 @@ internal static class CloseoutPrCommand
         var prToken = pr!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item.LinkedPr, repo!, prToken));
 
-        // Fallback: when linked_pr is absent, resolve via --issue (linked_issue.Number).
+        // Fallback A (operator-supplied): when linked_pr is absent, resolve via
+        // --issue (linked_issue.Number). Deterministic operator input wins.
         if (matchedItem is null && linkedIssueNumber.HasValue)
         {
             matchedItem = queueState.Items.FirstOrDefault(item =>
                 item.LinkedIssue?.Number == linkedIssueNumber.Value);
+        }
+
+        // G477 Fallback B (automatic, deterministic): when linked_pr is missing
+        // and the operator did not (or could not) disambiguate via --issue,
+        // recover from GitHub closing-issue facts. `linked_pr` is a host-owned
+        // projection that can be absent even when the GitHub issue/PR
+        // relationship is deterministic; a merged PR whose closing references
+        // identify exactly ONE queue item (by linked_issue) is safe to recover
+        // without forcing the operator to rerun with --issue <n>. Ambiguous
+        // evidence still fails closed (no guessing). The fetcher fail-softs to
+        // an empty list on any gh error, which routes to the existing
+        // not-found failure path.
+        var recoverableMissingLinkedPr = false;
+        int? inferredIssue = null;
+        string? recoverySource = null;
+        string? recoveryAction = null;
+        if (matchedItem is null)
+        {
+            var fetcher = PrClosingIssuesFetcherFactory?.Invoke() ?? new GhCliPrClosingIssuesFetcher();
+            var closingIssues = fetcher.Fetch(repo!, pr!.Value);
+            var reconstruction = GitHubLinkageReconstructor.Reconstruct(closingIssues, queueState, repo!);
+            switch (reconstruction.Kind)
+            {
+                case LinkageReconstructionKind.Deterministic:
+                    var candidate = reconstruction.Candidates[0];
+                    matchedItem = queueState.Items.First(item =>
+                        string.Equals(item.ExecutionUnit, candidate.ExecutionUnit, StringComparison.Ordinal));
+                    recoverableMissingLinkedPr = true;
+                    inferredIssue = candidate.LinkedIssueNumber;
+                    recoverySource = LinkageReconstructionConstants.RecoverySourceGitHubClosingReference;
+                    recoveryAction = RecoveryActionRecoverLinkedPr;
+                    break;
+
+                case LinkageReconstructionKind.Ambiguous:
+                    var candidateUnits = string.Join(", ", reconstruction.Candidates.Select(c =>
+                        $"{c.ExecutionUnit} (issue #{c.LinkedIssueNumber})"));
+                    EmitErrorResult(writer, format, NewFailureResult(domain, repo!, pr.Value, queueStatePath, runsLogPath, write,
+                        $"linkage-ambiguous: PR #{pr} closing-issues match {reconstruction.Candidates.Count} queue items "
+                        + $"({candidateUnits}); refusing to guess. Re-run `closeout pr --pr {pr} --issue <n>` with the correct linked issue.",
+                        stateLayout: stateLayout));
+                    return 1;
+
+                case LinkageReconstructionKind.NoClosingReferences:
+                case LinkageReconstructionKind.NoMatch:
+                default:
+                    break;
+            }
         }
 
         if (matchedItem is null)
@@ -184,11 +243,19 @@ internal static class CloseoutPrCommand
             BuildRunsEvent(executionUnit, "closeout-recorded", repo!, pr.Value, nowTs)
         };
 
+        // G477: when linkage was recovered from GitHub facts, repair the
+        // host-owned `linked_pr` projection while completing the item so the
+        // queue-state stops being deterministically incomplete. Stored as the
+        // canonical PR URL, matching the recovered-linkage payload shape.
+        var recoveredLinkedPr = recoverableMissingLinkedPr
+            ? $"https://github.com/{repo}/pull/{pr.Value}"
+            : null;
+
         if (write && !alreadyCompleted)
         {
             var updatedItems = queueState.Items
                 .Select(item => item.ExecutionUnit == matchedItem.ExecutionUnit
-                    ? UpdateItemState(item, QueueItemState.Completed)
+                    ? UpdateItemState(item, QueueItemState.Completed, recoveredLinkedPr)
                     : item)
                 .ToArray();
             var updatedState = new QueueState
@@ -257,7 +324,11 @@ internal static class CloseoutPrCommand
             ContinuationHint = continuation,
             NextSteps = nextSteps,
             Error = null,
-            StateLayout = stateLayout
+            StateLayout = stateLayout,
+            RecoverableMissingLinkedPr = recoverableMissingLinkedPr,
+            InferredIssue = inferredIssue,
+            RecoverySource = recoverySource,
+            RecoveryAction = recoveryAction
         };
 
         EmitResult(writer, result, format);
@@ -285,7 +356,7 @@ internal static class CloseoutPrCommand
         return linkedPr!.EndsWith($"/{prToken}", StringComparison.Ordinal);
     }
 
-    private static QueueItem UpdateItemState(QueueItem item, QueueItemState state)
+    private static QueueItem UpdateItemState(QueueItem item, QueueItemState state, string? recoveredLinkedPr = null)
     {
         return new QueueItem
         {
@@ -297,7 +368,9 @@ internal static class CloseoutPrCommand
             ClarificationReturnPath = item.ClarificationReturnPath,
             PacketPaths = item.PacketPaths,
             LinkedIssue = item.LinkedIssue,
-            LinkedPr = item.LinkedPr,
+            // G477: recover the missing linked_pr projection when GitHub facts
+            // deterministically identified this item; otherwise preserve it.
+            LinkedPr = recoveredLinkedPr ?? item.LinkedPr,
             WorkerRole = item.WorkerRole,
             ReviewRole = item.ReviewRole,
             Priority = item.Priority
@@ -419,6 +492,16 @@ internal static class CloseoutPrCommand
         writer.WriteLine($"- after: {result.QueueStateAfterState}");
         writer.WriteLine($"- already completed: {(result.QueueAlreadyCompleted ? "yes" : "no")}");
         writer.WriteLine();
+
+        if (result.RecoverableMissingLinkedPr)
+        {
+            writer.WriteLine("## Recovered linkage (G477)");
+            writer.WriteLine("- recoverable missing linked_pr: yes");
+            writer.WriteLine($"- inferred issue: #{result.InferredIssue}");
+            writer.WriteLine($"- recovery source: {result.RecoverySource}");
+            writer.WriteLine($"- recovery action: {result.RecoveryAction}");
+            writer.WriteLine();
+        }
 
         writer.WriteLine("## Runs events");
         if (result.RunsEvents.Count == 0)
@@ -619,6 +702,7 @@ internal static class CloseoutPrCommand
         writer.WriteLine("Records the queue/runs closeout for an accepted child PR. --dry-run plans only; --write applies queue + runs updates. Submodule sync remains a manual next step.");
         writer.WriteLine("  Supported states: queued, active, review, fixing → completed.");
         writer.WriteLine("  --issue <n>      Optional: fallback linked-issue number for queue items where linked_pr is absent.");
+        writer.WriteLine("  G477: when linked_pr is missing, closeout auto-recovers from GitHub closing-issue facts — a merged PR closing exactly one issue that maps to a single queue item completes without --issue. Ambiguous evidence fails closed (recovery_action / inferred_issue surfaced in the result).");
         writer.WriteLine("  --pr-merged true|false  Optional (G297): explicit GitHub merge state. When 'false', closeout refuses the operation so a draft / unmerged PR cannot record closeout; capture the value via 'gh pr view <n> --json merged --jq .merged'.");
     }
 
@@ -689,4 +773,37 @@ internal sealed record CloseoutPrResult
     /// </summary>
     [JsonPropertyName("state_layout")]
     public string? StateLayout { get; init; }
+
+    /// <summary>
+    /// G477: true when this closeout matched its queue item by recovering a
+    /// missing <c>linked_pr</c> from deterministic GitHub closing-issue facts
+    /// (the merged PR closed exactly one issue mapping to a single queue item)
+    /// rather than by a direct <c>linked_pr</c> match or an operator-supplied
+    /// <c>--issue</c>. Lets the host loop converge automatically instead of
+    /// treating the missing projection as an operator policy question.
+    /// </summary>
+    [JsonPropertyName("recoverable_missing_linked_pr")]
+    public bool RecoverableMissingLinkedPr { get; init; }
+
+    /// <summary>
+    /// G477: the linked-issue number inferred from GitHub closing references
+    /// when <see cref="RecoverableMissingLinkedPr"/> is true; null otherwise.
+    /// </summary>
+    [JsonPropertyName("inferred_issue")]
+    public int? InferredIssue { get; init; }
+
+    /// <summary>
+    /// G477: provenance of the recovery (<c>github-closing-reference</c>) when
+    /// linkage was recovered; null otherwise.
+    /// </summary>
+    [JsonPropertyName("recovery_source")]
+    public string? RecoverySource { get; init; }
+
+    /// <summary>
+    /// G477: the safe recovery/fallback action taken
+    /// (<c>recover-linked-pr-from-github-closing-reference</c>) when linkage was
+    /// recovered; null otherwise.
+    /// </summary>
+    [JsonPropertyName("recovery_action")]
+    public string? RecoveryAction { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/GuideCloseoutRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCloseoutRunCommand.cs
@@ -80,10 +80,8 @@ Stage 1 — select an accepted PR (read-only; required before any mutation):
 
 Stage 2 — plan (dry-run; required before any write):
 1. `intent-cli closeout pr --pr <n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --dry-run --format json` → inspect planned queue transition, runs events, continuation hint, and next_steps.
-   - If the result contains `linked_issue but not linked_pr` or `retry with --issue`: the queue item has a linked_issue but no linked_pr. Resolve the linked issue number:
-     a. `gh pr view <n> --repo {targetRepoPlaceholder} --json closingIssuesReferences` → extract the issue number from `closingIssuesReferences[0].number`.
-     b. Retry: `intent-cli closeout pr --pr <n> --issue <linked-issue-n> --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --dry-run --format json`
-   - If the result still has an `error` field after the retry, stop and report the error. Do not apply.
+   - G477: a missing `linked_pr` is host-owned projection drift, NOT an operator policy question. When the merged PR closes exactly one issue that maps to a single queue item, `closeout pr` recovers the linkage automatically and the result reports `recoverable_missing_linked_pr: true`, `inferred_issue`, and `recovery_action: recover-linked-pr-from-github-closing-reference`. No manual `--issue` rerun is needed — proceed.
+   - Only if the result has an `error` field: a `linkage-ambiguous` error means GitHub closing references match more than one queue item — disambiguate by rerunning with the correct `intent-cli closeout pr --pr <n> --issue <linked-issue-n> ...`. Any other `error` → stop and report it. Do not apply.
    - Confirm: execution_unit, queue_state_before → completed, linked issue close command in next_steps.
 2. Note the linked issue close command from `next_steps[0]` if present.
 
@@ -102,8 +100,8 @@ Stage 4 — submodule pointer sync (manual operator step):
 2. Do not guess the merge SHA; read it from `gh pr view <n> --repo {targetRepoPlaceholder} --json mergeCommit`.
 
 Stage 5 — apply queue/runs state (write):
-1. `intent-cli closeout pr --pr <n> [--issue <linked-issue-n>] --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --write --format json` → applies queue-state completed transition and appends runs events.
-   - Include `--issue <n>` if it was required in Stage 2 dry-run.
+1. `intent-cli closeout pr --pr <n> [--issue <linked-issue-n>] --repo {targetRepoPlaceholder} --domain {domainPlaceholder} --write --format json` → applies queue-state completed transition and appends runs events. G477: when linkage was auto-recovered, the write also repairs the missing `linked_pr` projection on the completed item.
+   - Include `--issue <n>` ONLY if Stage 2 reported a `linkage-ambiguous` error; the deterministic auto-recovery case needs no flag.
    - If the result has an `error` field, stop and report the error.
    - Confirm: mode is `write`, queue_state_after is `completed`.
 

--- a/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
@@ -11,11 +11,28 @@ public sealed class CloseoutPrCommandTests : IDisposable
     public CloseoutPrCommandTests()
     {
         CloseoutPrCommand.UtcNowFactory = () => new DateTimeOffset(2026, 5, 4, 12, 0, 0, TimeSpan.Zero);
+        // G477: default the closing-issues fetcher to a deterministic empty
+        // result so the missing-linked_pr auto-recovery path never shells out
+        // to live GitHub during unit tests. Recovery tests override this.
+        CloseoutPrCommand.PrClosingIssuesFetcherFactory = () => new FakeClosingIssuesFetcher(Array.Empty<int>());
     }
 
     public void Dispose()
     {
         CloseoutPrCommand.UtcNowFactory = null;
+        CloseoutPrCommand.PrClosingIssuesFetcherFactory = null;
+    }
+
+    private sealed class FakeClosingIssuesFetcher : IPrClosingIssuesFetcher
+    {
+        private readonly IReadOnlyList<int> _closingIssues;
+
+        public FakeClosingIssuesFetcher(IReadOnlyList<int> closingIssues)
+        {
+            _closingIssues = closingIssues;
+        }
+
+        public IReadOnlyList<int> Fetch(string repo, int prNumber) => _closingIssues;
     }
 
     // --- G324: durable writes use current RunEvent schema + auto-commit safe ---
@@ -646,6 +663,154 @@ public sealed class CloseoutPrCommandTests : IDisposable
 
         Assert.Equal(1, exitCode);
         Assert.Contains("--pr-merged must be 'true' or 'false'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // --- G477: auto-fallback closeout when linked_pr missing but deterministic ---
+
+    [Fact]
+    public void Execute_G477_MissingLinkedPrButDeterministicClosingIssue_RecoversWithoutIssueFlag()
+    {
+        // Queue item G412 has linked_issue #820 and null linked_pr; GitHub says
+        // merged PR #821 closes #820. `closeout pr --pr 821 --write` must succeed
+        // without the operator passing --issue 820.
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G412", "review", linkedIssueNumber: 820));
+        CloseoutPrCommand.PrClosingIssuesFetcherFactory = () => new FakeClosingIssuesFetcher(new[] { 820 });
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "821", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutPrResult>(writer.ToString())!;
+        Assert.Equal("G412", result.ExecutionUnit);
+        Assert.Equal("completed", result.QueueStateAfterState);
+        Assert.True(result.RecoverableMissingLinkedPr);
+        Assert.Equal(820, result.InferredIssue);
+        Assert.Equal("github-closing-reference", result.RecoverySource);
+        Assert.Equal("recover-linked-pr-from-github-closing-reference", result.RecoveryAction);
+
+        // The host-owned linked_pr projection is repaired on write.
+        var persisted = File.ReadAllText(workspace.Context.GetQueueStatePath());
+        Assert.Contains("https://github.com/J-Tech-Japan/intent-system/pull/821", persisted, StringComparison.Ordinal);
+        Assert.Contains("\"state\": \"completed\"", persisted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G477_MissingLinkedPrDeterministicDryRun_ReportsRecoverableFields()
+    {
+        // Dry-run must surface recoverable_missing_linked_pr, the inferred issue,
+        // and the recovery action without mutating state.
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G412", "review", linkedIssueNumber: 820));
+        var before = File.ReadAllText(workspace.Context.GetQueueStatePath());
+        CloseoutPrCommand.PrClosingIssuesFetcherFactory = () => new FakeClosingIssuesFetcher(new[] { 820 });
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "821", "--dry-run", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutPrResult>(writer.ToString())!;
+        Assert.True(result.RecoverableMissingLinkedPr);
+        Assert.Equal(820, result.InferredIssue);
+        Assert.Equal("recover-linked-pr-from-github-closing-reference", result.RecoveryAction);
+        // No mutation on dry-run.
+        Assert.Equal(before, File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
+    }
+
+    [Fact]
+    public void Execute_G477_MissingLinkedPrAmbiguousClosingIssues_FailsClosed()
+    {
+        // Two queue items link to two issues the PR closes — ambiguous. Must fail
+        // closed with a structured reason, not guess.
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildTwoItemsWithLinkedIssues(
+            ("G412", "review", 820),
+            ("G413", "review", 822)));
+        CloseoutPrCommand.PrClosingIssuesFetcherFactory = () => new FakeClosingIssuesFetcher(new[] { 820, 822 });
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "821", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutPrResult>(writer.ToString())!;
+        Assert.Contains("linkage-ambiguous", result.Error!, StringComparison.Ordinal);
+        Assert.Contains("refusing to guess", result.Error!, StringComparison.Ordinal);
+        // No mutation: both items stay un-completed.
+        var persisted = File.ReadAllText(workspace.Context.GetQueueStatePath());
+        Assert.DoesNotContain("\"state\": \"completed\"", persisted, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_G477_MissingLinkedPrNoClosingIssueMatch_StillHintsRetryWithIssue()
+    {
+        // GitHub returns a closing issue, but no queue item links to it. The
+        // command must fall through to the existing not-found failure (no guess).
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G412", "review", linkedIssueNumber: 820));
+        CloseoutPrCommand.PrClosingIssuesFetcherFactory = () => new FakeClosingIssuesFetcher(new[] { 999 });
+
+        using var writer = new StringWriter();
+        var exitCode = CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "821", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var result = JsonSerializer.Deserialize<CloseoutPrResult>(writer.ToString())!;
+        Assert.Contains("no queue item found with linked_pr matching #821", result.Error!, StringComparison.Ordinal);
+        Assert.False(result.RecoverableMissingLinkedPr);
+    }
+
+    private static string BuildTwoItemsWithLinkedIssues(
+        (string ExecutionUnit, string State, int LinkedIssueNumber) first,
+        (string ExecutionUnit, string State, int LinkedIssueNumber) second)
+    {
+        return $$"""
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "{{first.ExecutionUnit}}",
+                  "title": "first",
+                  "state": "{{first.State}}",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_issue": {"repo": "J-Tech-Japan/intent-system", "number": {{first.LinkedIssueNumber}}},
+                  "linked_pr": null,
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "{{second.ExecutionUnit}}",
+                  "title": "second",
+                  "state": "{{second.State}}",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "linked_issue": {"repo": "J-Tech-Japan/intent-system", "number": {{second.LinkedIssueNumber}}},
+                  "linked_pr": null,
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """;
     }
 
     private static string BuildQueueStateWithLinkedIssue(string executionUnit, string state, int linkedIssueNumber)


### PR DESCRIPTION
## Summary

Makes host closeout recover automatically when `intent-cli closeout pr --pr <n>` cannot match a queue item **only** because `linked_pr` was never projected into host durable state, while the merged PR + linked-issue evidence deterministically identify the execution unit (the Zero4Racer PR #821 / issue #820 deadlock). Previously the operator had to rerun with `--issue <n>` — correct but fragile tribal knowledge.

## Changes

- **Deterministic auto-fallback (Fallback B).** When the `linked_pr` match and the optional operator `--issue` both miss, `closeout pr` fetches the PR's closing-issue references (`IPrClosingIssuesFetcher` seam, fail-soft to empty on any `gh` error) and runs the existing `GitHubLinkageReconstructor`:
  - exactly one queue item matches by `linked_issue` → recover and complete, no `--issue` needed;
  - multiple matches → fail closed with a structured `linkage-ambiguous` error (no guessing);
  - no match / no closing refs → existing not-found hint.
- **Projection repair.** On `--write`, the recovered `linked_pr` is written onto the completed item (host closeout surface; child `--github-only` loops still never write `linked_pr`).
- **Machine-readable evidence.** Result exposes `recoverable_missing_linked_pr`, `inferred_issue`, `recovery_source` (`github-closing-reference`), and `recovery_action` (`recover-linked-pr-from-github-closing-reference`), plus a markdown section.
- **Guidance.** Updated the closeout-run guide and `docs/en|ja/07-recovery.md`: missing `linked_pr` is host-owned deterministic recovery, not an operator policy question; the manual `--issue` rerun is only for the ambiguous case.

## Tests

- `Execute_G477_MissingLinkedPrButDeterministicClosingIssue_RecoversWithoutIssueFlag` (write, repairs linked_pr)
- `Execute_G477_MissingLinkedPrDeterministicDryRun_ReportsRecoverableFields` (dry-run, no mutation)
- `Execute_G477_MissingLinkedPrAmbiguousClosingIssues_FailsClosed`
- `Execute_G477_MissingLinkedPrNoClosingIssueMatch_StillHintsRetryWithIssue`
- Full `IntentSystem.Cli.Tests`: 3064 passed, 1 skipped. `git diff --check` clean.

Note: the issue listed `intents/intent-cli/**`, `AutomationHostReviewDiagnosticsCommand.cs`, and `AutomationReconcileCommand.cs` among target paths. `intents/**` is host-owned and not editable from the child loop; the diagnostics/reconcile surfaces already route `linked_pr` recovery through the separate publish-recovery lane and did not present a manual `--issue` rerun as tribal knowledge, so no change there was warranted. This PR touches code, tests, and docs only.

Closes #1055
