### PR TITLE
G478 Prepare v0.3.8 release after G476-G477 closeout and preflight reliability fixes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -151,86 +151,83 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.3.6",
-  "nextVersion": "0.3.7"
-}
-```
-
-| Stage | Version form | How it is derived |
-| --- | --- | --- |
-| Local pack / install | `0.3.7-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.3.7-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.7-rc.N` | Tag `v0.3.7-rc.N` triggers release workflow |
-| Stable release | `0.3.7` | Tag `v0.3.7` triggers release workflow (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.3.8-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.8` |
-
-**After releasing `v0.3.7`**, bump both fields in `eng/version.json`:
-
-```json
-{
   "stableVersion": "0.3.7",
   "nextVersion": "0.3.8"
 }
 ```
 
+| Stage | Version form | How it is derived |
+| --- | --- | --- |
+| Local pack / install | `0.3.8-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.3.8-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.8-rc.N` | Tag `v0.3.8-rc.N` triggers release workflow |
+| Stable release | `0.3.8` | Tag `v0.3.8` triggers release workflow (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.3.9-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.9` |
+
+**After releasing `v0.3.8`**, bump both fields in `eng/version.json`:
+
+```json
+{
+  "stableVersion": "0.3.8",
+  "nextVersion": "0.3.9"
+}
+```
+
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.3.8-preview.<run>.<attempt>` / `0.3.8-<sha>-<G-unit>` rather than continuing to
-emit `0.3.7` (which would collide with the stable release version).
+`0.3.9-preview.<run>.<attempt>` / `0.3.9-<sha>-<G-unit>` rather than continuing to
+emit `0.3.8` (which would collide with the stable release version).
 
-### Next release readiness (v0.3.7)
+### Next release readiness (v0.3.8)
 
-**`v0.3.6` shipped** (GitHub Release + NuGet, 2026-06-05) and the version policy
-was bumped to the `0.3.7` development line (G470). The repository is now on the
-in-development **`0.3.7`** `nextVersion`; G475 (this packet) prepares the
-`v0.3.7` release — the next release is published by tagging `v0.3.7` once the
-[release-readiness gate](release-notes-v0.3.7.md#release-readiness-gate-g475)
+**`v0.3.7` shipped** (GitHub Release + NuGet) and the version policy was bumped
+to the `0.3.8` development line. The repository is now on the in-development
+**`0.3.8`** `nextVersion`; G478 (this packet) prepares the `v0.3.8` release — the
+next release is published by tagging `v0.3.8` once the
+[release-readiness gate](release-notes-v0.3.8.md#release-readiness-gate-g478)
 passes. Preparing the release does not cut it. Full changelog and operator
-checklist: [release-notes-v0.3.7.md](release-notes-v0.3.7.md).
+checklist: [release-notes-v0.3.8.md](release-notes-v0.3.8.md).
 
-**To ship in `v0.3.7` (changes since `v0.3.6`) — an automation-safety release:**
+**To ship in `v0.3.8` (changes since `v0.3.7`) — a loop-reliability release:**
 
-- **Non-default implementation base branches** (G471) — loop-prompt prose and
-  review guidance treat a non-default implementation base branch as a
-  first-class case, so child loops pick the correct PR base without reading host
-  metadata and review no longer mis-flags a correctly-based PR.
-- **`issue-published` queue compatibility** (G472) — review-closeout parsing
-  tolerates queue-state rows in the `issue-published` state instead of aborting
-  the closeout read; host review loop guidance is skill-free and treats
-  CI-pending as a defer condition.
-- **Installed guide over local rule docs** (G473) — when generating loop
-  prompts, the installed `intent-cli guide` output is canonical over local
-  `intents/rules/automations/*.md`; the hard rule forbids reading the local rule
-  docs even when an operator names them.
-- **Absorbed packet retirement safety** (G474) — machine-readable packet
-  lifecycle retirement (`lifecycle.yaml` sidecar + `intent-cli packet retire`)
-  excludes absorbed/superseded/retired packets from `intent next-slice`
-  issue-cut-ready selection and flags stale human `STATUS: ABSORBED` markers for
-  repair, so an absorbed packet is never re-cut as a duplicate issue.
+- **Packet evidence citations no longer deadlock child PR repair** (G476) —
+  `worker pr-comment-preflight` classifies a review comment by its requested
+  edit target, not by an incidental `.intent-cli/` / `intents/` mention, so a
+  comment that cites a packet path as evidence while asking to change
+  implementation files is `repair-required` / actionable instead of a
+  host-artifact deadlock. The result exposes `requested_edit_paths` vs
+  `host_evidence_paths`, and `worker next-action` consults the same classifier.
+- **Deterministic closeout recovery when `linked_pr` is missing** (G477) —
+  `closeout pr --pr <n>` auto-recovers when a merged PR's GitHub closing
+  references identify exactly one queue item by `linked_issue`, completing
+  without a manual `--issue <n>` rerun and repairing the missing `linked_pr`
+  projection. Ambiguous evidence fails closed with a `linkage-ambiguous` error;
+  the result surfaces `recoverable_missing_linked_pr` / `inferred_issue` /
+  `recovery_action`.
 
-**Release-readiness verification (run before tagging the next `v0.3.7`):**
+**Release-readiness verification (run before tagging the next `v0.3.8`):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.3.6 (published), nextVersion 0.3.7 (to release)
+cat eng/version.json   # stableVersion 0.3.7 (published), nextVersion 0.3.8 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.3.7-<sha>-G47x   (NOT a stale literal)
+#   expected shape: intent-cli 0.3.8-<sha>-G47x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.7.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.8.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-The official release is then cut by publishing a GitHub Release tagged `v0.3.7`;
-the release workflow passes `-p:Version=0.3.7` (which wins over the local
+The official release is then cut by publishing a GitHub Release tagged `v0.3.8`;
+the release workflow passes `-p:Version=0.3.8` (which wins over the local
 default). After the release publishes, apply the post-release `eng/version.json`
-bump above (`stableVersion → 0.3.7`, `nextVersion → 0.3.8`).
+bump above (`stableVersion → 0.3.8`, `nextVersion → 0.3.9`).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.3.8.md
+++ b/docs/en/release-notes-v0.3.8.md
@@ -1,0 +1,119 @@
+# Release Notes — intent-cli v0.3.8
+
+> **Release checklist for maintainers:** see [Creating the v0.3.8 GitHub Release](#creating-the-v038-github-release).
+> **Do NOT tag until the [release-readiness gate](#release-readiness-gate-g478) passes.**
+
+## What's in v0.3.8
+
+v0.3.8 is a loop-reliability release. It ships the two automation fixes
+completed after `v0.3.7` that keep implementation/review loops moving without
+manual operator intervention: child `pr-comment-preflight` no longer deadlocks
+when a review comment cites a host metadata path as evidence, and host closeout
+can recover deterministically when a queue item's `linked_pr` projection is
+missing. No package id, license, or workflow-semantics changes. The package id
+remains `JTechJapan.IntentSystem.Cli`.
+
+### Packet evidence citations no longer deadlock child PR repair (G476)
+
+- `intent-cli worker pr-comment-preflight` now classifies a review comment by
+  its **requested edit target**, not by any incidental `.intent-cli/` or
+  `intents/` mention. A G316-style request-update comment that cites a packet
+  path such as `.intent-cli/issues/<unit>/packet.yaml` as evidence while asking
+  to change implementation files is classified `repair-required` / actionable,
+  so the child worker can claim and fix it instead of waiting forever on a host
+  that has nothing to repair.
+- A comment is only `host-artifact-repair-required` when **every** requested
+  edit target is a host metadata path. Genuine host-artifact edit requests still
+  route to the host repair agent (G353 preserved).
+- Classification runs over the full comment body (not the truncated excerpt),
+  and the result exposes `actionable_comments[].requested_edit_paths` and
+  `actionable_comments[].host_evidence_paths` so the decision is explainable
+  without reading host metadata. `worker next-action` consults the same
+  classifier, so the two surfaces never disagree on child-claimability.
+
+### Deterministic closeout recovery when `linked_pr` is missing (G477)
+
+- `intent-cli closeout pr --pr <n>` now auto-recovers when it cannot match a
+  queue item only because `linked_pr` was never projected into host durable
+  state. When the merged PR's GitHub closing references identify exactly one
+  queue item (by `linked_issue`), closeout completes without the operator having
+  to know the `--issue <n>` fallback, and the write repairs the missing
+  `linked_pr` projection.
+- The result surfaces `recoverable_missing_linked_pr`, `inferred_issue`,
+  `recovery_source` (`github-closing-reference`), and `recovery_action` so the
+  recovery is auditable. Ambiguous evidence (closing references match more than
+  one queue item) fails closed with a `linkage-ambiguous` error rather than
+  guessing; only then is a manual `--issue <n>` rerun required.
+- This is host-owned deterministic recovery, not an operator policy question;
+  child `--github-only` loops still never write `linked_pr`.
+
+> Version metadata note: `eng/version.json` records `stableVersion: 0.3.7`,
+> `nextVersion: 0.3.8`; G478 (this packet) is the release-readiness preparation.
+> The post-v0.3.8 metadata advancement (`stableVersion → 0.3.8`,
+> `nextVersion → 0.3.9`) is the operator's post-release step and is out of scope
+> for this packet.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.8
+```
+
+Or download the self-contained binary from the
+[v0.3.8 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.8).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.7
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.8
+```
+
+There are no breaking changes from v0.3.7.
+
+## Release-readiness gate (G478)
+
+Do not create the `v0.3.8` tag/release until ALL of the following hold
+(this gate fails closed — if any item is unmet, stop and do not tag):
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G476, G477 (and G478 this prep). Confirm on the host/review side via the
+      host queue-state / GitHub PR state — the child implementation loop must not
+      read parent queue-state, so this is a host-owned precondition.
+- [ ] `eng/version.json` `nextVersion` is `0.3.8` (the intended release version)
+      and matches the tag to be created (`v0.3.8`). The release workflow derives
+      the package version from the tag; `-p:Version=` overrides the policy-derived
+      default in `src/IntentSystem.Cli/IntentSystem.Cli.csproj`.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+
+## Creating the v0.3.8 GitHub Release
+
+1. Confirm the [release-readiness gate](#release-readiness-gate-g478) — do not
+   proceed if any item is unmet.
+2. Tag the release commit: `git tag v0.3.8 && git push origin v0.3.8`.
+3. The `release.yml` workflow fires and builds binaries, `.nupkg`, and
+   checksums (version derived from the tag). Wait for it to complete green.
+4. The workflow creates the GitHub Release draft. Review it, paste the content
+   of this file as the release body, and publish.
+5. Confirm the NuGet publish step pushed `JTechJapan.IntentSystem.Cli 0.3.8`.
+6. Post-release verification checklist:
+   - [ ] NuGet.org package page links all resolve correctly.
+   - [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+         accessible.
+   - [ ] `.sha256` checksums match the downloaded artifacts.
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.8`)
+         then `intent-cli --version` reports `0.3.8`.
+   - [ ] Binary artifact smoke check: download the platform archive, verify its
+         `.sha256`, extract, and run `./intent-cli --version` → `0.3.8`.
+   - [ ] Local preview/dry-run version metadata uses the next development line
+         after `0.3.8` (bump `eng/version.json` per the post-release step in
+         [Version flow](09-developer-reference.md#version-flow)):
+         `stableVersion → 0.3.8`, `nextVersion → 0.3.9`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -141,74 +141,72 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.3.6",
-  "nextVersion": "0.3.7"
-}
-```
-
-| ステージ | バージョン形式 | 導出方法 |
-| --- | --- | --- |
-| ローカル pack / install | `0.3.7-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.3.7-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.7-rc.N` | タグ `v0.3.7-rc.N` がリリースワークフローをトリガー |
-| 安定版リリース | `0.3.7` | タグ `v0.3.7` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.3.8-preview.<run>.<attempt>` | `nextVersion` を `0.3.8` にバンプ後 |
-
-**`v0.3.7` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
-
-```json
-{
   "stableVersion": "0.3.7",
   "nextVersion": "0.3.8"
 }
 ```
 
+| ステージ | バージョン形式 | 導出方法 |
+| --- | --- | --- |
+| ローカル pack / install | `0.3.8-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.3.8-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.3.8-rc.N` | タグ `v0.3.8-rc.N` がリリースワークフローをトリガー |
+| 安定版リリース | `0.3.8` | タグ `v0.3.8` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.3.9-preview.<run>.<attempt>` | `nextVersion` を `0.3.9` にバンプ後 |
+
+**`v0.3.8` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+
+```json
+{
+  "stableVersion": "0.3.8",
+  "nextVersion": "0.3.9"
+}
+```
+
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.3.8-preview.<run>.<attempt>` / `0.3.8-<sha>-<G-unit>` を生成し、`0.3.7`（安定版
+`0.3.9-preview.<run>.<attempt>` / `0.3.9-<sha>-<G-unit>` を生成し、`0.3.8`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備（v0.3.7）
+### 次リリース準備（v0.3.8）
 
-**`v0.3.6` は publish 済み**（GitHub Release + NuGet, 2026-06-05）で、バージョンポリシーは
-`0.3.7` 開発ラインにバンプされました（G470）。リポジトリは現在 in-development の **`0.3.7`**
-`nextVersion` 上にあり、G475（本パケット）が `v0.3.7` リリースを準備します。次のリリースは
-[リリース準備ゲート](release-notes-v0.3.7.md#リリース準備ゲート-g475)を通過後に `v0.3.7`
+**`v0.3.7` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
+`0.3.8` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.8`**
+`nextVersion` 上にあり、G478（本パケット）が `v0.3.8` リリースを準備します。次のリリースは
+[リリース準備ゲート](release-notes-v0.3.8.md#リリース準備ゲート-g478)を通過後に `v0.3.8`
 タグ付けで publish されます。準備はリリースを cut しません。完全な changelog と operator
-チェックリスト: [release-notes-v0.3.7.md](release-notes-v0.3.7.md)。
+チェックリスト: [release-notes-v0.3.8.md](release-notes-v0.3.8.md)。
 
-**`v0.3.7` で出荷予定（`v0.3.6` 以降の変更）— automation 安全性リリース:**
+**`v0.3.8` で出荷予定（`v0.3.7` 以降の変更）— loop 信頼性リリース:**
 
-- **非デフォルト実装 base branch**（G471）— loop-prompt 本文と review ガイダンスが非デフォルトの
-  実装 base branch を first-class として扱い、child loop は host メタデータを読まずに正しい PR
-  base を選択し、review は正しい base の PR を誤判定しません。
-- **`issue-published` queue 互換**（G472）— review-closeout parsing が `issue-published`
-  state の queue-state 行を許容し closeout 読み取りを中断しません。host review loop ガイダンスは
-  skill-free で CI-pending を defer 条件として扱います。
-- **installed guide を local rule docs より優先**（G473）— loop prompt 生成時、インストール済み
-  `intent-cli guide` の出力がローカル `intents/rules/automations/*.md` より正統です。hard rule は
-  operator が名指ししてもローカル rule docs を読むことを禁じます。
-- **absorbed パケット retirement の安全性**（G474）— machine-readable なパケット lifecycle
-  retirement（`lifecycle.yaml` サイドカー + `intent-cli packet retire`）が absorbed/superseded/
-  retired パケットを `intent next-slice` の issue-cut-ready 選択から除外し、古い human
-  `STATUS: ABSORBED` marker を修復対象として flag するため、absorbed パケットが重複 issue として
-  再 cut されることはありません。
+- **packet evidence の引用が child PR 修復をデッドロックさせない**（G476）—
+  `worker pr-comment-preflight` が review コメントを、付随的な `.intent-cli/` / `intents/`
+  の言及ではなく要求された編集対象で分類するため、packet path を根拠として引用しつつ実装ファイルの
+  変更を求めるコメントは host-artifact デッドロックではなく `repair-required` / actionable に
+  なります。結果は `requested_edit_paths` と `host_evidence_paths` を公開し、`worker next-action`
+  も同じ分類器を参照します。
+- **`linked_pr` 欠落時の deterministic な closeout 回復**（G477）—
+  `closeout pr --pr <n>` が、merged PR の GitHub closing references が `linked_issue` 経由で
+  ちょうど 1 つの queue item を特定できる場合に自動回復し、手動 `--issue <n>` 再実行なしで完了し
+  欠落していた `linked_pr` projection を修復します。曖昧な証拠は `linkage-ambiguous` エラーで
+  fail closed し、結果は `recoverable_missing_linked_pr` / `inferred_issue` / `recovery_action`
+  を surface します。
 
-**リリース準備の検証（次の `v0.3.7` タグ付け前に実行）:**
+**リリース準備の検証（次の `v0.3.8` タグ付け前に実行）:**
 
 ```bash
-cat eng/version.json   # stableVersion 0.3.6（公開済み）, nextVersion 0.3.7（リリース対象）
+cat eng/version.json   # stableVersion 0.3.7（公開済み）, nextVersion 0.3.8（リリース対象）
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.3.7-<sha>-G47x （stale なリテラルではない）
+#   期待形: intent-cli 0.3.8-<sha>-G47x （stale なリテラルではない）
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.7.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.8.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-公式リリースは `v0.3.7` タグの GitHub Release publish で cut され、リリースワークフローが
-`-p:Version=0.3.7` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
-`eng/version.json` バンプ（`stableVersion → 0.3.7`, `nextVersion → 0.3.8`）を適用します。
+公式リリースは `v0.3.8` タグの GitHub Release publish で cut され、リリースワークフローが
+`-p:Version=0.3.8` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
+`eng/version.json` バンプ（`stableVersion → 0.3.8`, `nextVersion → 0.3.9`）を適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.3.8.md
+++ b/docs/ja/release-notes-v0.3.8.md
@@ -1,0 +1,115 @@
+# リリースノート — intent-cli v0.3.8
+
+> **メンテナ向けリリースチェックリスト:** [v0.3.8 GitHub リリースの作成](#v038-github-リリースの作成) を参照。
+> **[リリース準備ゲート](#リリース準備ゲート-g478) を通過するまでタグを打たないこと。**
+
+## v0.3.8 の内容
+
+v0.3.8 は loop 信頼性のリリースです。`v0.3.7` 後に完了した 2 つの automation 修正を
+出荷し、実装/レビュー loop が operator の手動介入なしで進み続けるようにします: child
+`pr-comment-preflight` が review コメントの host メタデータ path を根拠（evidence）と
+して引用してもデッドロックしなくなり、host closeout が queue item の `linked_pr`
+projection 欠落時に deterministic に回復できるようになりました。package id・ライセンス・
+ワークフロー semantics の変更はありません。package id は `JTechJapan.IntentSystem.Cli`
+のままです。
+
+### packet evidence の引用が child PR 修復をデッドロックさせない (G476)
+
+- `intent-cli worker pr-comment-preflight` が review コメントを、付随的な
+  `.intent-cli/` や `intents/` の言及ではなく **要求された編集対象（requested edit
+  target）** で分類するようになりました。G316 形式の request-update コメントが
+  `.intent-cli/issues/<unit>/packet.yaml` のような packet path を根拠として引用しつつ
+  実装ファイルの変更を求める場合は `repair-required` / actionable に分類され、child
+  worker は何も修復することのない host を永遠に待つのではなく claim して修復できます。
+- すべての要求された編集対象が host メタデータ path のときだけ
+  `host-artifact-repair-required` になります。本物の host-artifact 編集要求は引き続き
+  host 修復エージェントへ回送されます（G353 を維持）。
+- 分類は（truncate された excerpt ではなく）コメント本文全体で行われ、結果は
+  `actionable_comments[].requested_edit_paths` と
+  `actionable_comments[].host_evidence_paths` を公開するため、host メタデータを読まずに
+  判定理由を説明できます。`worker next-action` は同じ分類器を参照するため、2 つの surface
+  が child-claimability で食い違うことはありません。
+
+### `linked_pr` 欠落時の deterministic な closeout 回復 (G477)
+
+- `intent-cli closeout pr --pr <n>` が、`linked_pr` が host durable state に projection
+  されていないことだけを理由に queue item を照合できない場合に自動回復するようになりました。
+  merged PR の GitHub closing references が（`linked_issue` 経由で）ちょうど 1 つの queue
+  item を特定できれば、operator が `--issue <n>` の fallback を知らなくても closeout が
+  完了し、write 時に欠落していた `linked_pr` projection を修復します。
+- 結果は `recoverable_missing_linked_pr` / `inferred_issue` /
+  `recovery_source`（`github-closing-reference`）/ `recovery_action` を surface し、回復を
+  監査可能にします。曖昧な証拠（closing references が複数の queue item に一致）は推測せず
+  `linkage-ambiguous` エラーで fail closed します。その場合のみ手動 `--issue <n>` の再実行が
+  必要です。
+- これは host 所有の deterministic recovery であり operator の policy 判断ではありません。
+  child `--github-only` loop は引き続き `linked_pr` を書きません。
+
+> バージョンメタデータ注記: `eng/version.json` は `stableVersion: 0.3.7`,
+> `nextVersion: 0.3.8` を記録しており、G478（本パケット）はリリース準備です。v0.3.8 後の
+> メタデータ前進（`stableVersion → 0.3.8`, `nextVersion → 0.3.9`）は operator のリリース後
+> 手順であり、本パケットの対象外です。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.8
+```
+
+または
+[v0.3.8 GitHub リリース](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.8)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを
+検証してください。
+
+## v0.3.7 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.8
+```
+
+v0.3.7 からの破壊的変更はありません。
+
+## リリース準備ゲート (G478)
+
+以下が **すべて** 満たされるまで `v0.3.8` タグ/リリースを作成しないこと
+（このゲートは fail-closed — 1 つでも未達なら停止しタグを打たない）:
+
+- [ ] リリース対象パケットがすべて **完了し PR が `main` にマージ済み**:
+      G476, G477（および本準備 G478）。host/review 側で host queue-state /
+      GitHub PR state により確認すること — child 実装 loop は親 queue-state を読まないため、
+      これは host 所有の前提条件です。
+- [ ] `eng/version.json` の `nextVersion` が `0.3.8`（意図したリリースバージョン）で、
+      作成するタグ（`v0.3.8`）と一致すること。release ワークフローはタグからパッケージ
+      バージョンを導出し、`-p:Version=` が
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` のポリシー導出デフォルトを上書きします。
+- [ ] パッケージメタデータが正しいこと: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` が
+      `https://github.com/J-Tech-Japan/intent-system` を指す,
+      `PackageLicenseExpression = Apache-2.0`, README/docs リンクが解決し,
+      公式サービスサイト `https://www.intent-driven-development.com/` が README から
+      リンクされていること。
+- [ ] release コミットで **main CI が green**（`Build and test (source contract)`）で、
+      **preview-pack** ワークフローが green であること。
+
+## v0.3.8 GitHub リリースの作成
+
+1. [リリース準備ゲート](#リリース準備ゲート-g478) を確認 — 未達項目があれば進めない。
+2. release コミットにタグ: `git tag v0.3.8 && git push origin v0.3.8`。
+3. `release.yml` ワークフローが発火し、バイナリ・`.nupkg`・チェックサムをビルド
+   （バージョンはタグから導出）。green 完了を待つ。
+4. ワークフローが GitHub Release draft を作成。確認し、本ファイルの内容を release body
+   として貼り付け、publish。
+5. NuGet publish ステップが `JTechJapan.IntentSystem.Cli 0.3.8` を push したことを確認。
+6. リリース後の検証チェックリスト:
+   - [ ] NuGet.org パッケージページのリンクがすべて正しく解決する。
+   - [ ] GitHub release アセットリンク（`.tar.gz`, `.zip`, `.exe`, `.nupkg`）が
+         アクセス可能。
+   - [ ] `.sha256` チェックサムがダウンロードしたアーティファクトと一致する。
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`（または
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.8`）の後、
+         `intent-cli --version` が `0.3.8` を報告する。
+   - [ ] バイナリアーティファクトの smoke check: プラットフォームアーカイブをダウンロードし、
+         `.sha256` を検証、展開して `./intent-cli --version` → `0.3.8`。
+   - [ ] ローカル preview/dry-run のバージョンメタデータが `0.3.8` 後の次の開発ラインを
+         使う（[Version flow](09-developer-reference.md#version-flow) のリリース後手順に
+         従い `eng/version.json` を bump）: `stableVersion → 0.3.8`, `nextVersion → 0.3.9`。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.6",
-  "nextVersion": "0.3.7"
+  "stableVersion": "0.3.7",
+  "nextVersion": "0.3.8"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,10 +124,10 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.7 as the next development line
-        // (post-v0.3.6 release bump, see G470 — v0.3.6 was published to
+        // be parseable and must point to 0.3.8 as the next development line
+        // (post-v0.3.7 release bump, see G478 — v0.3.7 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.3.7 while recording 0.3.6 as the published stable).
+        // forward to 0.3.8 while recording 0.3.7 as the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -137,8 +137,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.7", policy.NextVersion);
-        Assert.Equal("0.3.6", policy.StableVersion);
+        Assert.Equal("0.3.8", policy.NextVersion);
+        Assert.Equal("0.3.7", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Prepares the repository for an explicit operator release of **v0.3.8** containing the G476 and G477 loop-reliability fixes (both already merged to `main`). This packet does not publish the release — release creation (tagging `v0.3.8`) remains an operator/host action after merge.

## Changes

- **Release notes** — new `docs/en/release-notes-v0.3.8.md` + `docs/ja/release-notes-v0.3.8.md` covering the two user-visible fixes:
  - **G476** — request-update comments that cite `.intent-cli/**` packet paths as evidence no longer deadlock child workers; `pr-comment-preflight` classifies by requested edit target.
  - **G477** — merged-PR closeout recovers automatically when `linked_pr` is missing but GitHub closing references deterministically identify the queue item.
  - Install/upgrade commands pinned to `0.3.8`, a fail-closed release-readiness gate, and a post-release operator verification checklist (NuGet `dotnet tool update/install` + `intent-cli --version` + binary smoke check).
- **Developer reference (en/ja)** — retarget the version-flow illustration and "Next release readiness" section to v0.3.8, link the release notes, document the post-release `eng/version.json` bump (`stable → 0.3.8`, `next → 0.3.9`).
- **`eng/version.json`** — advance to `stableVersion 0.3.7` (published) / `nextVersion 0.3.8` (release-to-cut). Verified locally: `intent-cli --version` → `0.3.8-<sha>-<unit>`.
- **Tests** — update `VersionPolicyTests` smoke assertion to the new policy (`next 0.3.8` / `stable 0.3.7`). `ReleasePackageMetadataTests` read the policy/docs dynamically and continue to pass.

## Verification

- `intent-cli --version` (Release, `--no-incremental`) → `0.3.8-a6aebb6-G477` (policy-derived 0.3.8 base).
- Full `IntentSystem.Cli.Tests`: 3064 passed, 1 skipped. `git diff --check` clean.
- `ReleasePackageMetadataTests` (package id / license / project URL / dev-reference / release notes existence + install version + release tag): 4 passed.

Notes: the release artifact version is tag-driven (`release.yml` passes `-p:Version=0.3.8`, which wins over the policy-derived local default). The release workflow is tag-driven / version-agnostic and already publishes NuGet plus osx-arm64 / win-x64 / linux-x64 binaries with sha256 sidecars; no workflow change is required. Package id remains `JTechJapan.IntentSystem.Cli`. This packet touches docs, version policy, and a version test only — no host metadata (`intents/**`, `.intent-cli/**`).

Closes #1057
