### PR TITLE
G482 Make packet creation emit complete publish-ready issue contracts

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskPacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskPacketDraftCommand.cs
@@ -71,9 +71,14 @@ internal static class GuideWorkflowTaskPacketDraftCommand
         new IssueContractSection { Section = "target-repo-path-part", Purpose = "Exact repository / folder / surface the change must land in. Disambiguates host-vs-child mutation targets." },
         new IssueContractSection { Section = "in-scope", Purpose = "Bullet list of what is in scope. Mirrors the slice goal; one slice cuts cleanly so this list stays small." },
         new IssueContractSection { Section = "out-of-scope", Purpose = "Bullet list of what is explicitly NOT in this slice. Reviewers refuse PRs that broaden scope without an out-of-scope amendment." },
+        // G482: standalone restatement and base branch policy are publish-ready
+        // contract sections too; list them so a scaffolded packet is complete by
+        // default and the agent does not have to memorize the full shape.
+        new IssueContractSection { Section = "standalone-child-issue-contract", Purpose = "One-paragraph restatement of exactly what the child PR must deliver, readable on its own without the surrounding design thread. The packet scaffold emits this section by default (G482)." },
         new IssueContractSection { Section = "acceptance-criteria", Purpose = "Testable, externally-verifiable criteria. Every criterion maps to a concrete assertion the reviewer can run." },
         new IssueContractSection { Section = "verification", Purpose = "Which tests / generated assertions prove the criteria. CI + the reviewer cite this list before approval (G316)." },
         new IssueContractSection { Section = "related-links", Purpose = "Predecessor slices and spec references (e.g. `specs/15-external-user-guided-workflow.md`). Operators trace the lineage without reading the host repo." },
+        new IssueContractSection { Section = "base-branch-policy", Purpose = "The expected PR base branch, stated in the body so child implementation agents pick the correct base without reading host metadata (G347). Required by the publish gate." },
         new IssueContractSection { Section = "additional-required-guidance", Purpose = "Standing guardrails: prefer intent-cli-backed mutation, child isolation rule, no AI provider launch. Repeated on every slice so the issue is self-contained." }
     };
 
@@ -115,6 +120,7 @@ internal static class GuideWorkflowTaskPacketDraftCommand
     internal static readonly IReadOnlyList<string> StopConditions = new[]
     {
         "`packet draft --dry-run` flags missing files: stop, repair the design host packet directory before publishing. Hand-editing the four files is allowed during design; routine automation mutates them through `packet draft --write` only.",
+        "**Dry-run the publish validation BEFORE declaring the packet issue-ready (G482)**: never call a packet ready for GitHub issue creation until a publish-validation dry-run reports zero missing contract sections. Run `intent-cli issue validate-body --from-file <github-body.md> --format json` (offline body check), `intent-cli packet draft --execution-unit <id> --dry-run --format json` (re-scaffold + contract check), and — for the host loop — `intent-cli intent next-slice --dry-run --format json`; all three share one required-section source of truth, so a clean result on one is a clean result on all. A freshly scaffolded packet already carries every required section (Goal, Current Observed State, Why This Slice Exists Now, Accepted Baseline You May Assume, Target Repo / Path / Part, In Scope, Out Of Scope, Standalone Child Issue Contract, Acceptance Criteria, Verification, Related Links, Base Branch Policy); fill the placeholders, do not delete sections.",
         "`issue validate-body --from-file <github-body.md> --format json` reports `errors[]` (missing contract sections): stop, repair the body, validate again, only then move to `issue publish-flow`.",
         "`packet.yaml` lacks `intent_reference_paths` or names them with broad-domain placeholders: stop, narrow to PR-specific references. Broad-domain intent paths defeat G316 review-context isolation.",
         "Operator names `intent-target` on the GitHub issue manually (raw `gh issue edit --add-label intent-target`): refuse, surface the gap — `intent-target` is the FINAL publish boundary applied by `automation issue-publish --write` after `issue publish-flow` succeeds, never the default."

--- a/src/IntentSystem.Cli/Commands/IssueValidateBodyValidator.cs
+++ b/src/IntentSystem.Cli/Commands/IssueValidateBodyValidator.cs
@@ -14,22 +14,9 @@ internal static class IssueValidateBodyValidator
     /// "Target Repo-Path-Part" is also accepted because both shapes are in
     /// active use across the host workflow.
     /// </summary>
-    public static IReadOnlyList<string> RequiredHeadings { get; } =
-    [
-        "Goal",
-        "Why This Slice Exists Now",
-        "Current Observed State",
-        "Accepted Baseline You May Assume",
-        "Target Repo / Path / Part",
-        "In Scope",
-        "Out Of Scope",
-        "Acceptance Criteria",
-        "Verification",
-        "Related Links",
-        // G347: child implementation agents must know the expected PR base branch
-        // from the issue body alone (no host metadata access in child-cwd mode).
-        "Base Branch Policy"
-    ];
+    // G482: shares the single source of truth with the packet scaffold so the
+    // publish gate and the draft contract check never disagree.
+    public static IReadOnlyList<string> RequiredHeadings => PublishContractSections.Required;
 
     private static readonly IReadOnlyDictionary<string, string[]> HeadingAliases =
         new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -32,24 +32,10 @@ internal static class PacketDraftCommand
         @"^[A-Za-z][A-Za-z0-9-]*$",
         RegexOptions.Compiled);
 
-    internal static readonly IReadOnlyList<string> RequiredContractSections =
-        new[]
-        {
-            "Goal",
-            "Why This Slice Exists Now",
-            "Current Observed State",
-            "Accepted Baseline You May Assume",
-            "Target Repo / Path / Part",
-            "In Scope",
-            "Out Of Scope",
-            "Acceptance Criteria",
-            "Verification",
-            "Related Links",
-            // G347: base branch policy must be explicit in the published contract so
-            // child implementation agents can choose the correct PR base branch
-            // without reading host metadata.
-            "Base Branch Policy"
-        };
+    // G482: the required publish-gate sections now live in the single shared
+    // source of truth so the scaffold's draft check and the publish-body
+    // validator can never drift apart.
+    internal static IReadOnlyList<string> RequiredContractSections => PublishContractSections.Required;
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -351,6 +337,10 @@ internal static class PacketDraftCommand
             ## Out Of Scope
 
             - TODO
+
+            ## Standalone Child Issue Contract
+
+            TODO: one-paragraph restatement of exactly what the child PR must deliver, readable on its own without the surrounding design thread.
 
             ## Acceptance Criteria
 

--- a/src/IntentSystem.Cli/Commands/PublishContractSections.cs
+++ b/src/IntentSystem.Cli/Commands/PublishContractSections.cs
@@ -1,0 +1,69 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G482: single source of truth for the GitHub issue "Child Issue Contract"
+/// section headings. Before G482 the same list was duplicated in
+/// <see cref="PacketDraftCommand"/> (scaffold + draft validation) and
+/// <c>IssueValidateBodyValidator</c> (publish validation); the two copies could
+/// silently drift. Both now reference this constant so the scaffold template,
+/// the draft contract check, and the publish gate can never disagree about
+/// which sections are required.
+///
+/// <para>
+/// <see cref="Required"/> is the fail-closed publish gate — the headings a
+/// <c>github-body.md</c> MUST carry to be publish-ready. Keeping this set stable
+/// preserves the contract for existing/in-flight host packets (G482 widens the
+/// scaffold output and guidance, not the hard gate).
+/// </para>
+/// <para>
+/// <see cref="ScaffoldHeadings"/> is the fuller shape a freshly drafted packet
+/// emits by default. It is a superset of <see cref="Required"/> — it also
+/// includes <c>Standalone Child Issue Contract</c> so a newly created packet is
+/// publish-ready and self-describing without the author memorizing every
+/// heading.
+/// </para>
+/// </summary>
+internal static class PublishContractSections
+{
+    /// <summary>
+    /// G482: the standalone <c>Standalone Child Issue Contract</c> heading — a
+    /// one-paragraph restatement of what the child PR must deliver. Emitted by
+    /// the scaffold so design-thread packets carry it by default.
+    /// </summary>
+    public const string StandaloneChildIssueContract = "Standalone Child Issue Contract";
+
+    /// <summary>
+    /// Required Child Issue Contract headings, in canonical order. This is the
+    /// fail-closed publish gate shared by the packet scaffold's draft check and
+    /// the publish-body validator. <c>Target Repo / Path / Part</c> is the
+    /// canonical form; the hyphen variant <c>Target Repo-Path-Part</c> is
+    /// accepted by the validator's alias map.
+    /// </summary>
+    public static readonly IReadOnlyList<string> Required =
+        new[]
+        {
+            "Goal",
+            "Why This Slice Exists Now",
+            "Current Observed State",
+            "Accepted Baseline You May Assume",
+            "Target Repo / Path / Part",
+            "In Scope",
+            "Out Of Scope",
+            "Acceptance Criteria",
+            "Verification",
+            "Related Links",
+            // G347: base branch policy must be explicit in the published contract
+            // so child implementation agents can choose the correct PR base
+            // branch without reading host metadata.
+            "Base Branch Policy",
+        };
+
+    /// <summary>
+    /// G482: the full set of headings a freshly scaffolded <c>github-body.md</c>
+    /// emits — every <see cref="Required"/> heading plus
+    /// <see cref="StandaloneChildIssueContract"/>. New packets carry the
+    /// complete publish-ready shape by default.
+    /// </summary>
+    public static readonly IReadOnlyList<string> ScaffoldHeadings =
+        [.. Required, StandaloneChildIssueContract];
+}

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
@@ -143,6 +143,30 @@ public sealed class GuideWorkflowTaskPacketDraftCommandTests
     }
 
     [Fact]
+    public void Execute_Guide_ListsCompletePublishContractAndPublishDryRunChecklist()
+    {
+        // G482: the guide enumerates the full publish-ready contract shape
+        // (including Standalone Child Issue Contract and Base Branch Policy) and
+        // tells agents to dry-run publish validation before declaring a packet
+        // ready for GitHub issue creation.
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowTaskPacketDraftCommand.Execute(
+            CreateContext(), Array.Empty<string>(), writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("standalone-child-issue-contract", output, StringComparison.Ordinal);
+        Assert.Contains("base-branch-policy", output, StringComparison.Ordinal);
+
+        var stopConditions = string.Join(" ", GuideWorkflowTaskPacketDraftCommand.StopConditions);
+        Assert.Contains(
+            "Dry-run the publish validation BEFORE declaring the packet issue-ready (G482)",
+            stopConditions,
+            StringComparison.Ordinal);
+        Assert.Contains("intent next-slice --dry-run", stopConditions, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Invariants_IncludeIntentTargetFinalBoundaryWarning()
     {
         // Acceptance criterion: "The guide warns that intent-target

--- a/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
@@ -39,6 +39,54 @@ public sealed class PacketDraftCommandTests
         }
     }
 
+    // ── G482: scaffold emits the complete publish-ready contract shape ───
+
+    [Fact]
+    public void Execute_Scaffold_EmitsEveryScaffoldHeadingIncludingStandaloneContract()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G482", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        var githubBody = File.ReadAllText(
+            Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G482", "github-body.md"));
+
+        // Every scaffolded heading (required gate + Standalone Child Issue
+        // Contract) must appear: removing one from the shared constant OR the
+        // template fails this test.
+        foreach (var section in PublishContractSections.ScaffoldHeadings)
+        {
+            Assert.Contains($"## {section}", githubBody, StringComparison.Ordinal);
+        }
+        Assert.Contains("## Standalone Child Issue Contract", githubBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RequiredContractSections_ShareSingleSourceOfTruthWithPublishValidator()
+    {
+        // G482: the packet scaffold's draft check and the publish-body validator
+        // must reference one shared list so they can never drift apart.
+        Assert.Same(PublishContractSections.Required, PacketDraftCommand.RequiredContractSections);
+        Assert.Same(PublishContractSections.Required, IssueValidateBodyValidator.RequiredHeadings);
+        Assert.Equal(PacketDraftCommand.RequiredContractSections, IssueValidateBodyValidator.RequiredHeadings);
+    }
+
+    [Fact]
+    public void ScaffoldHeadings_AreSupersetOfRequiredPlusStandaloneContract()
+    {
+        Assert.Contains(
+            PublishContractSections.StandaloneChildIssueContract,
+            PublishContractSections.ScaffoldHeadings);
+        foreach (var required in PublishContractSections.Required)
+        {
+            Assert.Contains(required, PublishContractSections.ScaffoldHeadings);
+        }
+    }
+
     [Fact]
     public void Execute_GivenExistingFiles_DoesNotOverwriteAndReportsSkipped()
     {


### PR DESCRIPTION
## Summary

Prevents the repeated next-slice publish blocks (G479/G480/G481 each initially missed `Current Observed State`) by making packet **creation guidance and scaffold output** produce the complete publish-ready issue contract by default, and by consolidating the duplicated required-section list so the scaffold and the publish validator can never drift apart.

## What changed

- **Single source of truth** — new `PublishContractSections`:
  - `Required` — the fail-closed publish gate (the headings a `github-body.md` MUST carry).
  - `ScaffoldHeadings` — `Required` + `Standalone Child Issue Contract` (the fuller shape a freshly drafted packet emits).
  - Both `PacketDraftCommand.RequiredContractSections` (scaffold draft check) and `IssueValidateBodyValidator.RequiredHeadings` (publish gate) now reference it — eliminating the previously duplicated, drift-prone copies.
- **Scaffold** (`intent-cli packet draft`) now emits a `## Standalone Child Issue Contract` section by default, so a freshly created `github-body.md` is complete and self-describing without the author memorizing every heading.
- **Guide** (`guide workflow task packet-draft`) now lists the full contract shape (adds `standalone-child-issue-contract` and `base-branch-policy`) and adds a stop-condition telling agents to **dry-run publish validation** (`issue validate-body --from-file`, `packet draft --dry-run`, `intent next-slice --dry-run`) and confirm zero missing sections **before** declaring a packet ready for GitHub issue creation.

## Scope note (deliberate)

The hard publish gate (`PublishContractSections.Required`) is left at its existing enforced set rather than expanded. The issue's mechanical failure was missing `Current Observed State`, which is already required and scaffolded. Expanding the gate with a brand-new required heading would touch 5 publish surfaces and ~9 test fixtures and could retroactively fail in-flight host queue packets I cannot inspect from a child-cwd loop. Instead G482 makes the **scaffold + guidance** emit the complete shape by default (including `Standalone Child Issue Contract`) and consolidates the lists; publish validation stays fail-closed for incomplete bodies. If the operator wants the gate to additionally enforce `Standalone Child Issue Contract`, that is a low-risk follow-up now that the shared constant exists.

## Tests

- `PacketDraftCommandTests`: scaffold emits every `ScaffoldHeadings` entry incl. `Standalone Child Issue Contract` (fails if a section is removed from the constant or the template); scaffold and validator share one source of truth (`Assert.Same` drift guard); `ScaffoldHeadings` ⊇ `Required` + Standalone.
- `GuideWorkflowTaskPacketDraftCommandTests`: guide lists the full contract (`standalone-child-issue-contract`, `base-branch-policy`) and the publish dry-run checklist.
- Full `IntentSystem.Cli.Tests` suite passes (**3090 passed, 1 skipped**); `git diff --check` clean.

## Acceptance Criteria mapping

- New scaffold/guide output includes `Current Observed State` and all other required sections by default ✅ (scaffold also adds Standalone Child Issue Contract)
- `issue publish-flow` succeeds on a freshly generated minimal packet after placeholders filled ✅ (scaffold emits all gate sections; gate unchanged)
- `intent next-slice --dry-run` no longer flags newly stacked complete packets as `clarification-required` for missing mechanical sections ✅ (shared constant; complete scaffold)
- Guide tells agents to dry-run publish validation before declaring ready ✅
- Tests fail if a required section is removed from the template ✅
- Existing incomplete historical packets still fail closed ✅ (gate unchanged, still fail-closed)

Out of scope (per packet): auto-migrating historical packets, weakening publish validation, changing the issue-publish GitHub mutation path, publishing G482 itself in this PR.

Closes #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)