### PR TITLE
G483 Prepare v0.3.9 release after G479-G482 loop-stability fixes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -151,83 +151,96 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.3.7",
-  "nextVersion": "0.3.8"
-}
-```
-
-| Stage | Version form | How it is derived |
-| --- | --- | --- |
-| Local pack / install | `0.3.8-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.3.8-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.8-rc.N` | Tag `v0.3.8-rc.N` triggers release workflow |
-| Stable release | `0.3.8` | Tag `v0.3.8` triggers release workflow (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.3.9-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.9` |
-
-**After releasing `v0.3.8`**, bump both fields in `eng/version.json`:
-
-```json
-{
   "stableVersion": "0.3.8",
   "nextVersion": "0.3.9"
 }
 ```
 
+| Stage | Version form | How it is derived |
+| --- | --- | --- |
+| Local pack / install | `0.3.9-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.3.9-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.9-rc.N` | Tag `v0.3.9-rc.N` triggers release workflow |
+| Stable release | `0.3.9` | Tag `v0.3.9` triggers release workflow (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.3.10-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.10` |
+
+**After releasing `v0.3.9`**, bump both fields in `eng/version.json`:
+
+```json
+{
+  "stableVersion": "0.3.9",
+  "nextVersion": "0.3.10"
+}
+```
+
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.3.9-preview.<run>.<attempt>` / `0.3.9-<sha>-<G-unit>` rather than continuing to
-emit `0.3.8` (which would collide with the stable release version).
+`0.3.10-preview.<run>.<attempt>` / `0.3.10-<sha>-<G-unit>` rather than continuing to
+emit `0.3.9` (which would collide with the stable release version).
 
-### Next release readiness (v0.3.8)
+### Next release readiness (v0.3.9)
 
-**`v0.3.7` shipped** (GitHub Release + NuGet) and the version policy was bumped
-to the `0.3.8` development line. The repository is now on the in-development
-**`0.3.8`** `nextVersion`; G478 (this packet) prepares the `v0.3.8` release — the
-next release is published by tagging `v0.3.8` once the
-[release-readiness gate](release-notes-v0.3.8.md#release-readiness-gate-g478)
+**`v0.3.8` shipped** (GitHub Release + NuGet) and the version policy was bumped
+to the `0.3.9` development line. The repository is now on the in-development
+**`0.3.9`** `nextVersion`; G483 (this packet) prepares the `v0.3.9` release — the
+next release is published by tagging `v0.3.9` once the
+[release-readiness gate](release-notes-v0.3.9.md#release-readiness-gate-g483)
 passes. Preparing the release does not cut it. Full changelog and operator
-checklist: [release-notes-v0.3.8.md](release-notes-v0.3.8.md).
+checklist: [release-notes-v0.3.9.md](release-notes-v0.3.9.md).
 
-**To ship in `v0.3.8` (changes since `v0.3.7`) — a loop-reliability release:**
+**To ship in `v0.3.9` (changes since `v0.3.8`) — a loop-stability release:**
 
-- **Packet evidence citations no longer deadlock child PR repair** (G476) —
-  `worker pr-comment-preflight` classifies a review comment by its requested
-  edit target, not by an incidental `.intent-cli/` / `intents/` mention, so a
-  comment that cites a packet path as evidence while asking to change
-  implementation files is `repair-required` / actionable instead of a
-  host-artifact deadlock. The result exposes `requested_edit_paths` vs
-  `host_evidence_paths`, and `worker next-action` consults the same classifier.
-- **Deterministic closeout recovery when `linked_pr` is missing** (G477) —
-  `closeout pr --pr <n>` auto-recovers when a merged PR's GitHub closing
-  references identify exactly one queue item by `linked_issue`, completing
-  without a manual `--issue <n>` rerun and repairing the missing `linked_pr`
-  projection. Ambiguous evidence fails closed with a `linkage-ambiguous` error;
-  the result surfaces `recoverable_missing_linked_pr` / `inferred_issue` /
-  `recovery_action`.
+- **Fail closed instead of Asking UI during loop wakes** (G479) — every
+  recurring loop prompt carries one shared policy: automation wakes do not stop
+  on interactive Asking UI for operational ambiguity. Asking is reserved for
+  narrow safety gates; recoverable ambiguity converges to safe repair or the
+  next wake, and non-recoverable ambiguity ends with `STOP: <classification>`
+  and one operator action. Unsafe options like continuing two concurrent host
+  loops are never offered.
+- **Host-orchestrator and semantic-reviewer roles are explicit** (G480) — the
+  host review / next-slice prompt makes the host-orchestrator, semantic-reviewer
+  (role-gated on the packet `review_role`, default `Codex`), and
+  child-implementer responsibilities distinct, so an agent neither over-reviews
+  nor concludes "the host never reviews." An already-approved PR stays mergeable
+  by the orchestrator even when a different agent performed the review; role
+  mismatch is a wait / `STOP`, never Asking UI.
+- **Duplicate host publish is detected and canonicalized fail-closed** (G481) —
+  `automation state-doctor` classifies duplicate execution-unit issues /
+  concurrent host publish (`concurrent-host-publish-detected`,
+  `canonical-issue-mismatch`, `pr-closes-noncanonical-issue`) and offers a safe
+  repair only for an unambiguous duplicate. Canonical selection prefers durable
+  queue-state over live GitHub recency; ambiguous races fail closed without
+  picking a winner by recency.
+- **Packet creation emits complete publish-ready contracts** (G482) — the packet
+  scaffold and the publish validator share one required-section source of truth,
+  the scaffold emits the full contract shape (including `Standalone Child Issue
+  Contract`) by default, and the guide tells agents to dry-run publish
+  validation before declaring a packet ready — so repeated missing-section
+  publish blocks stop recurring.
 
-**Release-readiness verification (run before tagging the next `v0.3.8`):**
+**Release-readiness verification (run before tagging the next `v0.3.9`):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.3.7 (published), nextVersion 0.3.8 (to release)
+cat eng/version.json   # stableVersion 0.3.8 (published), nextVersion 0.3.9 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.3.8-<sha>-G47x   (NOT a stale literal)
+#   expected shape: intent-cli 0.3.9-<sha>-G48x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.8.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.9.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-The official release is then cut by publishing a GitHub Release tagged `v0.3.8`;
-the release workflow passes `-p:Version=0.3.8` (which wins over the local
+The official release is then cut by publishing a GitHub Release tagged `v0.3.9`;
+the release workflow passes `-p:Version=0.3.9` (which wins over the local
 default). After the release publishes, apply the post-release `eng/version.json`
-bump above (`stableVersion → 0.3.8`, `nextVersion → 0.3.9`).
+bump above (`stableVersion → 0.3.9`, `nextVersion → 0.3.10`).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.3.9.md
+++ b/docs/en/release-notes-v0.3.9.md
@@ -1,0 +1,140 @@
+# Release Notes — intent-cli v0.3.9
+
+> **Release checklist for maintainers:** see [Creating the v0.3.9 GitHub Release](#creating-the-v039-github-release).
+> **Do NOT tag until the [release-readiness gate](#release-readiness-gate-g483) passes.**
+
+## What's in v0.3.9
+
+v0.3.9 is a loop-stability release. It ships the four reliability fixes
+completed after `v0.3.8` that keep Claude/Codex implementation and review loops
+moving without stalling on interactive prompts, role confusion, duplicate-issue
+races, or publish-blocking packet gaps. No package id, license, or
+workflow-semantics changes. The package id remains `JTechJapan.IntentSystem.Cli`.
+
+### Fail closed instead of Asking UI during loop wakes (G479)
+
+- Every recurring loop prompt (`intent-cli guide prompt-matrix`) now carries one
+  shared policy: during an automation loop wake, agents do **not** stop on
+  interactive Asking UI for operational ambiguity (duplicate publish, queue /
+  linkage mismatch, role confusion, CI pending, WIP-cap, draft PR, stale lease).
+- Asking is reserved for narrow safety gates only — security-sensitive approval,
+  external credentials / login, destructive local operations, irreversible
+  public release / publish, or an explicit operator-requested policy decision.
+- Recoverable ambiguity converges to intent-cli safe repair or a normal wait;
+  non-recoverable ambiguity ends with `STOP: <classification>` and exactly one
+  next operator action. Unsafe options such as continuing two concurrent host
+  loops are never offered — the safe invariant is one active wake per host
+  repo + domain.
+
+### Host-orchestrator and semantic-reviewer roles are explicit (G480)
+
+- The host review / next-slice prompt now makes three responsibilities distinct:
+  **host-orchestrator** (preflight, diagnostics, safe repair, merge approved
+  PRs, closeout, next-slice publish, metadata reconciliation),
+  **semantic-reviewer** (inspect diff, map to packet / intent, approve /
+  request-update — permitted only when the running agent is the packet
+  `review_role`, default `Codex`, or is explicitly assigned), and
+  **child-implementer**.
+- An agent neither over-reviews nor concludes "the host never reviews." An
+  already-approved PR stays mergeable by the orchestrator even when a different
+  agent performed the review; role mismatch is a wait / `STOP: review-role-mismatch`,
+  never Asking UI. The Claude host-orchestrator and Codex semantic-reviewer
+  prompt variants read correctly for each role.
+
+### Duplicate host publish is detected and canonicalized fail-closed (G481)
+
+- `intent-cli automation state-doctor` now classifies duplicate execution-unit
+  issues and concurrent host publish: `concurrent-host-publish-detected`,
+  `canonical-issue-mismatch`, and `pr-closes-noncanonical-issue` (the
+  last classified separately from ordinary missing-`linked_pr` recovery).
+- Canonical selection prefers durable evidence (queue-state `linked_issue`, then
+  packet `publish.yaml`) over live GitHub recency. A safe repair (closing the
+  non-canonical duplicate) is offered only as `duplicate-execution-unit-issue-detected`
+  when the canonical issue is unique and the duplicate carries no active PR.
+- Ambiguous or thrashing races fail closed without picking a winner by recency,
+  reopening/closing issues arbitrarily, or auto-editing a PR body mid-race.
+
+### Packet creation emits complete publish-ready contracts (G482)
+
+- The packet scaffold (`intent-cli packet draft`) and the publish-body validator
+  now share one required-section source of truth, so they can never drift apart.
+- A freshly scaffolded `github-body.md` carries the complete contract shape by
+  default, including `Standalone Child Issue Contract`, and the packet-draft
+  guide tells agents to dry-run publish validation (`issue validate-body`,
+  `packet draft --dry-run`, `intent next-slice --dry-run`) before declaring a
+  packet ready for GitHub issue creation. Publish validation stays fail-closed
+  for incomplete bodies — the repeated missing-section publish blocks stop
+  recurring.
+
+> Version metadata note: `eng/version.json` records `stableVersion: 0.3.8`,
+> `nextVersion: 0.3.9`; G483 (this packet) is the release-readiness preparation.
+> The post-v0.3.9 metadata advancement (`stableVersion → 0.3.9`,
+> `nextVersion → 0.3.10`) is the operator's post-release step and is out of scope
+> for this packet.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.9
+```
+
+Or download the self-contained binary from the
+[v0.3.9 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.9).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.8
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.9
+```
+
+There are no breaking changes from v0.3.8.
+
+## Release-readiness gate (G483)
+
+Do not create the `v0.3.9` tag/release until ALL of the following hold
+(this gate fails closed — if any item is unmet, stop and do not tag):
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G479, G480, G481, G482 (and G483 this prep). Confirm on the host/review
+      side via the host queue-state / GitHub PR state — the child implementation
+      loop must not read parent queue-state, so this is a host-owned precondition.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before tagging).
+- [ ] `eng/version.json` `nextVersion` is `0.3.9` (the intended release version)
+      and matches the tag to be created (`v0.3.9`). The release workflow derives
+      the package version from the tag; `-p:Version=` overrides the policy-derived
+      default in `src/IntentSystem.Cli/IntentSystem.Cli.csproj`.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+
+## Creating the v0.3.9 GitHub Release
+
+1. Confirm the [release-readiness gate](#release-readiness-gate-g483) — do not
+   proceed if any item is unmet.
+2. Tag the release commit: `git tag v0.3.9 && git push origin v0.3.9`.
+3. The `release.yml` workflow fires and builds binaries, `.nupkg`, and
+   checksums (version derived from the tag). Wait for it to complete green.
+4. The workflow creates the GitHub Release draft. Review it, paste the content
+   of this file as the release body, and publish.
+5. Confirm the NuGet publish step pushed `JTechJapan.IntentSystem.Cli 0.3.9`.
+6. Post-release verification checklist:
+   - [ ] NuGet.org package page links all resolve correctly.
+   - [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+         accessible.
+   - [ ] `.sha256` checksums match the downloaded artifacts.
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.9`)
+         then `intent-cli --version` reports `0.3.9`.
+   - [ ] Binary artifact smoke check: download the platform archive, verify its
+         `.sha256`, extract, and run `./intent-cli --version` → `0.3.9`.
+   - [ ] Local preview/dry-run version metadata uses the next development line
+         after `0.3.9` (bump `eng/version.json` per the post-release step in
+         [Version flow](09-developer-reference.md#version-flow)):
+         `stableVersion → 0.3.9`, `nextVersion → 0.3.10`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -141,72 +141,83 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.3.7",
-  "nextVersion": "0.3.8"
-}
-```
-
-| ステージ | バージョン形式 | 導出方法 |
-| --- | --- | --- |
-| ローカル pack / install | `0.3.8-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.3.8-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.8-rc.N` | タグ `v0.3.8-rc.N` がリリースワークフローをトリガー |
-| 安定版リリース | `0.3.8` | タグ `v0.3.8` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.3.9-preview.<run>.<attempt>` | `nextVersion` を `0.3.9` にバンプ後 |
-
-**`v0.3.8` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
-
-```json
-{
   "stableVersion": "0.3.8",
   "nextVersion": "0.3.9"
 }
 ```
 
+| ステージ | バージョン形式 | 導出方法 |
+| --- | --- | --- |
+| ローカル pack / install | `0.3.9-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.3.9-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.3.9-rc.N` | タグ `v0.3.9-rc.N` がリリースワークフローをトリガー |
+| 安定版リリース | `0.3.9` | タグ `v0.3.9` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.3.10-preview.<run>.<attempt>` | `nextVersion` を `0.3.10` にバンプ後 |
+
+**`v0.3.9` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+
+```json
+{
+  "stableVersion": "0.3.9",
+  "nextVersion": "0.3.10"
+}
+```
+
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.3.9-preview.<run>.<attempt>` / `0.3.9-<sha>-<G-unit>` を生成し、`0.3.8`（安定版
+`0.3.10-preview.<run>.<attempt>` / `0.3.10-<sha>-<G-unit>` を生成し、`0.3.9`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備（v0.3.8）
+### 次リリース準備（v0.3.9）
 
-**`v0.3.7` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
-`0.3.8` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.8`**
-`nextVersion` 上にあり、G478（本パケット）が `v0.3.8` リリースを準備します。次のリリースは
-[リリース準備ゲート](release-notes-v0.3.8.md#リリース準備ゲート-g478)を通過後に `v0.3.8`
+**`v0.3.8` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
+`0.3.9` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.9`**
+`nextVersion` 上にあり、G483（本パケット）が `v0.3.9` リリースを準備します。次のリリースは
+[リリース準備ゲート](release-notes-v0.3.9.md#リリース準備ゲート-g483)を通過後に `v0.3.9`
 タグ付けで publish されます。準備はリリースを cut しません。完全な changelog と operator
-チェックリスト: [release-notes-v0.3.8.md](release-notes-v0.3.8.md)。
+チェックリスト: [release-notes-v0.3.9.md](release-notes-v0.3.9.md)。
 
-**`v0.3.8` で出荷予定（`v0.3.7` 以降の変更）— loop 信頼性リリース:**
+**`v0.3.9` で出荷予定（`v0.3.8` 以降の変更）— loop 安定性リリース:**
 
-- **packet evidence の引用が child PR 修復をデッドロックさせない**（G476）—
-  `worker pr-comment-preflight` が review コメントを、付随的な `.intent-cli/` / `intents/`
-  の言及ではなく要求された編集対象で分類するため、packet path を根拠として引用しつつ実装ファイルの
-  変更を求めるコメントは host-artifact デッドロックではなく `repair-required` / actionable に
-  なります。結果は `requested_edit_paths` と `host_evidence_paths` を公開し、`worker next-action`
-  も同じ分類器を参照します。
-- **`linked_pr` 欠落時の deterministic な closeout 回復**（G477）—
-  `closeout pr --pr <n>` が、merged PR の GitHub closing references が `linked_issue` 経由で
-  ちょうど 1 つの queue item を特定できる場合に自動回復し、手動 `--issue <n>` 再実行なしで完了し
-  欠落していた `linked_pr` projection を修復します。曖昧な証拠は `linkage-ambiguous` エラーで
-  fail closed し、結果は `recoverable_missing_linked_pr` / `inferred_issue` / `recovery_action`
-  を surface します。
+- **loop wake 中の Asking UI ではなく fail closed**（G479）— すべての recurring loop
+  prompt が単一の共有ポリシーを持ちます: automation wake は操作上の曖昧さで interactive
+  Asking UI を使って停止しません。Asking は狭い safety gate のみに限定され、回復可能な曖昧さは
+  safe repair か次の wake に収束し、回復不能なものは `STOP: <classification>` と 1 つの
+  operator アクションで終わります。並行 host loop を両方継続するような unsafe な選択肢は提示
+  されません。
+- **host-orchestrator と semantic-reviewer の role を明示化**（G480）— host review /
+  next-slice prompt が host-orchestrator・semantic-reviewer（packet `review_role`、既定
+  `Codex` に role-gated）・child-implementer の責務を区別し、agent が過剰レビューも「host は
+  決してレビューしない」という結論も避けます。承認済み PR は別 agent がレビューしても
+  orchestrator が merge 可能なままで、role 不一致は wait / `STOP` であり Asking UI では
+  ありません。
+- **重複 host publish を検出し fail-closed で canonical 化**（G481）—
+  `automation state-doctor` が重複 execution-unit issue / 並行 host publish
+  （`concurrent-host-publish-detected`, `canonical-issue-mismatch`,
+  `pr-closes-noncanonical-issue`）を分類し、曖昧でない重複のみ safe repair を提示します。
+  canonical 選択は live GitHub recency より durable な queue-state を優先し、曖昧な race は
+  recency で勝者を選ばず fail closed します。
+- **packet 作成が完全な publish-ready contract を生成**（G482）— packet scaffold と publish
+  validator が必須セクションの単一情報源を共有し、scaffold は既定で完全な contract 形状
+  （`Standalone Child Issue Contract` を含む）を出力し、guide は packet を ready と宣言する前に
+  publish validation を dry-run するよう指示します。これにより繰り返し発生していた section 欠落
+  による publish ブロックが解消されます。
 
-**リリース準備の検証（次の `v0.3.8` タグ付け前に実行）:**
+**リリース準備の検証（次の `v0.3.9` タグ付け前に実行）:**
 
 ```bash
-cat eng/version.json   # stableVersion 0.3.7（公開済み）, nextVersion 0.3.8（リリース対象）
+cat eng/version.json   # stableVersion 0.3.8（公開済み）, nextVersion 0.3.9（リリース対象）
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.3.8-<sha>-G47x （stale なリテラルではない）
+#   期待形: intent-cli 0.3.9-<sha>-G48x （stale なリテラルではない）
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.8.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.9.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-公式リリースは `v0.3.8` タグの GitHub Release publish で cut され、リリースワークフローが
-`-p:Version=0.3.8` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
-`eng/version.json` バンプ（`stableVersion → 0.3.8`, `nextVersion → 0.3.9`）を適用します。
+公式リリースは `v0.3.9` タグの GitHub Release publish で cut され、リリースワークフローが
+`-p:Version=0.3.9` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
+`eng/version.json` バンプ（`stableVersion → 0.3.9`, `nextVersion → 0.3.10`）を適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.3.9.md
+++ b/docs/ja/release-notes-v0.3.9.md
@@ -1,0 +1,133 @@
+# リリースノート — intent-cli v0.3.9
+
+> **メンテナ向けリリースチェックリスト:** [v0.3.9 GitHub リリースの作成](#v039-github-リリースの作成) を参照。
+> **[リリース準備ゲート](#リリース準備ゲート-g483) を通過するまでタグを打たないこと。**
+
+## v0.3.9 の内容
+
+v0.3.9 は loop 安定性のリリースです。`v0.3.8` 後に完了した 4 つの信頼性修正を出荷し、
+Claude/Codex の実装/レビュー loop が interactive prompt・role 混乱・重複 issue race・
+publish ブロックする packet 欠落で停止せずに進み続けるようにします。package id・ライセンス・
+ワークフロー semantics の変更はありません。package id は `JTechJapan.IntentSystem.Cli`
+のままです。
+
+### loop wake 中の Asking UI ではなく fail closed (G479)
+
+- すべての recurring loop prompt（`intent-cli guide prompt-matrix`）が単一の共有ポリシーを
+  持つようになりました: automation loop wake 中、agent は操作上の曖昧さ（重複 publish・
+  queue / linkage 不一致・role 混乱・CI pending・WIP-cap・draft PR・stale lease）で
+  interactive Asking UI を使って **停止しません**。
+- Asking は狭い safety gate のみに限定されます — security 承認・外部認証 / login・破壊的
+  ローカル操作・不可逆な公開 publish・operator が明示的に要求した policy 判断。
+- 回復可能な曖昧さは intent-cli safe repair か通常の wait に収束し、回復不能なものは
+  `STOP: <classification>` と 1 つの operator アクションで終わります。並行 host loop を
+  両方継続するような unsafe な選択肢は提示されません — 安全な不変条件は host repo + domain
+  ごとに 1 つの active wake です。
+
+### host-orchestrator と semantic-reviewer の role を明示化 (G480)
+
+- host review / next-slice prompt が 3 つの責務を区別するようになりました:
+  **host-orchestrator**（preflight・diagnostics・safe repair・承認済み PR の merge・
+  closeout・next-slice publish・metadata 整合）、**semantic-reviewer**（diff レビュー・
+  packet / intent への対応付け・approve / request-update — running agent が packet
+  `review_role`、既定 `Codex` と一致、または明示割当のときのみ許可）、
+  **child-implementer**。
+- agent は過剰レビューも「host は決してレビューしない」という結論も避けます。承認済み PR は
+  別 agent がレビューしても orchestrator が merge 可能なままで、role 不一致は wait /
+  `STOP: review-role-mismatch` であり Asking UI ではありません。Claude host-orchestrator と
+  Codex semantic-reviewer の prompt variant がそれぞれの role で正しく読めます。
+
+### 重複 host publish を検出し fail-closed で canonical 化 (G481)
+
+- `intent-cli automation state-doctor` が重複 execution-unit issue と並行 host publish を
+  分類するようになりました: `concurrent-host-publish-detected`,
+  `canonical-issue-mismatch`, `pr-closes-noncanonical-issue`（最後のものは通常の
+  missing-`linked_pr` 回復とは別分類）。
+- canonical 選択は live GitHub recency より durable な証拠（queue-state `linked_issue`、
+  次に packet `publish.yaml`）を優先します。safe repair（非 canonical な重複を close）は、
+  canonical issue が一意で重複に active PR が無い場合の
+  `duplicate-execution-unit-issue-detected` のときのみ提示されます。
+- 曖昧または thrashing する race は、recency で勝者を選ぶ・issue を恣意的に reopen/close
+  する・race 中に PR body を自動編集する、のいずれもせず fail closed します。
+
+### packet 作成が完全な publish-ready contract を生成 (G482)
+
+- packet scaffold（`intent-cli packet draft`）と publish-body validator が必須セクションの
+  単一情報源を共有するようになり、二度と乖離しません。
+- 新規 scaffold された `github-body.md` は既定で完全な contract 形状（`Standalone Child
+  Issue Contract` を含む）を持ち、packet-draft guide は packet を GitHub issue 化の準備完了と
+  宣言する前に publish validation（`issue validate-body`, `packet draft --dry-run`,
+  `intent next-slice --dry-run`）を dry-run するよう指示します。publish validation は不完全な
+  body に対して引き続き fail-closed のままで、繰り返し発生していた section 欠落の publish
+  ブロックが解消されます。
+
+> バージョンメタデータ注記: `eng/version.json` は `stableVersion: 0.3.8`,
+> `nextVersion: 0.3.9` を記録しており、G483（本パケット）はリリース準備です。v0.3.9 後の
+> メタデータ前進（`stableVersion → 0.3.9`, `nextVersion → 0.3.10`）は operator のリリース後
+> 手順であり、本パケットの対象外です。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.9
+```
+
+または
+[v0.3.9 GitHub リリース](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.9)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを
+検証してください。
+
+## v0.3.8 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.9
+```
+
+v0.3.8 からの破壊的変更はありません。
+
+## リリース準備ゲート (G483)
+
+以下が **すべて** 満たされるまで `v0.3.9` タグ/リリースを作成しないこと
+（このゲートは fail-closed — 1 つでも未達なら停止しタグを打たない）:
+
+- [ ] リリース対象パケットがすべて **完了し PR が `main` にマージ済み**:
+      G479, G480, G481, G482（および本準備 G483）。host/review 側で host queue-state /
+      GitHub PR state により確認すること — child 実装 loop は親 queue-state を読まないため、
+      これは host 所有の前提条件です。
+- [ ] 本リリース対象の open な intent-system PR や WIP packet を取りこぼしていないこと
+      （タグ付け前に host queue / open PR 一覧を確認）。
+- [ ] `eng/version.json` の `nextVersion` が `0.3.9`（意図したリリースバージョン）で、
+      作成するタグ（`v0.3.9`）と一致すること。release ワークフローはタグからパッケージ
+      バージョンを導出し、`-p:Version=` が
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` のポリシー導出デフォルトを上書きします。
+- [ ] パッケージメタデータが正しいこと: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` が
+      `https://github.com/J-Tech-Japan/intent-system` を指す,
+      `PackageLicenseExpression = Apache-2.0`, README/docs リンクが解決し,
+      公式サービスサイト `https://www.intent-driven-development.com/` が README から
+      リンクされていること。
+- [ ] release コミットで **main CI が green**（`Build and test (source contract)`）で、
+      **preview-pack** ワークフローが green であること。
+
+## v0.3.9 GitHub リリースの作成
+
+1. [リリース準備ゲート](#リリース準備ゲート-g483) を確認 — 未達項目があれば進めない。
+2. release コミットにタグ: `git tag v0.3.9 && git push origin v0.3.9`。
+3. `release.yml` ワークフローが発火し、バイナリ・`.nupkg`・チェックサムをビルド
+   （バージョンはタグから導出）。green 完了を待つ。
+4. ワークフローが GitHub Release draft を作成。確認し、本ファイルの内容を release body
+   として貼り付け、publish。
+5. NuGet publish ステップが `JTechJapan.IntentSystem.Cli 0.3.9` を push したことを確認。
+6. リリース後の検証チェックリスト:
+   - [ ] NuGet.org パッケージページのリンクがすべて正しく解決する。
+   - [ ] GitHub release アセットリンク（`.tar.gz`, `.zip`, `.exe`, `.nupkg`）が
+         アクセス可能。
+   - [ ] `.sha256` チェックサムがダウンロードしたアーティファクトと一致する。
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`（または
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.9`）の後、
+         `intent-cli --version` が `0.3.9` を報告する。
+   - [ ] バイナリアーティファクトの smoke check: プラットフォームアーカイブをダウンロードし、
+         `.sha256` を検証、展開して `./intent-cli --version` → `0.3.9`。
+   - [ ] ローカル preview/dry-run のバージョンメタデータが `0.3.9` 後の次の開発ラインを
+         使う（[Version flow](09-developer-reference.md#version-flow) のリリース後手順に
+         従い `eng/version.json` を bump）: `stableVersion → 0.3.9`, `nextVersion → 0.3.10`。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.7",
-  "nextVersion": "0.3.8"
+  "stableVersion": "0.3.8",
+  "nextVersion": "0.3.9"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,10 +124,10 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.8 as the next development line
-        // (post-v0.3.7 release bump, see G478 — v0.3.7 was published to
+        // be parseable and must point to 0.3.9 as the next development line
+        // (post-v0.3.8 release bump, see G483 — v0.3.8 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.3.8 while recording 0.3.7 as the published stable).
+        // forward to 0.3.9 while recording 0.3.8 as the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -137,8 +137,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.8", policy.NextVersion);
-        Assert.Equal("0.3.7", policy.StableVersion);
+        Assert.Equal("0.3.9", policy.NextVersion);
+        Assert.Equal("0.3.8", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Prepares the repository for an explicit operator release of **v0.3.9**, a patch-level loop-stability release containing G479-G482. This packet **does not publish the release** — release creation remains an operator/host action after merge (out of scope per the issue).

All four release-bound fixes are merged to `main`: G479 ([#1060](https://github.com/J-Tech-Japan/intent-system/pull/1060)), G480 ([#1062](https://github.com/J-Tech-Japan/intent-system/pull/1062)), G481 ([#1064](https://github.com/J-Tech-Japan/intent-system/pull/1064)), G482 ([#1066](https://github.com/J-Tech-Japan/intent-system/pull/1066)). Latest public release is v0.3.8.

## What changed (same shape as the G478 v0.3.8 prep)

- **docs (en/ja release notes)** — new `release-notes-v0.3.9.md` covering the four user-visible fixes in user-facing language (G479 fail-closed loop-wake Asking UI policy, G480 host-orchestrator vs semantic-reviewer role boundaries, G481 duplicate host publish detection/canonicalization, G482 publish-ready packet scaffolding), install/upgrade pinned to `0.3.9`, a fail-closed **release-readiness gate** (including a "no open PR / WIP packet accidentally skipped" check), and a post-release operator verification checklist (`dotnet tool update/install`, `intent-cli --version`, binary smoke check).
- **docs (en/ja developer reference)** — retarget the version-flow table and "Next release readiness" section to v0.3.9 / G479-G482, link the release notes, and document the post-release `eng/version.json` bump (`stable → 0.3.9`, `next → 0.3.10`).
- **eng/version.json** — advance to `stableVersion 0.3.8` (published) / `nextVersion 0.3.9` (release-to-cut); local pack / `--version` now derive `0.3.9-<sha>-<unit>`.
- **tests** — update `VersionPolicyTests` smoke assertion to next `0.3.9` / stable `0.3.8`. `ReleasePackageMetadataTests` read the policy/docs dynamically and continue to pass.

## Verification

- `intent-cli --version` → `intent-cli 0.3.9-24cdb63-G482` (derived from `nextVersion`, not a stale literal).
- `VersionPolicyTests` + `ReleasePackageMetadataTests` pass; full `IntentSystem.Cli.Tests` suite passes (**3090 passed, 1 skipped**); `git diff --check` clean.
- The release workflow is tag-driven and version-agnostic (`release.yml` passes `-p:Version=0.3.9`, which wins over the policy default) and already publishes NuGet plus osx-arm64 / win-x64 / linux-x64 binaries with sha256 sidecars — **no workflow change required**. Package id remains `JTechJapan.IntentSystem.Cli`.

## Acceptance Criteria mapping

- v0.3.9 clearly identified as a patch release containing G479-G482 ✅
- Release notes mention all four fixes in user-facing language ✅
- Version source produces v0.3.9 for release artifacts; post-release dev line is strictly newer (`0.3.10`) ✅ (documented post-release bump)
- Package id remains `JTechJapan.IntentSystem.Cli`; metadata links absolute/valid ✅
- Short post-release verification checklist present ✅
- Release-readiness gate includes a "no open PR / WIP packet skipped" check ✅

Out of scope (per packet): new runtime features, changing G479-G482 behavior, and publishing the GitHub Release inside this PR.

Closes #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)