### PR TITLE
G484 Decode gh subprocess output as UTF-8 on Windows Japanese consoles

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -60,6 +60,16 @@ on your `PATH`.
 
 Release binaries and OSS preview CI artifacts carry no build-time expiry.
 
+### Japanese / non-UTF-8 Windows consoles (G484)
+
+intent-cli reads the GitHub CLI (`gh`) subprocess output as **UTF-8 regardless
+of the ambient console code page**, so Japanese issue/PR titles and bodies stay
+valid JSON on a Japanese Windows console (cp932/932). `worker next-action`,
+`worker issue-preflight`, `worker pr-comment-preflight`, and the host/review
+preflight paths all share this decoding. You do **not** need to run
+`chcp 65001` or set `$OutputEncoding` / `[Console]::OutputEncoding` manually.
+macOS/Linux behavior is unchanged (those consoles are already UTF-8).
+
 ---
 
 ## Packaged invocation (local smoke)

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -60,6 +60,16 @@ intent-cli --version
 
 リリースバイナリと OSS preview CI アーティファクトにはビルド時の有効期限はありません。
 
+### 日本語 / 非 UTF-8 の Windows コンソール (G484)
+
+intent-cli は GitHub CLI（`gh`）サブプロセスの出力を、**周囲のコンソールのコードページに
+依存せず UTF-8 として** 読み取ります。そのため日本語 Windows コンソール（cp932/932）でも
+issue/PR のタイトルや本文が valid な JSON のまま保たれます。`worker next-action`,
+`worker issue-preflight`, `worker pr-comment-preflight`, および host/review preflight の各経路が
+このデコードを共有します。`chcp 65001` の実行や `$OutputEncoding` /
+`[Console]::OutputEncoding` の手動設定は **不要** です。macOS/Linux の挙動は変わりません
+（これらのコンソールは既に UTF-8 です）。
+
 ---
 
 ## パッケージ化された実行（ローカルスモークテスト）

--- a/src/IntentSystem.Cli/Commands/AutomationPublishLifecycleRepairCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPublishLifecycleRepairCommand.cs
@@ -404,6 +404,10 @@ internal sealed class GhCliGitHubAutomationIssueLookup : IGitHubAutomationIssueL
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/GhIssueCreator.cs
+++ b/src/IntentSystem.Cli/Commands/GhIssueCreator.cs
@@ -21,7 +21,11 @@ internal sealed class GhIssueCreator : IGhIssueCreator
             FileName = "gh",
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            UseShellExecute = false
+            UseShellExecute = false,
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom
         };
 
         startInfo.ArgumentList.Add("issue");

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -258,6 +258,10 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubIssueClosingPrLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubIssueClosingPrLookup.cs
@@ -55,6 +55,10 @@ internal sealed class GhCliGitHubIssueClosingPrLookup : IGitHubIssueClosingPrLoo
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubIssueLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubIssueLookup.cs
@@ -41,6 +41,10 @@ internal sealed class GhCliGitHubIssueLookup : IGitHubIssueLookup
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelLister.cs
@@ -47,6 +47,10 @@ internal sealed class GhCliGitHubLabelLister : IGitHubLabelLister
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
@@ -240,6 +240,10 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelPaletteMutator.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelPaletteMutator.cs
@@ -74,6 +74,10 @@ internal sealed class GhCliGitHubLabelPaletteMutator : IGitHubLabelPaletteMutato
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubPrCommentsLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubPrCommentsLookup.cs
@@ -153,6 +153,10 @@ internal sealed class GhCliGitHubPrCommentsLookup : IGitHubPrCommentsLookup
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubPrLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubPrLookup.cs
@@ -85,6 +85,10 @@ internal sealed class GhCliGitHubPrLookup : IGitHubPrLookup
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubSignalGateway.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubSignalGateway.cs
@@ -134,6 +134,10 @@ internal sealed class GhCliGitHubSignalGateway : IGitHubSignalGateway
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             RedirectStandardInput = standardInput is not null,

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -1149,7 +1149,11 @@ internal sealed class GhCliIssueCreator : IIssueCreator
             FileName = "gh",
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            UseShellExecute = false
+            UseShellExecute = false,
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom
         };
         startInfo.ArgumentList.Add("issue");
         startInfo.ArgumentList.Add("create");

--- a/src/IntentSystem.Cli/GhCommandRunner.cs
+++ b/src/IntentSystem.Cli/GhCommandRunner.cs
@@ -13,7 +13,11 @@ internal sealed class GhCommandRunner : IGitHubCommandRunner
             FileName = "gh",
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            UseShellExecute = false
+            UseShellExecute = false,
+            // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
+            // console code page (Windows cp932) so Japanese payloads stay valid.
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom
         };
 
         foreach (var argument in arguments)

--- a/src/IntentSystem.Cli/GitHubCliProcessEncoding.cs
+++ b/src/IntentSystem.Cli/GitHubCliProcessEncoding.cs
@@ -1,0 +1,29 @@
+using System.Text;
+
+namespace IntentSystem.Cli;
+
+/// <summary>
+/// G484: shared decoding contract for <c>gh</c> subprocess output. GitHub CLI
+/// always emits UTF-8 (JSON and error text), but when a redirected
+/// <see cref="System.Diagnostics.ProcessStartInfo"/> does not pin
+/// <c>StandardOutputEncoding</c> / <c>StandardErrorEncoding</c>, .NET decodes
+/// the streams with <see cref="System.Console.OutputEncoding"/> — which on a
+/// Japanese Windows console defaults to cp932/OEM. That mis-decodes multi-byte
+/// UTF-8 sequences in Japanese issue titles/bodies and corrupts otherwise-valid
+/// <c>gh</c> JSON, breaking <c>worker next-action</c> / preflight selection.
+///
+/// Every <c>gh</c> invocation pins both stream encodings to
+/// <see cref="Utf8NoBom"/> so decoding is UTF-8 regardless of the ambient
+/// console code page, Git Bash, or PowerShell host encoding. This is identical
+/// to existing behavior on macOS/Linux (whose console is already UTF-8), so the
+/// fix is a no-op there and only repairs the Windows cp932 path.
+/// </summary>
+internal static class GitHubCliProcessEncoding
+{
+    /// <summary>
+    /// UTF-8 without a byte-order mark. Used as both
+    /// <c>StandardOutputEncoding</c> and <c>StandardErrorEncoding</c> for every
+    /// <c>gh</c> subprocess so JSON and diagnostics decode as UTF-8.
+    /// </summary>
+    public static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+}

--- a/src/IntentSystem.Review/GhReviewCommandRunner.cs
+++ b/src/IntentSystem.Review/GhReviewCommandRunner.cs
@@ -1,9 +1,14 @@
 using System.Diagnostics;
+using System.Text;
 
 namespace IntentSystem.Review;
 
 public sealed class GhReviewCommandRunner : IReviewCommandRunner
 {
+    // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient console
+    // code page (Windows cp932) so Japanese payloads stay valid JSON/text.
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
     public ReviewCommandResult Run(IReadOnlyList<string> arguments)
     {
         ArgumentNullException.ThrowIfNull(arguments);
@@ -13,7 +18,9 @@ public sealed class GhReviewCommandRunner : IReviewCommandRunner
             FileName = "gh",
             RedirectStandardOutput = true,
             RedirectStandardError = true,
-            UseShellExecute = false
+            UseShellExecute = false,
+            StandardOutputEncoding = Utf8NoBom,
+            StandardErrorEncoding = Utf8NoBom
         };
 
         foreach (var argument in arguments)

--- a/tests/IntentSystem.Cli.Tests/GitHubCliProcessEncodingTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GitHubCliProcessEncodingTests.cs
@@ -1,0 +1,85 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G484: the shared gh subprocess decoding contract. gh emits UTF-8 JSON; the
+/// runner must decode it as UTF-8 regardless of the ambient Windows console
+/// code page (cp932). These tests pin the decoding contract at the unit level
+/// (no real subprocess): UTF-8 bytes carrying a Japanese issue title must
+/// survive through the shared encoding and the JSON boundary, while decoding
+/// the same bytes with a non-UTF-8 code page corrupts them — proving the
+/// encoding choice is what fixes the bug.
+/// </summary>
+public sealed class GitHubCliProcessEncodingTests
+{
+    // gh issue list --json number,title,labels,url shape, with a Japanese title.
+    private const string JapaneseTitle = "G484 日本語タイトルのテスト（cp932 回帰）";
+
+    private static string JapaneseIssueListJson =>
+        "[{\"number\":1069,\"title\":\"" + JapaneseTitle + "\",\"labels\":[],\"url\":\"https://github.com/J-Tech-Japan/intent-system/issues/1069\"}]";
+
+    [Fact]
+    public void Utf8NoBom_IsUtf8WithoutPreamble()
+    {
+        Assert.Equal("Unicode (UTF-8)", GitHubCliProcessEncoding.Utf8NoBom.EncodingName);
+        // No BOM: gh JSON must not be prefixed with a byte-order mark on write.
+        Assert.Empty(GitHubCliProcessEncoding.Utf8NoBom.GetPreamble());
+    }
+
+    [Fact]
+    public void Utf8Decode_OfJapaneseGhJson_RoundTripsThroughBoundaryAndParser()
+    {
+        // What gh writes to the redirected stdout pipe: UTF-8 bytes.
+        var ghStdoutBytes = Encoding.UTF8.GetBytes(JapaneseIssueListJson);
+
+        // What the runner does (post-G484): decode with the pinned UTF-8 encoding.
+        var decoded = GitHubCliProcessEncoding.Utf8NoBom.GetString(ghStdoutBytes);
+
+        var extraction = GitHubCliJsonBoundary.ExtractJsonArray(decoded, "`gh issue list` for J-Tech-Japan/intent-system");
+        Assert.True(extraction.Succeeded);
+        Assert.Equal(GitHubCliJsonBoundary.Classifications.Valid, extraction.Classification);
+
+        using var document = JsonDocument.Parse(extraction.Json);
+        var title = document.RootElement[0].GetProperty("title").GetString();
+        Assert.Equal(JapaneseTitle, title); // Japanese text intact end-to-end.
+    }
+
+    [Fact]
+    public void NonUtf8Decode_OfJapaneseGhJson_CorruptsTitle_ProvingEncodingMatters()
+    {
+        var ghStdoutBytes = Encoding.UTF8.GetBytes(JapaneseIssueListJson);
+
+        // Simulate the pre-G484 Windows cp932 path with a non-UTF-8 single-byte
+        // code page (Latin1 is always available and, like cp932, mis-decodes the
+        // multi-byte UTF-8 sequences in the Japanese title).
+        var misdecoded = Encoding.Latin1.GetString(ghStdoutBytes);
+
+        Assert.DoesNotContain(JapaneseTitle, misdecoded, StringComparison.Ordinal);
+
+        // The mis-decoded payload either fails JSON parse or no longer carries
+        // the original Japanese title — i.e. selection would break, which is the
+        // reported bug. The UTF-8 path above is what keeps it valid.
+        var extraction = GitHubCliJsonBoundary.ExtractJsonArray(misdecoded, "`gh issue list` for J-Tech-Japan/intent-system");
+        var titleSurvived = extraction.Succeeded
+            && JsonDocument.Parse(extraction.Json).RootElement[0].GetProperty("title").GetString() == JapaneseTitle;
+        Assert.False(titleSurvived);
+    }
+
+    [Fact]
+    public void Utf8Decode_OfAsciiGhJson_IsUnchanged_NoRegression()
+    {
+        const string asciiJson =
+            "[{\"number\":1,\"title\":\"ASCII only title\",\"labels\":[],\"url\":\"https://example/1\"}]";
+        var bytes = Encoding.UTF8.GetBytes(asciiJson);
+
+        var decoded = GitHubCliProcessEncoding.Utf8NoBom.GetString(bytes);
+        Assert.Equal(asciiJson, decoded);
+
+        var extraction = GitHubCliJsonBoundary.ExtractJsonArray(decoded, "`gh issue list` for owner/repo");
+        Assert.True(extraction.Succeeded);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a release-critical locale bug: on a Windows 11 Japanese (cp932) console, `intent-cli worker next-action --github-only --format json` fails with invalid-JSON parse errors when the selected GitHub issue contains Japanese text.

**Root cause:** the `gh` subprocess `ProcessStartInfo` sites did not pin `StandardOutputEncoding` / `StandardErrorEncoding`, so .NET decoded `gh` stdout/stderr with `Console.OutputEncoding` — cp932 on a Japanese Windows console — which mis-decodes the multi-byte UTF-8 sequences in Japanese titles/bodies and corrupts otherwise-valid `gh` JSON.

## What changed

- **Shared decoding contract** — new `GitHubCliProcessEncoding.Utf8NoBom` (UTF-8 without BOM). Every `gh` subprocess site now pins `StandardOutputEncoding` + `StandardErrorEncoding` to it: the shared `GhCommandRunner`, all GitHub lookup adapters (issue / PR / comments / closing-PR / automation candidate / label lister), label + signal mutators, issue creator, publish-flow, publish-lifecycle repair, and the `IntentSystem.Review` gh runner (14 sites total).
- Decoding is now UTF-8 **regardless of the ambient console code page, Git Bash, or PowerShell host encoding** — and identical to the existing macOS/Linux behavior (already UTF-8), so it is a no-op there and only repairs the Windows cp932 path.
- **stderr** is decoded with the same UTF-8 encoding so diagnostics stay useful and non-ASCII text is not corrupted.
- **docs (en/ja developer reference)** — state that Japanese / non-UTF-8 Windows `gh` JSON ingestion is supported with no `chcp 65001` / manual `$OutputEncoding`.

## Tests

`GitHubCliProcessEncodingTests` pins the decoding contract at the unit level (no real subprocess, no `gh` call):
- UTF-8 bytes carrying a Japanese issue title survive through the shared encoding **and** the `GitHubCliJsonBoundary` parser (title intact end-to-end).
- Decoding the **same** bytes with a non-UTF-8 code page (Latin1, a portable cp932 stand-in) corrupts the title — proving the encoding choice is the fix.
- ASCII-only decode is unchanged (no regression); `Utf8NoBom` is UTF-8 with no BOM preamble.

Full `IntentSystem.Cli.Tests` suite passes (**3094 passed, 1 skipped**); `IntentSystem.Review` builds clean; `git diff --check` clean.

## Acceptance Criteria mapping

- `worker next-action --github-only --format json` parses a Japanese-titled issue under cp932 without JSON failure ✅ (shared UTF-8 decode)
- Worker preflight + host/review preflight gh paths use the same UTF-8 decoding ✅ (all adapters pinned)
- Unit tests cover UTF-8 JSON with Japanese text through the shared runner/parser path ✅
- gh error output is read as UTF-8 and stays useful ✅ (`StandardErrorEncoding` pinned)
- No regression for ASCII-only and macOS/Linux ✅ (UTF-8 is identical there)

## Verification note (Windows smoke)

A live cp932-console smoke (`chcp 932` + a Japanese issue title + `worker next-action`) requires a Windows host and is documented in the issue's Verification section; this PR proves the decoding contract portably via unit tests on the CI host.

Out of scope (per packet): changing issue selection semantics, requiring `chcp 65001`, replacing the `gh` integration with an API client.

Closes #1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)