### PR TITLE
G486 Prepare v0.3.10 release after G484-G485 dogfooding fixes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -194,96 +194,81 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.3.8",
-  "nextVersion": "0.3.9"
-}
-```
-
-| Stage | Version form | How it is derived |
-| --- | --- | --- |
-| Local pack / install | `0.3.9-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.3.9-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.9-rc.N` | Tag `v0.3.9-rc.N` triggers release workflow |
-| Stable release | `0.3.9` | Tag `v0.3.9` triggers release workflow (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.3.10-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.10` |
-
-**After releasing `v0.3.9`**, bump both fields in `eng/version.json`:
-
-```json
-{
   "stableVersion": "0.3.9",
   "nextVersion": "0.3.10"
 }
 ```
 
+| Stage | Version form | How it is derived |
+| --- | --- | --- |
+| Local pack / install | `0.3.10-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.3.10-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.10-rc.N` | Tag `v0.3.10-rc.N` triggers release workflow |
+| Stable release | `0.3.10` | Tag `v0.3.10` triggers release workflow (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.3.11-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.11` |
+
+**After releasing `v0.3.10`**, bump both fields in `eng/version.json`:
+
+```json
+{
+  "stableVersion": "0.3.10",
+  "nextVersion": "0.3.11"
+}
+```
+
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.3.10-preview.<run>.<attempt>` / `0.3.10-<sha>-<G-unit>` rather than continuing to
-emit `0.3.9` (which would collide with the stable release version).
+`0.3.11-preview.<run>.<attempt>` / `0.3.11-<sha>-<G-unit>` rather than continuing to
+emit `0.3.10` (which would collide with the stable release version).
 
-### Next release readiness (v0.3.9)
+### Next release readiness (v0.3.10)
 
-**`v0.3.8` shipped** (GitHub Release + NuGet) and the version policy was bumped
-to the `0.3.9` development line. The repository is now on the in-development
-**`0.3.9`** `nextVersion`; G483 (this packet) prepares the `v0.3.9` release — the
-next release is published by tagging `v0.3.9` once the
-[release-readiness gate](release-notes-v0.3.9.md#release-readiness-gate-g483)
+**`v0.3.9` shipped** (GitHub Release + NuGet) and the version policy was bumped
+to the `0.3.10` development line. The repository is now on the in-development
+**`0.3.10`** `nextVersion`; G486 (this packet) prepares the `v0.3.10` release — the
+next release is published by tagging `v0.3.10` once the
+[release-readiness gate](release-notes-v0.3.10.md#release-readiness-gate-g486)
 passes. Preparing the release does not cut it. Full changelog and operator
-checklist: [release-notes-v0.3.9.md](release-notes-v0.3.9.md).
+checklist: [release-notes-v0.3.10.md](release-notes-v0.3.10.md).
 
-**To ship in `v0.3.9` (changes since `v0.3.8`) — a loop-stability release:**
+**To ship in `v0.3.10` (changes since `v0.3.9`) — a dogfooding-stability release:**
 
-- **Fail closed instead of Asking UI during loop wakes** (G479) — every
-  recurring loop prompt carries one shared policy: automation wakes do not stop
-  on interactive Asking UI for operational ambiguity. Asking is reserved for
-  narrow safety gates; recoverable ambiguity converges to safe repair or the
-  next wake, and non-recoverable ambiguity ends with `STOP: <classification>`
-  and one operator action. Unsafe options like continuing two concurrent host
-  loops are never offered.
-- **Host-orchestrator and semantic-reviewer roles are explicit** (G480) — the
-  host review / next-slice prompt makes the host-orchestrator, semantic-reviewer
-  (role-gated on the packet `review_role`, default `Codex`), and
-  child-implementer responsibilities distinct, so an agent neither over-reviews
-  nor concludes "the host never reviews." An already-approved PR stays mergeable
-  by the orchestrator even when a different agent performed the review; role
-  mismatch is a wait / `STOP`, never Asking UI.
-- **Duplicate host publish is detected and canonicalized fail-closed** (G481) —
-  `automation state-doctor` classifies duplicate execution-unit issues /
-  concurrent host publish (`concurrent-host-publish-detected`,
-  `canonical-issue-mismatch`, `pr-closes-noncanonical-issue`) and offers a safe
-  repair only for an unambiguous duplicate. Canonical selection prefers durable
-  queue-state over live GitHub recency; ambiguous races fail closed without
-  picking a winner by recency.
-- **Packet creation emits complete publish-ready contracts** (G482) — the packet
-  scaffold and the publish validator share one required-section source of truth,
-  the scaffold emits the full contract shape (including `Standalone Child Issue
-  Contract`) by default, and the guide tells agents to dry-run publish
-  validation before declaring a packet ready — so repeated missing-section
-  publish blocks stop recurring.
+- **Windows Japanese `gh` JSON decoding** (G484) — every `gh` subprocess pins
+  UTF-8 stream decoding, so Japanese issue/PR titles and bodies stay valid JSON
+  on a Japanese Windows console (cp932). `worker next-action` / preflight no
+  longer break on non-ASCII payloads, with no `chcp 65001` or manual output
+  encoding required; macOS/Linux behavior is unchanged.
+- **Same-repo metadata publish-flow reliability** (G485) — `queue-seed-from-packet`
+  resolves the domain `execution_unit_regex` through the same shared resolver
+  `automation summary` uses, so a valid same-repo packet (code branch `main`,
+  metadata branch `main-metadata`) seeds and publishes through the regular
+  `queue-seed-from-packet` → `issue publish-flow` → `automation issue-publish`
+  path instead of being rejected as `missing-domain-binding-regex`. The
+  supported `[project]` same-repo config keys are now documented.
 
-**Release-readiness verification (run before tagging the next `v0.3.9`):**
+**Release-readiness verification (run before tagging the next `v0.3.10`):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.3.8 (published), nextVersion 0.3.9 (to release)
+cat eng/version.json   # stableVersion 0.3.9 (published), nextVersion 0.3.10 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.3.9-<sha>-G48x   (NOT a stale literal)
+#   expected shape: intent-cli 0.3.10-<sha>-G48x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.9.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.10.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-The official release is then cut by publishing a GitHub Release tagged `v0.3.9`;
-the release workflow passes `-p:Version=0.3.9` (which wins over the local
+The official release is then cut by publishing a GitHub Release tagged `v0.3.10`;
+the release workflow passes `-p:Version=0.3.10` (which wins over the local
 default). After the release publishes, apply the post-release `eng/version.json`
-bump above (`stableVersion → 0.3.9`, `nextVersion → 0.3.10`).
+bump above (`stableVersion → 0.3.10`, `nextVersion → 0.3.11`).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.3.10.md
+++ b/docs/en/release-notes-v0.3.10.md
@@ -1,0 +1,122 @@
+# Release Notes — intent-cli v0.3.10
+
+> **Release checklist for maintainers:** see [Creating the v0.3.10 GitHub Release](#creating-the-v0310-github-release).
+> **Do NOT tag until the [release-readiness gate](#release-readiness-gate-g486) passes.**
+
+## What's in v0.3.10
+
+v0.3.10 is a dogfooding-stability patch release. It ships the two fixes
+completed after `v0.3.9` that unblock real Estivo users running the
+public/NuGet-installed intent-cli outside the original developer environment:
+Japanese Windows `gh` JSON decoding, and same-repo metadata-branch publish-flow
+reliability. No package id, license, or workflow-semantics changes. The package
+id remains `JTechJapan.IntentSystem.Cli`.
+
+### Windows Japanese `gh` JSON decoding (G484)
+
+- Every `gh` subprocess now decodes stdout/stderr as **UTF-8 regardless of the
+  ambient Windows console code page** (cp932/932). Japanese issue/PR titles and
+  bodies stay valid JSON, so `worker next-action --github-only --format json`,
+  `worker issue-preflight`, `worker pr-comment-preflight`, and the host/review
+  preflight paths no longer break with invalid-JSON parse errors on a Japanese
+  Windows console.
+- You do **not** need to run `chcp 65001` or set `$OutputEncoding` /
+  `[Console]::OutputEncoding` manually. `gh` error output is decoded the same
+  way so diagnostics stay readable. macOS/Linux behavior is unchanged (those
+  consoles are already UTF-8).
+
+### Same-repo metadata publish-flow reliability (G485)
+
+- `automation queue-seed-from-packet` now resolves the domain's
+  `execution_unit_regex` through the **same shared resolver** `automation
+  summary` and the host loop use, instead of a duplicate parser that could
+  disagree. A valid same-repo packet (code branch `main`, metadata branch
+  `main-metadata`) now seeds and publishes through the regular
+  `queue-seed-from-packet` → `issue publish-flow` → `automation issue-publish`
+  path instead of being rejected as `missing-domain-binding-regex`.
+- The refusal diagnostic now names the exact bindings source consulted and
+  points at `automation summary --domain <d>` (the same source), so a missing
+  bindings file vs an empty regex field is actionable without manual queue-state
+  edits.
+- The supported same-repo `[project]` config keys (`same_repo_topology`,
+  `metadata_source_branch`, `metadata_write_branch`) and the seed → publish path
+  are now documented in the developer reference.
+
+> Version metadata note: `eng/version.json` records `stableVersion: 0.3.9`,
+> `nextVersion: 0.3.10`; G486 (this packet) is the release-readiness preparation.
+> The post-v0.3.10 metadata advancement (`stableVersion → 0.3.10`,
+> `nextVersion → 0.3.11`) is the operator's post-release step and is out of scope
+> for this packet.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.10
+```
+
+Or download the self-contained binary from the
+[v0.3.10 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.10).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.9
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.10
+```
+
+There are no breaking changes from v0.3.9.
+
+## Release-readiness gate (G486)
+
+Do not create the `v0.3.10` tag/release until ALL of the following hold
+(this gate fails closed — if any item is unmet, stop and do not tag):
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G484, G485 (and G486 this prep). Confirm on the host/review side via the
+      host queue-state / GitHub PR state — the child implementation loop must not
+      read parent queue-state, so this is a host-owned precondition.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before tagging).
+- [ ] `eng/version.json` `nextVersion` is `0.3.10` (the intended release version)
+      and matches the tag to be created (`v0.3.10`). The release workflow derives
+      the package version from the tag; `-p:Version=` overrides the policy-derived
+      default in `src/IntentSystem.Cli/IntentSystem.Cli.csproj`.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+
+## Creating the v0.3.10 GitHub Release
+
+1. Confirm the [release-readiness gate](#release-readiness-gate-g486) — do not
+   proceed if any item is unmet.
+2. Tag the release commit: `git tag v0.3.10 && git push origin v0.3.10`.
+3. The `release.yml` workflow fires and builds binaries, `.nupkg`, and
+   checksums (version derived from the tag). Wait for it to complete green.
+4. The workflow creates the GitHub Release draft. Review it, paste the content
+   of this file as the release body, and publish.
+5. Confirm the NuGet publish step pushed `JTechJapan.IntentSystem.Cli 0.3.10`.
+6. Post-release verification checklist:
+   - [ ] NuGet.org package page links all resolve correctly.
+   - [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+         accessible.
+   - [ ] `.sha256` checksums match the downloaded artifacts.
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.10`)
+         then `intent-cli --version` reports `0.3.10`.
+   - [ ] Binary artifact smoke check: download the platform archive, verify its
+         `.sha256`, extract, and run `./intent-cli --version` → `0.3.10`.
+   - [ ] **G484 Windows Japanese smoke**: on a Japanese Windows console (cp932),
+         `intent-cli worker next-action --repo <repo> --github-only --format json`
+         parses a Japanese-titled issue without a JSON error.
+   - [ ] **G485 same-repo smoke**: with `[project] same_repo_topology = true` +
+         `metadata_source_branch`/`metadata_write_branch` set, a valid packet
+         passes `automation queue-seed-from-packet` then `issue publish-flow`.
+   - [ ] Local preview/dry-run version metadata uses the next development line
+         after `0.3.10` (bump `eng/version.json` per the post-release step in
+         [Version flow](09-developer-reference.md#version-flow)):
+         `stableVersion → 0.3.10`, `nextVersion → 0.3.11`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -184,83 +184,71 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.3.8",
-  "nextVersion": "0.3.9"
-}
-```
-
-| ステージ | バージョン形式 | 導出方法 |
-| --- | --- | --- |
-| ローカル pack / install | `0.3.9-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.3.9-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.9-rc.N` | タグ `v0.3.9-rc.N` がリリースワークフローをトリガー |
-| 安定版リリース | `0.3.9` | タグ `v0.3.9` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.3.10-preview.<run>.<attempt>` | `nextVersion` を `0.3.10` にバンプ後 |
-
-**`v0.3.9` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
-
-```json
-{
   "stableVersion": "0.3.9",
   "nextVersion": "0.3.10"
 }
 ```
 
+| ステージ | バージョン形式 | 導出方法 |
+| --- | --- | --- |
+| ローカル pack / install | `0.3.10-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.3.10-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.3.10-rc.N` | タグ `v0.3.10-rc.N` がリリースワークフローをトリガー |
+| 安定版リリース | `0.3.10` | タグ `v0.3.10` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.3.11-preview.<run>.<attempt>` | `nextVersion` を `0.3.11` にバンプ後 |
+
+**`v0.3.10` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+
+```json
+{
+  "stableVersion": "0.3.10",
+  "nextVersion": "0.3.11"
+}
+```
+
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.3.10-preview.<run>.<attempt>` / `0.3.10-<sha>-<G-unit>` を生成し、`0.3.9`（安定版
+`0.3.11-preview.<run>.<attempt>` / `0.3.11-<sha>-<G-unit>` を生成し、`0.3.10`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備（v0.3.9）
+### 次リリース準備（v0.3.10）
 
-**`v0.3.8` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
-`0.3.9` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.9`**
-`nextVersion` 上にあり、G483（本パケット）が `v0.3.9` リリースを準備します。次のリリースは
-[リリース準備ゲート](release-notes-v0.3.9.md#リリース準備ゲート-g483)を通過後に `v0.3.9`
+**`v0.3.9` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
+`0.3.10` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.10`**
+`nextVersion` 上にあり、G486（本パケット）が `v0.3.10` リリースを準備します。次のリリースは
+[リリース準備ゲート](release-notes-v0.3.10.md#リリース準備ゲート-g486)を通過後に `v0.3.10`
 タグ付けで publish されます。準備はリリースを cut しません。完全な changelog と operator
-チェックリスト: [release-notes-v0.3.9.md](release-notes-v0.3.9.md)。
+チェックリスト: [release-notes-v0.3.10.md](release-notes-v0.3.10.md)。
 
-**`v0.3.9` で出荷予定（`v0.3.8` 以降の変更）— loop 安定性リリース:**
+**`v0.3.10` で出荷予定（`v0.3.9` 以降の変更）— dogfooding 安定性リリース:**
 
-- **loop wake 中の Asking UI ではなく fail closed**（G479）— すべての recurring loop
-  prompt が単一の共有ポリシーを持ちます: automation wake は操作上の曖昧さで interactive
-  Asking UI を使って停止しません。Asking は狭い safety gate のみに限定され、回復可能な曖昧さは
-  safe repair か次の wake に収束し、回復不能なものは `STOP: <classification>` と 1 つの
-  operator アクションで終わります。並行 host loop を両方継続するような unsafe な選択肢は提示
-  されません。
-- **host-orchestrator と semantic-reviewer の role を明示化**（G480）— host review /
-  next-slice prompt が host-orchestrator・semantic-reviewer（packet `review_role`、既定
-  `Codex` に role-gated）・child-implementer の責務を区別し、agent が過剰レビューも「host は
-  決してレビューしない」という結論も避けます。承認済み PR は別 agent がレビューしても
-  orchestrator が merge 可能なままで、role 不一致は wait / `STOP` であり Asking UI では
-  ありません。
-- **重複 host publish を検出し fail-closed で canonical 化**（G481）—
-  `automation state-doctor` が重複 execution-unit issue / 並行 host publish
-  （`concurrent-host-publish-detected`, `canonical-issue-mismatch`,
-  `pr-closes-noncanonical-issue`）を分類し、曖昧でない重複のみ safe repair を提示します。
-  canonical 選択は live GitHub recency より durable な queue-state を優先し、曖昧な race は
-  recency で勝者を選ばず fail closed します。
-- **packet 作成が完全な publish-ready contract を生成**（G482）— packet scaffold と publish
-  validator が必須セクションの単一情報源を共有し、scaffold は既定で完全な contract 形状
-  （`Standalone Child Issue Contract` を含む）を出力し、guide は packet を ready と宣言する前に
-  publish validation を dry-run するよう指示します。これにより繰り返し発生していた section 欠落
-  による publish ブロックが解消されます。
+- **Windows 日本語 `gh` JSON デコード**（G484）— すべての `gh` サブプロセスが UTF-8 の
+  ストリームデコードを pin するため、日本語 Windows コンソール（cp932）でも issue/PR の
+  タイトルや本文が valid な JSON のまま保たれます。`worker next-action` / preflight が非 ASCII
+  ペイロードで壊れなくなり、`chcp 65001` や手動の出力エンコーディング設定は不要です。
+  macOS/Linux の挙動は不変です。
+- **same-repo メタデータの publish-flow 信頼性**（G485）— `queue-seed-from-packet` が
+  ドメインの `execution_unit_regex` を `automation summary` と同じ共有 resolver で解決する
+  ため、valid な same-repo packet（コードブランチ `main`、メタデータブランチ `main-metadata`）が
+  `missing-domain-binding-regex` で拒否されず、正規の `queue-seed-from-packet` →
+  `issue publish-flow` → `automation issue-publish` 経路で seed/publish できます。サポートされる
+  `[project]` の same-repo 設定キーも文書化しました。
 
-**リリース準備の検証（次の `v0.3.9` タグ付け前に実行）:**
+**リリース準備の検証（次の `v0.3.10` タグ付け前に実行）:**
 
 ```bash
-cat eng/version.json   # stableVersion 0.3.8（公開済み）, nextVersion 0.3.9（リリース対象）
+cat eng/version.json   # stableVersion 0.3.9（公開済み）, nextVersion 0.3.10（リリース対象）
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.3.9-<sha>-G48x （stale なリテラルではない）
+#   期待形: intent-cli 0.3.10-<sha>-G48x （stale なリテラルではない）
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.9.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.10.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-公式リリースは `v0.3.9` タグの GitHub Release publish で cut され、リリースワークフローが
-`-p:Version=0.3.9` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
-`eng/version.json` バンプ（`stableVersion → 0.3.9`, `nextVersion → 0.3.10`）を適用します。
+公式リリースは `v0.3.10` タグの GitHub Release publish で cut され、リリースワークフローが
+`-p:Version=0.3.10` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
+`eng/version.json` バンプ（`stableVersion → 0.3.10`, `nextVersion → 0.3.11`）を適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.3.10.md
+++ b/docs/ja/release-notes-v0.3.10.md
@@ -1,0 +1,115 @@
+# リリースノート — intent-cli v0.3.10
+
+> **メンテナ向けリリースチェックリスト:** [v0.3.10 GitHub リリースの作成](#v0310-github-リリースの作成) を参照。
+> **[リリース準備ゲート](#リリース準備ゲート-g486) を通過するまでタグを打たないこと。**
+
+## v0.3.10 の内容
+
+v0.3.10 は dogfooding 安定性のパッチリリースです。`v0.3.9` 後に完了した 2 つの修正を出荷し、
+オリジナルの開発環境外で public/NuGet 版 intent-cli を使う実ユーザー（Estivo）の障害を解消
+します: 日本語 Windows での `gh` JSON デコードと、same-repo メタデータブランチの publish-flow
+信頼性です。package id・ライセンス・ワークフロー semantics の変更はありません。package id は
+`JTechJapan.IntentSystem.Cli` のままです。
+
+### Windows 日本語 `gh` JSON デコード (G484)
+
+- すべての `gh` サブプロセスが stdout/stderr を **周囲の Windows コンソールのコードページに
+  依存せず UTF-8 として** デコードするようになりました（cp932/932）。日本語 issue/PR の
+  タイトル・本文が valid な JSON のまま保たれるため、`worker next-action --github-only
+  --format json`・`worker issue-preflight`・`worker pr-comment-preflight`・host/review preflight
+  の各経路が日本語 Windows コンソールで invalid-JSON parse エラーにより壊れなくなりました。
+- `chcp 65001` の実行や `$OutputEncoding` / `[Console]::OutputEncoding` の手動設定は **不要**
+  です。`gh` のエラー出力も同じく UTF-8 でデコードされ診断が読めます。macOS/Linux の挙動は
+  不変です（既に UTF-8）。
+
+### same-repo メタデータの publish-flow 信頼性 (G485)
+
+- `automation queue-seed-from-packet` がドメインの `execution_unit_regex` を、乖離し得る
+  重複パーサではなく `automation summary` と host loop が使う **同じ共有 resolver** で解決する
+  ようになりました。valid な same-repo packet（コードブランチ `main`、メタデータブランチ
+  `main-metadata`）が `missing-domain-binding-regex` で拒否されず、正規の
+  `queue-seed-from-packet` → `issue publish-flow` → `automation issue-publish` 経路で
+  seed/publish できます。
+- 拒否時の診断は、参照した bindings ソースを明示し `automation summary --domain <d>`（同一
+  ソース）へ誘導するため、bindings ファイル欠落か空の regex フィールドかを手動 queue-state 編集
+  なしで判別できます。
+- サポートされる same-repo の `[project]` 設定キー（`same_repo_topology`,
+  `metadata_source_branch`, `metadata_write_branch`）と seed → publish 経路を developer
+  reference に文書化しました。
+
+> バージョンメタデータ注記: `eng/version.json` は `stableVersion: 0.3.9`,
+> `nextVersion: 0.3.10` を記録しており、G486（本パケット）はリリース準備です。v0.3.10 後の
+> メタデータ前進（`stableVersion → 0.3.10`, `nextVersion → 0.3.11`）は operator のリリース後
+> 手順であり、本パケットの対象外です。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.10
+```
+
+または
+[v0.3.10 GitHub リリース](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.10)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを
+検証してください。
+
+## v0.3.9 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.10
+```
+
+v0.3.9 からの破壊的変更はありません。
+
+## リリース準備ゲート (G486)
+
+以下が **すべて** 満たされるまで `v0.3.10` タグ/リリースを作成しないこと
+（このゲートは fail-closed — 1 つでも未達なら停止しタグを打たない）:
+
+- [ ] リリース対象パケットがすべて **完了し PR が `main` にマージ済み**:
+      G484, G485（および本準備 G486）。host/review 側で host queue-state /
+      GitHub PR state により確認すること — child 実装 loop は親 queue-state を読まないため、
+      これは host 所有の前提条件です。
+- [ ] 本リリース対象の open な intent-system PR や WIP packet を取りこぼしていないこと
+      （タグ付け前に host queue / open PR 一覧を確認）。
+- [ ] `eng/version.json` の `nextVersion` が `0.3.10`（意図したリリースバージョン）で、
+      作成するタグ（`v0.3.10`）と一致すること。release ワークフローはタグからパッケージ
+      バージョンを導出し、`-p:Version=` が
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` のポリシー導出デフォルトを上書きします。
+- [ ] パッケージメタデータが正しいこと: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` が
+      `https://github.com/J-Tech-Japan/intent-system` を指す,
+      `PackageLicenseExpression = Apache-2.0`, README/docs リンクが解決し,
+      公式サービスサイト `https://www.intent-driven-development.com/` が README から
+      リンクされていること。
+- [ ] release コミットで **main CI が green**（`Build and test (source contract)`）で、
+      **preview-pack** ワークフローが green であること。
+
+## v0.3.10 GitHub リリースの作成
+
+1. [リリース準備ゲート](#リリース準備ゲート-g486) を確認 — 未達項目があれば進めない。
+2. release コミットにタグ: `git tag v0.3.10 && git push origin v0.3.10`。
+3. `release.yml` ワークフローが発火し、バイナリ・`.nupkg`・チェックサムをビルド
+   （バージョンはタグから導出）。green 完了を待つ。
+4. ワークフローが GitHub Release draft を作成。確認し、本ファイルの内容を release body
+   として貼り付け、publish。
+5. NuGet publish ステップが `JTechJapan.IntentSystem.Cli 0.3.10` を push したことを確認。
+6. リリース後の検証チェックリスト:
+   - [ ] NuGet.org パッケージページのリンクがすべて正しく解決する。
+   - [ ] GitHub release アセットリンク（`.tar.gz`, `.zip`, `.exe`, `.nupkg`）が
+         アクセス可能。
+   - [ ] `.sha256` チェックサムがダウンロードしたアーティファクトと一致する。
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`（または
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.10`）の後、
+         `intent-cli --version` が `0.3.10` を報告する。
+   - [ ] バイナリアーティファクトの smoke check: プラットフォームアーカイブをダウンロードし、
+         `.sha256` を検証、展開して `./intent-cli --version` → `0.3.10`。
+   - [ ] **G484 Windows 日本語 smoke**: 日本語 Windows コンソール（cp932）で
+         `intent-cli worker next-action --repo <repo> --github-only --format json` が
+         日本語タイトルの issue を JSON エラーなく解析する。
+   - [ ] **G485 same-repo smoke**: `[project] same_repo_topology = true` ＋
+         `metadata_source_branch`/`metadata_write_branch` 設定で、valid な packet が
+         `automation queue-seed-from-packet` 後 `issue publish-flow` を通過する。
+   - [ ] ローカル preview/dry-run のバージョンメタデータが `0.3.10` 後の次の開発ラインを
+         使う（[Version flow](09-developer-reference.md#version-flow) のリリース後手順に
+         従い `eng/version.json` を bump）: `stableVersion → 0.3.10`, `nextVersion → 0.3.11`。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.8",
-  "nextVersion": "0.3.9"
+  "stableVersion": "0.3.9",
+  "nextVersion": "0.3.10"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,10 +124,10 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.9 as the next development line
-        // (post-v0.3.8 release bump, see G483 — v0.3.8 was published to
+        // be parseable and must point to 0.3.10 as the next development line
+        // (post-v0.3.9 release bump, see G486 — v0.3.9 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.3.9 while recording 0.3.8 as the published stable).
+        // forward to 0.3.10 while recording 0.3.9 as the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -137,8 +137,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.9", policy.NextVersion);
-        Assert.Equal("0.3.8", policy.StableVersion);
+        Assert.Equal("0.3.10", policy.NextVersion);
+        Assert.Equal("0.3.9", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Prepares the repository for an explicit operator release of **v0.3.10**, a patch-level dogfooding-stability release containing G484 and G485. This packet **does not publish the release** — release creation remains an operator/host action after merge (out of scope per the issue).

Both release-bound fixes are merged to `main`: G484 ([#1070](https://github.com/J-Tech-Japan/intent-system/pull/1070)), G485 ([#1072](https://github.com/J-Tech-Japan/intent-system/pull/1072)). Latest public release is v0.3.9.

## What changed (same shape as the G483 v0.3.9 prep)

- **docs (en/ja release notes)** — new `release-notes-v0.3.10.md` covering the two user-visible fixes in user-facing language (G484 UTF-8 `gh` decoding on Japanese Windows cp932 consoles, G485 same-repo `queue-seed`/`publish-flow` binding-resolution unification), install/upgrade pinned to `0.3.10`, a fail-closed **release-readiness gate** (incl. "no open PR / WIP packet accidentally skipped"), and a post-release verification checklist with **G484 Windows-Japanese** and **G485 same-repo** smoke steps.
- **docs (en/ja developer reference)** — retarget the version-flow table and "Next release readiness" section to v0.3.10 / G484-G485, link the release notes, document the post-release `eng/version.json` bump (`stable → 0.3.10`, `next → 0.3.11`).
- **eng/version.json** — advance to `stableVersion 0.3.9` (published) / `nextVersion 0.3.10` (release-to-cut); local pack / `--version` now derive `0.3.10-<sha>-<unit>`.
- **tests** — update `VersionPolicyTests` smoke assertion to next `0.3.10` / stable `0.3.9`. `ReleasePackageMetadataTests` read the policy/docs dynamically and continue to pass.

## Verification

- `intent-cli --version` → `intent-cli 0.3.10-2315c0d-G485` (derived from `nextVersion`, not a stale literal).
- `VersionPolicyTests` + `ReleasePackageMetadataTests` pass; full `IntentSystem.Cli.Tests` suite passes (**3097 passed, 1 skipped**); `git diff --check` clean.
- Release workflow is tag-driven and version-agnostic (`release.yml` passes `-p:Version=0.3.10`) and already publishes NuGet + osx-arm64 / win-x64 / linux-x64 binaries with sha256 sidecars — **no workflow change required**. Package id remains `JTechJapan.IntentSystem.Cli`.

## Acceptance Criteria mapping

- v0.3.10 clearly identified as a patch release containing G484 and G485 ✅
- Release notes mention both dogfooding fixes in user-facing language ✅
- Version source produces v0.3.10 for release; post-release dev line strictly newer (`0.3.11`) ✅ (documented bump)
- Package id `JTechJapan.IntentSystem.Cli`; metadata links absolute/valid ✅
- Post-release checklist covers tool update/install, `--version`, Windows-Japanese `worker next-action` smoke, same-repo `queue-seed`/`publish-flow` smoke, binary smoke ✅
- Release-readiness gate includes a "no open PR / WIP packet skipped" check ✅

Out of scope (per packet): new runtime features, changing G484/G485 behavior, and publishing the GitHub Release inside this PR.

Closes #1073

🤖 Generated with [Claude Code](https://claude.com/claude-code)