### PR TITLE
G487 Add agmsg-backed orchestrator-thread guide surface

### DIFF
--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -272,7 +272,9 @@ internal static class CommandRouter
                 // G334: self-discovery help surface for external users.
                 ["help"] = GuideHelpCommand.Execute,
                 // G438: external artifact intake guidance (external issue / PR review / PR adopt).
-                ["artifact-intake"] = GuideArtifactIntakeCommand.Execute
+                ["artifact-intake"] = GuideArtifactIntakeCommand.Execute,
+                // G487: optional agmsg-backed orchestrator-thread guide surface.
+                ["orchestrator-thread"] = GuideOrchestratorThreadCommand.Execute
             },
             ["intent"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -281,6 +281,13 @@ internal static class GuideHelpCommand
             Name = "artifact-intake",
             Purpose = "G438 AI-agent-facing guidance for importing external GitHub issues and PRs. Three lanes: external-issue (issue intake before intent-target), external-pr-review (PR review before transitions), external-pr-adopt (rare explicit host adoption). Each lane requires lightweight packet/review-context metadata before any label mutation.",
             Example = "intent-cli guide artifact-intake --lane external-issue --repo <owner/repo> --format markdown"
+        },
+        // G487: optional agmsg-backed orchestrator-thread guidance.
+        new GuideSubcommandEntry
+        {
+            Name = "orchestrator-thread",
+            Purpose = "G487 paste-ready prompts for an OPTIONAL agmsg-backed orchestrator thread plus the implementation/review threads it delegates to. agmsg is a message/progress/completion signal layer only; intent-cli and GitHub stay authoritative. Distinguishes timer-loop mode from orchestrator-message mode (no mixed-mode timer races), pins the structured reply contract, an orchestrator first-wake, and safety boundaries. Existing timer-loop mode is not replaced.",
+            Example = "intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --format markdown"
         }
     };
 

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -1,0 +1,400 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G487: read-only guide surface for an OPTIONAL agmsg-backed orchestrator
+/// thread (ADR-012 / spec-26). Renders paste-ready prompts for an orchestrator
+/// thread plus the implementation/review threads it delegates to, and pins the
+/// operating contract: agmsg is a message/progress/completion signal layer
+/// ONLY; <c>intent-cli</c> and GitHub remain authoritative for domain status,
+/// queue-state, issue/PR facts, labels, CI, and closeout. The existing
+/// timer-loop mode stays valid; orchestrator-message mode is opt-in and MUST
+/// NOT also launch implement/review recurring timer loops for the same
+/// domain/repo (no mixed-mode timer races). Host-state-free; never launches an
+/// AI provider; never sends agmsg messages itself.
+/// </summary>
+internal static class GuideOrchestratorThreadCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine =
+        "Usage: intent-cli guide orchestrator-thread [--domain <name>] [--target-repo <owner/repo>] [--agent <agent>] [--format markdown|json]";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var format, out var values, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var guide = BuildGuide(values);
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(guide, JsonOptions));
+            writer.WriteLine();
+            return 0;
+        }
+
+        WriteMarkdown(writer, guide);
+        return 0;
+    }
+
+    private static OrchestratorThreadGuide BuildGuide(IReadOnlyDictionary<string, string> values)
+    {
+        var domain = values["<domain>"];
+        var repo = values["<owner/repo>"];
+        var agent = values["<agent>"];
+
+        string Apply(string template) => template
+            .Replace("<domain>", domain, StringComparison.Ordinal)
+            .Replace("<owner/repo>", repo, StringComparison.Ordinal)
+            .Replace("<agent>", agent, StringComparison.Ordinal);
+
+        return new OrchestratorThreadGuide
+        {
+            Summary =
+                "Optional agmsg-backed orchestrator thread (ADR-012 / spec-26). agmsg carries natural-language "
+                + "delegation / progress / completion / blocker signals between threads; it is NOT workflow state. "
+                + "intent-cli and GitHub remain authoritative for domain status, queue-state, issue/PR facts, labels, "
+                + "CI, and closeout.",
+            ModeSeparation = new OrchestratorModeSeparation
+            {
+                TimerLoopMode =
+                    "Existing mode and still fully supported: implementation and review threads run on recurring "
+                    + "timers and use intent-cli `worker next-action` / host review-next-slice as their source of truth. "
+                    + "Use `intent-cli guide prompt-matrix` / `guide prompt-template` to set these up. No orchestrator "
+                    + "thread is required.",
+                OrchestratorMessageMode =
+                    "Opt-in mode: a fourth orchestrator thread delegates to implementation/review threads over agmsg "
+                    + "instead of relying on independent timers. Choose ONE mode per domain/repo.",
+                MixedModeWarning =
+                    "Do NOT run both modes for the same domain/repo. In orchestrator-message mode, do NOT launch the "
+                    + "implementation/review recurring timer loops for that domain/repo — two drivers (a timer AND the "
+                    + "orchestrator) would race on the same GitHub state. The orchestrator paces those threads; they do "
+                    + "not also self-schedule.",
+            },
+            Threads = new[]
+            {
+                new OrchestratorThreadPrompt
+                {
+                    Role = "orchestrator",
+                    Purpose =
+                        "Coordinate implementation/review threads for domain `" + domain + "` via agmsg; never mutate "
+                        + "workflow state directly.",
+                    Prompt = Apply(
+                        "You are the ORCHESTRATOR thread for domain `<domain>` against `<owner/repo>` using `<agent>`. "
+                        + "You coordinate the implementation and review threads over agmsg; you do NOT implement code, "
+                        + "perform semantic review, or mutate GitHub/intent-cli workflow state yourself. agmsg is a "
+                        + "signal layer only — intent-cli and GitHub are authoritative. Per wake: read pending agmsg "
+                        + "replies, ask intent-cli for the real state (`intent-cli intent status --domain <domain> "
+                        + "--format json`, `intent-cli worker next-action --repo <owner/repo> --github-only --format "
+                        + "json`, `intent-cli automation host-review-preflight --repo <owner/repo> --format json`), "
+                        + "verify the GitHub facts that an agmsg reply claims (merged PR, CI, labels), then send AT MOST "
+                        + "ONE message: a delegation (assign the next slice/PR), a repair request (point a stalled "
+                        + "thread back to the official intent-cli workflow), or an escalation to the operator. Do NOT "
+                        + "launch recurring implement/review timers for this domain/repo while orchestrating. Fail "
+                        + "closed: if you detect a second orchestrator for this domain/repo, or agmsg replies conflict "
+                        + "with GitHub/intent-cli facts, STOP and escalate rather than guessing."),
+                },
+                new OrchestratorThreadPrompt
+                {
+                    Role = "implementation",
+                    Purpose =
+                        "Implement exactly one delegated item, then report a structured agmsg reply.",
+                    Prompt = Apply(
+                        "You are the IMPLEMENTATION thread for domain `<domain>` against `<owner/repo>` using `<agent>`, "
+                        + "driven by orchestrator agmsg delegations (NOT a recurring timer). When delegated an item, run "
+                        + "the normal child implementation workflow: the issue/PR number comes from `intent-cli worker "
+                        + "next-action --repo <owner/repo> --github-only`, NOT from the agmsg text; claim, implement, "
+                        + "open the PR with a `Closes #<issue>` reference, and `worker complete` — all label transitions "
+                        + "through intent-cli worker/automation only. intent-cli and GitHub remain authoritative; agmsg "
+                        + "is only how you receive the delegation and send back your reply. When done or blocked, send "
+                        + "ONE structured agmsg reply (accepted / progress / completed / blocked) citing the GitHub "
+                        + "facts (PR number, CI). Do NOT read host metadata (`.intent-cli/**`, `intents/**`)."),
+                },
+                new OrchestratorThreadPrompt
+                {
+                    Role = "review",
+                    Purpose =
+                        "Review/closeout exactly one delegated PR through intent-cli, then report a structured agmsg reply.",
+                    Prompt = Apply(
+                        "You are the REVIEW thread for domain `<domain>` against `<owner/repo>` using `<agent>`, driven "
+                        + "by orchestrator agmsg delegations (NOT a recurring timer). When delegated a PR, run the "
+                        + "official host review/closeout through intent-cli surfaces (`review closeout-plan`, `guide "
+                        + "review`, `automation pr-transition`, `closeout pr`) — agmsg never replaces semantic review or "
+                        + "authorizes a merge. Perform semantic review only when you are the packet `review_role` or "
+                        + "explicitly assigned (G480); otherwise orchestrate the merge/closeout of an already-approved "
+                        + "PR. Report ONE structured agmsg reply (accepted / progress / completed / blocked) citing the "
+                        + "intent-cli/GitHub facts. intent-cli and GitHub stay authoritative."),
+                },
+            },
+            AgmsgReplyContract = new OrchestratorReplyContract
+            {
+                Description =
+                    "Implementation/review threads reply to a delegation with exactly one structured agmsg message. "
+                    + "The reply is a SIGNAL; the orchestrator re-verifies every claim against intent-cli / GitHub "
+                    + "before acting on it.",
+                Accepted = "{\"status\":\"accepted\",\"thread\":\"implementation\",\"ref\":\"issue#<n>\",\"note\":\"claimed; starting\"}",
+                Progress = "{\"status\":\"progress\",\"thread\":\"implementation\",\"ref\":\"issue#<n>\",\"note\":\"branch pushed; CI running\"}",
+                Completed = "{\"status\":\"completed\",\"thread\":\"implementation\",\"ref\":\"pr#<n>\",\"note\":\"PR opened, Closes #<n>, CI green\"}",
+                Blocked = "{\"status\":\"blocked\",\"thread\":\"review\",\"ref\":\"pr#<n>\",\"classification\":\"clarification-required\",\"note\":\"one operator action: <text>\"}",
+            },
+            OrchestratorFirstWake = new[]
+            {
+                "Confirm you are the ONLY orchestrator for this domain/repo; if a second is detected, STOP and escalate (fail closed).",
+                "Read pending agmsg replies from the implementation/review threads (signals only — do not trust them as state).",
+                Apply("Ask intent-cli for the real state: `intent-cli intent status --domain <domain> --format json` and `intent-cli worker next-action --repo <owner/repo> --github-only --format json`."),
+                "Verify every GitHub fact an agmsg reply claims (PR merged, CI concluded, labels) before acting on it.",
+                "Send AT MOST ONE message this wake: one delegation, one repair request, or one operator escalation — never a batch.",
+                "Do not launch implement/review recurring timers for this domain/repo while orchestrating.",
+            },
+            SafetyBoundaries = new[]
+            {
+                "agmsg is a message/progress/completion signal layer only; intent-cli and GitHub are authoritative for all workflow state.",
+                "No raw label mutation (`gh ... --add-label`/`--remove-label`); every label transition goes through intent-cli worker/automation.",
+                "No hand-editing queue-state, runs.jsonl, packets, or any host metadata (`.intent-cli/**`, `intents/**`).",
+                "agmsg never replaces semantic review or authorizes a merge; review/closeout decisions run through intent-cli review surfaces (G480).",
+                "Process at most one delegation/repair/escalation per orchestrator wake; one delegated item per implementation/review wake.",
+                "Fail closed on duplicate orchestrators for the same domain/repo, or when an agmsg reply conflicts with intent-cli/GitHub facts — STOP and escalate, never guess.",
+                "Never ask intent-cli to launch Claude/Codex/Copilot or any AI provider; intent-cli only emits text the human agent acts on.",
+            },
+            DetailedGuideCommands = new[]
+            {
+                Apply("intent-cli guide prompt-matrix --mode child-loop --target-repo <owner/repo> --agent <agent> --format markdown"),
+                Apply("intent-cli guide prompt-matrix --mode host-loop --domain <domain> --target-repo <owner/repo> --agent <agent> --format markdown"),
+                Apply("intent-cli automation summary --domain <domain> --format json"),
+            },
+        };
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string format,
+        out IReadOnlyDictionary<string, string> values,
+        out string error)
+    {
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        var parsed = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["<domain>"] = "<domain>",
+            ["<owner/repo>"] = "<owner/repo>",
+            ["<agent>"] = "<agent>",
+        };
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            if (!RequiresValue(arg))
+            {
+                values = parsed;
+                error = $"Unknown argument '{arg}'.";
+                return false;
+            }
+
+            if (i + 1 >= args.Length)
+            {
+                values = parsed;
+                error = $"{arg} requires a value.";
+                return false;
+            }
+
+            var value = args[++i];
+            switch (arg)
+            {
+                case "--format":
+                    format = value;
+                    break;
+                case "--domain":
+                    parsed["<domain>"] = value;
+                    break;
+                case "--target-repo":
+                    parsed["<owner/repo>"] = value;
+                    break;
+                case "--agent":
+                    parsed["<agent>"] = value;
+                    break;
+            }
+        }
+
+        if (!string.Equals(format, FormatMarkdown, StringComparison.Ordinal)
+            && !string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            values = parsed;
+            error = $"Unknown --format '{format}'. Supported: markdown, json.";
+            return false;
+        }
+
+        values = parsed;
+        return true;
+    }
+
+    private static bool RequiresValue(string arg) =>
+        string.Equals(arg, "--format", StringComparison.Ordinal)
+        || string.Equals(arg, "--domain", StringComparison.Ordinal)
+        || string.Equals(arg, "--target-repo", StringComparison.Ordinal)
+        || string.Equals(arg, "--agent", StringComparison.Ordinal);
+
+    private static void WriteMarkdown(TextWriter writer, OrchestratorThreadGuide guide)
+    {
+        writer.WriteLine("# Guide — agmsg-backed orchestrator thread (G487)");
+        writer.WriteLine();
+        writer.WriteLine(guide.Summary);
+        writer.WriteLine();
+
+        writer.WriteLine("## Mode separation");
+        writer.WriteLine();
+        writer.WriteLine($"- **timer-loop mode** — {guide.ModeSeparation.TimerLoopMode}");
+        writer.WriteLine($"- **orchestrator-message mode** — {guide.ModeSeparation.OrchestratorMessageMode}");
+        writer.WriteLine($"- **mixed-mode warning** — {guide.ModeSeparation.MixedModeWarning}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Thread prompts");
+        foreach (var thread in guide.Threads)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"### {thread.Role}");
+            writer.WriteLine();
+            writer.WriteLine($"- purpose: {thread.Purpose}");
+            writer.WriteLine();
+            writer.WriteLine("```text");
+            writer.WriteLine(thread.Prompt);
+            writer.WriteLine("```");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## agmsg reply contract");
+        writer.WriteLine();
+        writer.WriteLine(guide.AgmsgReplyContract.Description);
+        writer.WriteLine();
+        writer.WriteLine("```json");
+        writer.WriteLine(guide.AgmsgReplyContract.Accepted);
+        writer.WriteLine(guide.AgmsgReplyContract.Progress);
+        writer.WriteLine(guide.AgmsgReplyContract.Completed);
+        writer.WriteLine(guide.AgmsgReplyContract.Blocked);
+        writer.WriteLine("```");
+        writer.WriteLine();
+
+        writer.WriteLine("## Orchestrator first wake");
+        writer.WriteLine();
+        foreach (var step in guide.OrchestratorFirstWake)
+        {
+            writer.WriteLine($"1. {step}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Safety boundaries");
+        writer.WriteLine();
+        foreach (var boundary in guide.SafetyBoundaries)
+        {
+            writer.WriteLine($"- {boundary}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Detailed guide commands");
+        writer.WriteLine();
+        foreach (var command in guide.DetailedGuideCommands)
+        {
+            writer.WriteLine($"- `{command}`");
+        }
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide orchestrator-thread");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("Renders paste-ready prompts for an OPTIONAL agmsg-backed orchestrator thread plus the");
+        writer.WriteLine("implementation/review threads it delegates to. agmsg is a signal layer only; intent-cli and");
+        writer.WriteLine("GitHub remain authoritative. Existing timer-loop mode stays valid and is not replaced.");
+    }
+}
+
+internal sealed record OrchestratorThreadGuide
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("mode_separation")]
+    public required OrchestratorModeSeparation ModeSeparation { get; init; }
+
+    [JsonPropertyName("threads")]
+    public required IReadOnlyList<OrchestratorThreadPrompt> Threads { get; init; }
+
+    [JsonPropertyName("agmsg_reply_contract")]
+    public required OrchestratorReplyContract AgmsgReplyContract { get; init; }
+
+    [JsonPropertyName("orchestrator_first_wake")]
+    public required IReadOnlyList<string> OrchestratorFirstWake { get; init; }
+
+    [JsonPropertyName("safety_boundaries")]
+    public required IReadOnlyList<string> SafetyBoundaries { get; init; }
+
+    [JsonPropertyName("detailed_guide_commands")]
+    public required IReadOnlyList<string> DetailedGuideCommands { get; init; }
+}
+
+internal sealed record OrchestratorModeSeparation
+{
+    [JsonPropertyName("timer_loop_mode")]
+    public required string TimerLoopMode { get; init; }
+
+    [JsonPropertyName("orchestrator_message_mode")]
+    public required string OrchestratorMessageMode { get; init; }
+
+    [JsonPropertyName("mixed_mode_warning")]
+    public required string MixedModeWarning { get; init; }
+}
+
+internal sealed record OrchestratorThreadPrompt
+{
+    [JsonPropertyName("role")]
+    public required string Role { get; init; }
+
+    [JsonPropertyName("purpose")]
+    public required string Purpose { get; init; }
+
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+}
+
+internal sealed record OrchestratorReplyContract
+{
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    [JsonPropertyName("accepted")]
+    public required string Accepted { get; init; }
+
+    [JsonPropertyName("progress")]
+    public required string Progress { get; init; }
+
+    [JsonPropertyName("completed")]
+    public required string Completed { get; init; }
+
+    [JsonPropertyName("blocked")]
+    public required string Blocked { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -173,7 +173,9 @@ internal static class Program
                 || string.Equals(args[1], "help", StringComparison.Ordinal)
                 || string.Equals(args[1], "--help", StringComparison.Ordinal)
                 // G438: external artifact intake guidance — read-only, no host state required.
-                || string.Equals(args[1], "artifact-intake", StringComparison.Ordinal));
+                || string.Equals(args[1], "artifact-intake", StringComparison.Ordinal)
+                // G487: optional agmsg-backed orchestrator-thread guidance — read-only, no host state required.
+                || string.Equals(args[1], "orchestrator-thread", StringComparison.Ordinal));
     }
 
     /// <summary>

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G487: coverage for the optional agmsg-backed orchestrator-thread guide
+/// surface — mode separation (no mixed-mode timer races), the three thread
+/// prompts, the structured agmsg reply contract, the orchestrator first-wake,
+/// and the safety boundaries — across both markdown and JSON output.
+/// </summary>
+public sealed class GuideOrchestratorThreadCommandTests
+{
+    [Fact]
+    public void Execute_Markdown_SeparatesTimerLoopFromOrchestratorMode_AndForbidsMixedTimers()
+    {
+        var output = RunMarkdown(["--domain", "estivo", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("# Guide — agmsg-backed orchestrator thread (G487)", output, StringComparison.Ordinal);
+        Assert.Contains("## Mode separation", output, StringComparison.Ordinal);
+        Assert.Contains("timer-loop mode", output, StringComparison.Ordinal);
+        Assert.Contains("orchestrator-message mode", output, StringComparison.Ordinal);
+        // The existing timer-loop mode is preserved, not replaced.
+        Assert.Contains("still fully supported", output, StringComparison.Ordinal);
+        // Mixed-mode timer race is explicitly forbidden.
+        Assert.Contains("do NOT launch the implementation/review recurring timer loops", output, StringComparison.Ordinal);
+        // agmsg is signal-only; intent-cli/GitHub authoritative.
+        Assert.Contains("agmsg", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli and GitHub remain authoritative", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_EmitsThreePasteReadyThreadPrompts()
+    {
+        var output = RunMarkdown(["--domain", "estivo", "--target-repo", "owner/repo", "--agent", "codex"]);
+
+        Assert.Contains("### orchestrator", output, StringComparison.Ordinal);
+        Assert.Contains("### implementation", output, StringComparison.Ordinal);
+        Assert.Contains("### review", output, StringComparison.Ordinal);
+        // Placeholders are substituted into the prompts.
+        Assert.Contains("domain `estivo`", output, StringComparison.Ordinal);
+        Assert.Contains("`owner/repo`", output, StringComparison.Ordinal);
+        Assert.Contains("`codex`", output, StringComparison.Ordinal);
+        // Implementation thread still derives issue/PR numbers from worker next-action, not agmsg text.
+        Assert.Contains("worker next-action", output, StringComparison.Ordinal);
+        Assert.Contains("Closes #<issue>", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_EmitsStructuredReplyContractAndFirstWakeAndBoundaries()
+    {
+        var output = RunMarkdown([]);
+
+        // Reply contract: accepted / progress / completed / blocked.
+        Assert.Contains("## agmsg reply contract", output, StringComparison.Ordinal);
+        Assert.Contains("\"status\":\"accepted\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"status\":\"progress\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"status\":\"completed\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"status\":\"blocked\"", output, StringComparison.Ordinal);
+
+        // First wake: read replies, ask intent-cli, verify GitHub, one message per wake.
+        Assert.Contains("## Orchestrator first wake", output, StringComparison.Ordinal);
+        Assert.Contains("Send AT MOST ONE message this wake", output, StringComparison.Ordinal);
+
+        // Safety boundaries.
+        Assert.Contains("## Safety boundaries", output, StringComparison.Ordinal);
+        Assert.Contains("No raw label mutation", output, StringComparison.Ordinal);
+        Assert.Contains("No hand-editing queue-state", output, StringComparison.Ordinal);
+        Assert.Contains("never replaces semantic review", output, StringComparison.Ordinal);
+        Assert.Contains("Fail closed on duplicate orchestrators", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasStableShape_WithThreeThreadsAndReplyContract()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "estivo", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+
+        var roles = root.GetProperty("threads").EnumerateArray()
+            .Select(t => t.GetProperty("role").GetString())
+            .ToArray();
+        Assert.Equal(new[] { "orchestrator", "implementation", "review" }, roles);
+
+        var contract = root.GetProperty("agmsg_reply_contract");
+        Assert.True(contract.TryGetProperty("accepted", out _));
+        Assert.True(contract.TryGetProperty("progress", out _));
+        Assert.True(contract.TryGetProperty("completed", out _));
+        Assert.True(contract.TryGetProperty("blocked", out _));
+
+        Assert.NotEmpty(root.GetProperty("orchestrator_first_wake").EnumerateArray());
+        Assert.NotEmpty(root.GetProperty("safety_boundaries").EnumerateArray());
+
+        var mode = root.GetProperty("mode_separation");
+        Assert.True(mode.TryGetProperty("timer_loop_mode", out _));
+        Assert.True(mode.TryGetProperty("orchestrator_message_mode", out _));
+        Assert.True(mode.TryGetProperty("mixed_mode_warning", out _));
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ExitsOne()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(), ["--nope"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Help_ExplainsOptionalAndNonReplacing()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(), ["--help"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("guide orchestrator-thread", output, StringComparison.Ordinal);
+        Assert.Contains("OPTIONAL", output, StringComparison.Ordinal);
+        Assert.Contains("not replaced", output, StringComparison.Ordinal);
+    }
+
+    private static string RunMarkdown(string[] args)
+    {
+        using var writer = new StringWriter();
+        var fullArgs = args.Concat(new[] { "--format", "markdown" }).ToArray();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(CreateContext(), fullArgs, writer);
+        Assert.Equal(0, exitCode);
+        return writer.ToString();
+    }
+
+    private static CliContext CreateContext()
+    {
+        return new CliContext
+        {
+            RepoRoot = Path.GetTempPath(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                },
+            },
+        };
+    }
+}


### PR DESCRIPTION
## Summary

Turns the agmsg-backed orchestrator-thread design (ADR-012 / spec-26) into a canonical, read-only `intent-cli` guide surface, so agents stop inventing conflicting prompts, mixing timer loops with orchestrator messaging, or letting an orchestrator mutate workflow state directly.

## What changed

- New **`intent-cli guide orchestrator-thread`** command (`[--domain] [--target-repo] [--agent] [--format markdown|json]`). Host-state-free (added to the guide bootstrap allow-list in `Program.cs` and the `GuideHelpCommand` catalog), never launches an AI provider, never sends agmsg itself.
- Renders **paste-ready prompts** for the orchestrator, implementation, and review threads, plus the operating contract:
  - **Mode separation** — existing **timer-loop mode** stays fully supported; **orchestrator-message mode** is opt-in; **mixed-mode is forbidden** — in orchestrator-message mode the implementation/review recurring timers for the same domain/repo are **not** launched (no two-driver GitHub race).
  - **Structured agmsg reply contract** — `accepted` / `progress` / `completed` / `blocked`.
  - **Orchestrator first-wake** — confirm single orchestrator, read agmsg replies, ask intent-cli, verify GitHub facts, send **at most one** delegation/repair/escalation per wake.
  - **Safety boundaries** — agmsg is a signal layer only (intent-cli + GitHub authoritative); no raw label mutation; no queue-state/host-metadata hand edits; agmsg never replaces semantic review or authorizes a merge; fail closed on duplicate orchestrators or facts conflicting with intent-cli/GitHub.

## Tests

`GuideOrchestratorThreadCommandTests`: markdown + JSON coverage for mode separation (and the mixed-timer prohibition), the three thread prompts with placeholder substitution, the reply contract, the first-wake, and the safety boundaries; help text; unknown-argument handling. The existing `CommandRouter` registry / `GuideHelpCommand` catalog consistency test passes (new entry added). Full `IntentSystem.Cli.Tests` suite passes (**3103 passed, 1 skipped**); `git diff --check` clean.

## Acceptance Criteria mapping

- An AI can obtain a canonical agmsg-orchestrator guide from intent-cli ✅ (`guide orchestrator-thread`, host-state-free, discoverable via `guide help`)
- Guidance distinguishes timer-loop mode from orchestrator-message mode and avoids mixed-mode timer races ✅
- Implementation/review prompts require structured agmsg completion/blocker replies while keeping intent-cli/GitHub authoritative ✅
- Minimal orchestrator first-wake procedure included ✅
- Tests cover mode separation, reply contract, and safety boundaries ✅

Out of scope (per packet): installing/vendoring agmsg, sending agmsg from intent-cli, launching AI providers, replacing the existing timer-loop prompts, building a daemon/persistent state store. The ADR-012 / spec-26 / means-intent documents referenced by the issue are host-owned `intents/**` and are not modified by this child implementation PR.

Closes #1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)