### PR TITLE
G489: Add single/multi-domain routing to orchestrator-thread guide

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1,0 +1,113 @@
+# Agent-message orchestration (single-domain vs multi-domain)
+
+← [Review standing policy](11-review-standing-policy.md) | [docs index](README.md)
+
+This page describes the **optional** agmsg-backed orchestrator thread and, in
+particular, how it stays safe when a single host repository holds **several
+intent domains**. The authoritative, paste-ready prompts come from installed
+intent-cli guidance — do not copy prompts from this page by hand. Generate the
+current prompts with:
+
+```text
+intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --mode single-domain|multi-domain --format markdown
+```
+
+## What agmsg is (and is not)
+
+agmsg is a **message / progress / completion / blocker signal layer only**. It
+carries natural-language delegation and reply signals between threads.
+
+`intent-cli` and GitHub remain **authoritative** for queue-state, issue/PR
+facts, labels, CI, review, closeout, and recovery. A signal is never workflow
+state: the orchestrator re-verifies every claim against intent-cli / GitHub
+before acting on it. intent-cli never launches Claude/Codex or any AI provider.
+
+## Two driver modes (pick one per domain/repo)
+
+| Mode | Driver | Notes |
+|---|---|---|
+| **timer-loop mode** | recurring timers | Existing, fully supported. Implementation/review threads self-schedule and read `worker next-action` / host review-next-slice. No orchestrator required. |
+| **orchestrator-message mode** | a fourth orchestrator thread | Opt-in. The orchestrator paces the implementation/review threads over agmsg instead of timers. |
+
+Do **not** run both modes for the same domain/repo. In orchestrator-message
+mode, do not also launch the implementation/review recurring timer loops — two
+drivers would race on the same GitHub state.
+
+## Single-domain vs multi-domain orchestration
+
+A host checkout can legitimately contain **several** intent domains (for
+example `sekiban-as-a-service`, `sekiban-wasm-runtime`, and `intent-cli`), and
+**more than one domain may target the same GitHub repository**. Visibility is
+not authorization. The orchestrator therefore operates in one of two modes.
+
+### Single-domain orchestrator
+
+- Only the selected domain is in scope.
+- Other-domain queue items that are **visible** in the same host repo are
+  **out of scope** — do not publish, delegate, or repair them, even when they
+  target the same repository.
+- Escalate to the operator to switch domain/mode instead of treating a visible
+  other-domain item as delegable.
+
+### Multi-domain orchestrator
+
+- Intentionally coordinates several domains.
+- Requires **explicit routing metadata for each delegation** before
+  publishing, delegating, reviewing, or repairing.
+- Routes each execution unit only to the thread that owns that domain's
+  checkout.
+
+Every multi-domain delegation must carry:
+
+- domain
+- execution unit
+- target repo
+- implementation cwd/worktree
+- review cwd/worktree
+- base branch policy
+- destination thread
+
+Example delegation payload (note one repo serving two domains):
+
+```json
+{"delegate":{"domain":"sekiban-as-a-service","execution_unit":"G491","target_repo":"J-Tech-Japan/intent-system","impl_cwd":"/work/sekiban-saas","review_cwd":"/review/sekiban-saas","base_branch_policy":"direct-main","destination_thread":"implementation@sekiban-as-a-service"}}
+```
+
+### Execution-unit prefix is not a routing signal
+
+An execution-unit ID prefix that differs from the domain name (e.g. a `G###`
+unit whose number does not encode the domain) is **not by itself** a wrong-repo
+signal. Compare the **packet/domain metadata** and the **routing context** to
+decide ownership — never the prefix string alone.
+
+## Implementation thread: verify your checkout before claiming
+
+The implementation thread is driven by orchestrator delegations, but the
+worker target still comes from receiver-side
+`intent-cli worker next-action --repo <owner/repo> --github-only` — **not** from
+the agmsg text. Before claiming:
+
+1. Verify your local checkout context — cwd/worktree, git remote repo, and the
+   delegated domain — matches the routing you were handed.
+2. If the checkout does not match the delegated repo/domain, **stop and reply
+   blocked** instead of claiming.
+3. Remember that a prefix mismatch alone is not a wrong-repo signal; confirm
+   ownership via packet/domain metadata and the routing context.
+
+Implementation threads stay **GitHub-contract-only**: they do not read or
+mutate host metadata (`.intent-cli/**`, `intents/**`). All label transitions go
+through `intent-cli worker` / `intent-cli automation`.
+
+## Safety boundaries (summary)
+
+- agmsg is a signal layer only; intent-cli and GitHub are authoritative for all
+  workflow state.
+- No raw label mutation; every transition runs through intent-cli
+  worker/automation.
+- No hand-editing of queue-state, runs logs, packets, or host metadata.
+- agmsg never replaces semantic review or authorizes a merge.
+- Domain isolation: visibility is not authorization. Single-domain
+  orchestrators ignore/escalate other-domain items; multi-domain orchestrators
+  require explicit per-delegation routing.
+- Fail closed on duplicate orchestrators or when a signal conflicts with
+  intent-cli/GitHub facts — stop and escalate, never guess.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -25,6 +25,7 @@ The agent runs `intent-cli` internally and brings back questions or results. You
 7. [Recover when a loop looks wrong](07-recovery.md)
 8. [Command reference](08-command-reference.md) — agent-facing and power-user command surfaces
 9. [Developer reference](09-developer-reference.md) — packaged invocation, preview channel, version flow
+12. [Agent-message orchestration](12-agent-message-orchestration.md) — optional agmsg orchestrator thread; single-domain vs multi-domain routing
 
 ## What is Intent Storming?
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -1,0 +1,109 @@
+# agent メッセージオーケストレーション（single-domain と multi-domain）
+
+← [レビュー standing-policy](11-review-standing-policy.md) | [docs インデックス](README.md)
+
+このページは **オプションの** agmsg ベースの orchestrator スレッドと、特に
+1 つの host リポジトリが **複数の intent ドメイン** を保持する場合に、それを
+どう安全に保つかを説明します。権威ある貼り付け可能なプロンプトはインストール済み
+の intent-cli ガイダンスから生成され、このページのプロンプトを手で写してはいけません。
+現在のプロンプトは次で生成します:
+
+```text
+intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --mode single-domain|multi-domain --format markdown
+```
+
+## agmsg とは（そして何ではないか）
+
+agmsg は **メッセージ / 進捗 / 完了 / ブロッカーのシグナル層のみ** です。スレッド間で
+自然言語の委譲・返信シグナルを運びます。
+
+`intent-cli` と GitHub は queue-state、issue/PR の事実、label、CI、レビュー、closeout、
+recovery について **権威** であり続けます。シグナルはワークフロー状態ではありません。
+orchestrator はそれに従って行動する前に、すべての主張を intent-cli / GitHub に対して
+**再検証** します。intent-cli は Claude/Codex などの AI プロバイダーを起動しません。
+
+## 2 つのドライバーモード（domain/repo ごとに 1 つを選ぶ）
+
+| モード | ドライバー | 備考 |
+|---|---|---|
+| **timer-loop モード** | 定期タイマー | 既存・完全サポート。実装/レビュースレッドが自己スケジュールし、`worker next-action` / host review-next-slice を読む。orchestrator は不要。 |
+| **orchestrator-message モード** | 4 つ目の orchestrator スレッド | オプトイン。orchestrator がタイマーの代わりに agmsg 経由で実装/レビュースレッドをペース配分する。 |
+
+同じ domain/repo に対して両モードを同時に実行しては **いけません**。
+orchestrator-message モードでは、実装/レビューの定期タイマーループも起動しないでください。
+2 つのドライバーが同じ GitHub 状態を奪い合ってしまいます。
+
+## single-domain と multi-domain のオーケストレーション
+
+host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:
+`sekiban-as-a-service`、`sekiban-wasm-runtime`、`intent-cli`）。さらに
+**複数のドメインが同じ GitHub リポジトリを対象** にすることもあります。可視であることは
+権限ではありません。そのため orchestrator は次の 2 モードのいずれかで動作します。
+
+### single-domain orchestrator
+
+- 選択したドメインのみがスコープ内。
+- 同じ host repo に **可視** な他ドメインの queue 項目は **スコープ外** — たとえ
+  同じリポジトリを対象にしていても、publish / delegate / repair してはいけません。
+- 可視な他ドメイン項目を delegate 可能と見なすのではなく、domain/mode を切り替えるよう
+  オペレーターにエスカレーションします。
+
+### multi-domain orchestrator
+
+- 意図的に複数ドメインを調整します。
+- publish / delegate / review / repair の前に、**各委譲ごとに明示的なルーティング
+  メタデータ** を要求します。
+- 各 execution unit を、そのドメインのチェックアウトを所有するスレッドにのみ
+  ルーティングします。
+
+すべての multi-domain 委譲は次を伴わなければなりません:
+
+- domain
+- execution unit
+- target repo
+- implementation cwd/worktree
+- review cwd/worktree
+- base branch policy
+- destination thread
+
+委譲ペイロードの例（1 つの repo が 2 つのドメインに供給している点に注意）:
+
+```json
+{"delegate":{"domain":"sekiban-as-a-service","execution_unit":"G491","target_repo":"J-Tech-Japan/intent-system","impl_cwd":"/work/sekiban-saas","review_cwd":"/review/sekiban-saas","base_branch_policy":"direct-main","destination_thread":"implementation@sekiban-as-a-service"}}
+```
+
+### execution-unit の prefix はルーティングシグナルではない
+
+ドメイン名と異なる execution-unit ID の prefix（例: 番号がドメインを符号化していない
+`G###` ユニット）は、それ **単独では** wrong-repo シグナルでは **ありません**。
+所有権の判断には prefix 文字列ではなく **packet/domain メタデータ** と
+**ルーティングコンテキスト** を比較してください。
+
+## 実装スレッド: claim 前にチェックアウトを検証する
+
+実装スレッドは orchestrator の委譲で駆動されますが、worker のターゲットは依然として
+受信側の `intent-cli worker next-action --repo <owner/repo> --github-only` から来ます
+— agmsg のテキストからでは **ありません**。claim する前に:
+
+1. ローカルチェックアウトのコンテキスト — cwd/worktree、git remote repo、委譲された
+   domain — が、渡されたルーティングと一致することを検証する。
+2. チェックアウトが委譲された repo/domain と一致しない場合は、claim せずに
+   **停止して blocked を返す**。
+3. prefix の不一致だけでは wrong-repo シグナルにならないことを忘れない。所有権は
+   packet/domain メタデータとルーティングコンテキストで確認する。
+
+実装スレッドは **GitHub-contract-only** を維持します。host メタデータ
+（`.intent-cli/**`、`intents/**`）を読んだり変更したりしません。すべての label 遷移は
+`intent-cli worker` / `intent-cli automation` を経由します。
+
+## セーフティ境界（まとめ）
+
+- agmsg はシグナル層のみ。intent-cli と GitHub がすべてのワークフロー状態の権威。
+- 生の label 変更は禁止。すべての遷移は intent-cli worker/automation を経由。
+- queue-state、runs ログ、packet、host メタデータの手編集は禁止。
+- agmsg はセマンティックレビューを置き換えず、マージを認可しない。
+- ドメイン分離: 可視であることは権限ではない。single-domain orchestrator は他ドメイン
+  項目を無視/エスカレーションし、multi-domain orchestrator は委譲ごとの明示的ルーティング
+  を要求する。
+- orchestrator の重複や、シグナルが intent-cli/GitHub の事実と矛盾する場合は fail closed —
+  推測せず、停止してエスカレーションする。

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -25,6 +25,7 @@ agent が内部で `intent-cli` を実行し、質問や結果を返します。
 7. [ループがおかしいときの復旧](07-recovery.md)
 8. [コマンドリファレンス](08-command-reference.md) — agent 向け・パワーユーザー向けコマンド一覧
 9. [開発者リファレンス](09-developer-reference.md) — パッケージ化された実行、preview チャンネル、バージョンフロー
+12. [agent メッセージオーケストレーション](12-agent-message-orchestration.md) — オプションの agmsg orchestrator スレッド、single-domain と multi-domain のルーティング
 
 ## Intent Storming とは
 

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -14,14 +14,28 @@ namespace IntentSystem.Cli.Commands;
 /// NOT also launch implement/review recurring timer loops for the same
 /// domain/repo (no mixed-mode timer races). Host-state-free; never launches an
 /// AI provider; never sends agmsg messages itself.
+///
+/// G489: a host repo can legitimately hold several intent domains (e.g.
+/// <c>sekiban-as-a-service</c>, <c>sekiban-wasm-runtime</c>, <c>intent-cli</c>),
+/// and more than one domain may target the same GitHub repository. The guide
+/// therefore distinguishes a SINGLE-DOMAIN orchestrator (only one domain in
+/// scope even though other-domain metadata is visible) from a MULTI-DOMAIN
+/// orchestrator (intentionally coordinates several domains and must carry
+/// explicit per-delegation routing). <c>--mode single-domain|multi-domain</c>
+/// selects which contract the generated prompts emphasize. An execution-unit
+/// ID prefix mismatch alone is NOT a wrong-repo signal — packet/domain metadata
+/// and routing context decide.
 /// </summary>
 internal static class GuideOrchestratorThreadCommand
 {
     private const string FormatJson = "json";
     private const string FormatMarkdown = "markdown";
 
+    private const string ModeSingleDomain = "single-domain";
+    private const string ModeMultiDomain = "multi-domain";
+
     private const string UsageLine =
-        "Usage: intent-cli guide orchestrator-thread [--domain <name>] [--target-repo <owner/repo>] [--agent <agent>] [--format markdown|json]";
+        "Usage: intent-cli guide orchestrator-thread [--domain <name>] [--target-repo <owner/repo>] [--agent <agent>] [--mode single-domain|multi-domain] [--format markdown|json]";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -66,11 +80,32 @@ internal static class GuideOrchestratorThreadCommand
         var domain = values["<domain>"];
         var repo = values["<owner/repo>"];
         var agent = values["<agent>"];
+        var mode = values["<mode>"];
+        var multiDomain = string.Equals(mode, ModeMultiDomain, StringComparison.Ordinal);
 
         string Apply(string template) => template
             .Replace("<domain>", domain, StringComparison.Ordinal)
             .Replace("<owner/repo>", repo, StringComparison.Ordinal)
             .Replace("<agent>", agent, StringComparison.Ordinal);
+
+        // G489: the orchestrator prompt carries a mode-specific routing clause —
+        // single-domain orchestrators stay scoped to one domain; multi-domain
+        // orchestrators must attach explicit routing metadata to each delegation.
+        var routingClause = multiDomain
+            ? Apply(
+                " You are in MULTI-DOMAIN mode: you intentionally coordinate several domains, and a single host repo "
+                + "can hold several domains while one target repo (`<owner/repo>`) may receive work from more than one "
+                + "domain. Before EACH delegation you MUST attach explicit routing metadata — domain, execution unit, "
+                + "target repo, implementation cwd/worktree, review cwd/worktree, base branch policy, and destination "
+                + "thread — and send each execution unit only to the thread that owns that domain's checkout. Never "
+                + "delegate without complete routing. An execution-unit ID prefix that differs from the domain name is "
+                + "NOT by itself a wrong-repo signal — compare packet/domain metadata and the routing context, not the "
+                + "prefix.")
+            : Apply(
+                " You are in SINGLE-DOMAIN mode: only domain `<domain>` is in scope. A host checkout can expose other "
+                + "domains' metadata in the same repo; those other-domain items are OUT OF SCOPE — do NOT delegate, "
+                + "publish, or repair them, even if they target `<owner/repo>`. Escalate to the operator to switch "
+                + "domain/mode instead of treating a visible other-domain item as delegable.");
 
         return new OrchestratorThreadGuide
         {
@@ -95,6 +130,39 @@ internal static class GuideOrchestratorThreadCommand
                     + "orchestrator) would race on the same GitHub state. The orchestrator paces those threads; they do "
                     + "not also self-schedule.",
             },
+            DomainRouting = new OrchestratorDomainRouting
+            {
+                Mode = mode,
+                SingleDomainRule = Apply(
+                    "Single-domain orchestrator: only domain `<domain>` is in scope. A host repo can hold several "
+                    + "domains, so other-domain queue items may be VISIBLE in the same checkout — they are OUT OF SCOPE "
+                    + "unless the operator switches domain/mode. Do not publish, delegate, or repair another domain's "
+                    + "item just because it is visible or targets the same repo; escalate instead."),
+                MultiDomainRule = Apply(
+                    "Multi-domain orchestrator: intentionally coordinates several domains. One target repo can receive "
+                    + "work from more than one domain, so visibility is not authorization. Require explicit routing "
+                    + "metadata for EACH delegation before publishing, delegating, reviewing, or repairing, and route "
+                    + "each execution unit to the thread that owns that domain's checkout."),
+                RoutingMetadataFields = new[]
+                {
+                    "domain",
+                    "execution unit",
+                    "target repo",
+                    "implementation cwd/worktree",
+                    "review cwd/worktree",
+                    "base branch policy",
+                    "destination thread",
+                },
+                DelegationExample =
+                    "{\"delegate\":{\"domain\":\"sekiban-as-a-service\",\"execution_unit\":\"G491\","
+                    + "\"target_repo\":\"J-Tech-Japan/intent-system\",\"impl_cwd\":\"/work/sekiban-saas\","
+                    + "\"review_cwd\":\"/review/sekiban-saas\",\"base_branch_policy\":\"direct-main\","
+                    + "\"destination_thread\":\"implementation@sekiban-as-a-service\"}}",
+                PrefixMismatchNote =
+                    "Do NOT treat an execution-unit ID prefix that differs from the domain name as a wrong-repo signal "
+                    + "on its own (a host repo can hold several domains, and one repo can serve several domains). Compare "
+                    + "the packet/domain metadata and the routing context to decide ownership, not the prefix string.",
+            },
             Threads = new[]
             {
                 new OrchestratorThreadPrompt
@@ -116,7 +184,8 @@ internal static class GuideOrchestratorThreadCommand
                         + "thread back to the official intent-cli workflow), or an escalation to the operator. Do NOT "
                         + "launch recurring implement/review timers for this domain/repo while orchestrating. Fail "
                         + "closed: if you detect a second orchestrator for this domain/repo, or agmsg replies conflict "
-                        + "with GitHub/intent-cli facts, STOP and escalate rather than guessing."),
+                        + "with GitHub/intent-cli facts, STOP and escalate rather than guessing."
+                        + routingClause),
                 },
                 new OrchestratorThreadPrompt
                 {
@@ -127,12 +196,18 @@ internal static class GuideOrchestratorThreadCommand
                         "You are the IMPLEMENTATION thread for domain `<domain>` against `<owner/repo>` using `<agent>`, "
                         + "driven by orchestrator agmsg delegations (NOT a recurring timer). When delegated an item, run "
                         + "the normal child implementation workflow: the issue/PR number comes from `intent-cli worker "
-                        + "next-action --repo <owner/repo> --github-only`, NOT from the agmsg text; claim, implement, "
-                        + "open the PR with a `Closes #<issue>` reference, and `worker complete` — all label transitions "
-                        + "through intent-cli worker/automation only. intent-cli and GitHub remain authoritative; agmsg "
-                        + "is only how you receive the delegation and send back your reply. When done or blocked, send "
-                        + "ONE structured agmsg reply (accepted / progress / completed / blocked) citing the GitHub "
-                        + "facts (PR number, CI). Do NOT read host metadata (`.intent-cli/**`, `intents/**`)."),
+                        + "next-action --repo <owner/repo> --github-only`, NOT from the agmsg text. Before claiming, "
+                        + "verify your local checkout context matches the delegation: your cwd/worktree, the git remote "
+                        + "repo, and the delegated domain must line up with the routing you were handed. If the checkout "
+                        + "does not match the delegated repo/domain, STOP and reply blocked instead of claiming. An "
+                        + "execution-unit ID prefix that differs from the domain name is NOT by itself a wrong-repo "
+                        + "signal — confirm via packet/domain metadata and the routing context, not the prefix. Then "
+                        + "claim, implement, open the PR with a `Closes #<issue>` reference, and `worker complete` — all "
+                        + "label transitions through intent-cli worker/automation only. intent-cli and GitHub remain "
+                        + "authoritative; agmsg is only how you receive the delegation and send back your reply. When "
+                        + "done or blocked, send ONE structured agmsg reply (accepted / progress / completed / blocked) "
+                        + "citing the GitHub facts (PR number, CI). Do NOT read host metadata (`.intent-cli/**`, "
+                        + "`intents/**`)."),
                 },
                 new OrchestratorThreadPrompt
                 {
@@ -164,6 +239,7 @@ internal static class GuideOrchestratorThreadCommand
             OrchestratorFirstWake = new[]
             {
                 "Confirm you are the ONLY orchestrator for this domain/repo; if a second is detected, STOP and escalate (fail closed).",
+                Apply("Confirm domain scope: in single-domain mode, treat other-domain items visible in the host repo as OUT OF SCOPE (escalate, never delegate); in multi-domain mode, attach full routing metadata (domain, execution unit, target repo, implementation + review cwd/worktree, base branch policy, destination thread) before each delegation. Visibility is not authorization, and an execution-unit prefix mismatch alone is not a wrong-repo signal."),
                 "Read pending agmsg replies from the implementation/review threads (signals only — do not trust them as state).",
                 Apply("Ask intent-cli for the real state: `intent-cli intent status --domain <domain> --format json` and `intent-cli worker next-action --repo <owner/repo> --github-only --format json`."),
                 "Verify every GitHub fact an agmsg reply claims (PR merged, CI concluded, labels) before acting on it.",
@@ -177,6 +253,7 @@ internal static class GuideOrchestratorThreadCommand
                 "No hand-editing queue-state, runs.jsonl, packets, or any host metadata (`.intent-cli/**`, `intents/**`).",
                 "agmsg never replaces semantic review or authorizes a merge; review/closeout decisions run through intent-cli review surfaces (G480).",
                 "Process at most one delegation/repair/escalation per orchestrator wake; one delegated item per implementation/review wake.",
+                "Domain isolation: a host repo can hold several domains and one repo can serve several domains, so visibility is not authorization. Single-domain orchestrators ignore/escalate other-domain items; multi-domain orchestrators require explicit per-delegation routing. An execution-unit prefix mismatch alone is not a wrong-repo signal.",
                 "Fail closed on duplicate orchestrators for the same domain/repo, or when an agmsg reply conflicts with intent-cli/GitHub facts — STOP and escalate, never guess.",
                 "Never ask intent-cli to launch Claude/Codex/Copilot or any AI provider; intent-cli only emits text the human agent acts on.",
             },
@@ -203,6 +280,7 @@ internal static class GuideOrchestratorThreadCommand
             ["<domain>"] = "<domain>",
             ["<owner/repo>"] = "<owner/repo>",
             ["<agent>"] = "<agent>",
+            ["<mode>"] = ModeSingleDomain,
         };
 
         for (var i = 0; i < args.Length; i++)
@@ -237,6 +315,9 @@ internal static class GuideOrchestratorThreadCommand
                 case "--agent":
                     parsed["<agent>"] = value;
                     break;
+                case "--mode":
+                    parsed["<mode>"] = value;
+                    break;
             }
         }
 
@@ -248,6 +329,15 @@ internal static class GuideOrchestratorThreadCommand
             return false;
         }
 
+        var modeValue = parsed["<mode>"];
+        if (!string.Equals(modeValue, ModeSingleDomain, StringComparison.Ordinal)
+            && !string.Equals(modeValue, ModeMultiDomain, StringComparison.Ordinal))
+        {
+            values = parsed;
+            error = $"Unknown --mode '{modeValue}'. Supported: single-domain, multi-domain.";
+            return false;
+        }
+
         values = parsed;
         return true;
     }
@@ -256,7 +346,8 @@ internal static class GuideOrchestratorThreadCommand
         string.Equals(arg, "--format", StringComparison.Ordinal)
         || string.Equals(arg, "--domain", StringComparison.Ordinal)
         || string.Equals(arg, "--target-repo", StringComparison.Ordinal)
-        || string.Equals(arg, "--agent", StringComparison.Ordinal);
+        || string.Equals(arg, "--agent", StringComparison.Ordinal)
+        || string.Equals(arg, "--mode", StringComparison.Ordinal);
 
     private static void WriteMarkdown(TextWriter writer, OrchestratorThreadGuide guide)
     {
@@ -270,6 +361,25 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"- **timer-loop mode** — {guide.ModeSeparation.TimerLoopMode}");
         writer.WriteLine($"- **orchestrator-message mode** — {guide.ModeSeparation.OrchestratorMessageMode}");
         writer.WriteLine($"- **mixed-mode warning** — {guide.ModeSeparation.MixedModeWarning}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Domain routing — single-domain vs multi-domain");
+        writer.WriteLine();
+        writer.WriteLine($"- selected mode: `{guide.DomainRouting.Mode}`");
+        writer.WriteLine($"- **single-domain** — {guide.DomainRouting.SingleDomainRule}");
+        writer.WriteLine($"- **multi-domain** — {guide.DomainRouting.MultiDomainRule}");
+        writer.WriteLine($"- **execution-unit prefix** — {guide.DomainRouting.PrefixMismatchNote}");
+        writer.WriteLine();
+        writer.WriteLine("Routing metadata required for every multi-domain delegation:");
+        writer.WriteLine();
+        foreach (var field in guide.DomainRouting.RoutingMetadataFields)
+        {
+            writer.WriteLine($"- {field}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("```json");
+        writer.WriteLine(guide.DomainRouting.DelegationExample);
+        writer.WriteLine("```");
         writer.WriteLine();
 
         writer.WriteLine("## Thread prompts");
@@ -330,6 +440,12 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine("Renders paste-ready prompts for an OPTIONAL agmsg-backed orchestrator thread plus the");
         writer.WriteLine("implementation/review threads it delegates to. agmsg is a signal layer only; intent-cli and");
         writer.WriteLine("GitHub remain authoritative. Existing timer-loop mode stays valid and is not replaced.");
+        writer.WriteLine();
+        writer.WriteLine("--mode single-domain (default) scopes the orchestrator to one domain and treats other-domain");
+        writer.WriteLine("items visible in a shared host repo as out of scope. --mode multi-domain requires explicit");
+        writer.WriteLine("routing metadata (domain, execution unit, target repo, implementation + review cwd/worktree,");
+        writer.WriteLine("base branch policy, destination thread) for each delegation, since one repo may serve several");
+        writer.WriteLine("domains. An execution-unit prefix mismatch alone is not treated as a wrong-repo signal.");
     }
 }
 
@@ -340,6 +456,9 @@ internal sealed record OrchestratorThreadGuide
 
     [JsonPropertyName("mode_separation")]
     public required OrchestratorModeSeparation ModeSeparation { get; init; }
+
+    [JsonPropertyName("domain_routing")]
+    public required OrchestratorDomainRouting DomainRouting { get; init; }
 
     [JsonPropertyName("threads")]
     public required IReadOnlyList<OrchestratorThreadPrompt> Threads { get; init; }
@@ -367,6 +486,27 @@ internal sealed record OrchestratorModeSeparation
 
     [JsonPropertyName("mixed_mode_warning")]
     public required string MixedModeWarning { get; init; }
+}
+
+internal sealed record OrchestratorDomainRouting
+{
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("single_domain_rule")]
+    public required string SingleDomainRule { get; init; }
+
+    [JsonPropertyName("multi_domain_rule")]
+    public required string MultiDomainRule { get; init; }
+
+    [JsonPropertyName("routing_metadata_fields")]
+    public required IReadOnlyList<string> RoutingMetadataFields { get; init; }
+
+    [JsonPropertyName("delegation_example")]
+    public required string DelegationExample { get; init; }
+
+    [JsonPropertyName("prefix_mismatch_note")]
+    public required string PrefixMismatchNote { get; init; }
 }
 
 internal sealed record OrchestratorThreadPrompt

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -106,6 +106,93 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_SingleDomain_ScopesToOneDomain_AndDefersOtherDomainMetadata()
+    {
+        // Default mode is single-domain.
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Domain routing — single-domain vs multi-domain", output, StringComparison.Ordinal);
+        Assert.Contains("selected mode: `single-domain`", output, StringComparison.Ordinal);
+        // The orchestrator prompt scopes to one domain and defers other-domain items.
+        Assert.Contains("SINGLE-DOMAIN mode", output, StringComparison.Ordinal);
+        Assert.Contains("OUT OF SCOPE", output, StringComparison.Ordinal);
+        Assert.Contains("switch", output, StringComparison.Ordinal);
+        // Prefix mismatch is explicitly not a wrong-repo signal.
+        Assert.Contains("prefix", output, StringComparison.Ordinal);
+        Assert.Contains("packet/domain metadata", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_MultiDomain_RequiresExplicitRoutingMetadata()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude", "--mode", "multi-domain"]);
+
+        Assert.Contains("selected mode: `multi-domain`", output, StringComparison.Ordinal);
+        Assert.Contains("MULTI-DOMAIN mode", output, StringComparison.Ordinal);
+        // All required routing fields are listed.
+        Assert.Contains("execution unit", output, StringComparison.Ordinal);
+        Assert.Contains("implementation cwd/worktree", output, StringComparison.Ordinal);
+        Assert.Contains("review cwd/worktree", output, StringComparison.Ordinal);
+        Assert.Contains("base branch policy", output, StringComparison.Ordinal);
+        Assert.Contains("destination thread", output, StringComparison.Ordinal);
+        // Delegation example carries the full routing payload, incl. one repo serving multiple domains.
+        Assert.Contains("\"execution_unit\":\"G491\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"base_branch_policy\":\"direct-main\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"destination_thread\":", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_ImplementationThread_VerifiesLocalCheckoutBeforeClaiming()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        // Implementation-thread prompt: target from worker next-action, checkout must match before claiming.
+        Assert.Contains("verify your local checkout context matches the delegation", output, StringComparison.Ordinal);
+        Assert.Contains("STOP and reply blocked instead of claiming", output, StringComparison.Ordinal);
+        Assert.Contains("worker next-action", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasDomainRoutingShape_ForMultiDomain()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--mode", "multi-domain", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var routing = doc.RootElement.GetProperty("domain_routing");
+
+        Assert.Equal("multi-domain", routing.GetProperty("mode").GetString());
+        Assert.True(routing.TryGetProperty("single_domain_rule", out _));
+        Assert.True(routing.TryGetProperty("multi_domain_rule", out _));
+        Assert.True(routing.TryGetProperty("prefix_mismatch_note", out _));
+
+        var fields = routing.GetProperty("routing_metadata_fields").EnumerateArray()
+            .Select(f => f.GetString())
+            .ToArray();
+        Assert.Contains("domain", fields);
+        Assert.Contains("execution unit", fields);
+        Assert.Contains("implementation cwd/worktree", fields);
+        Assert.Contains("review cwd/worktree", fields);
+        Assert.Contains("base branch policy", fields);
+        Assert.Contains("destination thread", fields);
+    }
+
+    [Fact]
+    public void Execute_UnknownMode_ExitsOne()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(), ["--mode", "all-domains", "--format", "markdown"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown --mode", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownArgument_ExitsOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Closes #1079. Clarifies intent-cli's agmsg orchestrator guidance so a host repo holding several intent domains (`sekiban-as-a-service`, `sekiban-wasm-runtime`, `intent-cli`, …) is safe by default — including the case where more than one domain targets the same GitHub repository.

Surface: `intent-cli guide orchestrator-thread` (G487).

## Changes

- **`--mode single-domain|multi-domain`** (default `single-domain`) selects which contract the generated prompts emphasize.
- **Single-domain**: only the selected domain is in scope. Other-domain items visible in the shared host checkout are out of scope unless the operator switches domain/mode — escalate, never delegate.
- **Multi-domain**: requires explicit routing metadata for **each** delegation — domain, execution unit, target repo, implementation cwd/worktree, review cwd/worktree, base branch policy, destination thread — with a delegation example showing one repo serving multiple domains.
- **Implementation thread** prompt now verifies local checkout context (cwd/worktree, git remote repo, delegated domain) before claiming and blocks on mismatch; the worker target still comes from receiver-side `worker next-action`, not the agmsg text.
- **Prefix guard**: an execution-unit ID prefix that differs from the domain name is explicitly **not** a wrong-repo signal — packet/domain metadata and routing context decide ownership.
- New `domain_routing` JSON section + markdown rendering; new domain-isolation safety boundary and first-wake step.

## Acceptance criteria coverage

- ✅ Guide explains single-domain vs multi-domain orchestration.
- ✅ Single-domain prompts mark other-domain host metadata out of scope unless mode/domain switches.
- ✅ Multi-domain prompts require explicit routing metadata before each delegation.
- ✅ Delegation example includes domain, execution unit, target repo, impl + review cwd/worktree, base branch policy, destination thread.
- ✅ Implementation-thread prompt: target from `worker next-action`, local checkout must match before claiming.
- ✅ Prefix mismatch alone is not treated as wrong repo.
- ✅ Tests cover single-domain and multi-domain host scenarios (+ mode validation).

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 11 passed.
- `dotnet test … --filter ~Guide` — 943 passed.
- `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb