### PR TITLE
G490: Add scheduled orchestrator wake contract for agmsg mode

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -33,6 +33,52 @@ Do **not** run both modes for the same domain/repo. In orchestrator-message
 mode, do not also launch the implementation/review recurring timer loops — two
 drivers would race on the same GitHub state.
 
+## Scheduled orchestrator cadence
+
+In orchestrator-message mode the orchestrator thread is the **single recurring
+driver**. Schedule **only** the orchestrator; the implementation and review
+threads are long-lived but **loopless receivers** — they act only when the
+orchestrator delegates and never start their own recurring timer for the same
+domain/repo. This keeps a periodic driver (so design progress, agmsg replies,
+completed CI, and approved PRs are noticed without the operator poking stalled
+work) while avoiding the mixed-mode timer race.
+
+Schedule the orchestrator one of two ways:
+
+- **Codex automation (every 5m)** — run one orchestrator wake per fire: check
+  design progress and replies, ask intent-cli for state, verify the GitHub
+  facts, then send at most one message and exit.
+- **Claude same-thread `/loop 5m`** — in the orchestrator thread run
+  `/loop 5m` so the same thread re-wakes every 5 minutes for one pass each.
+
+Do **not** also run `/loop` or a Codex automation in the implementation or
+review threads — those are loopless receivers.
+
+### Each orchestrator wake
+
+Generate the authoritative wake prompt from intent-cli; each wake should:
+
+- Check design-side progress (new packets/issues, intent status changes).
+- Read pending agmsg replies (signals only — re-verify against intent-cli /
+  GitHub).
+- Ask intent-cli for worker state (`worker next-action --github-only`).
+- Check host review readiness (`automation host-review-preflight`).
+- Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge
+  state, closeout/label state.
+- Detect stale blockers and no-reply receivers.
+- Decide the single action this wake: delegate the next slice/PR, send one
+  repair message, or escalate one operator decision.
+
+### Repair vs escalate
+
+- **Repair** routine off-rail states yourself by messaging the appropriate
+  thread back onto the official intent-cli workflow — a receiver that stalled,
+  skipped `worker complete`, applied a label by hand, or has not replied.
+  Routine recovery is a repair message, not an escalation.
+- **Escalate** to the operator only for: product/design judgment, credentials
+  or security, a destructive local action, or an unresolved canonical ambiguity
+  (intent-cli/GitHub facts genuinely conflict or are missing).
+
 ## Single-domain vs multi-domain orchestration
 
 A host checkout can legitimately contain **several** intent domains (for

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -33,6 +33,49 @@ orchestrator はそれに従って行動する前に、すべての主張を int
 orchestrator-message モードでは、実装/レビューの定期タイマーループも起動しないでください。
 2 つのドライバーが同じ GitHub 状態を奪い合ってしまいます。
 
+## スケジュールされた orchestrator のケイデンス
+
+orchestrator-message モードでは、orchestrator スレッドが **唯一の定期ドライバー** です。
+**orchestrator のみ** をスケジュールしてください。実装/レビュースレッドは長命ですが
+**ループを持たない受信側（loopless receiver）** であり、orchestrator が委譲したときだけ
+動作し、同じ domain/repo に対して自分の定期タイマーを起動しません。これにより定期ドライバー
+を保ちつつ（設計進捗、agmsg 返信、完了した CI、承認済み PR を、オペレーターが停滞作業を
+突く必要なく検知できる）、mixed-mode のタイマー競合を回避します。
+
+orchestrator のスケジュール方法は次の 2 通り:
+
+- **Codex automation（5 分ごと）** — 起動ごとに 1 回の orchestrator wake を実行: 設計進捗
+  と返信を確認し、intent-cli に状態を問い合わせ、GitHub の事実を検証し、最大 1 通だけ
+  メッセージを送って終了する。
+- **Claude 同一スレッド `/loop 5m`** — orchestrator スレッドで `/loop 5m` を実行し、同じ
+  スレッドが 5 分ごとに 1 パスずつ再起動する。
+
+実装/レビュースレッドでは `/loop` や Codex automation を **同時に実行しないでください** —
+これらは loopless receiver です。
+
+### 各 orchestrator wake
+
+権威ある wake プロンプトは intent-cli から生成します。各 wake は次を行うべきです:
+
+- 設計側の進捗を確認（新しい packet/issue、intent status の変化）。
+- 保留中の agmsg 返信を読む（シグナルのみ — intent-cli / GitHub に対して再検証）。
+- intent-cli に worker 状態を問い合わせる（`worker next-action --github-only`）。
+- host レビュー準備状況を確認（`automation host-review-preflight`）。
+- GitHub の事実を直接検証: open PR、CI 結論、承認、マージ状態、closeout/label 状態。
+- 停滞ブロッカーと無返信の receiver を検知する。
+- この wake の単一アクションを決定する: 次の slice/PR を委譲、1 通の repair メッセージ送信、
+  または 1 件のオペレーター判断にエスカレーション。
+
+### repair と escalate
+
+- **repair**: ルーチンな脱線状態は、適切なスレッドへメッセージを送って公式の intent-cli
+  ワークフローに戻すことで自分で修復する — 停滞した receiver、`worker complete` を飛ばした、
+  label を手動適用した、返信がない、など。ルーチンな復旧は repair メッセージであり
+  エスカレーションではない。
+- **escalate**: オペレーターへのエスカレーションは次の場合のみ — プロダクト/設計判断、
+  認証情報やセキュリティ、破壊的なローカル操作、または解決不能な canonical な曖昧さ
+  （intent-cli/GitHub の事実が本当に矛盾するか欠落している）。
+
 ## single-domain と multi-domain のオーケストレーション
 
 host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -163,6 +163,55 @@ internal static class GuideOrchestratorThreadCommand
                     + "on its own (a host repo can hold several domains, and one repo can serve several domains). Compare "
                     + "the packet/domain metadata and the routing context to decide ownership, not the prefix string.",
             },
+            Scheduling = new OrchestratorScheduling
+            {
+                Summary =
+                    "In orchestrator-message mode the orchestrator thread is the SINGLE recurring driver. Schedule ONLY "
+                    + "the orchestrator (Codex automation every 5m, or Claude same-thread `/loop 5m`); the implementation "
+                    + "and review threads are long-lived but LOOPLESS receivers. This keeps a periodic driver — so "
+                    + "design progress, agmsg replies, completed CI, and approved PRs are noticed without the operator "
+                    + "poking stalled work — while avoiding the mixed-mode timer race.",
+                ScheduledThread = "orchestrator",
+                ReceiverNote =
+                    "Implementation and review threads are loopless receivers: do NOT start a recurring timer/loop in a "
+                    + "receiver thread for this domain/repo. A receiver waits for an agmsg delegation, acts once, replies "
+                    + "once, and waits again. Only the orchestrator is scheduled.",
+                CodexSetupPrompt = Apply(
+                    "Codex automation (run every 5 minutes) for the ORCHESTRATOR thread, domain `<domain>` against "
+                    + "`<owner/repo>` using `<agent>`: on each run perform exactly ONE orchestrator wake — check "
+                    + "design-side progress and agmsg replies, ask intent-cli for state (`intent status`, `worker "
+                    + "next-action --github-only`, `automation host-review-preflight`), verify the GitHub facts "
+                    + "(CI/approval/merge/closeout), then send AT MOST ONE message (one delegation, one repair, or one "
+                    + "escalation) and exit. Do not run implementation/review loops; they are loopless receivers."),
+                ClaudeLoopSetupPrompt = Apply(
+                    "Claude same-thread setup for the ORCHESTRATOR thread, domain `<domain>` against `<owner/repo>`: in "
+                    + "the orchestrator thread run `/loop 5m` with the orchestrator prompt so the same thread re-wakes "
+                    + "every 5 minutes. Each wake does exactly one orchestrator pass (read replies, check intent-cli / "
+                    + "GitHub state, send AT MOST ONE message). Do NOT also launch `/loop` in the implementation or "
+                    + "review threads — those are loopless receivers driven only by your delegations."),
+                WakeResponsibilities = new[]
+                {
+                    Apply("Check design-side progress: newly published packets/issues and intent status changes via `intent-cli intent status --domain <domain> --format json`."),
+                    "Read pending agmsg replies from the implementation/review receivers (signals only — re-verify against intent-cli / GitHub).",
+                    Apply("Ask intent-cli for worker state: `intent-cli worker next-action --repo <owner/repo> --github-only --format json`."),
+                    Apply("Check host review readiness: `intent-cli automation host-review-preflight --repo <owner/repo> --format json`."),
+                    "Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge state, and closeout/label state.",
+                    "Detect stale blockers and no-reply receivers: a delegation with no accepted/progress reply within the expected window, or a thread stuck off the official workflow.",
+                    "Decide the single action for this wake: delegate the next slice/PR, send one repair message, or escalate one operator decision.",
+                },
+                RepairVsEscalate = new OrchestratorRepairEscalate
+                {
+                    Repair =
+                        "REPAIR routine off-rail states yourself by messaging the appropriate thread back onto the "
+                        + "official intent-cli workflow — e.g. a receiver that stalled, skipped `worker complete`, "
+                        + "applied a label by hand, or has not replied. Routine recovery is a repair message, not an "
+                        + "escalation.",
+                    Escalate =
+                        "ESCALATE to the operator ONLY for: product/design judgment, credentials or security, a "
+                        + "destructive local action, or an unresolved canonical ambiguity (intent-cli/GitHub facts "
+                        + "genuinely conflict or are missing). Do not escalate states you can repair by message.",
+                },
+            },
             Threads = new[]
             {
                 new OrchestratorThreadPrompt
@@ -184,7 +233,10 @@ internal static class GuideOrchestratorThreadCommand
                         + "thread back to the official intent-cli workflow), or an escalation to the operator. Do NOT "
                         + "launch recurring implement/review timers for this domain/repo while orchestrating. Fail "
                         + "closed: if you detect a second orchestrator for this domain/repo, or agmsg replies conflict "
-                        + "with GitHub/intent-cli facts, STOP and escalate rather than guessing."
+                        + "with GitHub/intent-cli facts, STOP and escalate rather than guessing. In "
+                        + "orchestrator-message mode YOU are the single recurring driver: schedule only this "
+                        + "orchestrator thread (Codex automation every 5m, or Claude same-thread `/loop 5m`); the "
+                        + "implementation/review receivers stay loopless and act only on your delegations."
                         + routingClause),
                 },
                 new OrchestratorThreadPrompt
@@ -194,7 +246,9 @@ internal static class GuideOrchestratorThreadCommand
                         "Implement exactly one delegated item, then report a structured agmsg reply.",
                     Prompt = Apply(
                         "You are the IMPLEMENTATION thread for domain `<domain>` against `<owner/repo>` using `<agent>`, "
-                        + "driven by orchestrator agmsg delegations (NOT a recurring timer). When delegated an item, run "
+                        + "driven by orchestrator agmsg delegations. You are a LOOPLESS receiver: do NOT start your own "
+                        + "recurring timer/loop for this domain/repo — wait for a delegation, act once, reply once, then "
+                        + "wait again (only the orchestrator is scheduled). When delegated an item, run "
                         + "the normal child implementation workflow: the issue/PR number comes from `intent-cli worker "
                         + "next-action --repo <owner/repo> --github-only`, NOT from the agmsg text. Before claiming, "
                         + "verify your local checkout context matches the delegation: your cwd/worktree, the git remote "
@@ -216,7 +270,9 @@ internal static class GuideOrchestratorThreadCommand
                         "Review/closeout exactly one delegated PR through intent-cli, then report a structured agmsg reply.",
                     Prompt = Apply(
                         "You are the REVIEW thread for domain `<domain>` against `<owner/repo>` using `<agent>`, driven "
-                        + "by orchestrator agmsg delegations (NOT a recurring timer). When delegated a PR, run the "
+                        + "by orchestrator agmsg delegations. You are a LOOPLESS receiver: do NOT start your own "
+                        + "recurring timer/loop for this domain/repo — wait for a delegation, act once, reply once, then "
+                        + "wait again (only the orchestrator is scheduled). When delegated a PR, run the "
                         + "official host review/closeout through intent-cli surfaces (`review closeout-plan`, `guide "
                         + "review`, `automation pr-transition`, `closeout pr`) — agmsg never replaces semantic review or "
                         + "authorizes a merge. Perform semantic review only when you are the packet `review_role` or "
@@ -382,6 +438,36 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine("```");
         writer.WriteLine();
 
+        writer.WriteLine("## Scheduled orchestrator cadence");
+        writer.WriteLine();
+        writer.WriteLine(guide.Scheduling.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- scheduled thread: `{guide.Scheduling.ScheduledThread}` (the only scheduled thread)");
+        writer.WriteLine($"- **receivers are loopless** — {guide.Scheduling.ReceiverNote}");
+        writer.WriteLine();
+        writer.WriteLine("### Codex automation (5m) — orchestrator");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(guide.Scheduling.CodexSetupPrompt);
+        writer.WriteLine("```");
+        writer.WriteLine();
+        writer.WriteLine("### Claude `/loop 5m` — orchestrator");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(guide.Scheduling.ClaudeLoopSetupPrompt);
+        writer.WriteLine("```");
+        writer.WriteLine();
+        writer.WriteLine("### Each orchestrator wake");
+        writer.WriteLine();
+        foreach (var responsibility in guide.Scheduling.WakeResponsibilities)
+        {
+            writer.WriteLine($"- {responsibility}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **repair** — {guide.Scheduling.RepairVsEscalate.Repair}");
+        writer.WriteLine($"- **escalate** — {guide.Scheduling.RepairVsEscalate.Escalate}");
+        writer.WriteLine();
+
         writer.WriteLine("## Thread prompts");
         foreach (var thread in guide.Threads)
         {
@@ -460,6 +546,9 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("domain_routing")]
     public required OrchestratorDomainRouting DomainRouting { get; init; }
 
+    [JsonPropertyName("scheduling")]
+    public required OrchestratorScheduling Scheduling { get; init; }
+
     [JsonPropertyName("threads")]
     public required IReadOnlyList<OrchestratorThreadPrompt> Threads { get; init; }
 
@@ -507,6 +596,39 @@ internal sealed record OrchestratorDomainRouting
 
     [JsonPropertyName("prefix_mismatch_note")]
     public required string PrefixMismatchNote { get; init; }
+}
+
+internal sealed record OrchestratorScheduling
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("scheduled_thread")]
+    public required string ScheduledThread { get; init; }
+
+    [JsonPropertyName("receiver_note")]
+    public required string ReceiverNote { get; init; }
+
+    [JsonPropertyName("codex_setup_prompt")]
+    public required string CodexSetupPrompt { get; init; }
+
+    [JsonPropertyName("claude_loop_setup_prompt")]
+    public required string ClaudeLoopSetupPrompt { get; init; }
+
+    [JsonPropertyName("wake_responsibilities")]
+    public required IReadOnlyList<string> WakeResponsibilities { get; init; }
+
+    [JsonPropertyName("repair_vs_escalate")]
+    public required OrchestratorRepairEscalate RepairVsEscalate { get; init; }
+}
+
+internal sealed record OrchestratorRepairEscalate
+{
+    [JsonPropertyName("repair")]
+    public required string Repair { get; init; }
+
+    [JsonPropertyName("escalate")]
+    public required string Escalate { get; init; }
 }
 
 internal sealed record OrchestratorThreadPrompt

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -182,6 +182,72 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_SchedulesOnlyOrchestrator_WithCodexAndClaudeLoopPrompts()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Scheduled orchestrator cadence", output, StringComparison.Ordinal);
+        // Orchestrator is the single recurring driver.
+        Assert.Contains("single recurring driver", output, StringComparison.Ordinal);
+        Assert.Contains("scheduled thread: `orchestrator`", output, StringComparison.Ordinal);
+        // Both setup prompts are present.
+        Assert.Contains("Codex automation (5m)", output, StringComparison.Ordinal);
+        Assert.Contains("Claude `/loop 5m`", output, StringComparison.Ordinal);
+        // Receivers are explicitly loopless.
+        Assert.Contains("loopless receiver", output, StringComparison.Ordinal);
+        Assert.Contains("do NOT start your own", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_WakeResponsibilities_CoverStateChecksAndRepairEscalate()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "codex"]);
+
+        Assert.Contains("### Each orchestrator wake", output, StringComparison.Ordinal);
+        // State-check coverage.
+        Assert.Contains("design-side progress", output, StringComparison.Ordinal);
+        Assert.Contains("worker next-action", output, StringComparison.Ordinal);
+        Assert.Contains("host-review-preflight", output, StringComparison.Ordinal);
+        Assert.Contains("CI conclusion, approvals, merge state", output, StringComparison.Ordinal);
+        Assert.Contains("stale blockers and no-reply receivers", output, StringComparison.Ordinal);
+        // Repair vs escalate split.
+        Assert.Contains("**repair**", output, StringComparison.Ordinal);
+        Assert.Contains("**escalate**", output, StringComparison.Ordinal);
+        Assert.Contains("credentials or security", output, StringComparison.Ordinal);
+        Assert.Contains("destructive local action", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasSchedulingShape()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var scheduling = doc.RootElement.GetProperty("scheduling");
+
+        Assert.Equal("orchestrator", scheduling.GetProperty("scheduled_thread").GetString());
+        Assert.True(scheduling.TryGetProperty("codex_setup_prompt", out _));
+        Assert.True(scheduling.TryGetProperty("claude_loop_setup_prompt", out _));
+        Assert.True(scheduling.TryGetProperty("receiver_note", out _));
+        Assert.NotEmpty(scheduling.GetProperty("wake_responsibilities").EnumerateArray());
+
+        var repairEscalate = scheduling.GetProperty("repair_vs_escalate");
+        Assert.True(repairEscalate.TryGetProperty("repair", out _));
+        Assert.True(repairEscalate.TryGetProperty("escalate", out _));
+
+        // Receiver thread prompts stay explicitly loopless.
+        var prompts = doc.RootElement.GetProperty("threads").EnumerateArray()
+            .ToDictionary(t => t.GetProperty("role").GetString()!, t => t.GetProperty("prompt").GetString()!);
+        Assert.Contains("LOOPLESS receiver", prompts["implementation"], StringComparison.Ordinal);
+        Assert.Contains("LOOPLESS receiver", prompts["review"], StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Closes #1081. Adds the scheduled-orchestrator cadence contract for agmsg orchestrator-message mode: the **orchestrator is the single recurring driver**, while implementation/review threads are **loopless receivers**. Builds on G487 (orchestrator-thread baseline) and G489 (multi-domain routing), both merged.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `scheduling` section** in the guide:
  - Paste-ready **Codex automation 5m** orchestrator setup prompt.
  - Paste-ready **Claude same-thread `/loop 5m`** orchestrator setup prompt.
  - Explicit **loopless-receiver** note (only the orchestrator is scheduled).
  - **Per-wake responsibilities**: design-side progress, agmsg replies, intent status, `worker next-action`, `host-review-preflight`, GitHub CI/approval/merge/closeout facts, stale blockers, no-reply receivers.
  - Explicit **repair-vs-escalate** split.
- **Orchestrator prompt** now states it is the single scheduled driver.
- **Implementation/review prompts** now explicitly say not to start a recurring loop in a receiver thread.
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Guide explains the orchestrator is the recurring driver in orchestrator-message mode.
- ✅ Codex automation 5m orchestrator setup prompt.
- ✅ Claude same-thread `/loop 5m` orchestrator setup prompt.
- ✅ Implementation/review prompts explicitly forbid recurring loops in receiver threads.
- ✅ Wake steps cover design progress, replies, intent status, worker next-action, host-review-preflight, GitHub facts (CI/approval/merge/closeout), stale blockers, no-reply.
- ✅ Repair-vs-escalate guidance is explicit (escalate only for product judgment, credentials/security, destructive local action, unresolved canonical ambiguity).
- ✅ Tests cover generated prompt output (markdown + JSON).

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 14 passed.
- `dotnet test … --filter ~Guide` — 946 passed.
- `git diff --check` — clean.

## Scope note

The Knowledge Maintenance `intents/**` intent-tree write-back and ADR-012 cadence amendment are host metadata / closeout responsibilities (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb