### PR TITLE
G492: Add CI-pending wait state to orchestrator guidance

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -79,6 +79,26 @@ Generate the authoritative wake prompt from intent-cli; each wake should:
   or security, a destructive local action, or an unresolved canonical ambiguity
   (intent-cli/GitHub facts genuinely conflict or are missing).
 
+### CI wait state
+
+A PR with pending/running CI is an **active wait state**, not a blocker.
+GitHub checks are authoritative. Re-check the required checks on each wake;
+pending CI by itself never triggers a request-update label, a repair message,
+or an operator question. Always re-verify required checks immediately before
+delegating review, merge, or closeout — an earlier green read can go stale.
+
+- **pending / running** — wait and re-check next wake. No message, no
+  request-update, no operator question; track the PR as in-flight and move on.
+- **green** — all required checks passed. Delegate review/closeout through
+  intent-cli review surfaces; re-verify green at delegation time.
+- **red** — a required check failed. Route by ownership: a test/build/lint
+  failure the implementation thread can fix gets one repair message; anything
+  needing product/design or canonical judgment escalates. Never delegate
+  merge/closeout while a required check is red.
+- **stuck / ambiguous** — checks never started, hung well past a reasonable
+  window, or report conflicting/unknown status. Escalate one operator decision
+  (fail closed); do not guess green.
+
 ## Single-domain vs multi-domain orchestration
 
 A host checkout can legitimately contain **several** intent domains (for

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -76,6 +76,25 @@ orchestrator のスケジュール方法は次の 2 通り:
   認証情報やセキュリティ、破壊的なローカル操作、または解決不能な canonical な曖昧さ
   （intent-cli/GitHub の事実が本当に矛盾するか欠落している）。
 
+### CI 待ち状態
+
+pending/running の CI を持つ PR は **アクティブな待ち状態** であり、ブロッカーでは
+ありません。GitHub checks が権威です。各 wake で必須チェックを再確認します。pending な CI
+はそれ単独では request-update label、repair メッセージ、オペレーターへの質問を引き起こしません。
+review / merge / closeout を委譲する直前には必ず必須チェックを再検証してください — 以前読んだ
+green は古くなっている可能性があります。
+
+- **pending / running** — 次の wake で待って再確認する。メッセージなし、request-update なし、
+  オペレーター質問なし。PR を in-flight として追跡し、先へ進む。
+- **green** — すべての必須チェックが通過。intent-cli review surface 経由で review/closeout を
+  委譲する。委譲時に green を再検証する。
+- **red** — 必須チェックが失敗。所有権でルーティング: 実装スレッドが直せる test/build/lint の
+  失敗には 1 通の repair メッセージ。プロダクト/設計や canonical 判断が必要なものはエスカレーション。
+  必須チェックが red の間は merge/closeout を委譲しない。
+- **stuck / ambiguous** — チェックが開始されない、妥当な時間を大きく超えてハングする、または
+  矛盾/不明なステータスを報告する。1 件のオペレーター判断にエスカレーション（fail closed）。
+  green を推測しない。
+
 ## single-domain と multi-domain のオーケストレーション
 
 host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -196,6 +196,7 @@ internal static class GuideOrchestratorThreadCommand
                     Apply("Ask intent-cli for worker state: `intent-cli worker next-action --repo <owner/repo> --github-only --format json`."),
                     Apply("Check host review readiness: `intent-cli automation host-review-preflight --repo <owner/repo> --format json`."),
                     "Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge state, and closeout/label state.",
+                    "Classify each open PR's CI: pending = wait-and-recheck next wake (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate. Pending CI is normal progress, not a reason to message the operator.",
                     "Detect stale blockers and no-reply receivers: a delegation with no accepted/progress reply within the expected window, or a thread stuck off the official workflow.",
                     "Decide the single action for this wake: delegate the next slice/PR, send one repair message, or escalate one operator decision.",
                 },
@@ -210,6 +211,51 @@ internal static class GuideOrchestratorThreadCommand
                         "ESCALATE to the operator ONLY for: product/design judgment, credentials or security, a "
                         + "destructive local action, or an unresolved canonical ambiguity (intent-cli/GitHub facts "
                         + "genuinely conflict or are missing). Do not escalate states you can repair by message.",
+                },
+            },
+            CiWaitState = new OrchestratorCiWaitState
+            {
+                Summary =
+                    "A PR with pending/running CI is an ACTIVE WAIT STATE, not a blocker. GitHub checks are "
+                    + "authoritative for CI state. Re-check the required checks on each scheduled wake; pending CI is "
+                    + "normal progress and by itself NEVER triggers a request-update label, a repair message, or an "
+                    + "operator question. Always re-verify the required checks immediately before delegating review, "
+                    + "merge, or closeout — a green status read on an earlier wake can go stale.",
+                States = new[]
+                {
+                    new OrchestratorCiState
+                    {
+                        State = "pending",
+                        Routing =
+                            "PENDING / RUNNING — wait and re-check on the next wake. Do not send a message, do not apply "
+                            + "request-update, and do not ask the operator. Track the PR as in-flight and move on; the "
+                            + "scheduled cadence re-evaluates it.",
+                    },
+                    new OrchestratorCiState
+                    {
+                        State = "green",
+                        Routing =
+                            "GREEN — all required checks passed. Route to review/closeout: delegate the PR to the review "
+                            + "thread (or orchestrate merge/closeout of an already-approved PR) through intent-cli review "
+                            + "surfaces. Re-verify the checks are still green at delegation time.",
+                    },
+                    new OrchestratorCiState
+                    {
+                        State = "red",
+                        Routing =
+                            "RED — a required check failed. Route by ownership: if the implementation thread can fix it "
+                            + "(test/build/lint failure on the PR branch), send ONE repair message to that thread; if it "
+                            + "needs product/design or canonical judgment, escalate. Never delegate merge/closeout while "
+                            + "a required check is red.",
+                    },
+                    new OrchestratorCiState
+                    {
+                        State = "stuck",
+                        Routing =
+                            "STUCK / AMBIGUOUS — checks never started, hung well past a reasonable window, or report a "
+                            + "conflicting/unknown status that intent-cli and GitHub cannot resolve. Escalate one operator "
+                            + "decision (fail closed); do not guess green or force a merge.",
+                    },
                 },
             },
             Threads = new[]
@@ -228,7 +274,10 @@ internal static class GuideOrchestratorThreadCommand
                         + "replies, ask intent-cli for the real state (`intent-cli intent status --domain <domain> "
                         + "--format json`, `intent-cli worker next-action --repo <owner/repo> --github-only --format "
                         + "json`, `intent-cli automation host-review-preflight --repo <owner/repo> --format json`), "
-                        + "verify the GitHub facts that an agmsg reply claims (merged PR, CI, labels), then send AT MOST "
+                        + "verify the GitHub facts that an agmsg reply claims (merged PR, CI, labels). Treat pending/"
+                        + "running CI as an active wait state — re-check it on a later wake rather than asking the "
+                        + "operator; delegate review/closeout only after required checks are green, route red checks to "
+                        + "repair or escalation by ownership, and escalate only stuck/ambiguous CI. Then send AT MOST "
                         + "ONE message: a delegation (assign the next slice/PR), a repair request (point a stalled "
                         + "thread back to the official intent-cli workflow), or an escalation to the operator. Do NOT "
                         + "launch recurring implement/review timers for this domain/repo while orchestrating. Fail "
@@ -468,6 +517,16 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"- **escalate** — {guide.Scheduling.RepairVsEscalate.Escalate}");
         writer.WriteLine();
 
+        writer.WriteLine("## CI wait state");
+        writer.WriteLine();
+        writer.WriteLine(guide.CiWaitState.Summary);
+        writer.WriteLine();
+        foreach (var state in guide.CiWaitState.States)
+        {
+            writer.WriteLine($"- **{state.State}** — {state.Routing}");
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Thread prompts");
         foreach (var thread in guide.Threads)
         {
@@ -549,6 +608,9 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("scheduling")]
     public required OrchestratorScheduling Scheduling { get; init; }
 
+    [JsonPropertyName("ci_wait_state")]
+    public required OrchestratorCiWaitState CiWaitState { get; init; }
+
     [JsonPropertyName("threads")]
     public required IReadOnlyList<OrchestratorThreadPrompt> Threads { get; init; }
 
@@ -629,6 +691,24 @@ internal sealed record OrchestratorRepairEscalate
 
     [JsonPropertyName("escalate")]
     public required string Escalate { get; init; }
+}
+
+internal sealed record OrchestratorCiWaitState
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("states")]
+    public required IReadOnlyList<OrchestratorCiState> States { get; init; }
+}
+
+internal sealed record OrchestratorCiState
+{
+    [JsonPropertyName("state")]
+    public required string State { get; init; }
+
+    [JsonPropertyName("routing")]
+    public required string Routing { get; init; }
 }
 
 internal sealed record OrchestratorThreadPrompt

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -248,6 +248,53 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_CiWaitState_RoutesPendingGreenRedStuck()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## CI wait state", output, StringComparison.Ordinal);
+        // Pending is wait-and-recheck and does not trigger request-update/operator question.
+        Assert.Contains("active wait state", output, StringComparison.Ordinal);
+        Assert.Contains("- **pending**", output, StringComparison.Ordinal);
+        Assert.Contains("do not apply request-update", output, StringComparison.Ordinal);
+        // Green routes to review/closeout.
+        Assert.Contains("- **green**", output, StringComparison.Ordinal);
+        Assert.Contains("Route to review/closeout", output, StringComparison.Ordinal);
+        // Red routes to repair/escalate by ownership.
+        Assert.Contains("- **red**", output, StringComparison.Ordinal);
+        Assert.Contains("Route by ownership", output, StringComparison.Ordinal);
+        // Stuck escalates.
+        Assert.Contains("- **stuck**", output, StringComparison.Ordinal);
+        Assert.Contains("Escalate one operator decision", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasCiWaitStateShape_WithFourStates()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var ci = doc.RootElement.GetProperty("ci_wait_state");
+
+        Assert.True(ci.TryGetProperty("summary", out _));
+        var states = ci.GetProperty("states").EnumerateArray()
+            .Select(s => s.GetProperty("state").GetString())
+            .ToArray();
+        Assert.Equal(new[] { "pending", "green", "red", "stuck" }, states);
+
+        // The recurring-wake list references CI classification.
+        var wake = doc.RootElement.GetProperty("scheduling").GetProperty("wake_responsibilities").EnumerateArray()
+            .Select(w => w.GetString()!)
+            .ToArray();
+        Assert.Contains(wake, w => w.Contains("pending = wait-and-recheck", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Closes #1083. Adds a complete CI wait-state policy to the agmsg orchestrator guidance: a PR with pending CI is an **active wait state**, not a blocker. Builds on G490 (scheduled orchestrator wake contract), merged.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `ci_wait_state` section** in the guide with routing for four states:
  - **pending / running** — wait-and-recheck on the next wake; by itself never triggers a request-update label, a repair message, or an operator question.
  - **green** — delegate review/closeout through intent-cli review surfaces; re-verify green at delegation time.
  - **red** — route by ownership: a test/build/lint failure the implementation thread can fix gets one repair message; anything needing product/canonical judgment escalates. Never delegate merge/closeout while a required check is red.
  - **stuck / ambiguous** — escalate one operator decision (fail closed).
- **Orchestrator prompt** now treats pending CI as an active wait state and routes green/red/stuck explicitly.
- **Recurring-wake list** now classifies each open PR's CI.
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Guide explains CI-pending as wait-and-recheck.
- ✅ Pending checks do not trigger request-update / operator question by themselves.
- ✅ Green checks route to review/closeout delegation.
- ✅ Red checks route to repair / triage / escalation depending on ownership.
- ✅ Tests/snapshots cover pending/green/red (and stuck) guidance.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 16 passed.
- `dotnet test … --filter ~Guide` — 948 passed.
- `git diff --check` — clean.

## Scope note

The Knowledge Maintenance `intents/**` intent-tree write-back and ADR-012 pending-CI amendment are host metadata / closeout responsibilities (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb