### PR TITLE
G493: Add automated reviewer comment triage to review guidance

### DIFF
--- a/docs/en/06-review-next-slice-loop.md
+++ b/docs/en/06-review-next-slice-loop.md
@@ -59,6 +59,31 @@ copy a long loop body from this document.
 - Passing tests is **necessary but not sufficient** — approval requires packet/intent conformance evidence (see `guide review`)
 - Current-PR acceptance-criterion blockers get a durable PR comment before completing as request-update/clarification (see [recovery](07-recovery.md))
 
+## Automated reviewer comment triage
+
+Some repositories enable automated reviewers (e.g. Copilot). Their comments are
+**signals, not authoritative requirements** — the review agent triages each one
+before it becomes implementation work, and does **not** blindly apply every
+automated suggestion. `intent-cli guide review` surfaces this policy, which
+applies to **both** the timer-loop review flow and the orchestrator-message
+review flow. Each automated comment is classified as one of:
+
+- **accepted-actionable** — a valid implementation finding; include it in the
+  request-update / repair instructions, tied to a packet clause or acceptance
+  criterion. The implementer fixes it on the PR branch.
+- **rejected-not-applicable** — does not apply (wrong context, false positive,
+  out of scope). Record a brief reason and resolve/close the thread where
+  supported; never silently drop it.
+- **duplicate** — restates an existing finding; link to the canonical one,
+  resolve the duplicate, and do not raise a second request-update item.
+- **informational** — a nit / FYI with no required change; acknowledge and
+  resolve without a request-update.
+- **needs-human-judgment** — a product/design, security, or canonical-ambiguity
+  call the review agent cannot settle; escalate to the operator, do not route
+  it to implementation as if settled.
+
+Only accepted-actionable comments enter request-update / repair instructions.
+
 ## Command reference (for agents, maintainers, and troubleshooting)
 
 > **Note:** The commands below are run by the AI agent internally. The authoritative

--- a/docs/ja/06-review-next-slice-loop.md
+++ b/docs/ja/06-review-next-slice-loop.md
@@ -58,6 +58,28 @@
 - テスト通過は **必要だが十分ではない** — approve には packet/intent への適合証跡が必要（`guide review` 参照）
 - 現在 PR の受け入れ基準ブロッカーは、request-update/clarification として完了する前に永続的な PR コメントを残す（[復旧](07-recovery.md) 参照）
 
+## 自動レビュアーコメントの triage
+
+一部のリポジトリは自動レビュアー（例: Copilot）を有効化しています。それらのコメントは
+**シグナルであり、権威ある要件ではありません** — review agent は各コメントを実装作業に
+する前に triage し、すべての自動提案を盲目的に適用 **しません**。`intent-cli guide review`
+がこのポリシーを surface し、これは **timer-loop review flow と orchestrator-message
+review flow の両方** に適用されます。各自動コメントは次のいずれかに分類されます:
+
+- **accepted-actionable** — 有効な実装上の指摘。packet 条項や受け入れ基準に紐づけて
+  request-update / repair 指示に含める。実装者が PR ブランチで修正する。
+- **rejected-not-applicable** — 当てはまらない（誤ったコンテキスト、false positive、
+  スコープ外）。簡潔な理由を記録し、対応していればスレッドを resolve/close する。
+  黙って破棄しない。
+- **duplicate** — 既存の指摘の再掲。canonical な指摘へリンクし、重複を resolve し、
+  2 つ目の request-update 項目を作らない。
+- **informational** — 変更不要の nit / FYI。確認し、request-update を起こさず resolve する。
+- **needs-human-judgment** — review agent が決められないプロダクト/設計・セキュリティ・
+  canonical 曖昧さの判断。オペレーターにエスカレーションし、解決済みのように実装へ
+  ルーティングしない。
+
+request-update / repair 指示に入るのは accepted-actionable のコメントのみです。
+
 ## コマンドリファレンス（agent・メンテナ・トラブルシューティング向け）
 
 > **注意:** 以下のコマンドは AI agent が内部で実行します。ループの詳細条件は

--- a/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
@@ -123,6 +123,70 @@ internal static class GuideReviewCommand
         "Tests-only failure mode (\"tests pass but evidence missing\") is itself an implementation-finding when the PR cannot show packet/intent conformance — request the implementer to add the missing evidence (test names mapped to AC, comments tying changes to packet clauses, etc.)."
     };
 
+    // G493: triage policy for automated coding-agent reviewer comments
+    // (e.g. Copilot). Such comments are SIGNALS, not authoritative
+    // requirements: the review agent classifies each before it becomes
+    // implementation work, so the loop never blindly forwards every
+    // automated suggestion to the implementer. The same policy applies to
+    // both timer-loop review mode and orchestrator-message review mode —
+    // both flows resolve their PR guidance through this command.
+    private static readonly GuideReviewAutomatedCommentTriage AutomatedReviewerCommentTriagePolicy = new()
+    {
+        Summary =
+            "Automated coding-agent reviewer comments (e.g. Copilot) are SIGNALS, not authoritative requirements. The "
+            + "review agent triages each comment BEFORE it becomes implementation work; do not blindly apply every "
+            + "automated suggestion. Only accepted-actionable comments enter request-update / repair instructions; "
+            + "rejected, duplicate, and informational comments are documented and resolved where the platform supports "
+            + "it; needs-human-judgment comments escalate to the operator.",
+        DoNotBlindlyApply = true,
+        AppliesTo = new[]
+        {
+            "timer-loop review mode",
+            "orchestrator-message review mode",
+        },
+        Classifications = new[]
+        {
+            new GuideReviewAutomatedCommentClass
+            {
+                Classification = "accepted-actionable",
+                Handling =
+                    "A valid implementation finding. Include it in the request-update / repair instructions, tied to a "
+                    + "specific packet contract clause or acceptance criterion. Becomes implementation work on the PR "
+                    + "branch (the implementer fixes it).",
+            },
+            new GuideReviewAutomatedCommentClass
+            {
+                Classification = "rejected-not-applicable",
+                Handling =
+                    "Does not apply to this change (wrong context, false positive, out of scope). Record a brief reason "
+                    + "and resolve/close the comment thread where the platform supports it. Never silently drop it — the "
+                    + "rejection reason is the audit trail.",
+            },
+            new GuideReviewAutomatedCommentClass
+            {
+                Classification = "duplicate",
+                Handling =
+                    "Restates an existing finding or another automated comment. Link to the canonical finding, resolve "
+                    + "the duplicate thread, and do NOT create a second request-update item for it.",
+            },
+            new GuideReviewAutomatedCommentClass
+            {
+                Classification = "informational",
+                Handling =
+                    "A nit / FYI with no required change. Acknowledge it, optionally fold it into existing work, and "
+                    + "resolve it without raising a request-update.",
+            },
+            new GuideReviewAutomatedCommentClass
+            {
+                Classification = "needs-human-judgment",
+                Handling =
+                    "A product/design, security, or canonical-ambiguity call the review agent cannot settle on its own. "
+                    + "Escalate to the operator as a structured stop; do NOT route it to implementation as if it were "
+                    + "settled.",
+            },
+        },
+    };
+
     // G445: standing policy for device/operator/hardware-gated acceptance
     // criteria. AI review loops cannot always operate physical devices or
     // produce real hardware evidence; without a stable rule they stall,
@@ -284,6 +348,7 @@ internal static class GuideReviewCommand
             ReviewBoundaries = ReviewBoundaries,
             ApprovalSummaryRequirements = ApprovalSummaryRequirements,
             RequestUpdateRequirements = RequestUpdateRequirements,
+            AutomatedReviewerCommentTriage = AutomatedReviewerCommentTriagePolicy,
             // G451: device-gated rules now come from the resolved standing
             // policy (default == prior G445 rules; overridable per domain).
             DeviceGatedEvidencePolicy = standingPolicy.DeviceGatedEvidence.Rules,
@@ -531,6 +596,19 @@ internal static class GuideReviewCommand
         foreach (var item in result.RequestUpdateRequirements)
         {
             writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
+        // G493: triage policy for automated coding-agent reviewer comments.
+        writer.WriteLine("## Automated reviewer comment triage (G493)");
+        writer.WriteLine(result.AutomatedReviewerCommentTriage.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- do_not_blindly_apply: {(result.AutomatedReviewerCommentTriage.DoNotBlindlyApply ? "yes" : "no")}");
+        writer.WriteLine($"- applies to: {string.Join(", ", result.AutomatedReviewerCommentTriage.AppliesTo)}");
+        writer.WriteLine();
+        foreach (var classification in result.AutomatedReviewerCommentTriage.Classifications)
+        {
+            writer.WriteLine($"- **{classification.Classification}** — {classification.Handling}");
         }
         writer.WriteLine();
 
@@ -800,6 +878,16 @@ internal sealed record GuideReviewResult
     public required IReadOnlyList<string> RequestUpdateRequirements { get; init; }
 
     /// <summary>
+    /// G493: triage policy for automated coding-agent reviewer comments
+    /// (e.g. Copilot) — classifications and routing so the review agent
+    /// never blindly forwards every automated suggestion to the
+    /// implementer. Applies to both review flows (timer-loop and
+    /// orchestrator-message).
+    /// </summary>
+    [JsonPropertyName("automated_reviewer_comment_triage")]
+    public required GuideReviewAutomatedCommentTriage AutomatedReviewerCommentTriage { get; init; }
+
+    /// <summary>
     /// G445: standing policy for device/operator/hardware-gated evidence
     /// gaps — when to approve-with-recorded-gap vs hard-block, the
     /// no-false-claim rule, durable follow-up tracking, and not re-asking the
@@ -869,6 +957,39 @@ internal sealed record GuideReviewResult
 
     [JsonPropertyName("ready")]
     public required bool Ready { get; init; }
+}
+
+/// <summary>
+/// G493: triage policy for automated coding-agent reviewer comments —
+/// a summary, the review flows it applies to, the do-not-blindly-apply
+/// signal, and the per-classification handling/routing rules.
+/// </summary>
+internal sealed record GuideReviewAutomatedCommentTriage
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("do_not_blindly_apply")]
+    public required bool DoNotBlindlyApply { get; init; }
+
+    [JsonPropertyName("applies_to")]
+    public required IReadOnlyList<string> AppliesTo { get; init; }
+
+    [JsonPropertyName("classifications")]
+    public required IReadOnlyList<GuideReviewAutomatedCommentClass> Classifications { get; init; }
+}
+
+/// <summary>
+/// G493: a single automated-reviewer-comment classification and how the
+/// review agent routes it.
+/// </summary>
+internal sealed record GuideReviewAutomatedCommentClass
+{
+    [JsonPropertyName("classification")]
+    public required string Classification { get; init; }
+
+    [JsonPropertyName("handling")]
+    public required string Handling { get; init; }
 }
 
 /// <summary>

--- a/tests/IntentSystem.Cli.Tests/GuideReviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideReviewCommandTests.cs
@@ -60,6 +60,70 @@ public sealed class GuideReviewCommandTests
     }
 
     [Fact]
+    public void Execute_EmitsAutomatedReviewerCommentTriage_WithFiveClassifications_G493()
+    {
+        using var workspace = new GuideReviewWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G248", "review", title: "guide review", linkedPr: "598"));
+        workspace.WriteFile(".intent-cli/issues/G248/packet.yaml", "x");
+
+        using var writer = new StringWriter();
+        var exitCode = GuideReviewCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "598", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var triage = document.RootElement.GetProperty("automated_reviewer_comment_triage");
+
+        // Automated comments are not blindly applied.
+        Assert.True(triage.GetProperty("do_not_blindly_apply").GetBoolean());
+
+        // Policy applies to both review flows.
+        var appliesTo = triage.GetProperty("applies_to").EnumerateArray().Select(e => e.GetString()!).ToArray();
+        Assert.Contains("timer-loop review mode", appliesTo);
+        Assert.Contains("orchestrator-message review mode", appliesTo);
+
+        // The five required classifications are present.
+        var classes = triage.GetProperty("classifications").EnumerateArray()
+            .Select(c => c.GetProperty("classification").GetString())
+            .ToArray();
+        Assert.Equal(
+            new[] { "accepted-actionable", "rejected-not-applicable", "duplicate", "informational", "needs-human-judgment" },
+            classes);
+
+        // Accepted routes to request-update; rejected requires a reason.
+        var handlingByClass = triage.GetProperty("classifications").EnumerateArray()
+            .ToDictionary(c => c.GetProperty("classification").GetString()!, c => c.GetProperty("handling").GetString()!);
+        Assert.Contains("request-update", handlingByClass["accepted-actionable"], StringComparison.Ordinal);
+        Assert.Contains("reason", handlingByClass["rejected-not-applicable"], StringComparison.Ordinal);
+        Assert.Contains("escalate", handlingByClass["needs-human-judgment"], StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Markdown_IncludesAutomatedReviewerCommentTriageSection_G493()
+    {
+        using var workspace = new GuideReviewWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G248", "review", title: "guide review", linkedPr: "598"));
+        workspace.WriteFile(".intent-cli/issues/G248/packet.yaml", "x");
+
+        using var writer = new StringWriter();
+        GuideReviewCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "598", "--format", "markdown"],
+            writer);
+
+        var output = writer.ToString();
+        Assert.Contains("## Automated reviewer comment triage (G493)", output, StringComparison.Ordinal);
+        Assert.Contains("SIGNALS, not authoritative requirements", output, StringComparison.Ordinal);
+        Assert.Contains("- **accepted-actionable**", output, StringComparison.Ordinal);
+        Assert.Contains("- **rejected-not-applicable**", output, StringComparison.Ordinal);
+        Assert.Contains("- **duplicate**", output, StringComparison.Ordinal);
+        Assert.Contains("- **informational**", output, StringComparison.Ordinal);
+        Assert.Contains("- **needs-human-judgment**", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenQueueMatchAndReviewContext_EmitsReadyTrueWithExcerpt()
     {
         using var workspace = new GuideReviewWorkspace();


### PR DESCRIPTION
## Summary

Closes #1085. Adds automated coding-agent reviewer comment triage to intent-cli review guidance. Automated reviewer comments (e.g. Copilot) are **signals, not authoritative requirements**: the review agent triages each one before it becomes implementation work, instead of blindly forwarding every comment.

Surface: `intent-cli guide review` (the mode-agnostic G316 review surface that **both** the timer-loop review flow and the orchestrator-message review flow resolve through) + `docs/{en,ja}/06-review-next-slice-loop.md`.

## Changes

- **New `automated_reviewer_comment_triage` section** in `guide review` output with five classifications and routing:
  - **accepted-actionable** → request-update / repair, tied to a packet clause or acceptance criterion.
  - **rejected-not-applicable** → record a reason, resolve/close where supported, never silently drop.
  - **duplicate** → link to the canonical finding, resolve, no second request-update item.
  - **informational** → acknowledge and resolve without a request-update.
  - **needs-human-judgment** → escalate to the operator.
- Explicit `do_not_blindly_apply` signal and `applies_to` (`timer-loop review mode`, `orchestrator-message review mode`) so the policy is shared by both review flows.
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Guide defines accepted-actionable, rejected-not-applicable, duplicate, informational, needs-human-judgment classifications.
- ✅ Accepted comments are included in request-update/repair instructions.
- ✅ Rejected comments require a reason and are resolved/closed when supported.
- ✅ Implementation guidance says not to blindly apply every automated comment (`do_not_blindly_apply`).
- ✅ Policy applies to timer-loop and orchestrator-message review flows (`applies_to`).
- ✅ Tests/snapshots cover generated guidance.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideReviewCommandTests` — 23 passed.
- `dotnet test` (full Cli suite) — 3125 passed, 1 skipped.
- `git diff --check` — clean.

## Scope note

The Knowledge Maintenance `intents/**` intent-tree write-back and ADR-012 automated-reviewer amendment are host metadata / closeout responsibilities (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb