### PR TITLE
G491: Let orchestrator publish one ready next-slice issue per wake

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -99,6 +99,36 @@ delegating review, merge, or closeout — an earlier green read can go stale.
   window, or report conflicting/unknown status. Escalate one operator decision
   (fail closed); do not guess green.
 
+## Next-slice publication
+
+Routine next-slice issue publication is an **orchestrator responsibility**, not
+an operator question. When intent-cli reports a candidate as `issue-cut-ready`
+and all safety gates pass, the orchestrator publishes it itself through
+canonical intent-cli commands rather than stopping to ask the operator to create
+the GitHub issue. **At most one issue per wake.**
+
+Publish only when **all** of these hold:
+
+- same-domain context, or an explicitly routed multi-domain delegation (never
+  publish a cross-domain candidate without explicit routing);
+- the packet contract is complete (no missing required sections);
+- no open clarification or contract ambiguity;
+- dependencies are satisfied — never publish ahead of an uncut dependency;
+- under the WIP cap;
+- clean host-sync / preflight and an unambiguous target repo/domain.
+
+Otherwise **hold or escalate** — missing contract sections, open clarification,
+dependency mismatch, WIP cap reached, host-sync blocker, or ambiguous target
+repo/domain are all blockers.
+
+Publish through the canonical surfaces only — `intent-cli issue publish-flow`
+and `intent-cli automation issue-publish` — never raw `gh issue create` or
+`gh ... --add-label`. After publishing, verify via intent-cli / GitHub (not
+chat) that the issue exists with the expected body and the `intent-target`
+label and that durable state reflects it, then delegate implementation over
+agmsg. The implementation receiver still derives its target from
+`intent-cli worker next-action`, not the agmsg text.
+
 ## Single-domain vs multi-domain orchestration
 
 A host checkout can legitimately contain **several** intent domains (for

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -95,6 +95,34 @@ green は古くなっている可能性があります。
   矛盾/不明なステータスを報告する。1 件のオペレーター判断にエスカレーション（fail closed）。
   green を推測しない。
 
+## next-slice の publish
+
+ルーチンな next-slice issue の publish は **orchestrator の責務** であり、オペレーターへの
+質問ではありません。intent-cli が候補を `issue-cut-ready` と報告し、すべての安全ゲートを
+通過したら、orchestrator はオペレーターに GitHub issue 作成を依頼して止まるのではなく、
+canonical な intent-cli コマンドで自分で publish します。**1 wake につき最大 1 件** です。
+
+次の **すべて** が成り立つときのみ publish します:
+
+- same-domain コンテキスト、または明示的にルーティングされた multi-domain 委譲
+  （明示ルーティングなしに cross-domain 候補を publish しない）;
+- packet contract が完全（必須セクションの欠落なし）;
+- open な clarification や contract の曖昧さがない;
+- 依存が満たされている — 未 cut の依存より先に publish しない;
+- WIP 上限内;
+- host-sync / preflight がクリーンで、対象 repo/domain が一意。
+
+それ以外は **hold またはエスカレーション** — 必須セクションの欠落、open clarification、
+依存の不一致、WIP 上限到達、host-sync ブロッカー、対象 repo/domain の曖昧さはすべて
+ブロッカーです。
+
+publish は canonical な surface のみ — `intent-cli issue publish-flow` と
+`intent-cli automation issue-publish` — を使い、生の `gh issue create` や
+`gh ... --add-label` は使いません。publish 後は intent-cli / GitHub（チャットではなく）で
+issue が期待どおりの body と `intent-target` label を持つこと、durable state がそれを
+反映していることを検証し、その後 agmsg で実装を委譲します。実装 receiver は依然として
+`intent-cli worker next-action` からターゲットを得ます（agmsg テキストからではありません）。
+
 ## single-domain と multi-domain のオーケストレーション
 
 host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -198,7 +198,8 @@ internal static class GuideOrchestratorThreadCommand
                     "Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge state, and closeout/label state.",
                     "Classify each open PR's CI: pending = wait-and-recheck next wake (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate. Pending CI is normal progress, not a reason to message the operator.",
                     "Detect stale blockers and no-reply receivers: a delegation with no accepted/progress reply within the expected window, or a thread stuck off the official workflow.",
-                    "Decide the single action for this wake: delegate the next slice/PR, send one repair message, or escalate one operator decision.",
+                    "If intent-cli reports an `issue-cut-ready` candidate and all gates pass (same-domain or routed, complete contract, no open clarification, dependencies satisfied, under WIP, clean host-sync/preflight), publish ONE issue this wake via canonical publish-flow / issue-publish, then verify — do not ask the operator to create it.",
+                    "Decide the single action for this wake: publish one ready next-slice issue, delegate the next slice/PR, send one repair message, or escalate one operator decision.",
                 },
                 RepairVsEscalate = new OrchestratorRepairEscalate
                 {
@@ -258,6 +259,46 @@ internal static class GuideOrchestratorThreadCommand
                     },
                 },
             },
+            NextSlicePublication = new OrchestratorNextSlicePublication
+            {
+                Summary =
+                    "Routine next-slice issue publication is an ORCHESTRATOR responsibility, not an operator question. "
+                    + "When intent-cli reports a candidate as `issue-cut-ready` and ALL safety gates pass, the "
+                    + "orchestrator publishes it itself through canonical intent-cli commands instead of stopping to ask "
+                    + "the operator to create the GitHub issue. Publish AT MOST ONE issue per wake, then verify before "
+                    + "delegating implementation.",
+                OnePerWake = true,
+                Preconditions = new[]
+                {
+                    Apply("Same-domain context (`<domain>`), or an explicitly routed multi-domain delegation (domain, target repo, destination thread) — never publish a cross-domain candidate without explicit routing."),
+                    "The packet contract is complete: no missing required sections (goal, in/out of scope, acceptance criteria, base-branch policy).",
+                    "No open clarification or contract ambiguity on the candidate.",
+                    "Dependencies are satisfied — every dependency execution unit is completed or already cut; never publish ahead of an uncut dependency.",
+                    "Under the WIP cap — no in-progress blocker that should pace the queue first.",
+                    Apply("Clean host-sync / preflight: `intent-cli automation host-review-preflight --repo <owner/repo> --format json` and the publish preflight report no blocker, and the target repo/domain is unambiguous."),
+                },
+                Blockers = new[]
+                {
+                    "Missing contract sections — hold, do not publish.",
+                    "Open clarification / ambiguous contract — hold or escalate one operator decision.",
+                    "Dependency mismatch — an uncut or incomplete dependency; hold (publishing ahead would violate the dependency contract).",
+                    "WIP cap reached — let the in-progress work drain first.",
+                    "Host-sync blocker or failed preflight — fix the sync via intent-cli, do not force the publish.",
+                    "Ambiguous target repo or domain (no explicit routing in multi-domain) — escalate rather than guess.",
+                },
+                CanonicalCommands = new[]
+                {
+                    Apply("intent-cli issue publish-flow <execution-unit> --repo <owner/repo> --write --format json"),
+                    "intent-cli automation issue-publish --write --format json",
+                    "Never raw `gh issue create` or `gh ... --add-label`; publication and the `intent-target` label go through the canonical intent-cli surfaces only.",
+                },
+                PostPublishVerification = new[]
+                {
+                    "Confirm via intent-cli / GitHub (not chat) that the issue exists with the expected execution-unit body and the `intent-target` label.",
+                    "Confirm the durable workflow state (queue-state / linkage / label) reflects the publish through intent-cli surfaces.",
+                    "Only after verification, delegate implementation over agmsg — and the implementation receiver still derives its target from `intent-cli worker next-action`, not the agmsg text.",
+                },
+            },
             Threads = new[]
             {
                 new OrchestratorThreadPrompt
@@ -277,9 +318,12 @@ internal static class GuideOrchestratorThreadCommand
                         + "verify the GitHub facts that an agmsg reply claims (merged PR, CI, labels). Treat pending/"
                         + "running CI as an active wait state — re-check it on a later wake rather than asking the "
                         + "operator; delegate review/closeout only after required checks are green, route red checks to "
-                        + "repair or escalation by ownership, and escalate only stuck/ambiguous CI. Then send AT MOST "
-                        + "ONE message: a delegation (assign the next slice/PR), a repair request (point a stalled "
-                        + "thread back to the official intent-cli workflow), or an escalation to the operator. Do NOT "
+                        + "repair or escalation by ownership, and escalate only stuck/ambiguous CI. Then take AT MOST "
+                        + "ONE forward action: publish one ready next-slice issue (when intent-cli reports it "
+                        + "`issue-cut-ready` and all gates pass — via canonical `intent-cli issue publish-flow` / "
+                        + "`automation issue-publish`, then verify), send one delegation (assign the next slice/PR), send "
+                        + "one repair request (point a stalled thread back to the official intent-cli workflow), or "
+                        + "escalate one operator decision. Do NOT "
                         + "launch recurring implement/review timers for this domain/repo while orchestrating. Fail "
                         + "closed: if you detect a second orchestrator for this domain/repo, or agmsg replies conflict "
                         + "with GitHub/intent-cli facts, STOP and escalate rather than guessing. In "
@@ -527,6 +571,41 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Next-slice publication");
+        writer.WriteLine();
+        writer.WriteLine(guide.NextSlicePublication.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- one_per_wake: {(guide.NextSlicePublication.OnePerWake ? "yes" : "no")}");
+        writer.WriteLine();
+        writer.WriteLine("### Publish only when ALL hold");
+        writer.WriteLine();
+        foreach (var precondition in guide.NextSlicePublication.Preconditions)
+        {
+            writer.WriteLine($"- {precondition}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Blocked by (hold or escalate)");
+        writer.WriteLine();
+        foreach (var blocker in guide.NextSlicePublication.Blockers)
+        {
+            writer.WriteLine($"- {blocker}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Canonical publish commands");
+        writer.WriteLine();
+        foreach (var command in guide.NextSlicePublication.CanonicalCommands)
+        {
+            writer.WriteLine($"- {command}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Post-publish verification");
+        writer.WriteLine();
+        foreach (var step in guide.NextSlicePublication.PostPublishVerification)
+        {
+            writer.WriteLine($"- {step}");
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Thread prompts");
         foreach (var thread in guide.Threads)
         {
@@ -610,6 +689,9 @@ internal sealed record OrchestratorThreadGuide
 
     [JsonPropertyName("ci_wait_state")]
     public required OrchestratorCiWaitState CiWaitState { get; init; }
+
+    [JsonPropertyName("next_slice_publication")]
+    public required OrchestratorNextSlicePublication NextSlicePublication { get; init; }
 
     [JsonPropertyName("threads")]
     public required IReadOnlyList<OrchestratorThreadPrompt> Threads { get; init; }
@@ -709,6 +791,27 @@ internal sealed record OrchestratorCiState
 
     [JsonPropertyName("routing")]
     public required string Routing { get; init; }
+}
+
+internal sealed record OrchestratorNextSlicePublication
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("one_per_wake")]
+    public required bool OnePerWake { get; init; }
+
+    [JsonPropertyName("preconditions")]
+    public required IReadOnlyList<string> Preconditions { get; init; }
+
+    [JsonPropertyName("blockers")]
+    public required IReadOnlyList<string> Blockers { get; init; }
+
+    [JsonPropertyName("canonical_commands")]
+    public required IReadOnlyList<string> CanonicalCommands { get; init; }
+
+    [JsonPropertyName("post_publish_verification")]
+    public required IReadOnlyList<string> PostPublishVerification { get; init; }
 }
 
 internal sealed record OrchestratorThreadPrompt

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -295,6 +295,69 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_NextSlicePublication_IsOrchestratorResponsibility_OnePerWake()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Next-slice publication", output, StringComparison.Ordinal);
+        // Routine publication is the orchestrator's job, not an operator question.
+        Assert.Contains("ORCHESTRATOR responsibility, not an operator question", output, StringComparison.Ordinal);
+        Assert.Contains("one_per_wake: yes", output, StringComparison.Ordinal);
+        // Canonical publish surfaces are required; no raw gh.
+        Assert.Contains("issue publish-flow", output, StringComparison.Ordinal);
+        Assert.Contains("automation issue-publish", output, StringComparison.Ordinal);
+        Assert.Contains("Never raw `gh issue create`", output, StringComparison.Ordinal);
+        // Post-publish verification before delegating; receiver still uses worker next-action.
+        Assert.Contains("### Post-publish verification", output, StringComparison.Ordinal);
+        Assert.Contains("worker next-action", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_NextSlicePublication_ListsReadyGatesAndBlockers()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "codex"]);
+
+        // Ready preconditions cover same-domain/routed, contract, clarification, dependencies, WIP, host-sync.
+        Assert.Contains("### Publish only when ALL hold", output, StringComparison.Ordinal);
+        Assert.Contains("never publish a cross-domain candidate without explicit routing", output, StringComparison.Ordinal);
+        Assert.Contains("Dependencies are satisfied", output, StringComparison.Ordinal);
+        Assert.Contains("WIP cap", output, StringComparison.Ordinal);
+        Assert.Contains("host-sync / preflight", output, StringComparison.Ordinal);
+        // Blocked cases.
+        Assert.Contains("### Blocked by (hold or escalate)", output, StringComparison.Ordinal);
+        Assert.Contains("Missing contract sections", output, StringComparison.Ordinal);
+        Assert.Contains("Dependency mismatch", output, StringComparison.Ordinal);
+        Assert.Contains("Ambiguous target repo or domain", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasNextSlicePublicationShape()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var publication = doc.RootElement.GetProperty("next_slice_publication");
+
+        Assert.True(publication.GetProperty("one_per_wake").GetBoolean());
+        Assert.NotEmpty(publication.GetProperty("preconditions").EnumerateArray());
+        Assert.NotEmpty(publication.GetProperty("blockers").EnumerateArray());
+        Assert.NotEmpty(publication.GetProperty("canonical_commands").EnumerateArray());
+        Assert.NotEmpty(publication.GetProperty("post_publish_verification").EnumerateArray());
+
+        // The orchestrator prompt lists publication as a possible single action.
+        var orchestrator = doc.RootElement.GetProperty("threads").EnumerateArray()
+            .First(t => t.GetProperty("role").GetString() == "orchestrator")
+            .GetProperty("prompt").GetString()!;
+        Assert.Contains("publish one ready next-slice issue", orchestrator, StringComparison.Ordinal);
+        Assert.Contains("issue-cut-ready", orchestrator, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Closes #1087. Lets the scheduled agmsg orchestrator publish **one** ready next-slice GitHub issue per wake through canonical intent-cli commands, instead of stopping to ask the operator each time a candidate is `issue-cut-ready`. Builds on G489 (multi-domain routing) and G490 (scheduled wake contract), both merged.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `next_slice_publication` section** in the guide:
  - one-issue-**per-wake** bound (`one_per_wake: true`).
  - **publish preconditions** (all must hold): same-domain or explicitly routed multi-domain; complete packet contract; no open clarification; dependencies satisfied (never ahead of an uncut dependency); under the WIP cap; clean host-sync/preflight + unambiguous target repo/domain.
  - **blocker list**: missing contract sections, open clarification, dependency mismatch, WIP cap, host-sync blocker, ambiguous target repo/domain → hold or escalate.
  - **canonical publish surfaces**: `intent-cli issue publish-flow` / `intent-cli automation issue-publish`; never raw `gh issue create` / `--add-label`.
  - **post-publish verification** (GitHub/durable/label via intent-cli, not chat) before delegating implementation.
- **Orchestrator prompt + recurring-wake list** now include publishing one ready issue as a possible single action.
- **Receiver-side `worker next-action`** stays the implementation source of truth.
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Routine `issue-cut-ready` publication is handled by the orchestrator, not by asking the operator.
- ✅ Publication is limited to one issue per wake.
- ✅ Publication requires same-domain or explicitly routed multi-domain context.
- ✅ Publication is blocked by missing contract / open clarification / dependency mismatch / WIP cap / host-sync blocker / ambiguous target.
- ✅ Guide requires canonical publish-flow / issue-publish surfaces.
- ✅ Guide requires post-publish GitHub/durable/label verification.
- ✅ Implementation receiver prompt still requires `worker next-action` before claim.
- ✅ Tests cover ready and blocked cases.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 19 passed.
- `dotnet test … --filter ~Guide` — 953 passed.
- `git diff --check` — clean.

## Scope note

The Knowledge Maintenance `intents/**` intent-tree write-back and ADR-012 routine-publish amendment are host metadata / closeout responsibilities (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb