### PR TITLE
G494: Add design-thread guide for starting orchestrator mode

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -12,6 +12,36 @@ current prompts with:
 intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --mode single-domain|multi-domain --format markdown
 ```
 
+## Starting orchestrator mode (design-thread setup)
+
+A design thread that wants to run orchestration can ask intent-cli directly —
+`intent-cli guide workflow suggest --goal "I want to start agmsg orchestrator
+mode"` routes to the orchestrator setup guidance, and `guide orchestrator-thread`
+returns the concrete setup checklist. The shape:
+
+1. **Decide / record** — domain and target repo; host / orchestrator /
+   implementation / review paths (each role runs from its own folder, clone, or
+   worktree); base branch policy; per-role agents; agmsg team name; delivery
+   mode.
+2. **Register roles** — register orchestrator, implementation, and review under
+   one agmsg team (`join.sh`).
+3. **Set delivery** — give each role a way to receive messages, e.g. a streamed
+   inbox watch (`delivery.sh` / `watch.sh`).
+4. **Paste role prompts** — copy the orchestrator / implementation / review
+   prompts from `guide orchestrator-thread` into the matching threads.
+5. **First read-only wake** — run one confirm-only orchestrator wake; send
+   nothing.
+6. **Ping test** — send one agmsg message and confirm it lands in the target
+   role's inbox before any real delegation.
+7. **Schedule only the orchestrator** — Codex automation 5m or Claude
+   `/loop 5m`; receivers stay loopless.
+8. **Cleanup** — on teardown, leave/despawn the roles through the agmsg scripts
+   (`leave.sh` / `despawn.sh`) and stop any inbox watchers.
+
+> **Warning:** never edit the agmsg database or team files directly — register,
+> message, and clean up only through the agmsg scripts. Hand-editing agmsg state
+> corrupts delivery.
+
 ## What agmsg is (and is not)
 
 agmsg is a **message / progress / completion / blocker signal layer only**. It

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -12,6 +12,34 @@
 intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --mode single-domain|multi-domain --format markdown
 ```
 
+## orchestrator モードの開始（設計スレッドのセットアップ）
+
+オーケストレーションを動かしたい設計スレッドは intent-cli に直接尋ねられます —
+`intent-cli guide workflow suggest --goal "I want to start agmsg orchestrator mode"`
+が orchestrator setup ガイダンスへルーティングし、`guide orchestrator-thread` が
+具体的なセットアップチェックリストを返します。流れ:
+
+1. **決定 / 記録** — domain と target repo、host / orchestrator / implementation /
+   review のパス（各ロールは自分のフォルダー・クローン・worktree から実行）、base branch
+   policy、ロールごとの agent、agmsg team 名、delivery mode。
+2. **ロール登録** — orchestrator・implementation・review を 1 つの agmsg team に登録
+   （`join.sh`）。
+3. **delivery 設定** — 各ロールがメッセージを受け取れるようにする。例: ストリーミングの
+   inbox watch（`delivery.sh` / `watch.sh`）。
+4. **ロールプロンプトを貼る** — `guide orchestrator-thread` の orchestrator /
+   implementation / review プロンプトを対応するスレッドへコピーする。
+5. **最初の read-only wake** — 確認のみの orchestrator wake を 1 回実行し、何も送らない。
+6. **ping テスト** — agmsg メッセージを 1 通送り、実際の委譲の前に対象ロールの inbox に
+   届くことを確認する。
+7. **orchestrator のみスケジュール** — Codex automation 5m または Claude `/loop 5m`。
+   receiver は loopless のまま。
+8. **クリーンアップ** — 終了時は agmsg スクリプト（`leave.sh` / `despawn.sh`）でロールを
+   leave/despawn し、inbox watcher を停止する。
+
+> **警告:** agmsg のデータベースや team ファイルを直接編集しないでください — 登録・送信・
+> クリーンアップはすべて agmsg スクリプト経由で行います。agmsg state の手編集は delivery を
+> 壊します。
+
 ## agmsg とは（そして何ではないか）
 
 agmsg は **メッセージ / 進捗 / 完了 / ブロッカーのシグナル層のみ** です。スレッド間で

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -299,6 +299,56 @@ internal static class GuideOrchestratorThreadCommand
                     "Only after verification, delegate implementation over agmsg — and the implementation receiver still derives its target from `intent-cli worker next-action`, not the agmsg text.",
                 },
             },
+            Setup = new OrchestratorSetup
+            {
+                Summary =
+                    "Design-thread setup for starting orchestrator-message mode. The orchestrator is the single "
+                    + "scheduled driver; the implementation and review threads are loopless receivers. Decide the "
+                    + "inputs, register the agmsg roles under one team, paste the role prompts, run one read-only first "
+                    + "wake, ping-test the inbox, then schedule only the orchestrator. agmsg is a signal layer only; "
+                    + "intent-cli and GitHub stay authoritative.",
+                Decisions = new[]
+                {
+                    Apply("domain (`<domain>`) and target repo (`<owner/repo>`)"),
+                    "host / orchestrator / implementation / review paths — each role runs from its own folder, clone, or worktree",
+                    "base branch policy (e.g. direct-main)",
+                    Apply("per-role agents (e.g. orchestrator=`<agent>`, implementation=claude, review=codex)"),
+                    "agmsg team name",
+                    "delivery mode — how each role receives messages (e.g. a streamed inbox watch per role)",
+                },
+                Checklist = new[]
+                {
+                    "Record the decisions above (domain, repo, paths, base branch policy, agents, team, delivery mode).",
+                    "Register each role with agmsg under ONE team: orchestrator, implementation, review (agmsg `join.sh`).",
+                    "Set the delivery mode so each role receives messages — e.g. a streamed inbox watch per role (agmsg `delivery.sh` / `watch.sh`).",
+                    "Paste the role prompts from the `Thread prompts` section into the matching thread (orchestrator / implementation / review).",
+                    "Run ONE read-only first wake in the orchestrator (see `Orchestrator first wake`) — confirm only, send nothing.",
+                    "Ping-test the inbox before real delegation (see ping_test).",
+                    "Schedule ONLY the orchestrator (Codex automation 5m, or Claude same-thread `/loop 5m`); leave the receivers loopless.",
+                    "On teardown, clean up the agmsg roles through the agmsg scripts (see cleanup).",
+                },
+                AgmsgCommands = new[]
+                {
+                    "register a role / join the team — agmsg `join.sh`",
+                    "set the delivery mode — agmsg `delivery.sh`",
+                    "watch a role's inbox (receiver delivery) — agmsg `watch.sh`",
+                    "send a message / ping — agmsg `send.sh`",
+                    "list the team / identities — agmsg `team.sh`",
+                    "leave / clean up a role — agmsg `leave.sh` / `despawn.sh`",
+                },
+                PingTest =
+                    "Send one agmsg message from the orchestrator to each receiver and confirm it appears in that "
+                    + "receiver's inbox/stream before any real delegation. If the ping does not arrive, fix "
+                    + "delivery/registration first — do not start delegating against a broken channel.",
+                Cleanup = new[]
+                {
+                    "Leave the team / despawn each role through the agmsg scripts (`leave.sh` / `despawn.sh`).",
+                    "Stop any inbox watchers started for the roles.",
+                },
+                Warning =
+                    "Never edit the agmsg database or team files directly — register, message, and clean up ONLY through "
+                    + "the agmsg scripts. Hand-editing agmsg state corrupts delivery.",
+            },
             Threads = new[]
             {
                 new OrchestratorThreadPrompt
@@ -512,6 +562,43 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"- **mixed-mode warning** — {guide.ModeSeparation.MixedModeWarning}");
         writer.WriteLine();
 
+        writer.WriteLine("## Setup (starting orchestrator mode)");
+        writer.WriteLine();
+        writer.WriteLine(guide.Setup.Summary);
+        writer.WriteLine();
+        writer.WriteLine("### Decide / record");
+        writer.WriteLine();
+        foreach (var decision in guide.Setup.Decisions)
+        {
+            writer.WriteLine($"- {decision}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Setup checklist");
+        writer.WriteLine();
+        for (var i = 0; i < guide.Setup.Checklist.Count; i++)
+        {
+            writer.WriteLine($"{i + 1}. {guide.Setup.Checklist[i]}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### agmsg commands");
+        writer.WriteLine();
+        foreach (var command in guide.Setup.AgmsgCommands)
+        {
+            writer.WriteLine($"- {command}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **ping test** — {guide.Setup.PingTest}");
+        writer.WriteLine();
+        writer.WriteLine("### Cleanup");
+        writer.WriteLine();
+        foreach (var step in guide.Setup.Cleanup)
+        {
+            writer.WriteLine($"- {step}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"> **Warning:** {guide.Setup.Warning}");
+        writer.WriteLine();
+
         writer.WriteLine("## Domain routing — single-domain vs multi-domain");
         writer.WriteLine();
         writer.WriteLine($"- selected mode: `{guide.DomainRouting.Mode}`");
@@ -693,6 +780,9 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("next_slice_publication")]
     public required OrchestratorNextSlicePublication NextSlicePublication { get; init; }
 
+    [JsonPropertyName("setup")]
+    public required OrchestratorSetup Setup { get; init; }
+
     [JsonPropertyName("threads")]
     public required IReadOnlyList<OrchestratorThreadPrompt> Threads { get; init; }
 
@@ -791,6 +881,30 @@ internal sealed record OrchestratorCiState
 
     [JsonPropertyName("routing")]
     public required string Routing { get; init; }
+}
+
+internal sealed record OrchestratorSetup
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("decisions")]
+    public required IReadOnlyList<string> Decisions { get; init; }
+
+    [JsonPropertyName("checklist")]
+    public required IReadOnlyList<string> Checklist { get; init; }
+
+    [JsonPropertyName("agmsg_commands")]
+    public required IReadOnlyList<string> AgmsgCommands { get; init; }
+
+    [JsonPropertyName("ping_test")]
+    public required string PingTest { get; init; }
+
+    [JsonPropertyName("cleanup")]
+    public required IReadOnlyList<string> Cleanup { get; init; }
+
+    [JsonPropertyName("warning")]
+    public required string Warning { get; init; }
 }
 
 internal sealed record OrchestratorNextSlicePublication

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowSuggestCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowSuggestCommand.cs
@@ -21,6 +21,7 @@ internal static class GuideWorkflowSuggestCommand
     private const string WorkflowReview = "review";
     private const string WorkflowChildImplementation = "child-implementation";
     private const string WorkflowClarification = "clarification";
+    private const string WorkflowOrchestratorSetup = "orchestrator-setup";
     private const string WorkflowUnknown = "unknown";
 
     private const string UsageLine =
@@ -115,6 +116,15 @@ internal static class GuideWorkflowSuggestCommand
             return hit;
         }
 
+        // G494: orchestrator-setup is high-signal and checked first — a setup
+        // request like "I want to run orchestration" must not fall through to
+        // feature-intake (matches "want to") or review (a goal mentioning
+        // reviewing PRs via the orchestrator).
+        if (ContainsAny(new[] { "orchestrator", "orchestration", "agmsg", "オーケストレーター", "オーケストレーション" }))
+        {
+            return (WorkflowOrchestratorSetup, matched);
+        }
+
         if (ContainsAny(new[] { "clarif", "ambiguous", "blocker", "曖昧", "未決" }))
         {
             return (WorkflowClarification, matched);
@@ -202,6 +212,16 @@ internal static class GuideWorkflowSuggestCommand
                 new[] { "clarification", "child-issue-contract" },
                 "Clarification — surface open blockers and stop with a clarification-required summary; do not guess past ambiguous source-of-truth."),
 
+            WorkflowOrchestratorSetup => (
+                new[]
+                {
+                    $"intent-cli guide orchestrator-thread --domain {domain} --target-repo <owner/repo> --agent <agent> --format markdown",
+                    $"intent-cli guide orchestrator-thread --domain {domain} --target-repo <owner/repo> --agent <agent> --mode multi-domain --format markdown",
+                    $"intent-cli guide prompt-matrix --mode host-loop --domain {domain} --target-repo <owner/repo> --agent <agent> --format markdown"
+                },
+                new[] { "label-ownership", "clarification" },
+                "Orchestrator setup — the operator wants to start agmsg orchestrator-message mode. `guide orchestrator-thread` returns the full setup checklist (paths/roles/team/delivery, agmsg registration, paste-ready role prompts, first read-only wake, ping test, and cleanup). The orchestrator is the single scheduled driver; implementation/review stay loopless receivers. agmsg is a signal layer only — intent-cli and GitHub stay authoritative — and agmsg state is changed only through the agmsg scripts, never by editing its DB/team files."),
+
             _ => (
                 new[]
                 {
@@ -255,7 +275,8 @@ internal static class GuideWorkflowSuggestCommand
             {
                 "intent-cli run rereview --pr <n> — replay-mode rereview integration smoke; not the default review path."
             },
-            WorkflowFeatureIntake or WorkflowNextSlicePlanning or WorkflowClarification or WorkflowUnknown => Array.Empty<string>(),
+            WorkflowFeatureIntake or WorkflowNextSlicePlanning or WorkflowClarification
+                or WorkflowOrchestratorSetup or WorkflowUnknown => Array.Empty<string>(),
             _ => Array.Empty<string>()
         };
     }

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -358,6 +358,52 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_Setup_HasConcreteChecklist_PingTest_Cleanup_AndDbWarning_G494()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Setup (starting orchestrator mode)", output, StringComparison.Ordinal);
+        // Decisions displayed: paths, base branch policy, agents, team, delivery.
+        Assert.Contains("base branch policy", output, StringComparison.Ordinal);
+        Assert.Contains("agmsg team name", output, StringComparison.Ordinal);
+        Assert.Contains("delivery mode", output, StringComparison.Ordinal);
+        Assert.Contains("implementation / review paths", output, StringComparison.Ordinal);
+        // Role registration + delivery commands.
+        Assert.Contains("### agmsg commands", output, StringComparison.Ordinal);
+        Assert.Contains("join.sh", output, StringComparison.Ordinal);
+        Assert.Contains("delivery.sh", output, StringComparison.Ordinal);
+        // First read-only wake + ping test.
+        Assert.Contains("read-only first wake", output, StringComparison.Ordinal);
+        Assert.Contains("ping test", output, StringComparison.Ordinal);
+        // Cleanup via agmsg scripts.
+        Assert.Contains("### Cleanup", output, StringComparison.Ordinal);
+        Assert.Contains("leave.sh", output, StringComparison.Ordinal);
+        // Warn not to edit agmsg DB/team files directly.
+        Assert.Contains("Never edit the agmsg database or team files directly", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasSetupShape_G494()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var setup = doc.RootElement.GetProperty("setup");
+
+        Assert.NotEmpty(setup.GetProperty("decisions").EnumerateArray());
+        Assert.NotEmpty(setup.GetProperty("checklist").EnumerateArray());
+        Assert.NotEmpty(setup.GetProperty("agmsg_commands").EnumerateArray());
+        Assert.NotEmpty(setup.GetProperty("cleanup").EnumerateArray());
+        Assert.True(setup.TryGetProperty("ping_test", out _));
+        Assert.Contains("agmsg scripts", setup.GetProperty("warning").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowSuggestCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowSuggestCommandTests.cs
@@ -18,6 +18,9 @@ public sealed class GuideWorkflowSuggestCommandTests
     [InlineData("issue 605 を実装してほしい", "child-implementation")]
     [InlineData("source-of-truth が曖昧な部分がある", "clarification")]
     [InlineData("we have a clarification blocker", "clarification")]
+    [InlineData("I want to start agmsg orchestrator mode", "orchestrator-setup")]
+    [InlineData("set up an orchestrator to run orchestration", "orchestrator-setup")]
+    [InlineData("オーケストレーターを立ち上げたい", "orchestrator-setup")]
     [InlineData("xyzzy mumble", "unknown")]
     public void Execute_ClassifiesGoalIntoExpectedWorkflow(string goal, string expectedWorkflow)
     {
@@ -30,6 +33,30 @@ public sealed class GuideWorkflowSuggestCommandTests
         Assert.Equal(0, exitCode);
         using var document = JsonDocument.Parse(writer.ToString());
         Assert.Equal(expectedWorkflow, document.RootElement.GetProperty("workflow").GetString());
+    }
+
+    [Fact]
+    public void Execute_OrchestratorSetup_RoutesToOrchestratorThreadGuide_G494()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowSuggestCommand.Execute(
+            CreateContext(),
+            ["--goal", "I want to run agmsg orchestration", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("orchestrator-setup", document.RootElement.GetProperty("workflow").GetString());
+
+        // Routes to the orchestrator-thread guide (not generic feature intake).
+        var commands = document.RootElement.GetProperty("recommended_commands").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Contains(commands, c => c!.StartsWith("intent-cli guide orchestrator-thread", StringComparison.Ordinal));
+        Assert.DoesNotContain(commands, c => c!.StartsWith("intent-cli guide collaborate", StringComparison.Ordinal));
+
+        // Summary names the loopless-receiver / signal-only invariants.
+        var summary = document.RootElement.GetProperty("summary").GetString()!;
+        Assert.Contains("loopless", summary, StringComparison.Ordinal);
+        Assert.Contains("signal layer only", summary, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #1089. Lets a design thread answer "I want to start agmsg orchestrator mode" with a concrete setup plan from intent-cli, instead of relying on copied prompts. Builds on G487 / G490 / G491 (all merged).

Surfaces: `intent-cli guide workflow suggest` (routing) + `intent-cli guide orchestrator-thread` (setup checklist) + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **`guide workflow suggest`** recognizes orchestrator / orchestration / agmsg setup language (checked **first**, so "I want to run orchestration" does not fall through to feature-intake via "want to") and routes to a new **`orchestrator-setup`** workflow whose recommended commands point at `guide orchestrator-thread`.
- **`guide orchestrator-thread`** gains a **`setup`** section:
  - inputs to decide/record: domain, target repo, host/orchestrator/implementation/review paths, base branch policy, per-role agents, agmsg team name, delivery mode;
  - an ordered **setup checklist**;
  - agmsg **role-registration / delivery / ping / cleanup** commands (`join.sh` / `delivery.sh` / `watch.sh` / `send.sh` / `team.sh` / `leave.sh` / `despawn.sh`);
  - the **first read-only wake** and a **ping/inbox test**;
  - a **warning** never to edit the agmsg DB/team files by hand.
  - Receivers stay loopless; only the orchestrator is scheduled.
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Workflow suggestion routes orchestrator setup language to orchestrator setup guidance.
- ✅ Guide displays domain, target repo, host/orchestrator/implementation/review paths, base branch policy, agents, team name, delivery mode.
- ✅ Guide includes agmsg role registration commands.
- ✅ Guide includes paste-ready prompts for orchestrator, implementer, reviewer (existing `Thread prompts`, referenced from the checklist).
- ✅ Guide includes first read-only wake and ping/inbox test.
- ✅ Guide includes cleanup commands using agmsg scripts.
- ✅ Guide warns not to edit agmsg DB/team files directly.
- ✅ Tests/snapshots cover setup request output.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests|GuideWorkflowSuggestCommandTests` — 47 passed.
- `dotnet test` (full Cli suite) — 3134 passed, 1 skipped.
- `git diff --check` — clean.

## Scope note

The Knowledge Maintenance `intents/**` intent-tree write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb