### PR TITLE
G495: Add dependency-aware orchestrator planning

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -159,6 +159,35 @@ label and that durable state reflects it, then delegate implementation over
 agmsg. The implementation receiver still derives its target from
 `intent-cli worker next-action`, not the agmsg text.
 
+## Dependency planning
+
+Unmet dependencies are **normal orchestration work** when explicit and
+resolvable — not an operator stop. When the next candidate depends on work that
+is not yet complete, the orchestrator does **not** pause for operator judgment;
+it plans the chain deterministically: hold the dependent candidate and route
+this wake's action to the **earliest unmet** same-domain (or explicitly routed)
+dependency.
+
+Routing by dependency status:
+
+- **dependency-publish-ready** — the earliest unmet dependency is
+  `issue-cut-ready` with no GitHub issue → publish it this wake (one issue per
+  wake, under the next-slice publication gates); keep the dependent held.
+- **dependency-actionable** — the dependency already has an issue or PR that can
+  move → route it (implementation, review, closeout, or repair) using
+  intent-cli / GitHub facts.
+- **dependency-waiting** — the dependency is in flight (e.g. PR CI pending) →
+  wait and re-check next wake; keep the dependent held.
+- **dependency-ambiguous** — cannot be resolved deterministically (missing
+  dependency packet, conflicting GitHub linkage, cross-domain with no route
+  mapping) → escalate one operator decision.
+- **dependency-cycle** — the dependencies form a cycle → escalate (fail closed).
+
+The dependent candidate stays held until every dependency is completed/cut.
+**Escalate only** for: a missing dependency packet, a dependency cycle, a
+cross-domain dependency without route mapping, conflicting GitHub linkage,
+destructive recovery, credentials/security, or a human product/design judgment.
+
 ## Single-domain vs multi-domain orchestration
 
 A host checkout can legitimately contain **several** intent domains (for

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -151,6 +151,31 @@ issue が期待どおりの body と `intent-target` label を持つこと、dur
 反映していることを検証し、その後 agmsg で実装を委譲します。実装 receiver は依然として
 `intent-cli worker next-action` からターゲットを得ます（agmsg テキストからではありません）。
 
+## 依存の計画（dependency planning）
+
+未充足の依存は、明示的かつ解決可能であれば **通常のオーケストレーション作業** であり、
+オペレーターへの停止ではありません。次の候補が未完了の作業に依存している場合、orchestrator は
+オペレーター判断のために止まらず、チェーンを決定論的に計画します — 依存元の候補を hold し、
+この wake のアクションを **最も早い未充足の** same-domain（または明示ルーティングされた）依存に
+向けます。
+
+依存ステータスによるルーティング:
+
+- **dependency-publish-ready** — 最も早い未充足依存が `issue-cut-ready` で GitHub issue が
+  ない → この wake で publish（1 wake 1 件、next-slice publication ゲートに従う）。依存元は
+  hold のまま。
+- **dependency-actionable** — 依存にすでに issue または PR があり進められる → intent-cli /
+  GitHub の事実を使ってルーティング（実装・レビュー・closeout・repair）。
+- **dependency-waiting** — 依存が in flight（例: PR の CI が pending）→ 次の wake まで待って
+  再確認。依存元は hold のまま。
+- **dependency-ambiguous** — 決定論的に解決できない（依存 packet 欠落、GitHub linkage の矛盾、
+  ルートマッピングのない cross-domain）→ 1 件のオペレーター判断にエスカレーション。
+- **dependency-cycle** — 依存が循環している → エスカレーション（fail closed）。
+
+依存元の候補は、すべての依存が完了/cut されるまで hold されます。**エスカレーションは次の場合
+のみ**: 依存 packet の欠落、依存の循環、ルートマッピングのない cross-domain 依存、GitHub
+linkage の矛盾、破壊的な復旧、認証情報/セキュリティ、または人間のプロダクト/設計判断。
+
 ## single-domain と multi-domain のオーケストレーション
 
 host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -199,6 +199,7 @@ internal static class GuideOrchestratorThreadCommand
                     "Classify each open PR's CI: pending = wait-and-recheck next wake (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate. Pending CI is normal progress, not a reason to message the operator.",
                     "Detect stale blockers and no-reply receivers: a delegation with no accepted/progress reply within the expected window, or a thread stuck off the official workflow.",
                     "If intent-cli reports an `issue-cut-ready` candidate and all gates pass (same-domain or routed, complete contract, no open clarification, dependencies satisfied, under WIP, clean host-sync/preflight), publish ONE issue this wake via canonical publish-flow / issue-publish, then verify — do not ask the operator to create it.",
+                    "If the candidate has unmet dependencies, plan the chain instead of pausing: act on the EARLIEST unmet resolvable dependency (publish or route it), keep the dependent held, and escalate only ambiguous/cycle/cross-domain-unrouted cases.",
                     "Decide the single action for this wake: publish one ready next-slice issue, delegate the next slice/PR, send one repair message, or escalate one operator decision.",
                 },
                 RepairVsEscalate = new OrchestratorRepairEscalate
@@ -299,6 +300,72 @@ internal static class GuideOrchestratorThreadCommand
                     "Only after verification, delegate implementation over agmsg — and the implementation receiver still derives its target from `intent-cli worker next-action`, not the agmsg text.",
                 },
             },
+            DependencyPlanning = new OrchestratorDependencyPlanning
+            {
+                Summary =
+                    "Unmet dependencies are NORMAL orchestration work when explicit and resolvable — not an operator "
+                    + "stop. When a candidate depends on work that is not yet complete, do NOT pause for operator "
+                    + "judgment; plan the dependency chain deterministically: hold the dependent candidate and route this "
+                    + "wake's action to the earliest unmet dependency.",
+                SelectionRule =
+                    "Select the EARLIEST unmet same-domain dependency first (or an explicitly routed multi-domain "
+                    + "dependency). Act on that dependency this wake — publish or route it — rather than on the dependent "
+                    + "candidate. Walk the chain from its root, not from the visible leaf candidate.",
+                Statuses = new[]
+                {
+                    new OrchestratorDependencyStatus
+                    {
+                        Status = "dependency-publish-ready",
+                        Action =
+                            "The earliest unmet dependency is `issue-cut-ready` and has no GitHub issue — publish it this "
+                            + "wake under the next-slice publication gates (one issue per wake), then keep the dependent "
+                            + "candidate held.",
+                    },
+                    new OrchestratorDependencyStatus
+                    {
+                        Status = "dependency-actionable",
+                        Action =
+                            "The dependency already has an issue or PR that can move forward — route it (delegate "
+                            + "implementation, review, closeout, or repair) using intent-cli / GitHub facts, not the "
+                            + "dependent candidate.",
+                    },
+                    new OrchestratorDependencyStatus
+                    {
+                        Status = "dependency-waiting",
+                        Action =
+                            "The dependency is published and in flight (e.g. PR CI pending) — wait and re-check on the "
+                            + "next wake; do not ask the operator. Keep the dependent candidate held.",
+                    },
+                    new OrchestratorDependencyStatus
+                    {
+                        Status = "dependency-ambiguous",
+                        Action =
+                            "The dependency cannot be resolved deterministically (missing dependency packet, conflicting "
+                            + "GitHub linkage, or a cross-domain dependency with no route mapping) — escalate one operator "
+                            + "decision (fail closed).",
+                    },
+                    new OrchestratorDependencyStatus
+                    {
+                        Status = "dependency-cycle",
+                        Action =
+                            "The dependencies form a cycle — escalate (fail closed); never pick a node arbitrarily to "
+                            + "break the cycle.",
+                    },
+                },
+                DependentHold =
+                    "Keep the dependent candidate held — do not publish or delegate it — until every dependency is "
+                    + "completed/cut. Re-evaluate the chain on each wake.",
+                EscalationCases = new[]
+                {
+                    "A dependency packet is missing (referenced but no packet exists).",
+                    "The dependencies form a cycle.",
+                    "A cross-domain dependency has no explicit route mapping.",
+                    "Conflicting GitHub linkage (two issues/PRs claim the same dependency, or linkage disagrees with the packet).",
+                    "Destructive recovery would be required to proceed.",
+                    "Credentials / security are involved.",
+                    "A human product/design judgment is required.",
+                },
+            },
             Setup = new OrchestratorSetup
             {
                 Summary =
@@ -373,7 +440,10 @@ internal static class GuideOrchestratorThreadCommand
                         + "`issue-cut-ready` and all gates pass — via canonical `intent-cli issue publish-flow` / "
                         + "`automation issue-publish`, then verify), send one delegation (assign the next slice/PR), send "
                         + "one repair request (point a stalled thread back to the official intent-cli workflow), or "
-                        + "escalate one operator decision. Do NOT "
+                        + "escalate one operator decision. Unmet dependencies are normal work, not a stop: if the next "
+                        + "candidate depends on incomplete work, act on the EARLIEST unmet resolvable dependency "
+                        + "(publish or route it) and keep the dependent held, rather than pausing for the operator. Do "
+                        + "NOT "
                         + "launch recurring implement/review timers for this domain/repo while orchestrating. Fail "
                         + "closed: if you detect a second orchestrator for this domain/repo, or agmsg replies conflict "
                         + "with GitHub/intent-cli facts, STOP and escalate rather than guessing. In "
@@ -693,6 +763,28 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Dependency planning");
+        writer.WriteLine();
+        writer.WriteLine(guide.DependencyPlanning.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- **selection rule** — {guide.DependencyPlanning.SelectionRule}");
+        writer.WriteLine($"- **dependent hold** — {guide.DependencyPlanning.DependentHold}");
+        writer.WriteLine();
+        writer.WriteLine("### Dependency statuses");
+        writer.WriteLine();
+        foreach (var status in guide.DependencyPlanning.Statuses)
+        {
+            writer.WriteLine($"- **{status.Status}** — {status.Action}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Escalate only when");
+        writer.WriteLine();
+        foreach (var escalation in guide.DependencyPlanning.EscalationCases)
+        {
+            writer.WriteLine($"- {escalation}");
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Thread prompts");
         foreach (var thread in guide.Threads)
         {
@@ -779,6 +871,9 @@ internal sealed record OrchestratorThreadGuide
 
     [JsonPropertyName("next_slice_publication")]
     public required OrchestratorNextSlicePublication NextSlicePublication { get; init; }
+
+    [JsonPropertyName("dependency_planning")]
+    public required OrchestratorDependencyPlanning DependencyPlanning { get; init; }
 
     [JsonPropertyName("setup")]
     public required OrchestratorSetup Setup { get; init; }
@@ -881,6 +976,33 @@ internal sealed record OrchestratorCiState
 
     [JsonPropertyName("routing")]
     public required string Routing { get; init; }
+}
+
+internal sealed record OrchestratorDependencyPlanning
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("selection_rule")]
+    public required string SelectionRule { get; init; }
+
+    [JsonPropertyName("statuses")]
+    public required IReadOnlyList<OrchestratorDependencyStatus> Statuses { get; init; }
+
+    [JsonPropertyName("dependent_hold")]
+    public required string DependentHold { get; init; }
+
+    [JsonPropertyName("escalation_cases")]
+    public required IReadOnlyList<string> EscalationCases { get; init; }
+}
+
+internal sealed record OrchestratorDependencyStatus
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("action")]
+    public required string Action { get; init; }
 }
 
 internal sealed record OrchestratorSetup

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -404,6 +404,61 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_DependencyPlanning_RoutesToEarliestUnmetDependency_NotOperator_G495()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Dependency planning", output, StringComparison.Ordinal);
+        // Unmet deps are normal work, not an operator stop.
+        Assert.Contains("NORMAL orchestration work when explicit and resolvable", output, StringComparison.Ordinal);
+        Assert.Contains("not an operator", output, StringComparison.Ordinal);
+        // Earliest unmet dependency first; dependent held.
+        Assert.Contains("EARLIEST unmet same-domain dependency first", output, StringComparison.Ordinal);
+        Assert.Contains("**dependent hold**", output, StringComparison.Ordinal);
+        // The five structured statuses.
+        Assert.Contains("- **dependency-publish-ready**", output, StringComparison.Ordinal);
+        Assert.Contains("- **dependency-actionable**", output, StringComparison.Ordinal);
+        Assert.Contains("- **dependency-waiting**", output, StringComparison.Ordinal);
+        Assert.Contains("- **dependency-ambiguous**", output, StringComparison.Ordinal);
+        Assert.Contains("- **dependency-cycle**", output, StringComparison.Ordinal);
+        // Escalation reserved for ambiguous/cycle/cross-domain/etc.
+        Assert.Contains("### Escalate only when", output, StringComparison.Ordinal);
+        Assert.Contains("dependency packet is missing", output, StringComparison.Ordinal);
+        Assert.Contains("cross-domain dependency has no explicit route mapping", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasDependencyPlanningShape_WithFiveStatuses_G495()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var planning = doc.RootElement.GetProperty("dependency_planning");
+
+        Assert.True(planning.TryGetProperty("selection_rule", out _));
+        Assert.True(planning.TryGetProperty("dependent_hold", out _));
+        var statuses = planning.GetProperty("statuses").EnumerateArray()
+            .Select(s => s.GetProperty("status").GetString())
+            .ToArray();
+        Assert.Equal(
+            new[] { "dependency-publish-ready", "dependency-actionable", "dependency-waiting", "dependency-ambiguous", "dependency-cycle" },
+            statuses);
+        Assert.NotEmpty(planning.GetProperty("escalation_cases").EnumerateArray());
+
+        // The orchestrator prompt treats unmet dependencies as routine, not a stop.
+        var orchestrator = doc.RootElement.GetProperty("threads").EnumerateArray()
+            .First(t => t.GetProperty("role").GetString() == "orchestrator")
+            .GetProperty("prompt").GetString()!;
+        Assert.Contains("Unmet dependencies are normal work", orchestrator, StringComparison.Ordinal);
+        Assert.Contains("EARLIEST unmet resolvable dependency", orchestrator, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Closes #1091. Teaches the agmsg orchestrator that **unmet dependencies are normal orchestration work** when explicit and resolvable — not an operator stop. Instead of pausing when a dependent candidate becomes visible before its dependency is complete, the orchestrator plans the chain deterministically: hold the dependent and route to the earliest unmet dependency. Builds on G491 (bounded next-slice publish) and resolves the G491/G494-style failure surfaced in dogfooding.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `dependency_planning` section** in the guide:
  - **selection rule** — act on the earliest unmet same-domain (or explicitly routed) dependency first, walking the chain from its root.
  - **five structured statuses** with routing:
    - `dependency-publish-ready` → publish the dependency under the next-slice gates (one issue per wake);
    - `dependency-actionable` → route impl/review/closeout/repair via intent-cli/GitHub facts;
    - `dependency-waiting` → wait and re-check next wake;
    - `dependency-ambiguous` → escalate (fail closed);
    - `dependency-cycle` → escalate (fail closed).
  - **dependent hold** — the dependent candidate stays held until all dependencies are completed/cut.
  - **escalation** reserved for missing packet, cycle, cross-domain without route mapping, conflicting linkage, destructive recovery, credentials, or human product judgment.
- **Orchestrator prompt + recurring-wake list** now treat unmet dependencies as routine chain-planning, not a pause.
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Guidance says unmet dependencies are normal orchestration work when explicit and resolvable.
- ✅ Same-domain dependency chains planned from the earliest unmet dependency first.
- ✅ Issue-cut-ready dependency with no issue → publish (bounded one per wake).
- ✅ Dependency with an existing issue/PR → route implementation/review/CI-wait/closeout/repair via intent-cli/GitHub facts.
- ✅ Dependent candidates remain held until dependencies complete.
- ✅ Escalation reserved for missing packet, cycle, cross-domain unrouted, conflicting linkage, destructive recovery, credentials, product judgment.
- ✅ Tests cover a dependent-candidate-before-dependency scenario.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 23 passed.
- `dotnet test … --filter ~Guide` — 961 passed.
- `git diff --check` — clean.

## Scope note

The Related Links `intents/**` intent-tree / spec / ADR write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb