### PR TITLE
G496: Add stale-thread health check policy for orchestrator mode

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -188,6 +188,35 @@ The dependent candidate stays held until every dependency is completed/cut.
 cross-domain dependency without route mapping, conflicting GitHub linkage,
 destructive recovery, credentials/security, or a human product/design judgment.
 
+## Stale-thread health check
+
+Receivers are loopless, so **silence is ambiguous** — a receiver may be working,
+waiting for CI, waiting for a permission prompt, blocked, completed without a
+reply, or truly stale. When a receiver has had no reply past the threshold
+(default **30 minutes**, configurable), the orchestrator runs a **safe**
+liveness check: ask before acting, verify authoritative facts, and never
+auto-cancel work, auto-clear a permission prompt, or duplicate a task.
+
+Procedure:
+
+1. Send **one non-destructive status-request** — ask, do not retry/cancel/reset.
+2. Check read-only intent-cli / GitHub facts (`worker next-action`, issue/PR
+   state, CI, labels).
+3. If facts show progress (new commits, PR updated, CI running), **keep
+   watching** — do not re-send the work.
+4. If the receiver replies `waiting-permission`, it is an **operator notice** —
+   surface it; never auto-clear the prompt.
+5. Only after repeated no-reply **and** no progress, send **at most one
+   idempotent re-entry** referencing the same issue/PR.
+6. Escalate after repeated silence with no progress, or any unsafe case
+   (cancel/reset, destructive git, credentials).
+
+The status-request asks the receiver to reply with one of: `working`,
+`waiting-ci`, `waiting-permission`, `blocked`, `completed`, `idle`. A health
+check never clears a permission prompt, cancels/resets work, mutates labels, or
+runs destructive git. (Timer-loop mode is unaffected — this applies only to
+orchestrator-message receivers.)
+
 ## Single-domain vs multi-domain orchestration
 
 A host checkout can legitimately contain **several** intent domains (for

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -176,6 +176,31 @@ issue が期待どおりの body と `intent-target` label を持つこと、dur
 のみ**: 依存 packet の欠落、依存の循環、ルートマッピングのない cross-domain 依存、GitHub
 linkage の矛盾、破壊的な復旧、認証情報/セキュリティ、または人間のプロダクト/設計判断。
 
+## stale-thread ヘルスチェック
+
+receiver は loopless なので、**沈黙は曖昧** です — receiver は working、CI 待ち、
+permission プロンプト待ち、blocked、返信なしで completed、または本当に stale かもしれません。
+receiver がしきい値（デフォルト **30 分**、設定可能）を超えて返信しない場合、orchestrator は
+**安全な** liveness チェックを行います: 行動する前に尋ね、権威ある事実を検証し、作業の自動
+キャンセル・permission プロンプトの自動クリア・タスクの重複を決して行いません。
+
+手順:
+
+1. **非破壊的な status-request を 1 通** 送る — 尋ねるだけで、retry/cancel/reset しない。
+2. read-only の intent-cli / GitHub 事実を確認（`worker next-action`、issue/PR 状態、CI、label）。
+3. 事実が進捗を示すなら（新規コミット、PR 更新、CI 実行中）**監視を続ける** — 作業を再送しない。
+4. receiver が `waiting-permission` と返したら、それは **オペレーター通知** — surface する。
+   プロンプトを自動クリアしない。
+5. 繰り返しの no-reply **かつ** 進捗なしの後にのみ、同じ issue/PR を参照する
+   **冪等な re-entry を最大 1 通** 送る。
+6. 進捗のない沈黙が続く場合、または安全でないケース（cancel/reset、破壊的 git、認証情報）は
+   エスカレーションする。
+
+status-request は receiver に次のいずれかで返信するよう求めます: `working`、`waiting-ci`、
+`waiting-permission`、`blocked`、`completed`、`idle`。ヘルスチェックは permission プロンプトの
+クリア、作業の cancel/reset、label の変更、破壊的 git を決して行いません。（timer-loop モードは
+影響を受けません — これは orchestrator-message の receiver にのみ適用されます。）
+
 ## single-domain と multi-domain のオーケストレーション
 
 host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -198,6 +198,7 @@ internal static class GuideOrchestratorThreadCommand
                     "Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge state, and closeout/label state.",
                     "Classify each open PR's CI: pending = wait-and-recheck next wake (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate. Pending CI is normal progress, not a reason to message the operator.",
                     "Detect stale blockers and no-reply receivers: a delegation with no accepted/progress reply within the expected window, or a thread stuck off the official workflow.",
+                    "On a no-reply receiver past the threshold (default 30m), run the SAFE stale-thread health check: send one non-destructive status-request, check read-only intent-cli/GitHub facts, keep watching if there is progress, treat waiting-permission as an operator notice (never auto-clear), and only after repeated no-reply with no progress send one idempotent re-entry or escalate.",
                     "If intent-cli reports an `issue-cut-ready` candidate and all gates pass (same-domain or routed, complete contract, no open clarification, dependencies satisfied, under WIP, clean host-sync/preflight), publish ONE issue this wake via canonical publish-flow / issue-publish, then verify — do not ask the operator to create it.",
                     "If the candidate has unmet dependencies, plan the chain instead of pausing: act on the EARLIEST unmet resolvable dependency (publish or route it), keep the dependent held, and escalate only ambiguous/cycle/cross-domain-unrouted cases.",
                     "Decide the single action for this wake: publish one ready next-slice issue, delegate the next slice/PR, send one repair message, or escalate one operator decision.",
@@ -366,6 +367,48 @@ internal static class GuideOrchestratorThreadCommand
                     "A human product/design judgment is required.",
                 },
             },
+            StaleThreadHealthCheck = new OrchestratorStaleThreadHealthCheck
+            {
+                Summary =
+                    "The implementation/review receivers are loopless, so silence is ambiguous — a receiver may be "
+                    + "working, waiting for CI, waiting for a permission prompt, blocked, completed-without-reply, or "
+                    + "truly stale. When a receiver has had no reply past the threshold, run a SAFE liveness check: ask "
+                    + "before acting, verify authoritative facts, and never auto-cancel work, auto-clear a permission "
+                    + "prompt, or duplicate a task.",
+                NoReplyThreshold =
+                    "Default 30 minutes since the receiver's last reply (configurable). Below the threshold, treat "
+                    + "silence as normal in-progress work — do not poke.",
+                Procedure = new[]
+                {
+                    "On no reply for >= the threshold, send ONE non-destructive status-request (see status_request_template) — ask, do not retry, cancel, or reset yet.",
+                    "Check read-only intent-cli / GitHub facts: `worker next-action`, the issue/PR state, CI conclusion, and labels. Silence plus visible progress means the thread is working.",
+                    "If authoritative facts show progress (new commits, PR opened/updated, CI running), keep watching — do not re-send the work.",
+                    "If the receiver replies `waiting-permission`, treat it as an OPERATOR NOTICE — surface it; never auto-clear the permission/credential prompt.",
+                    "Only after repeated no-reply AND no observable progress, send AT MOST ONE idempotent re-entry prompt that references the same issue/PR so it cannot duplicate work.",
+                    "Escalate to the operator after repeated silence with no progress, or any unsafe case (would require cancel/reset, destructive git, or credentials).",
+                },
+                StatusRequestTemplate =
+                    "{\"type\":\"status-request\",\"to\":\"<thread>\",\"ref\":\"issue#<n>|pr#<n>\",\"ask\":"
+                    + "\"non-destructive liveness check: reply with one of working / waiting-ci / waiting-permission / "
+                    + "blocked / completed / idle; do not start new work\"}",
+                ReceiverStatuses = new[]
+                {
+                    new OrchestratorReceiverStatus { Status = "working", Meaning = "actively implementing/reviewing — keep watching, take no action." },
+                    new OrchestratorReceiverStatus { Status = "waiting-ci", Meaning = "waiting on CI to conclude — wait and re-check; pending CI is normal progress." },
+                    new OrchestratorReceiverStatus { Status = "waiting-permission", Meaning = "blocked on a permission/credential prompt — OPERATOR NOTICE; never auto-clear, surface it to the operator." },
+                    new OrchestratorReceiverStatus { Status = "blocked", Meaning = "blocked on a clarification or external dependency — read the structured blocker and route repair or escalate." },
+                    new OrchestratorReceiverStatus { Status = "completed", Meaning = "work finished — verify against intent-cli / GitHub; a completed-without-reply thread may just need its reply confirmed." },
+                    new OrchestratorReceiverStatus { Status = "idle", Meaning = "no current task — safe to delegate the next item." },
+                },
+                Safety = new[]
+                {
+                    "Never auto-clear a permission/credential prompt — `waiting-permission` is an operator notice only.",
+                    "Never auto-cancel or reset a receiver's work as part of a health check.",
+                    "No destructive git operations and no raw label mutation in a health check.",
+                    "Re-entry is idempotent: reference the existing issue/PR so a re-sent prompt cannot duplicate work.",
+                    "Ask (status-request) and verify authoritative facts before any retry or escalation.",
+                },
+            },
             Setup = new OrchestratorSetup
             {
                 Summary =
@@ -442,7 +485,10 @@ internal static class GuideOrchestratorThreadCommand
                         + "one repair request (point a stalled thread back to the official intent-cli workflow), or "
                         + "escalate one operator decision. Unmet dependencies are normal work, not a stop: if the next "
                         + "candidate depends on incomplete work, act on the EARLIEST unmet resolvable dependency "
-                        + "(publish or route it) and keep the dependent held, rather than pausing for the operator. Do "
+                        + "(publish or route it) and keep the dependent held, rather than pausing for the operator. For a "
+                        + "no-reply receiver past the threshold (default 30m), run the SAFE stale-thread health check — "
+                        + "send one non-destructive status-request and verify read-only intent-cli/GitHub facts before any "
+                        + "retry; never auto-clear a permission prompt, auto-cancel work, or duplicate a task. Do "
                         + "NOT "
                         + "launch recurring implement/review timers for this domain/repo while orchestrating. Fail "
                         + "closed: if you detect a second orchestrator for this domain/repo, or agmsg replies conflict "
@@ -785,6 +831,40 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Stale-thread health check");
+        writer.WriteLine();
+        writer.WriteLine(guide.StaleThreadHealthCheck.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- **no-reply threshold** — {guide.StaleThreadHealthCheck.NoReplyThreshold}");
+        writer.WriteLine();
+        writer.WriteLine("### Procedure");
+        writer.WriteLine();
+        for (var i = 0; i < guide.StaleThreadHealthCheck.Procedure.Count; i++)
+        {
+            writer.WriteLine($"{i + 1}. {guide.StaleThreadHealthCheck.Procedure[i]}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Status-request message");
+        writer.WriteLine();
+        writer.WriteLine("```json");
+        writer.WriteLine(guide.StaleThreadHealthCheck.StatusRequestTemplate);
+        writer.WriteLine("```");
+        writer.WriteLine();
+        writer.WriteLine("### Receiver statuses");
+        writer.WriteLine();
+        foreach (var status in guide.StaleThreadHealthCheck.ReceiverStatuses)
+        {
+            writer.WriteLine($"- **{status.Status}** — {status.Meaning}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Health-check safety");
+        writer.WriteLine();
+        foreach (var rule in guide.StaleThreadHealthCheck.Safety)
+        {
+            writer.WriteLine($"- {rule}");
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Thread prompts");
         foreach (var thread in guide.Threads)
         {
@@ -874,6 +954,9 @@ internal sealed record OrchestratorThreadGuide
 
     [JsonPropertyName("dependency_planning")]
     public required OrchestratorDependencyPlanning DependencyPlanning { get; init; }
+
+    [JsonPropertyName("stale_thread_health_check")]
+    public required OrchestratorStaleThreadHealthCheck StaleThreadHealthCheck { get; init; }
 
     [JsonPropertyName("setup")]
     public required OrchestratorSetup Setup { get; init; }
@@ -976,6 +1059,36 @@ internal sealed record OrchestratorCiState
 
     [JsonPropertyName("routing")]
     public required string Routing { get; init; }
+}
+
+internal sealed record OrchestratorStaleThreadHealthCheck
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("no_reply_threshold")]
+    public required string NoReplyThreshold { get; init; }
+
+    [JsonPropertyName("procedure")]
+    public required IReadOnlyList<string> Procedure { get; init; }
+
+    [JsonPropertyName("status_request_template")]
+    public required string StatusRequestTemplate { get; init; }
+
+    [JsonPropertyName("receiver_statuses")]
+    public required IReadOnlyList<OrchestratorReceiverStatus> ReceiverStatuses { get; init; }
+
+    [JsonPropertyName("safety")]
+    public required IReadOnlyList<string> Safety { get; init; }
+}
+
+internal sealed record OrchestratorReceiverStatus
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("meaning")]
+    public required string Meaning { get; init; }
 }
 
 internal sealed record OrchestratorDependencyPlanning

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -459,6 +459,65 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_StaleThreadHealthCheck_AsksBeforeActing_AndProtectsPermission_G496()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Stale-thread health check", output, StringComparison.Ordinal);
+        // Configurable 30-minute threshold.
+        Assert.Contains("30 minutes", output, StringComparison.Ordinal);
+        Assert.Contains("configurable", output, StringComparison.Ordinal);
+        // Non-destructive status-request before any retry/escalate (ask-first).
+        Assert.Contains("non-destructive status-request", output, StringComparison.Ordinal);
+        Assert.Contains("\"type\":\"status-request\"", output, StringComparison.Ordinal);
+        // Required receiver statuses.
+        Assert.Contains("- **working**", output, StringComparison.Ordinal);
+        Assert.Contains("- **waiting-ci**", output, StringComparison.Ordinal);
+        Assert.Contains("- **waiting-permission**", output, StringComparison.Ordinal);
+        Assert.Contains("- **blocked**", output, StringComparison.Ordinal);
+        Assert.Contains("- **completed**", output, StringComparison.Ordinal);
+        Assert.Contains("- **idle**", output, StringComparison.Ordinal);
+        // Permission-waiting cannot trigger automatic retry/clear.
+        Assert.Contains("never auto-clear", output, StringComparison.OrdinalIgnoreCase);
+        // Progress-detected => keep watching; repeated-no-progress => one idempotent re-entry.
+        Assert.Contains("keep watching", output, StringComparison.Ordinal);
+        Assert.Contains("idempotent re-entry", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasStaleThreadHealthCheckShape_WithSixReceiverStatuses_G496()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var health = doc.RootElement.GetProperty("stale_thread_health_check");
+
+        Assert.True(health.TryGetProperty("no_reply_threshold", out _));
+        Assert.True(health.TryGetProperty("status_request_template", out _));
+        Assert.NotEmpty(health.GetProperty("procedure").EnumerateArray());
+        Assert.NotEmpty(health.GetProperty("safety").EnumerateArray());
+
+        var statuses = health.GetProperty("receiver_statuses").EnumerateArray()
+            .Select(s => s.GetProperty("status").GetString())
+            .ToArray();
+        Assert.Equal(
+            new[] { "working", "waiting-ci", "waiting-permission", "blocked", "completed", "idle" },
+            statuses);
+
+        // The orchestrator prompt references the safe health check + no-auto-clear.
+        var orchestrator = doc.RootElement.GetProperty("threads").EnumerateArray()
+            .First(t => t.GetProperty("role").GetString() == "orchestrator")
+            .GetProperty("prompt").GetString()!;
+        Assert.Contains("stale-thread health check", orchestrator, StringComparison.Ordinal);
+        Assert.Contains("never auto-clear a permission prompt", orchestrator, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Closes #1093. Adds a **safe** stale-thread health check and re-entry policy for agmsg orchestrator-message mode. Receivers are loopless, so silence is ambiguous — the orchestrator needs a way to check liveness without accidentally cancelling work, clearing a permission prompt, or duplicating a task. Builds on G490 (scheduled wake) and G495 (dependency planning), both merged.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `stale_thread_health_check` section** in the guide:
  - configurable **no-reply threshold** (default 30 minutes); below it, silence is normal in-progress work.
  - a **non-destructive status-request** sent BEFORE any retry/escalation, with a generated message template.
  - **receiver statuses**: `working`, `waiting-ci`, `waiting-permission`, `blocked`, `completed`, `idle`.
  - `waiting-permission` is an **operator notice** — never auto-cleared.
  - read-only intent-cli/GitHub fact check → keep watching on progress → at most **one idempotent re-entry** after repeated no-reply + no progress → escalate after repeated silence or unsafe cases.
  - **safety rules**: no auto-clear, no auto-cancel/reset, no destructive git, no raw label mutation.
- **Orchestrator prompt + recurring-wake list** now run the safe health check on a no-reply receiver.
- **Timer-loop guidance is unchanged** (this applies only to orchestrator-message receivers).
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Guide documents the stale-thread health check policy.
- ✅ Status-request message text is generated.
- ✅ Receiver reply contract includes the required statuses (working / waiting-ci / waiting-permission / blocked / completed / idle).
- ✅ Permission-waiting cannot trigger automatic retry/clear.
- ✅ Tests cover no-reply, waiting-permission, progress-detected, and repeated-no-progress cases.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 25 passed.
- `dotnet test … --filter ~Guide` — 963 passed.
- `git diff --check` — clean.
- Existing timer-loop / mode-separation text unchanged.

## Scope note

The Related Links `intents/**` intent-tree / spec / ADR write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb