### PR TITLE
G497: Prepare v0.3.11 release metadata and orchestrator-mode docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ repository and paste one of these prompts:
 > Inspect `<target>` with intent-cli.
 > Observe the real behavior, separate evidence from inference, and propose packet candidates.
 
+**Start agmsg orchestrator mode (preview):**
+
+> I want to start agmsg orchestrator mode for `<owner>/<repo>` with intent-cli.
+> Ask intent-cli for the orchestrator setup checklist.
+
 The agent runs `intent-cli` commands internally and brings back questions or
 results. You focus on intent, priorities, and approval decisions. In **grill**
 mode (`intent-cli grill`) the thread stays persistent — it builds an
@@ -105,6 +110,20 @@ each answer until a stop condition is reached.
   — agent-facing and power-user command surfaces.
 - **Developer reference:** [`docs/en/09-developer-reference.md`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/09-developer-reference.md)
   — packaged invocation smoke test, preview channel, version flow.
+- **Agent-message orchestration (preview):** [`docs/en/12-agent-message-orchestration.md`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/12-agent-message-orchestration.md)
+  — the optional agmsg orchestrator mode (日本語: [`docs/ja/12`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/ja/12-agent-message-orchestration.md)).
+
+> **Orchestrator mode is preview/experimental.** By default, implementation and
+> review run as independent **timer loops** (fully supported, unchanged). The
+> optional **agmsg orchestrator mode** adds a fourth orchestrator thread that
+> paces the implementation and review threads over a local message bus instead
+> of timers: the orchestrator is the only scheduled driver, the implementation
+> and review threads are loopless receivers, and you should not also run their
+> recurring timers for the same route. It covers single/multi-domain routing,
+> next-slice publication, CI wait, dependency planning, a safe stale-thread
+> health check, and safe-repair vs escalation. agmsg is a signal layer only —
+> intent-cli and GitHub stay authoritative. This mode is opt-in and still being
+> hardened.
 
 ---
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -194,81 +194,84 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.3.9",
-  "nextVersion": "0.3.10"
-}
-```
-
-| Stage | Version form | How it is derived |
-| --- | --- | --- |
-| Local pack / install | `0.3.10-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.3.10-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.10-rc.N` | Tag `v0.3.10-rc.N` triggers release workflow |
-| Stable release | `0.3.10` | Tag `v0.3.10` triggers release workflow (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.3.11-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.11` |
-
-**After releasing `v0.3.10`**, bump both fields in `eng/version.json`:
-
-```json
-{
   "stableVersion": "0.3.10",
   "nextVersion": "0.3.11"
 }
 ```
 
+| Stage | Version form | How it is derived |
+| --- | --- | --- |
+| Local pack / install | `0.3.11-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.3.11-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.11-rc.N` | Tag `v0.3.11-rc.N` triggers release workflow |
+| Stable release | `0.3.11` | Tag `v0.3.11` triggers release workflow (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.3.12-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.12` |
+
+**After releasing `v0.3.11`**, bump both fields in `eng/version.json`:
+
+```json
+{
+  "stableVersion": "0.3.11",
+  "nextVersion": "0.3.12"
+}
+```
+
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.3.11-preview.<run>.<attempt>` / `0.3.11-<sha>-<G-unit>` rather than continuing to
-emit `0.3.10` (which would collide with the stable release version).
+`0.3.12-preview.<run>.<attempt>` / `0.3.12-<sha>-<G-unit>` rather than continuing to
+emit `0.3.11` (which would collide with the stable release version).
 
-### Next release readiness (v0.3.10)
+### Next release readiness (v0.3.11)
 
-**`v0.3.9` shipped** (GitHub Release + NuGet) and the version policy was bumped
-to the `0.3.10` development line. The repository is now on the in-development
-**`0.3.10`** `nextVersion`; G486 (this packet) prepares the `v0.3.10` release — the
-next release is published by tagging `v0.3.10` once the
-[release-readiness gate](release-notes-v0.3.10.md#release-readiness-gate-g486)
+**`v0.3.10` shipped** (GitHub Release + NuGet) and the version policy was bumped
+to the `0.3.11` development line. The repository is now on the in-development
+**`0.3.11`** `nextVersion`; G497 (this packet) prepares the `v0.3.11` release — the
+next release is published by tagging `v0.3.11` once the
+[release-readiness gate](release-notes-v0.3.11.md#release-readiness-gate-g497)
 passes. Preparing the release does not cut it. Full changelog and operator
-checklist: [release-notes-v0.3.10.md](release-notes-v0.3.10.md).
+checklist: [release-notes-v0.3.11.md](release-notes-v0.3.11.md).
 
-**To ship in `v0.3.10` (changes since `v0.3.9`) — a dogfooding-stability release:**
+**To ship in `v0.3.11` (changes since `v0.3.10`) — the agmsg orchestrator-mode
+preview:**
 
-- **Windows Japanese `gh` JSON decoding** (G484) — every `gh` subprocess pins
-  UTF-8 stream decoding, so Japanese issue/PR titles and bodies stay valid JSON
-  on a Japanese Windows console (cp932). `worker next-action` / preflight no
-  longer break on non-ASCII payloads, with no `chcp 65001` or manual output
-  encoding required; macOS/Linux behavior is unchanged.
-- **Same-repo metadata publish-flow reliability** (G485) — `queue-seed-from-packet`
-  resolves the domain `execution_unit_regex` through the same shared resolver
-  `automation summary` uses, so a valid same-repo packet (code branch `main`,
-  metadata branch `main-metadata`) seeds and publishes through the regular
-  `queue-seed-from-packet` → `issue publish-flow` → `automation issue-publish`
-  path instead of being rejected as `missing-domain-binding-regex`. The
-  supported `[project]` same-repo config keys are now documented.
+- **Agent-message (agmsg) orchestrator mode — preview/experimental** (G487–G496)
+  — an optional fourth orchestrator thread can coordinate the implementation and
+  review threads over a local message bus (agmsg) instead of independent timers.
+  `intent-cli guide orchestrator-thread` renders the paste-ready prompts, the
+  single/multi-domain routing rules, the scheduled-wake cadence, the CI wait
+  state, bounded next-slice publication, dependency-aware planning, the
+  stale-thread health check, and a design-thread setup checklist. agmsg is a
+  signal layer only; intent-cli and GitHub stay authoritative, and the existing
+  timer-loop mode is fully supported and unchanged. This mode is **preview**:
+  opt-in, still being hardened, and not yet the default workflow.
+- **Review guidance** also gains automated-reviewer-comment triage (G493) so a
+  review agent classifies automated reviewer comments (e.g. Copilot) instead of
+  forwarding every comment to implementation. See
+  [Agent-message orchestration](12-agent-message-orchestration.md).
 
-**Release-readiness verification (run before tagging the next `v0.3.10`):**
+**Release-readiness verification (run before tagging the next `v0.3.11`):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.3.9 (published), nextVersion 0.3.10 (to release)
+cat eng/version.json   # stableVersion 0.3.10 (published), nextVersion 0.3.11 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.3.10-<sha>-G48x   (NOT a stale literal)
+#   expected shape: intent-cli 0.3.11-<sha>-G49x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.10.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.11.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-The official release is then cut by publishing a GitHub Release tagged `v0.3.10`;
-the release workflow passes `-p:Version=0.3.10` (which wins over the local
+The official release is then cut by publishing a GitHub Release tagged `v0.3.11`;
+the release workflow passes `-p:Version=0.3.11` (which wins over the local
 default). After the release publishes, apply the post-release `eng/version.json`
-bump above (`stableVersion → 0.3.10`, `nextVersion → 0.3.11`).
+bump above (`stableVersion → 0.3.11`, `nextVersion → 0.3.12`).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.3.11.md
+++ b/docs/en/release-notes-v0.3.11.md
@@ -1,0 +1,141 @@
+# Release Notes — intent-cli v0.3.11
+
+> **Release checklist for maintainers:** see [Creating the v0.3.11 GitHub Release](#creating-the-v0311-github-release).
+> **Do NOT tag until the [release-readiness gate](#release-readiness-gate-g497) passes.**
+
+## What's in v0.3.11
+
+v0.3.11 introduces the **agmsg orchestrator mode (preview/experimental)** and
+the review-side automated-comment triage policy that were designed through the
+G487–G496 intent packets. No package id, license, or workflow-semantics changes,
+and the existing timer-loop mode is fully supported and unchanged. The package id
+remains `JTechJapan.IntentSystem.Cli`.
+
+> **Orchestrator mode is preview/experimental.** It is opt-in, still being
+> hardened, and not the default workflow. agmsg is the first local
+> message-bus example, not a permanent architecture boundary. intent-cli and
+> GitHub remain the authoritative source of truth for queue, issue, PR, label,
+> review, and closeout state; agmsg is only a message/progress/completion signal
+> layer.
+
+### Agent-message (agmsg) orchestrator mode — preview (G487–G496)
+
+An optional fourth **orchestrator** thread can coordinate the **implementation**
+and **review** threads over a local message bus (agmsg) instead of independent
+recurring timers. Generate the paste-ready prompts and the operating contract
+with:
+
+```bash
+intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --format markdown
+```
+
+The guide surface now covers:
+
+- **Roles and folders** — orchestrator / implementation / review, each running
+  from its own folder, clone, or worktree (G487, G494).
+- **Single-domain vs multi-domain routing** — a host repo can hold several
+  domains, and one repo may serve more than one domain; visibility is not
+  authorization (G489).
+- **Scheduled wake cadence** — the orchestrator is the single scheduled driver
+  (Codex automation 5m or Claude `/loop 5m`); implementation/review are loopless
+  receivers. **Do not also run implement/review recurring timers for the same
+  route in orchestrator mode** (G490).
+- **Bounded next-slice publication** — the orchestrator may publish one ready
+  `issue-cut-ready` issue per wake through canonical intent-cli surfaces, then
+  verify before delegating (G491).
+- **CI wait state** — pending CI is an active wait-and-recheck state, not a
+  blocker (G492).
+- **Automated reviewer comment triage** — `intent-cli guide review` classifies
+  automated reviewer comments (e.g. Copilot) instead of forwarding every comment
+  to implementation (G493).
+- **Dependency-aware planning** — unmet dependencies are routed to the earliest
+  unmet dependency rather than pausing for the operator (G495).
+- **Stale-thread health check** — a safe no-reply liveness check that asks
+  before acting and never auto-clears a permission prompt, cancels work, or
+  duplicates a task (G496).
+- **Design-thread setup** — a concrete setup checklist (paths, team, delivery,
+  role prompts, first read-only wake, ping test, cleanup) reachable from
+  `guide workflow suggest` (G494).
+
+Safe-repair vs escalation, next-slice publish, and delegation boundaries are all
+documented in [Agent-message orchestration](12-agent-message-orchestration.md).
+
+> Version metadata note: `eng/version.json` records `stableVersion: 0.3.10`,
+> `nextVersion: 0.3.11`; G497 (this packet) is the release-readiness preparation.
+> The post-v0.3.11 metadata advancement (`stableVersion → 0.3.11`,
+> `nextVersion → 0.3.12`) is the operator's post-release step and is out of scope
+> for this packet.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.11
+```
+
+Or download the self-contained binary from the
+[v0.3.11 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.11).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.10
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.11
+```
+
+There are no breaking changes from v0.3.10. Orchestrator mode is opt-in; existing
+timer-loop setups are unaffected.
+
+## Release-readiness gate (G497)
+
+Do not create the `v0.3.11` tag/release until ALL of the following hold
+(this gate fails closed — if any item is unmet, stop and do not tag):
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G487–G496 (and G497 this prep). Confirm on the host/review side via the
+      host queue-state / GitHub PR state — the child implementation loop must not
+      read parent queue-state, so this is a host-owned precondition.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before tagging).
+- [ ] `eng/version.json` `nextVersion` is `0.3.11` (the intended release version)
+      and matches the tag to be created (`v0.3.11`). The release workflow derives
+      the package version from the tag; `-p:Version=` overrides the policy-derived
+      default in `src/IntentSystem.Cli/IntentSystem.Cli.csproj`.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] Release notes / README state that **orchestrator mode is
+      preview/experimental** and opt-in, and that timer-loop mode is unchanged.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+
+## Creating the v0.3.11 GitHub Release
+
+1. Confirm the [release-readiness gate](#release-readiness-gate-g497) — do not
+   proceed if any item is unmet.
+2. Tag the release commit: `git tag v0.3.11 && git push origin v0.3.11`.
+3. The `release.yml` workflow fires and builds binaries, `.nupkg`, and
+   checksums (version derived from the tag). Wait for it to complete green.
+4. The workflow creates the GitHub Release draft. Review it, paste the content
+   of this file as the release body, and publish.
+5. Confirm the NuGet publish step pushed `JTechJapan.IntentSystem.Cli 0.3.11`.
+6. Post-release verification checklist:
+   - [ ] NuGet.org package page links all resolve correctly.
+   - [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+         accessible.
+   - [ ] `.sha256` checksums match the downloaded artifacts.
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.11`)
+         then `intent-cli --version` reports `0.3.11`.
+   - [ ] Binary artifact smoke check: download the platform archive, verify its
+         `.sha256`, extract, and run `./intent-cli --version` → `0.3.11`.
+   - [ ] **Orchestrator-mode preview smoke**: `intent-cli guide orchestrator-thread
+         --domain <d> --target-repo <repo> --agent <agent> --format markdown`
+         renders the role prompts, setup checklist, and safety boundaries; the
+         README and docs label the mode preview/experimental.
+   - [ ] Local preview/dry-run version metadata uses the next development line
+         after `0.3.11` (bump `eng/version.json` per the post-release step in
+         [Version flow](09-developer-reference.md#version-flow)):
+         `stableVersion → 0.3.11`, `nextVersion → 0.3.12`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -184,71 +184,72 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.3.9",
-  "nextVersion": "0.3.10"
-}
-```
-
-| ステージ | バージョン形式 | 導出方法 |
-| --- | --- | --- |
-| ローカル pack / install | `0.3.10-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.3.10-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.10-rc.N` | タグ `v0.3.10-rc.N` がリリースワークフローをトリガー |
-| 安定版リリース | `0.3.10` | タグ `v0.3.10` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.3.11-preview.<run>.<attempt>` | `nextVersion` を `0.3.11` にバンプ後 |
-
-**`v0.3.10` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
-
-```json
-{
   "stableVersion": "0.3.10",
   "nextVersion": "0.3.11"
 }
 ```
 
+| ステージ | バージョン形式 | 導出方法 |
+| --- | --- | --- |
+| ローカル pack / install | `0.3.11-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.3.11-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.3.11-rc.N` | タグ `v0.3.11-rc.N` がリリースワークフローをトリガー |
+| 安定版リリース | `0.3.11` | タグ `v0.3.11` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.3.12-preview.<run>.<attempt>` | `nextVersion` を `0.3.12` にバンプ後 |
+
+**`v0.3.11` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+
+```json
+{
+  "stableVersion": "0.3.11",
+  "nextVersion": "0.3.12"
+}
+```
+
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.3.11-preview.<run>.<attempt>` / `0.3.11-<sha>-<G-unit>` を生成し、`0.3.10`（安定版
+`0.3.12-preview.<run>.<attempt>` / `0.3.12-<sha>-<G-unit>` を生成し、`0.3.11`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備（v0.3.10）
+### 次リリース準備（v0.3.11）
 
-**`v0.3.9` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
-`0.3.10` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.10`**
-`nextVersion` 上にあり、G486（本パケット）が `v0.3.10` リリースを準備します。次のリリースは
-[リリース準備ゲート](release-notes-v0.3.10.md#リリース準備ゲート-g486)を通過後に `v0.3.10`
+**`v0.3.10` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
+`0.3.11` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.11`**
+`nextVersion` 上にあり、G497（本パケット）が `v0.3.11` リリースを準備します。次のリリースは
+[リリース準備ゲート](release-notes-v0.3.11.md#リリース準備ゲート-g497)を通過後に `v0.3.11`
 タグ付けで publish されます。準備はリリースを cut しません。完全な changelog と operator
-チェックリスト: [release-notes-v0.3.10.md](release-notes-v0.3.10.md)。
+チェックリスト: [release-notes-v0.3.11.md](release-notes-v0.3.11.md)。
 
-**`v0.3.10` で出荷予定（`v0.3.9` 以降の変更）— dogfooding 安定性リリース:**
+**`v0.3.11` で出荷予定（`v0.3.10` 以降の変更）— agmsg orchestrator モードのプレビュー:**
 
-- **Windows 日本語 `gh` JSON デコード**（G484）— すべての `gh` サブプロセスが UTF-8 の
-  ストリームデコードを pin するため、日本語 Windows コンソール（cp932）でも issue/PR の
-  タイトルや本文が valid な JSON のまま保たれます。`worker next-action` / preflight が非 ASCII
-  ペイロードで壊れなくなり、`chcp 65001` や手動の出力エンコーディング設定は不要です。
-  macOS/Linux の挙動は不変です。
-- **same-repo メタデータの publish-flow 信頼性**（G485）— `queue-seed-from-packet` が
-  ドメインの `execution_unit_regex` を `automation summary` と同じ共有 resolver で解決する
-  ため、valid な same-repo packet（コードブランチ `main`、メタデータブランチ `main-metadata`）が
-  `missing-domain-binding-regex` で拒否されず、正規の `queue-seed-from-packet` →
-  `issue publish-flow` → `automation issue-publish` 経路で seed/publish できます。サポートされる
-  `[project]` の same-repo 設定キーも文書化しました。
+- **エージェントメッセージ（agmsg）orchestrator モード — preview / experimental**（G487–G496）
+  — 任意の 4 つ目の orchestrator スレッドが、独立タイマーの代わりにローカルメッセージバス
+  （agmsg）経由で実装・レビュースレッドを調整できます。`intent-cli guide orchestrator-thread`
+  が貼り付け可能なプロンプト、single/multi-domain ルーティング、スケジュール wake のケイデンス、
+  CI 待ち状態、bounded な next-slice publish、依存を考慮した計画、stale-thread ヘルスチェック、
+  設計スレッド向けセットアップチェックリストをレンダリングします。agmsg はシグナル層のみで、
+  intent-cli と GitHub が権威であり続け、既存の timer-loop モードは完全サポート・不変です。
+  このモードは **preview** です: オプトインで、まだ hardening 中であり、デフォルトの workflow
+  ではありません。
+- **レビューガイダンス** にも自動レビュアーコメント triage（G493）が加わり、review agent が
+  自動レビュアー（例: Copilot）のコメントを分類してから実装に回します。
+  [エージェントメッセージオーケストレーション](12-agent-message-orchestration.md) を参照。
 
-**リリース準備の検証（次の `v0.3.10` タグ付け前に実行）:**
+**リリース準備の検証（次の `v0.3.11` タグ付け前に実行）:**
 
 ```bash
-cat eng/version.json   # stableVersion 0.3.9（公開済み）, nextVersion 0.3.10（リリース対象）
+cat eng/version.json   # stableVersion 0.3.10（公開済み）, nextVersion 0.3.11（リリース対象）
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.3.10-<sha>-G48x （stale なリテラルではない）
+#   期待形: intent-cli 0.3.11-<sha>-G49x （stale なリテラルではない）
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.10.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.11.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-公式リリースは `v0.3.10` タグの GitHub Release publish で cut され、リリースワークフローが
-`-p:Version=0.3.10` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
-`eng/version.json` バンプ（`stableVersion → 0.3.10`, `nextVersion → 0.3.11`）を適用します。
+公式リリースは `v0.3.11` タグの GitHub Release publish で cut され、リリースワークフローが
+`-p:Version=0.3.11` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
+`eng/version.json` バンプ（`stableVersion → 0.3.11`, `nextVersion → 0.3.12`）を適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.3.11.md
+++ b/docs/ja/release-notes-v0.3.11.md
@@ -1,0 +1,122 @@
+# リリースノート — intent-cli v0.3.11
+
+> **メンテナ向けリリースチェックリスト:** [v0.3.11 GitHub Release の作成](#v0311-github-release-の作成) を参照。
+> **[リリース準備ゲート](#リリース準備ゲート-g497) を通過するまでタグ付けしないでください。**
+
+## v0.3.11 の内容
+
+v0.3.11 は、G487–G496 の intent パケットで設計された **agmsg orchestrator モード
+（preview/experimental）** と、レビュー側の自動コメント triage ポリシーを導入します。
+package id・ライセンス・workflow セマンティクスの変更はなく、既存の timer-loop モードは
+完全サポート・不変です。package id は `JTechJapan.IntentSystem.Cli` のままです。
+
+> **orchestrator モードは preview/experimental です。** オプトインで、まだ hardening 中であり、
+> デフォルトの workflow ではありません。agmsg は最初のローカルメッセージバスの例であり、恒久的な
+> アーキテクチャ境界ではありません。intent-cli と GitHub は queue・issue・PR・label・review・
+> closeout の権威 source of truth であり続け、agmsg はメッセージ / 進捗 / 完了のシグナル層のみです。
+
+### エージェントメッセージ（agmsg）orchestrator モード — preview（G487–G496）
+
+任意の 4 つ目の **orchestrator** スレッドが、独立した定期タイマーの代わりにローカルメッセージ
+バス（agmsg）経由で **実装**・**レビュー** スレッドを調整できます。貼り付け可能なプロンプトと
+運用契約は次で生成します:
+
+```bash
+intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --format markdown
+```
+
+ガイド surface は次をカバーします:
+
+- **ロールとフォルダー** — orchestrator / implementation / review。各ロールは自分のフォルダー・
+  クローン・worktree から実行（G487, G494）。
+- **single-domain と multi-domain のルーティング** — host repo は複数ドメインを保持でき、
+  1 つの repo が複数ドメインに供給することもある。可視であることは権限ではない（G489）。
+- **スケジュール wake のケイデンス** — orchestrator が唯一のスケジュールドライバー
+  （Codex automation 5m または Claude `/loop 5m`）。実装/レビューは loopless receiver。
+  **orchestrator モードでは同じルートに対して実装/レビューの定期タイマーを同時実行しない**（G490）。
+- **bounded な next-slice publish** — orchestrator は canonical な intent-cli surface 経由で
+  wake ごとに 1 件の `issue-cut-ready` issue を publish し、委譲前に検証する（G491）。
+- **CI 待ち状態** — pending CI はブロッカーではなく、待って再確認するアクティブな状態（G492）。
+- **自動レビュアーコメント triage** — `intent-cli guide review` が自動レビュアー（例: Copilot）の
+  コメントを分類し、すべてを実装に回さない（G493）。
+- **依存を考慮した計画** — 未充足の依存は、オペレーターのために止まらず最も早い未充足依存に
+  ルーティングする（G495）。
+- **stale-thread ヘルスチェック** — 行動前に尋ね、permission プロンプトの自動クリア・作業の
+  キャンセル・タスクの重複を決して行わない安全な no-reply liveness チェック（G496）。
+- **設計スレッドのセットアップ** — `guide workflow suggest` から到達できる具体的なセットアップ
+  チェックリスト（パス・team・delivery・ロールプロンプト・最初の read-only wake・ping テスト・
+  クリーンアップ）（G494）。
+
+安全な repair とエスカレーション、next-slice publish、委譲の境界はすべて
+[エージェントメッセージオーケストレーション](12-agent-message-orchestration.md) に記載されています。
+
+> バージョンメタデータ注記: `eng/version.json` は `stableVersion: 0.3.10`,
+> `nextVersion: 0.3.11` を記録します。G497（本パケット）はリリース準備です。
+> v0.3.11 リリース後のメタデータ前進（`stableVersion → 0.3.11`, `nextVersion → 0.3.12`）は
+> オペレーターのリリース後ステップであり、本パケットのスコープ外です。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.11
+```
+
+または [v0.3.11 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.11)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを検証します。
+
+## v0.3.10 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.11
+```
+
+v0.3.10 からの破壊的変更はありません。orchestrator モードはオプトインで、既存の timer-loop
+セットアップには影響しません。
+
+## リリース準備ゲート (G497)
+
+次のすべてが成り立つまで `v0.3.11` タグ/リリースを作成しないでください
+（このゲートは fail closed です — 1 つでも未充足なら停止し、タグ付けしない）:
+
+- [ ] リリース対象の各パケットが **完了し PR が `main` にマージ済み**: G487–G496
+      （および本準備の G497）。host queue-state / GitHub PR 状態で host/review 側から確認する
+      （child 実装ループは parent queue-state を読まないため、これは host 所有の前提条件）。
+- [ ] 本リリース対象の open な intent-system PR や WIP パケットが誤ってスキップされていない
+      （タグ付け前に host queue / open PR リストを確認）。
+- [ ] `eng/version.json` の `nextVersion` が `0.3.11`（意図したリリースバージョン）で、作成する
+      タグ（`v0.3.11`）と一致する。リリースワークフローは package バージョンをタグから導出し、
+      `-p:Version=` が `src/IntentSystem.Cli/IntentSystem.Cli.csproj` のポリシー由来デフォルトを上書きする。
+- [ ] package メタデータが正しい: `PackageId = JTechJapan.IntentSystem.Cli`、
+      `RepositoryUrl` / `PackageProjectUrl` が `https://github.com/J-Tech-Japan/intent-system` を指す、
+      `PackageLicenseExpression = Apache-2.0`、README/docs リンクが解決し、公式サービスサイト
+      `https://www.intent-driven-development.com/` が README からリンクされている。
+- [ ] リリースノート / README が **orchestrator モードは preview/experimental** かつオプトインで
+      あること、timer-loop モードが不変であることを明記している。
+- [ ] リリースコミットで **Main CI が green**（`Build and test (source contract)`）であり、
+      **preview-pack** workflow も green。
+
+## v0.3.11 GitHub Release の作成
+
+1. [リリース準備ゲート](#リリース準備ゲート-g497) を確認 — 未充足項目があれば進めない。
+2. リリースコミットにタグ付け: `git tag v0.3.11 && git push origin v0.3.11`。
+3. `release.yml` workflow が発火し、バイナリ・`.nupkg`・チェックサムをビルドする（バージョンは
+   タグから導出）。green 完了を待つ。
+4. workflow が GitHub Release draft を作成する。レビューし、本ファイルの内容をリリース本文として
+   貼り付け、publish する。
+5. NuGet publish ステップが `JTechJapan.IntentSystem.Cli 0.3.11` を push したことを確認する。
+6. リリース後の検証チェックリスト:
+   - [ ] NuGet.org の package ページのリンクがすべて正しく解決する。
+   - [ ] GitHub release アセットリンク（`.tar.gz`, `.zip`, `.exe`, `.nupkg`）にアクセスできる。
+   - [ ] `.sha256` チェックサムがダウンロード成果物と一致する。
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`（または
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.11`）後、
+         `intent-cli --version` が `0.3.11` を報告する。
+   - [ ] バイナリ成果物スモーク: プラットフォームアーカイブをダウンロードし `.sha256` を検証、
+         展開して `./intent-cli --version` → `0.3.11`。
+   - [ ] **orchestrator モード preview スモーク**: `intent-cli guide orchestrator-thread
+         --domain <d> --target-repo <repo> --agent <agent> --format markdown` がロールプロンプト・
+         セットアップチェックリスト・安全境界をレンダリングする。README と docs がモードを
+         preview/experimental と表示している。
+   - [ ] ローカル preview/dry-run のバージョンメタデータが `0.3.11` の次の開発ラインを使う
+         （[バージョンフロー](09-developer-reference.md#バージョンフロー) のリリース後ステップに従い
+         `eng/version.json` をバンプ）: `stableVersion → 0.3.11`, `nextVersion → 0.3.12`。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.9",
-  "nextVersion": "0.3.10"
+  "stableVersion": "0.3.10",
+  "nextVersion": "0.3.11"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,10 +124,10 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.10 as the next development line
-        // (post-v0.3.9 release bump, see G486 — v0.3.9 was published to
+        // be parseable and must point to 0.3.11 as the next development line
+        // (post-v0.3.10 release bump, see G497 — v0.3.10 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.3.10 while recording 0.3.9 as the published stable).
+        // forward to 0.3.11 while recording 0.3.10 as the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -137,8 +137,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.10", policy.NextVersion);
-        Assert.Equal("0.3.9", policy.StableVersion);
+        Assert.Equal("0.3.11", policy.NextVersion);
+        Assert.Equal("0.3.10", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Closes #1095. Prepares the repository for an operator release of **v0.3.11** that bundles the **agmsg orchestrator-mode preview** (G487–G496). This packet does **not** publish the release — tagging/cutting remains an operator/host action after merge.

## Changes

- **`eng/version.json`** — advance to `stableVersion 0.3.10` (published) / `nextVersion 0.3.11` (release-to-cut). Verified: `intent-cli --version` reports `0.3.11-<sha>-G496`.
- **Release notes (en/ja)** — new `release-notes-v0.3.11.md`: describes orchestrator mode as **preview/experimental** and opt-in, the orchestrator/implementer/reviewer role + folder model, the no-mixed-timers rule, next-slice publish, CI wait, dependency planning, the stale-thread health check, and automated reviewer comment triage; install/upgrade pinned to `0.3.11`; a fail-closed **release-readiness gate (G497)**; and a post-release verification checklist.
- **Developer reference (en/ja)** — retarget the version-flow table and "Next release readiness" section to **v0.3.11** (G487–G496), link the release notes, and document the post-release bump (`stable → 0.3.11`, `next → 0.3.12`).
- **README** — add an orchestrator-mode (preview) overview, a setup prompt, and links to `docs/{en,ja}/12`; state that **timer-loop mode is the default and unchanged**.
- **tests** — update `VersionPolicyTests` smoke assertion to next `0.3.11` / stable `0.3.10`. `ReleasePackageMetadataTests` read the policy/docs dynamically and continue to pass.

The release artifact version stays **tag-driven** (`release.yml` passes `-p:Version=0.3.11`, which wins over the policy-derived local default). Package id remains `JTechJapan.IntentSystem.Cli`; no workflow change is required.

## Acceptance criteria coverage

- ✅ Version/release metadata ready for the next release (`eng/version.json` 0.3.10/0.3.11; `--version` → 0.3.11).
- ✅ README includes a concise orchestrator-mode explanation + setup prompt.
- ✅ docs/ja and docs/en include orchestration setup & safety guidance (doc 12 + dev-reference + release notes).
- ✅ Release-note text states orchestration mode is preview/experimental and opt-in.
- ✅ Documentation links valid (dev-reference → release-notes-v0.3.11 anchors verified; README → docs/12).
- ✅ Package metadata / docs-link checks pass (`VersionPolicyTests`, `ReleasePackageMetadataTests`, `VersionSourcePolicyGuardTests`).

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `intent-cli --version` → `0.3.11-74f0c45-G496`.
- `dotnet test … --filter VersionPolicyTests|ReleasePackageMetadataTests|VersionSourcePolicyGuardTests` — 16 passed.
- `dotnet test` (full Cli suite) — 3138 passed, 1 skipped.
- `git diff --check` — clean.
- Dev-reference → release-notes anchors verified; no stale "next 0.3.10" left in version-flow/readiness.

## Out of scope

- Performing the actual GitHub release (operator/host action after merge).
- Removing timer-loop mode; making agmsg mandatory; claiming orchestrator mode is fully stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb