### PR TITLE
G498: Add design-thread escalation filter for orchestrator mode

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -245,11 +245,23 @@ Escalate to the design thread only when:
 - a release / public publish decision;
 - an explicit policy decision the operator owns.
 
-A design escalation carries structured evidence and the exact decision needed:
+A design escalation carries a concise reason, the **current authoritative
+state** read from intent-cli/GitHub, the supporting evidence, options only when
+useful, and the exact decision needed — so the human can decide without
+re-deriving the state:
 
 ```json
-{"to":"design","type":"escalation","ref":"issue#<n>|pr#<n>","reason":"<clarification|product-ambiguity|permission|destructive|no-progress|canonical-conflict|release|policy>","evidence":"<intent-cli/GitHub facts>","decision_needed":"<the exact decision or action requested>"}
+{"to":"design","type":"escalation","ref":"issue#<n>|pr#<n>","reason":"<clarification|product-ambiguity|permission|destructive|no-progress|canonical-conflict|release|policy>","current_state":"<the current AUTHORITATIVE state read from intent-cli/GitHub: labels, PR/CI/review/merge state, queue position>","evidence":"<the intent-cli/GitHub facts that establish that state>","options":"<OPTIONAL: candidate choices, only when useful>","decision_needed":"<the exact decision or action requested from the human>"}
 ```
+
+- `reason` — which human-needed category triggered the escalation.
+- `current_state` — the current **authoritative** state, read from intent-cli /
+  GitHub (labels, PR/CI/review/merge state, queue position). **Required** — the
+  receiver must not have to re-derive it; generic evidence wording does not
+  substitute for the explicit state.
+- `evidence` — the intent-cli / GitHub facts that establish the current state.
+- `options` — **optional** candidate choices, included only when they help.
+- `decision_needed` — the exact decision or action requested from the human.
 
 ## Single-domain vs multi-domain orchestration
 

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -217,6 +217,40 @@ check never clears a permission prompt, cancels/resets work, mutates labels, or
 runs destructive git. (Timer-loop mode is unaffected — this applies only to
 orchestrator-message receivers.)
 
+## Design-thread escalation filter
+
+The **design thread** is the primary human communication surface. Humans mainly
+talk to the design thread; implementation and review run through the
+orchestrator, and only **human-needed** decisions return to the design thread.
+This is a **noise filter, not a failure filter** — never hide a failure that
+needs a human.
+
+Kept internal by default (no design-thread message):
+
+- normal progress / accepted / in-flight delegations;
+- CI waiting (pending checks are an active wait state);
+- successful implementation (PR opened, CI green);
+- successful review / approval;
+- closeout of an already-approved PR;
+- idle wakes with no actionable change.
+
+Escalate to the design thread only when:
+
+- clarification is required (ambiguous issue/packet contract);
+- product intent ambiguity or a design decision;
+- permission / credentials / security;
+- a destructive action would be required;
+- repeated no-reply / no-progress after the safe stale-thread health check;
+- unresolved canonical state (intent-cli / GitHub facts conflict or are missing);
+- a release / public publish decision;
+- an explicit policy decision the operator owns.
+
+A design escalation carries structured evidence and the exact decision needed:
+
+```json
+{"to":"design","type":"escalation","ref":"issue#<n>|pr#<n>","reason":"<clarification|product-ambiguity|permission|destructive|no-progress|canonical-conflict|release|policy>","evidence":"<intent-cli/GitHub facts>","decision_needed":"<the exact decision or action requested>"}
+```
+
 ## Single-domain vs multi-domain orchestration
 
 A host checkout can legitimately contain **several** intent domains (for

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -201,6 +201,39 @@ status-request は receiver に次のいずれかで返信するよう求めま�
 クリア、作業の cancel/reset、label の変更、破壊的 git を決して行いません。（timer-loop モードは
 影響を受けません — これは orchestrator-message の receiver にのみ適用されます。）
 
+## 設計スレッドへのエスカレーションフィルター
+
+**設計スレッド** が人間との主なコミュニケーション surface です。人間は主に設計スレッドと
+やり取りし、実装とレビューは orchestrator 経由で動きます。設計スレッドに戻すのは
+**人間が必要な** 判断のみです。これは **ノイズフィルターであり、失敗フィルターではありません** —
+人間が必要な失敗を決して隠しません。
+
+デフォルトで内部に留める（設計スレッドへ送らない）:
+
+- 通常の進捗 / accepted / in-flight な委譲;
+- CI 待ち（pending チェックはアクティブな待ち状態）;
+- 成功した実装（PR open、CI green）;
+- 成功したレビュー / 承認;
+- 承認済み PR の closeout;
+- 実行可能な変化のない idle wake。
+
+設計スレッドへエスカレーションするのは次の場合のみ:
+
+- clarification が必要（issue/packet contract が曖昧）;
+- プロダクト intent の曖昧さ、または設計判断;
+- permission / 認証情報 / セキュリティ;
+- 破壊的な操作が必要;
+- 安全な stale-thread ヘルスチェック後の繰り返し no-reply / 無進捗;
+- 未解決の canonical state（intent-cli / GitHub の事実が矛盾または欠落）;
+- リリース / 公開 publish の判断;
+- オペレーターが所有する明示的なポリシー判断。
+
+設計エスカレーションは構造化された evidence と必要な判断を運びます:
+
+```json
+{"to":"design","type":"escalation","ref":"issue#<n>|pr#<n>","reason":"<clarification|product-ambiguity|permission|destructive|no-progress|canonical-conflict|release|policy>","evidence":"<intent-cli/GitHub facts>","decision_needed":"<the exact decision or action requested>"}
+```
+
 ## single-domain と multi-domain のオーケストレーション
 
 host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -228,11 +228,21 @@ status-request は receiver に次のいずれかで返信するよう求めま�
 - リリース / 公開 publish の判断;
 - オペレーターが所有する明示的なポリシー判断。
 
-設計エスカレーションは構造化された evidence と必要な判断を運びます:
+設計エスカレーションは、簡潔な reason、intent-cli/GitHub から読んだ **現在の authoritative
+state**、それを裏付ける evidence、必要なときだけの options、そして必要な正確な判断を運びます —
+人間が state を再導出せずに判断できるようにします:
 
 ```json
-{"to":"design","type":"escalation","ref":"issue#<n>|pr#<n>","reason":"<clarification|product-ambiguity|permission|destructive|no-progress|canonical-conflict|release|policy>","evidence":"<intent-cli/GitHub facts>","decision_needed":"<the exact decision or action requested>"}
+{"to":"design","type":"escalation","ref":"issue#<n>|pr#<n>","reason":"<clarification|product-ambiguity|permission|destructive|no-progress|canonical-conflict|release|policy>","current_state":"<intent-cli/GitHub から読んだ現在の AUTHORITATIVE state: labels, PR/CI/review/merge 状態, queue 位置>","evidence":"<その state を establish する intent-cli/GitHub の事実>","options":"<任意: 候補の選択肢。役立つときのみ>","decision_needed":"<人間に求める正確な判断またはアクション>"}
 ```
+
+- `reason` — どの人間が必要なカテゴリがエスカレーションを引き起こしたか。
+- `current_state` — 現在の **authoritative** state。intent-cli / GitHub から読む（labels、
+  PR/CI/review/merge 状態、queue 位置）。**必須** — 受信側が再導出する必要がないようにする。
+  汎用的な evidence の文言は明示的な state の代替にならない。
+- `evidence` — 現在の state を establish する intent-cli / GitHub の事実。
+- `options` — **任意** の候補の選択肢。役立つときのみ含める。
+- `decision_needed` — 人間に求める正確な判断またはアクション。
 
 ## single-domain と multi-domain のオーケストレーション
 

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -416,7 +416,10 @@ internal static class GuideOrchestratorThreadCommand
                     "The design thread is the PRIMARY human communication surface. Humans mainly talk to the design "
                     + "thread; implementation and review run through the orchestrator, and only human-needed decisions "
                     + "return to the design thread. Keep routine orchestration internal — this is a NOISE filter, not a "
-                    + "failure filter: never hide a failure that needs a human.",
+                    + "failure filter: never hide a failure that needs a human. A design escalation carries a concise "
+                    + "reason, the current AUTHORITATIVE state read from intent-cli/GitHub, the supporting evidence, "
+                    + "options only when useful, and the exact decision needed — so the human can decide without "
+                    + "re-deriving the state.",
                 KeptInternal = new[]
                 {
                     "Normal progress, accepted, and in-flight delegations.",
@@ -440,8 +443,18 @@ internal static class GuideOrchestratorThreadCommand
                 EscalationMessageTemplate =
                     "{\"to\":\"design\",\"type\":\"escalation\",\"ref\":\"issue#<n>|pr#<n>\",\"reason\":\"<clarification|"
                     + "product-ambiguity|permission|destructive|no-progress|canonical-conflict|release|policy>\","
-                    + "\"evidence\":\"<intent-cli/GitHub facts>\",\"decision_needed\":\"<the exact decision or action "
-                    + "requested>\"}",
+                    + "\"current_state\":\"<the current AUTHORITATIVE state read from intent-cli/GitHub: labels, PR/CI/"
+                    + "review/merge state, queue position>\",\"evidence\":\"<the intent-cli/GitHub facts that establish "
+                    + "that state>\",\"options\":\"<OPTIONAL: candidate choices, only when useful>\",\"decision_needed\":"
+                    + "\"<the exact decision or action requested from the human>\"}",
+                MessageFields = new[]
+                {
+                    "reason — which human-needed category triggered the escalation.",
+                    "current_state — the current AUTHORITATIVE state, read from intent-cli / GitHub (labels, PR/CI/review/merge state, queue position). REQUIRED: the receiver must not have to re-derive it.",
+                    "evidence — the intent-cli / GitHub facts that establish the current state (do not pass generic wording as a substitute for the explicit state).",
+                    "options — OPTIONAL candidate choices, included only when they help the human decide.",
+                    "decision_needed — the exact decision or action requested from the human.",
+                },
             },
             Setup = new OrchestratorSetup
             {
@@ -927,6 +940,11 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine(guide.DesignThreadEscalation.EscalationMessageTemplate);
         writer.WriteLine("```");
         writer.WriteLine();
+        foreach (var field in guide.DesignThreadEscalation.MessageFields)
+        {
+            writer.WriteLine($"- {field}");
+        }
+        writer.WriteLine();
 
         writer.WriteLine("## Thread prompts");
         foreach (var thread in guide.Threads)
@@ -1140,6 +1158,9 @@ internal sealed record OrchestratorDesignThreadEscalation
 
     [JsonPropertyName("escalation_message_template")]
     public required string EscalationMessageTemplate { get; init; }
+
+    [JsonPropertyName("message_fields")]
+    public required IReadOnlyList<string> MessageFields { get; init; }
 }
 
 internal sealed record OrchestratorStaleThreadHealthCheck

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -202,6 +202,7 @@ internal static class GuideOrchestratorThreadCommand
                     "If intent-cli reports an `issue-cut-ready` candidate and all gates pass (same-domain or routed, complete contract, no open clarification, dependencies satisfied, under WIP, clean host-sync/preflight), publish ONE issue this wake via canonical publish-flow / issue-publish, then verify — do not ask the operator to create it.",
                     "If the candidate has unmet dependencies, plan the chain instead of pausing: act on the EARLIEST unmet resolvable dependency (publish or route it), keep the dependent held, and escalate only ambiguous/cycle/cross-domain-unrouted cases.",
                     "Decide the single action for this wake: publish one ready next-slice issue, delegate the next slice/PR, send one repair message, or escalate one operator decision.",
+                    "Apply the design-thread escalation filter: keep routine progress / CI-wait / success / closeout / idle internal; surface to the design thread ONLY human-needed decisions, with structured evidence and the exact decision needed. Never hide a failure that needs a human.",
                 },
                 RepairVsEscalate = new OrchestratorRepairEscalate
                 {
@@ -409,6 +410,39 @@ internal static class GuideOrchestratorThreadCommand
                     "Ask (status-request) and verify authoritative facts before any retry or escalation.",
                 },
             },
+            DesignThreadEscalation = new OrchestratorDesignThreadEscalation
+            {
+                Summary =
+                    "The design thread is the PRIMARY human communication surface. Humans mainly talk to the design "
+                    + "thread; implementation and review run through the orchestrator, and only human-needed decisions "
+                    + "return to the design thread. Keep routine orchestration internal — this is a NOISE filter, not a "
+                    + "failure filter: never hide a failure that needs a human.",
+                KeptInternal = new[]
+                {
+                    "Normal progress, accepted, and in-flight delegations.",
+                    "CI waiting — pending checks are an active wait state, not a design-thread event.",
+                    "Successful implementation (PR opened, CI green).",
+                    "Successful review / approval.",
+                    "Closeout of an already-approved PR.",
+                    "Idle wakes with no actionable change.",
+                },
+                EscalateWhen = new[]
+                {
+                    "Clarification required — the issue/packet contract is ambiguous.",
+                    "Product intent ambiguity or a design decision the orchestrator cannot make.",
+                    "Permission / credentials / security.",
+                    "A destructive action would be required to proceed.",
+                    "Repeated no-reply / no-progress after the safe stale-thread health check.",
+                    "Unresolved canonical state — intent-cli / GitHub facts conflict or are missing.",
+                    "Release / public publish decision.",
+                    "An explicit policy decision the operator owns.",
+                },
+                EscalationMessageTemplate =
+                    "{\"to\":\"design\",\"type\":\"escalation\",\"ref\":\"issue#<n>|pr#<n>\",\"reason\":\"<clarification|"
+                    + "product-ambiguity|permission|destructive|no-progress|canonical-conflict|release|policy>\","
+                    + "\"evidence\":\"<intent-cli/GitHub facts>\",\"decision_needed\":\"<the exact decision or action "
+                    + "requested>\"}",
+            },
             Setup = new OrchestratorSetup
             {
                 Summary =
@@ -488,7 +522,11 @@ internal static class GuideOrchestratorThreadCommand
                         + "(publish or route it) and keep the dependent held, rather than pausing for the operator. For a "
                         + "no-reply receiver past the threshold (default 30m), run the SAFE stale-thread health check — "
                         + "send one non-destructive status-request and verify read-only intent-cli/GitHub facts before any "
-                        + "retry; never auto-clear a permission prompt, auto-cancel work, or duplicate a task. Do "
+                        + "retry; never auto-clear a permission prompt, auto-cancel work, or duplicate a task. Report to "
+                        + "the human-facing DESIGN thread ONLY human-needed decisions (clarification, product ambiguity, "
+                        + "permission/credentials, destructive action, repeated no-progress, unresolved canonical state, "
+                        + "release/publish, explicit policy); keep routine progress / CI-wait / success / closeout / idle "
+                        + "internal — but never hide a failure that needs a human. Do "
                         + "NOT "
                         + "launch recurring implement/review timers for this domain/repo while orchestrating. Fail "
                         + "closed: if you detect a second orchestrator for this domain/repo, or agmsg replies conflict "
@@ -865,6 +903,31 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Design-thread escalation filter");
+        writer.WriteLine();
+        writer.WriteLine(guide.DesignThreadEscalation.Summary);
+        writer.WriteLine();
+        writer.WriteLine("### Kept internal (no design-thread message by default)");
+        writer.WriteLine();
+        foreach (var item in guide.DesignThreadEscalation.KeptInternal)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Escalate to the design thread when");
+        writer.WriteLine();
+        foreach (var item in guide.DesignThreadEscalation.EscalateWhen)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Design escalation message");
+        writer.WriteLine();
+        writer.WriteLine("```json");
+        writer.WriteLine(guide.DesignThreadEscalation.EscalationMessageTemplate);
+        writer.WriteLine("```");
+        writer.WriteLine();
+
         writer.WriteLine("## Thread prompts");
         foreach (var thread in guide.Threads)
         {
@@ -957,6 +1020,9 @@ internal sealed record OrchestratorThreadGuide
 
     [JsonPropertyName("stale_thread_health_check")]
     public required OrchestratorStaleThreadHealthCheck StaleThreadHealthCheck { get; init; }
+
+    [JsonPropertyName("design_thread_escalation")]
+    public required OrchestratorDesignThreadEscalation DesignThreadEscalation { get; init; }
 
     [JsonPropertyName("setup")]
     public required OrchestratorSetup Setup { get; init; }
@@ -1059,6 +1125,21 @@ internal sealed record OrchestratorCiState
 
     [JsonPropertyName("routing")]
     public required string Routing { get; init; }
+}
+
+internal sealed record OrchestratorDesignThreadEscalation
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("kept_internal")]
+    public required IReadOnlyList<string> KeptInternal { get; init; }
+
+    [JsonPropertyName("escalate_when")]
+    public required IReadOnlyList<string> EscalateWhen { get; init; }
+
+    [JsonPropertyName("escalation_message_template")]
+    public required string EscalationMessageTemplate { get; init; }
 }
 
 internal sealed record OrchestratorStaleThreadHealthCheck

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -518,6 +518,57 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_DesignThreadEscalation_KeepsRoutineInternal_EscalatesHumanNeeded_G498()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Design-thread escalation filter", output, StringComparison.Ordinal);
+        // Design thread is the primary human surface; this is a noise filter, not a failure filter.
+        Assert.Contains("PRIMARY human communication surface", output, StringComparison.Ordinal);
+        Assert.Contains("never hide a failure that needs a human", output, StringComparison.Ordinal);
+        // Quiet normal path: routine success/idle/progress kept internal.
+        Assert.Contains("### Kept internal", output, StringComparison.Ordinal);
+        Assert.Contains("Successful implementation", output, StringComparison.Ordinal);
+        Assert.Contains("Idle wakes", output, StringComparison.Ordinal);
+        Assert.Contains("CI waiting", output, StringComparison.Ordinal);
+        // Human-needed escalation path.
+        Assert.Contains("### Escalate to the design thread when", output, StringComparison.Ordinal);
+        Assert.Contains("Clarification required", output, StringComparison.Ordinal);
+        Assert.Contains("Permission / credentials / security", output, StringComparison.Ordinal);
+        Assert.Contains("Release / public publish decision", output, StringComparison.Ordinal);
+        // Structured escalation message with evidence + decision needed.
+        Assert.Contains("\"to\":\"design\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"decision_needed\"", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasDesignThreadEscalationShape_G498()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var escalation = doc.RootElement.GetProperty("design_thread_escalation");
+
+        Assert.NotEmpty(escalation.GetProperty("kept_internal").EnumerateArray());
+        Assert.NotEmpty(escalation.GetProperty("escalate_when").EnumerateArray());
+        var template = escalation.GetProperty("escalation_message_template").GetString()!;
+        Assert.Contains("evidence", template, StringComparison.Ordinal);
+        Assert.Contains("decision_needed", template, StringComparison.Ordinal);
+
+        // The orchestrator prompt applies the filter and never hides failures.
+        var orchestrator = doc.RootElement.GetProperty("threads").EnumerateArray()
+            .First(t => t.GetProperty("role").GetString() == "orchestrator")
+            .GetProperty("prompt").GetString()!;
+        Assert.Contains("human-facing DESIGN thread ONLY human-needed decisions", orchestrator, StringComparison.Ordinal);
+        Assert.Contains("never hide a failure that needs a human", orchestrator, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -536,9 +536,14 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("Clarification required", output, StringComparison.Ordinal);
         Assert.Contains("Permission / credentials / security", output, StringComparison.Ordinal);
         Assert.Contains("Release / public publish decision", output, StringComparison.Ordinal);
-        // Structured escalation message with evidence + decision needed.
+        // Structured escalation message with current authoritative state + evidence + decision needed.
         Assert.Contains("\"to\":\"design\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"current_state\"", output, StringComparison.Ordinal);
+        Assert.Contains("AUTHORITATIVE state", output, StringComparison.Ordinal);
         Assert.Contains("\"decision_needed\"", output, StringComparison.Ordinal);
+        // Field semantics make the current-state requirement explicit and options optional.
+        Assert.Contains("current_state — the current AUTHORITATIVE state", output, StringComparison.Ordinal);
+        Assert.Contains("options — OPTIONAL", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -557,8 +562,16 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.NotEmpty(escalation.GetProperty("kept_internal").EnumerateArray());
         Assert.NotEmpty(escalation.GetProperty("escalate_when").EnumerateArray());
         var template = escalation.GetProperty("escalation_message_template").GetString()!;
+        Assert.Contains("current_state", template, StringComparison.Ordinal);
         Assert.Contains("evidence", template, StringComparison.Ordinal);
         Assert.Contains("decision_needed", template, StringComparison.Ordinal);
+
+        // The required AC field — current authoritative state — is explicitly documented.
+        var fields = escalation.GetProperty("message_fields").EnumerateArray()
+            .Select(f => f.GetString()!)
+            .ToArray();
+        Assert.Contains(fields, f => f.StartsWith("current_state", StringComparison.Ordinal) && f.Contains("AUTHORITATIVE", StringComparison.Ordinal));
+        Assert.Contains(fields, f => f.StartsWith("options", StringComparison.Ordinal) && f.Contains("OPTIONAL", StringComparison.Ordinal));
 
         // The orchestrator prompt applies the filter and never hides failures.
         var orchestrator = doc.RootElement.GetProperty("threads").EnumerateArray()


### PR DESCRIPTION
## Summary

Closes #1097. Adds a design-thread escalation filter to agmsg orchestrator mode. The **design thread** is the primary human communication surface: the orchestrator keeps routine orchestration internal and returns only **human-needed** decisions to the design thread. This is a **noise filter, not a failure filter** — failures that need a human are never hidden. Builds on G496 (stale-thread health check), merged.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `design_thread_escalation` section** in the guide:
  - **kept internal** by default (no design-thread message): normal progress, CI waiting, successful implementation, successful review, closeout, idle wakes.
  - **escalate only when human-needed**: clarification, product intent ambiguity, permission/credentials/security, destructive action, repeated no-reply/no-progress (after the safe health check), unresolved canonical state, release/public publish, explicit policy decision.
  - a **structured design escalation message** carrying `reason`, `evidence`, and `decision_needed`.
  - never hide a failure that needs a human.
- **Orchestrator prompt + recurring-wake list** now apply the filter.
- **Timer-loop guidance is unchanged.**
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Guide explains what is reported to the design thread and what is kept internal.
- ✅ Routine success/idle/progress paths do not require design-thread messages by default.
- ✅ Human-needed paths return structured evidence and the exact decision needed.
- ✅ Tests cover a quiet normal path and a human-needed escalation path.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 27 passed.
- `dotnet test … --filter ~Guide` — 965 passed.
- `git diff --check` — clean.
- Existing timer-loop / mode-separation text unchanged.

## Scope note

The Related Links `intents/**` intent-tree / spec / ADR write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb