### PR TITLE
G499: Add managed worktree cleanup policy to avoid destructive rm prompts

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -263,6 +263,30 @@ re-deriving the state:
 - `options` — **optional** candidate choices, included only when they help.
 - `decision_needed` — the exact decision or action requested from the human.
 
+## Managed worktree cleanup
+
+Orchestrated work creates temporary worktrees for implementation and review.
+Allocate them under a **managed, allowlisted root** inside the workspace and
+clean them up with `git worktree remove` — **never** a raw `rm -rf` of an
+arbitrary `/tmp/intent-review-...` path. Safe cleanup design, not disabling
+approvals, is the right default: a destructive `rm -rf` approval prompt is the
+symptom of an unmanaged workspace.
+
+- **Managed root** — allocate under the `[project] worktree_root` (default
+  `.intent-cli/worktrees/`, git-ignored), not arbitrary `/tmp` paths. Create
+  each with `git worktree add .intent-cli/worktrees/<role>-<unit> <branch>`,
+  one per role/unit.
+- **Safe cleanup** — remove only with `git worktree remove` (it refuses a dirty
+  worktree); validate the target is inside the allowlisted root, is a registered
+  git worktree (`git worktree list`), and is clean; then `git worktree prune`.
+- **Refuse cleanup** when the target is outside the allowlisted root, is the
+  repo root / `$HOME` / a system path, is not a registered worktree, or has
+  uncommitted/untracked user work — stop and surface it; never delete user work.
+- **Approval policy** — `approval_policy=never` / `danger-full-access` is **not**
+  a substitute for safe cleanup design. Keep least-privilege approvals as the
+  default; the goal is to never need a destructive `rm -rf` prompt, not to
+  suppress it.
+
 ## Single-domain vs multi-domain orchestration
 
 A host checkout can legitimately contain **several** intent domains (for

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -244,6 +244,27 @@ state**、それを裏付ける evidence、必要なときだけの options、�
 - `options` — **任意** の候補の選択肢。役立つときのみ含める。
 - `decision_needed` — 人間に求める正確な判断またはアクション。
 
+## managed worktree のクリーンアップ
+
+オーケストレーション作業は実装・レビュー用の一時 worktree を作成します。ワークスペース内の
+**管理された allowlist 済みルート** の下に割り当て、`git worktree remove` でクリーンアップします
+— 任意の `/tmp/intent-review-...` パスを生の `rm -rf` で削除しては **いけません**。承認を無効化
+するのではなく安全なクリーンアップ設計が正しいデフォルトです: 破壊的な `rm -rf` 承認プロンプトは
+管理されていないワークスペースの症状です。
+
+- **管理ルート** — `[project] worktree_root`（デフォルト `.intent-cli/worktrees/`、git-ignored）の
+  下に割り当てる。任意の `/tmp` パスではない。`git worktree add .intent-cli/worktrees/<role>-<unit>
+  <branch>` で role/unit ごとに 1 つ作成する。
+- **安全なクリーンアップ** — `git worktree remove` でのみ削除（dirty な worktree は拒否される）。
+  ターゲットが allowlist 済みルート内であること、登録済み git worktree（`git worktree list`）で
+  あること、clean であることを検証してから `git worktree prune`。
+- **クリーンアップを拒否する** — ターゲットが allowlist 済みルートの外、repo root / `$HOME` /
+  システムパス、登録されていない worktree、または uncommitted/untracked のユーザー作業がある
+  場合は停止して surface する。ユーザー作業を決して削除しない。
+- **承認ポリシー** — `approval_policy=never` / `danger-full-access` は安全なクリーンアップ設計の
+  **代替ではありません**。最小権限の承認をデフォルトに保ちます。目標は破壊的な `rm -rf` プロンプトを
+  抑制することではなく、そもそも必要としないことです。
+
 ## single-domain と multi-domain のオーケストレーション
 
 host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -456,6 +456,45 @@ internal static class GuideOrchestratorThreadCommand
                     "decision_needed — the exact decision or action requested from the human.",
                 },
             },
+            WorktreeManagement = new OrchestratorWorktreeManagement
+            {
+                Summary =
+                    "Orchestrated work creates temporary worktrees for implementation and review. Allocate them under a "
+                    + "managed, allowlisted root inside the workspace and clean them up with `git worktree remove` — "
+                    + "NEVER a raw `rm -rf` of an arbitrary `/tmp/intent-review-...` path. Safe cleanup design, not "
+                    + "disabling approvals, is the right default: a destructive `rm -rf` approval prompt is the symptom "
+                    + "of an unmanaged workspace.",
+                ManagedRoot =
+                    "Allocate temporary worktrees under a repo/workspace-scoped managed root — the `[project] "
+                    + "worktree_root` (default `.intent-cli/worktrees/`), git-ignored — not arbitrary `/tmp/"
+                    + "intent-review-...` paths. A managed root is allowlisted, predictable, and removable with `git "
+                    + "worktree remove`.",
+                Allocation = new[]
+                {
+                    "Create each worktree under the managed root: `git worktree add .intent-cli/worktrees/<role>-<unit> <branch>`.",
+                    "Keep the managed root git-ignored so it never pollutes the tree.",
+                    "One worktree per role/unit; do not reuse a dirty worktree across units.",
+                },
+                SafeCleanup = new[]
+                {
+                    "Remove a worktree only with `git worktree remove` (it refuses a dirty worktree) — never raw `rm -rf`.",
+                    "Validate the target path is INSIDE the allowlisted managed root before removal.",
+                    "Confirm the path is a registered git worktree (it appears in `git worktree list`).",
+                    "Confirm the worktree state is clean (no uncommitted or untracked user work) before removing.",
+                    "Prune stale registrations with `git worktree prune` after removal.",
+                },
+                RefuseWhen = new[]
+                {
+                    "The target is OUTSIDE the allowlisted managed root.",
+                    "The target is the repo root, `$HOME`, or a system path (`/`, `/tmp` root, etc.).",
+                    "The path is not a registered git worktree.",
+                    "The worktree has uncommitted or untracked user work — STOP and surface it; do not delete user work.",
+                },
+                ApprovalPolicyNote =
+                    "`approval_policy=never` / `danger-full-access` is NOT a substitute for safe cleanup design. Keep "
+                    + "least-privilege approvals as the default; the goal is to never need a destructive `rm -rf` prompt, "
+                    + "not to suppress the prompt.",
+            },
             Setup = new OrchestratorSetup
             {
                 Summary =
@@ -621,6 +660,7 @@ internal static class GuideOrchestratorThreadCommand
                 "Process at most one delegation/repair/escalation per orchestrator wake; one delegated item per implementation/review wake.",
                 "Domain isolation: a host repo can hold several domains and one repo can serve several domains, so visibility is not authorization. Single-domain orchestrators ignore/escalate other-domain items; multi-domain orchestrators require explicit per-delegation routing. An execution-unit prefix mismatch alone is not a wrong-repo signal.",
                 "Fail closed on duplicate orchestrators for the same domain/repo, or when an agmsg reply conflicts with intent-cli/GitHub facts — STOP and escalate, never guess.",
+                "Allocate temporary worktrees under an allowlisted managed root and remove them with `git worktree remove`; never raw `rm -rf` of arbitrary temp paths, and `approval_policy=never`/`danger-full-access` is not a substitute for safe cleanup.",
                 "Never ask intent-cli to launch Claude/Codex/Copilot or any AI provider; intent-cli only emits text the human agent acts on.",
             },
             DetailedGuideCommands = new[]
@@ -946,6 +986,35 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Managed worktree cleanup");
+        writer.WriteLine();
+        writer.WriteLine(guide.WorktreeManagement.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- **managed root** — {guide.WorktreeManagement.ManagedRoot}");
+        writer.WriteLine($"- **approval policy** — {guide.WorktreeManagement.ApprovalPolicyNote}");
+        writer.WriteLine();
+        writer.WriteLine("### Allocation");
+        writer.WriteLine();
+        foreach (var item in guide.WorktreeManagement.Allocation)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Safe cleanup");
+        writer.WriteLine();
+        foreach (var item in guide.WorktreeManagement.SafeCleanup)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Refuse cleanup when");
+        writer.WriteLine();
+        foreach (var item in guide.WorktreeManagement.RefuseWhen)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Thread prompts");
         foreach (var thread in guide.Threads)
         {
@@ -1041,6 +1110,9 @@ internal sealed record OrchestratorThreadGuide
 
     [JsonPropertyName("design_thread_escalation")]
     public required OrchestratorDesignThreadEscalation DesignThreadEscalation { get; init; }
+
+    [JsonPropertyName("worktree_management")]
+    public required OrchestratorWorktreeManagement WorktreeManagement { get; init; }
 
     [JsonPropertyName("setup")]
     public required OrchestratorSetup Setup { get; init; }
@@ -1143,6 +1215,27 @@ internal sealed record OrchestratorCiState
 
     [JsonPropertyName("routing")]
     public required string Routing { get; init; }
+}
+
+internal sealed record OrchestratorWorktreeManagement
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("managed_root")]
+    public required string ManagedRoot { get; init; }
+
+    [JsonPropertyName("allocation")]
+    public required IReadOnlyList<string> Allocation { get; init; }
+
+    [JsonPropertyName("safe_cleanup")]
+    public required IReadOnlyList<string> SafeCleanup { get; init; }
+
+    [JsonPropertyName("refuse_when")]
+    public required IReadOnlyList<string> RefuseWhen { get; init; }
+
+    [JsonPropertyName("approval_policy_note")]
+    public required string ApprovalPolicyNote { get; init; }
 }
 
 internal sealed record OrchestratorDesignThreadEscalation

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -582,6 +582,55 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_ManagedWorktreeCleanup_RecommendsManagedRoot_ForbidsRawRm_G499()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Managed worktree cleanup", output, StringComparison.Ordinal);
+        // Recommend a managed root instead of arbitrary /tmp paths.
+        Assert.Contains(".intent-cli/worktrees", output, StringComparison.Ordinal);
+        Assert.Contains("git worktree add", output, StringComparison.Ordinal);
+        // Forbid raw rm -rf and use git worktree remove.
+        Assert.Contains("never raw `rm -rf`", output, StringComparison.Ordinal);
+        Assert.Contains("git worktree remove", output, StringComparison.Ordinal);
+        // approval_policy=never is not a substitute.
+        Assert.Contains("approval_policy=never", output, StringComparison.Ordinal);
+        Assert.Contains("not a substitute", output, StringComparison.Ordinal);
+        // Refuse unsafe paths and dirty user work.
+        Assert.Contains("### Refuse cleanup when", output, StringComparison.Ordinal);
+        Assert.Contains("OUTSIDE the allowlisted managed root", output, StringComparison.Ordinal);
+        Assert.Contains("uncommitted or untracked user work", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasWorktreeManagementShape_G499()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var worktree = doc.RootElement.GetProperty("worktree_management");
+
+        Assert.Contains(".intent-cli/worktrees", worktree.GetProperty("managed_root").GetString()!, StringComparison.Ordinal);
+        Assert.NotEmpty(worktree.GetProperty("allocation").EnumerateArray());
+        Assert.NotEmpty(worktree.GetProperty("safe_cleanup").EnumerateArray());
+        Assert.NotEmpty(worktree.GetProperty("refuse_when").EnumerateArray());
+        Assert.Contains("NOT a substitute", worktree.GetProperty("approval_policy_note").GetString()!, StringComparison.Ordinal);
+
+        // The guide does not instruct a raw rm -rf of arbitrary paths anywhere.
+        var safeCleanup = worktree.GetProperty("safe_cleanup").EnumerateArray().Select(s => s.GetString()!).ToArray();
+        Assert.Contains(safeCleanup, s => s.Contains("git worktree remove", StringComparison.Ordinal));
+
+        // A dedicated safety boundary reinforces the no-raw-rm rule.
+        var boundaries = doc.RootElement.GetProperty("safety_boundaries").EnumerateArray().Select(b => b.GetString()!).ToArray();
+        Assert.Contains(boundaries, b => b.Contains("never raw `rm -rf`", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Closes #1099. Adds managed worktree allocation + safe cleanup guidance so orchestrated agent work never triggers a destructive `rm -rf` approval prompt on arbitrary `/tmp/intent-review-...` paths. The safe default is a managed, allowlisted worktree root plus `git worktree remove` — **not** disabling approvals. Builds on G498, merged.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `worktree_management` section** in the guide:
  - **managed root** — allocate under the `[project] worktree_root` (default `.intent-cli/worktrees/`, git-ignored) with `git worktree add`, not arbitrary `/tmp` paths.
  - **safe cleanup** — remove only with `git worktree remove` (refuses dirty worktrees); validate the target is inside the allowlisted root, is a registered git worktree, and is clean; then `git worktree prune`.
  - **refuse cleanup** when the target is outside the root, is the repo root / `$HOME` / a system path, is not a registered worktree, or has uncommitted/untracked user work.
  - **approval policy** — `approval_policy=never` / `danger-full-access` is **not** a substitute for safe cleanup design; least-privilege approvals stay the default.
- **New safety boundary** reinforces the no-raw-`rm -rf` rule.
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Guide recommends managed worktree paths instead of arbitrary `/tmp` paths.
- ✅ Generated guidance does not instruct agents to run raw `rm -rf` on arbitrary paths (it forbids it; cleanup uses `git worktree remove`).
- ✅ Cleanup guidance refuses unsafe paths and dirty user work.
- ✅ Tests cover managed worktree guidance and unsafe-cleanup refusal language.
- ✅ No docs recommend `danger-full-access` as the normal default (verified).

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 29 passed.
- `dotnet test … --filter ~Guide` — 967 passed.
- `git diff --check` — clean.
- `grep danger-full-access` — only appears as "not a substitute"; never recommended as default.

## Scope note

The Related Links `intents/**` intent-tree / spec write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb