### PR TITLE
G501: Clarify agmsg monitor readiness and receiver boundaries

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -310,6 +310,43 @@ symptom of an unmanaged workspace.
   default; the goal is to never need a destructive `rm -rf` prompt, not to
   suppress it.
 
+## Receiver readiness
+
+Monitor configuration is **not enough**. A registered team plus a configured
+delivery mode does **not** mean a receiver will see your message — a newly
+launched or restarted session may not pick up messages sent before its
+monitor/watch path was active. Confirm each receiver is **ready** with a
+ping/ack before sending real work.
+
+Readiness states:
+
+- **registered** — the role joined the team (it appears in `team.sh`).
+- **delivery-configured** — the delivery mode is set (`delivery.sh status`).
+- **watcher-alive** — the monitor/watch process is running for the role.
+- **receiver-session-active** — a launched/restarted receiver session is
+  actually attached to the monitor path (a session started before delivery was
+  active may not receive earlier messages).
+- **ping-acknowledged** — the receiver replied to a ping; the only end-to-end
+  proof the channel works.
+
+**Ping/ack is required** for the orchestrator, implementer, and reviewer before
+any real delegation, and must be re-done after any launch/restart. A missing ack
+is **not-ready** — do not send real work. If a receiver was not ready, messages
+sent earlier may have been missed: resend after the ack, or read what is queued
+with `inbox.sh`; re-confirm `team.sh` and `delivery.sh status` first.
+
+Boundaries:
+
+- **`watch.sh`** streams a role's inbox live but **occupies a terminal** — it is
+  a debug/fallback option, not the default setup requirement. The normal path is
+  the monitor delivery hook.
+- **Codex Desktop app threads are not agmsg monitor receivers by default** — a
+  different execution surface from a CLI session. Use a CLI session as the
+  receiver (or read with `inbox.sh`).
+
+Diagnose with agmsg scripts only: `team.sh` (registration), `delivery.sh status`
+(delivery), `inbox.sh` (queued messages), `send.sh` (ping → ack).
+
 ## Single-domain vs multi-domain orchestration
 
 A host checkout can legitimately contain **several** intent domains (for

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -287,6 +287,40 @@ state**、それを裏付ける evidence、必要なときだけの options、�
   **代替ではありません**。最小権限の承認をデフォルトに保ちます。目標は破壊的な `rm -rf` プロンプトを
   抑制することではなく、そもそも必要としないことです。
 
+## receiver の準備状態（readiness）
+
+monitor の設定だけでは **不十分** です。team 登録 + delivery mode 設定があっても、receiver が
+メッセージを見られるとは **限りません** — 新しく起動/再起動したセッションは、その monitor/watch
+パスがアクティブになる前に送られたメッセージを拾わないことがあります。実際の作業を送る前に、
+各 receiver が ping/ack で **ready** であることを確認してください。
+
+readiness 状態:
+
+- **registered** — ロールが team に参加した（`team.sh` に表示される）。
+- **delivery-configured** — delivery mode が設定済み（`delivery.sh status`）。
+- **watcher-alive** — そのロールの monitor/watch プロセスが動いている。
+- **receiver-session-active** — 起動/再起動した receiver セッションが実際に monitor パスに
+  アタッチされている（delivery がアクティブになる前に開始したセッションは earlier なメッセージを
+  受け取らないことがある）。
+- **ping-acknowledged** — receiver が ping に返信した。チャネルが end-to-end で動く唯一の証拠。
+
+実際の委譲の前に orchestrator・implementer・reviewer に対して **ping/ack が必須** であり、
+起動/再起動のたびに再実行します。ack がなければ **not-ready** — 実際の作業を送らない。receiver が
+ready でなかった場合、earlier に送ったメッセージは missed の可能性があります: ack 後に resend するか、
+`inbox.sh` で queue を読む。先に `team.sh` と `delivery.sh status` を再確認します。
+
+境界:
+
+- **`watch.sh`** はロールの inbox をライブにストリームしますが **ターミナルを占有** します —
+  debug/fallback オプションであり、デフォルトのセットアップ要件ではありません。通常は monitor
+  delivery hook が標準パスです。
+- **Codex Desktop app のスレッドはデフォルトで agmsg monitor receiver ではありません** — CLI
+  セッションとは別の実行 surface です。receiver には CLI セッションを使う（または `inbox.sh` で
+  読む）。
+
+診断は agmsg スクリプトのみ: `team.sh`（登録）、`delivery.sh status`（delivery）、`inbox.sh`
+（queue 済みメッセージ）、`send.sh`（ping → ack）。
+
 ## single-domain と multi-domain のオーケストレーション
 
 host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -558,6 +558,47 @@ internal static class GuideOrchestratorThreadCommand
                     "Never edit the agmsg database or team files directly — register, message, and clean up ONLY through "
                     + "the agmsg scripts. Hand-editing agmsg state corrupts delivery.",
             },
+            ReceiverReadiness = new OrchestratorReceiverReadiness
+            {
+                Summary =
+                    "Monitor configuration is NOT enough. A registered team plus a configured delivery mode does NOT mean "
+                    + "a receiver will see your message — a newly launched or restarted session may not pick up messages "
+                    + "sent before its monitor/watch path was active. Confirm each receiver is READY with a ping/ack "
+                    + "before sending real work.",
+                States = new[]
+                {
+                    new OrchestratorReadinessState { State = "registered", Meaning = "the role joined the team (it appears in `team.sh`)." },
+                    new OrchestratorReadinessState { State = "delivery-configured", Meaning = "the delivery mode is set for the role (`delivery.sh status`)." },
+                    new OrchestratorReadinessState { State = "watcher-alive", Meaning = "the monitor / watch process is running for the role." },
+                    new OrchestratorReadinessState { State = "receiver-session-active", Meaning = "a launched/restarted receiver session is actually attached to the monitor path — a session started before delivery was active may not receive earlier messages." },
+                    new OrchestratorReadinessState { State = "ping-acknowledged", Meaning = "the receiver replied to a ping — the only proof the channel works end to end." },
+                },
+                PingAckRequired =
+                    "Before ANY real delegation, send a ping to the orchestrator, implementer, and reviewer and require "
+                    + "an ack from each. Treat a missing ack as NOT-READY and do not send real work until every receiver "
+                    + "has acked. Re-do the ping/ack after any receiver launch or restart.",
+                NotReadyRecovery = new[]
+                {
+                    "Messages sent before readiness may not have been received — resend them after the ack.",
+                    "Read what is already queued for a role with `inbox.sh` (a session can pull messages it missed).",
+                    "Re-confirm registration (`team.sh`) and delivery (`delivery.sh status`) before resending.",
+                },
+                WatchNote =
+                    "Manual `watch.sh` streams a role's inbox live but OCCUPIES a terminal — it is a debug / fallback "
+                    + "streaming option, not the default setup requirement. The normal path is the monitor delivery hook; "
+                    + "use `watch.sh` to diagnose, not as the standing receiver.",
+                CodexDesktopNote =
+                    "Codex Desktop app threads are NOT agmsg monitor receivers by default — they are a different "
+                    + "execution surface from a CLI session. Do not assume a Desktop-app thread will receive agmsg "
+                    + "messages; use a CLI session as the receiver (or read with `inbox.sh`).",
+                DiagnosticCommands = new[]
+                {
+                    "agmsg team.sh — confirm the role is registered in the team.",
+                    "agmsg delivery.sh status — confirm the delivery mode is configured/active for the role.",
+                    "agmsg inbox.sh — read what is queued for a role (catch messages sent before readiness).",
+                    "agmsg send.sh — send a ping; the receiver's ack proves the channel end to end.",
+                },
+            },
             Threads = new[]
             {
                 new OrchestratorThreadPrompt
@@ -818,7 +859,7 @@ internal static class GuideOrchestratorThreadCommand
             {
                 "Existing-loop conflict check: confirm no implementation/review recurring timer is running for this domain/repo (only the orchestrator is scheduled).",
                 "First read-only wake: run ONE confirm-only orchestrator wake — read state, send nothing.",
-                "Ping/inbox test: send one agmsg message from the orchestrator to each receiver and confirm it lands before any real delegation.",
+                "Receiver readiness: ping each receiver and require an ack BEFORE any real delegation — a registered+configured role is not ready until it acks (see the Receiver readiness section). A session launched before delivery was active may have missed earlier messages; resend or read with `inbox.sh`.",
             },
             LooplessReceiverNote = LooplessReceiverNote,
         };
@@ -1086,6 +1127,37 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
         writer.WriteLine($"> **Warning:** {guide.Setup.Warning}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Receiver readiness");
+        writer.WriteLine();
+        writer.WriteLine(guide.ReceiverReadiness.Summary);
+        writer.WriteLine();
+        writer.WriteLine("### Readiness states");
+        writer.WriteLine();
+        foreach (var state in guide.ReceiverReadiness.States)
+        {
+            writer.WriteLine($"- **{state.State}** — {state.Meaning}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **ping/ack required** — {guide.ReceiverReadiness.PingAckRequired}");
+        writer.WriteLine();
+        writer.WriteLine("### If a receiver is not ready");
+        writer.WriteLine();
+        foreach (var item in guide.ReceiverReadiness.NotReadyRecovery)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **`watch.sh`** — {guide.ReceiverReadiness.WatchNote}");
+        writer.WriteLine($"- **Codex Desktop app** — {guide.ReceiverReadiness.CodexDesktopNote}");
+        writer.WriteLine();
+        writer.WriteLine("### Diagnostic commands (agmsg scripts only)");
+        writer.WriteLine();
+        foreach (var command in guide.ReceiverReadiness.DiagnosticCommands)
+        {
+            writer.WriteLine($"- {command}");
+        }
         writer.WriteLine();
 
         writer.WriteLine("## Domain routing — single-domain vs multi-domain");
@@ -1477,6 +1549,9 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("setup")]
     public required OrchestratorSetup Setup { get; init; }
 
+    [JsonPropertyName("receiver_readiness")]
+    public required OrchestratorReceiverReadiness ReceiverReadiness { get; init; }
+
     [JsonPropertyName("threads")]
     public required IReadOnlyList<OrchestratorThreadPrompt> Threads { get; init; }
 
@@ -1671,6 +1746,39 @@ internal sealed record OrchestratorDependencyStatus
 
     [JsonPropertyName("action")]
     public required string Action { get; init; }
+}
+
+internal sealed record OrchestratorReceiverReadiness
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("states")]
+    public required IReadOnlyList<OrchestratorReadinessState> States { get; init; }
+
+    [JsonPropertyName("ping_ack_required")]
+    public required string PingAckRequired { get; init; }
+
+    [JsonPropertyName("not_ready_recovery")]
+    public required IReadOnlyList<string> NotReadyRecovery { get; init; }
+
+    [JsonPropertyName("watch_note")]
+    public required string WatchNote { get; init; }
+
+    [JsonPropertyName("codex_desktop_note")]
+    public required string CodexDesktopNote { get; init; }
+
+    [JsonPropertyName("diagnostic_commands")]
+    public required IReadOnlyList<string> DiagnosticCommands { get; init; }
+}
+
+internal sealed record OrchestratorReadinessState
+{
+    [JsonPropertyName("state")]
+    public required string State { get; init; }
+
+    [JsonPropertyName("meaning")]
+    public required string Meaning { get; init; }
 }
 
 internal sealed record OrchestratorSetup

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -672,9 +672,9 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("#### orchestrator", output, StringComparison.Ordinal);
         Assert.Contains("#### implementation", output, StringComparison.Ordinal);
         Assert.Contains("#### review", output, StringComparison.Ordinal);
-        // First validation: read-only wake, ping test, existing-loop conflict check.
+        // First validation: read-only wake, receiver readiness (ping/ack), existing-loop conflict check.
         Assert.Contains("First read-only wake", output, StringComparison.Ordinal);
-        Assert.Contains("Ping/inbox test", output, StringComparison.Ordinal);
+        Assert.Contains("Receiver readiness: ping each receiver and require an ack", output, StringComparison.Ordinal);
         Assert.Contains("Existing-loop conflict check", output, StringComparison.Ordinal);
     }
 
@@ -740,6 +740,67 @@ public sealed class GuideOrchestratorThreadCommandTests
 
         Assert.Equal(1, exitCode);
         Assert.Contains("Unknown --existing-loop-policy", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_ReceiverReadiness_RequiresPingAck_AndExplainsBoundaries_G501()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Receiver readiness", output, StringComparison.Ordinal);
+        // Monitor config is not enough.
+        Assert.Contains("Monitor configuration is NOT enough", output, StringComparison.Ordinal);
+        // The five readiness states.
+        Assert.Contains("- **registered**", output, StringComparison.Ordinal);
+        Assert.Contains("- **delivery-configured**", output, StringComparison.Ordinal);
+        Assert.Contains("- **watcher-alive**", output, StringComparison.Ordinal);
+        Assert.Contains("- **receiver-session-active**", output, StringComparison.Ordinal);
+        Assert.Contains("- **ping-acknowledged**", output, StringComparison.Ordinal);
+        // Ping/ack required for each receiver before real delegation, re-done after restart.
+        Assert.Contains("ping/ack required", output, StringComparison.Ordinal);
+        Assert.Contains("Treat a missing ack as NOT-READY", output, StringComparison.Ordinal);
+        Assert.Contains("after any receiver launch or restart", output, StringComparison.Ordinal);
+        // Not-ready recovery via inbox.sh / resend.
+        Assert.Contains("resend", output, StringComparison.Ordinal);
+        Assert.Contains("`inbox.sh`", output, StringComparison.Ordinal);
+        // watch.sh is debug/fallback and occupies a terminal.
+        Assert.Contains("debug / fallback", output, StringComparison.Ordinal);
+        Assert.Contains("OCCUPIES a terminal", output, StringComparison.Ordinal);
+        // Codex Desktop app is not a monitor receiver by default.
+        Assert.Contains("Codex Desktop app threads are NOT agmsg monitor receivers", output, StringComparison.Ordinal);
+        // Diagnostic commands use agmsg scripts only.
+        Assert.Contains("agmsg team.sh", output, StringComparison.Ordinal);
+        Assert.Contains("agmsg delivery.sh status", output, StringComparison.Ordinal);
+        Assert.Contains("agmsg inbox.sh", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_ReceiverReadiness_HasFiveStatesAndRecovery_G501()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var readiness = doc.RootElement.GetProperty("receiver_readiness");
+
+        var states = readiness.GetProperty("states").EnumerateArray()
+            .Select(s => s.GetProperty("state").GetString())
+            .ToArray();
+        Assert.Equal(
+            new[] { "registered", "delivery-configured", "watcher-alive", "receiver-session-active", "ping-acknowledged" },
+            states);
+
+        Assert.True(readiness.TryGetProperty("ping_ack_required", out _));
+        Assert.NotEmpty(readiness.GetProperty("not_ready_recovery").EnumerateArray());
+        Assert.Contains("inbox.sh", readiness.GetProperty("codex_desktop_note").GetString()! + string.Join(" ", readiness.GetProperty("not_ready_recovery").EnumerateArray().Select(e => e.GetString())), StringComparison.Ordinal);
+
+        // Diagnostic commands use only agmsg scripts (no raw gh / db edits).
+        var diagnostics = readiness.GetProperty("diagnostic_commands").EnumerateArray().Select(d => d.GetString()!).ToArray();
+        Assert.All(diagnostics, d => Assert.StartsWith("agmsg ", d, StringComparison.Ordinal));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #1103. Setup guidance previously treated agmsg monitor configuration as enough, which made agents overconfident: a newly launched/restarted session may not pick up messages sent before its monitor/watch path was active, and Codex Desktop app threads are not agmsg monitor receivers by default. This adds explicit **receiver readiness** plus a ping/ack requirement before real delegation. Builds on G494/G500.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `receiver_readiness` section** in the guide:
  - **five readiness states** — `registered`, `delivery-configured`, `watcher-alive`, `receiver-session-active`, `ping-acknowledged`.
  - **ping/ack required** for orchestrator, implementer, and reviewer before any real delegation, re-done after launch/restart; a missing ack is **not-ready**.
  - **not-ready recovery** — resend after ack, read queued messages with `inbox.sh`, re-confirm `team.sh` / `delivery.sh status`.
  - **`watch.sh`** is a debug/fallback stream that occupies a terminal, not the default requirement.
  - **Codex Desktop app** threads are not agmsg monitor receivers by default (different execution surface from a CLI session).
  - **diagnostic commands** use agmsg scripts only (`team.sh` / `delivery.sh status` / `inbox.sh` / `send.sh`).
- The setup-intake first-validation now requires receiver **ping/ack** (not just a ping) before real delegation.
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Guide distinguishes registration, delivery mode, watcher alive, receiver session active, and ping acknowledged.
- ✅ Setup guidance includes a receiver-readiness checklist before real delegation.
- ✅ Ping/ack required for each receiver after launch/restart.
- ✅ Missing ack is treated as not-ready → resend / manual `inbox.sh` guidance.
- ✅ `watch.sh` described as debug/fallback streaming that may occupy a terminal.
- ✅ Codex Desktop app is not described as an agmsg monitor receiver by default.
- ✅ Diagnostic commands use agmsg scripts only.
- ✅ Tests cover not-ready and ready-after-ping cases.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 36 passed.
- `dotnet test … --filter ~Guide` — 978 passed.
- `git diff --check` — clean.

## Scope note

The Knowledge Maintenance `intents/**` intent-tree write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb