### PR TITLE
G502: Add orchestrator receiver startup ordering guidance

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -339,6 +339,13 @@ Follow this order strictly — a send is not a delivery:
 > delegation. Recover by resending after the ack, or have the receiver read its
 > queue with `inbox.sh`.
 
+Copy-paste operator message when receivers were launched **after** the initial
+messages were sent:
+
+```text
+Heads up: your session started AFTER I sent earlier messages, so they may be in agmsg history but not visibly delivered to you. Read your queue now with `inbox.sh` to catch anything you missed. Any prior unacked message is receiver-not-ready (NOT a delegation you must act on) — reply `ack` to this ping and I will (re)send the current delegation.
+```
+
 Readiness states:
 
 - **registered** — the role joined the team (it appears in `team.sh`).

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -318,6 +318,27 @@ launched or restarted session may not pick up messages sent before its
 monitor/watch path was active. Confirm each receiver is **ready** with a
 ping/ack before sending real work.
 
+### Startup order
+
+Follow this order strictly — a send is not a delivery:
+
+1. Join the three roles to the team (`join.sh`).
+2. Set the delivery mode for each role (`delivery.sh set`).
+3. Launch or restart the receiver CLI sessions (implementation, review, and the
+   orchestrator).
+4. Wait for the monitor/bridge to attach in each receiver session before
+   sending anything.
+5. Send a ping to each receiver only **after** its session is active.
+6. Require an ack — or confirm receipt manually with `inbox.sh` — before
+   proceeding.
+7. Only then send the first real delegation.
+
+> **Send-before-ready:** messages sent before a receiver is ready may be stored
+> in agmsg history but **not** visibly delivered to a freshly launched/restarted
+> session. An unacked message is **receiver-not-ready**, not a successful
+> delegation. Recover by resending after the ack, or have the receiver read its
+> queue with `inbox.sh`.
+
 Readiness states:
 
 - **registered** — the role joined the team (it appears in `team.sh`).

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -311,6 +311,13 @@ monitor の設定だけでは **不十分** です。team 登録 + delivery mode
 > ないメッセージは **receiver-not-ready** であり、成功した委譲ではありません。ack 後に resend するか、
 > receiver に `inbox.sh` で queue を読ませて復旧します。
 
+receiver が initial メッセージ送信 **後** に launch された場合に送る、貼り付け可能なオペレーター
+メッセージ:
+
+```text
+Heads up: your session started AFTER I sent earlier messages, so they may be in agmsg history but not visibly delivered to you. Read your queue now with `inbox.sh` to catch anything you missed. Any prior unacked message is receiver-not-ready (NOT a delegation you must act on) — reply `ack` to this ping and I will (re)send the current delegation.
+```
+
 readiness 状態:
 
 - **registered** — ロールが team に参加した（`team.sh` に表示される）。

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -294,6 +294,23 @@ monitor の設定だけでは **不十分** です。team 登録 + delivery mode
 パスがアクティブになる前に送られたメッセージを拾わないことがあります。実際の作業を送る前に、
 各 receiver が ping/ack で **ready** であることを確認してください。
 
+### 起動順序（startup order）
+
+次の順序を厳密に守ってください — send は delivery ではありません:
+
+1. 3 つのロールを team に join する（`join.sh`）。
+2. 各ロールの delivery mode を設定する（`delivery.sh set`）。
+3. receiver の CLI セッション（implementation・review・orchestrator）を起動/再起動する。
+4. 何かを送る前に、各 receiver セッションで monitor/bridge がアタッチされるのを待つ。
+5. セッションがアクティブになった **後** にのみ各 receiver へ ping を送る。
+6. 進む前に ack を要求する — または `inbox.sh` で受信を手動確認する。
+7. その後にのみ最初の実際の委譲を送る。
+
+> **send-before-ready:** receiver が ready になる前に送ったメッセージは agmsg history に保存されて
+> いても、新しく起動/再起動したセッションには **可視に delivery されない** ことがあります。ack の
+> ないメッセージは **receiver-not-ready** であり、成功した委譲ではありません。ack 後に resend するか、
+> receiver に `inbox.sh` で queue を読ませて復旧します。
+
 readiness 状態:
 
 - **registered** — ロールが team に参加した（`team.sh` に表示される）。

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -565,6 +565,21 @@ internal static class GuideOrchestratorThreadCommand
                     + "a receiver will see your message — a newly launched or restarted session may not pick up messages "
                     + "sent before its monitor/watch path was active. Confirm each receiver is READY with a ping/ack "
                     + "before sending real work.",
+                StartupOrder = new[]
+                {
+                    "Join the three roles to the team (`join.sh`).",
+                    "Set the delivery mode for each role (`delivery.sh set`).",
+                    "Launch or restart the receiver CLI sessions (implementation, review, and the orchestrator).",
+                    "Wait for the monitor/bridge to attach in each receiver session before sending anything.",
+                    "Send a ping to each receiver only AFTER its session is active.",
+                    "Require an ack from each receiver — or confirm receipt manually with `inbox.sh` — before proceeding.",
+                    "Only then send the first real delegation.",
+                },
+                SendBeforeReadyWarning =
+                    "Messages sent BEFORE a receiver is ready may be stored in agmsg history but NOT visibly delivered "
+                    + "to a freshly launched/restarted session. A send is not a delivery: an unacked message is "
+                    + "receiver-NOT-READY, not a successful delegation. Recover by resending after the ack, or have the "
+                    + "receiver read its queue with `inbox.sh`.",
                 States = new[]
                 {
                     new OrchestratorReadinessState { State = "registered", Meaning = "the role joined the team (it appears in `team.sh`)." },
@@ -1132,6 +1147,15 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine("## Receiver readiness");
         writer.WriteLine();
         writer.WriteLine(guide.ReceiverReadiness.Summary);
+        writer.WriteLine();
+        writer.WriteLine("### Startup order");
+        writer.WriteLine();
+        for (var i = 0; i < guide.ReceiverReadiness.StartupOrder.Count; i++)
+        {
+            writer.WriteLine($"{i + 1}. {guide.ReceiverReadiness.StartupOrder[i]}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"> **Send-before-ready:** {guide.ReceiverReadiness.SendBeforeReadyWarning}");
         writer.WriteLine();
         writer.WriteLine("### Readiness states");
         writer.WriteLine();
@@ -1752,6 +1776,12 @@ internal sealed record OrchestratorReceiverReadiness
 {
     [JsonPropertyName("summary")]
     public required string Summary { get; init; }
+
+    [JsonPropertyName("startup_order")]
+    public required IReadOnlyList<string> StartupOrder { get; init; }
+
+    [JsonPropertyName("send_before_ready_warning")]
+    public required string SendBeforeReadyWarning { get; init; }
 
     [JsonPropertyName("states")]
     public required IReadOnlyList<OrchestratorReadinessState> States { get; init; }

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -580,6 +580,11 @@ internal static class GuideOrchestratorThreadCommand
                     + "to a freshly launched/restarted session. A send is not a delivery: an unacked message is "
                     + "receiver-NOT-READY, not a successful delegation. Recover by resending after the ack, or have the "
                     + "receiver read its queue with `inbox.sh`.",
+                RecoveryMessageTemplate =
+                    "Heads up: your session started AFTER I sent earlier messages, so they may be in agmsg history but "
+                    + "not visibly delivered to you. Read your queue now with `inbox.sh` to catch anything you missed. "
+                    + "Any prior unacked message is receiver-not-ready (NOT a delegation you must act on) — reply `ack` "
+                    + "to this ping and I will (re)send the current delegation.",
                 States = new[]
                 {
                     new OrchestratorReadinessState { State = "registered", Meaning = "the role joined the team (it appears in `team.sh`)." },
@@ -1156,6 +1161,12 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
         writer.WriteLine($"> **Send-before-ready:** {guide.ReceiverReadiness.SendBeforeReadyWarning}");
+        writer.WriteLine();
+        writer.WriteLine("Copy-paste operator message when receivers were launched after the initial messages were sent:");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(guide.ReceiverReadiness.RecoveryMessageTemplate);
+        writer.WriteLine("```");
         writer.WriteLine();
         writer.WriteLine("### Readiness states");
         writer.WriteLine();
@@ -1782,6 +1793,9 @@ internal sealed record OrchestratorReceiverReadiness
 
     [JsonPropertyName("send_before_ready_warning")]
     public required string SendBeforeReadyWarning { get; init; }
+
+    [JsonPropertyName("recovery_message_template")]
+    public required string RecoveryMessageTemplate { get; init; }
 
     [JsonPropertyName("states")]
     public required IReadOnlyList<OrchestratorReadinessState> States { get; init; }

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -804,6 +804,51 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_ReceiverStartupOrder_IsNumbered_AndWarnsSendBeforeReady_G502()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("### Startup order", output, StringComparison.Ordinal);
+        // The numbered order: join → delivery → launch/restart → wait attach → ping → ack/inbox → delegate.
+        Assert.Contains("1. Join the three roles to the team", output, StringComparison.Ordinal);
+        Assert.Contains("2. Set the delivery mode", output, StringComparison.Ordinal);
+        Assert.Contains("3. Launch or restart the receiver CLI sessions", output, StringComparison.Ordinal);
+        Assert.Contains("4. Wait for the monitor/bridge to attach", output, StringComparison.Ordinal);
+        Assert.Contains("5. Send a ping to each receiver only AFTER its session is active", output, StringComparison.Ordinal);
+        Assert.Contains("6. Require an ack from each receiver", output, StringComparison.Ordinal);
+        Assert.Contains("7. Only then send the first real delegation", output, StringComparison.Ordinal);
+        // Send-before-ready failure mode + recovery.
+        Assert.Contains("Send-before-ready:", output, StringComparison.Ordinal);
+        Assert.Contains("stored in agmsg history but NOT visibly delivered", output, StringComparison.Ordinal);
+        Assert.Contains("receiver-NOT-READY, not a successful delegation", output, StringComparison.Ordinal);
+        Assert.Contains("`inbox.sh`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_ReceiverStartupOrder_HasSevenStepsAndWarning_G502()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var readiness = doc.RootElement.GetProperty("receiver_readiness");
+
+        var order = readiness.GetProperty("startup_order").EnumerateArray().Select(s => s.GetString()!).ToArray();
+        Assert.Equal(7, order.Length);
+        // First step joins; last step delegates — ordering is meaningful.
+        Assert.StartsWith("Join the three roles", order[0], StringComparison.Ordinal);
+        Assert.Contains("real delegation", order[^1], StringComparison.Ordinal);
+
+        var warning = readiness.GetProperty("send_before_ready_warning").GetString()!;
+        Assert.Contains("not a successful delegation", warning, StringComparison.Ordinal);
+        Assert.Contains("inbox.sh", warning, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -846,6 +846,24 @@ public sealed class GuideOrchestratorThreadCommandTests
         var warning = readiness.GetProperty("send_before_ready_warning").GetString()!;
         Assert.Contains("not a successful delegation", warning, StringComparison.Ordinal);
         Assert.Contains("inbox.sh", warning, StringComparison.Ordinal);
+
+        // A short copy-paste operator message for receivers launched after the
+        // initial messages were sent (packet AC).
+        var template = readiness.GetProperty("recovery_message_template").GetString()!;
+        Assert.Contains("session started AFTER I sent earlier messages", template, StringComparison.Ordinal);
+        Assert.Contains("inbox.sh", template, StringComparison.Ordinal);
+        Assert.Contains("ack", template, StringComparison.Ordinal);
+        Assert.Contains("receiver-not-ready", template, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_HasCopyPasteRecoveryMessage_ForLateLaunchedReceivers_G502()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("Copy-paste operator message when receivers were launched after the initial messages were sent", output, StringComparison.Ordinal);
+        Assert.Contains("Heads up: your session started AFTER I sent earlier messages", output, StringComparison.Ordinal);
+        Assert.Contains("reply `ack`", output, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #1105. Direct follow-up to G501. Adds a concrete **startup order** plus a pre-delegation **ping/ack handshake** so agents do not hit the send-before-ready failure mode (messages sent before receiver CLI sessions / watch paths are active exist in agmsg history but are not visibly delivered to a freshly launched session). Builds on G501's receiver-readiness states.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **Extend the `receiver_readiness` section** in the guide:
  - **numbered startup order**: 1) join roles, 2) set delivery mode, 3) launch/restart receiver CLI sessions, 4) wait for monitor/bridge attach, 5) ping after the session is active, 6) require ack (or manual `inbox.sh` confirmation), 7) then send the first real delegation.
  - **send-before-ready warning**: pre-readiness messages may be stored in agmsg history but not visibly delivered to a freshly launched/restarted session; an unacked message is **receiver-not-ready**, not a successful delegation. Recover by resending after the ack or reading the queue with `inbox.sh`.
- Docs updated in EN + JA.

(G501 already supplied the readiness states, `watch.sh` debug/fallback note, and the agmsg-scripts-only diagnostics — reused here.)

## Acceptance criteria coverage

- ✅ Guide includes the numbered startup order.
- ✅ Guide warns that pre-readiness messages may be stored but not visible in receiver sessions.
- ✅ Missing ping ack classified as receiver-not-ready, not successful delegation.
- ✅ Recovery includes resend after readiness or manual `inbox.sh` confirmation.
- ✅ Manual `watch.sh` described as debug/fallback and terminal-occupying (from G501, present in this section).
- ✅ Diagnostic commands use agmsg scripts only (from G501).
- ✅ Tests cover send-before-ready and happy-path startup order.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 38 passed.
- `dotnet test … --filter ~Guide` — 980 passed.
- `git diff --check` — clean.

## Scope note

The Knowledge Maintenance `intents/**` intent-tree write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb