### PR TITLE
G503: Clear rereview-ready when PR transitions to approved

### DIFF
--- a/docs/en/04a-workflow-labels.md
+++ b/docs/en/04a-workflow-labels.md
@@ -42,6 +42,16 @@ intent-target + intent-pr-approved (on the PR)
 → The PR is approved and waiting for merge.
 ```
 
+`intent-pr-approved` is the **terminal review state**: it supersedes
+`intent-pr-rereview-ready` ("waiting for another review pass") and is mutually
+exclusive with the other active review labels. When a PR transitions to approved,
+intent-cli removes any stale `intent-pr-rereview-ready`, `intent-pr-request-update`,
+and `intent-pr-update-in-progress` so an approved PR never visibly carries both
+approved and an in-flight review label. If a PR is found with both (e.g. after a
+re-review approval), `intent-cli automation reconcile` flags it as a safe,
+high-confidence repair and clears the stale label through intent-cli-owned
+behavior — never a raw `gh label` edit.
+
 ## Important notes about labels
 
 - **Do not manually add or remove workflow labels**: in normal operation, workflow labels are managed by intent-cli/automation. Manual changes can cause loops to enter incorrect states.

--- a/docs/ja/04a-workflow-labels.md
+++ b/docs/ja/04a-workflow-labels.md
@@ -41,6 +41,14 @@ intent-target + intent-pr-approved（PR 側）
 → PR が承認済みで、マージを待っています。
 ```
 
+`intent-pr-approved` は **review の terminal state** です: `intent-pr-rereview-ready`
+（「再レビュー待ち」）を supersede し、他の active な review ラベルと排他です。PR が approved に
+遷移するとき、intent-cli は stale な `intent-pr-rereview-ready`・`intent-pr-request-update`・
+`intent-pr-update-in-progress` を除去するため、approved の PR が in-flight な review ラベルを
+同時に可視に持つことはありません。両方を持つ PR が見つかった場合（例: 再レビュー承認後）、
+`intent-cli automation reconcile` がそれを安全な high-confidence な repair として検出し、stale な
+ラベルを intent-cli 所有の振る舞いで除去します — 生の `gh label` 編集ではありません。
+
 ## ラベルについての注意
 
 - **手でラベルを付け外ししない**: 通常の運用では、workflow label は intent-cli/automation が管理します。手動で変更すると、ループが誤った状態に入る可能性があります。

--- a/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
@@ -164,6 +164,12 @@ internal static class AutomationPrTransitionCommand
                     WorkerNextActionConstants.Labels.IntentPrRereviewReady,
                     "rereview-ready",
                 ]),
+            // G503: approved is the terminal review state — it supersedes
+            // rereview-ready ("waiting for another review pass") and clears the
+            // other active review-state labels so a merged/approved PR never
+            // visibly carries both intent-pr-approved and a stale in-flight
+            // review label. Removing an absent label is a no-op (the write path
+            // filters to present labels), so the transition stays idempotent.
             TransitionApproved => new TransitionPlan(
                 AddLabels:
                 [
@@ -172,6 +178,10 @@ internal static class AutomationPrTransitionCommand
                 RemoveLabels:
                 [
                     WorkerPrReviewPreflightConstants.Labels.IntentPrReviewing,
+                    WorkerNextActionConstants.Labels.IntentPrRereviewReady,
+                    "rereview-ready",
+                    WorkerPrReviewPreflightConstants.Labels.IntentPrRequestUpdate,
+                    WorkerPrReviewPreflightConstants.Labels.IntentPrUpdateInProgress,
                 ]),
             TransitionRequestUpdate => new TransitionPlan(
                 AddLabels:
@@ -205,9 +215,13 @@ internal static class AutomationPrTransitionCommand
         // G292: review-release is also defensive about stale labels — only
         // remove labels that are actually present, so the dry-run plan
         // matches what gh will actually mutate.
+        // G503: approved joins this set so clearing rereview-ready /
+        // request-update / update-in-progress stays idempotent when those
+        // labels are absent.
         if (string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal)
             && (string.Equals(transition, TransitionReviewStart, StringComparison.Ordinal)
-                || string.Equals(transition, TransitionReviewRelease, StringComparison.Ordinal)))
+                || string.Equals(transition, TransitionReviewRelease, StringComparison.Ordinal)
+                || string.Equals(transition, TransitionApproved, StringComparison.Ordinal)))
         {
             var currentLabelSet = new HashSet<string>(currentLabels, StringComparer.Ordinal);
             return plannedRemoveLabels

--- a/src/IntentSystem.Cli/Commands/AutomationReconcileAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationReconcileAnalyzer.cs
@@ -112,6 +112,45 @@ internal static class AutomationReconcileAnalyzer
                 });
             }
 
+            // Repair 3 (G503): approved is the terminal review state and must not
+            // coexist with an in-flight review label. If a PR carries
+            // intent-pr-approved AND any of rereview-ready / request-update /
+            // update-in-progress, the stale review labels are mechanically
+            // removable (approved supersedes them).
+            if (prLabels.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrApproved, StringComparer.Ordinal))
+            {
+                var staleReviewLabels = new[]
+                {
+                    WorkerNextActionConstants.Labels.IntentPrRereviewReady,
+                    WorkerPrReviewPreflightConstants.Labels.IntentPrRequestUpdate,
+                    WorkerPrReviewPreflightConstants.Labels.IntentPrUpdateInProgress,
+                }
+                    .Where(label => prLabels.Contains(label, StringComparer.Ordinal))
+                    .ToArray();
+
+                if (staleReviewLabels.Length > 0)
+                {
+                    safeRepairs.Add(new AutomationReconcileRepair
+                    {
+                        Type = AutomationReconcileRepairTypes.ApprovedPrStaleReviewLabel,
+                        TargetKind = GhCliGitHubLabelMutator.Kinds.Pr,
+                        TargetNumber = pr.Number,
+                        TargetUrl = pr.Url,
+                        AddLabels = Array.Empty<string>(),
+                        RemoveLabels = staleReviewLabels,
+                        Evidence =
+                        [
+                            $"PR #{pr.Number} carries 'intent-pr-approved' (terminal review state)",
+                            $"PR #{pr.Number} also carries stale in-flight review label(s): {string.Join(", ", staleReviewLabels)}"
+                        ],
+                        Confidence = AutomationReconcileConfidence.High,
+                        Applied = false,
+                        Summary = $"Remove stale {string.Join(", ", staleReviewLabels)} from approved PR #{pr.Number} (approved supersedes rereview/in-flight review state).",
+                        RequiresFollowupCommand = null,
+                    });
+                }
+            }
+
             // Advisory: PR is intent-target but body has no Closes/Fixes/Resolves keyword
             // and no closing-issue reference. Cannot be repaired without operator input.
             if (prLabels.Contains(WorkerNextActionConstants.Labels.IntentTarget, StringComparer.Ordinal)

--- a/src/IntentSystem.Cli/Commands/AutomationReconcileResult.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationReconcileResult.cs
@@ -189,6 +189,11 @@ internal static class AutomationReconcileRepairTypes
     public const string MissingPrClosesKeyword = "missing-pr-closes-keyword";
     public const string MissingLinkedPrMetadata = "missing-linked-pr-metadata";
     public const string StaleNextSliceCandidateCache = "stale-next-slice-candidate-cache";
+
+    // G503: an approved PR still carries a stale in-flight review label
+    // (rereview-ready / request-update / update-in-progress). approved is the
+    // terminal review state and supersedes them.
+    public const string ApprovedPrStaleReviewLabel = "approved-pr-stale-review-label";
 }
 
 internal static class AutomationReconcileUnsafeStopKinds

--- a/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
@@ -230,6 +230,106 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_Approved_DryRunPlansClearingAllActiveReviewLabels_G503()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "approved",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.False(result.Applied);
+        Assert.Contains("intent-pr-approved", result.AddLabels);
+        // The dry-run plan supersedes rereview-ready and the other in-flight review labels.
+        Assert.Contains("intent-pr-rereview-ready", result.RemoveLabels);
+        Assert.Contains("intent-pr-reviewing", result.RemoveLabels);
+        Assert.Contains("intent-pr-request-update", result.RemoveLabels);
+        Assert.Contains("intent-pr-update-in-progress", result.RemoveLabels);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_Approved_WriteRemovesRereviewReady_WhenPresent_G503()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "approved",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Contains("intent-pr-approved", transition.AddLabels);
+        Assert.Contains("intent-pr-rereview-ready", transition.RemoveLabels);
+        // Only present labels are removed: reviewing/request-update/update-in-progress were absent.
+        Assert.DoesNotContain("intent-pr-reviewing", transition.RemoveLabels);
+        Assert.DoesNotContain("intent-pr-request-update", transition.RemoveLabels);
+    }
+
+    [Fact]
+    public void Execute_Approved_WriteIsIdempotent_WhenRereviewReadyAbsent_G503()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            // Already approved with no in-flight review labels left.
+            Labels = new[] { "intent-target", "intent-pr-approved" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "approved",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.Contains("intent-pr-approved", result.AddLabels);
+        // Idempotent: nothing to remove when no in-flight review label is present.
+        Assert.Empty(result.RemoveLabels);
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Empty(transition.RemoveLabels);
+    }
+
+    [Fact]
     public void Execute_RequestUpdate_DryRunPlansRepairRequestLabelsWithoutApplying()
     {
         using var workspace = new AutomationPrTransitionWorkspace();

--- a/tests/IntentSystem.Cli.Tests/AutomationReconcileCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationReconcileCommandTests.cs
@@ -115,6 +115,79 @@ public sealed class AutomationReconcileCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_DryRun_DetectsApprovedPrStillCarryingRereviewReady_G503()
+    {
+        using var workspace = new ReconcileWorkspace();
+        var lister = new FakeLister
+        {
+            AllPrs =
+            [
+                BuildPr(543, "approved but still rereview-ready",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/543",
+                    body: "Closes #561",
+                    labels: ["intent-target", "intent-pr-approved", "intent-pr-rereview-ready"]),
+            ],
+            PublishedIssues =
+            [
+                BuildIssue(561, "G229", "https://github.com/J-Tech-Japan/intent-system/issues/561",
+                    labels: ["intent-target", "intent-pr-created"]),
+            ],
+        };
+        AutomationReconcileCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            ["--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+
+        Assert.Contains(result.SafeRepairs, repair =>
+            string.Equals(repair.Type, AutomationReconcileRepairTypes.ApprovedPrStaleReviewLabel, StringComparison.Ordinal)
+            && repair.TargetNumber == 543
+            && repair.RemoveLabels.Contains("intent-pr-rereview-ready", StringComparer.Ordinal)
+            && !repair.AddLabels.Any()
+            && string.Equals(repair.Confidence, AutomationReconcileConfidence.High, StringComparison.Ordinal)
+            && !repair.Applied);
+    }
+
+    [Fact]
+    public void Execute_DryRun_ApprovedPrWithoutStaleReviewLabel_NoApprovedStaleRepair_G503()
+    {
+        using var workspace = new ReconcileWorkspace();
+        var lister = new FakeLister
+        {
+            AllPrs =
+            [
+                BuildPr(544, "cleanly approved",
+                    "https://github.com/J-Tech-Japan/intent-system/pull/544",
+                    body: "Closes #562",
+                    labels: ["intent-target", "intent-pr-approved"]),
+            ],
+            PublishedIssues =
+            [
+                BuildIssue(562, "G230", "https://github.com/J-Tech-Japan/intent-system/issues/562",
+                    labels: ["intent-target", "intent-pr-created"]),
+            ],
+        };
+        AutomationReconcileCommand.CandidateListerFactory = () => lister;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationReconcileCommand.Execute(
+            workspace.Context,
+            ["--lane", "host-review", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
+
+        Assert.DoesNotContain(result.SafeRepairs, repair =>
+            string.Equals(repair.Type, AutomationReconcileRepairTypes.ApprovedPrStaleReviewLabel, StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Execute_NoDriftReturnsCleanPlanWithSummaryAndZeroExit()
     {
         using var workspace = new ReconcileWorkspace();


### PR DESCRIPTION
## Summary

Closes #1107. Fixes the PR workflow label state machine so a PR marked `intent-pr-approved` no longer coexists with `intent-pr-rereview-ready` (or other in-flight review labels). Approved is the **terminal review state** and supersedes "waiting for another review pass". This is an actual behavioral fix to the transition + reconcile logic (not the orchestrator guide).

## Changes

- **`automation pr-transition`** — the `approved` transition now removes `intent-pr-rereview-ready` (both label forms), `intent-pr-request-update`, and `intent-pr-update-in-progress` in addition to `intent-pr-reviewing`. `approved` joins `review-start`/`review-release` in the present-only remove filter, so the write path stays **idempotent** when those labels are absent (the dry-run plan still lists the full supersede set).
- **`automation reconcile`** — new high-confidence safe repair `approved-pr-stale-review-label` detects a PR carrying `intent-pr-approved` plus any stale in-flight review label and clears the stale label(s) through the host-owned reconcile mutator — **never a raw `gh` edit**.
- **docs (en/ja workflow labels)** — document that approved is the terminal review state, supersedes rereview-ready, and that reconcile repairs a both-label PR.

## Acceptance criteria coverage

- ✅ Approved transition removes `intent-pr-rereview-ready`.
- ✅ Approved transition remains idempotent when `intent-pr-rereview-ready` is absent.
- ✅ Approved transition clears other active review-state labels (reviewing / request-update / update-in-progress).
- ✅ Guide/docs explain that approved supersedes rereview-ready.
- ✅ Audit/recovery (`automation reconcile`) identifies PRs with both approved and rereview-ready and repairs via intent-cli-owned behavior.
- ✅ Tests cover the above.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter AutomationPrTransitionCommandTests|AutomationReconcileCommandTests` — 44 passed.
- `dotnet test` (full Cli suite) — 3161 passed, 1 skipped.
- `git diff --check` — clean.

## Out of scope

- Renaming labels; reworking the whole workflow state machine; recommending raw label edits as the normal fix.

## Scope note

The Knowledge Maintenance `intents/**` intent-tree write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb