### PR TITLE
G504: Prepare v0.3.12 patch release metadata for G502-G503 fixes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -194,84 +194,83 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.3.10",
-  "nextVersion": "0.3.11"
-}
-```
-
-| Stage | Version form | How it is derived |
-| --- | --- | --- |
-| Local pack / install | `0.3.11-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.3.11-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.11-rc.N` | Tag `v0.3.11-rc.N` triggers release workflow |
-| Stable release | `0.3.11` | Tag `v0.3.11` triggers release workflow (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.3.12-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.12` |
-
-**After releasing `v0.3.11`**, bump both fields in `eng/version.json`:
-
-```json
-{
   "stableVersion": "0.3.11",
   "nextVersion": "0.3.12"
 }
 ```
 
+| Stage | Version form | How it is derived |
+| --- | --- | --- |
+| Local pack / install | `0.3.12-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.3.12-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.12-rc.N` | Tag `v0.3.12-rc.N` triggers release workflow |
+| Stable release | `0.3.12` | Tag `v0.3.12` triggers release workflow (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.3.13-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.13` |
+
+**After releasing `v0.3.12`**, bump both fields in `eng/version.json`:
+
+```json
+{
+  "stableVersion": "0.3.12",
+  "nextVersion": "0.3.13"
+}
+```
+
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.3.12-preview.<run>.<attempt>` / `0.3.12-<sha>-<G-unit>` rather than continuing to
-emit `0.3.11` (which would collide with the stable release version).
+`0.3.13-preview.<run>.<attempt>` / `0.3.13-<sha>-<G-unit>` rather than continuing to
+emit `0.3.12` (which would collide with the stable release version).
 
-### Next release readiness (v0.3.11)
+### Next release readiness (v0.3.12)
 
-**`v0.3.10` shipped** (GitHub Release + NuGet) and the version policy was bumped
-to the `0.3.11` development line. The repository is now on the in-development
-**`0.3.11`** `nextVersion`; G497 (this packet) prepares the `v0.3.11` release — the
-next release is published by tagging `v0.3.11` once the
-[release-readiness gate](release-notes-v0.3.11.md#release-readiness-gate-g497)
+**`v0.3.11` shipped** (GitHub Release + NuGet) and the version policy was bumped
+to the `0.3.12` development line. The repository is now on the in-development
+**`0.3.12`** `nextVersion`; G504 (this packet) prepares the `v0.3.12` patch
+release — the next release is published by tagging `v0.3.12` once the
+[release-readiness gate](release-notes-v0.3.12.md#release-readiness-gate-g504)
 passes. Preparing the release does not cut it. Full changelog and operator
-checklist: [release-notes-v0.3.11.md](release-notes-v0.3.11.md).
+checklist: [release-notes-v0.3.12.md](release-notes-v0.3.12.md).
 
-**To ship in `v0.3.11` (changes since `v0.3.10`) — the agmsg orchestrator-mode
-preview:**
+**To ship in `v0.3.12` (changes since `v0.3.11`) — orchestrator-mode preview
+patch fixes:**
 
-- **Agent-message (agmsg) orchestrator mode — preview/experimental** (G487–G496)
-  — an optional fourth orchestrator thread can coordinate the implementation and
-  review threads over a local message bus (agmsg) instead of independent timers.
-  `intent-cli guide orchestrator-thread` renders the paste-ready prompts, the
-  single/multi-domain routing rules, the scheduled-wake cadence, the CI wait
-  state, bounded next-slice publication, dependency-aware planning, the
-  stale-thread health check, and a design-thread setup checklist. agmsg is a
-  signal layer only; intent-cli and GitHub stay authoritative, and the existing
-  timer-loop mode is fully supported and unchanged. This mode is **preview**:
-  opt-in, still being hardened, and not yet the default workflow.
-- **Review guidance** also gains automated-reviewer-comment triage (G493) so a
-  review agent classifies automated reviewer comments (e.g. Copilot) instead of
-  forwarding every comment to implementation. See
+- **agmsg receiver startup ordering** (G502) — the orchestrator setup guidance
+  now requires a strict startup order and a ping/ack handshake before real
+  delegation, so work is not sent before receiver sessions are launched/
+  restarted, the monitor/bridge is attached, and the ack succeeds. Includes a
+  copy-paste recovery message for receivers launched after the initial sends.
+- **approved PR label cleanup** (G503) — the `approved` PR transition now removes
+  a stale `intent-pr-rereview-ready` (and other in-flight review labels), and
+  `automation reconcile` repairs a PR that carries both, so an approved PR no
+  longer visibly shows `intent-pr-approved` and `intent-pr-rereview-ready`
+  together.
+- Orchestrator mode remains **preview/experimental**: opt-in, still being
+  hardened, with the timer-loop mode fully supported and unchanged. See
   [Agent-message orchestration](12-agent-message-orchestration.md).
 
-**Release-readiness verification (run before tagging the next `v0.3.11`):**
+**Release-readiness verification (run before tagging the next `v0.3.12`):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.3.10 (published), nextVersion 0.3.11 (to release)
+cat eng/version.json   # stableVersion 0.3.11 (published), nextVersion 0.3.12 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.3.11-<sha>-G49x   (NOT a stale literal)
+#   expected shape: intent-cli 0.3.12-<sha>-G50x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.11.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.12.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-The official release is then cut by publishing a GitHub Release tagged `v0.3.11`;
-the release workflow passes `-p:Version=0.3.11` (which wins over the local
+The official release is then cut by publishing a GitHub Release tagged `v0.3.12`;
+the release workflow passes `-p:Version=0.3.12` (which wins over the local
 default). After the release publishes, apply the post-release `eng/version.json`
-bump above (`stableVersion → 0.3.11`, `nextVersion → 0.3.12`).
+bump above (`stableVersion → 0.3.12`, `nextVersion → 0.3.13`).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.3.12.md
+++ b/docs/en/release-notes-v0.3.12.md
@@ -1,0 +1,125 @@
+# Release Notes — intent-cli v0.3.12
+
+> **Release checklist for maintainers:** see [Creating the v0.3.12 GitHub Release](#creating-the-v0312-github-release).
+> **Do NOT tag until the [release-readiness gate](#release-readiness-gate-g504) passes.**
+
+## What's in v0.3.12
+
+v0.3.12 is a **patch release** that ships two orchestrator-mode preview fixes
+completed after `v0.3.11`: agmsg receiver startup ordering (G502) and approved-PR
+label cleanup (G503). No package id, license, or workflow-semantics changes, and
+the existing timer-loop mode is fully supported and unchanged. The package id
+remains `JTechJapan.IntentSystem.Cli`.
+
+> **Orchestrator mode is still preview/experimental.** It is opt-in, still being
+> hardened, and not the default workflow. intent-cli and GitHub remain the
+> authoritative source of truth; agmsg is only a message/progress/completion
+> signal layer.
+
+### agmsg receiver startup ordering (G502)
+
+- The orchestrator setup guidance (`intent-cli guide orchestrator-thread`) now
+  requires a strict startup order and a **ping/ack handshake before any real
+  delegation**: join roles → set delivery mode → launch/restart the receiver CLI
+  sessions → wait for the monitor/bridge to attach → ping after the session is
+  active → require an ack (or confirm with `inbox.sh`) → only then delegate.
+- It warns that messages sent before a receiver is ready may be stored in agmsg
+  history but **not visibly delivered** to a freshly launched/restarted session —
+  an unacked send is receiver-not-ready, not a successful delegation — and
+  provides a copy-paste recovery message for the operator to send when receivers
+  were launched after the initial messages.
+
+### Approved PR label cleanup (G503)
+
+- The `approved` PR transition now removes a stale `intent-pr-rereview-ready`
+  (and the other in-flight review labels `intent-pr-request-update` /
+  `intent-pr-update-in-progress`) in addition to `intent-pr-reviewing`, so an
+  approved PR never visibly carries both `intent-pr-approved` and a
+  "waiting for re-review" label. The transition stays idempotent when those
+  labels are absent.
+- `intent-cli automation reconcile` detects a PR that already carries both
+  `intent-pr-approved` and a stale in-flight review label and repairs it as a
+  high-confidence, intent-cli-owned label cleanup (never a raw `gh label` edit).
+
+> Version metadata note: `eng/version.json` records `stableVersion: 0.3.11`,
+> `nextVersion: 0.3.12`; G504 (this packet) is the release-readiness preparation.
+> The post-v0.3.12 metadata advancement (`stableVersion → 0.3.12`,
+> `nextVersion → 0.3.13`) is the operator's post-release step and is out of scope
+> for this packet.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.12
+```
+
+Or download the self-contained binary from the
+[v0.3.12 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.12).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.11
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.12
+```
+
+There are no breaking changes from v0.3.11. Orchestrator mode remains opt-in;
+existing timer-loop setups are unaffected.
+
+## Release-readiness gate (G504)
+
+Do not create the `v0.3.12` tag/release until ALL of the following hold
+(this gate fails closed — if any item is unmet, stop and do not tag):
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G502, G503 (and G504 this prep). Confirm on the host/review side via the
+      host queue-state / GitHub PR state — the child implementation loop must not
+      read parent queue-state, so this is a host-owned precondition.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before tagging).
+- [ ] `eng/version.json` `nextVersion` is `0.3.12` (the intended release version)
+      and matches the tag to be created (`v0.3.12`). The release workflow derives
+      the package version from the tag; `-p:Version=` overrides the policy-derived
+      default in `src/IntentSystem.Cli/IntentSystem.Cli.csproj`.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] Release notes / README keep **orchestrator mode described as
+      preview/experimental** and opt-in, with timer-loop mode unchanged.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+
+## Creating the v0.3.12 GitHub Release
+
+1. Confirm the [release-readiness gate](#release-readiness-gate-g504) — do not
+   proceed if any item is unmet.
+2. Tag the release commit: `git tag v0.3.12 && git push origin v0.3.12`.
+3. The `release.yml` workflow fires and builds binaries, `.nupkg`, and
+   checksums (version derived from the tag). Wait for it to complete green.
+4. The workflow creates the GitHub Release draft. Review it, paste the content
+   of this file as the release body, and publish.
+5. Confirm the NuGet publish step pushed `JTechJapan.IntentSystem.Cli 0.3.12`.
+6. Post-release verification checklist:
+   - [ ] NuGet.org package page links all resolve correctly.
+   - [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+         accessible.
+   - [ ] `.sha256` checksums match the downloaded artifacts.
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.12`)
+         then `intent-cli --version` reports `0.3.12`.
+   - [ ] Binary artifact smoke check: download the platform archive, verify its
+         `.sha256`, extract, and run `./intent-cli --version` → `0.3.12`.
+   - [ ] **Orchestrator setup guide smoke** (G502): `intent-cli guide
+         orchestrator-thread --domain <d> --target-repo <repo> --agent <agent>
+         --format markdown` renders the numbered startup order, the ping/ack
+         requirement, and the copy-paste recovery message.
+   - [ ] **Approved-label transition smoke** (G503): `intent-cli automation
+         pr-transition --transition approved --pr <n> --repo <repo> --format json`
+         plans removing `intent-pr-rereview-ready` alongside `intent-pr-approved`.
+   - [ ] Local preview/dry-run version metadata uses the next development line
+         after `0.3.12` (bump `eng/version.json` per the post-release step in
+         [Version flow](09-developer-reference.md#version-flow)):
+         `stableVersion → 0.3.12`, `nextVersion → 0.3.13`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -184,72 +184,71 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.3.10",
-  "nextVersion": "0.3.11"
-}
-```
-
-| ステージ | バージョン形式 | 導出方法 |
-| --- | --- | --- |
-| ローカル pack / install | `0.3.11-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.3.11-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.11-rc.N` | タグ `v0.3.11-rc.N` がリリースワークフローをトリガー |
-| 安定版リリース | `0.3.11` | タグ `v0.3.11` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.3.12-preview.<run>.<attempt>` | `nextVersion` を `0.3.12` にバンプ後 |
-
-**`v0.3.11` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
-
-```json
-{
   "stableVersion": "0.3.11",
   "nextVersion": "0.3.12"
 }
 ```
 
+| ステージ | バージョン形式 | 導出方法 |
+| --- | --- | --- |
+| ローカル pack / install | `0.3.12-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.3.12-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.3.12-rc.N` | タグ `v0.3.12-rc.N` がリリースワークフローをトリガー |
+| 安定版リリース | `0.3.12` | タグ `v0.3.12` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.3.13-preview.<run>.<attempt>` | `nextVersion` を `0.3.13` にバンプ後 |
+
+**`v0.3.12` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+
+```json
+{
+  "stableVersion": "0.3.12",
+  "nextVersion": "0.3.13"
+}
+```
+
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.3.12-preview.<run>.<attempt>` / `0.3.12-<sha>-<G-unit>` を生成し、`0.3.11`（安定版
+`0.3.13-preview.<run>.<attempt>` / `0.3.13-<sha>-<G-unit>` を生成し、`0.3.12`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備（v0.3.11）
+### 次リリース準備（v0.3.12）
 
-**`v0.3.10` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
-`0.3.11` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.11`**
-`nextVersion` 上にあり、G497（本パケット）が `v0.3.11` リリースを準備します。次のリリースは
-[リリース準備ゲート](release-notes-v0.3.11.md#リリース準備ゲート-g497)を通過後に `v0.3.11`
+**`v0.3.11` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
+`0.3.12` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.12`**
+`nextVersion` 上にあり、G504（本パケット）が `v0.3.12` パッチリリースを準備します。次のリリースは
+[リリース準備ゲート](release-notes-v0.3.12.md#リリース準備ゲート-g504)を通過後に `v0.3.12`
 タグ付けで publish されます。準備はリリースを cut しません。完全な changelog と operator
-チェックリスト: [release-notes-v0.3.11.md](release-notes-v0.3.11.md)。
+チェックリスト: [release-notes-v0.3.12.md](release-notes-v0.3.12.md)。
 
-**`v0.3.11` で出荷予定（`v0.3.10` 以降の変更）— agmsg orchestrator モードのプレビュー:**
+**`v0.3.12` で出荷予定（`v0.3.11` 以降の変更）— orchestrator モードプレビューのパッチ修正:**
 
-- **エージェントメッセージ（agmsg）orchestrator モード — preview / experimental**（G487–G496）
-  — 任意の 4 つ目の orchestrator スレッドが、独立タイマーの代わりにローカルメッセージバス
-  （agmsg）経由で実装・レビュースレッドを調整できます。`intent-cli guide orchestrator-thread`
-  が貼り付け可能なプロンプト、single/multi-domain ルーティング、スケジュール wake のケイデンス、
-  CI 待ち状態、bounded な next-slice publish、依存を考慮した計画、stale-thread ヘルスチェック、
-  設計スレッド向けセットアップチェックリストをレンダリングします。agmsg はシグナル層のみで、
-  intent-cli と GitHub が権威であり続け、既存の timer-loop モードは完全サポート・不変です。
-  このモードは **preview** です: オプトインで、まだ hardening 中であり、デフォルトの workflow
-  ではありません。
-- **レビューガイダンス** にも自動レビュアーコメント triage（G493）が加わり、review agent が
-  自動レビュアー（例: Copilot）のコメントを分類してから実装に回します。
+- **agmsg receiver の起動順序**（G502）— orchestrator setup ガイダンスが、実際の委譲前に厳密な
+  起動順序と ping/ack ハンドシェイクを要求するようになり、receiver セッションの起動/再起動・
+  monitor/bridge のアタッチ・ack 成功の前に作業が送られないようにします。initial 送信後に launch
+  された receiver 向けの貼り付け可能な復旧メッセージを含みます。
+- **approved PR の label クリーンアップ**（G503）— `approved` PR 遷移が stale な
+  `intent-pr-rereview-ready`（および他の in-flight review ラベル）を除去し、`automation reconcile`
+  が両方を持つ PR を修復するため、approved の PR が `intent-pr-approved` と `intent-pr-rereview-ready`
+  を同時に可視に持つことがなくなります。
+- orchestrator モードは引き続き **preview/experimental** です: オプトインで、まだ hardening 中であり、
+  timer-loop モードは完全サポート・不変です。
   [エージェントメッセージオーケストレーション](12-agent-message-orchestration.md) を参照。
 
-**リリース準備の検証（次の `v0.3.11` タグ付け前に実行）:**
+**リリース準備の検証（次の `v0.3.12` タグ付け前に実行）:**
 
 ```bash
-cat eng/version.json   # stableVersion 0.3.10（公開済み）, nextVersion 0.3.11（リリース対象）
+cat eng/version.json   # stableVersion 0.3.11（公開済み）, nextVersion 0.3.12（リリース対象）
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.3.11-<sha>-G49x （stale なリテラルではない）
+#   期待形: intent-cli 0.3.12-<sha>-G50x （stale なリテラルではない）
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.11.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.12.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-公式リリースは `v0.3.11` タグの GitHub Release publish で cut され、リリースワークフローが
-`-p:Version=0.3.11` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
-`eng/version.json` バンプ（`stableVersion → 0.3.11`, `nextVersion → 0.3.12`）を適用します。
+公式リリースは `v0.3.12` タグの GitHub Release publish で cut され、リリースワークフローが
+`-p:Version=0.3.12` を渡します（ローカルデフォルトより優先）。publish 後、上記のリリース後
+`eng/version.json` バンプ（`stableVersion → 0.3.12`, `nextVersion → 0.3.13`）を適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.3.12.md
+++ b/docs/ja/release-notes-v0.3.12.md
@@ -1,0 +1,109 @@
+# リリースノート — intent-cli v0.3.12
+
+> **メンテナ向けリリースチェックリスト:** [v0.3.12 GitHub Release の作成](#v0312-github-release-の作成) を参照。
+> **[リリース準備ゲート](#リリース準備ゲート-g504) を通過するまでタグ付けしないでください。**
+
+## v0.3.12 の内容
+
+v0.3.12 は **パッチリリース** で、`v0.3.11` 以降に完了した 2 つの orchestrator モードプレビュー
+修正を出荷します: agmsg receiver の起動順序（G502）と approved-PR ラベルクリーンアップ（G503）。
+package id・ライセンス・workflow セマンティクスの変更はなく、既存の timer-loop モードは完全
+サポート・不変です。package id は `JTechJapan.IntentSystem.Cli` のままです。
+
+> **orchestrator モードは引き続き preview/experimental です。** オプトインで、まだ hardening 中で
+> あり、デフォルトの workflow ではありません。intent-cli と GitHub が権威 source of truth であり
+> 続け、agmsg はメッセージ / 進捗 / 完了のシグナル層のみです。
+
+### agmsg receiver の起動順序（G502）
+
+- orchestrator setup ガイダンス（`intent-cli guide orchestrator-thread`）が、実際の委譲前に
+  厳密な起動順序と **ping/ack ハンドシェイク** を要求するようになりました: ロールを join →
+  delivery mode 設定 → receiver の CLI セッション起動/再起動 → monitor/bridge のアタッチを待つ →
+  セッションがアクティブになった後に ping → ack を要求（または `inbox.sh` で確認）→ その後にのみ委譲。
+- receiver が ready になる前に送ったメッセージは agmsg history に保存されても、新しく起動/再起動
+  したセッションには **可視に delivery されない** こと（ack のない送信は receiver-not-ready であり
+  成功した委譲ではない）を警告し、receiver が initial メッセージ送信後に launch された場合に
+  オペレーターが送る貼り付け可能な復旧メッセージを提供します。
+
+### approved PR の label クリーンアップ（G503）
+
+- `approved` PR 遷移が、`intent-pr-reviewing` に加え stale な `intent-pr-rereview-ready`
+  （および他の in-flight review ラベル `intent-pr-request-update` / `intent-pr-update-in-progress`）
+  を除去するようになり、approved の PR が `intent-pr-approved` と「再レビュー待ち」ラベルを同時に
+  可視に持つことがなくなります。これらが不在のときも遷移はべき等です。
+- `intent-cli automation reconcile` が、すでに `intent-pr-approved` と stale な in-flight review
+  ラベルの両方を持つ PR を検出し、high-confidence な intent-cli 所有のラベルクリーンアップとして
+  修復します（生の `gh label` 編集ではありません）。
+
+> バージョンメタデータ注記: `eng/version.json` は `stableVersion: 0.3.11`,
+> `nextVersion: 0.3.12` を記録します。G504（本パケット）はリリース準備です。
+> v0.3.12 リリース後のメタデータ前進（`stableVersion → 0.3.12`, `nextVersion → 0.3.13`）は
+> オペレーターのリリース後ステップであり、本パケットのスコープ外です。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.12
+```
+
+または [v0.3.12 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.12)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを検証します。
+
+## v0.3.11 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.12
+```
+
+v0.3.11 からの破壊的変更はありません。orchestrator モードはオプトインのままで、既存の timer-loop
+セットアップには影響しません。
+
+## リリース準備ゲート (G504)
+
+次のすべてが成り立つまで `v0.3.12` タグ/リリースを作成しないでください
+（このゲートは fail closed です — 1 つでも未充足なら停止し、タグ付けしない）:
+
+- [ ] リリース対象の各パケットが **完了し PR が `main` にマージ済み**: G502・G503
+      （および本準備の G504）。host queue-state / GitHub PR 状態で host/review 側から確認する
+      （child 実装ループは parent queue-state を読まないため、これは host 所有の前提条件）。
+- [ ] 本リリース対象の open な intent-system PR や WIP パケットが誤ってスキップされていない
+      （タグ付け前に host queue / open PR リストを確認）。
+- [ ] `eng/version.json` の `nextVersion` が `0.3.12`（意図したリリースバージョン）で、作成する
+      タグ（`v0.3.12`）と一致する。リリースワークフローは package バージョンをタグから導出し、
+      `-p:Version=` が `src/IntentSystem.Cli/IntentSystem.Cli.csproj` のポリシー由来デフォルトを上書きする。
+- [ ] package メタデータが正しい: `PackageId = JTechJapan.IntentSystem.Cli`、
+      `RepositoryUrl` / `PackageProjectUrl` が `https://github.com/J-Tech-Japan/intent-system` を指す、
+      `PackageLicenseExpression = Apache-2.0`、README/docs リンクが解決し、公式サービスサイト
+      `https://www.intent-driven-development.com/` が README からリンクされている。
+- [ ] リリースノート / README が **orchestrator モードは preview/experimental** かつオプトインで
+      あること、timer-loop モードが不変であることを保っている。
+- [ ] リリースコミットで **Main CI が green**（`Build and test (source contract)`）であり、
+      **preview-pack** workflow も green。
+
+## v0.3.12 GitHub Release の作成
+
+1. [リリース準備ゲート](#リリース準備ゲート-g504) を確認 — 未充足項目があれば進めない。
+2. リリースコミットにタグ付け: `git tag v0.3.12 && git push origin v0.3.12`。
+3. `release.yml` workflow が発火し、バイナリ・`.nupkg`・チェックサムをビルドする（バージョンは
+   タグから導出）。green 完了を待つ。
+4. workflow が GitHub Release draft を作成する。レビューし、本ファイルの内容をリリース本文として
+   貼り付け、publish する。
+5. NuGet publish ステップが `JTechJapan.IntentSystem.Cli 0.3.12` を push したことを確認する。
+6. リリース後の検証チェックリスト:
+   - [ ] NuGet.org の package ページのリンクがすべて正しく解決する。
+   - [ ] GitHub release アセットリンク（`.tar.gz`, `.zip`, `.exe`, `.nupkg`）にアクセスできる。
+   - [ ] `.sha256` チェックサムがダウンロード成果物と一致する。
+   - [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`（または
+         `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.12`）後、
+         `intent-cli --version` が `0.3.12` を報告する。
+   - [ ] バイナリ成果物スモーク: プラットフォームアーカイブをダウンロードし `.sha256` を検証、
+         展開して `./intent-cli --version` → `0.3.12`。
+   - [ ] **orchestrator setup ガイドスモーク**（G502）: `intent-cli guide orchestrator-thread
+         --domain <d> --target-repo <repo> --agent <agent> --format markdown` が numbered な
+         起動順序・ping/ack 要件・貼り付け可能な復旧メッセージをレンダリングする。
+   - [ ] **approved-label 遷移スモーク**（G503）: `intent-cli automation pr-transition
+         --transition approved --pr <n> --repo <repo> --format json` が `intent-pr-approved` と
+         ともに `intent-pr-rereview-ready` の除去を計画する。
+   - [ ] ローカル preview/dry-run のバージョンメタデータが `0.3.12` の次の開発ラインを使う
+         （[バージョンフロー](09-developer-reference.md#バージョンフロー) のリリース後ステップに従い
+         `eng/version.json` をバンプ）: `stableVersion → 0.3.12`, `nextVersion → 0.3.13`。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.10",
-  "nextVersion": "0.3.11"
+  "stableVersion": "0.3.11",
+  "nextVersion": "0.3.12"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,10 +124,10 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.11 as the next development line
-        // (post-v0.3.10 release bump, see G497 — v0.3.10 was published to
+        // be parseable and must point to 0.3.12 as the next development line
+        // (post-v0.3.11 release bump, see G504 — v0.3.11 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.3.11 while recording 0.3.10 as the published stable).
+        // forward to 0.3.12 while recording 0.3.11 as the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -137,8 +137,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.11", policy.NextVersion);
-        Assert.Equal("0.3.10", policy.StableVersion);
+        Assert.Equal("0.3.12", policy.NextVersion);
+        Assert.Equal("0.3.11", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Closes #1109. Prepares the repository for an operator release of **v0.3.12**, a patch release bundling the two orchestrator-mode preview fixes completed after v0.3.11: G502 (agmsg receiver startup ordering) and G503 (approved-PR label cleanup). This packet does **not** publish the release — tagging/cutting remains an operator/host action after merge. Confirmed both G502 and G503 are merged on `main`.

## Changes

- **`eng/version.json`** — advance to `stableVersion 0.3.11` (published) / `nextVersion 0.3.12` (release-to-cut). Verified: `intent-cli --version` reports `0.3.12-<sha>-G503`.
- **Release notes (en/ja)** — new `release-notes-v0.3.12.md`: covers G502 (strict startup order + ping/ack handshake + copy-paste recovery message) and G503 (approved removes stale rereview-ready; reconcile repairs both-label PRs), keeps orchestrator mode **preview/experimental**, install/upgrade pinned to `0.3.12`, a fail-closed **release-readiness gate (G504)**, and a post-release checklist with orchestrator-setup-guide + approved-label transition smoke.
- **Developer reference (en/ja)** — retarget the version-flow table and "Next release readiness" section to **v0.3.12** (G502–G503), link the release notes, document the post-release bump (`stable → 0.3.12`, `next → 0.3.13`).
- **tests** — update `VersionPolicyTests` smoke assertion to next `0.3.12` / stable `0.3.11`. `ReleasePackageMetadataTests` read the policy/docs dynamically and continue to pass.

The release artifact version stays **tag-driven** (`release.yml` passes `-p:Version=0.3.12`). Package id remains `JTechJapan.IntentSystem.Cli`; no workflow change required.

## Acceptance criteria coverage

- ✅ Release prep identifies v0.3.12 as a patch release containing G502 and G503.
- ✅ Release notes explain receiver startup ordering and approved/rereview-ready label cleanup in user-facing language.
- ✅ Version metadata produces v0.3.12 for artifacts and a strictly newer dev identifier after release (post-release bump → 0.3.13).
- ✅ NuGet package id remains `JTechJapan.IntentSystem.Cli`; metadata links absolute and valid.
- ✅ Orchestrator mode remains preview/experimental.
- ✅ Post-release checklist covers `dotnet tool update/install`, `intent-cli --version`, orchestrator setup guide smoke, and approved-label transition smoke.
- ✅ No open intent-system PR / WIP packet skipped (release-readiness gate checks the queue).

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `intent-cli --version` → `0.3.12-b01b32f-G503`.
- `dotnet test … --filter VersionPolicyTests|ReleasePackageMetadataTests|VersionSourcePolicyGuardTests` — 16 passed.
- `dotnet test` (full Cli suite) — 3161 passed, 1 skipped.
- `git diff --check` — clean.
- Dev-reference → release-notes-v0.3.12 anchors verified; no stale "next 0.3.11" left in version-flow/readiness.

## Out of scope

- Creating the GitHub Release inside this PR; removing preview wording; new runtime features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb