### PR TITLE
G507: Correct v0.3.13 release-process docs before public release

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -224,14 +224,15 @@ emit `0.3.13` (which would collide with the stable release version).
 
 **`v0.3.12` shipped** (GitHub Release + NuGet) and the version policy was bumped
 to the `0.3.13` development line. The repository is now on the in-development
-**`0.3.13`** `nextVersion`; G506 (this packet) is **prepare-only** — it bumps the
-version metadata and docs and adds no publish steps. Once the version-bump merge
-lands on `main` and the
+**`0.3.13`** `nextVersion`; G506 is **prepare-only** — it bumps the version
+metadata and docs and adds no publish steps. The version-bump merge does **not**
+create a GitHub Release or tag. After it merges and the
 [release-readiness gate](release-notes-v0.3.13.md#release-readiness-gate-g506)
-holds, the **existing release automation cuts and publishes `v0.3.13`
-automatically** (binaries, `.nupkg`, GitHub Release, and NuGet), exactly as
-v0.3.11 and v0.3.12 were published — no manual tag or GitHub Release creation is
-required. Full changelog and operator checklist:
+holds, a **maintainer/operator (or external release automation) creates and
+publishes the GitHub Release** for `v0.3.13`; publishing that Release fires
+`.github/workflows/release.yml` (`on: release: published`), which builds and
+publishes the NuGet package and the per-platform binary artifacts. Full
+changelog and operator checklist:
 [release-notes-v0.3.13.md](release-notes-v0.3.13.md).
 
 **To ship in `v0.3.13` (changes since `v0.3.12`) — orchestrator-mode preview
@@ -267,10 +268,12 @@ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-After the version-bump merge lands on `main`, the release automation cuts and
-publishes `v0.3.13` (binaries, `.nupkg`, GitHub Release, and NuGet) without a
-manual tag. Once it has published, apply the post-release `eng/version.json`
-bump above (`stableVersion → 0.3.13`, `nextVersion → 0.3.14`).
+After the version-bump merge lands on `main`, a maintainer/operator (or external
+release automation) creates and publishes the GitHub Release for `v0.3.13`;
+publishing it triggers `release.yml` (`on: release: published`) to build and
+publish the NuGet package and the per-platform binary artifacts. Once it has
+published, apply the post-release `eng/version.json` bump above
+(`stableVersion → 0.3.13`, `nextVersion → 0.3.14`).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.3.13.md
+++ b/docs/en/release-notes-v0.3.13.md
@@ -1,11 +1,14 @@
 # Release Notes — intent-cli v0.3.13
 
-> **Release model:** v0.3.13 is cut and published **automatically** by the
-> release automation when the version-bump merge lands on `main` (the same way
-> v0.3.11 and v0.3.12 were published). This packet is **prepare-only**: it bumps
-> version metadata and docs and adds **no** publish steps. See the
-> [pre-merge release-readiness gate](#release-readiness-gate-g506) and the
-> [post-merge automated release](#post-merge-automated-release-of-v0313).
+> **Release model:** a maintainer/operator (or external release automation)
+> **creates and publishes the GitHub Release** for `v0.3.13` — the version-bump
+> merge does **not** create a Release or tag on its own. Publishing the GitHub
+> Release fires `.github/workflows/release.yml` (`on: release: published`), which
+> then builds and publishes the NuGet package and platform binary artifacts.
+> This packet is **prepare-only**: it bumps version metadata and docs and adds
+> **no** publish steps. See the
+> [pre-merge release-readiness gate](#release-readiness-gate-g506) and
+> [publishing v0.3.13](#publishing-v0313).
 
 ## What's in v0.3.13
 
@@ -66,20 +69,20 @@ existing timer-loop setups are unaffected.
 
 ## Release-readiness gate (G506)
 
-These items must hold **before the version-bump merge lands on `main`**, because
-that merge triggers the automated release. This gate fails closed — if any item
-is unmet, do not merge the version bump yet.
+These items must hold **before the GitHub Release for `v0.3.13` is published**.
+This gate fails closed — if any item is unmet, do not publish the Release yet.
 
 - [ ] Every release-bound packet is **complete and its PR merged to `main`**:
-      G505 (and G506 this prep). Confirm on the host/review side via the host
-      queue-state / GitHub PR state — the child implementation loop must not read
-      parent queue-state, so this is a host-owned precondition.
+      G505 (and G506 this prep, plus G507 this correction). Confirm on the
+      host/review side via the host queue-state / GitHub PR state — the child
+      implementation loop must not read parent queue-state, so this is a
+      host-owned precondition.
 - [ ] No open intent-system PR or WIP packet intended for this release is
-      accidentally skipped (check the host queue / open PR list before merge).
+      accidentally skipped (check the host queue / open PR list before publishing).
 - [ ] `eng/version.json` `nextVersion` is `0.3.13` (the intended release
-      version). The release automation derives the package version for the cut
-      from this version bump; `src/IntentSystem.Cli/IntentSystem.Cli.csproj`
-      derives its default from the same policy.
+      version). `release.yml` builds the package version from the published
+      Release/tag; `src/IntentSystem.Cli/IntentSystem.Cli.csproj` derives its
+      local default from the same policy.
 - [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
       `RepositoryUrl` / `PackageProjectUrl` point to
       `https://github.com/J-Tech-Japan/intent-system`,
@@ -91,16 +94,22 @@ is unmet, do not merge the version bump yet.
 - [ ] **Main CI is green** (`Build and test (source contract)`) on the release
       commit, and the **preview-pack** workflow is green.
 
-## Post-merge automated release of v0.3.13
+## Publishing v0.3.13
 
-This packet does **not** publish the release and adds **no** publish steps. Once
-the version-bump merge lands on `main` and the readiness gate above holds, the
-**existing release automation cuts and publishes `v0.3.13` automatically** —
-building the binaries, `.nupkg`, and checksums and publishing the GitHub Release
-and NuGet package — exactly as v0.3.11 and v0.3.12 were published. No manual
-tagging or GitHub Release creation is required.
+This packet does **not** publish the release and adds **no** publish steps. The
+version-bump merge does **not** create a GitHub Release or tag on its own.
 
-Post-release verification (after the automation has published):
+1. After this version bump is merged and the readiness gate above holds, a
+   **maintainer/operator (or external release automation) creates and publishes
+   the GitHub Release** for `v0.3.13` (tagging the release commit). This is a
+   post-merge host/operator/external action.
+2. Publishing that GitHub Release fires `.github/workflows/release.yml`
+   (`on: release: published`), which builds and publishes the NuGet package and
+   the per-platform binary archives (with `.sha256` checksums) and attaches them
+   to the triggering Release.
+
+Post-release verification (after the GitHub Release is published and
+`release.yml` has run):
 
 - [ ] NuGet.org package page links all resolve correctly.
 - [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -214,11 +214,13 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 **`v0.3.12` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
 `0.3.13` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.13`**
-`nextVersion` 上にあり、G506（本パケット）は **prepare-only** です — version メタデータと docs を
-バンプするだけで publish ステップを追加しません。version-bump マージが `main` に入り、
-[リリース準備ゲート](release-notes-v0.3.13.md#リリース準備ゲート-g506)が成り立つと、**既存の
-release automation が `v0.3.13` を自動的に cut・publish** します（バイナリ・`.nupkg`・GitHub
-Release・NuGet）。v0.3.11・v0.3.12 と同じ方式で、手動のタグ付けや GitHub Release 作成は不要です。
+`nextVersion` 上にあり、G506 は **prepare-only** です — version メタデータと docs をバンプするだけで
+publish ステップを追加しません。version-bump マージ自体は GitHub Release やタグを作成しません。
+マージされ
+[リリース準備ゲート](release-notes-v0.3.13.md#リリース準備ゲート-g506)が成り立った後、
+**メンテナ/オペレーター（または外部のリリース automation）が `v0.3.13` の GitHub Release を作成・
+publish** します。その Release の publish が `.github/workflows/release.yml`（`on: release: published`）を
+発火させ、NuGet package とプラットフォームごとのバイナリ成果物を build・publish します。
 完全な changelog と operator チェックリスト:
 [release-notes-v0.3.13.md](release-notes-v0.3.13.md)。
 
@@ -245,9 +247,11 @@ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-version-bump マージが `main` に入ると、release automation が手動タグなしで `v0.3.13` を
-cut・publish します（バイナリ・`.nupkg`・GitHub Release・NuGet）。publish 後、上記のリリース後
-`eng/version.json` バンプ（`stableVersion → 0.3.13`, `nextVersion → 0.3.14`）を適用します。
+version-bump マージが `main` に入った後、メンテナ/オペレーター（または外部のリリース automation）が
+`v0.3.13` の GitHub Release を作成・publish します。その publish が `release.yml`
+（`on: release: published`）を発火させ、NuGet package とプラットフォームごとのバイナリ成果物を
+build・publish します。publish 後、上記のリリース後 `eng/version.json` バンプ
+（`stableVersion → 0.3.13`, `nextVersion → 0.3.14`）を適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.3.13.md
+++ b/docs/ja/release-notes-v0.3.13.md
@@ -1,10 +1,12 @@
 # リリースノート — intent-cli v0.3.13
 
-> **リリースモデル:** v0.3.13 は、version-bump マージが `main` に入ったときに release automation が
-> **自動的に** cut・publish します（v0.3.11・v0.3.12 と同じ方式）。本パケットは **prepare-only** で、
-> version メタデータと docs をバンプするだけで publish ステップを **追加しません**。
+> **リリースモデル:** メンテナ/オペレーター（または外部のリリース automation）が `v0.3.13` の
+> **GitHub Release を作成・publish** します — version-bump マージ自体は Release やタグを作成しません。
+> GitHub Release の publish が `.github/workflows/release.yml`（`on: release: published`）を発火させ、
+> NuGet package とプラットフォームバイナリ成果物を build・publish します。本パケットは
+> **prepare-only** で、version メタデータと docs をバンプするだけで publish ステップを **追加しません**。
 > [マージ前 リリース準備ゲート](#リリース準備ゲート-g506) と
-> [マージ後の v0.3.13 自動リリース](#マージ後の-v0313-自動リリース) を参照。
+> [v0.3.13 の publish](#v0313-の-publish) を参照。
 
 ## v0.3.13 の内容
 
@@ -58,18 +60,17 @@ v0.3.12 からの破壊的変更はありません。orchestrator モードは�
 
 ## リリース準備ゲート (G506)
 
-次の項目は **version-bump マージが `main` に入る前** に成り立っている必要があります。そのマージが
-自動リリースをトリガーするためです。このゲートは fail closed です — 1 つでも未充足なら、まだ
-version bump をマージしないでください。
+次の項目は **`v0.3.13` の GitHub Release が publish される前** に成り立っている必要があります。
+このゲートは fail closed です — 1 つでも未充足なら、まだ Release を publish しないでください。
 
 - [ ] リリース対象の各パケットが **完了し PR が `main` にマージ済み**: G505
-      （および本準備の G506）。host queue-state / GitHub PR 状態で host/review 側から確認する
-      （child 実装ループは parent queue-state を読まないため、これは host 所有の前提条件）。
+      （および本準備の G506、本修正の G507）。host queue-state / GitHub PR 状態で host/review 側から
+      確認する（child 実装ループは parent queue-state を読まないため、これは host 所有の前提条件）。
 - [ ] 本リリース対象の open な intent-system PR や WIP パケットが誤ってスキップされていない
-      （マージ前に host queue / open PR リストを確認）。
-- [ ] `eng/version.json` の `nextVersion` が `0.3.13`（意図したリリースバージョン）。release
-      automation はこの version bump から cut の package バージョンを導出し、
-      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` も同じポリシーからデフォルトを導出する。
+      （publish 前に host queue / open PR リストを確認）。
+- [ ] `eng/version.json` の `nextVersion` が `0.3.13`（意図したリリースバージョン）。`release.yml`
+      は publish された Release/タグから package バージョンをビルドし、
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` も同じポリシーからローカルデフォルトを導出する。
 - [ ] package メタデータが正しい: `PackageId = JTechJapan.IntentSystem.Cli`、
       `RepositoryUrl` / `PackageProjectUrl` が `https://github.com/J-Tech-Japan/intent-system` を指す、
       `PackageLicenseExpression = Apache-2.0`、README/docs リンクが解決し、公式サービスサイト
@@ -79,15 +80,19 @@ version bump をマージしないでください。
 - [ ] リリースコミットで **Main CI が green**（`Build and test (source contract)`）であり、
       **preview-pack** workflow も green。
 
-## マージ後の v0.3.13 自動リリース
+## v0.3.13 の publish
 
-本パケットはリリースを publish せず、publish ステップを **追加しません**。version-bump マージが
-`main` に入り、上記の準備ゲートが成り立つと、**既存の release automation が `v0.3.13` を自動的に
-cut・publish** します — バイナリ・`.nupkg`・チェックサムをビルドし、GitHub Release と NuGet
-package を publish します。v0.3.11・v0.3.12 と同じ方式で、手動のタグ付けや GitHub Release 作成は
-不要です。
+本パケットはリリースを publish せず、publish ステップを **追加しません**。version-bump マージ自体は
+GitHub Release やタグを作成しません。
 
-リリース後の検証（automation が publish した後）:
+1. この version bump がマージされ上記の準備ゲートが成り立った後、**メンテナ/オペレーター（または
+   外部のリリース automation）が `v0.3.13` の GitHub Release を作成・publish** します
+   （リリースコミットにタグ付け）。これはマージ後の host/operator/外部リリースアクションです。
+2. その GitHub Release の publish が `.github/workflows/release.yml`（`on: release: published`）を
+   発火させ、NuGet package とプラットフォームごとのバイナリアーカイブ（`.sha256` チェックサム付き）を
+   build・publish し、トリガーとなった Release に添付します。
+
+リリース後の検証（GitHub Release が publish され `release.yml` が実行された後）:
 
 - [ ] NuGet.org の package ページのリンクがすべて正しく解決する。
 - [ ] GitHub release アセットリンク（`.tar.gz`, `.zip`, `.exe`, `.nupkg`）にアクセスできる。


### PR DESCRIPTION
## Summary

Closes #1115. Corrects the v0.3.13 release-process documentation (introduced in G506) to match the **verified repository reality** before the public v0.3.13 release is cut. G506's docs claimed v0.3.13 is cut/published *automatically by the version-bump merge*; that is wrong.

Verified: `.github/workflows/release.yml` triggers on **`release: published`** (and `workflow_dispatch`) and does **not** create a Release or tag on merge.

## Corrected release model

1. The version-bump merge does **not** create a GitHub Release or tag.
2. After merge (and the readiness gate holds), a **maintainer/operator (or external release automation) creates and publishes the GitHub Release** for `v0.3.13` — a post-merge host/operator/external action.
3. Publishing that GitHub Release fires `release.yml` (`on: release: published`), which builds and publishes the NuGet package and per-platform binary artifacts and attaches them to the triggering Release.

## Changes

- **`docs/en/release-notes-v0.3.13.md` + `docs/ja/release-notes-v0.3.13.md`** — replaced the "automatic on version-bump merge" wording with the actual create/publish-Release-then-`release.yml` model. The readiness gate is now phrased as "before the GitHub Release is published". Renamed the publish section ("Publishing v0.3.13" / "v0.3.13 の publish").
- **`docs/en/09-developer-reference.md` + `docs/ja/09-developer-reference.md`** — "Next release readiness" section corrected to the same model.

G506 stays **prepare-only** (no publish steps). The post-release verification checklist, G505 content, version metadata, and preview/experimental wording are preserved.

## Acceptance criteria coverage

- ✅ v0.3.13 release notes no longer claim the version-bump merge auto-creates/publishes the GitHub Release.
- ✅ Docs state: create/publish the GitHub Release/tag first; then `release.yml` runs on `release: published` and publishes NuGet/binary artifacts.
- ✅ Docs keep G506 prepare-only and make GitHub Release creation a post-merge host/operator/external action.
- ✅ Post-release verification checklist intact.
- ✅ Version metadata remains appropriate for v0.3.13 readiness + a newer post-release dev version (0.3.14).
- ✅ Orchestrator-message mode remains preview/experimental.

## Verification

- Inspected `.github/workflows/release.yml` — `on: release: [published]` + `workflow_dispatch`; no tag/Release creation on merge.
- `dotnet test … --filter VersionPolicyTests|ReleasePackageMetadataTests` — passed.
- `dotnet test` (full Cli suite) — 3163 passed, 1 skipped.
- `git diff --check` — clean.
- Confirmed no residual "auto cut on merge" wording in en/ja release notes or developer reference.

## Out of scope

- Creating the GitHub Release inside this PR; changing release workflow triggers; product behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb