### PR TITLE
G508: Make orchestrator setup guide produce concrete agmsg startup steps

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -413,6 +413,42 @@ agmsg の inbox を確認してください。あなたは `<team>` の design �
 > should read its inbox with `inbox.sh` to catch earlier escalations, exactly
 > like the other receivers (see Receiver readiness / startup order).
 
+## Preflight (all three cwds)
+
+Before mutating anything, preflight **all three checkouts** (orchestrator,
+implementation, review cwds). A receiver acting in the wrong repo, on the wrong
+branch, or over dirty user work is the most common orchestration failure.
+
+- For each cwd, confirm `git status` is clean — no uncommitted/untracked work a
+  checkout/branch switch would clobber.
+- Confirm each cwd's git remote is the **expected repo** for its role (the
+  implementation/review receivers must point at the delegated target repo).
+- Confirm each cwd is on the **expected branch/base** — a receiver on a stale
+  branch implements against the wrong base.
+- If a checkout exposes multiple domains, the orchestrator must **filter by the
+  requested domain/target repo** before publishing or delegating (visibility is
+  not authorization).
+- **Existing-loop conflict check** — no timer-loop may be running for this
+  domain/repo; orchestrator-message mode and timer-loop mode must not run
+  together for the same route.
+
+## Troubleshooting
+
+- **Message not received by a receiver** — confirm registration (`team.sh`) and
+  delivery (`delivery.sh status`); the receiver may have missed it (monitor not
+  yet active) — read its queue with `inbox.sh`, or resend after a ping/ack.
+- **Monitor/delivery configured after the session started** — a session started
+  before its monitor/watch path was active will not pick up earlier messages
+  live; restart the receiver session (or read with `inbox.sh`), then re-confirm
+  with a ping/ack before delegating.
+- **Codex Desktop app thread is the receiver** — Codex Desktop app threads are
+  not agmsg monitor receivers by default; they receive manually only. Use a CLI
+  session, or have the Desktop thread read with `inbox.sh`.
+- **Receiver cwd sees a different repo/domain than delegated** — stop; do not
+  claim. The receiver's cwd/worktree, git remote, and delegated domain must
+  match the routing; reply blocked and re-route. An execution-unit prefix
+  mismatch alone is not the signal — compare packet/domain metadata.
+
 ## Single-domain vs multi-domain orchestration
 
 A host checkout can legitimately contain **several** intent domains (for

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -381,6 +381,37 @@ agmsg の inbox を確認してください。あなたは `<team>` の design �
 > で inbox を読んで earlier なエスカレーションを拾うべきです。他の receiver と同様です
 > （Receiver readiness / startup order 参照）。
 
+## preflight（3 つの cwd すべて）
+
+何かを変更する前に、**3 つのチェックアウト全部**（orchestrator・implementation・review の cwd）を
+preflight します。receiver が誤った repo・誤ったブランチ・dirty なユーザー作業の上で動くのは、最も
+よくあるオーケストレーション失敗です。
+
+- 各 cwd で `git status` が clean であることを確認 — checkout/branch 切替で壊れる uncommitted/
+  untracked 作業がないこと。
+- 各 cwd の git remote がそのロールの **期待 repo** であることを確認（implementation/review receiver
+  は委譲された target repo を指す必要がある）。
+- 各 cwd が **期待ブランチ/base** にあることを確認 — stale なブランチ上の receiver は誤った base に
+  対して実装する。
+- チェックアウトが複数ドメインを露出している場合、orchestrator は publish/delegate の前に
+  **要求された domain/target repo でフィルター** しなければならない（可視であることは権限ではない）。
+- **既存ループ競合チェック** — この domain/repo に対して timer-loop が動いていないこと。
+  orchestrator-message モードと timer-loop モードは同じルートで同時に動かしてはいけない。
+
+## トラブルシューティング
+
+- **receiver がメッセージを受信しない** — 登録（`team.sh`）と delivery（`delivery.sh status`）を確認。
+  receiver が取りこぼした可能性がある（monitor 未アクティブ）— `inbox.sh` で queue を読むか、ping/ack 後に
+  resend する。
+- **monitor/delivery をセッション開始後に設定した** — monitor/watch パスがアクティブになる前に開始した
+  セッションは earlier なメッセージをライブで拾わない。receiver セッションを再起動する（または `inbox.sh`
+  で読む）。その後、委譲前に ping/ack で再確認する。
+- **Codex Desktop app スレッドが receiver** — Codex Desktop app スレッドはデフォルトで agmsg monitor
+  receiver ではない。手動でのみ受信する。CLI セッションを使うか、Desktop スレッドに `inbox.sh` で読ませる。
+- **receiver の cwd が委譲と異なる repo/domain を見る** — 停止。claim しない。receiver の cwd/worktree・
+  git remote・委譲された domain がルーティングと一致する必要がある。blocked を返して re-route する。
+  execution-unit prefix の不一致だけでは signal にならない — packet/domain メタデータを比較する。
+
 ## single-domain と multi-domain のオーケストレーション
 
 host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -589,6 +589,44 @@ internal static class GuideOrchestratorThreadCommand
                     "Never edit the agmsg database or team files directly — register, message, and clean up ONLY through "
                     + "the agmsg scripts. Hand-editing agmsg state corrupts delivery.",
             },
+            Preflight = new OrchestratorPreflight
+            {
+                Summary =
+                    "Before mutating anything, preflight ALL THREE checkouts (the orchestrator, implementation, and "
+                    + "review cwds). A receiver acting in the wrong repo, on the wrong branch, or over dirty user work is "
+                    + "the most common orchestration failure — catch it before the first delegation.",
+                Checks = new[]
+                {
+                    "For each cwd (orchestrator / implementation / review), confirm `git status` is clean — no uncommitted or untracked work that a checkout/branch switch would clobber.",
+                    "Confirm each cwd's git remote is the EXPECTED repo for its role — the implementation/review receivers must point at the delegated target repo, not a sibling clone.",
+                    "Confirm each cwd is on the expected branch/base (e.g. the base-branch policy's base, or a fresh work branch) — a receiver on a stale branch implements against the wrong base.",
+                    "Confirm the host repo / domain context: if a checkout exposes multiple domains, the orchestrator MUST filter by the requested domain/target repo before publishing or delegating (visibility is not authorization).",
+                    "Existing-loop conflict check: confirm no timer-loop (implement/review recurring timer) is already running for this domain/repo — orchestrator-message mode and timer-loop mode must not run together for the same route.",
+                },
+            },
+            Troubleshooting = new[]
+            {
+                new OrchestratorTroubleshooting
+                {
+                    Symptom = "Message not received by a receiver",
+                    Action = "Confirm the role is registered (`team.sh`) and delivery is set (`delivery.sh status`). The receiver may have missed it (monitor not yet active) — have it read its queue with `inbox.sh`, or resend after a ping/ack.",
+                },
+                new OrchestratorTroubleshooting
+                {
+                    Symptom = "Monitor/delivery configured AFTER the session started",
+                    Action = "A session started before its monitor/watch path was active will not pick up earlier messages live — restart the receiver session (or read with `inbox.sh`) so the monitor hook attaches, then re-confirm with a ping/ack before delegating.",
+                },
+                new OrchestratorTroubleshooting
+                {
+                    Symptom = "Codex Desktop app thread is the receiver",
+                    Action = "Codex Desktop app threads are NOT agmsg monitor receivers by default — they receive manually only. Use a CLI session as the receiver, or have the Desktop thread read its queue with `inbox.sh`.",
+                },
+                new OrchestratorTroubleshooting
+                {
+                    Symptom = "Receiver cwd sees a different repo/domain than delegated",
+                    Action = "STOP — do not claim. The receiver's cwd/worktree, git remote, and delegated domain must match the routing; reply blocked and re-route. An execution-unit ID prefix mismatch alone is NOT the signal — compare packet/domain metadata and the routing context.",
+                },
+            },
             ReceiverReadiness = new OrchestratorReceiverReadiness
             {
                 Summary =
@@ -908,6 +946,7 @@ internal static class GuideOrchestratorThreadCommand
             RolePrompts = rolePrompts,
             FirstValidation = new[]
             {
+                $"Preflight all three cwds BEFORE mutating: `{orchestratorPath}` (orchestrator), `{implementationPath}` (implementation), `{reviewPath}` (review) — clean `git status`, expected git remote/repo, expected branch/base, and no existing timer-loop for this domain/repo (see Preflight).",
                 "Existing-loop conflict check: confirm no implementation/review recurring timer is running for this domain/repo (only the orchestrator is scheduled).",
                 "First read-only wake: run ONE confirm-only orchestrator wake — read state, send nothing.",
                 "Receiver readiness: ping each receiver and require an ack BEFORE any real delegation — a registered+configured role is not ready until it acks (see the Receiver readiness section). A session launched before delivery was active may have missed earlier messages; resend or read with `inbox.sh`.",
@@ -1180,6 +1219,16 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"> **Warning:** {guide.Setup.Warning}");
         writer.WriteLine();
 
+        writer.WriteLine("## Preflight (all three cwds)");
+        writer.WriteLine();
+        writer.WriteLine(guide.Preflight.Summary);
+        writer.WriteLine();
+        foreach (var check in guide.Preflight.Checks)
+        {
+            writer.WriteLine($"- {check}");
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Receiver readiness");
         writer.WriteLine();
         writer.WriteLine(guide.ReceiverReadiness.Summary);
@@ -1223,6 +1272,14 @@ internal static class GuideOrchestratorThreadCommand
         foreach (var command in guide.ReceiverReadiness.DiagnosticCommands)
         {
             writer.WriteLine($"- {command}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("## Troubleshooting");
+        writer.WriteLine();
+        foreach (var entry in guide.Troubleshooting)
+        {
+            writer.WriteLine($"- **{entry.Symptom}** — {entry.Action}");
         }
         writer.WriteLine();
 
@@ -1647,6 +1704,12 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("setup")]
     public required OrchestratorSetup Setup { get; init; }
 
+    [JsonPropertyName("preflight")]
+    public required OrchestratorPreflight Preflight { get; init; }
+
+    [JsonPropertyName("troubleshooting")]
+    public required IReadOnlyList<OrchestratorTroubleshooting> Troubleshooting { get; init; }
+
     [JsonPropertyName("receiver_readiness")]
     public required OrchestratorReceiverReadiness ReceiverReadiness { get; init; }
 
@@ -1862,6 +1925,24 @@ internal sealed record OrchestratorDependencyStatus
 {
     [JsonPropertyName("status")]
     public required string Status { get; init; }
+
+    [JsonPropertyName("action")]
+    public required string Action { get; init; }
+}
+
+internal sealed record OrchestratorPreflight
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("checks")]
+    public required IReadOnlyList<string> Checks { get; init; }
+}
+
+internal sealed record OrchestratorTroubleshooting
+{
+    [JsonPropertyName("symptom")]
+    public required string Symptom { get; init; }
 
     [JsonPropertyName("action")]
     public required string Action { get; init; }

--- a/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuidePromptMatrixCommand.cs
@@ -1482,7 +1482,13 @@ Hard rules:
     {
         writer.WriteLine("# Guide prompt matrix");
         writer.WriteLine();
-        writer.WriteLine("Canonical matrix of the four operational modes.");
+        writer.WriteLine("Canonical matrix of the four operational modes (timer-loop based).");
+        writer.WriteLine();
+        writer.WriteLine("> There is also an OPTIONAL, preview agmsg **orchestrator-message mode** where a single");
+        writer.WriteLine("> scheduled orchestrator paces loopless implementation/review receivers over agmsg instead of");
+        writer.WriteLine("> independent timers. It does not replace these timer-loop modes; the two must not run for the");
+        writer.WriteLine("> same domain/repo at once. Generate its setup/startup/troubleshooting guidance with");
+        writer.WriteLine("> `intent-cli guide orchestrator-thread --domain <d> --target-repo <owner/repo> --agent <a> --format markdown`.");
         writer.WriteLine();
 
         foreach (var entry in entries)

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -928,6 +928,79 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_Preflight_RequiresAllThreeCwdChecks_G508()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Preflight (all three cwds)", output, StringComparison.Ordinal);
+        // git status / dirty, expected repo, expected branch/base.
+        Assert.Contains("`git status` is clean", output, StringComparison.Ordinal);
+        Assert.Contains("git remote is the EXPECTED repo", output, StringComparison.Ordinal);
+        Assert.Contains("expected branch/base", output, StringComparison.Ordinal);
+        // Multi-domain filtering before publish/delegate.
+        Assert.Contains("filter by the requested domain/target repo", output, StringComparison.Ordinal);
+        // Existing timer-loop conflict check.
+        Assert.Contains("no timer-loop", output, StringComparison.Ordinal);
+        Assert.Contains("must not run together", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_Troubleshooting_CoversTheFourFailureModes_G508()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("## Troubleshooting", output, StringComparison.Ordinal);
+        Assert.Contains("**Message not received by a receiver**", output, StringComparison.Ordinal);
+        Assert.Contains("**Monitor/delivery configured AFTER the session started**", output, StringComparison.Ordinal);
+        Assert.Contains("**Codex Desktop app thread is the receiver**", output, StringComparison.Ordinal);
+        Assert.Contains("**Receiver cwd sees a different repo/domain than delegated**", output, StringComparison.Ordinal);
+        // Each routes through agmsg scripts / blocked-and-reroute, no raw label/db edits.
+        Assert.Contains("`inbox.sh`", output, StringComparison.Ordinal);
+        Assert.Contains("reply blocked and re-route", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasPreflightAndTroubleshootingShape_G508()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+
+        var preflight = doc.RootElement.GetProperty("preflight");
+        Assert.True(preflight.TryGetProperty("summary", out _));
+        Assert.NotEmpty(preflight.GetProperty("checks").EnumerateArray());
+
+        var troubleshooting = doc.RootElement.GetProperty("troubleshooting").EnumerateArray()
+            .Select(t => t.GetProperty("symptom").GetString()!)
+            .ToArray();
+        Assert.Contains(troubleshooting, s => s.Contains("Message not received", StringComparison.Ordinal));
+        Assert.Contains(troubleshooting, s => s.Contains("different repo/domain", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_Markdown_SetupReady_FirstValidation_IncludesPreflightOfThreeCwds_G508()
+    {
+        var output = RunMarkdown([
+            "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system",
+            "--orchestrator-path", "/work/orch", "--implementation-path", "/work/impl", "--review-path", "/work/review",
+            "--orchestrator-agent", "claude", "--implementer-agent", "claude", "--reviewer-agent", "codex",
+            "--team", "intent-orch", "--delivery-mode", "streamed-inbox-watch", "--existing-loop-policy", "none",
+        ]);
+
+        Assert.Contains("status: `setup-ready`", output, StringComparison.Ordinal);
+        // The first-validation references preflighting the three concrete cwds.
+        Assert.Contains("Preflight all three cwds BEFORE mutating", output, StringComparison.Ordinal);
+        Assert.Contains("/work/orch", output, StringComparison.Ordinal);
+        Assert.Contains("/work/impl", output, StringComparison.Ordinal);
+        Assert.Contains("/work/review", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuidePromptMatrixCommandTests.cs
@@ -25,6 +25,10 @@ public sealed class GuidePromptMatrixCommandTests
         Assert.Contains("host-loop", output, StringComparison.Ordinal);
         Assert.Contains("child-oneshot", output, StringComparison.Ordinal);
         Assert.Contains("host-oneshot", output, StringComparison.Ordinal);
+        // G508: the optional agmsg orchestrator-message mode is discoverable from
+        // the prompt matrix, and the timer-loop modes are not removed.
+        Assert.Contains("orchestrator-message mode", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide orchestrator-thread", output, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #1117. A real three-folder orchestrator trial (SekibanAsAService) showed the guide was conceptually correct but operationally weak — it needed operator steering for cwd preflight and common failure modes. Adds the missing concrete pieces. Builds on the G489–G505 orchestrator-message work (setup intake, receiver readiness/startup, domain routing, design receiver already shipped).

Surface: `intent-cli guide orchestrator-thread` + `guide prompt-matrix` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `preflight` section** in `guide orchestrator-thread`: preflight **all three cwds** (orchestrator/implementation/review) before mutation — clean `git status`, expected git remote/repo, expected branch/base, multi-domain filter-by-requested-domain before publish/delegate, and an existing **timer-loop conflict check**.
- **New `troubleshooting` section** covering the four observed failure modes: message-not-received, monitor configured after session start, Codex Desktop app manual-inbox-only, and receiver cwd seeing a different repo/domain.
- The **setup-intake first-validation** now references preflighting the three concrete cwds (using the supplied folder values).
- **`guide prompt-matrix`** now points to the optional agmsg **orchestrator-message mode** (`guide orchestrator-thread`) so it is discoverable; the four timer-loop modes are unchanged and not broken.
- Docs updated in EN + JA.

(The concrete paste-ready per-role `agmsg join.sh`/`delivery.sh` checklist from folder + agent inputs, explicit startup ordering, live-monitor caveat, loopless receivers, and multi-domain routing were already shipped in G500/G501/G502/G489/G505 and are reused here.)

## Acceptance criteria coverage

- ✅ Given domain/repo/cwds/agents, the setup intake emits a concrete paste-ready checklist (G500, reused) — not only conceptual guidance.
- ✅ Guide tells the user to run agmsg join/delivery for all three roles with correct role names + cwd values.
- ✅ Startup order is explicit (configure roles → start/restart CLIs so monitor hooks attach → verify → send).
- ✅ Live-monitor caveat documented (resend / manual `inbox.sh`).
- ✅ Only the orchestrator gets the recurring loop; implementation/review stay loopless.
- ✅ **Preflight of all three cwds** before mutation: git branch/status, expected repo, expected branch/base, dirty state, existing timer-loop conflict.
- ✅ Multi-domain host repo: orchestrator filters by requested domain/target repo before publish/delegate.
- ✅ No raw label / DB / team-file edit guidance.
- ✅ **Troubleshooting** for message-not-received, monitor-after-start, Codex Desktop manual-inbox-only, receiver-cwd-different-repo/domain.
- ✅ Existing timer-loop prompt guidance remains available and unbroken.

## Verification

- `intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent claude --mode single-domain --format markdown` — renders Preflight + Troubleshooting (and the existing setup/startup sections).
- `intent-cli guide prompt-matrix --format markdown` — orchestrator-message mode discoverable; four timer-loop modes intact.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests|GuidePromptMatrixCommandTests` — 231 passed.
- `dotnet test` (full Cli suite) — 3167 passed, 1 skipped.
- `git diff --check` — clean.

## Scope note

The Related Links `intents/**` intent-tree write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb