### PR TITLE
G509: Add design-thread handoff and monitor recovery guidance for orchestrator mode

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -413,6 +413,51 @@ agmsg の inbox を確認してください。あなたは `<team>` の design �
 > should read its inbox with `inbox.sh` to catch earlier escalations, exactly
 > like the other receivers (see Receiver readiness / startup order).
 
+## Design handoff (start / resume)
+
+Setup does not stop at role registration. After the agmsg roles are registered
+and ready, the **design thread** starts (or resumes) orchestration by sending
+**one** message to the orchestrator; the orchestrator then drives the loop
+autonomously and returns to design only for human decisions.
+
+First message — design → orchestrator (paste into the design thread):
+
+```json
+{"to":"orchestrator","type":"start","domain":"<domain>","target_repo":"<owner/repo>","requested_action":"<e.g. publish the next ready slice and drive it to a PR>","constraints":"one action per wake; escalate to design ONLY for human decisions (product/clarification, release/credentials/security, destructive actions, unresolved blockers)"}
+```
+
+- **Autonomous publish** — if `intent-cli` reports the next slice
+  `issue-cut-ready` and all publish gates pass, the orchestrator creates/
+  publishes **one** GitHub issue itself via canonical intent-cli commands
+  (`issue publish-flow` / `automation issue-publish`) — it does **not** ask
+  design to do each step. At most one issue per wake; verify before delegating.
+- **Escalation boundary** — routine delegation (publish, delegate, CI wait,
+  review, closeout) stays orchestrator↔receivers. Return to **design** only for
+  human decisions (product/design clarification, release/credentials/security,
+  destructive actions, an unresolved blocker) using the structured escalation
+  message.
+- **Design inbox workflow** — the design thread is a loopless receiver and reads
+  on demand; check the design inbox with `inbox.sh` to pick up escalations,
+  especially when monitor delivery did not appear live or the design session
+  started after the orchestrator sent.
+
+## Monitor recovery
+
+- **Monitor did not start** — restart the receiver session so the monitor/watch
+  hook attaches on a fresh turn; verify with `delivery.sh status` and a
+  ping/ack. Until then, read with `inbox.sh`.
+- **Message not visible** — it may be queued but not delivered live; read the
+  role's queue with `inbox.sh`, re-confirm `team.sh` / `delivery.sh status`, then
+  resend after an ack.
+- **Receiver started after the message was sent** — earlier messages are in
+  history but not delivered live; read them with `inbox.sh`, or resend after the
+  receiver acks.
+- **Orchestrator idle despite a packet existing** — confirm the orchestrator
+  received the design start/resume message (`inbox.sh`) and that `worker
+  next-action` / `intent status` report an actionable item for **this**
+  domain/repo (not another visible domain). If issue-cut-ready and safe, the
+  orchestrator should publish one issue itself rather than wait.
+
 ## Preflight (all three cwds)
 
 Before mutating anything, preflight **all three checkouts** (orchestrator,

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -381,6 +381,44 @@ agmsg の inbox を確認してください。あなたは `<team>` の design �
 > で inbox を読んで earlier なエスカレーションを拾うべきです。他の receiver と同様です
 > （Receiver readiness / startup order 参照）。
 
+## design ハンドオフ（start / resume）
+
+セットアップはロール登録で終わりません。agmsg ロールが登録されて ready になった後、**design
+スレッド** が orchestrator に **1 通** メッセージを送ってオーケストレーションを start（または
+resume）します。その後 orchestrator がループを自律的に駆動し、人間が必要な判断のときだけ design に
+戻ります。
+
+最初のメッセージ — design → orchestrator（design スレッドに貼り付け）:
+
+```json
+{"to":"orchestrator","type":"start","domain":"<domain>","target_repo":"<owner/repo>","requested_action":"<例: 次の ready なスライスを publish して PR まで進める>","constraints":"one action per wake; escalate to design ONLY for human decisions (product/clarification, release/credentials/security, destructive actions, unresolved blockers)"}
+```
+
+- **autonomous publish** — `intent-cli` が次のスライスを `issue-cut-ready` と報告し、すべての
+  publish ゲートが通れば、orchestrator は canonical な intent-cli コマンド（`issue publish-flow` /
+  `automation issue-publish`）で **1 つ** の GitHub issue を自分で作成・publish します — 各ステップを
+  design に頼みません。1 wake につき最大 1 件。委譲前に検証します。
+- **escalation boundary** — ルーチンな委譲（publish、delegate、CI 待ち、review、closeout）は
+  orchestrator↔receivers に留まります。**design** に戻すのは人間が必要な判断のときだけ（product/設計
+  clarification、release/認証情報/セキュリティ、破壊的操作、未解決ブロッカー）。構造化された
+  エスカレーションメッセージを使います。
+- **design inbox workflow** — design スレッドは loopless receiver でオンデマンドに読みます。
+  エスカレーションを拾うには `inbox.sh` で design inbox を確認します — 特に monitor delivery が
+  ライブで現れなかった場合や、design セッションが orchestrator の送信後に開始した場合。
+
+## monitor リカバリ
+
+- **monitor が起動しなかった** — receiver セッションを再起動して monitor/watch hook を新しい turn で
+  アタッチさせる。`delivery.sh status` と ping/ack で検証。それまでは `inbox.sh` で読む。
+- **メッセージが可視でない** — queue 済みだがライブ delivery されていない可能性。ロールの queue を
+  `inbox.sh` で読み、`team.sh` / `delivery.sh status` を再確認し、ack 後に resend する。
+- **メッセージ送信後に receiver が開始した** — earlier なメッセージは history にあるがライブ delivery
+  されない。`inbox.sh` で読むか、receiver の ack 後に resend する。
+- **packet があるのに orchestrator が idle** — orchestrator が design の start/resume メッセージを
+  受信したか（`inbox.sh`）、`worker next-action` / `intent status` が **この** domain/repo に対して
+  実行可能項目を報告しているか（host repo に見える別ドメインではない）を確認する。issue-cut-ready で
+  安全なら、orchestrator は待たずに自分で 1 つ issue を publish すべき。
+
 ## preflight（3 つの cwd すべて）
 
 何かを変更する前に、**3 つのチェックアウト全部**（orchestrator・implementation・review の cwd）を

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -500,6 +500,56 @@ internal static class GuideOrchestratorThreadCommand
                     + "delivered — the design thread should read its inbox with `inbox.sh` to catch earlier escalations, "
                     + "exactly like the other receivers (see Receiver readiness / startup order).",
             },
+            DesignHandoff = new OrchestratorDesignHandoff
+            {
+                Summary =
+                    "Setup does not stop at role registration. After the agmsg roles are registered and ready, the "
+                    + "DESIGN thread starts (or resumes) orchestration by sending ONE message to the orchestrator; the "
+                    + "orchestrator then drives the loop autonomously and returns to design only for human decisions.",
+                FirstMessageTemplate = Apply(
+                    "{\"to\":\"orchestrator\",\"type\":\"start\",\"domain\":\"<domain>\",\"target_repo\":"
+                    + "\"<owner/repo>\",\"requested_action\":\"<e.g. publish the next ready slice and drive it to a PR>\","
+                    + "\"constraints\":\"one action per wake; escalate to design ONLY for human decisions (product/"
+                    + "clarification, release/credentials/security, destructive actions, unresolved blockers)\"}"),
+                AutonomousPublishRule =
+                    "If `intent-cli` reports the next slice `issue-cut-ready` and all publish gates pass (see Next-slice "
+                    + "publication), the orchestrator creates/publishes ONE GitHub issue ITSELF via canonical intent-cli "
+                    + "commands (`issue publish-flow` / `automation issue-publish`) — it does NOT ask design to do each "
+                    + "step. At most one issue per wake; verify after publishing before delegating implementation.",
+                EscalationBoundary =
+                    "Routine delegation (publish, delegate, CI wait, review, closeout) stays orchestrator↔receivers and "
+                    + "does NOT go to design. Return to DESIGN only for human decisions — product/design clarification, "
+                    + "release/credentials/security, destructive actions, or an unresolved blocker — using the structured "
+                    + "escalation message (reason / current_state / evidence / decision_needed).",
+                DesignInboxWorkflow =
+                    "The design thread is a loopless receiver and reads on demand. To pick up escalations, the human (or "
+                    + "the design thread) checks the design inbox with `inbox.sh` — especially when monitor delivery did "
+                    + "not appear live or the design session started after the orchestrator sent. Read, decide/reply, "
+                    + "then the orchestrator continues.",
+            },
+            MonitorRecovery = new[]
+            {
+                new OrchestratorTroubleshooting
+                {
+                    Symptom = "Monitor did not start",
+                    Action = "Restart the receiver session so the monitor/watch hook attaches on a fresh turn; verify with `delivery.sh status` and a ping/ack. Until then, read with `inbox.sh`.",
+                },
+                new OrchestratorTroubleshooting
+                {
+                    Symptom = "Message not visible",
+                    Action = "It may be queued but not delivered live — read the role's queue with `inbox.sh`; if still missing, re-confirm registration (`team.sh`) and delivery, then resend after an ack.",
+                },
+                new OrchestratorTroubleshooting
+                {
+                    Symptom = "Receiver started after the message was sent",
+                    Action = "Earlier messages are in history but not delivered live to the new session — read them with `inbox.sh`, or have the sender resend after the receiver acks.",
+                },
+                new OrchestratorTroubleshooting
+                {
+                    Symptom = "Orchestrator idle despite a packet existing",
+                    Action = "Confirm the orchestrator received the design start/resume message (`inbox.sh` on the orchestrator) and that `worker next-action` / `intent status` report an actionable item for THIS domain/repo (not another domain visible in the host repo). If issue-cut-ready and safe, the orchestrator should publish one issue itself rather than wait.",
+                },
+            },
             WorktreeManagement = new OrchestratorWorktreeManagement
             {
                 Summary =
@@ -1283,6 +1333,14 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Monitor recovery");
+        writer.WriteLine();
+        foreach (var entry in guide.MonitorRecovery)
+        {
+            writer.WriteLine($"- **{entry.Symptom}** — {entry.Action}");
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Domain routing — single-domain vs multi-domain");
         writer.WriteLine();
         writer.WriteLine($"- selected mode: `{guide.DomainRouting.Mode}`");
@@ -1492,6 +1550,21 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"> **Pre-start messages:** {guide.DesignReceiver.PreStartNote}");
         writer.WriteLine();
 
+        writer.WriteLine("## Design handoff (start / resume)");
+        writer.WriteLine();
+        writer.WriteLine(guide.DesignHandoff.Summary);
+        writer.WriteLine();
+        writer.WriteLine("First message — design → orchestrator (paste into the design thread):");
+        writer.WriteLine();
+        writer.WriteLine("```json");
+        writer.WriteLine(guide.DesignHandoff.FirstMessageTemplate);
+        writer.WriteLine("```");
+        writer.WriteLine();
+        writer.WriteLine($"- **autonomous publish** — {guide.DesignHandoff.AutonomousPublishRule}");
+        writer.WriteLine($"- **escalation boundary** — {guide.DesignHandoff.EscalationBoundary}");
+        writer.WriteLine($"- **design inbox workflow** — {guide.DesignHandoff.DesignInboxWorkflow}");
+        writer.WriteLine();
+
         writer.WriteLine("## Managed worktree cleanup");
         writer.WriteLine();
         writer.WriteLine(guide.WorktreeManagement.Summary);
@@ -1698,6 +1771,12 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("design_receiver")]
     public required OrchestratorDesignReceiver DesignReceiver { get; init; }
 
+    [JsonPropertyName("design_handoff")]
+    public required OrchestratorDesignHandoff DesignHandoff { get; init; }
+
+    [JsonPropertyName("monitor_recovery")]
+    public required IReadOnlyList<OrchestratorTroubleshooting> MonitorRecovery { get; init; }
+
     [JsonPropertyName("worktree_management")]
     public required OrchestratorWorktreeManagement WorktreeManagement { get; init; }
 
@@ -1832,6 +1911,24 @@ internal sealed record OrchestratorWorktreeManagement
 
     [JsonPropertyName("approval_policy_note")]
     public required string ApprovalPolicyNote { get; init; }
+}
+
+internal sealed record OrchestratorDesignHandoff
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("first_message_template")]
+    public required string FirstMessageTemplate { get; init; }
+
+    [JsonPropertyName("autonomous_publish_rule")]
+    public required string AutonomousPublishRule { get; init; }
+
+    [JsonPropertyName("escalation_boundary")]
+    public required string EscalationBoundary { get; init; }
+
+    [JsonPropertyName("design_inbox_workflow")]
+    public required string DesignInboxWorkflow { get; init; }
 }
 
 internal sealed record OrchestratorDesignReceiver

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -1001,6 +1001,67 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_DesignHandoff_HasFirstMessage_AutonomousPublish_AndBoundary_G509()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Design handoff (start / resume)", output, StringComparison.Ordinal);
+        // First message pattern design → orchestrator with domain, target repo, requested action,
+        // one-action-per-wake, escalation boundary.
+        Assert.Contains("\"to\":\"orchestrator\",\"type\":\"start\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"domain\":\"intent-cli\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"target_repo\":\"J-Tech-Japan/intent-system\"", output, StringComparison.Ordinal);
+        Assert.Contains("one action per wake", output, StringComparison.Ordinal);
+        // Autonomous publish: orchestrator publishes one issue-cut-ready issue itself.
+        Assert.Contains("**autonomous publish**", output, StringComparison.Ordinal);
+        Assert.Contains("creates/publishes ONE GitHub issue ITSELF", output, StringComparison.Ordinal);
+        Assert.Contains("does NOT ask design to do each step", output, StringComparison.Ordinal);
+        // Human-decision escalation vs routine delegation.
+        Assert.Contains("**escalation boundary**", output, StringComparison.Ordinal);
+        Assert.Contains("Return to DESIGN only for human decisions", output, StringComparison.Ordinal);
+        // Design-thread manual inbox workflow.
+        Assert.Contains("**design inbox workflow**", output, StringComparison.Ordinal);
+        Assert.Contains("`inbox.sh`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_MonitorRecovery_CoversTheFourRecoveryCases_G509()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("## Monitor recovery", output, StringComparison.Ordinal);
+        Assert.Contains("**Monitor did not start**", output, StringComparison.Ordinal);
+        Assert.Contains("**Message not visible**", output, StringComparison.Ordinal);
+        Assert.Contains("**Receiver started after the message was sent**", output, StringComparison.Ordinal);
+        Assert.Contains("**Orchestrator idle despite a packet existing**", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasDesignHandoffAndMonitorRecoveryShape_G509()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+
+        var handoff = doc.RootElement.GetProperty("design_handoff");
+        Assert.True(handoff.TryGetProperty("first_message_template", out _));
+        Assert.Contains("issue-cut-ready", handoff.GetProperty("autonomous_publish_rule").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("human decisions", handoff.GetProperty("escalation_boundary").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("inbox.sh", handoff.GetProperty("design_inbox_workflow").GetString()!, StringComparison.Ordinal);
+
+        var recovery = doc.RootElement.GetProperty("monitor_recovery").EnumerateArray()
+            .Select(r => r.GetProperty("symptom").GetString()!)
+            .ToArray();
+        Assert.Contains(recovery, s => s.Contains("Monitor did not start", StringComparison.Ordinal));
+        Assert.Contains(recovery, s => s.Contains("Orchestrator idle despite a packet", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Closes #1119. Another SekibanAsAService dogfooding run showed orchestrator-message setup did not stop at role registration — the operator still had to know how design starts orchestration, when the orchestrator publishes autonomously, and how to recover when monitor delivery was not visible. Adds the post-setup behavior. Builds on G508 (setup/preflight/troubleshooting).

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `design_handoff` section** in the guide:
  - a concrete **first message pattern** (design → orchestrator) carrying domain, target repo, requested action, one-action-per-wake, and the escalation boundary;
  - the **autonomous-publish rule**: when next-slice is `issue-cut-ready` and publish is safe, the orchestrator publishes one issue itself via canonical intent-cli commands (`issue publish-flow` / `automation issue-publish`) instead of asking design per step;
  - the **human-decision escalation vs routine-delegation** boundary;
  - the **design-thread manual inbox workflow** (`inbox.sh` on demand).
- **New `monitor_recovery` checklist**: monitor did not start, message not visible, receiver started after the message, and orchestrator idle despite a packet existing.
- Docs updated in EN + JA.

(turn vs monitor / Codex Desktop manual-inbox / restart-first-turn caveats already shipped in G501/G502/G508 and are reused/cross-referenced.)

## Acceptance criteria coverage

- ✅ After the design receiver is registered, the guide gives the exact first message pattern to start/resume (domain, target repo, requested action, one-action-per-wake, escalation boundaries).
- ✅ If next-slice is issue-cut-ready and publish is safe, the orchestrator publishes one issue itself via canonical commands instead of asking design per step.
- ✅ Human-decision escalation is distinguished from routine delegation.
- ✅ turn vs monitor behavior documented, incl. Codex Desktop/manual inbox + restart/first-turn (G501/G502/G508 + this section).
- ✅ Recovery checklist for monitor-did-not-start, message-not-visible, receiver-started-after-message, orchestrator-idle-despite-packet.
- ✅ Design-thread manual inbox workflow included.
- ✅ Existing G508 setup guidance intact and not contradicted.

## Verification

- `intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent claude --mode single-domain --format markdown` — renders Design handoff + Monitor recovery; G508 Preflight + Troubleshooting still present.
- `intent-cli guide prompt-matrix --format markdown` — orchestrator-message mode still discoverable.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 48 passed.
- `dotnet test` (full Cli suite) — 3170 passed, 1 skipped (one unrelated test flaked on the first run; green on re-run, and my new tests are deterministic).
- `git diff --check` — clean.

## Scope note

The Related Links `intents/**` intent-tree write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb