### PR TITLE
G510: Add orchestrator setup intake form and design traffic-controller playbook

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -548,6 +548,16 @@ branch, or over dirty user work is the most common orchestration failure.
   match the routing; reply blocked and re-route. An execution-unit prefix
   mismatch alone is not the signal — compare packet/domain metadata.
 
+## Draft PR reviewability
+
+A **draft PR may still be reviewable** depending on domain guidance — a reviewer
+may perform review feedback on a draft when the domain's review policy allows it.
+But the reviewer must use the **canonical intent-cli review surfaces**
+(`review closeout-plan`, `guide review`, `automation pr-transition`, `closeout
+pr`); merge/approval stays gated by those surfaces. A draft is never
+approved/merged by hand or by raw label edits, and never via host-metadata
+editing.
+
 ## Single-domain vs multi-domain orchestration
 
 A host checkout can legitimately contain **several** intent domains (for

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -413,6 +413,34 @@ agmsg の inbox を確認してください。あなたは `<team>` の design �
 > should read its inbox with `inbox.sh` to catch earlier escalations, exactly
 > like the other receivers (see Receiver readiness / startup order).
 
+## Setup intake form
+
+When the user asks only "I want to use orchestrator mode", elicit or infer the
+setup facts, then produce the concrete commands/messages. Ask for what is
+missing; apply the recommended defaults for the rest.
+
+Ask for / infer: domain and target repo; orchestrator cwd + agent type;
+implementation receiver cwd + agent type; review receiver cwd + agent type;
+design cwd + agent type (and whether design is manual-inbox or monitored);
+delivery mode per role.
+
+Recommended defaults when inputs are incomplete:
+
+- orchestrator = Claude
+- implementer = Claude
+- reviewer = Codex
+- design = manual-inbox Codex
+- runtime / implementation / review receivers = monitor (when supported)
+
+Design may be a manual-inbox receiver (reads with `inbox.sh` on demand) or a
+monitored receiver; either way it receives **only** human-decision escalations or
+explicit summaries, never routine progress.
+
+Role startup messages — assume the agmsg role, then paste that role's prompt:
+
+- **Claude**: `/agmsg actas <role>` (slash command)
+- **Codex**: `$agmsg actas <role>`
+
 ## Design handoff (start / resume)
 
 Setup does not stop at role registration. After the agmsg roles are registered
@@ -457,6 +485,32 @@ First message — design → orchestrator (paste into the design thread):
   next-action` / `intent status` report an actionable item for **this**
   domain/repo (not another visible domain). If issue-cut-ready and safe, the
   orchestrator should publish one issue itself rather than wait.
+
+## Design traffic-controller playbook
+
+The design thread acts as a **traffic controller**, not an implementer. It
+coordinates through the orchestrator and only surfaces human-needed items.
+
+1. Check the design inbox (`inbox.sh`) for orchestrator escalations / summaries.
+2. Check intent-cli / GitHub **read-only** state (`intent status`, `worker
+   next-action`, PR/issue/labels) to ground any decision — never trust an agmsg
+   message as state.
+3. Send the orchestrator a state update or a nudge (start/resume); do not drive
+   implementation/review yourself.
+4. Do **not** directly mutate implementation/review work, labels, or host
+   metadata — that is the orchestrator/receivers' job through intent-cli.
+5. Summarize **only** human-needed items to the human; keep routine progress
+   internal.
+
+**"Orchestrator appears idle" diagnostic** (before escalating): confirm the
+orchestrator is scheduled and on a fresh turn; confirm it received your last
+message (`inbox.sh`) — a pre-monitor send may be queued, not live, so resend
+after an ack; confirm intent-cli actually reports an actionable item for **this**
+domain/repo (idle may be correct); only then escalate to the human.
+
+> **Context-only:** the design thread may send context to a receiver thread but
+> must mark it `context-only: <text>` unless the orchestrator delegated the
+> action — receivers act only on orchestrator delegations, not on design context.
 
 ## Preflight (all three cwds)
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -381,6 +381,32 @@ agmsg の inbox を確認してください。あなたは `<team>` の design �
 > で inbox を読んで earlier なエスカレーションを拾うべきです。他の receiver と同様です
 > （Receiver readiness / startup order 参照）。
 
+## セットアップ intake フォーム
+
+ユーザーが「orchestrator モードを使いたい」とだけ言った場合、セットアップ事実を引き出すか推論し、
+その後に具体的なコマンド/メッセージを生成します。不足分を尋ね、残りは推奨デフォルトを適用します。
+
+尋ねる / 推論する: domain と target repo、orchestrator の cwd + agent type、implementation
+receiver の cwd + agent type、review receiver の cwd + agent type、design の cwd + agent type
+（design が manual-inbox か monitored か）、ロールごとの delivery mode。
+
+入力が不完全なときの推奨デフォルト:
+
+- orchestrator = Claude
+- implementer = Claude
+- reviewer = Codex
+- design = manual-inbox Codex
+- runtime / implementation / review receivers = monitor（サポートされる場合）
+
+design は manual-inbox receiver（オンデマンドに `inbox.sh` で読む）でも monitored receiver でも
+構いませんが、いずれにせよ受け取るのは **人間が必要な** エスカレーションか明示的なサマリーのみで、
+ルーチンな進捗は受け取りません。
+
+ロール起動メッセージ — agmsg ロールを引き受け、その後そのロールのプロンプトを貼り付ける:
+
+- **Claude**: `/agmsg actas <role>`（スラッシュコマンド）
+- **Codex**: `$agmsg actas <role>`
+
 ## design ハンドオフ（start / resume）
 
 セットアップはロール登録で終わりません。agmsg ロールが登録されて ready になった後、**design
@@ -418,6 +444,29 @@ resume）します。その後 orchestrator がループを自律的に駆動し
   受信したか（`inbox.sh`）、`worker next-action` / `intent status` が **この** domain/repo に対して
   実行可能項目を報告しているか（host repo に見える別ドメインではない）を確認する。issue-cut-ready で
   安全なら、orchestrator は待たずに自分で 1 つ issue を publish すべき。
+
+## design traffic-controller プレイブック
+
+design スレッドは実装者ではなく **traffic controller**（交通整理役）として振る舞います。
+orchestrator を通じて調整し、人間が必要な項目だけを surface します。
+
+1. design inbox（`inbox.sh`）を確認し、orchestrator のエスカレーション/サマリーを読む。
+2. intent-cli / GitHub の **read-only** state（`intent status`、`worker next-action`、PR/issue/
+   labels）を確認して判断の根拠にする — agmsg メッセージを state として信用しない。
+3. orchestrator に state 更新や nudge（start/resume）を送る。implementation/review を自分で
+   駆動しない。
+4. implementation/review の作業・labels・host メタデータを直接 **変更しない** — それは
+   orchestrator/receivers が intent-cli 経由で行う仕事。
+5. 人間が必要な項目 **だけ** を人間に要約する。ルーチンな進捗は内部に留める。
+
+**「orchestrator が idle に見える」診断**（エスカレーション前）: orchestrator がスケジュールされ
+新しい turn にあるか確認。最後のメッセージを受信したか確認（`inbox.sh`）— pre-monitor の送信は
+queue 済みでライブでない可能性があるので ack 後に resend。intent-cli が **この** domain/repo に
+実行可能項目を報告しているか確認（idle が正しい場合もある）。その後にのみ人間にエスカレーション。
+
+> **context-only:** design スレッドは receiver スレッドに context を送ってよいが、orchestrator が
+> アクションを委譲していない限り `context-only: <text>` とマークしなければならない — receiver は
+> design の context ではなく orchestrator の委譲にのみ反応する。
 
 ## preflight（3 つの cwd すべて）
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -499,6 +499,15 @@ preflight します。receiver が誤った repo・誤ったブランチ・dirty
   git remote・委譲された domain がルーティングと一致する必要がある。blocked を返して re-route する。
   execution-unit prefix の不一致だけでは signal にならない — packet/domain メタデータを比較する。
 
+## draft PR のレビュー可否
+
+**draft PR は domain guidance によってはレビュー可能** です — domain の review policy が許す場合、
+reviewer は draft に対してレビューフィードバックを行ってよいです。ただし reviewer は **canonical な
+intent-cli review surface**（`review closeout-plan`、`guide review`、`automation pr-transition`、
+`closeout pr`）を使わなければなりません。merge/approval はそれらの surface で gate され続けます。
+draft が手作業や生の label 編集で approve/merge されることはなく、host メタデータ編集を経ることも
+ありません。
+
 ## single-domain と multi-domain のオーケストレーション
 
 host チェックアウトは正当に **複数** の intent ドメインを含み得ます（例:

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -550,6 +550,75 @@ internal static class GuideOrchestratorThreadCommand
                     Action = "Confirm the orchestrator received the design start/resume message (`inbox.sh` on the orchestrator) and that `worker next-action` / `intent status` report an actionable item for THIS domain/repo (not another domain visible in the host repo). If issue-cut-ready and safe, the orchestrator should publish one issue itself rather than wait.",
                 },
             },
+            IntakeForm = new OrchestratorIntakeForm
+            {
+                Summary =
+                    "When the user asks only \"I want to use orchestrator mode\", elicit or infer the setup facts, then "
+                    + "produce the concrete commands/messages (see Setup intake / Setup). Ask for what is missing; apply "
+                    + "the recommended defaults for the rest.",
+                Questions = new[]
+                {
+                    "domain and target repo",
+                    "orchestrator cwd + agent type",
+                    "implementation receiver cwd + agent type",
+                    "review receiver cwd + agent type",
+                    "design cwd + agent type, and whether design is manual-inbox or monitored",
+                    "delivery mode per role (monitored / streamed inbox watch, or manual inbox)",
+                },
+                Defaults = new[]
+                {
+                    "orchestrator = Claude",
+                    "implementer = Claude",
+                    "reviewer = Codex",
+                    "design = manual-inbox Codex",
+                    "runtime / implementation / review receivers = monitor (when supported)",
+                },
+                DesignDeliveryNote =
+                    "Design may be a manual-inbox receiver (reads with `inbox.sh` on demand) or a monitored receiver; "
+                    + "either way it receives ONLY human-decision escalations or explicit summaries, never routine "
+                    + "progress.",
+                RoleStartupMessages = new[]
+                {
+                    new OrchestratorRoleStartup
+                    {
+                        AgentType = "claude",
+                        ActasInvocation = "/agmsg actas <role>",
+                        Note = "In a Claude session, paste the slash-command form to assume the agmsg role, then paste that role's prompt from the Thread prompts section.",
+                    },
+                    new OrchestratorRoleStartup
+                    {
+                        AgentType = "codex",
+                        ActasInvocation = "$agmsg actas <role>",
+                        Note = "In a Codex session, paste the `$agmsg actas <role>` form to assume the agmsg role, then paste that role's prompt from the Thread prompts section.",
+                    },
+                },
+            },
+            DesignTrafficController = new OrchestratorDesignTrafficController
+            {
+                Summary =
+                    "The design thread acts as a TRAFFIC CONTROLLER, not an implementer. It coordinates through the "
+                    + "orchestrator and only surfaces human-needed items — it does not drive implementation/review or "
+                    + "mutate workflow state itself.",
+                Playbook = new[]
+                {
+                    "Check the design inbox (`inbox.sh`) for orchestrator escalations / summaries.",
+                    "Check intent-cli / GitHub READ-ONLY state (`intent status`, `worker next-action`, PR/issue/labels) to ground any decision — never trust an agmsg message as state.",
+                    "Send the orchestrator a state update or a nudge (start/resume); do not drive implementation/review yourself.",
+                    "Do NOT directly mutate implementation/review work, labels, or host metadata — that is the orchestrator/receivers' job through intent-cli.",
+                    "Summarize ONLY human-needed items to the human; keep routine progress internal.",
+                },
+                IdleDiagnostic = new[]
+                {
+                    "Confirm the orchestrator is actually scheduled and on a fresh turn (its `/loop` or Codex automation is running).",
+                    "Confirm it received your last message (`inbox.sh` on the orchestrator) — a pre-monitor send may be queued, not delivered live; resend after an ack.",
+                    "Confirm intent-cli actually reports an actionable item for THIS domain/repo (`worker next-action` / `intent status`) — idle may be correct (nothing to do).",
+                    "Only after these, escalate to the human as a structured decision.",
+                },
+                ContextOnlyRule =
+                    "The design thread MAY send context to a receiver thread, but MUST mark it context-only (e.g. "
+                    + "`context-only: <text>`) unless the orchestrator delegated the action — receivers act only on "
+                    + "orchestrator delegations, not on design context.",
+            },
             WorktreeManagement = new OrchestratorWorktreeManagement
             {
                 Summary =
@@ -1269,6 +1338,34 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"> **Warning:** {guide.Setup.Warning}");
         writer.WriteLine();
 
+        writer.WriteLine("## Setup intake form");
+        writer.WriteLine();
+        writer.WriteLine(guide.IntakeForm.Summary);
+        writer.WriteLine();
+        writer.WriteLine("### Ask for / infer");
+        writer.WriteLine();
+        foreach (var question in guide.IntakeForm.Questions)
+        {
+            writer.WriteLine($"- {question}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Recommended defaults (when inputs are incomplete)");
+        writer.WriteLine();
+        foreach (var fallback in guide.IntakeForm.Defaults)
+        {
+            writer.WriteLine($"- {fallback}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **design delivery** — {guide.IntakeForm.DesignDeliveryNote}");
+        writer.WriteLine();
+        writer.WriteLine("### Role startup messages (assume the agmsg role)");
+        writer.WriteLine();
+        foreach (var startup in guide.IntakeForm.RoleStartupMessages)
+        {
+            writer.WriteLine($"- **{startup.AgentType}** — `{startup.ActasInvocation}` — {startup.Note}");
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Preflight (all three cwds)");
         writer.WriteLine();
         writer.WriteLine(guide.Preflight.Summary);
@@ -1565,6 +1662,27 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"- **design inbox workflow** — {guide.DesignHandoff.DesignInboxWorkflow}");
         writer.WriteLine();
 
+        writer.WriteLine("## Design traffic-controller playbook");
+        writer.WriteLine();
+        writer.WriteLine(guide.DesignTrafficController.Summary);
+        writer.WriteLine();
+        writer.WriteLine("### Playbook");
+        writer.WriteLine();
+        for (var i = 0; i < guide.DesignTrafficController.Playbook.Count; i++)
+        {
+            writer.WriteLine($"{i + 1}. {guide.DesignTrafficController.Playbook[i]}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### \"Orchestrator appears idle\" diagnostic (before escalating)");
+        writer.WriteLine();
+        for (var i = 0; i < guide.DesignTrafficController.IdleDiagnostic.Count; i++)
+        {
+            writer.WriteLine($"{i + 1}. {guide.DesignTrafficController.IdleDiagnostic[i]}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"> **Context-only:** {guide.DesignTrafficController.ContextOnlyRule}");
+        writer.WriteLine();
+
         writer.WriteLine("## Managed worktree cleanup");
         writer.WriteLine();
         writer.WriteLine(guide.WorktreeManagement.Summary);
@@ -1777,6 +1895,12 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("monitor_recovery")]
     public required IReadOnlyList<OrchestratorTroubleshooting> MonitorRecovery { get; init; }
 
+    [JsonPropertyName("intake_form")]
+    public required OrchestratorIntakeForm IntakeForm { get; init; }
+
+    [JsonPropertyName("design_traffic_controller")]
+    public required OrchestratorDesignTrafficController DesignTrafficController { get; init; }
+
     [JsonPropertyName("worktree_management")]
     public required OrchestratorWorktreeManagement WorktreeManagement { get; init; }
 
@@ -1911,6 +2035,51 @@ internal sealed record OrchestratorWorktreeManagement
 
     [JsonPropertyName("approval_policy_note")]
     public required string ApprovalPolicyNote { get; init; }
+}
+
+internal sealed record OrchestratorIntakeForm
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("questions")]
+    public required IReadOnlyList<string> Questions { get; init; }
+
+    [JsonPropertyName("defaults")]
+    public required IReadOnlyList<string> Defaults { get; init; }
+
+    [JsonPropertyName("design_delivery_note")]
+    public required string DesignDeliveryNote { get; init; }
+
+    [JsonPropertyName("role_startup_messages")]
+    public required IReadOnlyList<OrchestratorRoleStartup> RoleStartupMessages { get; init; }
+}
+
+internal sealed record OrchestratorRoleStartup
+{
+    [JsonPropertyName("agent_type")]
+    public required string AgentType { get; init; }
+
+    [JsonPropertyName("actas_invocation")]
+    public required string ActasInvocation { get; init; }
+
+    [JsonPropertyName("note")]
+    public required string Note { get; init; }
+}
+
+internal sealed record OrchestratorDesignTrafficController
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("playbook")]
+    public required IReadOnlyList<string> Playbook { get; init; }
+
+    [JsonPropertyName("idle_diagnostic")]
+    public required IReadOnlyList<string> IdleDiagnostic { get; init; }
+
+    [JsonPropertyName("context_only_rule")]
+    public required string ContextOnlyRule { get; init; }
 }
 
 internal sealed record OrchestratorDesignHandoff

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -275,6 +275,12 @@ internal static class GuideOrchestratorThreadCommand
                     },
                 },
             },
+            DraftPrReviewability =
+                "A DRAFT PR may still be reviewable depending on domain guidance — a reviewer MAY perform review "
+                + "feedback on a draft when the domain's review policy allows it. But the reviewer must use the canonical "
+                + "intent-cli review surfaces (`review closeout-plan`, `guide review`, `automation pr-transition`, "
+                + "`closeout pr`); merge/approval stays gated by those surfaces. A draft is never approved/merged by hand "
+                + "or by raw label edits, and never via host-metadata editing.",
             NextSlicePublication = new OrchestratorNextSlicePublication
             {
                 Summary =
@@ -1497,6 +1503,11 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Draft PR reviewability");
+        writer.WriteLine();
+        writer.WriteLine(guide.DraftPrReviewability);
+        writer.WriteLine();
+
         writer.WriteLine("## Next-slice publication");
         writer.WriteLine();
         writer.WriteLine(guide.NextSlicePublication.Summary);
@@ -1873,6 +1884,9 @@ internal sealed record OrchestratorThreadGuide
 
     [JsonPropertyName("ci_wait_state")]
     public required OrchestratorCiWaitState CiWaitState { get; init; }
+
+    [JsonPropertyName("draft_pr_reviewability")]
+    public required string DraftPrReviewability { get; init; }
 
     [JsonPropertyName("next_slice_publication")]
     public required OrchestratorNextSlicePublication NextSlicePublication { get; init; }

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -1129,6 +1129,32 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_DraftPrReviewability_DocumentsDomainGatedReviewViaCanonicalSurfaces_G510()
+    {
+        var markdown = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Draft PR reviewability", markdown, StringComparison.Ordinal);
+        // A draft may still be reviewable depending on domain guidance.
+        Assert.Contains("DRAFT PR may still be reviewable depending on domain guidance", markdown, StringComparison.Ordinal);
+        // But review/merge/approval go through canonical intent-cli review surfaces.
+        Assert.Contains("canonical", markdown, StringComparison.Ordinal);
+        Assert.Contains("review closeout-plan", markdown, StringComparison.Ordinal);
+        Assert.Contains("closeout pr", markdown, StringComparison.Ordinal);
+        // No raw label / host-metadata editing.
+        Assert.Contains("never approved/merged by hand or by raw label edits", markdown, StringComparison.Ordinal);
+
+        using var writer = new StringWriter();
+        GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var note = doc.RootElement.GetProperty("draft_pr_reviewability").GetString()!;
+        Assert.Contains("reviewable depending on domain guidance", note, StringComparison.Ordinal);
+        Assert.Contains("review closeout-plan", note, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -1062,6 +1062,73 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_IntakeForm_HasQuestionsDefaultsAndActasMessages_G510()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Setup intake form", output, StringComparison.Ordinal);
+        // Questions elicited/inferred include design cwd/type + manual-inbox-vs-monitored.
+        Assert.Contains("### Ask for / infer", output, StringComparison.Ordinal);
+        Assert.Contains("orchestrator cwd + agent type", output, StringComparison.Ordinal);
+        Assert.Contains("design cwd + agent type, and whether design is manual-inbox or monitored", output, StringComparison.Ordinal);
+        Assert.Contains("delivery mode per role", output, StringComparison.Ordinal);
+        // Recommended defaults: orchestrator=Claude, implementer=Claude, reviewer=Codex, design=manual Codex, receivers=monitor.
+        Assert.Contains("orchestrator = Claude", output, StringComparison.Ordinal);
+        Assert.Contains("reviewer = Codex", output, StringComparison.Ordinal);
+        Assert.Contains("design = manual-inbox Codex", output, StringComparison.Ordinal);
+        Assert.Contains("receivers = monitor", output, StringComparison.Ordinal);
+        // Role startup messages: Claude /agmsg actas vs Codex $agmsg actas.
+        Assert.Contains("`/agmsg actas <role>`", output, StringComparison.Ordinal);
+        Assert.Contains("`$agmsg actas <role>`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_DesignTrafficController_HasPlaybookIdleDiagnosticAndContextOnly_G510()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("## Design traffic-controller playbook", output, StringComparison.Ordinal);
+        Assert.Contains("TRAFFIC CONTROLLER, not an implementer", output, StringComparison.Ordinal);
+        // Playbook: inbox, read-only state, nudge, no direct mutation, summarize only human-needed.
+        Assert.Contains("Check the design inbox", output, StringComparison.Ordinal);
+        Assert.Contains("READ-ONLY state", output, StringComparison.Ordinal);
+        Assert.Contains("Do NOT directly mutate", output, StringComparison.Ordinal);
+        Assert.Contains("Summarize ONLY human-needed", output, StringComparison.Ordinal);
+        // Idle diagnostic before escalating.
+        Assert.Contains("\"Orchestrator appears idle\" diagnostic", output, StringComparison.Ordinal);
+        // Context-only rule for design -> receiver.
+        Assert.Contains("Context-only:", output, StringComparison.Ordinal);
+        Assert.Contains("mark it context-only", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasIntakeFormAndTrafficControllerShape_G510()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+
+        var intake = doc.RootElement.GetProperty("intake_form");
+        Assert.NotEmpty(intake.GetProperty("questions").EnumerateArray());
+        Assert.NotEmpty(intake.GetProperty("defaults").EnumerateArray());
+        var startupTypes = intake.GetProperty("role_startup_messages").EnumerateArray()
+            .Select(s => s.GetProperty("agent_type").GetString())
+            .ToArray();
+        Assert.Contains("claude", startupTypes);
+        Assert.Contains("codex", startupTypes);
+
+        var controller = doc.RootElement.GetProperty("design_traffic_controller");
+        Assert.NotEmpty(controller.GetProperty("playbook").EnumerateArray());
+        Assert.NotEmpty(controller.GetProperty("idle_diagnostic").EnumerateArray());
+        Assert.Contains("context-only", controller.GetProperty("context_only_rule").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Closes #1121. A SekibanWasmRuntime trial went smoothly once the operator supplied complete setup facts (orchestrator=Claude, implementer=Claude, reviewer=Codex, runtime receivers=monitor, design=manual inbox, concrete folders/domain/repo). Turn that into guide behavior: elicit/infer the missing facts, apply sensible defaults, and give the design thread a traffic-controller workflow. Builds on G508/G509.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `intake_form` section** in the guide:
  - the **questions to ask/infer** (domain, target repo, orchestrator/implementation/review/design cwd + agent type, design manual-inbox-vs-monitored, delivery mode per role);
  - **recommended defaults** when inputs are incomplete (orchestrator=Claude, implementer=Claude, reviewer=Codex, design=manual-inbox Codex, runtime/impl/review receivers=monitor when supported);
  - **role startup messages** — Claude `/agmsg actas <role>` vs Codex `$agmsg actas <role>`;
  - design receives only human-decision escalations or summaries.
- **New `design_traffic_controller` section**: a playbook (check inbox, read-only intent-cli/GitHub state, nudge orchestrator, no direct implementation/review/label/host mutation, summarize only human-needed), a safe **"orchestrator appears idle" diagnostic** before escalating, and a **context-only rule** for design→receiver messages.
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ On a general request, the guide asks for/infers domain, target repo, orchestrator/implementation/review/design cwd+type, delivery mode per role, and design manual-inbox-vs-monitored.
- ✅ Recommended defaults provided (orchestrator=Claude, implementer=Claude, reviewer=Codex, design=manual Codex, runtime receivers=monitor).
- ✅ Startup messages per role: Claude `/agmsg actas ...` vs Codex `$agmsg actas ...`.
- ✅ Design-thread traffic-controller playbook (inbox, read-only state, nudge, no direct mutation, summarize human-needed only).
- ✅ Safe "orchestrator appears idle" diagnostic before escalating.
- ✅ Design may send context to receivers but must mark it context-only unless the orchestrator delegated the action.
- ✅ Mode-separated; does not mix orchestrator-message with same-domain timer loops.
- ✅ agmsg remains transport; intent-cli/GitHub remain authority.

## Verification

- `intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent claude --mode single-domain --format markdown` — renders the Setup intake form + Design traffic-controller playbook; prior sections intact.
- `intent-cli guide prompt-matrix --format markdown` — orchestrator-message mode still discoverable.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 51 passed.
- `dotnet test` (full Cli suite) — 3173 passed, 1 skipped.
- `git diff --check` — clean.

## Scope note

The Related Links `intents/**` intent-tree write-back is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR satisfies the `src/**` + `docs/**` target paths and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb