### PR TITLE
G511 Document Claude Code Monitor tool vs agmsg delivery-mode for orchestrator inbox streaming

### DIFF
--- a/docs/en/orchestrator-message-mode.md
+++ b/docs/en/orchestrator-message-mode.md
@@ -1,0 +1,69 @@
+# Orchestrator-message mode — Monitor tool vs delivery-mode
+
+← [Agent-message orchestration](12-agent-message-orchestration.md) | [docs index](README.md)
+
+This page documents one operationally critical distinction for orchestrator-message
+mode: **Claude Code's `Monitor` tool is the real mechanism that streams agmsg inbox
+messages into a receiver, and agmsg's `delivery.sh status` `mode=monitor` is only
+configuration — not proof that a Monitor is attached and streaming.** The
+authoritative, paste-ready guidance is rendered by installed intent-cli — generate it
+with:
+
+```text
+intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --format markdown
+```
+
+This page mirrors the **Monitor tool vs delivery-mode (G511)** section of that guide so
+the published docs and the guide stay in sync. The verification/repair checklist below
+is what tells a healthy receiver from a silently broken one.
+
+## Why "monitor" is overloaded
+
+The word "monitor" names three unrelated things, so operators and agents cannot tell a
+healthy receiver from a silently broken one until the distinction is named:
+
+1. Claude Code's generic `Monitor` tool — the real inbox-stream delivery mechanism.
+2. agmsg's `delivery.sh` `mode=monitor` configuration.
+3. Unrelated `Azure Monitor` / other MCP `monitor` tools.
+
+Claude Code's `Monitor` is a generic Claude Code tool — the real mechanism that streams
+the agmsg inbox into a receiver. agmsg attaches it by launching `watch.sh` from the
+Claude Code SessionStart directive; the running Monitor task is what turns incoming
+agmsg lines into live transcript events.
+
+agmsg `delivery.sh status` `mode=monitor` is configuration only and is **not** proof
+that a Monitor tool is attached and streaming — a receiver can report `mode=monitor`
+while no Claude Code `Monitor` is running and nothing is delivered live. Confirm live
+attachment with the success markers below, not with the delivery mode alone.
+
+## Live-attachment success markers
+
+Verify all four to confirm the inbox stream is live:
+
+- `ToolSearch select:Monitor` resolves Monitor in the receiver session (the tool is available).
+- the transcript shows `Monitor(agmsg inbox stream)` — the Monitor tool attached to the inbox stream.
+- the Claude Code footer shows `1 monitor` (a live Monitor task is attached).
+- the transcript shows `Monitor event` lines as inbox messages arrive (the stream is live).
+
+## Failure markers
+
+A receiver reporting `mode=monitor` may still be silently broken:
+
+- delivery falls back to a plain `Bash` / background `watch.sh` task instead of an attached Monitor — no live stream.
+- the footer shows `1 shell` instead of `1 monitor` (a background shell is running, not a Monitor).
+- confusion with `Azure Monitor` / other MCP `monitor` tools — those are unrelated to agmsg inbox streaming and never prove attachment.
+
+## Trust-repair runbook
+
+When the success markers are missing:
+
+- Root cause: the exact-cwd project key in `~/.claude.json` with
+  `hasTrustDialogAccepted=false` suppresses the SessionStart directive that launches
+  Monitor, so no Monitor attaches and the inbox never streams (the receiver still reports
+  `mode=monitor`).
+- Repair (operator action only): repair Claude project trust for that exact cwd, restart
+  the receiver session, then re-verify the success markers above. intent-cli never
+  auto-detects or edits `~/.claude.json`.
+
+This page does not change agmsg scripts (`watch.sh` / `delivery.sh`) and intent-cli does
+not edit `~/.claude.json`; the trust repair is an operator action only.

--- a/docs/ja/orchestrator-message-mode.md
+++ b/docs/ja/orchestrator-message-mode.md
@@ -1,0 +1,68 @@
+# orchestrator-message モード — Monitor ツールと delivery-mode の違い
+
+← [agent メッセージオーケストレーション](12-agent-message-orchestration.md) | [docs インデックス](README.md)
+
+このページは orchestrator-message モードにおける運用上きわめて重要な 1 つの区別を
+ドキュメント化します: **Claude Code の `Monitor` ツールこそが agmsg inbox のメッセージ
+を receiver にストリーミングする実際の仕組みであり、agmsg の `delivery.sh status`
+`mode=monitor` は設定にすぎず、Monitor が attach されてストリーミングしている証明には
+ならない、という点です。** 権威ある貼り付け可能なガイダンスはインストール済みの
+intent-cli が生成します。次で生成してください:
+
+```text
+intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --format markdown
+```
+
+このページはそのガイドの **Monitor tool vs delivery-mode (G511)** セクションを反映し、
+公開ドキュメントとガイドが同期し続けるようにします。以下の検証/修復チェックリストが、
+健全な receiver と無言で壊れた receiver を見分ける手段です。
+
+## なぜ "monitor" は紛らわしいのか
+
+"monitor" という語は無関係な 3 つのものを指すため、区別が明示されるまで、operator や
+agent は健全な receiver と無言で壊れた receiver を見分けられません:
+
+1. Claude Code の汎用 `Monitor` ツール — inbox ストリーム配信の実際の仕組み。
+2. agmsg の `delivery.sh` `mode=monitor` 設定。
+3. 無関係な `Azure Monitor` / その他 MCP の `monitor` ツール。
+
+Claude Code の `Monitor` は汎用の Claude Code ツールであり、agmsg inbox を receiver に
+ストリーミングする実際の仕組みです。agmsg は Claude Code の SessionStart ディレクティブ
+から `watch.sh` を起動して `Monitor` を attach します。実行中の Monitor タスクこそが、
+到着する agmsg の行をライブの transcript イベントに変えます。
+
+agmsg `delivery.sh status` `mode=monitor` は設定にすぎず、Monitor ツールが attach されて
+ストリーミングしている **証明にはなりません**。receiver は `mode=monitor` と報告しつつ、
+Claude Code の `Monitor` が一切実行されておらずライブ配信が何もない、という状態があり得ます。
+ライブ attach は delivery mode だけでなく、以下の success marker で確認してください。
+
+## ライブ attach の success marker
+
+inbox ストリームがライブであることを確認するため、4 つすべてを検証します:
+
+- `ToolSearch select:Monitor` resolves Monitor — receiver セッションで Monitor が解決される（ツールが利用可能）。
+- transcript に `Monitor(agmsg inbox stream)` が表示される — Monitor ツールが inbox ストリームに attach されている。
+- Claude Code のフッターに `1 monitor` が表示される（ライブの Monitor タスクが attach されている）。
+- inbox メッセージ到着時に transcript へ `Monitor event` の行が表示される（ストリームがライブ）。
+
+## failure marker
+
+`mode=monitor` を報告していても receiver が無言で壊れていることがあります:
+
+- 配信が attach された Monitor ではなく、素の `Bash` / バックグラウンドの `watch.sh` タスクへ fallback している — ライブストリームなし。
+- フッターに `1 monitor` ではなく `1 shell` が表示される（Monitor ではなくバックグラウンドシェルが実行中）。
+- `Azure Monitor` / その他 MCP の `monitor` ツールとの混同 — これらは agmsg inbox ストリーミングと無関係で、attach の証明にはなりません。
+
+## trust 修復 runbook
+
+success marker が欠けている場合:
+
+- 根本原因: `~/.claude.json` の exact-cwd の project キーが `hasTrustDialogAccepted=false`
+  だと、Monitor を起動する SessionStart ディレクティブが抑制され、Monitor が attach されず
+  inbox がストリーミングされません（receiver は依然として `mode=monitor` を報告します）。
+- 修復（operator のアクションのみ）: その exact cwd について Claude project trust を修復し、
+  receiver セッションを再起動してから、上記の success marker を再検証します。intent-cli は
+  `~/.claude.json` を自動検出も自動編集もしません。
+
+このページは agmsg スクリプト（`watch.sh` / `delivery.sh`）を変更せず、intent-cli は
+`~/.claude.json` を編集しません。trust の修復は operator のアクションのみです。

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -556,6 +556,38 @@ internal static class GuideOrchestratorThreadCommand
                     Action = "Confirm the orchestrator received the design start/resume message (`inbox.sh` on the orchestrator) and that `worker next-action` / `intent status` report an actionable item for THIS domain/repo (not another domain visible in the host repo). If issue-cut-ready and safe, the orchestrator should publish one issue itself rather than wait.",
                 },
             },
+            MonitorToolDistinction = new OrchestratorMonitorDistinction
+            {
+                Summary =
+                    "Claude Code's `Monitor` is a generic Claude Code tool — the real mechanism that streams the agmsg "
+                    + "inbox into a receiver. agmsg attaches it by launching `watch.sh` from the Claude Code SessionStart "
+                    + "directive; the running Monitor task is what turns incoming agmsg lines into live transcript events. "
+                    + "The word \"monitor\" is overloaded — do NOT confuse this Claude Code `Monitor` tool with agmsg's "
+                    + "delivery-mode config or with unrelated `Azure Monitor` / other MCP `monitor` tools.",
+                DeliveryModeNote =
+                    "agmsg `delivery.sh status` `mode=monitor` is configuration only and is NOT proof that a Monitor tool "
+                    + "is attached and streaming — a receiver can report `mode=monitor` while no Claude Code `Monitor` is "
+                    + "running and nothing is delivered live. Confirm live attachment with the success markers below, not "
+                    + "with the delivery mode alone.",
+                SuccessMarkers = new[]
+                {
+                    "`ToolSearch select:Monitor` resolves Monitor in the receiver session (the tool is available).",
+                    "the transcript shows `Monitor(agmsg inbox stream)` — the Monitor tool attached to the inbox stream.",
+                    "the Claude Code footer shows `1 monitor` (a live Monitor task is attached).",
+                    "the transcript shows `Monitor event` lines as inbox messages arrive (the stream is live).",
+                },
+                FailureMarkers = new[]
+                {
+                    "delivery falls back to a plain `Bash` / background `watch.sh` task instead of an attached Monitor — no live stream.",
+                    "the footer shows `1 shell` instead of `1 monitor` (a background shell is running, not a Monitor).",
+                    "confusion with `Azure Monitor` / other MCP `monitor` tools — those are unrelated to agmsg inbox streaming and never prove attachment.",
+                },
+                TrustRepair = new[]
+                {
+                    "Root cause: the exact-cwd project key in `~/.claude.json` with `hasTrustDialogAccepted=false` suppresses the SessionStart directive that launches Monitor, so no Monitor attaches and the inbox never streams (the receiver still reports `mode=monitor`).",
+                    "Repair (operator action only): repair Claude project trust for that exact cwd, restart the receiver session, then re-verify the success markers above. intent-cli never auto-detects or edits `~/.claude.json`.",
+                },
+            },
             IntakeForm = new OrchestratorIntakeForm
             {
                 Summary =
@@ -1444,6 +1476,34 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Monitor tool vs delivery-mode (G511)");
+        writer.WriteLine();
+        writer.WriteLine(guide.MonitorToolDistinction.Summary);
+        writer.WriteLine();
+        writer.WriteLine(guide.MonitorToolDistinction.DeliveryModeNote);
+        writer.WriteLine();
+        writer.WriteLine("Live-attachment success markers — verify all four to confirm the inbox stream is live:");
+        writer.WriteLine();
+        foreach (var marker in guide.MonitorToolDistinction.SuccessMarkers)
+        {
+            writer.WriteLine($"- {marker}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("Failure markers — a receiver reporting `mode=monitor` may still be silently broken:");
+        writer.WriteLine();
+        foreach (var marker in guide.MonitorToolDistinction.FailureMarkers)
+        {
+            writer.WriteLine($"- {marker}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("Trust-repair runbook (when the success markers are missing):");
+        writer.WriteLine();
+        foreach (var step in guide.MonitorToolDistinction.TrustRepair)
+        {
+            writer.WriteLine($"- {step}");
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Domain routing — single-domain vs multi-domain");
         writer.WriteLine();
         writer.WriteLine($"- selected mode: `{guide.DomainRouting.Mode}`");
@@ -1909,6 +1969,9 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("monitor_recovery")]
     public required IReadOnlyList<OrchestratorTroubleshooting> MonitorRecovery { get; init; }
 
+    [JsonPropertyName("monitor_tool_distinction")]
+    public required OrchestratorMonitorDistinction MonitorToolDistinction { get; init; }
+
     [JsonPropertyName("intake_form")]
     public required OrchestratorIntakeForm IntakeForm { get; init; }
 
@@ -2226,6 +2289,24 @@ internal sealed record OrchestratorTroubleshooting
 
     [JsonPropertyName("action")]
     public required string Action { get; init; }
+}
+
+internal sealed record OrchestratorMonitorDistinction
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("delivery_mode_note")]
+    public required string DeliveryModeNote { get; init; }
+
+    [JsonPropertyName("success_markers")]
+    public required IReadOnlyList<string> SuccessMarkers { get; init; }
+
+    [JsonPropertyName("failure_markers")]
+    public required IReadOnlyList<string> FailureMarkers { get; init; }
+
+    [JsonPropertyName("trust_repair")]
+    public required IReadOnlyList<string> TrustRepair { get; init; }
 }
 
 internal sealed record OrchestratorReceiverReadiness

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -142,6 +142,59 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_DistinguishesMonitorToolFromDeliveryMode_WithVerificationAndRepairMarkers()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        // G511 section is present.
+        Assert.Contains("## Monitor tool vs delivery-mode (G511)", output, StringComparison.Ordinal);
+
+        // The distinction: Monitor is a generic Claude Code tool fed by agmsg via watch.sh from SessionStart.
+        Assert.Contains("`Monitor` is a generic Claude Code tool", output, StringComparison.Ordinal);
+        Assert.Contains("`watch.sh` from the Claude Code SessionStart", output, StringComparison.Ordinal);
+
+        // delivery-mode config is not proof of attachment.
+        Assert.Contains("`delivery.sh status` `mode=monitor` is configuration only", output, StringComparison.Ordinal);
+        Assert.Contains("NOT proof that a Monitor tool is attached and streaming", output, StringComparison.Ordinal);
+
+        // The four live-attachment success markers, in checkable form.
+        Assert.Contains("`ToolSearch select:Monitor` resolves Monitor", output, StringComparison.Ordinal);
+        Assert.Contains("`Monitor(agmsg inbox stream)`", output, StringComparison.Ordinal);
+        Assert.Contains("footer shows `1 monitor`", output, StringComparison.Ordinal);
+        Assert.Contains("`Monitor event`", output, StringComparison.Ordinal);
+
+        // The failure markers.
+        Assert.Contains("falls back to a plain `Bash` / background `watch.sh`", output, StringComparison.Ordinal);
+        Assert.Contains("footer shows `1 shell`", output, StringComparison.Ordinal);
+        Assert.Contains("`Azure Monitor` / other MCP `monitor` tools", output, StringComparison.Ordinal);
+
+        // The trust-repair runbook root cause and repair.
+        Assert.Contains("`~/.claude.json` with `hasTrustDialogAccepted=false` suppresses", output, StringComparison.Ordinal);
+        Assert.Contains("repair Claude project trust for that exact cwd, restart", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli never auto-detects or edits `~/.claude.json`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_CarriesMonitorToolDistinction_WithMarkerArrays()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var distinction = doc.RootElement.GetProperty("monitor_tool_distinction");
+
+        Assert.True(distinction.TryGetProperty("summary", out _));
+        Assert.True(distinction.TryGetProperty("delivery_mode_note", out _));
+        Assert.Equal(4, distinction.GetProperty("success_markers").GetArrayLength());
+        Assert.NotEmpty(distinction.GetProperty("failure_markers").EnumerateArray());
+        Assert.NotEmpty(distinction.GetProperty("trust_repair").EnumerateArray());
+    }
+
+    [Fact]
     public void Execute_Markdown_ImplementationThread_VerifiesLocalCheckoutBeforeClaiming()
     {
         var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);


### PR DESCRIPTION
Closes #1123

## Summary

Documents one operationally critical distinction for orchestrator-message mode: **Claude Code's generic `Monitor` tool is the real mechanism that streams the agmsg inbox into a receiver**, attached via `watch.sh` from the Claude Code SessionStart directive — and agmsg `delivery.sh status` `mode=monitor` is **configuration only**, not proof a Monitor is attached and streaming.

## Changes

- **`guide orchestrator-thread` surface** (`GuideOrchestratorThreadCommand.cs`): new `## Monitor tool vs delivery-mode (G511)` section rendered after Monitor recovery, plus a `monitor_tool_distinction` object in the JSON output. Contains:
  - the Monitor-tool vs delivery-mode distinction;
  - four live-attachment **success markers**: `ToolSearch select:Monitor` resolves Monitor; transcript `Monitor(agmsg inbox stream)`; footer `1 monitor`; transcript `Monitor event`;
  - **failure markers**: fallback to `Bash` / background `watch.sh`; footer `1 shell`; `Azure Monitor` / MCP `monitor` confusion;
  - **trust-repair runbook**: exact-cwd `~/.claude.json` `hasTrustDialogAccepted=false` suppresses Monitor → repair Claude project trust and restart, then re-verify.
- **Docs**: new `docs/en/orchestrator-message-mode.md` and `docs/ja/orchestrator-message-mode.md` mirroring the same distinction and verification/repair checklist.
- **Tests**: focused guide-rendering tests asserting the distinction, success/failure markers, and trust-repair guidance render in both markdown and JSON.

## Verification

- `dotnet test --filter "FullyQualifiedName~GuideOrchestratorThreadCommandTests"` → 54 passed.
- Full suite: 3176 passed, 1 skipped (pre-existing).
- `git diff --check` clean; diff touches only the guide surface, the two orchestrator-message-mode docs, and tests — no agmsg scripts, no `~/.claude.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)