### PR TITLE
G512: Prepare intent-cli v0.3.14 patch release metadata (G508-G511)

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -194,74 +194,83 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.3.12",
-  "nextVersion": "0.3.13"
-}
-```
-
-| Stage | Version form | How it is derived |
-| --- | --- | --- |
-| Local pack / install | `0.3.13-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.3.13-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.13-rc.N` | Tag `v0.3.13-rc.N` triggers release workflow |
-| Stable release | `0.3.13` | Tag `v0.3.13` triggers release workflow (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.3.14-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.14` |
-
-**After releasing `v0.3.13`**, bump both fields in `eng/version.json`:
-
-```json
-{
   "stableVersion": "0.3.13",
   "nextVersion": "0.3.14"
 }
 ```
 
+| Stage | Version form | How it is derived |
+| --- | --- | --- |
+| Local pack / install | `0.3.14-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.3.14-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.14-rc.N` | Tag `v0.3.14-rc.N` triggers release workflow |
+| Stable release | `0.3.14` | Tag `v0.3.14` triggers release workflow (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.3.15-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.15` |
+
+**After releasing `v0.3.14`**, bump both fields in `eng/version.json`:
+
+```json
+{
+  "stableVersion": "0.3.14",
+  "nextVersion": "0.3.15"
+}
+```
+
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.3.14-preview.<run>.<attempt>` / `0.3.14-<sha>-<G-unit>` rather than continuing to
-emit `0.3.13` (which would collide with the stable release version).
+`0.3.15-preview.<run>.<attempt>` / `0.3.15-<sha>-<G-unit>` rather than continuing to
+emit `0.3.14` (which would collide with the stable release version).
 
-### Next release readiness (v0.3.13)
+### Next release readiness (v0.3.14)
 
-**`v0.3.12` shipped** (GitHub Release + NuGet) and the version policy was bumped
-to the `0.3.13` development line. The repository is now on the in-development
-**`0.3.13`** `nextVersion`; G506 is **prepare-only** — it bumps the version
+**`v0.3.13` shipped** (GitHub Release + NuGet) and the version policy was bumped
+to the `0.3.14` development line. The repository is now on the in-development
+**`0.3.14`** `nextVersion`; G512 is **prepare-only** — it bumps the version
 metadata and docs and adds no publish steps. The version-bump merge does **not**
 create a GitHub Release or tag. After it merges and the
-[release-readiness gate](release-notes-v0.3.13.md#release-readiness-gate-g506)
+[release-readiness gate](release-notes-v0.3.14.md#release-readiness-gate-g512)
 holds, a **maintainer/operator (or external release automation) creates and
-publishes the GitHub Release** for `v0.3.13`; publishing that Release fires
+publishes the GitHub Release** for `v0.3.14`; publishing that Release fires
 `.github/workflows/release.yml` (`on: release: published`), which builds and
 publishes the NuGet package and the per-platform binary artifacts. Full
 changelog and operator checklist:
-[release-notes-v0.3.13.md](release-notes-v0.3.13.md).
+[release-notes-v0.3.14.md](release-notes-v0.3.14.md).
 
-**To ship in `v0.3.13` (changes since `v0.3.12`) — orchestrator-mode preview
-patch fix:**
+**To ship in `v0.3.14` (changes since `v0.3.13`) — orchestrator-mode preview
+guidance patch:**
 
-- **design-thread agmsg receiver guidance** (G505) — the orchestrator-thread
-  guide now documents an optional fourth role, a design/human receiver, so
-  human-needed escalations can be delivered over agmsg (including manual inbox
-  checks) while routine progress stays internal to orchestrator/implementation/
-  review. Implementation/review stay loopless.
+- **concrete agmsg startup steps** (G508) — the orchestrator setup guide
+  produces actionable, ordered, copy-paste agmsg setup/startup/troubleshooting
+  steps from a three-folder request, plus a preflight of all three cwds.
+- **design-thread handoff + monitor recovery** (G509) — the first design→
+  orchestrator start/resume message, autonomous one-issue-per-wake publish, and
+  a monitor-recovery checklist.
+- **setup intake form + traffic-controller playbook** (G510) — eliciting/inferring
+  the setup facts with recommended defaults, role startup messages, and a design
+  traffic-controller playbook; plus the draft-PR reviewability rule via canonical
+  review surfaces.
+- **Claude Code Monitor vs agmsg delivery-mode** (G511) — distinguishes Claude
+  Code's `Monitor` tool (the real inbox-stream mechanism) from agmsg
+  `delivery.sh mode=monitor` config, with live-attachment success/failure markers
+  and a project-trust repair runbook.
 - Orchestrator mode remains **preview/experimental**: opt-in, still being
   hardened, with the timer-loop mode fully supported and unchanged. See
   [Agent-message orchestration](12-agent-message-orchestration.md).
 
-**Release-readiness verification (run before merging the `v0.3.13` version
+**Release-readiness verification (run before merging the `v0.3.14` version
 bump):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.3.12 (published), nextVersion 0.3.13 (to release)
+cat eng/version.json   # stableVersion 0.3.13 (published), nextVersion 0.3.14 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.3.13-<sha>-G50x   (NOT a stale literal)
+#   expected shape: intent-cli 0.3.14-<sha>-G51x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.13.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.14.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -269,11 +278,11 @@ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
 ```
 
 After the version-bump merge lands on `main`, a maintainer/operator (or external
-release automation) creates and publishes the GitHub Release for `v0.3.13`;
+release automation) creates and publishes the GitHub Release for `v0.3.14`;
 publishing it triggers `release.yml` (`on: release: published`) to build and
 publish the NuGet package and the per-platform binary artifacts. Once it has
 published, apply the post-release `eng/version.json` bump above
-(`stableVersion → 0.3.13`, `nextVersion → 0.3.14`).
+(`stableVersion → 0.3.14`, `nextVersion → 0.3.15`).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -203,8 +203,8 @@ literal:
 | --- | --- | --- |
 | Local pack / install | `0.3.14-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
 | Main CI preview | `0.3.14-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.14-rc.N` | Tag `v0.3.14-rc.N` triggers release workflow |
-| Stable release | `0.3.14` | Tag `v0.3.14` triggers release workflow (`-p:Version=<tag>` wins) |
+| Release candidate (optional) | `0.3.14-rc.N` | Publishing the GitHub Release for tag `v0.3.14-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
+| Stable release | `0.3.14` | Publishing the GitHub Release for tag `v0.3.14` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
 | Post-release main builds | `0.3.15-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.15` |
 
 **After releasing `v0.3.14`**, bump both fields in `eng/version.json`:

--- a/docs/en/release-notes-v0.3.14.md
+++ b/docs/en/release-notes-v0.3.14.md
@@ -1,0 +1,148 @@
+# Release Notes — intent-cli v0.3.14
+
+> **Release model:** a maintainer/operator (or external release automation)
+> **creates and publishes the GitHub Release** for `v0.3.14` — the version-bump
+> merge does **not** create a Release or tag on its own. Publishing the GitHub
+> Release fires `.github/workflows/release.yml` (`on: release: published`), which
+> then builds and publishes the NuGet package and platform binary artifacts.
+> This packet is **prepare-only**: it bumps version metadata and docs and adds
+> **no** publish steps. See the
+> [pre-merge release-readiness gate](#release-readiness-gate-g512) and
+> [publishing v0.3.14](#publishing-v0314).
+
+## What's in v0.3.14
+
+v0.3.14 is a **patch release** that ships the orchestrator-mode guidance work
+completed after `v0.3.13` (G508–G511). No package id, license, or
+workflow-semantics changes, and the existing timer-loop mode is fully supported
+and unchanged. The package id remains `JTechJapan.IntentSystem.Cli`.
+
+> **Orchestrator mode is still preview/experimental.** It is opt-in, still being
+> hardened, and not the default workflow. intent-cli and GitHub remain the
+> authoritative source of truth; agmsg is only a message/progress/completion
+> signal layer.
+
+### Concrete agmsg startup steps in the setup guide (G508)
+
+- The orchestrator-thread guide (`intent-cli guide orchestrator-thread`) now
+  produces **concrete agmsg startup steps** — a preflight and copy-paste
+  registration/delivery commands plus first role prompts — so an operator can
+  bring up the orchestrator, implementation, and review receivers without
+  guessing the sequence.
+
+### Design-thread handoff and monitor recovery (G509)
+
+- The guide documents the **design-thread handoff** and a **monitor recovery**
+  checklist for orchestrator mode: what to do when a receiver's monitor did not
+  start, a message is not visible, or a receiver started after a message was
+  sent (read with `inbox.sh`, re-confirm registration/delivery, resend after an
+  ack).
+
+### Setup intake form and traffic-controller playbook (G510)
+
+- The guide renders a **setup intake form** (with `missing-inputs` /
+  `setup-ready` / `blocked` outcomes) and a **design traffic-controller
+  playbook**, so a design thread that asks for orchestrator mode is walked
+  through the required inputs and the routing/escalation rules.
+
+### Monitor tool vs agmsg delivery-mode (G511)
+
+- The guide and the new `orchestrator-message-mode` docs distinguish Claude
+  Code's generic **`Monitor` tool** (the real inbox-stream delivery mechanism,
+  attached by agmsg via `watch.sh` from the SessionStart directive) from agmsg's
+  `delivery.sh status` `mode=monitor` configuration (which is **not** proof a
+  Monitor is attached and streaming). They add a **live-attachment
+  success-marker** list (`ToolSearch select:Monitor` resolves Monitor;
+  `Monitor(agmsg inbox stream)`; footer `1 monitor`; `Monitor event`), a
+  **failure-marker** list (fallback to Bash/background `watch.sh`; footer
+  `1 shell`; Azure Monitor / MCP monitor confusion), and a **project-trust
+  repair runbook** (exact-cwd `~/.claude.json` `hasTrustDialogAccepted=false`
+  suppresses Monitor → repair Claude project trust and restart, then re-verify).
+
+> Version metadata note: `eng/version.json` records `stableVersion: 0.3.13`,
+> `nextVersion: 0.3.14`; G512 (this packet) is the release-prep metadata bump.
+> The post-v0.3.14 metadata advancement (`stableVersion → 0.3.14`,
+> `nextVersion → 0.3.15`) is the operator's post-release step and is out of scope
+> for this packet.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.14
+```
+
+Or download the self-contained binary from the
+[v0.3.14 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.14).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.13
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.14
+```
+
+There are no breaking changes from v0.3.13. Orchestrator mode remains opt-in;
+existing timer-loop setups are unaffected.
+
+## Release-readiness gate (G512)
+
+These items must hold **before the GitHub Release for `v0.3.14` is published**.
+This gate fails closed — if any item is unmet, do not publish the Release yet.
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G508, G509, G510, G511 (and G512 this prep). Confirm on the host/review
+      side via the host queue-state / GitHub PR state — the child implementation
+      loop must not read parent queue-state, so this is a host-owned precondition.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before publishing).
+- [ ] `eng/version.json` `nextVersion` is `0.3.14` (the intended release
+      version). `release.yml` builds the package version from the published
+      Release/tag; `src/IntentSystem.Cli/IntentSystem.Cli.csproj` derives its
+      local default from the same policy.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] Release notes / README keep **orchestrator mode described as
+      preview/experimental** and opt-in, with timer-loop mode unchanged.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+
+## Publishing v0.3.14
+
+This packet does **not** publish the release and adds **no** publish steps. The
+version-bump merge does **not** create a GitHub Release or tag on its own.
+
+1. After this version bump is merged and the readiness gate above holds, a
+   **maintainer/operator (or external release automation) creates and publishes
+   the GitHub Release** for `v0.3.14` (tagging the release commit). This is a
+   post-merge host/operator/external action.
+2. Publishing that GitHub Release fires `.github/workflows/release.yml`
+   (`on: release: published`), which builds and publishes the NuGet package and
+   the per-platform binary archives (with `.sha256` checksums) and attaches them
+   to the triggering Release.
+
+Post-release verification (after the GitHub Release is published and
+`release.yml` has run):
+
+- [ ] NuGet.org package page links all resolve correctly.
+- [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+      accessible.
+- [ ] `.sha256` checksums match the downloaded artifacts.
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.14`)
+      then `intent-cli --version` reports `0.3.14`.
+- [ ] Binary artifact smoke check: download the platform archive, verify its
+      `.sha256`, extract, and run `./intent-cli --version` → `0.3.14`.
+- [ ] **Orchestrator guide smoke** (G508–G511): `intent-cli guide
+      orchestrator-thread --domain <d> --target-repo <repo> --agent <agent>
+      --format markdown` renders the concrete agmsg startup steps, the
+      design-thread handoff / monitor recovery, the setup intake form and
+      traffic-controller playbook, and the **Monitor tool vs delivery-mode**
+      section with the success/failure markers and trust-repair runbook.
+- [ ] Local preview/dry-run version metadata uses the next development line
+      after `0.3.14` (bump `eng/version.json` per the post-release step in
+      [Version flow](09-developer-reference.md#version-flow)):
+      `stableVersion → 0.3.14`, `nextVersion → 0.3.15`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -193,8 +193,8 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 | --- | --- | --- |
 | ローカル pack / install | `0.3.14-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
 | Main CI preview | `0.3.14-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.14-rc.N` | タグ `v0.3.14-rc.N` がリリースワークフローをトリガー |
-| 安定版リリース | `0.3.14` | タグ `v0.3.14` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
+| リリース候補（任意） | `0.3.14-rc.N` | タグ `v0.3.14-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
+| 安定版リリース | `0.3.14` | タグ `v0.3.14` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
 | リリース後の main ビルド | `0.3.15-preview.<run>.<attempt>` | `nextVersion` を `0.3.15` にバンプ後 |
 
 **`v0.3.14` リリース後**、`eng/version.json` の両フィールドをバンプしてください:

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -184,74 +184,81 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.3.12",
-  "nextVersion": "0.3.13"
-}
-```
-
-| ステージ | バージョン形式 | 導出方法 |
-| --- | --- | --- |
-| ローカル pack / install | `0.3.13-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.3.13-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.13-rc.N` | タグ `v0.3.13-rc.N` がリリースワークフローをトリガー |
-| 安定版リリース | `0.3.13` | タグ `v0.3.13` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.3.14-preview.<run>.<attempt>` | `nextVersion` を `0.3.14` にバンプ後 |
-
-**`v0.3.13` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
-
-```json
-{
   "stableVersion": "0.3.13",
   "nextVersion": "0.3.14"
 }
 ```
 
+| ステージ | バージョン形式 | 導出方法 |
+| --- | --- | --- |
+| ローカル pack / install | `0.3.14-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.3.14-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.3.14-rc.N` | タグ `v0.3.14-rc.N` がリリースワークフローをトリガー |
+| 安定版リリース | `0.3.14` | タグ `v0.3.14` がリリースワークフローをトリガー（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.3.15-preview.<run>.<attempt>` | `nextVersion` を `0.3.15` にバンプ後 |
+
+**`v0.3.14` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+
+```json
+{
+  "stableVersion": "0.3.14",
+  "nextVersion": "0.3.15"
+}
+```
+
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.3.14-preview.<run>.<attempt>` / `0.3.14-<sha>-<G-unit>` を生成し、`0.3.13`（安定版
+`0.3.15-preview.<run>.<attempt>` / `0.3.15-<sha>-<G-unit>` を生成し、`0.3.14`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備（v0.3.13）
+### 次リリース準備（v0.3.14）
 
-**`v0.3.12` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
-`0.3.13` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.13`**
-`nextVersion` 上にあり、G506 は **prepare-only** です — version メタデータと docs をバンプするだけで
+**`v0.3.13` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
+`0.3.14` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.14`**
+`nextVersion` 上にあり、G512 は **prepare-only** です — version メタデータと docs をバンプするだけで
 publish ステップを追加しません。version-bump マージ自体は GitHub Release やタグを作成しません。
 マージされ
-[リリース準備ゲート](release-notes-v0.3.13.md#リリース準備ゲート-g506)が成り立った後、
-**メンテナ/オペレーター（または外部のリリース automation）が `v0.3.13` の GitHub Release を作成・
+[リリース準備ゲート](release-notes-v0.3.14.md#リリース準備ゲート-g512)が成り立った後、
+**メンテナ/オペレーター（または外部のリリース automation）が `v0.3.14` の GitHub Release を作成・
 publish** します。その Release の publish が `.github/workflows/release.yml`（`on: release: published`）を
 発火させ、NuGet package とプラットフォームごとのバイナリ成果物を build・publish します。
 完全な changelog と operator チェックリスト:
-[release-notes-v0.3.13.md](release-notes-v0.3.13.md)。
+[release-notes-v0.3.14.md](release-notes-v0.3.14.md)。
 
-**`v0.3.13` で出荷予定（`v0.3.12` 以降の変更）— orchestrator モードプレビューのパッチ修正:**
+**`v0.3.14` で出荷予定（`v0.3.13` 以降の変更）— orchestrator モードプレビューのガイダンスパッチ:**
 
-- **design-thread agmsg receiver ガイダンス**（G505）— orchestrator-thread ガイドが、任意の
-  4 つ目のロールである design/human receiver を文書化し、人間が必要なエスカレーションを agmsg で
-  配信できる（手動の inbox 確認を含む）ようにしました。ルーチンな進捗は orchestrator/implementation/
-  review の内部に留まります。implementation/review は loopless のままです。
+- **具体的な agmsg 起動ステップ**（G508）— orchestrator setup ガイドが、3 フォルダーの要求から
+  実行可能で順序付き・貼り付け可能な agmsg setup/startup/troubleshooting ステップと、3 つの cwd の
+  preflight を生成します。
+- **design-thread ハンドオフ + monitor リカバリ**（G509）— 最初の design→orchestrator start/resume
+  メッセージ、wake ごとの自律的な 1 issue publish、monitor リカバリチェックリスト。
+- **setup intake フォーム + traffic-controller プレイブック**（G510）— セットアップ事実の引き出し/推論と
+  推奨デフォルト、ロール起動メッセージ、design traffic-controller プレイブック。draft-PR レビュー可否
+  （canonical review surface 経由）も含む。
+- **Claude Code Monitor vs agmsg delivery-mode**（G511）— Claude Code の `Monitor` ツール（実際の
+  inbox-stream の仕組み）と agmsg `delivery.sh mode=monitor` 設定を区別。live-attachment の
+  success/failure マーカーと project-trust 修復 runbook 付き。
 - orchestrator モードは引き続き **preview/experimental** です: オプトインで、まだ hardening 中であり、
   timer-loop モードは完全サポート・不変です。
   [エージェントメッセージオーケストレーション](12-agent-message-orchestration.md) を参照。
 
-**リリース準備の検証（`v0.3.13` version bump のマージ前に実行）:**
+**リリース準備の検証（`v0.3.14` version bump のマージ前に実行）:**
 
 ```bash
-cat eng/version.json   # stableVersion 0.3.12（公開済み）, nextVersion 0.3.13（リリース対象）
+cat eng/version.json   # stableVersion 0.3.13（公開済み）, nextVersion 0.3.14（リリース対象）
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.3.13-<sha>-G50x （stale なリテラルではない）
+#   期待形: intent-cli 0.3.14-<sha>-G51x （stale なリテラルではない）
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.13.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.14.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
 version-bump マージが `main` に入った後、メンテナ/オペレーター（または外部のリリース automation）が
-`v0.3.13` の GitHub Release を作成・publish します。その publish が `release.yml`
+`v0.3.14` の GitHub Release を作成・publish します。その publish が `release.yml`
 （`on: release: published`）を発火させ、NuGet package とプラットフォームごとのバイナリ成果物を
 build・publish します。publish 後、上記のリリース後 `eng/version.json` バンプ
-（`stableVersion → 0.3.13`, `nextVersion → 0.3.14`）を適用します。
+（`stableVersion → 0.3.14`, `nextVersion → 0.3.15`）を適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.3.14.md
+++ b/docs/ja/release-notes-v0.3.14.md
@@ -1,0 +1,129 @@
+# リリースノート — intent-cli v0.3.14
+
+> **リリースモデル:** メンテナ/オペレーター（または外部のリリース automation）が `v0.3.14` の
+> **GitHub Release を作成・publish** します — version-bump マージ自体は Release やタグを作成しません。
+> GitHub Release の publish が `.github/workflows/release.yml`（`on: release: published`）を発火させ、
+> NuGet package とプラットフォームバイナリ成果物を build・publish します。本パケットは
+> **prepare-only** で、version メタデータと docs をバンプするだけで publish ステップを **追加しません**。
+> [マージ前 リリース準備ゲート](#リリース準備ゲート-g512) と
+> [v0.3.14 の publish](#v0314-の-publish) を参照。
+
+## v0.3.14 の内容
+
+v0.3.14 は **パッチリリース** で、`v0.3.13` 以降に完了した orchestrator モードガイダンス作業
+（G508–G511）を出荷します。package id・ライセンス・workflow セマンティクスの変更はなく、
+既存の timer-loop モードは完全サポート・不変です。package id は `JTechJapan.IntentSystem.Cli`
+のままです。
+
+> **orchestrator モードは引き続き preview/experimental です。** オプトインで、まだ hardening 中で
+> あり、デフォルトの workflow ではありません。intent-cli と GitHub が権威 source of truth であり
+> 続け、agmsg はメッセージ / 進捗 / 完了のシグナル層のみです。
+
+### セットアップガイドの具体的な agmsg 起動手順（G508）
+
+- orchestrator-thread ガイド（`intent-cli guide orchestrator-thread`）が、**具体的な agmsg
+  起動手順** — preflight と貼り付け可能な登録/delivery コマンド、各ロールの最初のプロンプト —
+  を生成し、オペレーターが順序を推測せずに orchestrator・implementation・review の各 receiver を
+  立ち上げられるようにしました。
+
+### design-thread ハンドオフと monitor recovery（G509）
+
+- ガイドが orchestrator モード向けの **design-thread ハンドオフ** と **monitor recovery**
+  チェックリストを文書化しました: receiver の monitor が起動しなかった、メッセージが見えない、
+  メッセージ送信後に receiver が起動した場合の対処（`inbox.sh` で読む、登録/delivery を再確認、
+  ack 後に再送）。
+
+### セットアップ intake フォームと traffic-controller プレイブック（G510）
+
+- ガイドが **セットアップ intake フォーム**（`missing-inputs` / `setup-ready` / `blocked` の結果）と
+  **design traffic-controller プレイブック** をレンダリングし、orchestrator モードを求める design
+  スレッドを必要な入力とルーティング/エスカレーションのルールに沿って案内します。
+
+### Monitor ツールと agmsg delivery-mode の区別（G511）
+
+- ガイドと新しい `orchestrator-message-mode` ドキュメントが、Claude Code の汎用 **`Monitor`
+  ツール**（agmsg が SessionStart ディレクティブから `watch.sh` を起動して attach する、実際の
+  inbox ストリーム配信の仕組み）を、agmsg の `delivery.sh status` `mode=monitor` 設定（Monitor が
+  attach されストリーミングしている **証明にはならない**）と区別します。**ライブ attach の
+  success-marker** リスト（`ToolSearch select:Monitor` で Monitor が解決される；
+  `Monitor(agmsg inbox stream)`；フッター `1 monitor`；`Monitor event`）、**failure-marker**
+  リスト（Bash/バックグラウンド `watch.sh` への fallback；フッター `1 shell`；Azure Monitor /
+  MCP monitor との混同）、および **project-trust 修復 runbook**（exact-cwd の `~/.claude.json`
+  `hasTrustDialogAccepted=false` が Monitor を抑制 → Claude project trust を修復して再起動し、
+  再検証）を追加しました。
+
+> バージョンメタデータ注記: `eng/version.json` は `stableVersion: 0.3.13`,
+> `nextVersion: 0.3.14` を記録します。G512（本パケット）はリリース準備のメタデータバンプです。
+> v0.3.14 リリース後のメタデータ前進（`stableVersion → 0.3.14`, `nextVersion → 0.3.15`）は
+> オペレーターのリリース後ステップであり、本パケットのスコープ外です。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.14
+```
+
+または [v0.3.14 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.14)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを検証します。
+
+## v0.3.13 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.14
+```
+
+v0.3.13 からの破壊的変更はありません。orchestrator モードはオプトインのままで、既存の timer-loop
+セットアップには影響しません。
+
+## リリース準備ゲート (G512)
+
+次の項目は **`v0.3.14` の GitHub Release が publish される前** に成り立っている必要があります。
+このゲートは fail closed です — 1 つでも未充足なら、まだ Release を publish しないでください。
+
+- [ ] リリース対象の各パケットが **完了し PR が `main` にマージ済み**: G508、G509、G510、G511
+      （および本準備の G512）。host queue-state / GitHub PR 状態で host/review 側から確認する
+      （child 実装ループは parent queue-state を読まないため、これは host 所有の前提条件）。
+- [ ] 本リリース対象の open な intent-system PR や WIP パケットが誤ってスキップされていない
+      （publish 前に host queue / open PR リストを確認）。
+- [ ] `eng/version.json` の `nextVersion` が `0.3.14`（意図したリリースバージョン）。`release.yml`
+      は publish された Release/タグから package バージョンをビルドし、
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` も同じポリシーからローカルデフォルトを導出する。
+- [ ] package メタデータが正しい: `PackageId = JTechJapan.IntentSystem.Cli`、
+      `RepositoryUrl` / `PackageProjectUrl` が `https://github.com/J-Tech-Japan/intent-system` を指す、
+      `PackageLicenseExpression = Apache-2.0`、README/docs リンクが解決し、公式サービスサイト
+      `https://www.intent-driven-development.com/` が README からリンクされている。
+- [ ] リリースノート / README が **orchestrator モードは preview/experimental** かつオプトインで
+      あること、timer-loop モードが不変であることを保っている。
+- [ ] リリースコミットで **Main CI が green**（`Build and test (source contract)`）であり、
+      **preview-pack** workflow も green。
+
+## v0.3.14 の publish
+
+本パケットはリリースを publish せず、publish ステップを **追加しません**。version-bump マージ自体は
+GitHub Release やタグを作成しません。
+
+1. この version bump がマージされ上記の準備ゲートが成り立った後、**メンテナ/オペレーター（または
+   外部のリリース automation）が `v0.3.14` の GitHub Release を作成・publish** します
+   （リリースコミットにタグ付け）。これはマージ後の host/operator/外部リリースアクションです。
+2. その GitHub Release の publish が `.github/workflows/release.yml`（`on: release: published`）を
+   発火させ、NuGet package とプラットフォームごとのバイナリアーカイブ（`.sha256` チェックサム付き）を
+   build・publish し、トリガーとなった Release に添付します。
+
+リリース後の検証（GitHub Release が publish され `release.yml` が実行された後）:
+
+- [ ] NuGet.org の package ページのリンクがすべて正しく解決する。
+- [ ] GitHub release アセットリンク（`.tar.gz`, `.zip`, `.exe`, `.nupkg`）にアクセスできる。
+- [ ] `.sha256` チェックサムがダウンロード成果物と一致する。
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`（または
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.14`）後、
+      `intent-cli --version` が `0.3.14` を報告する。
+- [ ] バイナリ成果物スモーク: プラットフォームアーカイブをダウンロードし `.sha256` を検証、
+      展開して `./intent-cli --version` → `0.3.14`。
+- [ ] **orchestrator ガイドスモーク**（G508–G511）: `intent-cli guide orchestrator-thread
+      --domain <d> --target-repo <repo> --agent <agent> --format markdown` が、具体的な agmsg
+      起動手順、design-thread ハンドオフ / monitor recovery、セットアップ intake フォームと
+      traffic-controller プレイブック、そして success/failure marker と trust 修復 runbook を含む
+      **Monitor tool vs delivery-mode** セクションをレンダリングする。
+- [ ] ローカル preview/dry-run のバージョンメタデータが `0.3.14` の次の開発ラインを使う
+      （[バージョンフロー](09-developer-reference.md#バージョンフロー) のリリース後ステップに従い
+      `eng/version.json` をバンプ）: `stableVersion → 0.3.14`, `nextVersion → 0.3.15`。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.12",
-  "nextVersion": "0.3.13"
+  "stableVersion": "0.3.13",
+  "nextVersion": "0.3.14"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,10 +124,10 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.13 as the next development line
-        // (post-v0.3.12 release bump, see G506 — v0.3.12 was published to
+        // be parseable and must point to 0.3.14 as the next development line
+        // (post-v0.3.13 release bump, see G512 — v0.3.13 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.3.13 while recording 0.3.12 as the published stable).
+        // forward to 0.3.14 while recording 0.3.13 as the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -137,8 +137,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.13", policy.NextVersion);
-        Assert.Equal("0.3.12", policy.StableVersion);
+        Assert.Equal("0.3.14", policy.NextVersion);
+        Assert.Equal("0.3.13", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Closes #1125. Prepares the repository for an operator release of **v0.3.14**, a patch release bundling the orchestrator-mode guidance work completed since v0.3.13 (G508–G511). This packet is **prepare-only**: it bumps version metadata and docs and adds **no** publish steps. Uses the G507-corrected release model — a maintainer/operator creates and publishes the GitHub Release after merge, which fires `release.yml` on `release: published`; the version-bump merge does **not** create the Release/tag. Confirmed G508–G511 are all merged on `main`.

## Changes

- **`eng/version.json`** — advance to `stableVersion 0.3.13` (published) / `nextVersion 0.3.14` (release-to-cut). Verified: `intent-cli --version` reports `0.3.14-<sha>-G511`.
- **Release notes (en/ja)** — new `release-notes-v0.3.14.md`: summarizes G508 (concrete agmsg startup steps), G509 (design handoff + monitor recovery), G510 (setup intake form + traffic-controller playbook), G511 (Claude Code Monitor tool vs agmsg delivery-mode + trust repair). Uses the prepare-only release model, keeps orchestrator mode **preview/experimental**, package id `JTechJapan.IntentSystem.Cli`, timer-loop unchanged; install/upgrade pinned to `0.3.14`; a fail-closed **release-readiness gate (G512)**; post-release verification checklist incl. an orchestrator-guide smoke covering the new sections.
- **Developer reference (en/ja)** — retarget the version-flow table and "Next release readiness" section to **v0.3.14** (G508–G511), link the release notes, document the post-release bump (`stable → 0.3.14`, `next → 0.3.15`).
- **tests** — update `VersionPolicyTests` smoke assertion to next `0.3.14` / stable `0.3.13`.

## Acceptance criteria coverage

- ✅ `eng/version.json` bumped to `stableVersion 0.3.13` / `nextVersion 0.3.14`; `VersionPolicy` tests pass.
- ✅ `docs/{en,ja}/release-notes-v0.3.14.md` exist and summarize G508/G509/G510/G511.
- ✅ Notes use the prepare-only release model (operator publishes the Release → `release.yml` on `release.published` → NuGet+binaries; merge does not cut the Release).
- ✅ Orchestrator mode kept preview/experimental; package id unchanged; timer-loop unchanged.
- ✅ Post-release verification checklist preserved (Release, workflow, NuGet, binaries, sha256, `intent-cli --version` = 0.3.14).
- ✅ Developer-reference release docs updated for v0.3.14.
- ✅ No GitHub Release/tag created; no `release.yml` trigger change; no raw gh / host-metadata edits.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `intent-cli --version` → `0.3.14-88b257d-G511`.
- `dotnet test … --filter VersionPolicyTests|ReleasePackageMetadataTests` — 13 passed.
- `dotnet test` (full Cli suite) — 3176 passed, 1 skipped.
- `git diff --check` — clean; diff touches only `eng/version.json`, the two v0.3.14 release notes, the developer reference, and the version test — no workflow files, no Release creation.
- Dev-reference → release-notes-v0.3.14 anchors verified (`release-readiness-gate-g512` / `リリース準備ゲート-g512`); no stale "next 0.3.13" left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb