### PR TITLE
G513: Enforce design-thread ownership for packet authoring in orchestrator mode

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -65,6 +65,35 @@ The full reference checklist follows the intake:
 > message, and clean up only through the agmsg scripts. Hand-editing agmsg state
 > corrupts delivery.
 
+## Role boundary — design authors, orchestrator coordinates
+
+**Design creates packets; the orchestrator moves ready packets through the
+workflow.** The orchestrator must **not** silently become the product/release/
+design author.
+
+- **Design owns** — intent shaping and clarifications; ADRs and design
+  decisions; release scope and version selection; packet content and acceptance
+  criteria (the durable packet files).
+- **Orchestrator owns** — inspect canonical intent-cli/GitHub state; publish
+  exactly **one already-authored, `issue-cut-ready` packet per wake**; delegate
+  implementation/review; wait for CI/review; close out approved PRs through the
+  canonical review surfaces; report blockers and missing packets back to design.
+
+When a needed packet is absent, incomplete, or would require product/release/
+design judgment, the orchestrator does **not** invent it — it sends a structured
+`packet-needed` message to design and **waits** for design to author/update the
+packet (or give an explicit instruction):
+
+```json
+{"to":"design","type":"packet-needed","domain":"<domain>","need":"<what is needed>","reason":"<why the orchestrator cannot proceed>","blocking":"<the work that is waiting>"}
+```
+
+**Release-prep is design-owned:** design decides the release version and scope
+and authors the release-prep packet; the orchestrator may publish and coordinate
+it only **after** it exists and is `issue-cut-ready` — it must not pick the
+version, decide scope, or author the release notes/packet from a vague "prepare a
+release" instruction.
+
 ## What agmsg is (and is not)
 
 agmsg is a **message / progress / completion / blocker signal layer only**. It

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -62,6 +62,31 @@ intake の後に、完全なリファレンスチェックリストが続きま�
 > クリーンアップはすべて agmsg スクリプト経由で行います。agmsg state の手編集は delivery を
 > 壊します。
 
+## ロール境界 — design が authoring、orchestrator は coordinate
+
+**design が packet を作成し、orchestrator は ready な packet を workflow に通します。**
+orchestrator は黙ってプロダクト/リリース/設計の author になっては **いけません**。
+
+- **design が所有** — intent shaping と clarification; ADR と設計判断; リリーススコープと
+  バージョン選択; packet 内容と受け入れ基準（durable な packet ファイル）。
+- **orchestrator が所有** — canonical な intent-cli/GitHub state の検査; **1 wake につき
+  既に authoring 済みの `issue-cut-ready` packet を 1 件だけ** publish; implementation/review
+  への委譲; CI/review の待機; canonical review surface 経由の approved PR の closeout;
+  blocker と不足 packet を design に報告。
+
+必要な packet が不在・不完全、またはプロダクト/リリース/設計判断を要する場合、orchestrator は
+それを **でっち上げません** — 構造化された `packet-needed` メッセージを design に送り、design が
+packet を author/更新する（または明示的に指示する）のを **待ちます**:
+
+```json
+{"to":"design","type":"packet-needed","domain":"<domain>","need":"<what is needed>","reason":"<why the orchestrator cannot proceed>","blocking":"<the work that is waiting>"}
+```
+
+**release-prep は design 所有:** design がリリースバージョンとスコープを決め、release-prep
+packet を author します。orchestrator はそれが存在し `issue-cut-ready` になった **後** にのみ
+publish・coordinate できます — 曖昧な「リリースを準備して」という指示からバージョンを選んだり、
+スコープを決めたり、リリースノート/packet を自分で author してはいけません。
+
 ## agmsg とは（そして何ではないか）
 
 agmsg は **メッセージ / 進捗 / 完了 / ブロッカーのシグナル層のみ** です。スレッド間で

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -143,6 +143,46 @@ internal static class GuideOrchestratorThreadCommand
                     + "orchestrator) would race on the same GitHub state. The orchestrator paces those threads; they do "
                     + "not also self-schedule.",
             },
+            RoleBoundary = new OrchestratorRoleBoundary
+            {
+                Summary =
+                    "ROLE BOUNDARY: DESIGN creates packets; the ORCHESTRATOR moves READY packets through the workflow. "
+                    + "The orchestrator must NOT silently become the product/release/design author. When a needed packet "
+                    + "is absent, incomplete, or would require product/release/design judgment, ask design to create or "
+                    + "update it — do NOT draft it yourself.",
+                DesignOwns = new[]
+                {
+                    "Intent shaping and clarifications.",
+                    "ADRs and design decisions.",
+                    "Release scope and version selection.",
+                    "Packet content and acceptance criteria (the durable packet files).",
+                },
+                OrchestratorOwns = new[]
+                {
+                    "Inspect canonical intent-cli / GitHub state.",
+                    "Publish exactly ONE already-authored, `issue-cut-ready` packet per wake (via canonical publish surfaces — see Next-slice publication).",
+                    "Delegate implementation/review to the loopless receivers.",
+                    "Wait for CI / review and track review state.",
+                    "Close out approved PRs through the canonical review surfaces.",
+                    "Report blockers and missing packets back to design.",
+                },
+                MissingPacketResponse =
+                    "When a needed packet is absent or incomplete, or a vague goal would require authoring intent / "
+                    + "acceptance criteria / release scope, the orchestrator does NOT invent the packet. It sends a "
+                    + "structured request to DESIGN describing what is needed and WAITS for design to author/update the "
+                    + "packet (or give an explicit instruction). The orchestrator only publishes/coordinates a packet "
+                    + "that already exists and is `issue-cut-ready`.",
+                MissingPacketMessageTemplate = Apply(
+                    "{\"to\":\"design\",\"type\":\"packet-needed\",\"domain\":\"<domain>\",\"need\":\"<what is needed: "
+                    + "e.g. a release-prep packet for vX.Y.Z, or acceptance criteria for <topic>>\",\"reason\":\"<why the "
+                    + "orchestrator cannot proceed: requires product/release/design judgment, or the packet is absent/"
+                    + "incomplete>\",\"blocking\":\"<the work that is waiting on it>\"}"),
+                ReleasePrepRule =
+                    "Release-prep is design-owned: DESIGN decides the release version and scope and AUTHORS the "
+                    + "release-prep packet. The orchestrator may publish and coordinate that release-prep packet ONLY "
+                    + "after it exists and is `issue-cut-ready` — it must not pick the version, decide scope, or author "
+                    + "the release notes/packet itself from a vague \"prepare a release\" instruction.",
+            },
             DomainRouting = new OrchestratorDomainRouting
             {
                 Mode = mode,
@@ -1339,6 +1379,34 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"- **mixed-mode warning** — {guide.ModeSeparation.MixedModeWarning}");
         writer.WriteLine();
 
+        writer.WriteLine("## Role boundary (design authors; orchestrator coordinates)");
+        writer.WriteLine();
+        writer.WriteLine(guide.RoleBoundary.Summary);
+        writer.WriteLine();
+        writer.WriteLine("### Design owns");
+        writer.WriteLine();
+        foreach (var item in guide.RoleBoundary.DesignOwns)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("### Orchestrator owns");
+        writer.WriteLine();
+        foreach (var item in guide.RoleBoundary.OrchestratorOwns)
+        {
+            writer.WriteLine($"- {item}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **missing packet** — {guide.RoleBoundary.MissingPacketResponse}");
+        writer.WriteLine($"- **release-prep** — {guide.RoleBoundary.ReleasePrepRule}");
+        writer.WriteLine();
+        writer.WriteLine("Structured packet-needed message (orchestrator → design):");
+        writer.WriteLine();
+        writer.WriteLine("```json");
+        writer.WriteLine(guide.RoleBoundary.MissingPacketMessageTemplate);
+        writer.WriteLine("```");
+        writer.WriteLine();
+
         writer.WriteLine("## Setup (starting orchestrator mode)");
         writer.WriteLine();
         writer.WriteLine(guide.Setup.Summary);
@@ -1936,6 +2004,9 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("mode_separation")]
     public required OrchestratorModeSeparation ModeSeparation { get; init; }
 
+    [JsonPropertyName("role_boundary")]
+    public required OrchestratorRoleBoundary RoleBoundary { get; init; }
+
     [JsonPropertyName("domain_routing")]
     public required OrchestratorDomainRouting DomainRouting { get; init; }
 
@@ -2007,6 +2078,27 @@ internal sealed record OrchestratorThreadGuide
 
     [JsonPropertyName("detailed_guide_commands")]
     public required IReadOnlyList<string> DetailedGuideCommands { get; init; }
+}
+
+internal sealed record OrchestratorRoleBoundary
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("design_owns")]
+    public required IReadOnlyList<string> DesignOwns { get; init; }
+
+    [JsonPropertyName("orchestrator_owns")]
+    public required IReadOnlyList<string> OrchestratorOwns { get; init; }
+
+    [JsonPropertyName("missing_packet_response")]
+    public required string MissingPacketResponse { get; init; }
+
+    [JsonPropertyName("missing_packet_message_template")]
+    public required string MissingPacketMessageTemplate { get; init; }
+
+    [JsonPropertyName("release_prep_rule")]
+    public required string ReleasePrepRule { get; init; }
 }
 
 internal sealed record OrchestratorModeSeparation

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -1208,6 +1208,53 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_RoleBoundary_DesignAuthorsOrchestratorCoordinates_G513()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Role boundary (design authors; orchestrator coordinates)", output, StringComparison.Ordinal);
+        // Design owns packet authoring; orchestrator must not become the author.
+        Assert.Contains("DESIGN creates packets", output, StringComparison.Ordinal);
+        Assert.Contains("must NOT silently become the product/release/design author", output, StringComparison.Ordinal);
+        Assert.Contains("### Design owns", output, StringComparison.Ordinal);
+        Assert.Contains("Packet content and acceptance criteria", output, StringComparison.Ordinal);
+        // Orchestrator may publish exactly one already-authored issue-cut-ready packet per wake.
+        Assert.Contains("### Orchestrator owns", output, StringComparison.Ordinal);
+        Assert.Contains("Publish exactly ONE already-authored, `issue-cut-ready` packet per wake", output, StringComparison.Ordinal);
+        // Missing-packet behavior: request to design + wait, do not author.
+        Assert.Contains("**missing packet**", output, StringComparison.Ordinal);
+        Assert.Contains("does NOT invent the packet", output, StringComparison.Ordinal);
+        Assert.Contains("\"type\":\"packet-needed\"", output, StringComparison.Ordinal);
+        // Release-prep is design-owned.
+        Assert.Contains("**release-prep**", output, StringComparison.Ordinal);
+        Assert.Contains("Release-prep is design-owned", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasRoleBoundaryShape_G513()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var boundary = doc.RootElement.GetProperty("role_boundary");
+
+        Assert.NotEmpty(boundary.GetProperty("design_owns").EnumerateArray());
+        Assert.NotEmpty(boundary.GetProperty("orchestrator_owns").EnumerateArray());
+        Assert.Contains("packet-needed", boundary.GetProperty("missing_packet_message_template").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("design-owned", boundary.GetProperty("release_prep_rule").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("does NOT invent the packet", boundary.GetProperty("missing_packet_response").GetString()!, StringComparison.Ordinal);
+
+        // Existing orchestrator publish ability is preserved (not removed).
+        var publication = doc.RootElement.GetProperty("next_slice_publication");
+        Assert.True(publication.GetProperty("one_per_wake").GetBoolean());
+    }
+
+    [Fact]
     public void Execute_UnknownMode_ExitsOne()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Closes #1127. Dogfooding exposed a role-boundary violation: after G511 the design thread asked for release prep and the orchestrator **authored and published G512 itself**. The orchestrator must not silently become the product/release/design author. This encodes the boundary in intent-cli guidance so future agents do not repeat it. Builds on the G489–G512 orchestrator-mode work.

Surface: `intent-cli guide orchestrator-thread` + `docs/{en,ja}/12-agent-message-orchestration.md`.

## Changes

- **New `role_boundary` section** in the guide (rendered right after Mode separation):
  - **Design owns** — intent shaping, clarifications, ADRs/design decisions, release scope + version selection, and packet content + acceptance criteria (the durable packet files).
  - **Orchestrator owns** — inspect canonical intent-cli/GitHub state; publish exactly **one already-authored, `issue-cut-ready` packet per wake**; delegate implementation/review; wait for CI/review; close out approved PRs through the canonical review surfaces; report blockers and missing packets back to design.
  - **Missing-packet behavior** — send a structured `packet-needed` message to design and **wait**; do not invent the packet.
  - **Release-prep is design-owned** — design decides version/scope and authors the release-prep packet; the orchestrator executes it only after it exists and is `issue-cut-ready`.
- Docs updated in EN + JA.

## Acceptance criteria coverage

- ✅ Guide states packet authoring belongs to the design thread.
- ✅ Guide states the orchestrator may publish exactly one already-authored issue-cut-ready packet per wake.
- ✅ Structured missing-packet response (report to design, wait) with a `packet-needed` template.
- ✅ Release-prep: design decides version/scope and authors the packet; orchestrator executes only after it exists.
- ✅ Documentation updated so the boundary is discoverable outside private conversation history.
- ✅ Tests updated (markdown + JSON).
- ✅ Existing timer-loop guidance and orchestrator publish/delegate/closeout behavior intact.

## Verification

- `intent-cli guide orchestrator-thread … --format markdown` — renders the Role boundary section; still allows publishing existing issue-cut-ready packets; no longer implies the orchestrator authors missing packets.
- `intent-cli guide prompt-matrix --format markdown` — four timer-loop modes intact; orchestrator-message mode discoverable.
- `dotnet test … --filter GuideOrchestratorThreadCommandTests` — 56 passed.
- `dotnet test` (full Cli suite) — 3178 passed, 1 skipped.
- `git diff --check` — clean. No workflow / release automation behavior changed.

## Scope note

The Knowledge Maintenance ADR / intent-tree role-boundary writeback under `intents/intent-cli/design/decisions/**` is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR covers the guide surface + `docs/**` and does not touch host metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb