### PR TITLE
G514: Fix bootstrap automation commands to load same-repo project config

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -172,6 +172,17 @@ reports `not-configured`, the keys above are not being resolved — check they a
 under `[project]` (not a different table) and spelled exactly
 `metadata_source_branch` / `metadata_write_branch`.
 
+Host vs child bootstrap (G514): the host-side automation commands
+(`automation summary`, `automation same-repo-metadata-preflight`,
+`automation queue-seed-from-packet`) load `.intent-cli/config.toml` from the
+resolved repo root, so they see the same effective `[project]` config — and the
+same configured same-repo topology — as every other host command. A
+child/standalone implementation repo that carries **no** `.intent-cli/config.toml`
+keeps the safe default bootstrap behavior (no parent metadata required). If you
+run a host command from a same-repo host repo and still see default behavior,
+confirm the command is run from within the repo (the resolver walks up to the
+`.intent-cli/` directory) and that the config file exists.
+
 The supported publish path for a packet is **`automation queue-seed-from-packet`
 → `issue publish-flow` → `automation issue-publish`**, with no manual
 queue-state edits or raw `gh issue create`. The domain's `execution_unit_regex`

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -163,6 +163,15 @@ metadata_write_branch  = "main-metadata"   # host loop がメタデータを WRI
 配下にあること、`metadata_source_branch` / `metadata_write_branch` の綴りが正確であることを
 確認してください。
 
+host と child の bootstrap（G514）: host 側 automation コマンド（`automation summary`、
+`automation same-repo-metadata-preflight`、`automation queue-seed-from-packet`）は解決された
+repo root の `.intent-cli/config.toml` をロードするため、他の host コマンドと同じ effective な
+`[project]` 設定（同じ same-repo トポロジ設定）を参照します。`.intent-cli/config.toml` を **持たない**
+child/standalone 実装 repo は安全なデフォルト bootstrap 挙動を保ちます（parent metadata 不要）。
+same-repo host repo で host コマンドを実行してもデフォルト挙動になる場合、コマンドが repo 内から
+実行されている（resolver は `.intent-cli/` ディレクトリまで上に辿る）こと、config ファイルが
+存在することを確認してください。
+
 packet の正規の publish 経路は **`automation queue-seed-from-packet` →
 `issue publish-flow` → `automation issue-publish`** で、手動の queue-state 編集や raw
 `gh issue create` は不要です。ドメインの `execution_unit_regex`（

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -321,8 +321,33 @@ internal static class Program
         return false;
     }
 
-    private static CliContext CreateBootstrapContext(string currentDirectory, string[] args)
+    internal static CliContext CreateBootstrapContext(string currentDirectory, string[] args)
     {
+        // G514: when a host repo with `.intent-cli/config.toml` is present,
+        // bootstrap-routed automation commands (`automation summary`,
+        // `automation same-repo-metadata-preflight`,
+        // `automation queue-seed-from-packet`, …) must use the SAME effective
+        // project config as the normal path. Previously this always built a
+        // default config, so same-repo topology / metadata-branch /
+        // base-branch settings were silently replaced by defaults and
+        // `same-repo-metadata-preflight` reported `not-configured`. Resolve the
+        // host repo root with the normal resolver and load the config when it
+        // exists; otherwise keep the safe default bootstrap behavior for
+        // child/standalone repos that carry no host metadata.
+        var repoRoot = RepoRootResolver.Resolve(currentDirectory);
+        if (repoRoot is not null)
+        {
+            var configPath = CliRuntimeContracts.GetConfigPath(repoRoot);
+            if (File.Exists(configPath))
+            {
+                return new CliContext
+                {
+                    RepoRoot = repoRoot,
+                    Config = CliConfigLoader.LoadFromFile(configPath)
+                };
+            }
+        }
+
         var domain = args.Length >= 3 && !string.IsNullOrWhiteSpace(args[2])
             ? args[2].Trim()
             : "bootstrap";

--- a/tests/IntentSystem.Cli.Tests/ProgramTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ProgramTests.cs
@@ -45,6 +45,66 @@ public sealed class ProgramTests
     }
 
     [Fact]
+    public void CreateBootstrapContext_GivenHostRepoWithSameRepoConfig_LoadsConfiguredValues_G514()
+    {
+        // G514: bootstrap-routed automation commands (summary /
+        // same-repo-metadata-preflight / queue-seed-from-packet) must use the
+        // SAME effective project config as the normal path — non-default
+        // same-repo topology values must NOT be silently replaced by default
+        // bootstrap config. The config uses deliberately non-default values so a
+        // default config cannot accidentally pass.
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateDirectory(Path.Combine("repo", ".intent-cli"));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "config.toml"),
+            """
+            [project]
+            domain = "estivo"
+            artifact_root = ".intent-cli"
+            same_repo_topology = true
+            metadata_source_branch = "main-metadata"
+            metadata_write_branch = "main-metadata"
+            implementation_base_branch = "main"
+            base_branch_policy = "main-ai"
+            """);
+        // Invoke from a nested cwd so the resolver must walk up to the repo root.
+        var workingDirectory = tempDirectory.CreateDirectory(Path.Combine("repo", "src", "feature"));
+
+        var context = Program.CreateBootstrapContext(
+            workingDirectory,
+            ["automation", "summary", "--domain", "estivo"]);
+
+        Assert.Equal(repoRoot, context.RepoRoot);
+        Assert.Equal("estivo", context.Config.Project.Domain);
+        Assert.True(context.Config.Project.SameRepoTopology);
+        Assert.Equal("main-metadata", context.Config.Project.MetadataSourceBranch);
+        Assert.Equal("main-metadata", context.Config.Project.MetadataWriteBranch);
+        Assert.Equal("main", context.Config.Project.ImplementationBaseBranch);
+        Assert.Equal("main-ai", context.Config.Project.BaseBranchPolicy);
+    }
+
+    [Fact]
+    public void CreateBootstrapContext_GivenNoIntentCliConfig_KeepsSafeDefaultBootstrap_G514()
+    {
+        // G514: a child/standalone repo with no `.intent-cli/config.toml` must
+        // keep the safe default bootstrap behavior — no parent metadata
+        // required, default same-repo topology (false), and the cwd as RepoRoot.
+        using var tempDirectory = new TemporaryDirectory();
+        var childCwd = tempDirectory.CreateDirectory("child-impl");
+
+        var context = Program.CreateBootstrapContext(
+            childCwd,
+            ["automation", "summary", "mydomain"]);
+
+        Assert.Equal(childCwd, context.RepoRoot);
+        Assert.Equal("mydomain", context.Config.Project.Domain);
+        Assert.False(context.Config.Project.SameRepoTopology);
+        Assert.Equal(string.Empty, context.Config.Project.MetadataSourceBranch);
+        Assert.Equal(".intent-cli", context.Config.Project.ArtifactRoot);
+    }
+
+    [Fact]
     public void Main_GivenDirectoryWithoutIntentCliRoot_ReturnsExitCodeOne_AndEmitsStructuredFailClosed()
     {
         // G299: a non-bootstrap command (e.g. `project status`) invoked from a


### PR DESCRIPTION
## Summary

Closes #1129. Fixes Bug B from the 2026-06-26 Slack dogfooding report: host-side bootstrap-routed automation commands (`automation summary`, `automation same-repo-metadata-preflight`, `automation queue-seed-from-packet`) always built a **default** `CliConfig` in `CreateBootstrapContext` and never loaded `.intent-cli/config.toml`. Same-repo topology settings were silently replaced by defaults, so `same-repo-metadata-preflight` reported `not-configured` and `queue-seed-from-packet` lost its binding/config state.

## Change (minimal fix per the issue's implementation notes)

`Program.CreateBootstrapContext` now:

1. resolves the host repo root with the normal `RepoRootResolver`;
2. if `.intent-cli/config.toml` exists at that root, loads it via `CliConfigLoader.LoadFromFile` (so `RepoRoot` and config agree) — the **same effective config the normal path uses**;
3. otherwise keeps the existing default bootstrap config, so **child/standalone implementation repos** with no `.intent-cli/config.toml` still bootstrap safely with no parent metadata.

All three commands route through this one context, so they now agree on the effective same-repo project config.

## Acceptance criteria coverage

- ✅ `automation summary` reads `.intent-cli/config.toml [project]` values in a same-repo host repo (shared bootstrap context).
- ✅ `automation same-repo-metadata-preflight` honors the configured metadata branches instead of `not-configured` from default bootstrap config.
- ✅ `automation queue-seed-from-packet` uses the same effective project config / binding context as `automation summary` (same bootstrap context).
- ✅ Child/standalone repos without `.intent-cli/config.toml` still bootstrap safely without parent metadata.
- ✅ Tests cover a same-repo fixture with **non-default** config values (`same_repo_topology=true`, `metadata_source_branch`/`metadata_write_branch="main-metadata"`, `implementation_base_branch="main"`, `base_branch_policy="main-ai"`) so defaults cannot accidentally pass, plus a no-config repo keeping the default bootstrap.
- ✅ Docs explain the host-vs-child bootstrap behavior.

## Verification

- `dotnet build src/IntentSystem.Cli` — succeeded.
- `dotnet test … --filter ProgramTests` — 8 passed (incl. the 2 new G514 tests).
- `dotnet test` (full Cli suite) — 3180 passed, 1 skipped.
- `git diff --check` — clean; the diff touches only `src/IntentSystem.Cli/Program.cs`, `ProgramTests.cs`, and the en/ja developer-reference docs.

## Out of scope (confirmed untouched)

- No agmsg scripts, no workflow files, no `~/.claude.json`, no GitHub Release/tag. The cp932 fix (G484) is not reopened. No child repo is required to copy/read/mutate parent `.intent-cli` metadata.

## Scope note

The Knowledge Maintenance `intents/intent-cli/**` invariant writeback is host metadata / closeout responsibility (G329); this GitHub-contract-only implementation PR covers `src/**`, tests, and `docs/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb