### PR TITLE
G515: Update v0.3.14 release metadata for G513-G514

### DIFF
--- a/docs/en/release-notes-v0.3.14.md
+++ b/docs/en/release-notes-v0.3.14.md
@@ -13,9 +13,11 @@
 ## What's in v0.3.14
 
 v0.3.14 is a **patch release** that ships the orchestrator-mode guidance work
-completed after `v0.3.13` (G508–G511). No package id, license, or
-workflow-semantics changes, and the existing timer-loop mode is fully supported
-and unchanged. The package id remains `JTechJapan.IntentSystem.Cli`.
+completed after `v0.3.13` (G508–G511), the orchestrator-mode role boundary
+(G513), and a same-repo bootstrap config-loading fix (G514). No package id,
+license, or workflow-semantics changes, and the existing timer-loop mode is
+fully supported and unchanged. The package id remains
+`JTechJapan.IntentSystem.Cli`.
 
 > **Orchestrator mode is still preview/experimental.** It is opt-in, still being
 > hardened, and not the default workflow. intent-cli and GitHub remain the
@@ -59,6 +61,34 @@ and unchanged. The package id remains `JTechJapan.IntentSystem.Cli`.
   repair runbook** (exact-cwd `~/.claude.json` `hasTrustDialogAccepted=false`
   suppresses Monitor → repair Claude project trust and restart, then re-verify).
 
+### Orchestrator-mode role boundary (G513)
+
+- The orchestrator-thread guide now encodes the **role boundary**: the **design
+  thread owns packet authoring** — intent shaping, clarifications, ADRs/design
+  decisions, release scope and version selection, and packet content/acceptance
+  criteria. The **orchestrator coordinates already-ready packets** — it inspects
+  canonical intent-cli/GitHub state, publishes exactly one already-authored
+  `issue-cut-ready` packet per wake, delegates implementation/review, waits for
+  CI/review, closes out, and **reports blockers and missing packets back to
+  design** instead of synthesizing durable design/release artifacts itself.
+- When a needed packet is absent or would require product/release/design
+  judgment (including release-prep: design decides the version/scope and authors
+  the release-prep packet), the orchestrator sends a structured `packet-needed`
+  message to design and waits, rather than drafting the packet.
+
+### Same-repo bootstrap config loading (G514)
+
+- Host-side bootstrap-routed automation commands now load the host
+  `.intent-cli/config.toml` when present, so `automation summary`,
+  `automation same-repo-metadata-preflight`, and
+  `automation queue-seed-from-packet` agree on the effective same-repo topology
+  and metadata/base-branch config (`same_repo_topology`,
+  `metadata_source_branch`, `metadata_write_branch`, `implementation_base_branch`,
+  `base_branch_policy`). Previously the bootstrap context always used a default
+  config, so `same-repo-metadata-preflight` could report `not-configured` even
+  when the keys were set. Repos without `.intent-cli/config.toml` keep the safe
+  default child/standalone metadata-free bootstrap.
+
 > Version metadata note: `eng/version.json` records `stableVersion: 0.3.13`,
 > `nextVersion: 0.3.14`; G512 (this packet) is the release-prep metadata bump.
 > The post-v0.3.14 metadata advancement (`stableVersion → 0.3.14`,
@@ -90,9 +120,10 @@ These items must hold **before the GitHub Release for `v0.3.14` is published**.
 This gate fails closed — if any item is unmet, do not publish the Release yet.
 
 - [ ] Every release-bound packet is **complete and its PR merged to `main`**:
-      G508, G509, G510, G511 (and G512 this prep). Confirm on the host/review
-      side via the host queue-state / GitHub PR state — the child implementation
-      loop must not read parent queue-state, so this is a host-owned precondition.
+      G508, G509, G510, G511, G513, G514 (and the G512/G515 release-notes prep).
+      Confirm on the host/review side via the host queue-state / GitHub PR
+      state — the child implementation loop must not read parent queue-state, so
+      this is a host-owned precondition.
 - [ ] No open intent-system PR or WIP packet intended for this release is
       accidentally skipped (check the host queue / open PR list before publishing).
 - [ ] `eng/version.json` `nextVersion` is `0.3.14` (the intended release
@@ -136,12 +167,18 @@ Post-release verification (after the GitHub Release is published and
       then `intent-cli --version` reports `0.3.14`.
 - [ ] Binary artifact smoke check: download the platform archive, verify its
       `.sha256`, extract, and run `./intent-cli --version` → `0.3.14`.
-- [ ] **Orchestrator guide smoke** (G508–G511): `intent-cli guide
+- [ ] **Orchestrator guide smoke** (G508–G511, G513): `intent-cli guide
       orchestrator-thread --domain <d> --target-repo <repo> --agent <agent>
       --format markdown` renders the concrete agmsg startup steps, the
       design-thread handoff / monitor recovery, the setup intake form and
-      traffic-controller playbook, and the **Monitor tool vs delivery-mode**
-      section with the success/failure markers and trust-repair runbook.
+      traffic-controller playbook, the **Monitor tool vs delivery-mode**
+      section with the success/failure markers and trust-repair runbook, and the
+      **role boundary** (design authors packets; orchestrator coordinates).
+- [ ] **Same-repo bootstrap smoke** (G514): in a same-repo host repo,
+      `intent-cli automation same-repo-metadata-preflight` honors the configured
+      `[project]` metadata branches (not `not-configured`), and `automation
+      summary` / `automation queue-seed-from-packet` agree on the same effective
+      config.
 - [ ] Local preview/dry-run version metadata uses the next development line
       after `0.3.14` (bump `eng/version.json` per the post-release step in
       [Version flow](09-developer-reference.md#version-flow)):

--- a/docs/ja/release-notes-v0.3.14.md
+++ b/docs/ja/release-notes-v0.3.14.md
@@ -11,7 +11,8 @@
 ## v0.3.14 の内容
 
 v0.3.14 は **パッチリリース** で、`v0.3.13` 以降に完了した orchestrator モードガイダンス作業
-（G508–G511）を出荷します。package id・ライセンス・workflow セマンティクスの変更はなく、
+（G508–G511）、orchestrator モードのロール境界（G513）、same-repo bootstrap config ロード修正
+（G514）を出荷します。package id・ライセンス・workflow セマンティクスの変更はなく、
 既存の timer-loop モードは完全サポート・不変です。package id は `JTechJapan.IntentSystem.Cli`
 のままです。
 
@@ -52,6 +53,30 @@ v0.3.14 は **パッチリリース** で、`v0.3.13` 以降に完了した orch
   `hasTrustDialogAccepted=false` が Monitor を抑制 → Claude project trust を修復して再起動し、
   再検証）を追加しました。
 
+### orchestrator モードのロール境界（G513）
+
+- orchestrator-thread ガイドが **ロール境界** を encode しました: **design スレッドが packet
+  authoring を所有** します — intent shaping、clarification、ADR/設計判断、リリーススコープと
+  バージョン選択、packet 内容/受け入れ基準。**orchestrator は ready な packet を coordinate**
+  します — canonical な intent-cli/GitHub state を検査し、1 wake につき既に authoring 済みの
+  `issue-cut-ready` packet を 1 件だけ publish、implementation/review へ委譲、CI/review を待ち、
+  closeout し、durable な設計/リリース成果物を自分で合成せず **blocker と不足 packet を design に
+  報告** します。
+- 必要な packet が不在、またはプロダクト/リリース/設計判断を要する場合（release-prep を含む:
+  design がバージョン/スコープを決め release-prep packet を author する）、orchestrator は packet を
+  でっち上げず、構造化された `packet-needed` メッセージを design に送って待ちます。
+
+### same-repo bootstrap config ロード（G514）
+
+- host 側の bootstrap 経由 automation コマンドが、host の `.intent-cli/config.toml` を存在時に
+  ロードするようになり、`automation summary`、`automation same-repo-metadata-preflight`、
+  `automation queue-seed-from-packet` が effective な same-repo トポロジと metadata/base ブランチ
+  設定（`same_repo_topology`、`metadata_source_branch`、`metadata_write_branch`、
+  `implementation_base_branch`、`base_branch_policy`）で一致します。以前は bootstrap context が常に
+  default config を使っていたため、キーが設定されていても `same-repo-metadata-preflight` が
+  `not-configured` を返すことがありました。`.intent-cli/config.toml` を持たない repo は安全な
+  default の child/standalone metadata-free bootstrap を保ちます。
+
 > バージョンメタデータ注記: `eng/version.json` は `stableVersion: 0.3.13`,
 > `nextVersion: 0.3.14` を記録します。G512（本パケット）はリリース準備のメタデータバンプです。
 > v0.3.14 リリース後のメタデータ前進（`stableVersion → 0.3.14`, `nextVersion → 0.3.15`）は
@@ -80,9 +105,10 @@ v0.3.13 からの破壊的変更はありません。orchestrator モードは�
 次の項目は **`v0.3.14` の GitHub Release が publish される前** に成り立っている必要があります。
 このゲートは fail closed です — 1 つでも未充足なら、まだ Release を publish しないでください。
 
-- [ ] リリース対象の各パケットが **完了し PR が `main` にマージ済み**: G508、G509、G510、G511
-      （および本準備の G512）。host queue-state / GitHub PR 状態で host/review 側から確認する
-      （child 実装ループは parent queue-state を読まないため、これは host 所有の前提条件）。
+- [ ] リリース対象の各パケットが **完了し PR が `main` にマージ済み**: G508、G509、G510、G511、
+      G513、G514（および release-notes 準備の G512/G515）。host queue-state / GitHub PR 状態で
+      host/review 側から確認する（child 実装ループは parent queue-state を読まないため、これは
+      host 所有の前提条件）。
 - [ ] 本リリース対象の open な intent-system PR や WIP パケットが誤ってスキップされていない
       （publish 前に host queue / open PR リストを確認）。
 - [ ] `eng/version.json` の `nextVersion` が `0.3.14`（意図したリリースバージョン）。`release.yml`
@@ -119,11 +145,16 @@ GitHub Release やタグを作成しません。
       `intent-cli --version` が `0.3.14` を報告する。
 - [ ] バイナリ成果物スモーク: プラットフォームアーカイブをダウンロードし `.sha256` を検証、
       展開して `./intent-cli --version` → `0.3.14`。
-- [ ] **orchestrator ガイドスモーク**（G508–G511）: `intent-cli guide orchestrator-thread
+- [ ] **orchestrator ガイドスモーク**（G508–G511, G513）: `intent-cli guide orchestrator-thread
       --domain <d> --target-repo <repo> --agent <agent> --format markdown` が、具体的な agmsg
       起動手順、design-thread ハンドオフ / monitor recovery、セットアップ intake フォームと
-      traffic-controller プレイブック、そして success/failure marker と trust 修復 runbook を含む
-      **Monitor tool vs delivery-mode** セクションをレンダリングする。
+      traffic-controller プレイブック、success/failure marker と trust 修復 runbook を含む
+      **Monitor tool vs delivery-mode** セクション、そして **ロール境界**（design が packet を author、
+      orchestrator は coordinate）をレンダリングする。
+- [ ] **same-repo bootstrap スモーク**（G514）: same-repo host repo で
+      `intent-cli automation same-repo-metadata-preflight` が設定済みの `[project]` metadata ブランチを
+      尊重する（`not-configured` ではない）。`automation summary` / `automation queue-seed-from-packet`
+      が同じ effective config で一致する。
 - [ ] ローカル preview/dry-run のバージョンメタデータが `0.3.14` の次の開発ラインを使う
       （[バージョンフロー](09-developer-reference.md#バージョンフロー) のリリース後ステップに従い
       `eng/version.json` をバンプ）: `stableVersion → 0.3.14`, `nextVersion → 0.3.15`。


### PR DESCRIPTION
## Summary

Closes #1131. G512 prepared the v0.3.14 release notes for G508–G511. G513 and G514 completed before the v0.3.14 GitHub Release was cut, so the notes would otherwise omit completed release-bound work. **Docs-only**, prepare-only.

## Changes

- **`docs/en/release-notes-v0.3.14.md` + `docs/ja/release-notes-v0.3.14.md`**:
  - new **"Orchestrator-mode role boundary (G513)"** section — design owns packet authoring / intent shaping / release scope + version; the orchestrator coordinates already-ready packets (publish one `issue-cut-ready` per wake, delegate, wait, closeout) and reports blockers / missing packets to design instead of authoring them.
  - new **"Same-repo bootstrap config loading (G514)"** section — bootstrap automation commands load `.intent-cli/config.toml` so `automation summary`, `automation same-repo-metadata-preflight`, and `automation queue-seed-from-packet` agree on same-repo topology and metadata/base-branch config; no-config repos keep the safe default.
  - scope summary + release-readiness gate packet list updated to include G513/G514; added G513/G514 smoke checks.
- Existing G508–G511 content and the prepare-only release model wording are preserved.

## Acceptance criteria coverage

- ✅ EN and JA v0.3.14 notes include G513 and G514 alongside G508–G511.
- ✅ G513 description makes the design/orchestrator responsibility boundary clear.
- ✅ G514 description makes the same-repo bootstrap config-loading fix clear and names the affected commands (`automation summary`, `automation same-repo-metadata-preflight`, `automation queue-seed-from-packet`).
- ✅ The release-readiness checklist enumerating v0.3.14 scope includes G513/G514.
- ✅ `eng/version.json` remains `stableVersion=0.3.13` / `nextVersion=0.3.14` (unchanged).
- ✅ No GitHub Release/tag/NuGet publish/workflow trigger change.
- ✅ `git diff --check` clean.

## Verification

- `git status` — only the two `release-notes-v0.3.14.md` files changed; `eng/version.json` and `.github/**` untouched.
- `dotnet test … --filter ReleasePackageMetadataTests|VersionPolicyTests` — 13 passed (these read the policy/docs dynamically).
- `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb