### PR TITLE
G516: Document agmsg Monitor troubleshooting in intent-cli guides

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -514,6 +514,13 @@ First message — design → orchestrator (paste into the design thread):
   next-action` / `intent status` report an actionable item for **this**
   domain/repo (not another visible domain). If issue-cut-ready and safe, the
   orchestrator should publish one issue itself rather than wait.
+- **`mode=monitor` but no live stream** — `delivery.sh status` `mode=monitor` is
+  configuration only, not proof a Claude Code `Monitor` is attached. Verify the
+  live-attachment success markers (`1 monitor` / `Monitor event`), check Windows
+  Git Bash startup, and work the bounded fallback ladder (restart → verify trust
+  → Git Bash on Windows → compare known-good → `turn`/manual `inbox.sh` or
+  escalate). Full checklist:
+  [Orchestrator-message mode — Monitor tool vs delivery-mode](orchestrator-message-mode.md).
 
 ## Design traffic-controller playbook
 

--- a/docs/en/orchestrator-message-mode.md
+++ b/docs/en/orchestrator-message-mode.md
@@ -65,5 +65,39 @@ When the success markers are missing:
   the receiver session, then re-verify the success markers above. intent-cli never
   auto-detects or edits `~/.claude.json`.
 
+## Windows guidance
+
+- On Windows, start the monitor-mode Claude Code receiver from **Git Bash**. Dogfooding
+  showed PowerShell / native-Windows startup may not attach the agmsg Monitor reliably
+  (the SessionStart `watch.sh` directive assumes a bash environment), so the receiver can
+  report `mode=monitor` yet never stream.
+- If Git Bash is unavailable or the Monitor still does not attach on Windows, fall back to
+  `turn` delivery or manual `inbox.sh` polling (see the fallback ladder) — do not report
+  the receiver ready on `mode=monitor` alone.
+
+## Fallback ladder — orchestrator mode stays usable without realtime Monitor
+
+Realtime Monitor delivery is a convenience, **not** a requirement for orchestrator mode.
+When the success markers are missing, work this bounded ladder and then keep going with
+an explicit fallback; do not silently claim a live monitor.
+
+1. Restart the receiver Claude Code session so the SessionStart directive re-launches
+   `watch.sh`/Monitor on a fresh turn, then re-check the success markers.
+2. Verify project trust / session: the exact-cwd `~/.claude.json` project key must have
+   trust accepted (see the trust-repair runbook); confirm `ToolSearch select:Monitor`
+   resolves the generic Monitor tool in that session.
+3. On Windows, relaunch the receiver from Git Bash (see Windows guidance) rather than
+   PowerShell / a native shell.
+4. Compare against a known-good receiver project (one already showing `1 monitor` /
+   `Monitor event`) to isolate whether the break is this cwd's config or the environment.
+5. If it still will not attach, fall back to `turn` delivery or manual `inbox.sh` polling
+   and say so explicitly, or escalate to the operator. A Bash/background `watch.sh`
+   (`1 shell`) is diagnostic/fallback only — never a substitute for the Claude Code
+   Monitor, and never a reason to report the receiver as live-monitored.
+
+See the [agmsg monitor-delivery docs](https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md)
+for backend-specific delivery/watch details; intent-cli does not own or modify agmsg
+internals or Claude Code tool availability.
+
 This page does not change agmsg scripts (`watch.sh` / `delivery.sh`) and intent-cli does
 not edit `~/.claude.json`; the trust repair is an operator action only.

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -469,6 +469,12 @@ resume）します。その後 orchestrator がループを自律的に駆動し
   受信したか（`inbox.sh`）、`worker next-action` / `intent status` が **この** domain/repo に対して
   実行可能項目を報告しているか（host repo に見える別ドメインではない）を確認する。issue-cut-ready で
   安全なら、orchestrator は待たずに自分で 1 つ issue を publish すべき。
+- **`mode=monitor` だがライブストリームがない** — `delivery.sh status` `mode=monitor` は設定にすぎず、
+  Claude Code `Monitor` が attach されている証明ではない。ライブ attach の success marker（`1 monitor` /
+  `Monitor event`）を検証し、Windows では Git Bash 起動を確認し、bounded なフォールバック段階手順
+  （再起動 → trust 検証 → Windows で Git Bash → 既知の正常環境と比較 → `turn`/手動 `inbox.sh` または
+  エスカレーション）を実施する。完全なチェックリスト:
+  [orchestrator-message モード — Monitor ツールと delivery-mode の違い](orchestrator-message-mode.md)。
 
 ## design traffic-controller プレイブック
 

--- a/docs/ja/orchestrator-message-mode.md
+++ b/docs/ja/orchestrator-message-mode.md
@@ -64,5 +64,41 @@ success marker が欠けている場合:
   receiver セッションを再起動してから、上記の success marker を再検証します。intent-cli は
   `~/.claude.json` を自動検出も自動編集もしません。
 
+## Windows ガイダンス
+
+- Windows では monitor モードの Claude Code receiver を **Git Bash** から起動してください。
+  dogfooding では PowerShell / ネイティブ Windows 起動だと agmsg Monitor が確実に attach
+  されない場合が確認されました（SessionStart の `watch.sh` ディレクティブは bash 環境を
+  前提とします）。そのため receiver が `mode=monitor` と報告してもストリーミングしない
+  ことがあります。
+- Git Bash が使えない、または Windows で Monitor が依然として attach されない場合は、
+  `turn` 配信または手動の `inbox.sh` ポーリングへフォールバックしてください（下記
+  フォールバックの段階手順を参照）。`mode=monitor` だけを根拠に receiver を ready と
+  報告しないでください。
+
+## フォールバックの段階手順 — realtime Monitor なしでも orchestrator モードは使える
+
+realtime Monitor 配信は利便性であり、orchestrator モードの **必須要件ではありません**。
+success marker が欠けている場合は、この bounded な段階手順を実施し、その後は明示的な
+フォールバックで作業を続けてください。ライブ monitor だと無言で主張しないこと。
+
+1. receiver の Claude Code セッションを再起動し、SessionStart ディレクティブが新しい turn で
+   `watch.sh`/Monitor を再起動するようにしてから、success marker を再確認する。
+2. project trust / セッションを検証: exact-cwd の `~/.claude.json` project キーが trust
+   accepted である必要がある（trust 修復 runbook を参照）。そのセッションで
+   `ToolSearch select:Monitor` が汎用 Monitor ツールを解決することを確認する。
+3. Windows では、PowerShell / ネイティブシェルではなく Git Bash から receiver を再起動する
+   （Windows ガイダンスを参照）。
+4. 既知の正常な receiver プロジェクト（すでに `1 monitor` / `Monitor event` を表示している
+   もの）と比較し、破損がこの cwd の設定か環境かを切り分ける。
+5. それでも attach しない場合は、`turn` 配信または手動 `inbox.sh` ポーリングへフォールバック
+   してその旨を明示するか、operator にエスカレーションする。Bash/バックグラウンドの
+   `watch.sh`（`1 shell`）は診断/フォールバック専用であり、Claude Code Monitor の代替には
+   決してならず、receiver を live-monitored と報告する根拠にもなりません。
+
+backend 固有の配信/watch の詳細は
+[agmsg monitor-delivery ドキュメント](https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md)
+を参照してください。intent-cli は agmsg 内部や Claude Code のツール可用性を所有・変更しません。
+
 このページは agmsg スクリプト（`watch.sh` / `delivery.sh`）を変更せず、intent-cli は
 `~/.claude.json` を編集しません。trust の修復は operator のアクションのみです。

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -627,6 +627,21 @@ internal static class GuideOrchestratorThreadCommand
                     "Root cause: the exact-cwd project key in `~/.claude.json` with `hasTrustDialogAccepted=false` suppresses the SessionStart directive that launches Monitor, so no Monitor attaches and the inbox never streams (the receiver still reports `mode=monitor`).",
                     "Repair (operator action only): repair Claude project trust for that exact cwd, restart the receiver session, then re-verify the success markers above. intent-cli never auto-detects or edits `~/.claude.json`.",
                 },
+                WindowsGuidance = new[]
+                {
+                    "On Windows, start the monitor-mode Claude Code receiver from **Git Bash**. Dogfooding showed PowerShell / native-Windows startup may not attach the agmsg Monitor reliably (the SessionStart `watch.sh` directive assumes a bash environment), so the receiver can report `mode=monitor` yet never stream.",
+                    "If Git Bash is unavailable or the Monitor still does not attach on Windows, fall back to `turn` delivery or manual `inbox.sh` polling (see the fallback ladder) — do NOT report the receiver ready on `mode=monitor` alone.",
+                },
+                FallbackLadder = new[]
+                {
+                    "Realtime Monitor delivery is NOT required for orchestrator mode — it is a convenience. When the success markers are missing, work the bounded ladder below and then keep going with an explicit fallback; do not silently claim a live monitor.",
+                    "Restart the receiver Claude Code session so the SessionStart directive re-launches `watch.sh`/Monitor on a fresh turn, then re-check the success markers.",
+                    "Verify project trust / session: the exact-cwd `~/.claude.json` project key must have trust accepted (see the trust-repair runbook); confirm `ToolSearch select:Monitor` resolves the generic Monitor tool in that session.",
+                    "On Windows, relaunch the receiver from Git Bash (see Windows guidance) rather than PowerShell / a native shell.",
+                    "Compare against a known-good receiver project (one already showing `1 monitor` / `Monitor event`) to isolate whether the break is this cwd's config or the environment.",
+                    "If it still will not attach, fall back to `turn` delivery or manual `inbox.sh` polling and say so explicitly, or escalate to the operator. A Bash/background `watch.sh` (`1 shell`) is diagnostic/fallback only — never a substitute for the Claude Code Monitor, and never a reason to report the receiver as live-monitored.",
+                    "See the agmsg monitor-delivery docs (https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md) for backend-specific delivery/watch details; intent-cli does not own or modify agmsg internals or Claude Code tool availability.",
+                },
             },
             IntakeForm = new OrchestratorIntakeForm
             {
@@ -1571,6 +1586,20 @@ internal static class GuideOrchestratorThreadCommand
             writer.WriteLine($"- {step}");
         }
         writer.WriteLine();
+        writer.WriteLine("Windows guidance:");
+        writer.WriteLine();
+        foreach (var note in guide.MonitorToolDistinction.WindowsGuidance)
+        {
+            writer.WriteLine($"- {note}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("Fallback ladder — orchestrator mode stays usable without realtime Monitor:");
+        writer.WriteLine();
+        foreach (var step in guide.MonitorToolDistinction.FallbackLadder)
+        {
+            writer.WriteLine($"- {step}");
+        }
+        writer.WriteLine();
 
         writer.WriteLine("## Domain routing — single-domain vs multi-domain");
         writer.WriteLine();
@@ -2399,6 +2428,12 @@ internal sealed record OrchestratorMonitorDistinction
 
     [JsonPropertyName("trust_repair")]
     public required IReadOnlyList<string> TrustRepair { get; init; }
+
+    [JsonPropertyName("windows_guidance")]
+    public required IReadOnlyList<string> WindowsGuidance { get; init; }
+
+    [JsonPropertyName("fallback_ladder")]
+    public required IReadOnlyList<string> FallbackLadder { get; init; }
 }
 
 internal sealed record OrchestratorReceiverReadiness

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -172,6 +172,17 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("`~/.claude.json` with `hasTrustDialogAccepted=false` suppresses", output, StringComparison.Ordinal);
         Assert.Contains("repair Claude project trust for that exact cwd, restart", output, StringComparison.Ordinal);
         Assert.Contains("intent-cli never auto-detects or edits `~/.claude.json`", output, StringComparison.Ordinal);
+
+        // G516: Windows / Git Bash guidance.
+        Assert.Contains("Windows guidance:", output, StringComparison.Ordinal);
+        Assert.Contains("start the monitor-mode Claude Code receiver from **Git Bash**", output, StringComparison.Ordinal);
+        Assert.Contains("PowerShell / native-Windows startup may not attach the agmsg Monitor", output, StringComparison.Ordinal);
+
+        // G516: bounded fallback ladder keeps orchestrator mode usable without realtime Monitor.
+        Assert.Contains("Fallback ladder — orchestrator mode stays usable without realtime Monitor:", output, StringComparison.Ordinal);
+        Assert.Contains("Realtime Monitor delivery is NOT required for orchestrator mode", output, StringComparison.Ordinal);
+        Assert.Contains("fall back to `turn` delivery or manual `inbox.sh` polling", output, StringComparison.Ordinal);
+        Assert.Contains("diagnostic/fallback only — never a substitute for the Claude Code Monitor", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -192,6 +203,8 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Equal(4, distinction.GetProperty("success_markers").GetArrayLength());
         Assert.NotEmpty(distinction.GetProperty("failure_markers").EnumerateArray());
         Assert.NotEmpty(distinction.GetProperty("trust_repair").EnumerateArray());
+        Assert.NotEmpty(distinction.GetProperty("windows_guidance").EnumerateArray());
+        Assert.NotEmpty(distinction.GetProperty("fallback_ladder").EnumerateArray());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #1133. Dogfooding surfaced a repeated confusion: `delivery.sh status` says `mode: monitor` and `watch.sh` is running, yet Claude Code is not actually receiving `Monitor event: "agmsg inbox stream"` — and agents sometimes report success because a shell watcher (`1 shell`) exists. This packet turns the G511 conceptual clarification into accessible, guide-first setup/troubleshooting coverage. **Guide/docs only** — no agmsg internals, Claude Code, or release-workflow changes.

## Changes

- **`guide orchestrator-thread`** (`GuideOrchestratorThreadCommand.cs`): extend the **"Monitor tool vs delivery-mode"** section with:
  - **Windows guidance** — start the monitor-mode receiver from **Git Bash**; PowerShell/native-Windows startup may not attach the agmsg Monitor reliably; fall back to `turn`/manual `inbox.sh` when needed (do not report ready on `mode=monitor` alone).
  - a **bounded fallback ladder** — restart → verify project trust/session → Git Bash on Windows → compare with a known-good receiver → `turn`/manual `inbox.sh` or escalate. Reaffirms realtime Monitor is **not required** for orchestrator mode, and `1 shell` background `watch.sh` is diagnostic/fallback only, never a substitute for the Claude Code `Monitor`.
  - new `windows_guidance` + `fallback_ladder` JSON fields.
- **`docs/{en,ja}/orchestrator-message-mode.md`**: mirror the Windows guidance and fallback-ladder sections.
- **`docs/{en,ja}/12-agent-message-orchestration.md`**: add a Monitor-recovery bullet (`mode=monitor` but no live stream) pointing to the full checklist page for discoverability.
- **Tests** (`GuideOrchestratorThreadCommandTests.cs`): assert the Windows guidance + fallback ladder render in markdown and the new JSON marker arrays are present.

## Acceptance criteria coverage

- ✅ Guide/docs explain Claude Code's `Monitor` is a generic tool and agmsg feeds `watch.sh` through it (existing G511 text, retained).
- ✅ `delivery.sh status mode: monitor` is configuration-only, not runtime proof.
- ✅ Runtime success markers listed: `ToolSearch select:Monitor`, `Monitor(agmsg inbox stream)`, `1 monitor`, `Monitor event: "agmsg inbox stream"`.
- ✅ Failure/fallback markers listed: Bash/background `watch.sh`, `1 shell`, Azure/MCP monitor confusion.
- ✅ Bounded fallback: restart → verify trust/session → Git Bash on Windows → compare known-good → `turn`/manual inbox or escalate.
- ✅ JA + EN docs updated.
- ✅ Guide snapshot tests updated.
- ✅ Orchestrator mode stays usable without realtime monitor (explicit fallback documented).

## Out of scope (unchanged)

- No agmsg code, no Claude Code changes, monitor delivery not required for all usage, `turn`/manual delivery retained, agmsg docs not replaced.
- `eng/version.json`, `.github/**`, and agmsg scripts untouched.

## Verification

- `dotnet build` — succeeded.
- `dotnet test` (full suite) — **3180 passed, 1 skipped, 0 failed**.
- `intent-cli guide orchestrator-thread … --format markdown` — the Windows guidance + fallback ladder render under the Monitor section.
- `git diff --check` — clean; only the guide command, its tests, and the 4 docs files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb