### PR TITLE
G517: Add Claude project-settings diagnosis for missing agmsg Monitor

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -521,6 +521,13 @@ First message — design → orchestrator (paste into the design thread):
   → Git Bash on Windows → compare known-good → `turn`/manual `inbox.sh` or
   escalate). Full checklist:
   [Orchestrator-message mode — Monitor tool vs delivery-mode](orchestrator-message-mode.md).
+- **`ToolSearch select:Monitor` finds no Monitor tool at all** — this is a Claude
+  Code tool-surface problem *before* it is an agmsg problem, regardless of
+  `mode=monitor`. Compare `.claude/settings.json` / `.claude/settings.local.json`
+  / `~/.claude.json` against a known-good folder and remove suspect project-level
+  `env` overrides (e.g. `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=true`),
+  preserving agmsg hooks, then restart and re-verify. See
+  [Missing-Monitor project-settings diagnosis](orchestrator-message-mode.md#missing-monitor-project-settings-diagnosis).
 
 ## Design traffic-controller playbook
 

--- a/docs/en/orchestrator-message-mode.md
+++ b/docs/en/orchestrator-message-mode.md
@@ -99,5 +99,49 @@ See the [agmsg monitor-delivery docs](https://github.com/fujibee/agmsg/blob/main
 for backend-specific delivery/watch details; intent-cli does not own or modify agmsg
 internals or Claude Code tool availability.
 
+## Missing-Monitor project-settings diagnosis
+
+The trust-repair runbook and fallback ladder above assume a `Monitor` tool *exists* but is
+not attached. A distinct, higher-priority failure is when **`ToolSearch select:Monitor`
+finds no `Monitor` tool at all** — the tool is simply absent, not `1 shell` vs `1 monitor`.
+That is a **Claude Code tool-surface problem first, before it is an agmsg delivery
+problem**, regardless of what `delivery.sh status` `mode=monitor` reports. agmsg cannot
+stream through a Monitor tool that Claude Code is not exposing, so debugging agmsg here
+wastes effort.
+
+**Known-good comparison checklist** — diff this project's Claude Code config against a
+folder where `1 monitor` already works:
+
+- `.claude/settings.json`
+- `.claude/settings.local.json`
+- `~/.claude.json` project trust / onboarding flags
+- the enabled / disabled MCP server lists
+- project-level `env` settings
+
+**Suspect project-level `env` overrides** (observed in dogfooding under `.claude/settings.json`
+`env`) that can suppress the tool surface so `Monitor` never appears:
+
+- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=true`
+- `CLAUDE_CODE_ENABLE_TELEMETRY=false`
+- `DISABLE_ERROR_REPORTING=true`
+- `DISABLE_TELEMETRY=true`
+
+Removing or isolating these project `env` overrides (agmsg hooks preserved) restored
+`ToolSearch select:Monitor` in the affected folders.
+
+**Safe remediation** (operator action; does not touch agmsg):
+
+1. Close the Claude Code sessions.
+2. Remove or isolate the suspect project-level `env` settings, **preserving the agmsg
+   SessionStart hooks**.
+3. Reopen Claude Code.
+4. Run `ToolSearch select:Monitor`.
+5. Verify `Monitor(agmsg inbox stream)`, the footer `1 monitor`, and
+   `Monitor event: "agmsg inbox stream"` as inbox messages arrive.
+
+This is a Claude Code project-config repair, not an agmsg change. Preserve the G516
+distinction throughout: `1 monitor` is success, `1 shell` is fallback/failure.
+
 This page does not change agmsg scripts (`watch.sh` / `delivery.sh`) and intent-cli does
-not edit `~/.claude.json`; the trust repair is an operator action only.
+not edit `.claude/settings.json` or `~/.claude.json`; the trust repair and project-settings
+repair are operator actions only.

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -475,6 +475,12 @@ resume）します。その後 orchestrator がループを自律的に駆動し
   （再起動 → trust 検証 → Windows で Git Bash → 既知の正常環境と比較 → `turn`/手動 `inbox.sh` または
   エスカレーション）を実施する。完全なチェックリスト:
   [orchestrator-message モード — Monitor ツールと delivery-mode の違い](orchestrator-message-mode.md)。
+- **`ToolSearch select:Monitor` が Monitor ツールを一切見つけられない** — これは `mode=monitor` の
+  状態に関わらず、agmsg の問題である *前に* Claude Code の tool-surface の問題。`.claude/settings.json` /
+  `.claude/settings.local.json` / `~/.claude.json` を既知の正常フォルダと比較し、疑わしい project レベルの
+  `env` オーバーライド（例: `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=true`）を削除する（agmsg hooks は保持）。
+  その後、再起動して再検証する。参照:
+  [Monitor が見つからない場合の project-settings 診断](orchestrator-message-mode.md#monitor-が見つからない場合の-project-settings-診断)。
 
 ## design traffic-controller プレイブック
 

--- a/docs/ja/orchestrator-message-mode.md
+++ b/docs/ja/orchestrator-message-mode.md
@@ -100,5 +100,49 @@ backend 固有の配信/watch の詳細は
 [agmsg monitor-delivery ドキュメント](https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md)
 を参照してください。intent-cli は agmsg 内部や Claude Code のツール可用性を所有・変更しません。
 
+## Monitor が見つからない場合の project-settings 診断
+
+上記の trust 修復 runbook とフォールバック段階手順は、`Monitor` ツールが *存在するが* attach
+されていないことを前提とします。より優先度の高い別の失敗は、**`ToolSearch select:Monitor` が
+`Monitor` ツールを一切見つけられない**場合です — `1 shell` と `1 monitor` の違いではなく、
+ツール自体が存在しません。これは `delivery.sh status` `mode=monitor` が何を報告していても、
+**agmsg 配信の問題である前に、まず Claude Code の tool-surface の問題**です。Claude Code が
+露出していない Monitor ツールを通じて agmsg はストリーミングできないため、ここで agmsg を
+デバッグするのは無駄になります。
+
+**既知の正常環境との比較チェックリスト** — `1 monitor` がすでに機能するフォルダと、この
+プロジェクトの Claude Code 設定を diff します:
+
+- `.claude/settings.json`
+- `.claude/settings.local.json`
+- `~/.claude.json` の project trust / onboarding フラグ
+- 有効/無効な MCP サーバーのリスト
+- project レベルの `env` 設定
+
+**疑わしい project レベルの `env` オーバーライド**（dogfooding で `.claude/settings.json` の
+`env` 配下に観測）— tool surface を抑制し `Monitor` が現れなくなる原因:
+
+- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=true`
+- `CLAUDE_CODE_ENABLE_TELEMETRY=false`
+- `DISABLE_ERROR_REPORTING=true`
+- `DISABLE_TELEMETRY=true`
+
+これらの project `env` オーバーライドを削除または隔離する（agmsg hooks は保持）ことで、
+該当フォルダで `ToolSearch select:Monitor` が復旧しました。
+
+**安全な修復手順**（operator のアクション。agmsg には触れない）:
+
+1. Claude Code セッションを閉じる。
+2. 疑わしい project レベルの `env` 設定を削除または隔離する（**agmsg SessionStart hooks は
+   保持**）。
+3. Claude Code を再度開く。
+4. `ToolSearch select:Monitor` を実行する。
+5. inbox メッセージ到着時に `Monitor(agmsg inbox stream)`、フッター `1 monitor`、
+   `Monitor event: "agmsg inbox stream"` を検証する。
+
+これは agmsg の変更ではなく Claude Code の project-config 修復です。全体を通じて G516 の区別を
+保ちます: `1 monitor` は成功、`1 shell` はフォールバック/失敗です。
+
 このページは agmsg スクリプト（`watch.sh` / `delivery.sh`）を変更せず、intent-cli は
-`~/.claude.json` を編集しません。trust の修復は operator のアクションのみです。
+`.claude/settings.json` や `~/.claude.json` を編集しません。trust の修復と project-settings の
+修復は operator のアクションのみです。

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -642,6 +642,14 @@ internal static class GuideOrchestratorThreadCommand
                     "If it still will not attach, fall back to `turn` delivery or manual `inbox.sh` polling and say so explicitly, or escalate to the operator. A Bash/background `watch.sh` (`1 shell`) is diagnostic/fallback only — never a substitute for the Claude Code Monitor, and never a reason to report the receiver as live-monitored.",
                     "See the agmsg monitor-delivery docs (https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md) for backend-specific delivery/watch details; intent-cli does not own or modify agmsg internals or Claude Code tool availability.",
                 },
+                ProjectSettingsDiagnosis = new[]
+                {
+                    "When `ToolSearch select:Monitor` finds NO generic `Monitor` tool at all (not `1 shell` vs `1 monitor` — the tool is simply absent), treat it as a Claude Code TOOL-SURFACE problem FIRST, before debugging agmsg delivery — regardless of what `delivery.sh status` `mode=monitor` reports. agmsg cannot stream through a Monitor tool that Claude Code is not exposing.",
+                    "Known-good comparison checklist — diff this project's Claude Code config against a folder where `1 monitor` already works: `.claude/settings.json`, `.claude/settings.local.json`, `~/.claude.json` project trust/onboarding flags, the enabled/disabled MCP server lists, and project-level `env` settings.",
+                    "Suspect project-level `env` overrides observed in dogfooding (in `.claude/settings.json` `env`) that can suppress the tool surface: `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=true`, `CLAUDE_CODE_ENABLE_TELEMETRY=false`, `DISABLE_ERROR_REPORTING=true`, `DISABLE_TELEMETRY=true`. Removing/isolating these project `env` overrides (agmsg hooks preserved) restored `ToolSearch select:Monitor` in the affected folders.",
+                    "Safe remediation (operator action, does NOT touch agmsg): close the Claude Code sessions → remove or isolate the suspect project-level `env` settings while PRESERVING the agmsg SessionStart hooks → reopen Claude Code → run `ToolSearch select:Monitor` → verify `Monitor(agmsg inbox stream)`, the footer `1 monitor`, and `Monitor event` as inbox messages arrive.",
+                    "This is a Claude Code project-config repair, not an agmsg change — intent-cli never edits `.claude/settings.json`, `~/.claude.json`, or agmsg internals. Preserve the G516 distinction throughout: `1 monitor` = live success, `1 shell` = diagnostic/fallback only, never success.",
+                },
             },
             IntakeForm = new OrchestratorIntakeForm
             {
@@ -1600,6 +1608,13 @@ internal static class GuideOrchestratorThreadCommand
             writer.WriteLine($"- {step}");
         }
         writer.WriteLine();
+        writer.WriteLine("Missing-Monitor project-settings diagnosis (G517) — when `ToolSearch select:Monitor` finds no Monitor tool at all:");
+        writer.WriteLine();
+        foreach (var step in guide.MonitorToolDistinction.ProjectSettingsDiagnosis)
+        {
+            writer.WriteLine($"- {step}");
+        }
+        writer.WriteLine();
 
         writer.WriteLine("## Domain routing — single-domain vs multi-domain");
         writer.WriteLine();
@@ -2434,6 +2449,9 @@ internal sealed record OrchestratorMonitorDistinction
 
     [JsonPropertyName("fallback_ladder")]
     public required IReadOnlyList<string> FallbackLadder { get; init; }
+
+    [JsonPropertyName("project_settings_diagnosis")]
+    public required IReadOnlyList<string> ProjectSettingsDiagnosis { get; init; }
 }
 
 internal sealed record OrchestratorReceiverReadiness

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -183,6 +183,16 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("Realtime Monitor delivery is NOT required for orchestrator mode", output, StringComparison.Ordinal);
         Assert.Contains("fall back to `turn` delivery or manual `inbox.sh` polling", output, StringComparison.Ordinal);
         Assert.Contains("diagnostic/fallback only — never a substitute for the Claude Code Monitor", output, StringComparison.Ordinal);
+
+        // G517: missing-Monitor project-settings diagnosis (tool-surface first, before agmsg).
+        Assert.Contains("Missing-Monitor project-settings diagnosis (G517)", output, StringComparison.Ordinal);
+        Assert.Contains("Claude Code TOOL-SURFACE problem FIRST, before debugging agmsg delivery", output, StringComparison.Ordinal);
+        Assert.Contains("`.claude/settings.json`, `.claude/settings.local.json`, `~/.claude.json` project trust/onboarding flags", output, StringComparison.Ordinal);
+        Assert.Contains("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=true", output, StringComparison.Ordinal);
+        Assert.Contains("DISABLE_TELEMETRY=true", output, StringComparison.Ordinal);
+        Assert.Contains("PRESERVING the agmsg SessionStart hooks", output, StringComparison.Ordinal);
+        // G517 preserves the G516 marker distinction.
+        Assert.Contains("`1 monitor` = live success, `1 shell` = diagnostic/fallback only", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -205,6 +215,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.NotEmpty(distinction.GetProperty("trust_repair").EnumerateArray());
         Assert.NotEmpty(distinction.GetProperty("windows_guidance").EnumerateArray());
         Assert.NotEmpty(distinction.GetProperty("fallback_ladder").EnumerateArray());
+        Assert.NotEmpty(distinction.GetProperty("project_settings_diagnosis").EnumerateArray());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #1135. Dogfooding surfaced a failure mode G516 did not cover: in the AIC setup `ToolSearch select:Monitor` did not find Claude Code's generic `Monitor` tool **at all** — the cause was project-level Claude Code settings (`.claude/settings.json` `env` suppression), not agmsg. Agents got stuck debugging agmsg delivery instead of Claude project settings. This adds a first-class, tool-surface-first troubleshooting path. **Guide/docs only**; complements G511 + G516.

## Changes

- **`guide orchestrator-thread`** (`GuideOrchestratorThreadCommand.cs`): new `project_settings_diagnosis` block under the **Monitor tool vs delivery-mode** section:
  - `ToolSearch select:Monitor` finding **no** Monitor tool = a Claude Code **tool-surface problem first**, before it is an agmsg delivery problem, regardless of `delivery.sh status mode=monitor`.
  - **known-good comparison checklist**: `.claude/settings.json`, `.claude/settings.local.json`, `~/.claude.json` trust/onboarding flags, enabled/disabled MCP server lists, project-level `env`.
  - **named suspect `env` overrides**: `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=true`, `CLAUDE_CODE_ENABLE_TELEMETRY=false`, `DISABLE_ERROR_REPORTING=true`, `DISABLE_TELEMETRY=true`.
  - **safe remediation** (operator action): close sessions → remove/isolate suspect project `env` while **preserving agmsg hooks** → reopen → `ToolSearch select:Monitor` → verify `Monitor(agmsg inbox stream)`, `1 monitor`, `Monitor event`.
  - preserves the G516 distinction: `1 monitor` = success, `1 shell` = fallback/failure.
- **`docs/{en,ja}/orchestrator-message-mode.md`**: mirror the diagnosis section.
- **`docs/{en,ja}/12-agent-message-orchestration.md`**: Monitor-recovery pointer for the no-Monitor-tool case.
- **Tests** (`GuideOrchestratorThreadCommandTests.cs`): assert the section renders in markdown and the new JSON array is present.

## Acceptance criteria coverage

- ✅ Guide includes a missing-Monitor troubleshooting section.
- ✅ `ToolSearch select:Monitor` failing ⇒ Claude Code tool availability not ready, regardless of agmsg `mode: monitor`.
- ✅ Inspect/compare `.claude/settings.json`, `.claude/settings.local.json`, `~/.claude.json` vs a known-good folder.
- ✅ Names project-level `env` suppression settings as suspects to remove/isolate.
- ✅ Preserves G516: `1 monitor` = success, `1 shell` = fallback/failure.
- ✅ JA + EN docs updated.
- ✅ Guide tests updated.

## Out of scope (unchanged)

- No agmsg scripts/internals, no Claude Code changes, monitor not mandatory, `turn`/manual fallback retained, `watch.sh` (`1 shell`) never treated as success.
- intent-cli never edits `.claude/settings.json` / `~/.claude.json`; remediation is an operator action.
- `release-notes-v0.3.14` (design-owned), `eng/version.json`, and `.github/**` untouched.

## Verification

- Branched from current `origin/main` (`e41bf2c`, includes G516) — no pre-squash rebase risk.
- `dotnet build` — succeeded.
- Guide tests — **56 passed**.
- `intent-cli guide orchestrator-thread … --format markdown` renders the "Missing-Monitor project-settings diagnosis (G517)" block.
- `git diff --check` clean; only the guide command, its tests, and the 4 docs files changed; release-notes untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NSs9BQSjGK5EoDSQADcKb