### PR TITLE
G519: Prepare v0.3.15 patch release metadata for G517-G518

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -205,83 +205,79 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.3.13",
-  "nextVersion": "0.3.14"
-}
-```
-
-| Stage | Version form | How it is derived |
-| --- | --- | --- |
-| Local pack / install | `0.3.14-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.3.14-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.14-rc.N` | Publishing the GitHub Release for tag `v0.3.14-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
-| Stable release | `0.3.14` | Publishing the GitHub Release for tag `v0.3.14` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.3.15-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.15` |
-
-**After releasing `v0.3.14`**, bump both fields in `eng/version.json`:
-
-```json
-{
   "stableVersion": "0.3.14",
   "nextVersion": "0.3.15"
 }
 ```
 
+| Stage | Version form | How it is derived |
+| --- | --- | --- |
+| Local pack / install | `0.3.15-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.3.15-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.3.15-rc.N` | Publishing the GitHub Release for tag `v0.3.15-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
+| Stable release | `0.3.15` | Publishing the GitHub Release for tag `v0.3.15` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.3.16-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.16` |
+
+**After releasing `v0.3.15`**, bump both fields in `eng/version.json`:
+
+```json
+{
+  "stableVersion": "0.3.15",
+  "nextVersion": "0.3.16"
+}
+```
+
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.3.15-preview.<run>.<attempt>` / `0.3.15-<sha>-<G-unit>` rather than continuing to
-emit `0.3.14` (which would collide with the stable release version).
+`0.3.16-preview.<run>.<attempt>` / `0.3.16-<sha>-<G-unit>` rather than continuing to
+emit `0.3.15` (which would collide with the stable release version).
 
-### Next release readiness (v0.3.14)
+### Next release readiness (v0.3.15)
 
-**`v0.3.13` shipped** (GitHub Release + NuGet) and the version policy was bumped
-to the `0.3.14` development line. The repository is now on the in-development
-**`0.3.14`** `nextVersion`; G512 is **prepare-only** — it bumps the version
+**`v0.3.14` shipped** (GitHub Release + NuGet) and the version policy was bumped
+to the `0.3.15` development line. The repository is now on the in-development
+**`0.3.15`** `nextVersion`; G519 is **prepare-only** — it bumps the version
 metadata and docs and adds no publish steps. The version-bump merge does **not**
 create a GitHub Release or tag. After it merges and the
-[release-readiness gate](release-notes-v0.3.14.md#release-readiness-gate-g512)
+[release-readiness gate](release-notes-v0.3.15.md#release-readiness-gate-g519)
 holds, a **maintainer/operator (or external release automation) creates and
-publishes the GitHub Release** for `v0.3.14`; publishing that Release fires
+publishes the GitHub Release** for `v0.3.15`; publishing that Release fires
 `.github/workflows/release.yml` (`on: release: published`), which builds and
 publishes the NuGet package and the per-platform binary artifacts. Full
 changelog and operator checklist:
-[release-notes-v0.3.14.md](release-notes-v0.3.14.md).
+[release-notes-v0.3.15.md](release-notes-v0.3.15.md).
 
-**To ship in `v0.3.14` (changes since `v0.3.13`) — orchestrator-mode preview
-guidance patch:**
+**To ship in `v0.3.15` (changes since `v0.3.14`) — orchestrator/agmsg
+operational fixes:**
 
-- **concrete agmsg startup steps** (G508) — the orchestrator setup guide
-  produces actionable, ordered, copy-paste agmsg setup/startup/troubleshooting
-  steps from a three-folder request, plus a preflight of all three cwds.
-- **design-thread handoff + monitor recovery** (G509) — the first design→
-  orchestrator start/resume message, autonomous one-issue-per-wake publish, and
-  a monitor-recovery checklist.
-- **setup intake form + traffic-controller playbook** (G510) — eliciting/inferring
-  the setup facts with recommended defaults, role startup messages, and a design
-  traffic-controller playbook; plus the draft-PR reviewability rule via canonical
-  review surfaces.
-- **Claude Code Monitor vs agmsg delivery-mode** (G511) — distinguishes Claude
-  Code's `Monitor` tool (the real inbox-stream mechanism) from agmsg
-  `delivery.sh mode=monitor` config, with live-attachment success/failure markers
-  and a project-trust repair runbook.
+- **Claude project-settings diagnosis for a missing agmsg Monitor** (G517) —
+  when `ToolSearch select:Monitor` finds no Claude Code `Monitor` tool at all
+  (a tool-surface problem, not the `1 shell` vs `1 monitor` delivery-mode
+  confusion), the guide adds a known-good comparison checklist, names suspect
+  project-level `env` overrides, and documents safe operator remediation.
+- **orchestrator-mode timers shift to a design-side watchdog** (G518) — the
+  normal steady state is now message-driven (implementation/review replies
+  wake the orchestrator), with an explicit orchestrator timer supported only
+  as a fallback/legacy polling option, and a new optional, low-frequency
+  design-side watchdog as the recommended safety net.
 - Orchestrator mode remains **preview/experimental**: opt-in, still being
   hardened, with the timer-loop mode fully supported and unchanged. See
   [Agent-message orchestration](12-agent-message-orchestration.md).
 
-**Release-readiness verification (run before merging the `v0.3.14` version
+**Release-readiness verification (run before merging the `v0.3.15` version
 bump):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.3.13 (published), nextVersion 0.3.14 (to release)
+cat eng/version.json   # stableVersion 0.3.14 (published), nextVersion 0.3.15 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.3.14-<sha>-G51x   (NOT a stale literal)
+#   expected shape: intent-cli 0.3.15-<sha>-G51x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.14.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.15.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -289,11 +285,11 @@ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
 ```
 
 After the version-bump merge lands on `main`, a maintainer/operator (or external
-release automation) creates and publishes the GitHub Release for `v0.3.14`;
+release automation) creates and publishes the GitHub Release for `v0.3.15`;
 publishing it triggers `release.yml` (`on: release: published`) to build and
 publish the NuGet package and the per-platform binary artifacts. Once it has
 published, apply the post-release `eng/version.json` bump above
-(`stableVersion → 0.3.14`, `nextVersion → 0.3.15`).
+(`stableVersion → 0.3.15`, `nextVersion → 0.3.16`).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.3.15.md
+++ b/docs/en/release-notes-v0.3.15.md
@@ -1,0 +1,161 @@
+# Release Notes — intent-cli v0.3.15
+
+> **Release model:** a maintainer/operator (or external release automation)
+> **creates and publishes the GitHub Release** for `v0.3.15` — the version-bump
+> merge does **not** create a Release or tag on its own. Publishing the GitHub
+> Release fires `.github/workflows/release.yml` (`on: release: published`), which
+> then builds and publishes the NuGet package and platform binary artifacts.
+> This packet is **prepare-only**: it bumps version metadata and docs and adds
+> **no** publish steps. See the
+> [pre-merge release-readiness gate](#release-readiness-gate-g519) and
+> [publishing v0.3.15](#publishing-v0315).
+
+## What's in v0.3.15
+
+v0.3.15 is a **patch release** that ships two orchestrator/agmsg operational
+fixes completed after `v0.3.14`: a Claude Code project-settings diagnosis for a
+missing agmsg `Monitor` tool (G517) and a shift of orchestrator-mode timers to
+a message-driven steady state with an optional design-side watchdog (G518). No
+package id, license, or workflow-semantics changes, and the existing
+timer-loop mode is fully supported and unchanged. The package id remains
+`JTechJapan.IntentSystem.Cli`.
+
+> **Orchestrator mode is still preview/experimental.** It is opt-in, still being
+> hardened, and not the default workflow. intent-cli and GitHub remain the
+> authoritative source of truth; agmsg is only a message/progress/completion
+> signal layer.
+
+### Claude project-settings diagnosis for a missing agmsg Monitor (G517)
+
+- Dogfooding surfaced a failure mode where `ToolSearch select:Monitor` finds
+  **no** Claude Code `Monitor` tool at all — a different, earlier failure than
+  the "`1 shell` vs `1 monitor`" delivery-mode confusion covered by G511/G516.
+  When the tool itself is absent, the orchestrator-thread guide now treats it
+  as a **Claude Code tool-surface problem first**, before debugging agmsg
+  delivery, regardless of what `delivery.sh status` reports.
+- The guide adds a **known-good comparison checklist** (diff `.claude/
+  settings.json`, `.claude/settings.local.json`, `~/.claude.json` project
+  trust/onboarding flags, enabled/disabled MCP server lists, and project-level
+  `env` settings against a folder where `1 monitor` already works), names
+  **suspect project-level `env` overrides** observed in dogfooding
+  (`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `CLAUDE_CODE_ENABLE_TELEMETRY`,
+  `DISABLE_ERROR_REPORTING`, `DISABLE_TELEMETRY`), and documents **safe
+  remediation** (an operator action: close sessions, remove/isolate the
+  suspect `env` overrides while preserving the agmsg SessionStart hooks,
+  reopen, then re-verify the Monitor success markers). intent-cli never edits
+  `.claude/settings.json` or `~/.claude.json` itself.
+
+### Orchestrator-mode timers shift to a design-side watchdog (G518)
+
+- The orchestrator-thread guide now frames the **normal steady state as
+  message-driven**: implementation/review receivers already send
+  accepted/progress/completed/blocked replies to the orchestrator, and those
+  replies wake the orchestrator path, so a fast recurring orchestrator loop is
+  no longer required by default. An explicit orchestrator timer (Codex
+  automation every 5 minutes, or Claude same-thread `/loop 5m`) remains
+  **supported**, but only as an opt-in **fallback/legacy polling** option.
+- The recommended safety net for the message-driven steady state is a new
+  **optional, low-frequency design-side watchdog**: it checks the design/HITL
+  (human-in-the-loop) inbox and orchestrator staleness, sends **at most one**
+  canonical repair/status request, and stops or archives itself once both the
+  backlog and the human-decision queues are drained. The watchdog's safety
+  rules explicitly **prohibit** duplicate delegation, clearing a permission
+  prompt, cancelling/resetting in-flight work, force-closing an issue/PR, and
+  speculative durable-state surgery — it only sends a message and reads
+  read-only facts.
+
+> Version metadata note: `eng/version.json` records `stableVersion: 0.3.14`,
+> `nextVersion: 0.3.15`; G519 (this packet) is the release-prep metadata bump.
+> The post-v0.3.15 metadata advancement (`stableVersion → 0.3.15`,
+> `nextVersion → 0.3.16`) is the operator's post-release step and is out of
+> scope for this packet.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.15
+```
+
+Or download the self-contained binary from the
+[v0.3.15 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.15).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.14
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.15
+```
+
+There are no breaking changes from v0.3.14. Orchestrator mode remains opt-in;
+existing timer-loop setups are unaffected, and an explicit orchestrator timer
+remains available as a fallback/legacy polling option.
+
+## Release-readiness gate (G519)
+
+These items must hold **before the GitHub Release for `v0.3.15` is published**.
+This gate fails closed — if any item is unmet, do not publish the Release yet.
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G517, G518 (and this G519 release-notes prep). Confirm on the host/review
+      side via the host queue-state / GitHub PR state — the child implementation
+      loop must not read parent queue-state, so this is a host-owned
+      precondition.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before publishing).
+- [ ] `eng/version.json` `nextVersion` is `0.3.15` (the intended release
+      version). `release.yml` builds the package version from the published
+      Release/tag; `src/IntentSystem.Cli/IntentSystem.Cli.csproj` derives its
+      local default from the same policy.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] Release notes / README keep **orchestrator mode described as
+      preview/experimental** and opt-in, with timer-loop mode unchanged.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+
+## Publishing v0.3.15
+
+This packet does **not** publish the release and adds **no** publish steps. The
+version-bump merge does **not** create a GitHub Release or tag on its own.
+
+1. After this version bump is merged and the readiness gate above holds, a
+   **maintainer/operator (or external release automation) creates and publishes
+   the GitHub Release** for `v0.3.15` (tagging the release commit). This is a
+   post-merge host/operator/external action.
+2. Publishing that GitHub Release fires `.github/workflows/release.yml`
+   (`on: release: published`), which builds and publishes the NuGet package and
+   the per-platform binary archives (with `.sha256` checksums) and attaches them
+   to the triggering Release.
+
+Post-release verification (after the GitHub Release is published and
+`release.yml` has run):
+
+- [ ] NuGet.org package page links all resolve correctly.
+- [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+      accessible.
+- [ ] `.sha256` checksums match the downloaded artifacts.
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.15`)
+      then `intent-cli --version` reports `0.3.15`.
+- [ ] Binary artifact smoke check: download the platform archive, verify its
+      `.sha256`, extract, and run `./intent-cli --version` → `0.3.15`.
+- [ ] **Missing-Monitor diagnosis smoke** (G517): `intent-cli guide
+      orchestrator-thread --domain <d> --target-repo <repo> --agent <agent>
+      --format markdown` renders the **Missing-Monitor project-settings
+      diagnosis** subsection (known-good comparison checklist, suspect `env`
+      overrides, safe remediation) under **Monitor tool vs delivery-mode**.
+- [ ] **Design-side watchdog smoke** (G518): the same guide output renders the
+      **Scheduled orchestrator cadence** section framed as message-driven
+      steady state (orchestrator timer as fallback/legacy only) and the new
+      **Design-side watchdog (optional safety net)** section (frequency,
+      HITL/staleness checks, one repair/status request, stop condition, and
+      the safety rules prohibiting duplicate delegation, permission-prompt
+      clearing, cancellation, force-close, and durable-state surgery).
+- [ ] Local preview/dry-run version metadata uses the next development line
+      after `0.3.15` (bump `eng/version.json` per the post-release step in
+      [Version flow](09-developer-reference.md#version-flow)):
+      `stableVersion → 0.3.15`, `nextVersion → 0.3.16`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -193,81 +193,78 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.3.13",
-  "nextVersion": "0.3.14"
-}
-```
-
-| ステージ | バージョン形式 | 導出方法 |
-| --- | --- | --- |
-| ローカル pack / install | `0.3.14-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.3.14-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.14-rc.N` | タグ `v0.3.14-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
-| 安定版リリース | `0.3.14` | タグ `v0.3.14` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.3.15-preview.<run>.<attempt>` | `nextVersion` を `0.3.15` にバンプ後 |
-
-**`v0.3.14` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
-
-```json
-{
   "stableVersion": "0.3.14",
   "nextVersion": "0.3.15"
 }
 ```
 
+| ステージ | バージョン形式 | 導出方法 |
+| --- | --- | --- |
+| ローカル pack / install | `0.3.15-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.3.15-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.3.15-rc.N` | タグ `v0.3.15-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
+| 安定版リリース | `0.3.15` | タグ `v0.3.15` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.3.16-preview.<run>.<attempt>` | `nextVersion` を `0.3.16` にバンプ後 |
+
+**`v0.3.15` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+
+```json
+{
+  "stableVersion": "0.3.15",
+  "nextVersion": "0.3.16"
+}
+```
+
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.3.15-preview.<run>.<attempt>` / `0.3.15-<sha>-<G-unit>` を生成し、`0.3.14`（安定版
+`0.3.16-preview.<run>.<attempt>` / `0.3.16-<sha>-<G-unit>` を生成し、`0.3.15`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備（v0.3.14）
+### 次リリース準備（v0.3.15）
 
-**`v0.3.13` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
-`0.3.14` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.14`**
-`nextVersion` 上にあり、G512 は **prepare-only** です — version メタデータと docs をバンプするだけで
+**`v0.3.14` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
+`0.3.15` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.15`**
+`nextVersion` 上にあり、G519 は **prepare-only** です — version メタデータと docs をバンプするだけで
 publish ステップを追加しません。version-bump マージ自体は GitHub Release やタグを作成しません。
 マージされ
-[リリース準備ゲート](release-notes-v0.3.14.md#リリース準備ゲート-g512)が成り立った後、
-**メンテナ/オペレーター（または外部のリリース automation）が `v0.3.14` の GitHub Release を作成・
+[リリース準備ゲート](release-notes-v0.3.15.md#リリース準備ゲート-g519)が成り立った後、
+**メンテナ/オペレーター（または外部のリリース automation）が `v0.3.15` の GitHub Release を作成・
 publish** します。その Release の publish が `.github/workflows/release.yml`（`on: release: published`）を
 発火させ、NuGet package とプラットフォームごとのバイナリ成果物を build・publish します。
 完全な changelog と operator チェックリスト:
-[release-notes-v0.3.14.md](release-notes-v0.3.14.md)。
+[release-notes-v0.3.15.md](release-notes-v0.3.15.md)。
 
-**`v0.3.14` で出荷予定（`v0.3.13` 以降の変更）— orchestrator モードプレビューのガイダンスパッチ:**
+**`v0.3.15` で出荷予定（`v0.3.14` 以降の変更）— orchestrator/agmsg 運用修正:**
 
-- **具体的な agmsg 起動ステップ**（G508）— orchestrator setup ガイドが、3 フォルダーの要求から
-  実行可能で順序付き・貼り付け可能な agmsg setup/startup/troubleshooting ステップと、3 つの cwd の
-  preflight を生成します。
-- **design-thread ハンドオフ + monitor リカバリ**（G509）— 最初の design→orchestrator start/resume
-  メッセージ、wake ごとの自律的な 1 issue publish、monitor リカバリチェックリスト。
-- **setup intake フォーム + traffic-controller プレイブック**（G510）— セットアップ事実の引き出し/推論と
-  推奨デフォルト、ロール起動メッセージ、design traffic-controller プレイブック。draft-PR レビュー可否
-  （canonical review surface 経由）も含む。
-- **Claude Code Monitor vs agmsg delivery-mode**（G511）— Claude Code の `Monitor` ツール（実際の
-  inbox-stream の仕組み）と agmsg `delivery.sh mode=monitor` 設定を区別。live-attachment の
-  success/failure マーカーと project-trust 修復 runbook 付き。
+- **agmsg Monitor 欠落時の Claude project-settings 診断**（G517）— `ToolSearch select:Monitor` が
+  Claude Code の `Monitor` ツールをまったく見つけられない場合（`1 shell` vs `1 monitor` の
+  delivery-mode 混同ではなく、ツールサーフェス問題）、ガイドに known-good 比較チェックリスト、
+  疑わしい project-level `env` override、安全なオペレーター修復手順を追加。
+- **orchestrator モードのタイマーを design-side watchdog へシフト**（G518）— 通常の定常状態が
+  メッセージ駆動になり（implementation/review の返信が orchestrator を起こす）、明示的な
+  orchestrator タイマーは fallback/legacy ポーリングオプションとしてのみサポートされ、新しい
+  任意・低頻度の design-side watchdog が推奨セーフティネットとして追加された。
 - orchestrator モードは引き続き **preview/experimental** です: オプトインで、まだ hardening 中であり、
   timer-loop モードは完全サポート・不変です。
   [エージェントメッセージオーケストレーション](12-agent-message-orchestration.md) を参照。
 
-**リリース準備の検証（`v0.3.14` version bump のマージ前に実行）:**
+**リリース準備の検証（`v0.3.15` version bump のマージ前に実行）:**
 
 ```bash
-cat eng/version.json   # stableVersion 0.3.13（公開済み）, nextVersion 0.3.14（リリース対象）
+cat eng/version.json   # stableVersion 0.3.14（公開済み）, nextVersion 0.3.15（リリース対象）
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.3.14-<sha>-G51x （stale なリテラルではない）
+#   期待形: intent-cli 0.3.15-<sha>-G51x （stale なリテラルではない）
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.14.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.15.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
 version-bump マージが `main` に入った後、メンテナ/オペレーター（または外部のリリース automation）が
-`v0.3.14` の GitHub Release を作成・publish します。その publish が `release.yml`
+`v0.3.15` の GitHub Release を作成・publish します。その publish が `release.yml`
 （`on: release: published`）を発火させ、NuGet package とプラットフォームごとのバイナリ成果物を
 build・publish します。publish 後、上記のリリース後 `eng/version.json` バンプ
-（`stableVersion → 0.3.14`, `nextVersion → 0.3.15`）を適用します。
+（`stableVersion → 0.3.15`, `nextVersion → 0.3.16`）を適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.3.15.md
+++ b/docs/ja/release-notes-v0.3.15.md
@@ -1,0 +1,135 @@
+# リリースノート — intent-cli v0.3.15
+
+> **リリースモデル:** メンテナ/オペレーター（または外部のリリース automation）が `v0.3.15` の
+> **GitHub Release を作成・publish** します — version-bump マージ自体は Release やタグを作成しません。
+> GitHub Release の publish が `.github/workflows/release.yml`（`on: release: published`）を発火させ、
+> NuGet package とプラットフォームバイナリ成果物を build・publish します。本パケットは
+> **prepare-only** で、version メタデータと docs をバンプするだけで publish ステップを **追加しません**。
+> [マージ前 リリース準備ゲート](#リリース準備ゲート-g519) と
+> [v0.3.15 の publish](#v0315-の-publish) を参照。
+
+## v0.3.15 の内容
+
+v0.3.15 は **パッチリリース** で、`v0.3.14` 以降に完了した 2 件の orchestrator/agmsg 運用修正、
+agmsg `Monitor` ツールが欠落した場合の Claude project-settings 診断（G517）と、orchestrator モードの
+タイマーをメッセージ駆動の定常状態＋任意の design-side watchdog へシフトする変更（G518）を出荷します。
+package id・ライセンス・workflow セマンティクスの変更はなく、既存の timer-loop モードは完全サポート・
+不変です。package id は `JTechJapan.IntentSystem.Cli` のままです。
+
+> **orchestrator モードは引き続き preview/experimental です。** オプトインで、まだ hardening 中で
+> あり、デフォルトの workflow ではありません。intent-cli と GitHub が権威 source of truth であり
+> 続け、agmsg はメッセージ / 進捗 / 完了のシグナル層のみです。
+
+### agmsg Monitor 欠落時の Claude project-settings 診断（G517）
+
+- dogfooding により、`ToolSearch select:Monitor` が Claude Code の `Monitor` ツールを **まったく**
+  見つけられない失敗モードが判明しました — これは G511/G516 が扱う「`1 shell` vs `1 monitor`」の
+  delivery-mode 混同とは異なる、より手前の失敗です。ツール自体が存在しない場合、orchestrator-thread
+  ガイドはまず（`delivery.sh status` が何を報告していても）**Claude Code のツールサーフェス問題**
+  として扱うようになりました。agmsg delivery のデバッグはその後です。
+- ガイドに **known-good 比較チェックリスト**（`1 monitor` が既に動いているフォルダーと、
+  `.claude/settings.json`、`.claude/settings.local.json`、`~/.claude.json` の project trust/onboarding
+  フラグ、有効/無効な MCP server リスト、project-level `env` 設定を diff する）、dogfooding で
+  観測された **疑わしい project-level `env` override**（`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`、
+  `CLAUDE_CODE_ENABLE_TELEMETRY`、`DISABLE_ERROR_REPORTING`、`DISABLE_TELEMETRY`）、および
+  **安全な修復手順**（オペレーターアクション: セッションを閉じ、agmsg の SessionStart フックを
+  保ったまま疑わしい `env` override を削除/隔離し、再度開いて Monitor の success marker を再検証する）
+  を追加しました。intent-cli 自身は `.claude/settings.json` や `~/.claude.json` を編集しません。
+
+### orchestrator モードのタイマーを design-side watchdog へシフト（G518）
+
+- orchestrator-thread ガイドは、**通常の定常状態をメッセージ駆動** として枠組みし直しました:
+  implementation/review receiver はすでに accepted/progress/completed/blocked の返信を orchestrator に
+  送っており、その返信が orchestrator を起こすため、既定では高速な定期 orchestrator ループは不要に
+  なりました。明示的な orchestrator タイマー（Codex automation 5 分ごと、または Claude 同一スレッド
+  `/loop 5m`）は引き続き **サポート** されますが、オプトインの **fallback/legacy ポーリング**
+  オプションとしてのみです。
+- メッセージ駆動の定常状態に推奨されるセーフティネットとして、新しい **任意・低頻度の
+  design-side watchdog** を追加しました: design/HITL（human-in-the-loop）inbox と orchestrator の
+  停滞を確認し、canonical な repair/status リクエストを **最大 1 通** 送り、backlog と
+  human-decision キューの両方がなくなったら停止/アーカイブします。watchdog の安全ルールは、
+  重複した delegation、permission プロンプトのクリア、進行中作業のキャンセル/リセット、
+  issue/PR の強制クローズ、推測的な durable-state の手術を明示的に **禁止** します — watchdog は
+  メッセージを送り read-only な事実を読むだけです。
+
+> バージョンメタデータ注記: `eng/version.json` は `stableVersion: 0.3.14`,
+> `nextVersion: 0.3.15` を記録します。G519（本パケット）はリリース準備のメタデータバンプです。
+> v0.3.15 リリース後のメタデータ前進（`stableVersion → 0.3.15`, `nextVersion → 0.3.16`）は
+> オペレーターのリリース後ステップであり、本パケットのスコープ外です。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.15
+```
+
+または [v0.3.15 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.3.15)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを検証します。
+
+## v0.3.14 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.3.15
+```
+
+v0.3.14 からの破壊的変更はありません。orchestrator モードはオプトインのままで、既存の timer-loop
+セットアップには影響しません。明示的な orchestrator タイマーは引き続き fallback/legacy ポーリング
+オプションとして利用できます。
+
+## リリース準備ゲート (G519)
+
+次の項目は **`v0.3.15` の GitHub Release が publish される前** に成り立っている必要があります。
+このゲートは fail closed です — 1 つでも未充足なら、まだ Release を publish しないでください。
+
+- [ ] リリース対象の各パケットが **完了し PR が `main` にマージ済み**: G517、G518（および
+      release-notes 準備の G519）。host queue-state / GitHub PR 状態で host/review 側から確認する
+      （child 実装ループは parent queue-state を読まないため、これは host 所有の前提条件）。
+- [ ] 本リリース対象の open な intent-system PR や WIP パケットが誤ってスキップされていない
+      （publish 前に host queue / open PR リストを確認）。
+- [ ] `eng/version.json` の `nextVersion` が `0.3.15`（意図したリリースバージョン）。`release.yml`
+      は publish された Release/タグから package バージョンをビルドし、
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` も同じポリシーからローカルデフォルトを導出する。
+- [ ] package メタデータが正しい: `PackageId = JTechJapan.IntentSystem.Cli`、
+      `RepositoryUrl` / `PackageProjectUrl` が `https://github.com/J-Tech-Japan/intent-system` を指す、
+      `PackageLicenseExpression = Apache-2.0`、README/docs リンクが解決し、公式サービスサイト
+      `https://www.intent-driven-development.com/` が README からリンクされている。
+- [ ] リリースノート / README が **orchestrator モードは preview/experimental** かつオプトインで
+      あること、timer-loop モードが不変であることを保っている。
+- [ ] リリースコミットで **Main CI が green**（`Build and test (source contract)`）であり、
+      **preview-pack** workflow も green。
+
+## v0.3.15 の publish
+
+本パケットはリリースを publish せず、publish ステップを **追加しません**。version-bump マージ自体は
+GitHub Release やタグを作成しません。
+
+1. この version bump がマージされ上記の準備ゲートが成り立った後、**メンテナ/オペレーター（または
+   外部のリリース automation）が `v0.3.15` の GitHub Release を作成・publish** します
+   （リリースコミットにタグ付け）。これはマージ後の host/operator/外部リリースアクションです。
+2. その GitHub Release の publish が `.github/workflows/release.yml`（`on: release: published`）を
+   発火させ、NuGet package とプラットフォームごとのバイナリアーカイブ（`.sha256` チェックサム付き）を
+   build・publish し、トリガーとなった Release に添付します。
+
+リリース後の検証（GitHub Release が publish され `release.yml` が実行された後）:
+
+- [ ] NuGet.org の package ページのリンクがすべて正しく解決する。
+- [ ] GitHub release アセットリンク（`.tar.gz`, `.zip`, `.exe`, `.nupkg`）にアクセスできる。
+- [ ] `.sha256` チェックサムがダウンロード成果物と一致する。
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`（または
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.3.15`）後、
+      `intent-cli --version` が `0.3.15` を報告する。
+- [ ] バイナリ成果物スモーク: プラットフォームアーカイブをダウンロードし `.sha256` を検証、
+      展開して `./intent-cli --version` → `0.3.15`。
+- [ ] **Missing-Monitor 診断スモーク**（G517）: `intent-cli guide orchestrator-thread
+      --domain <d> --target-repo <repo> --agent <agent> --format markdown` が、**Monitor tool vs
+      delivery-mode** の下に **Missing-Monitor project-settings diagnosis** サブセクション
+      （known-good 比較チェックリスト、疑わしい `env` override、安全な修復手順）をレンダリングする。
+- [ ] **design-side watchdog スモーク**（G518）: 同じガイド出力が、メッセージ駆動の定常状態
+      （orchestrator タイマーは fallback/legacy のみ）として枠組みされた **Scheduled orchestrator
+      cadence** セクションと、新しい **Design-side watchdog (optional safety net)** セクション
+      （頻度、HITL/停滞チェック、repair/status リクエスト最大 1 通、停止条件、重複 delegation・
+      permission プロンプトのクリア・キャンセル・強制クローズ・durable-state の手術を禁止する
+      安全ルール）をレンダリングする。
+- [ ] ローカル preview/dry-run のバージョンメタデータが `0.3.15` の次の開発ラインを使う
+      （[バージョンフロー](09-developer-reference.md#バージョンフロー) のリリース後ステップに従い
+      `eng/version.json` をバンプ）: `stableVersion → 0.3.15`, `nextVersion → 0.3.16`。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.13",
-  "nextVersion": "0.3.14"
+  "stableVersion": "0.3.14",
+  "nextVersion": "0.3.15"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,10 +124,10 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.14 as the next development line
-        // (post-v0.3.13 release bump, see G512 — v0.3.13 was published to
+        // be parseable and must point to 0.3.15 as the next development line
+        // (post-v0.3.14 release bump, see G519 — v0.3.14 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.3.14 while recording 0.3.13 as the published stable).
+        // forward to 0.3.15 while recording 0.3.14 as the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -137,8 +137,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.14", policy.NextVersion);
-        Assert.Equal("0.3.13", policy.StableVersion);
+        Assert.Equal("0.3.15", policy.NextVersion);
+        Assert.Equal("0.3.14", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Closes #1139. Prepare the repository for an operator release of v0.3.15, a patch release bundling the orchestrator/agmsg operational fixes completed since v0.3.14 (G517–G518). **Release-prep only.**

## Changes

- **`eng/version.json`** — advance to `stableVersion: 0.3.14` (published) / `nextVersion: 0.3.15` (release-to-cut); local pack / `--version` now derive `0.3.15-<sha>-<unit>` (verified: `intent-cli --version` reports `0.3.15-95996e2-G518`).
- **`docs/en/release-notes-v0.3.15.md` + `docs/ja/release-notes-v0.3.15.md`** (new): summarize G517 (Claude project-settings diagnosis for a missing agmsg `Monitor`) and G518 (orchestrator-mode timers shift to a message-driven steady state + optional design-side watchdog) in user-understandable language, using the prepare-only release model (operator publishes the GitHub Release → `release.yml` on `release.published` → NuGet + binaries), with a fail-closed release-readiness gate and a post-release verification checklist (including guide smokes for both G517 and G518).
- **`docs/en/09-developer-reference.md` + `docs/ja/09-developer-reference.md`** — retarget the version-flow table/JSON examples and the "Next release readiness" section to v0.3.15 (G517–G518), link the new release notes, and document the post-release bump (`stableVersion → 0.3.15`, `nextVersion → 0.3.16`).
- **`tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs`** — update the `eng/version.json` smoke assertion to `nextVersion: 0.3.15` / `stableVersion: 0.3.14`.

## Acceptance criteria coverage

- ✅ Version metadata updated to the next patch version after v0.3.14 (`0.3.15`).
- ✅ Release notes include G517 and G518 in user-understandable language.
- ✅ No tag/release/publish/credential action occurs in this PR.
- ✅ Verification commands / focused metadata tests documented (below).

## Out of scope (unchanged)

- No tag creation, no GitHub Release, no NuGet publish, no credentials.
- No runtime behavior change beyond release metadata/docs.
- `.github/**` untouched.

## Verification

- Branched from current `origin/main` (includes the G518 merge `95996e2`).
- `dotnet build` — succeeded.
- `dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version` → `intent-cli 0.3.15-95996e2-G518` (expected shape, not a stale literal).
- `dotnet test … --filter "FullyQualifiedName~VersionPolicyTests|FullyQualifiedName~ReleasePackageMetadataTests"` — **13 passed**.
- `dotnet test` (full suite) — **3182 passed, 1 skipped, 0 failed**.
- `git diff --check` — clean; only `eng/version.json`, the two new `release-notes-v0.3.15.md` files, the two `09-developer-reference.md` docs, and `VersionPolicyTests.cs` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyAC7Waoksgu8wMDAtQpY7