### PR TITLE
G520: Enforce managed review worktrees and design-alignment checks in orchestrator mode

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -31,7 +31,9 @@ outcome is one of `missing-inputs`, `setup-ready`, or `blocked`:
   (existing-loop conflict check, read-only first wake, ping/inbox test).
 - **blocked** — an existing implementation/review timer loop for this domain/repo
   would race the orchestrator; stop it (or pass `--existing-loop-policy
-  will-stop`) before starting. Only the orchestrator is scheduled.
+  will-stop`) before starting. Receivers are never scheduled; when an explicit
+  fallback/legacy timer is used (message-driven wakes are the default), the
+  orchestrator is the only thread ever scheduled.
 
 ```bash
 intent-cli guide orchestrator-thread --domain <d> --target-repo <owner/repo> \

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -353,6 +353,59 @@ symptom of an unmanaged workspace.
   default; the goal is to never need a destructive `rm -rf` prompt, not to
   suppress it.
 
+## Review delegation — managed worktrees and design alignment
+
+Review delegation must carry the managed-worktree policy and require
+design-alignment evidence **up front** — not leave the reviewer to discover
+it. Dogfooding showed a reviewer allocate a raw `/tmp/...review...` worktree
+and Codex correctly ask to approve a destructive `rm -rf` — the **right**
+safety behavior for the **wrong** workflow. The fix is a managed root, **not**
+weakening approval settings.
+
+- **Managed worktree root** — review worktrees use the **same** managed,
+  workspace-local root as the rest of orchestrated work — the `[project]
+  worktree_root` (default `.intent-cli/worktrees/`), e.g.
+  `.intent-cli/worktrees/review-<unit>` — **never** an arbitrary
+  `/tmp/...review...` path.
+- **Prohibited pattern** — a raw `/tmp/...` review worktree, and a
+  `rm -rf /tmp/... && git worktree add ...` cleanup chain, are **prohibited**
+  as the normal path. Reaching for this pattern is the signal to stop and
+  allocate under the managed root instead — not to ask the operator to
+  approve the `rm -rf`.
+- **Cleanup rule** — cleanup is `git worktree remove <managed-path>` for a
+  **registered, clean** worktree only (confirm via `git worktree list` and a
+  clean `git status` first).
+- **Unsafe/stale path rule** — a stale path that is not a registered git
+  worktree, is outside the managed root, or is dirty/unsafe is **never** an
+  operator `rm -rf` approval prompt — it is a **structured blocker** agmsg
+  reply to the orchestrator (`status: blocked`) so the orchestrator can route
+  the repair, not something the reviewer resolves by force-deleting an
+  unmanaged path.
+
+Review delegation example (orchestrator → review):
+
+```json
+{"delegate":{"domain":"<domain>","execution_unit":"<unit>","target_repo":"<owner/repo>","pr":"<n>","review_cwd":"/review/<domain>","managed_worktree_policy":"required — allocate under [project] worktree_root (default .intent-cli/worktrees/), never /tmp","design_alignment_required":true,"destination_thread":"review@<domain>"}}
+```
+
+A review `completed` reply must include design-alignment evidence:
+
+```json
+{"status":"completed","thread":"review","ref":"pr#<n>","note":"approved; closeout done","design_alignment_checked":true,"design_alignment_sources_checked":["packet","review-context","intent-tree","adr-decision-notes","relevant-docs"],"managed_worktree_policy":"compliant — .intent-cli/worktrees/review-<unit>, removed after review"}
+```
+
+Design-alignment sources a review reply may cite as checked: the **packet**
+(content and acceptance criteria), the **review-context** artifact for the
+PR/unit, the relevant **intent tree** entries, any linked **ADR / decision
+notes**, and **relevant docs** the change touches.
+
+**Review-incomplete rule:** a review `completed` reply that omits
+`design_alignment_checked: true` and the checked-source list is
+**incomplete** — the orchestrator does not route merge/closeout on that reply
+alone. The only exception is when an authoritative **prior** approval state
+already proves equivalent design-alignment review (the orchestrator must
+point to that specific prior evidence, not assume equivalence).
+
 ## Receiver readiness
 
 Monitor configuration is **not enough**. A registered team plus a configured
@@ -649,6 +702,14 @@ branch, or over dirty user work is the most common orchestration failure.
   claim. The receiver's cwd/worktree, git remote, and delegated domain must
   match the routing; reply blocked and re-route. An execution-unit prefix
   mismatch alone is not the signal — compare packet/domain metadata.
+- **Codex asks to approve `rm -rf /tmp/...review...`** — this is the **right**
+  safety behavior for the **wrong** workflow: the review worktree was
+  allocated at an unmanaged `/tmp` path instead of the managed root. The fix
+  is the managed root (`.intent-cli/worktrees/review-<unit>`), **not**
+  weakening approval settings — re-allocate under the managed root (see
+  [Review delegation](#review-delegation--managed-worktrees-and-design-alignment)),
+  and do not approve the `rm -rf` for the stale `/tmp` path; reply blocked to
+  the orchestrator instead so it can route the cleanup as a repair.
 
 ## Draft PR reviewability
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -29,8 +29,9 @@ intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> 
   分の最初のプロンプト、最初の検証（existing-loop 競合チェック、read-only first wake、ping/inbox
   テスト）を emit する。
 - **blocked** — 同じ domain/repo の既存の実装/レビュー timer loop が orchestrator と競合する。
-  開始前に停止する（または `--existing-loop-policy will-stop` を渡す）。orchestrator のみが
-  スケジュールされる。
+  開始前に停止する（または `--existing-loop-policy will-stop` を渡す）。receiver は決してスケジュール
+  されない — 明示的な fallback/legacy タイマーを使う場合（既定はメッセージ駆動の wake）のみ、
+  orchestrator が唯一スケジュールされるスレッドになる。
 
 ```bash
 intent-cli guide orchestrator-thread --domain <d> --target-repo <owner/repo> \

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -324,6 +324,52 @@ state**、それを裏付ける evidence、必要なときだけの options、�
   **代替ではありません**。最小権限の承認をデフォルトに保ちます。目標は破壊的な `rm -rf` プロンプトを
   抑制することではなく、そもそも必要としないことです。
 
+## review 委譲 — managed worktree と design alignment
+
+review の委譲は managed-worktree ポリシーと design-alignment のエビデンス要求を **あらかじめ**
+含んでいる必要があります — reviewer に発見させてはいけません。dogfooding では、reviewer が生の
+`/tmp/...review...` worktree を割り当て、Codex が破壊的な `rm -rf` の承認を正しく求めるという
+事例が見つかりました — これは **正しい** 安全動作ですが、**間違った** workflow です。修正は
+managed root であり、承認設定を弱めることでは **ありません**。
+
+- **managed worktree root** — review worktree は他のオーケストレーション作業と **同じ** managed・
+  workspace-local root を使います — `[project] worktree_root`（デフォルト `.intent-cli/worktrees/`）、
+  例: `.intent-cli/worktrees/review-<unit>` — 任意の `/tmp/...review...` パスは **決して** 使いません。
+- **禁止パターン** — 生の `/tmp/...` review worktree と `rm -rf /tmp/... && git worktree add ...`
+  のクリーンアップチェーンは、通常のパスとして **禁止** されます。このパターンに手が伸びたら、
+  それは停止して managed root の下に割り当て直す合図です — オペレーターに `rm -rf` の承認を
+  求める合図ではありません。
+- **クリーンアップルール** — クリーンアップは **登録済みで clean な** worktree に対してのみ
+  `git worktree remove <managed-path>` を使います（`git worktree list` と clean な `git status`
+  でまず確認する）。
+- **unsafe/stale パスのルール** — 登録済み git worktree ではない、managed root の外にある、
+  または dirty/unsafe な stale パスは **決して** オペレーターの `rm -rf` 承認プロンプトには
+  なりません — それは orchestrator への **structured blocker** agmsg 返信（`status: blocked`）
+  であり、orchestrator が repair としてルーティングできるようにします。reviewer が unmanaged な
+  パスを force-delete して解決するものではありません。
+
+review 委譲の例（orchestrator → review）:
+
+```json
+{"delegate":{"domain":"<domain>","execution_unit":"<unit>","target_repo":"<owner/repo>","pr":"<n>","review_cwd":"/review/<domain>","managed_worktree_policy":"required — allocate under [project] worktree_root (default .intent-cli/worktrees/), never /tmp","design_alignment_required":true,"destination_thread":"review@<domain>"}}
+```
+
+review の `completed` 返信は design-alignment のエビデンスを含む必要があります:
+
+```json
+{"status":"completed","thread":"review","ref":"pr#<n>","note":"approved; closeout done","design_alignment_checked":true,"design_alignment_sources_checked":["packet","review-context","intent-tree","adr-decision-notes","relevant-docs"],"managed_worktree_policy":"compliant — .intent-cli/worktrees/review-<unit>, removed after review"}
+```
+
+review 返信がチェック済みとして挙げられる design-alignment ソース: **packet**（内容と受け入れ基準）、
+その PR/unit の **review-context** artifact、関連する **intent tree** のエントリ、リンクされた
+**ADR / decision notes**、変更が触れる **関連 docs**。
+
+**review-incomplete ルール:** `design_alignment_checked: true` とチェック済みソースのリストを
+省いた review の `completed` 返信は **incomplete** です — orchestrator はその返信だけでは
+merge/closeout をルーティングしません。唯一の例外は、権威ある **事前の** approval state が
+すでに同等の design-alignment review を証明している場合です（orchestrator はその具体的な
+事前エビデンスを指し示す必要があり、同等性を仮定してはいけません）。
+
 ## receiver の準備状態（readiness）
 
 monitor の設定だけでは **不十分** です。team 登録 + delivery mode 設定があっても、receiver が
@@ -590,6 +636,13 @@ preflight します。receiver が誤った repo・誤ったブランチ・dirty
 - **receiver の cwd が委譲と異なる repo/domain を見る** — 停止。claim しない。receiver の cwd/worktree・
   git remote・委譲された domain がルーティングと一致する必要がある。blocked を返して re-route する。
   execution-unit prefix の不一致だけでは signal にならない — packet/domain メタデータを比較する。
+- **Codex が `rm -rf /tmp/...review...` の承認を求めてくる** — これは **正しい** 安全動作ですが
+  **間違った** workflow です: review worktree が managed root ではなく unmanaged な `/tmp` パスに
+  割り当てられています。修正は managed root（`.intent-cli/worktrees/review-<unit>`）であり、承認
+  設定を弱めることでは **ありません** — managed root の下に再割り当てしてください
+  （[review 委譲](#review-委譲--managed-worktree-と-design-alignment) 参照）。stale な `/tmp` パスの
+  `rm -rf` は承認せず、代わりに orchestrator に blocked を返信して repair としてルーティングして
+  もらいます。
 
 ## draft PR のレビュー可否
 

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -231,7 +231,8 @@ internal static class GuideOrchestratorThreadCommand
                 ReceiverNote =
                     "Implementation and review threads are loopless receivers: do NOT start a recurring timer/loop in a "
                     + "receiver thread for this domain/repo. A receiver waits for an agmsg delegation, acts once, replies "
-                    + "once, and waits again. Only the orchestrator is scheduled.",
+                    + "once, and waits again. Receivers are NEVER scheduled; when an explicit fallback/legacy timer is "
+                    + "used (message-driven wakes are the default), the orchestrator is the only thread ever scheduled.",
                 CodexSetupPrompt = Apply(
                     "OPTIONAL fallback/legacy polling — Codex automation (run every 5 minutes) for the ORCHESTRATOR "
                     + "thread, domain `<domain>` against `<owner/repo>` using `<agent>`: on each run perform exactly "
@@ -1061,7 +1062,7 @@ internal static class GuideOrchestratorThreadCommand
                         "You are the IMPLEMENTATION thread for domain `<domain>` against `<owner/repo>` using `<agent>`, "
                         + "driven by orchestrator agmsg delegations. You are a LOOPLESS receiver: do NOT start your own "
                         + "recurring timer/loop for this domain/repo — wait for a delegation, act once, reply once, then "
-                        + "wait again (only the orchestrator is scheduled). When delegated an item, run "
+                        + "wait again (receivers are never scheduled; the orchestrator is message-driven by default, with an explicit fallback/legacy timer as the only case where it is scheduled). When delegated an item, run "
                         + "the normal child implementation workflow: the issue/PR number comes from `intent-cli worker "
                         + "next-action --repo <owner/repo> --github-only`, NOT from the agmsg text. Before claiming, "
                         + "verify your local checkout context matches the delegation: your cwd/worktree, the git remote "
@@ -1085,7 +1086,7 @@ internal static class GuideOrchestratorThreadCommand
                         "You are the REVIEW thread for domain `<domain>` against `<owner/repo>` using `<agent>`, driven "
                         + "by orchestrator agmsg delegations. You are a LOOPLESS receiver: do NOT start your own "
                         + "recurring timer/loop for this domain/repo — wait for a delegation, act once, reply once, then "
-                        + "wait again (only the orchestrator is scheduled). When delegated a PR, run the "
+                        + "wait again (receivers are never scheduled; the orchestrator is message-driven by default, with an explicit fallback/legacy timer as the only case where it is scheduled). When delegated a PR, run the "
                         + "official host review/closeout through intent-cli surfaces (`review closeout-plan`, `guide "
                         + "review`, `automation pr-transition`, `closeout pr`) — agmsg never replaces semantic review or "
                         + "authorizes a merge. Perform semantic review only when you are the packet `review_role` or "
@@ -1241,7 +1242,9 @@ internal static class GuideOrchestratorThreadCommand
                 Headline =
                     "blocked — existing implementation/review timer loops for this domain/repo would race the "
                     + "orchestrator (mixed-mode). Stop the existing loops (or re-run with --existing-loop-policy "
-                    + "will-stop) before starting orchestrator mode; only the orchestrator is scheduled.",
+                    + "will-stop) before starting orchestrator mode; receivers are never scheduled — orchestrator "
+                    + "wakes are message-driven by default, with an explicit fallback/legacy timer as the only case "
+                    + "where the orchestrator itself is scheduled.",
                 MissingFields = Array.Empty<string>(),
                 Inputs = inputs,
                 LooplessReceiverNote = LooplessReceiverNote,

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -812,6 +812,44 @@ internal static class GuideOrchestratorThreadCommand
                     + "least-privilege approvals as the default; the goal is to never need a destructive `rm -rf` prompt, "
                     + "not to suppress the prompt.",
             },
+            ReviewDelegationContract = new OrchestratorReviewDelegationContract
+            {
+                Summary =
+                    "Review delegation must carry the managed-worktree policy and require design-alignment evidence up "
+                    + "front — not leave the reviewer to discover it. Dogfooding showed a reviewer allocate a raw "
+                    + "`/tmp/...review...` worktree and Codex correctly ask to approve a destructive `rm -rf` — the "
+                    + "RIGHT safety behavior for the WRONG workflow. The fix is a managed root, NOT weakening approval "
+                    + "settings.",
+                ManagedWorktreeRoot =
+                    "Review worktrees use the SAME managed, workspace-local root as the rest of orchestrated work — the "
+                    + "`[project] worktree_root` (default `.intent-cli/worktrees/`), e.g. "
+                    + "`.intent-cli/worktrees/review-<unit>` — NEVER an arbitrary `/tmp/...review...` path.",
+                ProhibitedPattern =
+                    "PROHIBITED as the normal path: a raw `/tmp/...` review worktree, and a `rm -rf /tmp/... && git "
+                    + "worktree add ...` cleanup chain. Reaching for this pattern is the signal to STOP and allocate "
+                    + "under the managed root instead — not to ask the operator to approve the `rm -rf`.",
+                CleanupRule =
+                    "Cleanup is `git worktree remove <managed-path>` for a REGISTERED, CLEAN worktree only — confirmed "
+                    + "via `git worktree list` and a clean `git status` first.",
+                UnsafeStalePathRule =
+                    "A stale path that is NOT a registered git worktree, is OUTSIDE the managed root, or is dirty/"
+                    + "unsafe is NEVER an operator `rm -rf` approval prompt — it is a STRUCTURED BLOCKER agmsg reply to "
+                    + "the orchestrator (`status: blocked`) so the orchestrator can route the repair, not something the "
+                    + "reviewer resolves by force-deleting an unmanaged path.",
+                DelegationExample =
+                    "{\"delegate\":{\"domain\":\"<domain>\",\"execution_unit\":\"<unit>\",\"target_repo\":"
+                    + "\"<owner/repo>\",\"pr\":\"<n>\",\"review_cwd\":\"/review/<domain>\",\"managed_worktree_policy\":"
+                    + "\"required — allocate under [project] worktree_root (default .intent-cli/worktrees/), never "
+                    + "/tmp\",\"design_alignment_required\":true,\"destination_thread\":\"review@<domain>\"}}",
+                DesignAlignmentSources = new[]
+                {
+                    "packet — the authored packet content and acceptance criteria.",
+                    "review-context — the review-context artifact for this PR/unit.",
+                    "intent tree — the relevant intent-tree entries for the touched domain.",
+                    "ADR / decision notes — any linked architecture or design-decision records.",
+                    "relevant docs — user-facing or developer docs the change touches.",
+                },
+            },
             Setup = new OrchestratorSetup
             {
                 Summary =
@@ -901,6 +939,11 @@ internal static class GuideOrchestratorThreadCommand
                 {
                     Symptom = "Receiver cwd sees a different repo/domain than delegated",
                     Action = "STOP — do not claim. The receiver's cwd/worktree, git remote, and delegated domain must match the routing; reply blocked and re-route. An execution-unit ID prefix mismatch alone is NOT the signal — compare packet/domain metadata and the routing context.",
+                },
+                new OrchestratorTroubleshooting
+                {
+                    Symptom = "Codex asks to approve `rm -rf /tmp/...review...`",
+                    Action = "This is the RIGHT safety behavior for the WRONG workflow — the review worktree was allocated at an unmanaged `/tmp` path instead of the managed root. The fix is the managed root (`.intent-cli/worktrees/review-<unit>`), NOT weakening approval settings: re-allocate under the managed root (see Review delegation — managed worktrees and design alignment), and do NOT approve the `rm -rf` for the stale `/tmp` path — reply blocked to the orchestrator so it can route the cleanup as a repair instead.",
                 },
             },
             ReceiverReadiness = new OrchestratorReceiverReadiness
@@ -1047,8 +1090,18 @@ internal static class GuideOrchestratorThreadCommand
                         + "review`, `automation pr-transition`, `closeout pr`) — agmsg never replaces semantic review or "
                         + "authorizes a merge. Perform semantic review only when you are the packet `review_role` or "
                         + "explicitly assigned (G480); otherwise orchestrate the merge/closeout of an already-approved "
-                        + "PR. Report ONE structured agmsg reply (accepted / progress / completed / blocked) citing the "
-                        + "intent-cli/GitHub facts. intent-cli and GitHub stay authoritative."),
+                        + "PR. If you need a review worktree, allocate it under the MANAGED root "
+                        + "(`.intent-cli/worktrees/review-<unit>`) — NEVER a raw `/tmp/...review...` path, and NEVER "
+                        + "`rm -rf /tmp/... && git worktree add ...`; remove it only with `git worktree remove` once it "
+                        + "is a registered, clean worktree. A non-registered, dirty, or otherwise unsafe stale path is a "
+                        + "STRUCTURED BLOCKER reply to the orchestrator, not an operator `rm -rf` approval prompt (see "
+                        + "Review delegation — managed worktrees and design alignment). Your review must be grounded in "
+                        + "design intent, not only diff/CI: check the packet, review-context, intent tree, ADR/decision "
+                        + "notes, and relevant docs, and your reply must set `design_alignment_checked: true` plus which "
+                        + "of those sources you checked — the orchestrator treats a reply missing that evidence as an "
+                        + "INCOMPLETE review unless an authoritative prior approval state already proves equivalent "
+                        + "review. Report ONE structured agmsg reply (accepted / progress / completed / blocked) citing "
+                        + "the intent-cli/GitHub facts. intent-cli and GitHub stay authoritative."),
                 },
             },
             AgmsgReplyContract = new OrchestratorReplyContract
@@ -1061,6 +1114,16 @@ internal static class GuideOrchestratorThreadCommand
                 Progress = "{\"status\":\"progress\",\"thread\":\"implementation\",\"ref\":\"issue#<n>\",\"note\":\"branch pushed; CI running\"}",
                 Completed = "{\"status\":\"completed\",\"thread\":\"implementation\",\"ref\":\"pr#<n>\",\"note\":\"PR opened, Closes #<n>, CI green\"}",
                 Blocked = "{\"status\":\"blocked\",\"thread\":\"review\",\"ref\":\"pr#<n>\",\"classification\":\"clarification-required\",\"note\":\"one operator action: <text>\"}",
+                ReviewCompletedExample =
+                    "{\"status\":\"completed\",\"thread\":\"review\",\"ref\":\"pr#<n>\",\"note\":\"approved; closeout done\","
+                    + "\"design_alignment_checked\":true,\"design_alignment_sources_checked\":[\"packet\","
+                    + "\"review-context\",\"intent-tree\",\"adr-decision-notes\",\"relevant-docs\"],"
+                    + "\"managed_worktree_policy\":\"compliant — .intent-cli/worktrees/review-<unit>, removed after review\"}",
+                ReviewIncompleteRule =
+                    "A review `completed` reply that omits `design_alignment_checked: true` and the checked-source list "
+                    + "is INCOMPLETE — the orchestrator does not route merge/closeout on that reply alone. The only "
+                    + "exception is when an authoritative PRIOR approval state already proves equivalent design-alignment "
+                    + "review (the orchestrator must point to that specific prior evidence, not assume equivalence).",
             },
             OrchestratorFirstWake = new[]
             {
@@ -1989,6 +2052,29 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Review delegation — managed worktrees and design alignment");
+        writer.WriteLine();
+        writer.WriteLine(guide.ReviewDelegationContract.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- **managed worktree root** — {guide.ReviewDelegationContract.ManagedWorktreeRoot}");
+        writer.WriteLine($"- **prohibited pattern** — {guide.ReviewDelegationContract.ProhibitedPattern}");
+        writer.WriteLine($"- **cleanup rule** — {guide.ReviewDelegationContract.CleanupRule}");
+        writer.WriteLine($"- **unsafe/stale path rule** — {guide.ReviewDelegationContract.UnsafeStalePathRule}");
+        writer.WriteLine();
+        writer.WriteLine("Review delegation example (orchestrator → review):");
+        writer.WriteLine();
+        writer.WriteLine("```json");
+        writer.WriteLine(guide.ReviewDelegationContract.DelegationExample);
+        writer.WriteLine("```");
+        writer.WriteLine();
+        writer.WriteLine("Design-alignment sources a review reply may cite as checked:");
+        writer.WriteLine();
+        foreach (var source in guide.ReviewDelegationContract.DesignAlignmentSources)
+        {
+            writer.WriteLine($"- {source}");
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Thread prompts");
         foreach (var thread in guide.Threads)
         {
@@ -2013,6 +2099,14 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine(guide.AgmsgReplyContract.Completed);
         writer.WriteLine(guide.AgmsgReplyContract.Blocked);
         writer.WriteLine("```");
+        writer.WriteLine();
+        writer.WriteLine("Review `completed` reply — must include design-alignment evidence:");
+        writer.WriteLine();
+        writer.WriteLine("```json");
+        writer.WriteLine(guide.AgmsgReplyContract.ReviewCompletedExample);
+        writer.WriteLine("```");
+        writer.WriteLine();
+        writer.WriteLine($"- **review-incomplete rule** — {guide.AgmsgReplyContract.ReviewIncompleteRule}");
         writer.WriteLine();
 
         writer.WriteLine("## Orchestrator first wake");
@@ -2193,6 +2287,9 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("worktree_management")]
     public required OrchestratorWorktreeManagement WorktreeManagement { get; init; }
 
+    [JsonPropertyName("review_delegation_contract")]
+    public required OrchestratorReviewDelegationContract ReviewDelegationContract { get; init; }
+
     [JsonPropertyName("setup")]
     public required OrchestratorSetup Setup { get; init; }
 
@@ -2345,6 +2442,30 @@ internal sealed record OrchestratorWorktreeManagement
 
     [JsonPropertyName("approval_policy_note")]
     public required string ApprovalPolicyNote { get; init; }
+}
+
+internal sealed record OrchestratorReviewDelegationContract
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("managed_worktree_root")]
+    public required string ManagedWorktreeRoot { get; init; }
+
+    [JsonPropertyName("prohibited_pattern")]
+    public required string ProhibitedPattern { get; init; }
+
+    [JsonPropertyName("cleanup_rule")]
+    public required string CleanupRule { get; init; }
+
+    [JsonPropertyName("unsafe_stale_path_rule")]
+    public required string UnsafeStalePathRule { get; init; }
+
+    [JsonPropertyName("delegation_example")]
+    public required string DelegationExample { get; init; }
+
+    [JsonPropertyName("design_alignment_sources")]
+    public required IReadOnlyList<string> DesignAlignmentSources { get; init; }
 }
 
 internal sealed record OrchestratorIntakeForm
@@ -2696,4 +2817,10 @@ internal sealed record OrchestratorReplyContract
 
     [JsonPropertyName("blocked")]
     public required string Blocked { get; init; }
+
+    [JsonPropertyName("review_completed_example")]
+    public required string ReviewCompletedExample { get; init; }
+
+    [JsonPropertyName("review_incomplete_rule")]
+    public required string ReviewIncompleteRule { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -890,8 +890,11 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("- implementer agent", output, StringComparison.Ordinal);
         Assert.Contains("- delivery mode", output, StringComparison.Ordinal);
         Assert.Contains("- existing-loop stop policy", output, StringComparison.Ordinal);
-        // Only the orchestrator is scheduled.
-        Assert.Contains("Only the orchestrator is scheduled", output, StringComparison.Ordinal);
+        // Receivers are never scheduled; the orchestrator is message-driven by default,
+        // with an explicit fallback/legacy timer as the only case where it is scheduled.
+        Assert.Contains("Receivers are NEVER scheduled", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Only the orchestrator is scheduled", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("only the orchestrator is scheduled", output, StringComparison.Ordinal);
         // No setup-intake agmsg registration block emitted while inputs are missing
         // (the setup-ready path adds this header; reference sections may mention
         // agmsg commands generically).

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -773,6 +773,107 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_ReviewDelegation_RequiresManagedWorktreeRoot_ProhibitsRawTmpRm_G520()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Review delegation — managed worktrees and design alignment", output, StringComparison.Ordinal);
+        Assert.Contains(".intent-cli/worktrees/review-<unit>", output, StringComparison.Ordinal);
+        Assert.Contains("PROHIBITED as the normal path", output, StringComparison.Ordinal);
+        Assert.Contains("/tmp/...review...", output, StringComparison.Ordinal);
+        Assert.Contains("rm -rf /tmp/... && git worktree add ...", output, StringComparison.Ordinal);
+        Assert.Contains("git worktree remove <managed-path>", output, StringComparison.Ordinal);
+        Assert.Contains("REGISTERED, CLEAN worktree only", output, StringComparison.Ordinal);
+        // Unsafe/stale paths become a structured blocker reply, never an operator approval prompt.
+        Assert.Contains("STRUCTURED BLOCKER agmsg reply to", output, StringComparison.Ordinal);
+        Assert.Contains("NEVER an operator `rm -rf` approval prompt", output, StringComparison.Ordinal);
+        // Delegation example carries the policy + design-alignment requirement.
+        Assert.Contains("\"managed_worktree_policy\":", output, StringComparison.Ordinal);
+        Assert.Contains("\"design_alignment_required\":true", output, StringComparison.Ordinal);
+        // Design-alignment sources checklist.
+        Assert.Contains("review-context — the review-context artifact", output, StringComparison.Ordinal);
+        Assert.Contains("intent tree — the relevant intent-tree entries", output, StringComparison.Ordinal);
+        Assert.Contains("ADR / decision notes", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_HasReviewDelegationContractShape_G520()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var review = doc.RootElement.GetProperty("review_delegation_contract");
+
+        Assert.Contains(".intent-cli/worktrees", review.GetProperty("managed_worktree_root").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("PROHIBITED", review.GetProperty("prohibited_pattern").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("git worktree remove", review.GetProperty("cleanup_rule").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("STRUCTURED BLOCKER", review.GetProperty("unsafe_stale_path_rule").GetString()!, StringComparison.Ordinal);
+
+        var delegationExample = review.GetProperty("delegation_example").GetString()!;
+        Assert.Contains("\"managed_worktree_policy\"", delegationExample, StringComparison.Ordinal);
+        Assert.Contains("\"design_alignment_required\":true", delegationExample, StringComparison.Ordinal);
+
+        Assert.Equal(5, review.GetProperty("design_alignment_sources").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_Markdown_ReviewThreadPrompt_RequiresManagedWorktreeAndDesignAlignment_G520()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        // The review thread prompt (Thread prompts / review) carries both requirements inline.
+        var reviewPromptIndex = output.IndexOf("### review", StringComparison.Ordinal);
+        Assert.True(reviewPromptIndex >= 0, "review thread prompt section must be present.");
+        var reviewSection = output.Substring(reviewPromptIndex);
+
+        Assert.Contains(".intent-cli/worktrees/review-<unit>", reviewSection, StringComparison.Ordinal);
+        Assert.Contains("NEVER a raw `/tmp/...review...` path", reviewSection, StringComparison.Ordinal);
+        Assert.Contains("STRUCTURED BLOCKER reply to the orchestrator", reviewSection, StringComparison.Ordinal);
+        Assert.Contains("design_alignment_checked: true", reviewSection, StringComparison.Ordinal);
+        Assert.Contains("packet, review-context, intent tree, ADR/decision", reviewSection, StringComparison.Ordinal);
+        Assert.Contains("INCOMPLETE review", reviewSection, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_AgmsgReplyContract_HasReviewCompletedExample_AndIncompleteRule_G520()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var contract = doc.RootElement.GetProperty("agmsg_reply_contract");
+
+        var reviewCompleted = contract.GetProperty("review_completed_example").GetString()!;
+        Assert.Contains("\"design_alignment_checked\":true", reviewCompleted, StringComparison.Ordinal);
+        Assert.Contains("\"design_alignment_sources_checked\":", reviewCompleted, StringComparison.Ordinal);
+        Assert.Contains("\"managed_worktree_policy\":", reviewCompleted, StringComparison.Ordinal);
+
+        var incompleteRule = contract.GetProperty("review_incomplete_rule").GetString()!;
+        Assert.Contains("INCOMPLETE", incompleteRule, StringComparison.Ordinal);
+        Assert.Contains("authoritative PRIOR approval state", incompleteRule, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_Troubleshooting_IncludesRmRfTmpReviewSymptom_G520()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("Codex asks to approve `rm -rf /tmp/...review...`", output, StringComparison.Ordinal);
+        Assert.Contains("RIGHT safety behavior for the WRONG workflow", output, StringComparison.Ordinal);
+        // The fix is the managed root, not weakening approval settings.
+        Assert.Contains("NOT weakening approval settings", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_Markdown_SetupIntake_NoInputs_IsMissingInputs_ListsOnlyMissingFields_G500()
     {
         var output = RunMarkdown([]);


### PR DESCRIPTION
## Summary

Closes #1141. Dogfooding showed a reviewer preparing a review worktree at a raw `/tmp/...review...` path and Codex correctly asking to approve a destructive `rm -rf` — the right safety behavior, but the wrong orchestration workflow. The same run showed review needs to stay grounded in design intent, not just diff/CI. **Guide/docs/tests only.**

## Changes

- **`guide orchestrator-thread`** (`GuideOrchestratorThreadCommand.cs`):
  - New **"Review delegation — managed worktrees and design alignment"** section / JSON field (`review_delegation_contract`):
    - review worktrees go under the managed root (`.intent-cli/worktrees/review-<unit>`), **never** `/tmp`;
    - explicitly **prohibits** `rm -rf /tmp/... && git worktree add ...` as the normal path;
    - cleanup is `git worktree remove <managed-path>` for a **registered, clean** worktree only;
    - a non-registered/dirty/unsafe stale path becomes a **structured blocker** reply to the orchestrator, **never** an operator `rm -rf` approval prompt;
    - includes a review-delegation JSON example (`managed_worktree_policy` + `design_alignment_required`) and the design-alignment source checklist (packet, review-context, intent tree, ADR/decision notes, relevant docs).
  - **`agmsg reply contract`**: new `review_completed_example` (with `design_alignment_checked`, `design_alignment_sources_checked`, `managed_worktree_policy`) and `review_incomplete_rule` — a review `completed` reply missing that evidence is **incomplete**, unless an authoritative **prior** approval state already proves equivalent review.
  - **Review thread prompt**: inlines the managed-worktree and design-alignment requirements so the reviewer sees them without a second lookup.
  - New **troubleshooting** entry for the dogfooded `rm -rf /tmp/...review...` approval-prompt symptom — the fix is the managed root, not weakening approval settings.
- **`docs/{en,ja}/12-agent-message-orchestration.md`**: mirror the new review-delegation section and the troubleshooting entry.
- **Tests** (`GuideOrchestratorThreadCommandTests.cs`): new markdown + JSON coverage for `review_delegation_contract`, the review-completed reply shape, the review thread prompt, and the troubleshooting entry.

## Acceptance criteria coverage

- ✅ Guide tells review receivers to use a managed workspace-local root (`.intent-cli/worktrees/` / configured `worktree_root`).
- ✅ Guide prohibits raw `/tmp/...` review worktrees and `rm -rf /tmp/... && git worktree add ...` chains.
- ✅ Guide states cleanup = `git worktree remove <managed-path>` for registered clean worktrees.
- ✅ Guide states non-registered/dirty/unsafe stale paths become a structured blocker, not an operator approval prompt.
- ✅ Orchestrator review-delegation example includes managed-worktree policy + design-alignment requirement.
- ✅ Review reply example includes `design_alignment_checked: true`, checked sources, and managed-worktree policy status.
- ✅ Orchestrator guidance says review is incomplete if design-alignment evidence is missing (unless authoritative prior approval state proves equivalence).
- ✅ Troubleshooting includes the `rm -rf /tmp/...review...` approval-prompt symptom.
- ✅ EN + JA docs updated; guide tests updated.

## Out of scope (unchanged)

- No agmsg internals changes, no AI-provider launch from intent-cli.
- No weakening of Codex/Claude approval settings.
- Design thread is not required to manually approve every review.

## Verification

- Branched from current `origin/main` (`40ab908`, includes G519/v0.3.15 release-prep).
- `dotnet build` — succeeded.
- `dotnet test` (full suite) — **3187 passed, 1 skipped, 0 failed**.
- `intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --format markdown` — renders the new "Review delegation — managed worktrees and design alignment" section and the new troubleshooting entry.
- `git diff --check` — clean; only the guide command, its tests, and the two `12-agent-message-orchestration.md` docs changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyAC7Waoksgu8wMDAtQpY7