### PR TITLE
G521: Document agmsg Codex monitor (beta) failure modes and setup preflight

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -653,6 +653,13 @@ the two field-verified failure modes. See the
 [agmsg codex-monitor-beta doc](https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md)
 for implementation internals.
 
+> Observed at agmsg 1.1.6 / Codex v0.144.1 (macOS, `codex()` shim launch) — the
+> setup preflight, healthy-state markers, and troubleshooting entries below
+> are observations from that tested environment, not a permanent bridge
+> contract. Re-verify against the installed agmsg/Codex versions after an
+> upgrade before trusting the exact mechanics (e.g. retry interval, thread
+> attachment order) described here.
+
 **Setup preflight** — before launching a Codex receiver, verify the (project,
 codex) pair resolves to exactly **one** identity: `whoami.sh <project> codex`
 should print a single `agent=` line. Clean up any stale registration first

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -643,6 +643,51 @@ are alternative safety nets, not both required together.
   preserving agmsg hooks, then restart and re-verify. See
   [Missing-Monitor project-settings diagnosis](orchestrator-message-mode.md#missing-monitor-project-settings-diagnosis).
 
+## Codex monitor (beta) failure modes
+
+The agmsg Codex monitor (beta) is a different delivery backend from the Claude
+Code `Monitor` tool above — it bridges agmsg into a Codex CLI session instead.
+intent-cli does not own or modify agmsg internals; this section only covers
+what an operator needs to set up a Codex receiver and recognize/recover from
+the two field-verified failure modes. See the
+[agmsg codex-monitor-beta doc](https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md)
+for implementation internals.
+
+**Setup preflight** — before launching a Codex receiver, verify the (project,
+codex) pair resolves to exactly **one** identity: `whoami.sh <project> codex`
+should print a single `agent=` line. Clean up any stale registration first
+(e.g. a leftover `actas` registering another role into the project) — more
+than one identity blocks the bridge launcher silently.
+
+**Healthy-state markers:**
+
+- `delivery.sh status` shows `Codex bridge: <team>/<role> alive (pid N)`.
+- The bridge arms on the **first turn** sent to the session, not at Codex
+  startup — do not expect delivery before that first turn.
+- An already-running Codex session stays unmonitored until it is restarted
+  after the bridge is enabled.
+
+**Troubleshooting:**
+
+- **`mode: monitor` but the Codex bridge never starts** — the (project, codex)
+  pair resolves to more than one identity; `codex-bridge-launcher.sh` proceeds
+  only when there is exactly one, and otherwise retries silently every 0.3s
+  forever (e.g. a stale `actas` registration for another role). Check the
+  identity count with `whoami.sh <project> codex`, remove the stale
+  registration, then relaunch.
+- **Bridge alive (pid shown) but the Codex TUI never moves / never reacts to
+  messages** — the shared Codex app-server accumulates loaded threads across
+  sessions, and `codex-bridge.js` attaches to the FIRST (oldest) entry of
+  `thread/loaded/list` — turns are injected into an old background thread
+  while the visible TUI never reacts. Recover by: quit the TUI, stop the
+  app-server/bridge/launcher processes, remove the recorded app-server/bridge
+  state files (`codex-app-server.*.{pid,port,version}` and the bridge
+  `{pid,appserver,meta}` files), relaunch codex, then send one turn to
+  re-arm.
+- **Responses to one message appear twice across a restart window** —
+  suspect a doubled bridge; verify only one bridge pid exists
+  (`delivery.sh status`) before relaunching.
+
 ## Design traffic-controller playbook
 
 The design thread acts as a **traffic controller**, not an implementer. It

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -584,6 +584,49 @@ watchdog の安全ルールは次を **禁止** します:
   その後、再起動して再検証する。参照:
   [Monitor が見つからない場合の project-settings 診断](orchestrator-message-mode.md#monitor-が見つからない場合の-project-settings-診断)。
 
+## Codex monitor（beta）の failure mode
+
+agmsg の Codex monitor（beta）は、上記の Claude Code `Monitor` ツールとは別の
+delivery backend であり、agmsg を Codex CLI セッションへブリッジします。
+intent-cli は agmsg の内部実装を所有・変更しません。ここでは、オペレーターが
+Codex receiver をセットアップする際に必要な情報と、フィールドで確認済みの
+2 つの failure mode を認識・復旧する方法だけを扱います。内部実装については
+[agmsg codex-monitor-beta doc](https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md)
+を参照してください。
+
+**setup preflight** — Codex receiver を起動する前に、(project, codex) のペアが
+ちょうど 1 つの identity に解決されることを確認する: `whoami.sh <project> codex`
+は `agent=` の行を 1 行だけ出力するはず。まず古い登録を掃除する（例えば別ロールを
+そのプロジェクトに登録したままの `actas` の残骸）— identity が 2 つ以上あると
+bridge launcher は無言でブロックされる。
+
+**healthy-state marker:**
+
+- `delivery.sh status` が `Codex bridge: <team>/<role> alive (pid N)` を表示する。
+- bridge はセッション起動時ではなく、送信された **最初の turn** で arm する —
+  その最初の turn より前に delivery を期待しない。
+- 既に起動済みの Codex セッションは、bridge を有効化した後に再起動するまで
+  監視対象外のままになる。
+
+**トラブルシューティング:**
+
+- **`mode: monitor` だが Codex bridge が一切起動しない** — (project, codex) の
+  ペアが 2 つ以上の identity に解決されている。`codex-bridge-launcher.sh` は
+  ちょうど 1 つのときのみ処理を進め、それ以外は 0.3 秒ごとに無言でリトライし
+  続ける（例えば別ロールの `actas` の残骸）。`whoami.sh <project> codex` で
+  identity 数を確認し、古い登録を削除してから再起動する。
+- **bridge は alive（pid 表示あり）だが Codex の TUI が全く動かない/メッセージに
+  反応しない** — 共有の Codex app-server はセッションをまたいで loaded thread を
+  蓄積し、`codex-bridge.js` は `thread/loaded/list` の最初（最も古い）エントリに
+  attach する — turn は古いバックグラウンド thread に注入され、可視の TUI は
+  一切反応しない。復旧手順: TUI を終了し、app-server/bridge/launcher の
+  プロセスを停止し、記録されている app-server/bridge の state ファイル
+  （`codex-app-server.*.{pid,port,version}` と bridge の `{pid,appserver,meta}`
+  ファイル）を削除し、codex を再起動してから 1 turn 送信して re-arm する。
+- **再起動をまたいで 1 件のメッセージへの返信が二重に現れる** — bridge が
+  二重になっている疑いがある。再起動前に `delivery.sh status` で bridge の
+  pid が 1 つだけであることを確認する。
+
 ## design traffic-controller プレイブック
 
 design スレッドは実装者ではなく **traffic controller**（交通整理役）として振る舞います。

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -594,6 +594,13 @@ Codex receiver をセットアップする際に必要な情報と、フィー�
 [agmsg codex-monitor-beta doc](https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md)
 を参照してください。
 
+> agmsg 1.1.6 / Codex v0.144.1（macOS、`codex()` shim launch）で観測した内容です —
+> 以下の setup preflight・healthy-state marker・トラブルシューティング項目は、
+> その検証環境における観測にすぎず、永続的な bridge の契約ではありません。
+> アップグレード後は、ここに書かれている具体的な挙動（リトライ間隔、thread の
+> attach 順序など）を鵜呑みにする前に、インストール済みの agmsg/Codex の
+> バージョンに対して再確認してください。
+
 **setup preflight** — Codex receiver を起動する前に、(project, codex) のペアが
 ちょうど 1 つの identity に解決されることを確認する: `whoami.sh <project> codex`
 は `agent=` の行を 1 行だけ出力するはず。まず古い登録を掃除する（例えば別ロールを

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -705,6 +705,41 @@ internal static class GuideOrchestratorThreadCommand
                     "This is a Claude Code project-config repair, not an agmsg change — intent-cli never edits `.claude/settings.json`, `~/.claude.json`, or agmsg internals. Preserve the G516 distinction throughout: `1 monitor` = live success, `1 shell` = diagnostic/fallback only, never success.",
                 },
             },
+            CodexBridgeGuidance = new OrchestratorCodexBridgeGuidance
+            {
+                SetupPreflight =
+                    "Before launching a Codex receiver, verify the (project, codex) pair resolves to exactly ONE "
+                    + "identity — `whoami.sh <project> codex` should print a single `agent=` line. Clean up any stale "
+                    + "registration first (e.g. a leftover `actas` registering another role into the project); more "
+                    + "than one identity blocks the bridge launcher silently.",
+                HealthyStateMarkers = new[]
+                {
+                    "`delivery.sh status` shows `Codex bridge: <team>/<role> alive (pid N)`.",
+                    "The bridge arms on the FIRST turn sent to the session, not at Codex startup — do not expect delivery before that first turn.",
+                    "An already-running Codex session stays unmonitored until it is restarted after the bridge is enabled.",
+                },
+                Troubleshooting = new[]
+                {
+                    new OrchestratorTroubleshooting
+                    {
+                        Symptom = "mode: monitor but the Codex bridge never starts",
+                        Action = "The (project, codex) pair resolves to more than one identity — `codex-bridge-launcher.sh` proceeds only when there is exactly ONE, and otherwise retries silently every 0.3s forever (e.g. a stale `actas` registration for another role). Check the identity count with `whoami.sh <project> codex`, remove the stale registration, then relaunch.",
+                    },
+                    new OrchestratorTroubleshooting
+                    {
+                        Symptom = "bridge alive (pid shown) but the Codex TUI never moves / never reacts to messages",
+                        Action = "The shared Codex app-server accumulates loaded threads across sessions, and `codex-bridge.js` attaches to the FIRST (oldest) entry of `thread/loaded/list` — turns are injected into an old background thread while the visible TUI never reacts. Recover by: quit the TUI, stop the app-server/bridge/launcher processes, remove the recorded app-server/bridge state files (`codex-app-server.*.{pid,port,version}` and the bridge `{pid,appserver,meta}` files), relaunch codex, then send one turn to re-arm.",
+                    },
+                    new OrchestratorTroubleshooting
+                    {
+                        Symptom = "responses to one message appear twice across a restart window",
+                        Action = "Suspect a doubled bridge — verify only one bridge pid exists (`delivery.sh status`) before relaunching; kill any duplicate bridge process first.",
+                    },
+                },
+                ReferenceLink =
+                    "See the agmsg codex-monitor-beta doc (https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md) "
+                    + "for internals — intent-cli does not own or modify agmsg's Codex bridge implementation.",
+            },
             IntakeForm = new OrchestratorIntakeForm
             {
                 Summary =
@@ -1742,6 +1777,27 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Codex monitor (beta) failure modes (G521)");
+        writer.WriteLine();
+        writer.WriteLine($"- **setup preflight** — {guide.CodexBridgeGuidance.SetupPreflight}");
+        writer.WriteLine();
+        writer.WriteLine("Healthy-state markers:");
+        writer.WriteLine();
+        foreach (var marker in guide.CodexBridgeGuidance.HealthyStateMarkers)
+        {
+            writer.WriteLine($"- {marker}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("Troubleshooting:");
+        writer.WriteLine();
+        foreach (var entry in guide.CodexBridgeGuidance.Troubleshooting)
+        {
+            writer.WriteLine($"- **{entry.Symptom}** — {entry.Action}");
+        }
+        writer.WriteLine();
+        writer.WriteLine(guide.CodexBridgeGuidance.ReferenceLink);
+        writer.WriteLine();
+
         writer.WriteLine("## Domain routing — single-domain vs multi-domain");
         writer.WriteLine();
         writer.WriteLine($"- selected mode: `{guide.DomainRouting.Mode}`");
@@ -2281,6 +2337,9 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("monitor_tool_distinction")]
     public required OrchestratorMonitorDistinction MonitorToolDistinction { get; init; }
 
+    [JsonPropertyName("codex_bridge_guidance")]
+    public required OrchestratorCodexBridgeGuidance CodexBridgeGuidance { get; init; }
+
     [JsonPropertyName("intake_form")]
     public required OrchestratorIntakeForm IntakeForm { get; init; }
 
@@ -2703,6 +2762,21 @@ internal sealed record OrchestratorMonitorDistinction
 
     [JsonPropertyName("project_settings_diagnosis")]
     public required IReadOnlyList<string> ProjectSettingsDiagnosis { get; init; }
+}
+
+internal sealed record OrchestratorCodexBridgeGuidance
+{
+    [JsonPropertyName("setup_preflight")]
+    public required string SetupPreflight { get; init; }
+
+    [JsonPropertyName("healthy_state_markers")]
+    public required IReadOnlyList<string> HealthyStateMarkers { get; init; }
+
+    [JsonPropertyName("troubleshooting")]
+    public required IReadOnlyList<OrchestratorTroubleshooting> Troubleshooting { get; init; }
+
+    [JsonPropertyName("reference_link")]
+    public required string ReferenceLink { get; init; }
 }
 
 internal sealed record OrchestratorReceiverReadiness

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -707,6 +707,12 @@ internal static class GuideOrchestratorThreadCommand
             },
             CodexBridgeGuidance = new OrchestratorCodexBridgeGuidance
             {
+                ObservedVersions =
+                    "Observed at agmsg 1.1.6 / Codex v0.144.1 (macOS, `codex()` shim launch) — the setup preflight, "
+                    + "healthy-state markers, and troubleshooting entries below are observations from that tested "
+                    + "environment, not a permanent bridge contract. Re-verify against the installed agmsg/Codex "
+                    + "versions after an upgrade before trusting the exact mechanics (e.g. retry interval, thread "
+                    + "attachment order) described here.",
                 SetupPreflight =
                     "Before launching a Codex receiver, verify the (project, codex) pair resolves to exactly ONE "
                     + "identity — `whoami.sh <project> codex` should print a single `agent=` line. Clean up any stale "
@@ -1779,6 +1785,8 @@ internal static class GuideOrchestratorThreadCommand
 
         writer.WriteLine("## Codex monitor (beta) failure modes (G521)");
         writer.WriteLine();
+        writer.WriteLine($"> {guide.CodexBridgeGuidance.ObservedVersions}");
+        writer.WriteLine();
         writer.WriteLine($"- **setup preflight** — {guide.CodexBridgeGuidance.SetupPreflight}");
         writer.WriteLine();
         writer.WriteLine("Healthy-state markers:");
@@ -2766,6 +2774,9 @@ internal sealed record OrchestratorMonitorDistinction
 
 internal sealed record OrchestratorCodexBridgeGuidance
 {
+    [JsonPropertyName("observed_versions")]
+    public required string ObservedVersions { get; init; }
+
     [JsonPropertyName("setup_preflight")]
     public required string SetupPreflight { get; init; }
 

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -202,6 +202,11 @@ public sealed class GuideOrchestratorThreadCommandTests
 
         Assert.Contains("## Codex monitor (beta) failure modes (G521)", output, StringComparison.Ordinal);
 
+        // Version-observation framing: scopes the failure modes to the tested environment, not a permanent contract.
+        Assert.Contains("Observed at agmsg 1.1.6 / Codex v0.144.1", output, StringComparison.Ordinal);
+        Assert.Contains("not a permanent bridge contract", output, StringComparison.Ordinal);
+        Assert.Contains("Re-verify against the installed agmsg/Codex versions after an upgrade", output, StringComparison.Ordinal);
+
         // Setup preflight: single-identity precondition before launching a Codex receiver.
         Assert.Contains("resolves to exactly ONE identity", output, StringComparison.Ordinal);
         Assert.Contains("`whoami.sh <project> codex` should print a single `agent=` line", output, StringComparison.Ordinal);
@@ -243,6 +248,8 @@ public sealed class GuideOrchestratorThreadCommandTests
         using var doc = JsonDocument.Parse(writer.ToString());
         var guidance = doc.RootElement.GetProperty("codex_bridge_guidance");
 
+        Assert.Contains("agmsg 1.1.6", guidance.GetProperty("observed_versions").GetString(), StringComparison.Ordinal);
+        Assert.Contains("Codex v0.144.1", guidance.GetProperty("observed_versions").GetString(), StringComparison.Ordinal);
         Assert.True(guidance.TryGetProperty("setup_preflight", out _));
         Assert.NotEmpty(guidance.GetProperty("healthy_state_markers").EnumerateArray());
         Assert.Equal(3, guidance.GetProperty("troubleshooting").GetArrayLength());

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -196,6 +196,60 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_CodexBridgeGuidance_CoversSetupPreflightAndFailureModes_G521()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        Assert.Contains("## Codex monitor (beta) failure modes (G521)", output, StringComparison.Ordinal);
+
+        // Setup preflight: single-identity precondition before launching a Codex receiver.
+        Assert.Contains("resolves to exactly ONE identity", output, StringComparison.Ordinal);
+        Assert.Contains("`whoami.sh <project> codex` should print a single `agent=` line", output, StringComparison.Ordinal);
+
+        // Healthy-state markers.
+        Assert.Contains("`delivery.sh status` shows `Codex bridge: <team>/<role> alive (pid N)`", output, StringComparison.Ordinal);
+        Assert.Contains("bridge arms on the FIRST turn", output, StringComparison.Ordinal);
+        Assert.Contains("already-running Codex session stays unmonitored until it is restarted", output, StringComparison.Ordinal);
+
+        // Troubleshooting entry 1: silent launcher blocked by multiple identities.
+        Assert.Contains("mode: monitor but the Codex bridge never starts", output, StringComparison.Ordinal);
+        Assert.Contains("resolves to more than one identity", output, StringComparison.Ordinal);
+        Assert.Contains("retries silently every 0.3s forever", output, StringComparison.Ordinal);
+
+        // Troubleshooting entry 2: static TUI from stale loaded app-server threads, full recovery sequence.
+        Assert.Contains("bridge alive (pid shown) but the Codex TUI never moves", output, StringComparison.Ordinal);
+        Assert.Contains("attaches to the FIRST (oldest) entry of `thread/loaded/list`", output, StringComparison.Ordinal);
+        Assert.Contains("quit the TUI, stop the app-server/bridge/launcher processes", output, StringComparison.Ordinal);
+        Assert.Contains("send one turn to re-arm", output, StringComparison.Ordinal);
+
+        // Troubleshooting entry 3: doubled bridge.
+        Assert.Contains("responses to one message appear twice across a restart window", output, StringComparison.Ordinal);
+        Assert.Contains("Suspect a doubled bridge", output, StringComparison.Ordinal);
+
+        // Links out to agmsg internals rather than restating them.
+        Assert.Contains("https://github.com/fujibee/agmsg/blob/main/docs/codex-monitor-beta.md", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_CarriesCodexBridgeGuidance_WithTroubleshootingArray()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var guidance = doc.RootElement.GetProperty("codex_bridge_guidance");
+
+        Assert.True(guidance.TryGetProperty("setup_preflight", out _));
+        Assert.NotEmpty(guidance.GetProperty("healthy_state_markers").EnumerateArray());
+        Assert.Equal(3, guidance.GetProperty("troubleshooting").GetArrayLength());
+        Assert.True(guidance.TryGetProperty("reference_link", out _));
+    }
+
+    [Fact]
     public void Execute_Json_CarriesMonitorToolDistinction_WithMarkerArrays()
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary
- Adds a Codex monitor (beta) setup-preflight (single-identity precondition) and healthy-state markers to `intent-cli guide orchestrator-thread`.
- Adds three symptom/action troubleshooting entries: silent launcher (multiple identities), static TUI (stale loaded app-server threads, with full quit → kill → delete-state → relaunch → first-turn recovery sequence), and doubled responses (doubled bridge).
- Mirrors the same content as a "Codex monitor (beta) failure modes" subsection in `docs/ja/12-agent-message-orchestration.md` and `docs/en/12-agent-message-orchestration.md`, linking out to the agmsg codex-monitor-beta doc for internals.
- Adds focused tests pinning the new guide output (markdown + JSON shape).

Closes #1143

## Test plan
- [x] `dotnet build src/IntentSystem.Cli` — succeeds, 0 warnings/errors.
- [x] `dotnet test tests/IntentSystem.Cli.Tests --filter FullyQualifiedName~GuideOrchestratorThreadCommandTests` — 65 passed.
- [x] `dotnet test tests/IntentSystem.Cli.Tests` (full suite) — 3189 passed, 1 skipped (pre-existing).
- [x] `dotnet run --project src/IntentSystem.Cli -- guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --format markdown` — confirmed the new preflight text and three troubleshooting entries render.
- [x] `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4yoyeXmTeJWD16RLvktQd