### PR TITLE
G522: Derive domain from packet metadata on execution-unit-resolving surfaces

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -217,22 +217,28 @@ domain, or `queue-seed-from-packet` running the wrong domain's
 unchanged and still used elsewhere; only what these surfaces consult when
 `--domain` is omitted has changed.
 
-Per-surface notes:
+All three surfaces apply the full order strictly — none of them fall back to
+`[project] domain` when a domain cannot be derived:
 
-- `automation queue-seed-from-packet` applies the full order strictly — when
-  neither `--domain` nor the packet's `domain:` field is available, the
-  command refuses to seed rather than falling back to `[project] domain`.
-- `review closeout-plan` is a read-only planning surface: when a domain
-  genuinely cannot be derived (no matched queue item, or its packet.yaml
-  declares no `domain:` field), it keeps reporting the host's default domain
-  binding rather than hard-failing an otherwise-successful gap report — an
-  explicit `--domain` still wins, and a contradiction with a
-  packet-declared domain is still an error.
-- `automation publish-recovery` accepts an optional `--domain` that scopes
-  the candidate set to that domain's `execution_unit_regex` binding, so a
-  different domain's execution unit never leaks into this domain's recovery
-  analysis. Omitting `--domain` preserves the original unscoped broad-scan
-  behavior.
+- `automation queue-seed-from-packet` — when neither `--domain` nor the
+  packet's `domain:` field is available, the command refuses to seed.
+- `review closeout-plan` — when a domain cannot be derived for the resolved
+  queue item (no matched item, or its packet.yaml declares no `domain:`
+  field), the command fails loud naming candidate domains and the exact
+  `--domain` re-invocation, instead of reporting the host's default domain
+  binding.
+- `automation publish-recovery` resolves a domain for EVERY candidate
+  execution unit before it may join repair analysis — from `--domain` when
+  given (erroring per-candidate on contradiction with that candidate's own
+  packet-declared domain) or otherwise from that candidate's own
+  packet-declared domain. A candidate with neither becomes a structured
+  `domain-underivable` unsafe stop rather than silently joining (or being
+  silently dropped from) the scan; a candidate contradicting an explicit
+  `--domain` becomes a structured `domain-contradiction` unsafe stop. This
+  applies to both the `--pr`-scoped path and the broad (unscoped) scan.
+  Omitting `--domain` entirely does not request cross-candidate scoping, so
+  multiple candidates with different (but each individually derivable)
+  domains may still coexist in one broad-scan result.
 
 ---
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -192,6 +192,48 @@ resolved from one shared source, so `automation summary --domain <d>` and
 valid. A unit that does not match the active domain's regex is refused with a
 precise diagnostic that names the consulted bindings source.
 
+### Domain resolution order for execution-unit-resolving surfaces (G522)
+
+Surfaces that resolve an execution unit from `--pr` or `--execution-unit`
+(`review closeout-plan`, `automation queue-seed-from-packet`,
+`automation publish-recovery`, and peers using the same lookup) apply this
+resolution order when `--domain` is omitted:
+
+1. an explicit `--domain` wins; it is an error if it contradicts the domain
+   declared by the resolved packet's own `domain:` scalar;
+2. otherwise the domain declared by the resolved packet.yaml / queue metadata
+   is used;
+3. otherwise the surface fails loud, naming candidate domains (scanned from
+   `intents/*/`) and the exact `--domain` re-invocation — it never silently
+   falls back to the host's default domain binding (`[project] domain` in
+   `.intent-cli/config.toml`).
+
+This closes a multi-domain-host gap: the default binding fallback could
+previously report or validate against the WRONG domain for a packet whose
+own `domain:` field says otherwise (e.g. `review closeout-plan --pr <n>`
+reporting the host's default domain instead of the resolved packet's actual
+domain, or `queue-seed-from-packet` running the wrong domain's
+`execution_unit_regex` check). The default binding mechanism itself is
+unchanged and still used elsewhere; only what these surfaces consult when
+`--domain` is omitted has changed.
+
+Per-surface notes:
+
+- `automation queue-seed-from-packet` applies the full order strictly — when
+  neither `--domain` nor the packet's `domain:` field is available, the
+  command refuses to seed rather than falling back to `[project] domain`.
+- `review closeout-plan` is a read-only planning surface: when a domain
+  genuinely cannot be derived (no matched queue item, or its packet.yaml
+  declares no `domain:` field), it keeps reporting the host's default domain
+  binding rather than hard-failing an otherwise-successful gap report — an
+  explicit `--domain` still wins, and a contradiction with a
+  packet-declared domain is still an error.
+- `automation publish-recovery` accepts an optional `--domain` that scopes
+  the candidate set to that domain's `execution_unit_regex` binding, so a
+  different domain's execution unit never leaks into this domain's recovery
+  analysis. Omitting `--domain` preserves the original unscoped broad-scan
+  behavior.
+
 ---
 
 ## Version flow

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -207,22 +207,29 @@ binding fallback は、packet 自身の `domain:` フィールドが別の値を
 されておらず他の箇所では引き続き使われます。変わったのは、これらの
 サーフェスが `--domain` 省略時に何を参照するかだけです。
 
-サーフェスごとの補足:
+3つのサーフェスすべてがこの順序を厳密に適用します — domain を導出できない
+場合に `[project] domain` へ fallback することはありません:
 
-- `automation queue-seed-from-packet` はこの順序を厳密に適用します —
-  `--domain` と packet の `domain:` フィールドのどちらも無い場合、
-  `[project] domain` へ fallback せず seed を拒否します。
-- `review closeout-plan` は read-only な planning サーフェスです:
-  domain を本当に導出できない場合（一致する queue item が無い、または
-  その packet.yaml に `domain:` フィールドが無い場合）、成功している gap
-  report を hard-fail させるのではなく、ホストの default domain binding を
-  引き続き報告します — 明示的な `--domain` は引き続き優先され、
-  packet が宣言する domain との矛盾は引き続きエラーになります。
-- `automation publish-recovery` はオプションの `--domain` を受け付け、
-  その domain の `execution_unit_regex` binding に候補セットを絞り込みます。
-  これにより、別 domain の execution unit がこの domain の recovery
-  解析に紛れ込むことがなくなります。`--domain` を省略した場合は、
-  従来のスコープなしの broad-scan 挙動のままです。
+- `automation queue-seed-from-packet` — `--domain` と packet の `domain:`
+  フィールドのどちらも無い場合、seed を拒否します。
+- `review closeout-plan` — 解決された queue item に対して domain を
+  導出できない場合（一致する queue item が無い、またはその packet.yaml に
+  `domain:` フィールドが無い場合）、ホストの default domain binding を
+  報告する代わりに、候補 domain と正確な `--domain` 再実行コマンドを示して
+  fail loud します。
+- `automation publish-recovery` は、各 execution unit の候補が repair 解析に
+  参加する前に、必ず domain を解決します — `--domain` が指定されていれば
+  それを使用し（その候補自身が宣言する packet-declared domain と矛盾する
+  場合は候補ごとにエラーになります）、指定が無ければその候補自身の
+  packet-declared domain から導出します。どちらも無い候補は、スキャンに
+  黙って参加する（あるいは黙って除外される）のではなく、構造化された
+  `domain-underivable` の unsafe stop になります。明示的な `--domain` と
+  矛盾する候補は構造化された `domain-contradiction` の unsafe stop に
+  なります。これは `--pr` でスコープされたパスと、スコープなしの broad
+  scan の両方に適用されます。`--domain` を完全に省略した場合は
+  cross-candidate なスコープを要求したことにはならないため、
+  （個別に導出可能な）異なる domain を持つ複数の候補が 1 回の broad-scan
+  結果に共存することがあります。
 
 ---
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -181,6 +181,49 @@ packet の正規の publish 経路は **`automation queue-seed-from-packet` →
 アクティブなドメインの regex に一致しない unit は、参照した bindings ソースを明示する精密な
 診断とともに拒否されます。
 
+### execution-unit を解決するサーフェスの domain 解決順序 (G522)
+
+`--pr` や `--execution-unit` から execution unit を解決するサーフェス
+（`review closeout-plan`、`automation queue-seed-from-packet`、
+`automation publish-recovery`、および同じ lookup を使う peer サーフェス）は、
+`--domain` が省略された場合に次の解決順序を適用します:
+
+1. 明示的な `--domain` が優先される — 解決された packet 自身の `domain:`
+   スカラーが宣言する値と矛盾する場合はエラーになる。
+2. それ以外の場合、解決された packet.yaml / queue metadata が宣言する
+   domain を使用する。
+3. それ以外の場合、サーフェスは fail loud する — `intents/*/` から
+   スキャンした候補 domain と、正確な `--domain` 再実行コマンドを示す。
+   ホストのデフォルト domain binding（`.intent-cli/config.toml` の
+   `[project] domain`）へ黙って fallback することは決してない。
+
+これは multi-domain host での既知のギャップを解消します: 従来の default
+binding fallback は、packet 自身の `domain:` フィールドが別の値を宣言して
+いても、間違った domain に対して報告・検証してしまうことがありました
+（例: `review closeout-plan --pr <n>` が、解決された packet の実際の domain
+ではなくホストの default domain を報告してしまう、あるいは
+`queue-seed-from-packet` が間違った domain の `execution_unit_regex`
+チェックを実行してしまう、など）。default binding の仕組み自体は変更
+されておらず他の箇所では引き続き使われます。変わったのは、これらの
+サーフェスが `--domain` 省略時に何を参照するかだけです。
+
+サーフェスごとの補足:
+
+- `automation queue-seed-from-packet` はこの順序を厳密に適用します —
+  `--domain` と packet の `domain:` フィールドのどちらも無い場合、
+  `[project] domain` へ fallback せず seed を拒否します。
+- `review closeout-plan` は read-only な planning サーフェスです:
+  domain を本当に導出できない場合（一致する queue item が無い、または
+  その packet.yaml に `domain:` フィールドが無い場合）、成功している gap
+  report を hard-fail させるのではなく、ホストの default domain binding を
+  引き続き報告します — 明示的な `--domain` は引き続き優先され、
+  packet が宣言する domain との矛盾は引き続きエラーになります。
+- `automation publish-recovery` はオプションの `--domain` を受け付け、
+  その domain の `execution_unit_regex` binding に候補セットを絞り込みます。
+  これにより、別 domain の execution unit がこの domain の recovery
+  解析に紛れ込むことがなくなります。`--domain` を省略した場合は、
+  従来のスコープなしの broad-scan 挙動のままです。
+
 ---
 
 ## バージョンフロー

--- a/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -79,25 +78,8 @@ internal static class AutomationPublishRecoveryCommand
             return 1;
         }
 
-        // G522: `--domain` is optional here (this surface, unlike
-        // `review closeout-plan` / `automation queue-seed-from-packet`, has
-        // no single resolved packet to derive a domain from until AFTER an
-        // execution unit is scoped, and a broad scan may legitimately span
-        // several domains). When `--domain` IS given, scope the candidate
-        // set to that domain's `execution_unit_regex` binding so a
-        // cross-domain execution unit (e.g. a different domain's unit
-        // sharing the same host) never leaks into this domain's analysis —
-        // the concrete bug this closes. Missing/invalid bindings degrade to
-        // "no filter" (same fail-open convention as
-        // NextSliceDomainBindingsExecutionUnitRegex's other callers) rather
-        // than blocking recovery on a misconfigured bindings file.
-        Regex? domainFilterRegex = null;
-        if (!string.IsNullOrWhiteSpace(domain))
-        {
-            domainFilterRegex = NextSliceDomainBindingsExecutionUnitRegex.TryLoad(context, domain);
-        }
-
-        var candidates = BuildCandidates(context, queueState, domainFilterRegex);
+        var rawCandidates = BuildCandidates(context, queueState);
+        var candidateDomains = DomainCandidateScanner.Scan(context);
 
         IReadOnlyList<GitHubAutomationPrCandidate> openPrs;
         try
@@ -112,17 +94,79 @@ internal static class AutomationPublishRecoveryCommand
             return 1;
         }
 
-        // G351: when --pr is given, scope the analysis to only the queue
-        // item relevant to the selected PR. This avoids flooding the
-        // operator with unrelated unsafe stops from a broad scan.
+        // G522: domain resolution order — explicit `--domain` > the
+        // resolved candidate's own packet-declared domain > structured
+        // fail-loud. No candidate participates in repair analysis
+        // unfiltered: every candidate's domain is resolved before it is
+        // allowed into `PublishRecoveryAnalyzer`, and an underivable or
+        // contradictory candidate becomes a structured unsafe stop instead
+        // of silently joining (or silently being dropped from) the scan.
         PublishRecoveryAnalysis analysis;
+        var domainBlockedStops = new List<PublishRecoveryUnsafeStop>();
         if (selectedPr is int prNumber)
         {
-            analysis = PublishRecoveryAnalyzer.AnalyzeScopedToPr(repo!, candidates, openPrs, prNumber);
+            // G351: run the scoped analyzer against the FULL (domain-
+            // unfiltered) candidate set first, to identify the single
+            // execution unit relevant to this PR — then domain-check ONLY
+            // that unit. This preserves the "scoped result returns at most
+            // one repair or one unsafe stop" contract while still refusing
+            // to let a domain-blocked candidate produce a safe repair.
+            var scoped = PublishRecoveryAnalyzer.AnalyzeScopedToPr(repo!, rawCandidates, openPrs, prNumber);
+            var relevantUnit = scoped.SafeRepairs.Count > 0
+                ? scoped.SafeRepairs[0].ExecutionUnit
+                : scoped.UnsafeStops.Count > 0 ? scoped.UnsafeStops[0].ExecutionUnit : null;
+            var domainResolution = relevantUnit is null
+                ? (PacketDomainResolutionResult?)null
+                : ResolveCandidateDomain(context, domain, relevantUnit, candidateDomains, repo!, selectedPr);
+            if (domainResolution is { IsError: true } blocked)
+            {
+                analysis = new PublishRecoveryAnalysis
+                {
+                    Repo = repo!,
+                    SafeRepairs = Array.Empty<PublishRecoveryRepair>(),
+                    UnsafeStops = new[]
+                    {
+                        new PublishRecoveryUnsafeStop
+                        {
+                            Kind = blocked.Reason!,
+                            ExecutionUnit = relevantUnit!,
+                            Reason = blocked.ErrorMessage!,
+                            PublishArtifactPath = IssuePublishArtifactPathResolver.Resolve(relevantUnit!),
+                        },
+                    },
+                };
+            }
+            else
+            {
+                analysis = scoped;
+            }
         }
         else
         {
-            analysis = PublishRecoveryAnalyzer.Analyze(repo!, candidates, openPrs);
+            // Broad scan: resolve every candidate's domain up front; only
+            // domain-eligible candidates reach the analyzer.
+            var eligible = new List<PublishRecoveryCandidate>();
+            foreach (var candidate in rawCandidates)
+            {
+                var resolution = ResolveCandidateDomain(context, domain, candidate.ExecutionUnit, candidateDomains, repo!, selectedPr: null);
+                if (resolution.IsError)
+                {
+                    domainBlockedStops.Add(new PublishRecoveryUnsafeStop
+                    {
+                        Kind = resolution.Reason!,
+                        ExecutionUnit = candidate.ExecutionUnit,
+                        Reason = resolution.ErrorMessage!,
+                        PublishArtifactPath = candidate.PublishArtifactExpectedPath,
+                    });
+                    continue;
+                }
+                eligible.Add(candidate);
+            }
+
+            var scanned = PublishRecoveryAnalyzer.Analyze(repo!, eligible, openPrs);
+            analysis = domainBlockedStops.Count == 0
+                ? scanned
+                : scanned with { UnsafeStops = domainBlockedStops.Concat(scanned.UnsafeStops).ToArray() };
         }
 
         var applied = new List<PublishRecoveryRepair>();
@@ -192,10 +236,42 @@ internal static class AutomationPublishRecoveryCommand
             onlyLinkedPrMissing: hasSafeLinkedPrRepair).Classification;
     }
 
-    private static IReadOnlyList<PublishRecoveryCandidate> BuildCandidates(
+    /// <summary>
+    /// G522: resolve a single candidate execution unit's domain via the
+    /// shared order (explicit `--domain` &gt; the candidate's own
+    /// packet-declared domain &gt; structured fail-loud). Reads
+    /// <c>.intent-cli/issues/&lt;unit&gt;/packet.yaml</c> directly rather than
+    /// a binding regex — the packet's own `domain:` field is authoritative
+    /// and needs no per-domain bindings.md lookup.
+    /// </summary>
+    private static PacketDomainResolutionResult ResolveCandidateDomain(
         CliContext context,
-        QueueState queueState,
-        Regex? domainFilterRegex)
+        string? explicitDomain,
+        string executionUnit,
+        IReadOnlyList<string> candidateDomains,
+        string repo,
+        int? selectedPr)
+    {
+        var packetYamlPath = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit, "packet.yaml");
+        string? packetDeclaredDomain = null;
+        if (File.Exists(packetYamlPath))
+        {
+            try
+            {
+                PreparedPacketYamlScalarParser.Parse(File.ReadAllText(packetYamlPath)).TryGetValue("domain", out packetDeclaredDomain);
+            }
+            catch (FormatException)
+            {
+                packetDeclaredDomain = null;
+            }
+        }
+
+        var reinvocation = $"intent-cli automation publish-recovery --repo {repo} --domain <name>"
+            + (selectedPr is int pr ? $" --pr {pr}" : string.Empty);
+        return PacketDomainResolution.Resolve(explicitDomain, packetDeclaredDomain, candidateDomains, reinvocation);
+    }
+
+    private static IReadOnlyList<PublishRecoveryCandidate> BuildCandidates(CliContext context, QueueState queueState)
     {
         var candidates = new List<PublishRecoveryCandidate>();
         foreach (var item in queueState.Items)
@@ -204,15 +280,6 @@ internal static class AutomationPublishRecoveryCommand
             // are now in scope (queue-state-backed lane). Skip only items
             // that already have a linked_pr — those are fully linked.
             if (!string.IsNullOrWhiteSpace(item.LinkedPr))
-            {
-                continue;
-            }
-
-            // G522: when a domain filter is active, skip execution units
-            // that don't match the requested domain's binding regex so a
-            // different domain's unit never leaks into this domain's
-            // recovery analysis.
-            if (domainFilterRegex is not null && !domainFilterRegex.IsMatch(item.ExecutionUnit))
             {
                 continue;
             }

--- a/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -54,7 +55,7 @@ internal static class AutomationPublishRecoveryCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (!TryParseArguments(args, out var repo, out var selectedPr, out var write, out var format, out var error))
+        if (!TryParseArguments(args, out var repo, out var selectedPr, out var domain, out var write, out var format, out var error))
         {
             writer.WriteLine(error);
             return 1;
@@ -78,7 +79,25 @@ internal static class AutomationPublishRecoveryCommand
             return 1;
         }
 
-        var candidates = BuildCandidates(context, queueState);
+        // G522: `--domain` is optional here (this surface, unlike
+        // `review closeout-plan` / `automation queue-seed-from-packet`, has
+        // no single resolved packet to derive a domain from until AFTER an
+        // execution unit is scoped, and a broad scan may legitimately span
+        // several domains). When `--domain` IS given, scope the candidate
+        // set to that domain's `execution_unit_regex` binding so a
+        // cross-domain execution unit (e.g. a different domain's unit
+        // sharing the same host) never leaks into this domain's analysis —
+        // the concrete bug this closes. Missing/invalid bindings degrade to
+        // "no filter" (same fail-open convention as
+        // NextSliceDomainBindingsExecutionUnitRegex's other callers) rather
+        // than blocking recovery on a misconfigured bindings file.
+        Regex? domainFilterRegex = null;
+        if (!string.IsNullOrWhiteSpace(domain))
+        {
+            domainFilterRegex = NextSliceDomainBindingsExecutionUnitRegex.TryLoad(context, domain);
+        }
+
+        var candidates = BuildCandidates(context, queueState, domainFilterRegex);
 
         IReadOnlyList<GitHubAutomationPrCandidate> openPrs;
         try
@@ -126,6 +145,7 @@ internal static class AutomationPublishRecoveryCommand
             Repo = repo!,
             Mode = write ? ModeWrite : ModeDryRun,
             SelectedPr = selectedPr,
+            Domain = domain,
             QueueStatePath = queueStatePath,
             SafeRepairs = analysis.SafeRepairs,
             UnsafeStops = analysis.UnsafeStops,
@@ -172,7 +192,10 @@ internal static class AutomationPublishRecoveryCommand
             onlyLinkedPrMissing: hasSafeLinkedPrRepair).Classification;
     }
 
-    private static IReadOnlyList<PublishRecoveryCandidate> BuildCandidates(CliContext context, QueueState queueState)
+    private static IReadOnlyList<PublishRecoveryCandidate> BuildCandidates(
+        CliContext context,
+        QueueState queueState,
+        Regex? domainFilterRegex)
     {
         var candidates = new List<PublishRecoveryCandidate>();
         foreach (var item in queueState.Items)
@@ -181,6 +204,15 @@ internal static class AutomationPublishRecoveryCommand
             // are now in scope (queue-state-backed lane). Skip only items
             // that already have a linked_pr — those are fully linked.
             if (!string.IsNullOrWhiteSpace(item.LinkedPr))
+            {
+                continue;
+            }
+
+            // G522: when a domain filter is active, skip execution units
+            // that don't match the requested domain's binding regex so a
+            // different domain's unit never leaks into this domain's
+            // recovery analysis.
+            if (domainFilterRegex is not null && !domainFilterRegex.IsMatch(item.ExecutionUnit))
             {
                 continue;
             }
@@ -325,6 +357,10 @@ internal static class AutomationPublishRecoveryCommand
     {
         writer.WriteLine($"# automation publish-recovery — `{result.Repo}` ({result.Mode})");
         writer.WriteLine();
+        if (!string.IsNullOrWhiteSpace(result.Domain))
+        {
+            writer.WriteLine($"- domain: `{result.Domain}`");
+        }
         writer.WriteLine($"- queue_state_path: `{result.QueueStatePath}`");
         writer.WriteLine($"- safe_repairs: {result.SafeRepairs.Count} (applied: {result.AppliedCount})");
         writer.WriteLine($"- unsafe_stops: {result.UnsafeStops.Count}");
@@ -360,12 +396,14 @@ internal static class AutomationPublishRecoveryCommand
         string[] args,
         out string? repo,
         out int? selectedPr,
+        out string? domain,
         out bool write,
         out string format,
         out string error)
     {
         repo = null;
         selectedPr = null;
+        domain = null;
         write = false;
         format = FormatMarkdown;
         error = string.Empty;
@@ -382,6 +420,18 @@ internal static class AutomationPublishRecoveryCommand
                         return false;
                     }
                     repo = args[++index].Trim();
+                    break;
+                // G522: optional domain scoping — filters candidates to the
+                // requested domain's execution-unit binding so a different
+                // domain's unit never leaks into this domain's recovery
+                // analysis on a multi-domain host.
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[++index].Trim();
                     break;
                 case "--pr":
                     // G351: optional PR scoping — scope analysis to the queue
@@ -457,6 +507,14 @@ internal sealed record AutomationPublishRecoveryResult
     /// <summary>G351: when --pr was supplied, the selected PR number. Null for a broad scan.</summary>
     [JsonPropertyName("selected_pr")]
     public int? SelectedPr { get; init; }
+
+    /// <summary>
+    /// G522: when --domain was supplied, candidates are scoped to that
+    /// domain's execution-unit binding regex. Null when --domain was
+    /// omitted (unscoped broad-scan behavior, unchanged).
+    /// </summary>
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
 
     [JsonPropertyName("queue_state_path")]
     public required string QueueStatePath { get; init; }

--- a/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
@@ -64,26 +64,6 @@ internal static class AutomationQueueSeedFromPacketCommand
             return 1;
         }
 
-        // PR #830 review repair (19:07 comment): `--domain` is
-        // optional on the CLI, but the underlying domain-binding
-        // regex check MUST ALWAYS RUN — otherwise a wrong-domain
-        // packet could be seeded as long as `target_repo` matches
-        // (fail-open). When `--domain` is omitted, default to the
-        // host config's `Project.Domain`. Refuse to proceed if
-        // neither is available: there is no safe deterministic way
-        // to pick a domain in that case, and silently skipping the
-        // regex check is exactly the gap the reviewer flagged.
-        var effectiveDomain = !string.IsNullOrWhiteSpace(domain)
-            ? domain!
-            : context.Config?.Project?.Domain;
-        if (string.IsNullOrWhiteSpace(effectiveDomain))
-        {
-            writer.WriteLine(
-                "--domain is required when `[project] domain` is not set in `.intent-cli/config.toml`. "
-                + "The domain-binding regex check refuses to silently fail open on wrong-domain packets.");
-            return 1;
-        }
-
         var packetDirectoryRelative = $".intent-cli/issues/{executionUnit}/";
         var packetDirectoryAbsolute = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit);
         if (!Directory.Exists(packetDirectoryAbsolute))
@@ -99,6 +79,31 @@ internal static class AutomationQueueSeedFromPacketCommand
             EmitResult(writer, format, missing);
             return 1;
         }
+
+        // G522: domain resolution order is explicit `--domain` > the
+        // domain declared by the packet's own `domain:` scalar > fail
+        // loud. The previous fallback to the host config's
+        // `Project.Domain` silently resolved wrong-domain packets
+        // against the WRONG domain's binding regex on multi-domain
+        // hosts (the packet's own declared domain is authoritative —
+        // see G522 issue). `--domain` remains optional on the CLI, but
+        // the underlying domain-binding regex check MUST ALWAYS RUN —
+        // otherwise a wrong-domain packet could be seeded as long as
+        // `target_repo` matches (fail-open).
+        var packetFields = ReadPacketFields(packetDirectoryAbsolute);
+        var packetDeclaredDomain = LookupScalar(packetFields, "domain");
+        var domainResolution = PacketDomainResolution.Resolve(
+            domain,
+            packetDeclaredDomain,
+            DomainCandidateScanner.Scan(context),
+            $"intent-cli automation queue-seed-from-packet --execution-unit {executionUnit} --domain <name>"
+                + (string.IsNullOrWhiteSpace(targetRepo) ? string.Empty : $" --target-repo {targetRepo}"));
+        if (domainResolution.IsError)
+        {
+            writer.WriteLine(domainResolution.ErrorMessage);
+            return 1;
+        }
+        var effectiveDomain = domainResolution.Domain!;
 
         // G485: resolve the domain-binding `execution_unit_regex` through the
         // SAME shared resolver the host loop and `automation summary` use
@@ -120,11 +125,10 @@ internal static class AutomationQueueSeedFromPacketCommand
             GithubBodyMarkdown = TryReadFile(Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNameGithubBodyMarkdown)),
             ExecutionUnitRegex = regexResolution.Pattern,
             RequestedTargetRepo = targetRepo,
-            // PR #830 review repair (19:07 comment): always require
-            // a domain binding now that `effectiveDomain` is always
-            // populated (either from `--domain` or the host config).
-            // Closes the fail-open path where omitting `--domain`
-            // skipped the regex check.
+            // Always require a domain binding now that `effectiveDomain`
+            // is always populated (via G522's `--domain` > packet-declared
+            // > fail-loud order). Closes the fail-open path where omitting
+            // `--domain` skipped the regex check.
             RequireDomainBinding = true,
         });
 
@@ -145,7 +149,6 @@ internal static class AutomationQueueSeedFromPacketCommand
             return 1;
         }
 
-        var packetFields = ReadPacketFields(packetDirectoryAbsolute);
         // PR #830 review repair #2: resolve the canonical clarification
         // return path for the host domain so packets that omit the
         // `clarification_return_path` field still seed with a usable
@@ -156,11 +159,9 @@ internal static class AutomationQueueSeedFromPacketCommand
         // `string.Empty` here would silently break the packet ↔
         // queue-item clarification path contract enforced by
         // ClarifyOpenCommand and MetadataValidateAnalyzer.
-        // PR #830 review repair (19:07 comment): `effectiveDomain`
-        // is already resolved above (--domain → host config Domain,
-        // with a hard refusal when neither is set) so the
-        // clarification path computation reuses the same value
-        // rather than re-deriving it.
+        // `effectiveDomain` is already resolved above (G522: --domain >
+        // packet-declared domain > fail-loud) so the clarification path
+        // computation reuses the same value rather than re-deriving it.
         var defaultClarificationReturnPath = $"intents/{effectiveDomain}/clarifications/open.md";
 
         // PR #830 review repair #3 (08:27 comment): align role /

--- a/src/IntentSystem.Cli/Commands/PacketDomainResolution.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDomainResolution.cs
@@ -1,0 +1,133 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G522: shared domain-resolution order for execution-unit-resolving
+/// surfaces (<c>review closeout-plan</c>, <c>automation
+/// queue-seed-from-packet</c>, <c>automation publish-recovery</c>, and
+/// peers that resolve an execution unit from <c>--pr</c> /
+/// <c>--execution-unit</c>). Resolution order when a single execution
+/// unit's packet is in view:
+///
+/// <list type="number">
+/// <item>an explicit <c>--domain</c> wins; it is an error if it
+///   contradicts the domain declared by the resolved packet.yaml /
+///   queue metadata;</item>
+/// <item>otherwise the domain declared by the resolved packet.yaml /
+///   queue metadata is used;</item>
+/// <item>otherwise the surface fails loud, naming candidate domains
+///   and the exact re-invocation — it never silently falls back to the
+///   host's default domain binding (<c>[project] domain</c>).</item>
+/// </list>
+///
+/// This does not change the default-binding mechanism itself (still
+/// used by surfaces outside this resolution order); it only changes
+/// what execution-unit-resolving surfaces consult when <c>--domain</c>
+/// is omitted.
+/// </summary>
+internal static class PacketDomainResolution
+{
+    public const string ReasonContradiction = "domain-contradiction";
+    public const string ReasonUnderivable = "domain-underivable";
+
+    public static PacketDomainResolutionResult Resolve(
+        string? explicitDomain,
+        string? packetDeclaredDomain,
+        IReadOnlyList<string> candidateDomains,
+        string reinvocationHint)
+    {
+        ArgumentNullException.ThrowIfNull(candidateDomains);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reinvocationHint);
+
+        var normalizedExplicit = string.IsNullOrWhiteSpace(explicitDomain) ? null : explicitDomain!.Trim();
+        var normalizedPacket = string.IsNullOrWhiteSpace(packetDeclaredDomain) ? null : packetDeclaredDomain!.Trim();
+
+        if (normalizedExplicit is not null)
+        {
+            if (normalizedPacket is not null
+                && !string.Equals(normalizedExplicit, normalizedPacket, StringComparison.Ordinal))
+            {
+                return PacketDomainResolutionResult.Error(
+                    ReasonContradiction,
+                    $"--domain '{normalizedExplicit}' contradicts the domain declared by the resolved packet "
+                    + $"('{normalizedPacket}'). Pass the matching --domain, or fix the packet's `domain:` field "
+                    + "if it is wrong.");
+            }
+
+            return PacketDomainResolutionResult.Ok(normalizedExplicit);
+        }
+
+        if (normalizedPacket is not null)
+        {
+            return PacketDomainResolutionResult.Ok(normalizedPacket);
+        }
+
+        var candidates = candidateDomains.Count > 0
+            ? string.Join(", ", candidateDomains)
+            : "(none found under intents/)";
+        return PacketDomainResolutionResult.Error(
+            ReasonUnderivable,
+            "--domain could not be derived: the resolved packet/queue metadata does not declare a `domain:` field "
+            + $"and no --domain was passed. Candidate domains: {candidates}. Re-invoke with: {reinvocationHint}");
+    }
+}
+
+/// <summary>G522: outcome of <see cref="PacketDomainResolution.Resolve"/>.</summary>
+internal readonly record struct PacketDomainResolutionResult
+{
+    public string? Domain { get; init; }
+
+    public bool IsError { get; init; }
+
+    public string? Reason { get; init; }
+
+    public string? ErrorMessage { get; init; }
+
+    public static PacketDomainResolutionResult Ok(string domain) => new() { Domain = domain };
+
+    public static PacketDomainResolutionResult Error(string reason, string message) => new()
+    {
+        IsError = true,
+        Reason = reason,
+        ErrorMessage = message,
+    };
+}
+
+/// <summary>
+/// G522: best-effort candidate-domain enumeration for the fail-loud
+/// error message — lists the domain directory names under
+/// <c>intents/</c> (parent host root when configured, else the child
+/// <see cref="CliContext.RepoRoot"/>), mirroring the parent-aware
+/// lookup convention used by <see cref="NextSliceDomainBindingsExecutionUnitRegex"/>.
+/// Purely advisory: an empty/missing <c>intents/</c> directory yields
+/// an empty list rather than an error.
+/// </summary>
+internal static class DomainCandidateScanner
+{
+    public static IReadOnlyList<string> Scan(CliContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var root = context.ResolveParentIntentRepoRootPath();
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            root = context.RepoRoot;
+        }
+        if (string.IsNullOrWhiteSpace(root))
+        {
+            return Array.Empty<string>();
+        }
+
+        var intentsDirectory = Path.Combine(root, "intents");
+        if (!Directory.Exists(intentsDirectory))
+        {
+            return Array.Empty<string>();
+        }
+
+        return Directory.EnumerateDirectories(intentsDirectory)
+            .Select(Path.GetFileName)
+            .Where(name => !string.IsNullOrWhiteSpace(name))
+            .Select(name => name!)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
+    }
+}

--- a/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
@@ -324,6 +324,7 @@ internal static class ReviewCloseoutPlanCommand
         IReadOnlyList<string> packetFiles = Array.Empty<string>();
         IReadOnlyList<string> missingSections = Array.Empty<string>();
         ReviewCloseoutLinkedIssue? linkedIssue = null;
+        string? packetDeclaredDomain = null;
         if (matchedItem is not null)
         {
             packetDirectory = Path.Combine(context.RepoRoot, ".intent-cli", "issues", matchedItem.ExecutionUnit);
@@ -333,6 +334,28 @@ internal static class ReviewCloseoutPlanCommand
                     .Select(file => Path.GetFileName(file))
                     .OrderBy(name => name, StringComparer.Ordinal)
                     .ToArray();
+
+                // G522: the packet's own `domain:` scalar is authoritative
+                // for which domain this execution unit belongs to — more
+                // reliable than the probe domain used above just to locate
+                // the (possibly legacy, unscoped) queue-state file. See the
+                // domain resolution applied to `domain` below.
+                var packetYamlPath = Path.Combine(packetDirectory, "packet.yaml");
+                if (File.Exists(packetYamlPath))
+                {
+                    try
+                    {
+                        var packetFields = PreparedPacketYamlScalarParser.Parse(File.ReadAllText(packetYamlPath));
+                        packetFields.TryGetValue("domain", out packetDeclaredDomain);
+                    }
+                    catch (FormatException)
+                    {
+                        // Malformed packet.yaml is surfaced elsewhere (G361
+                        // validation on the write-side commands); here it
+                        // just means no domain can be derived from it.
+                        packetDeclaredDomain = null;
+                    }
+                }
 
                 var githubBodyPath = Path.Combine(packetDirectory, "github-body.md");
                 if (!File.Exists(githubBodyPath))
@@ -381,6 +404,29 @@ internal static class ReviewCloseoutPlanCommand
                 };
             }
         }
+
+        // G522: domain resolution order — explicit `--domain` wins (it is
+        // an error if it contradicts the packet-declared domain); else the
+        // domain declared by the resolved packet is authoritative for the
+        // REPORTED domain, overriding the probe domain used above only to
+        // locate the (possibly legacy/unscoped) queue-state file. When no
+        // domain can be derived from the packet (no matched item, no
+        // packet.yaml, or no `domain:` field on it), this read-only
+        // planning surface keeps reporting the probe domain — hard-failing
+        // an otherwise-successful gap report isn't warranted here, unlike
+        // the write-gated `automation queue-seed-from-packet` surface.
+        var domainResolution = PacketDomainResolution.Resolve(
+            domainOverride,
+            packetDeclaredDomain,
+            Array.Empty<string>(),
+            $"intent-cli review closeout-plan --pr {pr} --repo {repo} --domain <name>");
+        if (domainResolution.IsError
+            && string.Equals(domainResolution.Reason, PacketDomainResolution.ReasonContradiction, StringComparison.Ordinal))
+        {
+            writer.WriteLine(domainResolution.ErrorMessage);
+            return 1;
+        }
+        var reportedDomain = domainResolution.IsError ? domain : domainResolution.Domain!;
 
         var expectedSubmodulePath = DeriveSubmodulePath(repo!);
 
@@ -485,7 +531,7 @@ internal static class ReviewCloseoutPlanCommand
 
         var result = new ReviewCloseoutPlanResult
         {
-            Domain = domain,
+            Domain = reportedDomain,
             Repo = repo!,
             Pr = pr!.Value,
             QueueStatePath = queueStatePath,

--- a/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
@@ -409,24 +409,21 @@ internal static class ReviewCloseoutPlanCommand
         // an error if it contradicts the packet-declared domain); else the
         // domain declared by the resolved packet is authoritative for the
         // REPORTED domain, overriding the probe domain used above only to
-        // locate the (possibly legacy/unscoped) queue-state file. When no
-        // domain can be derived from the packet (no matched item, no
-        // packet.yaml, or no `domain:` field on it), this read-only
-        // planning surface keeps reporting the probe domain — hard-failing
-        // an otherwise-successful gap report isn't warranted here, unlike
-        // the write-gated `automation queue-seed-from-packet` surface.
+        // locate the (possibly legacy/unscoped) queue-state file; else the
+        // surface fails loud naming candidate domains and the exact
+        // re-invocation — it never silently falls back to the host's
+        // default domain binding.
         var domainResolution = PacketDomainResolution.Resolve(
             domainOverride,
             packetDeclaredDomain,
-            Array.Empty<string>(),
+            DomainCandidateScanner.Scan(context),
             $"intent-cli review closeout-plan --pr {pr} --repo {repo} --domain <name>");
-        if (domainResolution.IsError
-            && string.Equals(domainResolution.Reason, PacketDomainResolution.ReasonContradiction, StringComparison.Ordinal))
+        if (domainResolution.IsError)
         {
             writer.WriteLine(domainResolution.ErrorMessage);
             return 1;
         }
-        var reportedDomain = domainResolution.IsError ? domain : domainResolution.Domain!;
+        var reportedDomain = domainResolution.Domain!;
 
         var expectedSubmodulePath = DeriveSubmodulePath(repo!);
 

--- a/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
@@ -443,6 +443,76 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         Assert.Contains("--repo", writer.ToString(), StringComparison.Ordinal);
     }
 
+    // --- G522: --domain scoped candidate filtering ----
+
+    [Fact]
+    public void Execute_WithDomain_ExcludesExecutionUnitsOutsideDomainBinding()
+    {
+        // G522: without domain scoping, a broad scan mixes execution units
+        // from every domain sharing this host's queue-state.json — the
+        // "misidentified SKS-G512 for an intent-cli workstream" bug from the
+        // G522 issue. With --domain, only execution units matching that
+        // domain's binding regex are analyzed; a different domain's unit
+        // must not appear at all.
+        using var workspace = new RecoveryWorkspace();
+        var liIntentCli = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 795,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/795" };
+        var liOtherDomain = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 512,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/512" };
+        workspace.WriteQueueState(BuildQueueStateMulti(
+            ("G346", liIntentCli, null),
+            ("SKS-G512", liOtherDomain, null)));
+        workspace.WriteBindings("intent-cli", "^G[0-9]+$");
+
+        AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
+            new[] { BuildPr(796, "Closes #795"), BuildPr(900, "Closes #512") });
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
+        Assert.Equal(1, root.GetProperty("safe_repairs").GetArrayLength());
+        Assert.Equal("G346", root.GetProperty("safe_repairs")[0].GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_WithoutDomain_BroadScanRemainsUnfiltered()
+    {
+        // G522: `--domain` is optional — omitting it preserves the existing
+        // unscoped broad-scan behavior (backward compatible for
+        // single-domain hosts and hosts not yet passing --domain).
+        using var workspace = new RecoveryWorkspace();
+        var liIntentCli = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 795,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/795" };
+        var liOtherDomain = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 512,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/512" };
+        workspace.WriteQueueState(BuildQueueStateMulti(
+            ("G346", liIntentCli, null),
+            ("SKS-G512", liOtherDomain, null)));
+        workspace.WriteBindings("intent-cli", "^G[0-9]+$");
+
+        AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
+            new[] { BuildPr(796, "Closes #795"), BuildPr(900, "Closes #512") });
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("domain").ValueKind);
+        Assert.Equal(2, root.GetProperty("safe_repairs").GetArrayLength());
+    }
+
     // --- G351: --pr scoped recovery ----
 
     [Fact]
@@ -727,6 +797,14 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
                 PublishedLabelName = "intent-target"
             };
             File.WriteAllText(Path.Combine(dir, "publish.yaml"), IssuePublishArtifactYaml.Serialize(artifact));
+        }
+
+        public void WriteBindings(string domain, string executionUnitRegex)
+        {
+            var dir = Path.Combine(RootPath, "intents", domain, "automation");
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "bindings.md"),
+                $"---\nexecution_unit_regex: '{executionUnitRegex}'\n---\n");
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
@@ -33,7 +33,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -61,7 +61,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -91,7 +91,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -120,7 +120,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--write", "--format", "json"],
             writer);
 
         using var doc = JsonDocument.Parse(writer.ToString());
@@ -150,7 +150,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -187,7 +187,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -214,7 +214,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -242,7 +242,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -278,7 +278,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -307,7 +307,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -341,7 +341,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var recoveryWriter = new StringWriter();
         var recoveryExit = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "3642", "--write", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "3642", "--write", "--format", "json"],
             recoveryWriter);
 
         Assert.Equal(0, recoveryExit);
@@ -368,7 +368,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var closeoutWriter = new StringWriter();
         var closeoutExit = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "3642", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "3642", "--format", "json"],
             closeoutWriter);
 
         Assert.Equal(0, closeoutExit);
@@ -409,7 +409,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -446,14 +446,14 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
     // --- G522: --domain scoped candidate filtering ----
 
     [Fact]
-    public void Execute_WithDomain_ExcludesExecutionUnitsOutsideDomainBinding()
+    public void Execute_ExplicitDomain_ExcludesCandidateContradictingItAsUnsafeStop()
     {
-        // G522: without domain scoping, a broad scan mixes execution units
-        // from every domain sharing this host's queue-state.json — the
-        // "misidentified SKS-G512 for an intent-cli workstream" bug from the
-        // G522 issue. With --domain, only execution units matching that
-        // domain's binding regex are analyzed; a different domain's unit
-        // must not appear at all.
+        // G522 (tightened per PR #1146 review): explicit `--domain` is
+        // checked against EACH candidate's own packet-declared domain. A
+        // candidate whose packet declares a DIFFERENT domain must not
+        // silently join the scan (the "misidentified SKS-G512 for an
+        // intent-cli workstream" bug) — it must surface as a structured
+        // domain-contradiction unsafe stop instead.
         using var workspace = new RecoveryWorkspace();
         var liIntentCli = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 795,
             Url = "https://github.com/J-Tech-Japan/intent-system/issues/795" };
@@ -462,7 +462,8 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         workspace.WriteQueueState(BuildQueueStateMulti(
             ("G346", liIntentCli, null),
             ("SKS-G512", liOtherDomain, null)));
-        workspace.WriteBindings("intent-cli", "^G[0-9]+$");
+        workspace.WritePacketDomain("G346", "intent-cli");
+        workspace.WritePacketDomain("SKS-G512", "sekiban-as-a-service");
 
         AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
             new[] { BuildPr(796, "Closes #795"), BuildPr(900, "Closes #512") });
@@ -479,14 +480,20 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         Assert.Equal("intent-cli", root.GetProperty("domain").GetString());
         Assert.Equal(1, root.GetProperty("safe_repairs").GetArrayLength());
         Assert.Equal("G346", root.GetProperty("safe_repairs")[0].GetProperty("execution_unit").GetString());
+        var stops = root.GetProperty("unsafe_stops").EnumerateArray().ToArray();
+        Assert.Contains(stops, s => s.GetProperty("execution_unit").GetString() == "SKS-G512"
+            && s.GetProperty("kind").GetString() == "domain-contradiction");
     }
 
     [Fact]
-    public void Execute_WithoutDomain_BroadScanRemainsUnfiltered()
+    public void Execute_DomainOmitted_DerivesEachCandidateFromItsOwnPacketMetadata()
     {
-        // G522: `--domain` is optional — omitting it preserves the existing
-        // unscoped broad-scan behavior (backward compatible for
-        // single-domain hosts and hosts not yet passing --domain).
+        // G522: with `--domain` omitted, each candidate's domain is derived
+        // from its OWN packet metadata (no cross-candidate scoping is
+        // requested) — a candidate with a resolvable domain still
+        // participates even alongside a candidate from a different domain,
+        // as long as EVERY included candidate's domain was explicitly
+        // derived (never silently assumed).
         using var workspace = new RecoveryWorkspace();
         var liIntentCli = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 795,
             Url = "https://github.com/J-Tech-Japan/intent-system/issues/795" };
@@ -495,7 +502,8 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         workspace.WriteQueueState(BuildQueueStateMulti(
             ("G346", liIntentCli, null),
             ("SKS-G512", liOtherDomain, null)));
-        workspace.WriteBindings("intent-cli", "^G[0-9]+$");
+        workspace.WritePacketDomain("G346", "intent-cli");
+        workspace.WritePacketDomain("SKS-G512", "sekiban-as-a-service");
 
         AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
             new[] { BuildPr(796, "Closes #795"), BuildPr(900, "Closes #512") });
@@ -511,6 +519,73 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         var root = doc.RootElement;
         Assert.Equal(JsonValueKind.Null, root.GetProperty("domain").ValueKind);
         Assert.Equal(2, root.GetProperty("safe_repairs").GetArrayLength());
+        Assert.Equal(0, root.GetProperty("unsafe_stops").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_DomainOmittedAndNoPacketDeclaresADomain_AllCandidatesFailLoud()
+    {
+        // G522: a candidate with NO derivable domain (no `--domain`, no
+        // packet-declared domain) must never silently participate in an
+        // unfiltered scan — it becomes a structured domain-underivable
+        // unsafe stop instead.
+        using var workspace = new RecoveryWorkspace();
+        var liIntentCli = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 795,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/795" };
+        var liOtherDomain = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 512,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/512" };
+        workspace.WriteQueueState(BuildQueueStateMulti(
+            ("G346", liIntentCli, null),
+            ("SKS-G512", liOtherDomain, null)));
+        // No packet.yaml written for either unit — no domain to derive.
+
+        AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
+            new[] { BuildPr(796, "Closes #795"), BuildPr(900, "Closes #512") });
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal(0, root.GetProperty("safe_repairs").GetArrayLength());
+        var stops = root.GetProperty("unsafe_stops").EnumerateArray().ToArray();
+        Assert.Equal(2, stops.Length);
+        Assert.All(stops, s => Assert.Equal("domain-underivable", s.GetProperty("kind").GetString()));
+    }
+
+    [Fact]
+    public void Execute_ScopedToPr_CandidateContradictsExplicitDomain_ProducesSingleDomainStop()
+    {
+        // G522: the `--pr`-scoped path must ALSO enforce domain isolation —
+        // a domain-contradicting candidate must not produce a safe repair
+        // just because it was the one PR-scoped candidate.
+        using var workspace = new RecoveryWorkspace();
+        var li795 = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 795,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/795" };
+        workspace.WriteQueueState(BuildQueueState("SKS-G219", linkedIssue: li795, linkedPr: null));
+        workspace.WritePacketDomain("SKS-G219", "sekiban-as-a-service");
+
+        AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(
+            new[] { BuildPr(559, "Closes #795") });
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "559", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var root = doc.RootElement;
+        Assert.Equal(0, root.GetProperty("safe_repairs").GetArrayLength());
+        Assert.Equal(1, root.GetProperty("unsafe_stops").GetArrayLength());
+        var stop = root.GetProperty("unsafe_stops")[0];
+        Assert.Equal("SKS-G219", stop.GetProperty("execution_unit").GetString());
+        Assert.Equal("domain-contradiction", stop.GetProperty("kind").GetString());
     }
 
     // --- G351: --pr scoped recovery ----
@@ -538,7 +613,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "796", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -572,7 +647,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--write", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "796", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -598,7 +673,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
 
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "not-a-number"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "not-a-number"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -621,7 +696,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "796", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -649,7 +724,7 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "796", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -799,12 +874,16 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
             File.WriteAllText(Path.Combine(dir, "publish.yaml"), IssuePublishArtifactYaml.Serialize(artifact));
         }
 
-        public void WriteBindings(string domain, string executionUnitRegex)
+        /// <summary>
+        /// G522: write a minimal packet.yaml declaring `domain:` for a
+        /// candidate execution unit, so <c>automation publish-recovery</c>
+        /// can derive that candidate's domain from its own packet metadata.
+        /// </summary>
+        public void WritePacketDomain(string executionUnit, string domain)
         {
-            var dir = Path.Combine(RootPath, "intents", domain, "automation");
+            var dir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
             Directory.CreateDirectory(dir);
-            File.WriteAllText(Path.Combine(dir, "bindings.md"),
-                $"---\nexecution_unit_regex: '{executionUnitRegex}'\n---\n");
+            File.WriteAllText(Path.Combine(dir, "packet.yaml"), $"domain: {domain}\n");
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/AutomationQueueSeedFromPacketCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationQueueSeedFromPacketCommandTests.cs
@@ -557,23 +557,20 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_DomainFlagOmitted_DefaultsToHostConfigDomain_AndRegexCheckStillRuns()
+    public void Execute_DomainFlagOmitted_DerivesFromPacketDeclaredDomain_AndRegexCheckStillRuns()
     {
-        // PR #830 review repair (19:07 comment, fail-open fix): when
-        // `--domain` is omitted, the command MUST default to the
-        // host config's `Project.Domain` so the domain-binding
-        // regex check still runs. Previously,
-        // `RequireDomainBinding = !string.IsNullOrWhiteSpace(domain)`
-        // skipped the check entirely when the flag was omitted —
-        // a fail-open path where a wrong-domain packet could be
-        // seeded as long as `target_repo` matched.
+        // G522: when `--domain` is omitted, the command derives the
+        // domain from the packet's own `domain:` scalar (NOT the host
+        // config's `Project.Domain` default binding — see G522) so the
+        // domain-binding regex check still runs against the packet's
+        // actual domain.
         //
         // This test writes a packet whose execution unit does NOT
-        // match the host domain's binding regex, omits `--domain`,
+        // match its declared domain's binding regex, omits `--domain`,
         // and asserts the seed is REFUSED (classification: unsafe)
-        // because the regex check now runs against the configured
-        // host domain.
-        workspace.WritePreparedPacket("Q9X-G10", targetRepo: "J-Tech-Creations/Zero4Racer");
+        // because the regex check runs against the packet-declared
+        // domain.
+        workspace.WritePreparedPacket("Q9X-G10", targetRepo: "J-Tech-Creations/Zero4Racer", domain: "intent-cli");
         workspace.WriteBindings("intent-cli", "^Z4R-G[0-9]+$");
 
         using var writer = new StringWriter();
@@ -599,23 +596,21 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_DomainFlagAndHostConfigDomainBothMissing_RefusesWithUsageError()
+    public void Execute_DomainFlagAndPacketDeclaredDomainBothMissing_FailsLoudNamingCandidates()
     {
-        // PR #830 review repair (19:07 comment, defensive case):
-        // when neither `--domain` nor `[project] domain` in
-        // `.intent-cli/config.toml` is set, there's no safe way to
-        // pick a domain for the regex check. Refuse to proceed
-        // rather than silently failing open. This is a stricter
-        // guarantee than the old behavior, but it's the right one:
-        // the only callers reaching this branch are misconfigured
-        // hosts that would have skipped the regex check before.
+        // G522: when neither `--domain` nor the packet's own `domain:`
+        // scalar is set, there's no safe way to pick a domain for the
+        // regex check. Refuse to proceed rather than silently falling
+        // back to the host config's `Project.Domain` default binding —
+        // that fallback is exactly the gap G522 closes (it can resolve
+        // to the WRONG domain's binding regex on a multi-domain host).
         using var emptyDomainWorkspace = new TestWorkspace();
         var newContext = new CliContext
         {
             RepoRoot = emptyDomainWorkspace.Context.RepoRoot,
             Config = emptyDomainWorkspace.Context.Config with
             {
-                Project = emptyDomainWorkspace.Context.Config.Project with { Domain = string.Empty },
+                Project = emptyDomainWorkspace.Context.Config.Project with { Domain = "intent-cli" },
             },
         };
         emptyDomainWorkspace.WritePreparedPacket("Z4R-G10", targetRepo: "J-Tech-Creations/Zero4Racer");
@@ -634,8 +629,64 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
             writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("--domain is required", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("fail open", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--domain could not be derived", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Candidate domains:", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--execution-unit Z4R-G10 --domain <name>", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ExplicitDomainMatchingPacketDeclaredDomain_Succeeds()
+    {
+        // G522: explicit --domain wins and is used when it agrees with the
+        // packet's own declared domain.
+        workspace.WritePreparedPacket("Z4R-G10", targetRepo: "J-Tech-Creations/Zero4Racer", domain: "intent-cli");
+        workspace.WriteBindings("intent-cli", "^Z4R-G[0-9]+$");
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationQueueSeedFromPacketCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--execution-unit", "Z4R-G10",
+                "--domain", "intent-cli",
+                "--target-repo", "J-Tech-Creations/Zero4Racer",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(
+            AutomationQueueSeedFromPacketCommand.ClassificationReady,
+            doc.RootElement.GetProperty("classification").GetString());
+    }
+
+    [Fact]
+    public void Execute_ExplicitDomainContradictsPacketDeclaredDomain_FailsLoud()
+    {
+        // G522: explicit --domain contradicting the packet's own declared
+        // domain must error rather than silently picking one — a
+        // misconfigured (or forged) `domain:` field must not slip an
+        // execution unit into the wrong domain's queue-state either.
+        workspace.WritePreparedPacket("Z4R-G10", targetRepo: "J-Tech-Creations/Zero4Racer", domain: "sekiban-as-a-service");
+        workspace.WriteBindings("intent-cli", "^Z4R-G[0-9]+$");
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationQueueSeedFromPacketCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--execution-unit", "Z4R-G10",
+                "--domain", "intent-cli",
+                "--target-repo", "J-Tech-Creations/Zero4Racer",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("contradicts the domain declared by the resolved packet", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(workspace.QueueStatePath));
     }
 
     [Fact]
@@ -835,12 +886,13 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
         public string QueueStatePath => Path.Combine(RootPath, ".intent-cli", "queue-state.json");
         public string RunsPath => Path.Combine(RootPath, ".intent-cli", "runs.jsonl");
 
-        public void WritePreparedPacket(string executionUnit, string targetRepo)
+        public void WritePreparedPacket(string executionUnit, string targetRepo, string? domain = null)
         {
             var dir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
             Directory.CreateDirectory(dir);
+            var domainLine = domain is null ? string.Empty : $"domain: {domain}\n";
             File.WriteAllText(Path.Combine(dir, "packet.yaml"),
-                $"implementation_issue_packet:\n  source_execution_unit: {executionUnit}\n  issue_title: Demo\n  target_repo: {targetRepo}\n");
+                $"{domainLine}implementation_issue_packet:\n  source_execution_unit: {executionUnit}\n  issue_title: Demo\n  target_repo: {targetRepo}\n");
             File.WriteAllText(Path.Combine(dir, "implementation.md"), "# impl\n");
             File.WriteAllText(Path.Combine(dir, "review-context.md"), "# review\n");
             File.WriteAllText(Path.Combine(dir, "github-body.md"),

--- a/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
@@ -1465,6 +1465,119 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         Assert.Contains("pr-transition", output, StringComparison.Ordinal);
     }
 
+    // ----- G522: domain resolution order (explicit > packet-declared > fallback) -----
+
+    [Fact]
+    public void Execute_DomainOmitted_DerivesReportedDomainFromPacketDeclaredDomain()
+    {
+        // G522: the workspace's host config default domain is "intent-cli"
+        // (see ReviewCloseoutPlanWorkspace ctor), but the packet declares a
+        // DIFFERENT domain. Without --domain, the packet-declared domain
+        // must be reported — this is the exact bug G522 fixes (a
+        // multi-domain host reporting its default binding instead of the
+        // matched packet's real domain).
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review",
+            linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/796",
+            linkedIssue: ("J-Tech-Japan/intent-system", 795, "https://github.com/J-Tech-Japan/intent-system/issues/795")));
+        WriteCompliantPacketFiles(workspace, "G247");
+        workspace.WriteFile(".intent-cli/issues/G247/packet.yaml", "domain: sekiban-as-a-service\n");
+
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("sekiban-as-a-service", doc.RootElement.GetProperty("domain").GetString());
+    }
+
+    [Fact]
+    public void Execute_ExplicitDomainMatchingPacketDeclaredDomain_Succeeds()
+    {
+        // G522: explicit --domain wins and is reported when it agrees with
+        // the packet's own declared domain.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review",
+            linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/796",
+            linkedIssue: ("J-Tech-Japan/intent-system", 795, "https://github.com/J-Tech-Japan/intent-system/issues/795")));
+        WriteCompliantPacketFiles(workspace, "G247");
+        workspace.WriteFile(".intent-cli/issues/G247/packet.yaml", "domain: sekiban-as-a-service\n");
+
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--domain", "sekiban-as-a-service", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("sekiban-as-a-service", doc.RootElement.GetProperty("domain").GetString());
+    }
+
+    [Fact]
+    public void Execute_ExplicitDomainContradictsPacketDeclaredDomain_FailsLoud()
+    {
+        // G522: explicit --domain contradicting the packet's own declared
+        // domain must error rather than silently pick one.
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review",
+            linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/796",
+            linkedIssue: ("J-Tech-Japan/intent-system", 795, "https://github.com/J-Tech-Japan/intent-system/issues/795")));
+        WriteCompliantPacketFiles(workspace, "G247");
+        workspace.WriteFile(".intent-cli/issues/G247/packet.yaml", "domain: sekiban-as-a-service\n");
+
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("contradicts the domain declared by the resolved packet", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_PacketDeclaresNoDomainField_FallsBackToHostConfigDefault()
+    {
+        // G522 scoping decision (documented in the PR description): this
+        // read-only, gap-reporting surface keeps its pre-existing fallback
+        // to the host config default when the packet declares no `domain:`
+        // field at all — hard-failing an otherwise-successful plan isn't
+        // warranted here (unlike the write-gated
+        // `automation queue-seed-from-packet`, which fails loud).
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G247", "review",
+            linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/796",
+            linkedIssue: ("J-Tech-Japan/intent-system", 795, "https://github.com/J-Tech-Japan/intent-system/issues/795")));
+        WriteCompliantPacketFiles(workspace, "G247");
+        // No packet.yaml written at all — no domain field to derive from.
+
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory =
+            () => new FakePrClosingIssuesFetcher(Array.Empty<int>());
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("intent-cli", doc.RootElement.GetProperty("domain").GetString());
+    }
+
     private static void WriteCompliantPacketFiles(ReviewCloseoutPlanWorkspace workspace, string executionUnit)
     {
         workspace.WriteFile(

--- a/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
@@ -56,7 +56,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -86,7 +86,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -108,7 +108,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -126,7 +126,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -144,7 +144,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -167,7 +167,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "670", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "670", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -197,7 +197,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "670", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "670", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -242,7 +242,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/SekibanAsAService", "--pr", "647", "--format", "json"],
+            ["--repo", "J-Tech-Japan/SekibanAsAService", "--domain", "intent-cli", "--pr", "647", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -285,7 +285,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -317,7 +317,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -355,7 +355,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -389,7 +389,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/SekibanAsAService", "--pr", "647", "--format", "json"],
+            ["--repo", "J-Tech-Japan/SekibanAsAService", "--domain", "intent-cli", "--pr", "647", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -411,7 +411,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "670", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "670", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -434,7 +434,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -468,7 +468,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "670", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "670", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -487,7 +487,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -544,7 +544,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/SekibanAsAService", "--pr", "490", "--format", "json"],
+            ["--repo", "J-Tech-Japan/SekibanAsAService", "--domain", "intent-cli", "--pr", "490", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -590,7 +590,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
 
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596", "--format", "yaml"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596", "--format", "yaml"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -607,7 +607,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "596"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "596"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -695,7 +695,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             workspace.Context,
             new[]
             {
-                "--repo", "J-Tech-Japan/intent-system",
+                "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli",
                 "--pr", "760",
                 "--closing-issues", "759",
                 "--format", "json"
@@ -742,7 +742,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             workspace.Context,
             new[]
             {
-                "--repo", "J-Tech-Japan/intent-system",
+                "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli",
                 "--pr", "760",
                 "--closing-issues", "759",
                 "--format", "json"
@@ -794,7 +794,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             workspace.Context,
             new[]
             {
-                "--repo", "J-Tech-Japan/intent-system",
+                "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli",
                 "--pr", "760",
                 "--closing-issues", "759",
                 "--format", "json"
@@ -830,7 +830,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             workspace.Context,
             new[]
             {
-                "--repo", "J-Tech-Japan/intent-system",
+                "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli",
                 "--pr", "760",
                 "--format", "json"
             },
@@ -863,7 +863,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             workspace.Context,
             new[]
             {
-                "--repo", "J-Tech-Japan/intent-system",
+                "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli",
                 "--pr", "760",
                 "--closing-issues", "759",
                 "--format", "json"
@@ -896,7 +896,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             workspace.Context,
             new[]
             {
-                "--repo", "J-Tech-Japan/intent-system",
+                "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli",
                 "--pr", "760",
                 "--closing-issues", "759",
                 "--format", "json"
@@ -933,7 +933,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "760", "--format", "json" },
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "760", "--format", "json" },
             writer);
 
         Assert.Equal(0, exitCode);
@@ -964,7 +964,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "760", "--format", "json" },
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "760", "--format", "json" },
             writer);
 
         Assert.Equal(1, exitCode);
@@ -1000,7 +1000,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             workspace.Context,
             new[]
             {
-                "--repo", "J-Tech-Japan/intent-system",
+                "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli",
                 "--pr", "760",
                 "--write-recovered-linkage",
                 "--format", "json"
@@ -1054,7 +1054,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             workspace.Context,
             new[]
             {
-                "--repo", "J-Tech-Japan/intent-system",
+                "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli",
                 "--pr", "760",
                 "--write-recovered-linkage",
                 "--format", "json"
@@ -1093,7 +1093,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             workspace.Context,
             new[]
             {
-                "--repo", "J-Tech-Japan/intent-system",
+                "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli",
                 "--pr", "760",
                 "--closing-issues", "759",
                 "--format", "json"
@@ -1117,7 +1117,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             workspace.Context,
             new[]
             {
-                "--repo", "J-Tech-Japan/intent-system",
+                "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli",
                 "--pr", "760",
                 "--closing-issues", "759,not-a-number",
                 "--format", "json"
@@ -1158,7 +1158,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exit = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "770", "--format", "json" },
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "770", "--format", "json" },
             writer);
 
         Assert.Equal(0, exit);
@@ -1189,7 +1189,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exit = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "770", "--format", "json" },
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "770", "--format", "json" },
             writer);
 
         Assert.Equal(0, exit);
@@ -1225,7 +1225,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exit = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "770", "--format", "json" },
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "770", "--format", "json" },
             writer);
 
         Assert.Equal(0, exit);
@@ -1369,7 +1369,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "796", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -1402,7 +1402,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "796", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -1433,7 +1433,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "796", "--format", "json"],
             writer);
 
         using var doc = JsonDocument.Parse(writer.ToString());
@@ -1457,7 +1457,7 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
         using var writer = new StringWriter();
         ReviewCloseoutPlanCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--pr", "796"],
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--pr", "796"],
             writer);
 
         var output = writer.ToString();
@@ -1549,14 +1549,14 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_PacketDeclaresNoDomainField_FallsBackToHostConfigDefault()
+    public void Execute_PacketDeclaresNoDomainFieldAndNoExplicitDomain_FailsLoudNamingCandidates()
     {
-        // G522 scoping decision (documented in the PR description): this
-        // read-only, gap-reporting surface keeps its pre-existing fallback
-        // to the host config default when the packet declares no `domain:`
-        // field at all — hard-failing an otherwise-successful plan isn't
-        // warranted here (unlike the write-gated
-        // `automation queue-seed-from-packet`, which fails loud).
+        // G522 AC (tightened per PR #1146 review — no config-default
+        // fallback is authorized): when the resolved packet declares no
+        // `domain:` field and no `--domain` was passed, this surface must
+        // fail loud naming candidate domains and the exact re-invocation —
+        // it must NOT silently resolve against the host's default domain
+        // binding, even though this is a read-only, gap-reporting surface.
         using var workspace = new ReviewCloseoutPlanWorkspace();
         workspace.WriteQueueState(BuildQueueState("G247", "review",
             linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/796",
@@ -1573,9 +1573,10 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
             ["--repo", "J-Tech-Japan/intent-system", "--pr", "796", "--format", "json"],
             writer);
 
-        Assert.Equal(0, exitCode);
-        using var doc = JsonDocument.Parse(writer.ToString());
-        Assert.Equal("intent-cli", doc.RootElement.GetProperty("domain").GetString());
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--domain could not be derived", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("Candidate domains:", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--pr 796 --repo J-Tech-Japan/intent-system --domain <name>", writer.ToString(), StringComparison.Ordinal);
     }
 
     private static void WriteCompliantPacketFiles(ReviewCloseoutPlanWorkspace workspace, string executionUnit)


### PR DESCRIPTION
## Summary
- Adds a shared `PacketDomainResolution` helper: explicit `--domain` wins (erroring on contradiction with the packet's own `domain:` scalar) > the domain declared by the resolved packet.yaml/queue metadata > fail loud naming candidate domains (scanned from `intents/*/`) and the exact re-invocation.
- **`automation queue-seed-from-packet`**: applies the order strictly — the domain-binding regex check now runs against the packet's own declared domain instead of the host's default binding; refuses to seed (rather than falling back to the config default) when neither `--domain` nor the packet's `domain:` field resolves.
- **`review closeout-plan`**: reports the packet-declared domain when derivable (fixing the exact bug: this surface previously echoed the host's default domain even when the matched packet belonged to a different one); an explicit `--domain` contradicting the packet's domain is now an error.
- **`automation publish-recovery`**: adds an optional `--domain` that scopes the candidate set to that domain's `execution_unit_regex` binding, so a different domain's execution unit can no longer leak into this domain's recovery analysis (the "misidentified SKS-G512" bug).
- Documents the new resolution order in `docs/ja/09-developer-reference.md` and `docs/en/09-developer-reference.md`.

Closes #1145

## Scoping decisions (flagging for reviewer judgment)
- **`review closeout-plan`** keeps its pre-existing fallback to the host's config-default domain *only* for the case where no domain can be derived at all (no matched queue item, or a packet.yaml with no `domain:` field) — hard-failing an otherwise-successful gap report didn't seem warranted for this read-only planning surface, unlike the write-gated `queue-seed-from-packet`. Happy to tighten this further if review disagrees.
- **`automation publish-recovery`** had *zero* pre-existing domain awareness (no `--domain` flag, no config-default fallback) — I added domain-scoped filtering as the natural fix for the concretely-described cross-domain-noise bug, but did not attempt packet.yaml-based derivation for its unscoped broad-scan mode (no single execution unit to derive from before PR-scoping runs).

## Test plan
- [x] `dotnet build` (full solution) — 0 warnings/errors.
- [x] `dotnet test` (full solution) — all green (3197 passed, 1 pre-existing skip across `IntentSystem.Cli.Tests`; all other test projects green).
- [x] New focused tests for derivation / explicit-override / contradiction / underivable-fail-loud on all three surfaces.
- [x] Manual multi-domain fixture check: built the CLI and ran `automation queue-seed-from-packet` and `review closeout-plan` against a fixture where the host's default domain (`sekiban-as-a-service`) differs from the packet's declared domain (`intent-cli`) — both correctly resolve/report `intent-cli`, and an explicit `--domain sekiban-as-a-service` correctly fails loud with the contradiction message.
- [x] `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4yoyeXmTeJWD16RLvktQd