### PR TITLE
G523: Add automation stalled-work surface reporting pending pipeline transitions

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -285,14 +285,18 @@ when its packet-declared domain matches the requested `--domain` exactly. A
 candidate whose packet-declared domain contradicts `--domain`, or whose
 domain cannot be derived at all (no packet.yaml, or no `domain:` field on
 it), is FAIL-CLOSED: excluded from `items[]` and reported instead in
-`excluded[]` (`kind`, `execution_unit`, `issue`/`pr`, `reason` —
-`domain-contradiction` or `domain-underivable` — and a `detail` message
-naming candidate domains and the exact `--domain` re-invocation). Unlike the
-other G522 surfaces (where an explicit `--domain` can stand alone for a
-single operator-named execution unit), this is a broad multi-candidate scan
-over a shared repo's issues/PRs — an explicit `--domain` alone is never
-trusted to apply to a candidate whose own metadata cannot corroborate it, so
-a candidate never silently joins the scan and never silently disappears.
+`excluded[]` (`kind`, `execution_unit`, `issue`/`pr`, `reason`, `detail`).
+`reason` is `domain-contradiction` (with `detail` naming the specific
+conflicting packet-declared domain) or `domain-underivable` (with `detail`
+naming the candidate domains scanned from `intents/*/` AND the exact,
+runnable re-invocation — `intent-cli automation stalled-work --domain <name>
+--repo <owner/repo> --format json` — inherited from the G522 underivable
+diagnostic contract). Unlike the other G522 surfaces (where an explicit
+`--domain` can stand alone for a single operator-named execution unit), this
+is a broad multi-candidate scan over a shared repo's issues/PRs — an
+explicit `--domain` alone is never trusted to apply to a candidate whose own
+metadata cannot corroborate it, so a candidate never silently joins the scan
+and never silently disappears.
 
 This slice is detection only — consuming the surface from the orchestrator
 wake procedure and from an external heartbeat are separate follow-up slices.

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -261,23 +261,38 @@ Categories:
   `Completed` (closeout — `pr-merged` + `closeout-recorded` runs events —
   has not been recorded).
 
-Each item reports `kind`, `execution_unit` (derived from the `<unit>: ...`
-title prefix convention used across this repo's own issues/PRs), `issue`
-and/or `pr` (number + url), `age_minutes`, and `recommended_action` — the
-exact canonical command to run next (`worker claim`, `automation
-pr-transition --transition review-start`, or `closeout pr`, respectively).
-`--stale-minutes` filters out items younger than the given threshold
-(default `0` — report everything with its age; callers pick their own
-threshold). `age_minutes` is approximated from the relevant GitHub entity's
-`createdAt`/`updatedAt` timestamp, since GitHub does not expose
-per-label-application timestamps.
+Each item reports `kind`, `execution_unit`, `issue` and/or `pr` (number +
+url), `age_minutes`, and `recommended_action` — the exact canonical command
+to run next (`worker claim`, `automation pr-transition --transition
+review-start`, or `closeout pr`, respectively). `--stale-minutes` filters
+out items younger than the given threshold (default `0` — report everything
+with its age; callers pick their own threshold). `age_minutes` is
+approximated from the relevant GitHub entity's `createdAt`/`updatedAt`
+timestamp, since GitHub does not expose per-label-application timestamps.
+`published-not-delegated` also checks the already-fetched PR closing
+references independently of issue labels, so a completion label that has
+drifted out of sync with reality (an open PR already closes the issue, but
+`intent-pr-created` was never applied or was removed) never produces a
+false `worker claim` recommendation.
 
-Domain scoping follows the execution-unit-regex binding convention (not the
-per-candidate packet.yaml lookup from G522): an item whose derived execution
-unit does not match the requested domain's `execution_unit_regex`
-(`intents/<domain>/automation/bindings.md`) is excluded. A missing/invalid
-binding degrades to "no filter" (with a surfaced `warnings` entry) rather
-than blocking this diagnostic-only surface.
+**Domain isolation is grounded in packet/queue metadata, consistent with
+G522 — never in a title-prefix regex match.** A `<unit>: ...` title prefix
+is derived for every GitHub issue/PR candidate, but it is used ONLY to
+locate that candidate's `.intent-cli/issues/<unit>/packet.yaml` — the
+packet's own declared `domain:` field is the sole authority consulted
+against the requested `--domain`. A candidate is included in `items[]` only
+when its packet-declared domain matches the requested `--domain` exactly. A
+candidate whose packet-declared domain contradicts `--domain`, or whose
+domain cannot be derived at all (no packet.yaml, or no `domain:` field on
+it), is FAIL-CLOSED: excluded from `items[]` and reported instead in
+`excluded[]` (`kind`, `execution_unit`, `issue`/`pr`, `reason` —
+`domain-contradiction` or `domain-underivable` — and a `detail` message
+naming candidate domains and the exact `--domain` re-invocation). Unlike the
+other G522 surfaces (where an explicit `--domain` can stand alone for a
+single operator-named execution unit), this is a broad multi-candidate scan
+over a shared repo's issues/PRs — an explicit `--domain` alone is never
+trusted to apply to a candidate whose own metadata cannot corroborate it, so
+a candidate never silently joins the scan and never silently disappears.
 
 This slice is detection only — consuming the surface from the orchestrator
 wake procedure and from an external heartbeat are separate follow-up slices.

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -240,6 +240,48 @@ All three surfaces apply the full order strictly — none of them fall back to
   multiple candidates with different (but each individually derivable)
   domains may still coexist in one broad-scan result.
 
+### Stalled-work detection (G523)
+
+`intent-cli automation stalled-work --domain <d> --repo <r> [--stale-minutes <m>] --format json|markdown`
+is a **read-only** inventory of pending pipeline transitions with ages, so a
+single orchestrator wake (or an external heartbeat) can detect and recover a
+stalled pipeline without a human cross-checking GitHub labels, PR state, and
+queue-state by hand. It never mutates GitHub labels, queue-state, or
+`runs.jsonl`.
+
+Categories:
+
+- `published-not-delegated` — an OPEN issue carries `intent-target` but has
+  no claim label (`intent-issue-in-progress` / `intent-pr-created`) yet, and
+  no PR was ever created for it.
+- `pr-created-not-reviewing` — the source issue carries `intent-pr-created`
+  and its closing PR has not had the `review-start` transition applied (no
+  `intent-pr-reviewing` / `intent-pr-approved` on the PR).
+- `merged-not-closed-out` — a MERGED PR's linked queue-state item is not yet
+  `Completed` (closeout — `pr-merged` + `closeout-recorded` runs events —
+  has not been recorded).
+
+Each item reports `kind`, `execution_unit` (derived from the `<unit>: ...`
+title prefix convention used across this repo's own issues/PRs), `issue`
+and/or `pr` (number + url), `age_minutes`, and `recommended_action` — the
+exact canonical command to run next (`worker claim`, `automation
+pr-transition --transition review-start`, or `closeout pr`, respectively).
+`--stale-minutes` filters out items younger than the given threshold
+(default `0` — report everything with its age; callers pick their own
+threshold). `age_minutes` is approximated from the relevant GitHub entity's
+`createdAt`/`updatedAt` timestamp, since GitHub does not expose
+per-label-application timestamps.
+
+Domain scoping follows the execution-unit-regex binding convention (not the
+per-candidate packet.yaml lookup from G522): an item whose derived execution
+unit does not match the requested domain's `execution_unit_regex`
+(`intents/<domain>/automation/bindings.md`) is excluded. A missing/invalid
+binding degrades to "no filter" (with a surfaced `warnings` entry) rather
+than blocking this diagnostic-only surface.
+
+This slice is detection only — consuming the surface from the orchestrator
+wake procedure and from an external heartbeat are separate follow-up slices.
+
 ---
 
 ## Version flow

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -231,6 +231,48 @@ binding fallback は、packet 自身の `domain:` フィールドが別の値を
   （個別に導出可能な）異なる domain を持つ複数の候補が 1 回の broad-scan
   結果に共存することがあります。
 
+### stalled-work 検出 (G523)
+
+`intent-cli automation stalled-work --domain <d> --repo <r> [--stale-minutes <m>] --format json|markdown`
+は、保留中の pipeline transition を age 付きで一覧化する **read-only** な
+サーフェスです。これにより、1 回の orchestrator wake（あるいは外部の
+heartbeat）だけで、人間が GitHub label・PR state・queue-state を手で
+突き合わせることなく stall を検出・復旧できます。GitHub label、
+queue-state、`runs.jsonl` を変更することは一切ありません。
+
+カテゴリ:
+
+- `published-not-delegated` — OPEN の issue が `intent-target` を持つが、
+  claim label（`intent-issue-in-progress` / `intent-pr-created`）がまだ無く、
+  PR も一度も作成されていない。
+- `pr-created-not-reviewing` — 元の issue が `intent-pr-created` を持ち、
+  その issue を close する PR に `review-start` transition がまだ適用
+  されていない（PR に `intent-pr-reviewing` / `intent-pr-approved` が無い）。
+- `merged-not-closed-out` — MERGED 状態の PR に紐づく queue-state item が
+  まだ `Completed` になっていない（closeout — `pr-merged` +
+  `closeout-recorded` の runs event — がまだ記録されていない）。
+
+各 item は `kind`、`execution_unit`（このリポジトリ自身の issue/PR で
+使われている `<unit>: ...` というタイトル prefix の慣習から導出）、
+`issue` および/または `pr`（番号 + url）、`age_minutes`、
+`recommended_action`（次に実行すべき正確な canonical コマンド —
+それぞれ `worker claim`、`automation pr-transition --transition
+review-start`、`closeout pr`）を報告します。`--stale-minutes` は、
+指定した閾値より新しい item を除外します（デフォルトは `0` —
+すべてを age 付きで報告し、閾値は呼び出し側が選ぶ）。`age_minutes` は、
+GitHub が label 適用時刻を公開していないため、該当する GitHub entity の
+`createdAt`/`updatedAt` タイムスタンプからの近似値です。
+
+domain スコープは（G522 の per-candidate packet.yaml lookup ではなく）
+execution-unit-regex binding の慣習に従います: 導出された execution unit
+が要求された domain の `execution_unit_regex`
+（`intents/<domain>/automation/bindings.md`）に一致しない item は除外
+されます。binding が無い/不正な場合は、この診断専用サーフェスをブロック
+するのではなく「フィルタなし」に degrade します（`warnings` に明示）。
+
+このスライスは検出のみです — orchestrator wake procedure や外部
+heartbeat からこのサーフェスを利用する部分は、別の後続スライスです。
+
 ---
 
 ## バージョンフロー

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -252,23 +252,41 @@ queue-state、`runs.jsonl` を変更することは一切ありません。
   まだ `Completed` になっていない（closeout — `pr-merged` +
   `closeout-recorded` の runs event — がまだ記録されていない）。
 
-各 item は `kind`、`execution_unit`（このリポジトリ自身の issue/PR で
-使われている `<unit>: ...` というタイトル prefix の慣習から導出）、
-`issue` および/または `pr`（番号 + url）、`age_minutes`、
-`recommended_action`（次に実行すべき正確な canonical コマンド —
-それぞれ `worker claim`、`automation pr-transition --transition
-review-start`、`closeout pr`）を報告します。`--stale-minutes` は、
-指定した閾値より新しい item を除外します（デフォルトは `0` —
-すべてを age 付きで報告し、閾値は呼び出し側が選ぶ）。`age_minutes` は、
-GitHub が label 適用時刻を公開していないため、該当する GitHub entity の
-`createdAt`/`updatedAt` タイムスタンプからの近似値です。
+各 item は `kind`、`execution_unit`、`issue` および/または `pr`
+（番号 + url）、`age_minutes`、`recommended_action`（次に実行すべき
+正確な canonical コマンド — それぞれ `worker claim`、`automation
+pr-transition --transition review-start`、`closeout pr`）を報告します。
+`--stale-minutes` は、指定した閾値より新しい item を除外します
+（デフォルトは `0` — すべてを age 付きで報告し、閾値は呼び出し側が選ぶ）。
+`age_minutes` は、GitHub が label 適用時刻を公開していないため、
+該当する GitHub entity の `createdAt`/`updatedAt` タイムスタンプからの
+近似値です。`published-not-delegated` は、既に取得済みの PR closing
+reference も issue label とは独立にチェックします — そのため、
+completion label が実態とずれてしまっていても（intent-pr-created が
+一度も付与されていない、または削除されてしまったが、OPEN の PR が
+既にその issue を close している場合）、誤って `worker claim` を推奨する
+ことはありません。
 
-domain スコープは（G522 の per-candidate packet.yaml lookup ではなく）
-execution-unit-regex binding の慣習に従います: 導出された execution unit
-が要求された domain の `execution_unit_regex`
-（`intents/<domain>/automation/bindings.md`）に一致しない item は除外
-されます。binding が無い/不正な場合は、この診断専用サーフェスをブロック
-するのではなく「フィルタなし」に degrade します（`warnings` に明示）。
+**domain isolation は（title-prefix の正規表現一致ではなく）G522 と同様に
+packet/queue metadata に基づきます。** すべての GitHub issue/PR candidate
+について `<unit>: ...` というタイトル prefix を導出しますが、これは
+その candidate の `.intent-cli/issues/<unit>/packet.yaml` を特定するため
+だけに使われます — 要求された `--domain` と照合する唯一の権威は、
+その packet 自身が宣言する `domain:` フィールドです。candidate が
+`items[]` に含まれるのは、packet が宣言する domain が要求された
+`--domain` と完全に一致する場合のみです。packet が宣言する domain が
+`--domain` と矛盾する candidate、あるいは domain を全く導出できない
+candidate（packet.yaml が無い、またはそれに `domain:` フィールドが
+無い）は FAIL-CLOSED になります: `items[]` から除外され、代わりに
+`excluded[]`（`kind`、`execution_unit`、`issue`/`pr`、`reason` —
+`domain-contradiction` または `domain-underivable` —、候補 domain と
+正確な `--domain` 再実行コマンドを示す `detail`）に報告されます。
+（単一の operator 指定 execution unit に対しては明示的な `--domain`
+単独で成立する）他の G522 サーフェスとは異なり、これは共有 repo の
+issue/PR にまたがる broad multi-candidate scan です — 明示的な
+`--domain` だけでは、自身のメタデータで裏付けが取れない candidate に
+適用されると信頼することはありません。したがって candidate が黙って
+scan に紛れ込むことも、黙って消えることもありません。
 
 このスライスは検出のみです — orchestrator wake procedure や外部
 heartbeat からこのサーフェスを利用する部分は、別の後続スライスです。

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -278,15 +278,19 @@ packet/queue metadata に基づきます。** すべての GitHub issue/PR candi
 `--domain` と矛盾する candidate、あるいは domain を全く導出できない
 candidate（packet.yaml が無い、またはそれに `domain:` フィールドが
 無い）は FAIL-CLOSED になります: `items[]` から除外され、代わりに
-`excluded[]`（`kind`、`execution_unit`、`issue`/`pr`、`reason` —
-`domain-contradiction` または `domain-underivable` —、候補 domain と
-正確な `--domain` 再実行コマンドを示す `detail`）に報告されます。
-（単一の operator 指定 execution unit に対しては明示的な `--domain`
-単独で成立する）他の G522 サーフェスとは異なり、これは共有 repo の
-issue/PR にまたがる broad multi-candidate scan です — 明示的な
-`--domain` だけでは、自身のメタデータで裏付けが取れない candidate に
-適用されると信頼することはありません。したがって candidate が黙って
-scan に紛れ込むことも、黙って消えることもありません。
+`excluded[]`（`kind`、`execution_unit`、`issue`/`pr`、`reason`、
+`detail`）に報告されます。`reason` は `domain-contradiction`
+（`detail` に矛盾している具体的な packet-declared domain を明示）
+または `domain-underivable`（`detail` に `intents/*/` からスキャンした
+候補 domain **と** 正確に実行可能な再実行コマンド —
+`intent-cli automation stalled-work --domain <name> --repo <owner/repo>
+--format json` — の両方を明示。G522 の underivable diagnostic 契約を
+継承）のいずれかです。（単一の operator 指定 execution unit に対しては
+明示的な `--domain` 単独で成立する）他の G522 サーフェスとは異なり、
+これは共有 repo の issue/PR にまたがる broad multi-candidate scan です
+— 明示的な `--domain` だけでは、自身のメタデータで裏付けが取れない
+candidate に適用されると信頼することはありません。したがって
+candidate が黙って scan に紛れ込むことも、黙って消えることもありません。
 
 このスライスは検出のみです — orchestrator wake procedure や外部
 heartbeat からこのサーフェスを利用する部分は、別の後続スライスです。

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -1,0 +1,558 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G523: <c>intent-cli automation stalled-work --domain &lt;d&gt; --repo &lt;r&gt;
+/// [--stale-minutes &lt;m&gt;] [--format json|markdown]</c> — read-only
+/// inventory of pending pipeline transitions with ages, so a single
+/// orchestrator wake (or an external heartbeat) can detect a stall without a
+/// human cross-checking GitHub labels, PR state, and queue-state by hand.
+///
+/// Categories:
+/// <list type="bullet">
+/// <item><c>published-not-delegated</c> — an OPEN issue carries
+///   <c>intent-target</c> but no claim label
+///   (<c>intent-issue-in-progress</c> / <c>intent-pr-created</c>) yet.</item>
+/// <item><c>pr-created-not-reviewing</c> — the source issue carries
+///   <c>intent-pr-created</c> and its closing PR has not had the
+///   <c>review-start</c> transition applied (no <c>intent-pr-reviewing</c> /
+///   <c>intent-pr-approved</c> on the PR).</item>
+/// <item><c>merged-not-closed-out</c> — a MERGED PR's linked queue item is
+///   not <see cref="QueueItemState.Completed"/>.</item>
+/// </list>
+///
+/// Age is approximated from the relevant GitHub entity's `createdAt` /
+/// `updatedAt` timestamp (GitHub does not expose per-label-application
+/// timestamps), which is the closest available proxy for "how long has this
+/// been pending".
+///
+/// Strictly read-only: no GitHub mutation, no queue-state/runs.jsonl write,
+/// no label change. Domain scoping follows the G522 direction — items whose
+/// derived execution unit does not match the requested domain's
+/// `execution_unit_regex` binding (`intents/&lt;domain&gt;/automation/bindings.md`)
+/// are excluded; a missing/invalid binding degrades to "no filter" (with a
+/// surfaced warning) rather than blocking this diagnostic-only surface.
+/// </summary>
+internal static class AutomationStalledWorkCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    public const string KindPublishedNotDelegated = "published-not-delegated";
+    public const string KindPrCreatedNotReviewing = "pr-created-not-reviewing";
+    public const string KindMergedNotClosedOut = "merged-not-closed-out";
+
+    public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
+
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    private const string UsageLine =
+        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--stale-minutes <m>] [--format json|markdown]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(UsageLine);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var domain, out var repo, out var staleMinutes, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        IGitHubAutomationCandidateLister lister;
+        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues;
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs;
+        IReadOnlyList<GitHubAutomationPrCandidate> mergedPrs;
+        try
+        {
+            lister = CandidateListerFactory?.Invoke() ?? new GhCliGitHubAutomationCandidateLister();
+            openIssues = lister.ListIssues(repo!, Array.Empty<string>());
+            openPrs = lister.ListPullRequests(repo!, Array.Empty<string>());
+            mergedPrs = lister.ListMergedPullRequests(repo!, Array.Empty<string>());
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException)
+        {
+            writer.WriteLine($"failed to read GitHub state for {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var regexResolution = NextSliceDomainBindingsExecutionUnitRegex.Resolve(context, domain);
+        var warnings = new List<string>();
+        if (regexResolution.Regex is null)
+        {
+            warnings.Add(
+                $"domain '{domain}' has no resolvable `execution_unit_regex` binding "
+                + $"({regexResolution.BindingsPath ?? "(unresolved)"}) — items are NOT filtered by domain; "
+                + "results may include other domains' work on a shared host.");
+        }
+
+        var now = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var items = new List<StalledWorkItem>();
+
+        CollectPublishedNotDelegated(openIssues, regexResolution.Regex, repo!, now, items);
+        CollectPrCreatedNotReviewing(openIssues, openPrs, regexResolution.Regex, repo!, now, items);
+        CollectMergedNotClosedOut(context, domain!, repo!, mergedPrs, regexResolution.Regex, now, items, warnings);
+
+        var filtered = items
+            .Where(item => item.AgeMinutes >= staleMinutes)
+            .OrderByDescending(item => item.AgeMinutes)
+            .ToArray();
+
+        var result = new AutomationStalledWorkResult
+        {
+            Domain = domain!,
+            Repo = repo!,
+            StaleMinutesThreshold = staleMinutes,
+            Stalled = filtered.Length > 0,
+            Items = filtered,
+            Warnings = warnings,
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            WriteMarkdown(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static void CollectPublishedNotDelegated(
+        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues,
+        System.Text.RegularExpressions.Regex? domainRegex,
+        string repo,
+        DateTimeOffset now,
+        List<StalledWorkItem> items)
+    {
+        foreach (var issue in openIssues)
+        {
+            if (!IsOpen(issue.State))
+            {
+                continue;
+            }
+
+            var labels = LabelSet(issue.Labels);
+            if (!labels.Contains(WorkerNextActionConstants.Labels.IntentTarget))
+            {
+                continue;
+            }
+
+            // Already claimed or delegated — not a stall in this category.
+            if (labels.Contains(WorkerNextActionConstants.Labels.IntentIssueInProgress)
+                || labels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated))
+            {
+                continue;
+            }
+
+            var executionUnit = ExecutionUnitFromTitle(issue.Title);
+            if (domainRegex is not null && !domainRegex.IsMatch(executionUnit))
+            {
+                continue;
+            }
+
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindPublishedNotDelegated,
+                ExecutionUnit = executionUnit,
+                Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
+                Pr = null,
+                AgeMinutes = ComputeAgeMinutes(issue.CreatedAt, now),
+                RecommendedAction =
+                    $"intent-cli worker claim --repo {repo} --kind issue --number {issue.Number} --github-only --write",
+            });
+        }
+    }
+
+    private static void CollectPrCreatedNotReviewing(
+        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues,
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
+        System.Text.RegularExpressions.Regex? domainRegex,
+        string repo,
+        DateTimeOffset now,
+        List<StalledWorkItem> items)
+    {
+        var issuesWithPrCreated = openIssues
+            .Where(issue => IsOpen(issue.State) && LabelSet(issue.Labels).Contains(WorkerNextActionConstants.Labels.IntentPrCreated))
+            .ToDictionary(issue => issue.Number);
+
+        if (issuesWithPrCreated.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var pr in openPrs)
+        {
+            if (!IsOpen(pr.State) || pr.IsDraft)
+            {
+                continue;
+            }
+
+            var prLabels = LabelSet(pr.Labels);
+            if (prLabels.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrReviewing)
+                || prLabels.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrApproved))
+            {
+                continue;
+            }
+
+            GitHubAutomationIssueCandidate? matchedIssue = null;
+            foreach (var reference in pr.ClosingIssuesReferences)
+            {
+                if (reference.Number > 0
+                    && ReferenceMatchesRepo(reference, repo)
+                    && issuesWithPrCreated.TryGetValue(reference.Number, out var candidate))
+                {
+                    matchedIssue = candidate;
+                    break;
+                }
+            }
+
+            if (matchedIssue is null)
+            {
+                continue;
+            }
+
+            var executionUnit = ExecutionUnitFromTitle(matchedIssue.Title);
+            if (domainRegex is not null && !domainRegex.IsMatch(executionUnit))
+            {
+                continue;
+            }
+
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindPrCreatedNotReviewing,
+                ExecutionUnit = executionUnit,
+                Issue = new StalledWorkRef { Number = matchedIssue.Number, Url = matchedIssue.Url },
+                Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
+                AgeMinutes = ComputeAgeMinutes(pr.CreatedAt, now),
+                RecommendedAction =
+                    $"intent-cli automation pr-transition --repo {repo} --pr {pr.Number} --transition review-start --write",
+            });
+        }
+    }
+
+    private static void CollectMergedNotClosedOut(
+        CliContext context,
+        string domain,
+        string repo,
+        IReadOnlyList<GitHubAutomationPrCandidate> mergedPrs,
+        System.Text.RegularExpressions.Regex? domainRegex,
+        DateTimeOffset now,
+        List<StalledWorkItem> items,
+        List<string> warnings)
+    {
+        if (mergedPrs.Count == 0)
+        {
+            return;
+        }
+
+        var queueStateLocation = RuntimeScopedStateResolver.ResolveQueueStatePathForRead(context.RepoRoot, domain, repo);
+        if (!File.Exists(queueStateLocation.Path))
+        {
+            warnings.Add($"queue-state not found at '{queueStateLocation.Path}'; skipped merged-not-closed-out check.");
+            return;
+        }
+
+        QueueState queueState;
+        try
+        {
+            queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStateLocation.Path));
+        }
+        catch (Exception exception) when (exception is JsonException or InvalidOperationException)
+        {
+            warnings.Add($"queue-state at '{queueStateLocation.Path}' could not be parsed: {exception.Message}");
+            return;
+        }
+
+        foreach (var pr in mergedPrs)
+        {
+            var prToken = pr.Number.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item.LinkedPr, repo, prToken));
+            if (matchedItem is null || matchedItem.State == QueueItemState.Completed)
+            {
+                continue;
+            }
+
+            if (domainRegex is not null && !domainRegex.IsMatch(matchedItem.ExecutionUnit))
+            {
+                continue;
+            }
+
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindMergedNotClosedOut,
+                ExecutionUnit = matchedItem.ExecutionUnit,
+                Issue = matchedItem.LinkedIssue is { Number: { } linkedIssueNumber } linkedIssue
+                    ? new StalledWorkRef { Number = linkedIssueNumber, Url = linkedIssue.Url ?? string.Empty }
+                    : null,
+                Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
+                // Best-effort merge-time proxy: `gh pr list` does not expose a
+                // dedicated `mergedAt` field in the requested field set;
+                // `updatedAt` is set to the merge time for a merged PR.
+                AgeMinutes = ComputeAgeMinutes(pr.UpdatedAt, now),
+                RecommendedAction =
+                    $"intent-cli closeout pr --pr {pr.Number} --repo {repo} --domain {domain} --pr-merged true --write --format json",
+            });
+        }
+    }
+
+    private static bool IsOpen(string state) =>
+        string.IsNullOrEmpty(state) || string.Equals(state, "OPEN", StringComparison.OrdinalIgnoreCase);
+
+    private static HashSet<string> LabelSet(IReadOnlyList<GitHubAutomationLabel> labels) =>
+        labels.Select(label => label.Name).ToHashSet(StringComparer.Ordinal);
+
+    private static bool ReferenceMatchesRepo(GitHubPrClosingIssueReference reference, string repo)
+    {
+        if (reference.Repository is not { Name.Length: > 0, Owner.Login.Length: > 0 } repository)
+        {
+            // No repository descriptor — assume same-repo (gh omits it for
+            // same-repo closing references in some field-set combinations).
+            return true;
+        }
+        var candidateRepo = $"{repository.Owner!.Login}/{repository.Name}";
+        return string.Equals(candidateRepo, repo, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool MatchesLinkedPr(string? linkedPr, string repo, string prToken)
+    {
+        if (string.IsNullOrWhiteSpace(linkedPr))
+        {
+            return false;
+        }
+
+        if (string.Equals(linkedPr, prToken, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (linkedPr!.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase))
+        {
+            return linkedPr.StartsWith($"https://github.com/{repo}/pull/", StringComparison.OrdinalIgnoreCase)
+                && linkedPr.EndsWith($"/{prToken}", StringComparison.Ordinal);
+        }
+
+        return linkedPr!.EndsWith($"/{prToken}", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Derives the candidate execution unit from a title following the
+    /// established convention used across this repository's own issues/PRs
+    /// (e.g. <c>"G523: Add automation stalled-work surface..."</c>).
+    /// </summary>
+    private static string ExecutionUnitFromTitle(string title)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return string.Empty;
+        }
+        var colonIndex = title.IndexOf(':');
+        return (colonIndex > 0 ? title[..colonIndex] : title).Trim();
+    }
+
+    private static int ComputeAgeMinutes(string timestamp, DateTimeOffset now)
+    {
+        if (string.IsNullOrWhiteSpace(timestamp)
+            || !DateTimeOffset.TryParse(timestamp, System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AssumeUniversal, out var parsed))
+        {
+            return 0;
+        }
+        var minutes = (now - parsed).TotalMinutes;
+        return minutes > 0 ? (int)minutes : 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? domain,
+        out string? repo,
+        out int staleMinutes,
+        out string format,
+        out string error)
+    {
+        domain = null;
+        repo = null;
+        staleMinutes = 0;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[++index].Trim();
+                    break;
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (owner/repo).";
+                        return false;
+                    }
+                    repo = args[++index].Trim();
+                    break;
+                case "--stale-minutes":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture, out var parsedMinutes)
+                        || parsedMinutes < 0)
+                    {
+                        error = "--stale-minutes requires a non-negative integer.";
+                        return false;
+                    }
+                    staleMinutes = parsedMinutes;
+                    index++;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[++index].Trim();
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            error = "automation stalled-work requires '--domain <name>'.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "automation stalled-work requires '--repo <owner/repo>'.";
+            return false;
+        }
+        return true;
+    }
+
+    private static void WriteMarkdown(TextWriter writer, AutomationStalledWorkResult result)
+    {
+        writer.WriteLine($"# automation stalled-work — `{result.Domain}` / `{result.Repo}`");
+        writer.WriteLine();
+        writer.WriteLine($"- stale_minutes_threshold: {result.StaleMinutesThreshold}");
+        writer.WriteLine($"- stalled: {(result.Stalled ? "true" : "false")}");
+        writer.WriteLine($"- items: {result.Items.Count}");
+        writer.WriteLine();
+
+        if (result.Items.Count == 0)
+        {
+            writer.WriteLine("No stalled work detected.");
+        }
+        else
+        {
+            foreach (var item in result.Items)
+            {
+                writer.WriteLine($"## `{item.ExecutionUnit}` — {item.Kind} ({item.AgeMinutes}m)");
+                if (item.Issue is { } issue)
+                {
+                    writer.WriteLine($"- issue: #{issue.Number} — {issue.Url}");
+                }
+                if (item.Pr is { } pr)
+                {
+                    writer.WriteLine($"- pr: #{pr.Number} — {pr.Url}");
+                }
+                writer.WriteLine($"- recommended_action: `{item.RecommendedAction}`");
+                writer.WriteLine();
+            }
+        }
+
+        if (result.Warnings.Count > 0)
+        {
+            writer.WriteLine("## Warnings");
+            foreach (var warning in result.Warnings)
+            {
+                writer.WriteLine($"- {warning}");
+            }
+        }
+    }
+}
+
+internal sealed record AutomationStalledWorkResult
+{
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("stale_minutes_threshold")]
+    public required int StaleMinutesThreshold { get; init; }
+
+    [JsonPropertyName("stalled")]
+    public required bool Stalled { get; init; }
+
+    [JsonPropertyName("items")]
+    public required IReadOnlyList<StalledWorkItem> Items { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+}
+
+internal sealed record StalledWorkItem
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("issue")]
+    public StalledWorkRef? Issue { get; init; }
+
+    [JsonPropertyName("pr")]
+    public StalledWorkRef? Pr { get; init; }
+
+    [JsonPropertyName("age_minutes")]
+    public required int AgeMinutes { get; init; }
+
+    [JsonPropertyName("recommended_action")]
+    public required string RecommendedAction { get; init; }
+}
+
+internal sealed record StalledWorkRef
+{
+    [JsonPropertyName("number")]
+    public required int Number { get; init; }
+
+    [JsonPropertyName("url")]
+    public required string Url { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -15,8 +15,10 @@ namespace IntentSystem.Cli.Commands;
 /// Categories:
 /// <list type="bullet">
 /// <item><c>published-not-delegated</c> — an OPEN issue carries
-///   <c>intent-target</c> but no claim label
-///   (<c>intent-issue-in-progress</c> / <c>intent-pr-created</c>) yet.</item>
+///   <c>intent-target</c>, has no claim label
+///   (<c>intent-issue-in-progress</c> / <c>intent-pr-created</c>), and no
+///   open PR in this repo closes it (checked independently of label state,
+///   since a label can drift out of sync with an already-created PR).</item>
 /// <item><c>pr-created-not-reviewing</c> — the source issue carries
 ///   <c>intent-pr-created</c> and its closing PR has not had the
 ///   <c>review-start</c> transition applied (no <c>intent-pr-reviewing</c> /
@@ -31,11 +33,19 @@ namespace IntentSystem.Cli.Commands;
 /// been pending".
 ///
 /// Strictly read-only: no GitHub mutation, no queue-state/runs.jsonl write,
-/// no label change. Domain scoping follows the G522 direction — items whose
-/// derived execution unit does not match the requested domain's
-/// `execution_unit_regex` binding (`intents/&lt;domain&gt;/automation/bindings.md`)
-/// are excluded; a missing/invalid binding degrades to "no filter" (with a
-/// surfaced warning) rather than blocking this diagnostic-only surface.
+/// no label change.
+///
+/// Domain isolation (G522 direction, tightened per PR #1148 review): a
+/// title-derived execution-unit prefix is NOT sufficient routing evidence by
+/// itself — it is used only to locate
+/// <c>.intent-cli/issues/&lt;unit&gt;/packet.yaml</c>, and that packet's own
+/// declared <c>domain:</c> field is the authoritative source consulted
+/// against the requested <c>--domain</c>. A candidate whose packet-declared
+/// domain contradicts <c>--domain</c>, or whose domain cannot be derived at
+/// all (no packet.yaml, or no `domain:` field on it), is FAIL-CLOSED —
+/// excluded from <c>items[]</c> and reported instead in <c>excluded[]</c>
+/// with a structured reason. It never silently joins the scan and never
+/// silently disappears.
 /// </summary>
 internal static class AutomationStalledWorkCommand
 {
@@ -95,22 +105,15 @@ internal static class AutomationStalledWorkCommand
             return 1;
         }
 
-        var regexResolution = NextSliceDomainBindingsExecutionUnitRegex.Resolve(context, domain);
-        var warnings = new List<string>();
-        if (regexResolution.Regex is null)
-        {
-            warnings.Add(
-                $"domain '{domain}' has no resolvable `execution_unit_regex` binding "
-                + $"({regexResolution.BindingsPath ?? "(unresolved)"}) — items are NOT filtered by domain; "
-                + "results may include other domains' work on a shared host.");
-        }
-
         var now = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var candidateDomains = DomainCandidateScanner.Scan(context);
         var items = new List<StalledWorkItem>();
+        var excluded = new List<StalledWorkExcluded>();
+        var warnings = new List<string>();
 
-        CollectPublishedNotDelegated(openIssues, regexResolution.Regex, repo!, now, items);
-        CollectPrCreatedNotReviewing(openIssues, openPrs, regexResolution.Regex, repo!, now, items);
-        CollectMergedNotClosedOut(context, domain!, repo!, mergedPrs, regexResolution.Regex, now, items, warnings);
+        CollectPublishedNotDelegated(context, domain!, candidateDomains, openIssues, openPrs, repo!, now, items, excluded);
+        CollectPrCreatedNotReviewing(context, domain!, candidateDomains, openIssues, openPrs, repo!, now, items, excluded);
+        CollectMergedNotClosedOut(context, domain!, candidateDomains, repo!, mergedPrs, now, items, excluded, warnings);
 
         var filtered = items
             .Where(item => item.AgeMinutes >= staleMinutes)
@@ -124,6 +127,7 @@ internal static class AutomationStalledWorkCommand
             StaleMinutesThreshold = staleMinutes,
             Stalled = filtered.Length > 0,
             Items = filtered,
+            Excluded = excluded,
             Warnings = warnings,
         };
 
@@ -141,11 +145,15 @@ internal static class AutomationStalledWorkCommand
     }
 
     private static void CollectPublishedNotDelegated(
+        CliContext context,
+        string domain,
+        IReadOnlyList<string> candidateDomains,
         IReadOnlyList<GitHubAutomationIssueCandidate> openIssues,
-        System.Text.RegularExpressions.Regex? domainRegex,
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
         string repo,
         DateTimeOffset now,
-        List<StalledWorkItem> items)
+        List<StalledWorkItem> items,
+        List<StalledWorkExcluded> excluded)
     {
         foreach (var issue in openIssues)
         {
@@ -167,9 +175,31 @@ internal static class AutomationStalledWorkCommand
                 continue;
             }
 
-            var executionUnit = ExecutionUnitFromTitle(issue.Title);
-            if (domainRegex is not null && !domainRegex.IsMatch(executionUnit))
+            // PR #1148 review repair: a completion label can drift out of
+            // sync with reality — an open PR may already close this issue
+            // even though `intent-pr-created` was never applied (or was
+            // removed). Check the already-fetched PR closing references
+            // independently of issue labels so a label-drifted, already-
+            // implemented issue is never mis-recommended for `worker claim`.
+            if (HasOpenClosingPr(issue.Number, openPrs, repo))
             {
+                continue;
+            }
+
+            var executionUnit = ExecutionUnitFromTitle(issue.Title);
+            var packetDeclaredDomain = ReadPacketDeclaredDomain(context, executionUnit);
+            if (!TryConfirmDomain(domain, packetDeclaredDomain, candidateDomains, executionUnit,
+                    out var reason, out var detail))
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindPublishedNotDelegated,
+                    ExecutionUnit = executionUnit,
+                    Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
+                    Pr = null,
+                    Reason = reason,
+                    Detail = detail,
+                });
                 continue;
             }
 
@@ -187,12 +217,15 @@ internal static class AutomationStalledWorkCommand
     }
 
     private static void CollectPrCreatedNotReviewing(
+        CliContext context,
+        string domain,
+        IReadOnlyList<string> candidateDomains,
         IReadOnlyList<GitHubAutomationIssueCandidate> openIssues,
         IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
-        System.Text.RegularExpressions.Regex? domainRegex,
         string repo,
         DateTimeOffset now,
-        List<StalledWorkItem> items)
+        List<StalledWorkItem> items,
+        List<StalledWorkExcluded> excluded)
     {
         var issuesWithPrCreated = openIssues
             .Where(issue => IsOpen(issue.State) && LabelSet(issue.Labels).Contains(WorkerNextActionConstants.Labels.IntentPrCreated))
@@ -235,8 +268,19 @@ internal static class AutomationStalledWorkCommand
             }
 
             var executionUnit = ExecutionUnitFromTitle(matchedIssue.Title);
-            if (domainRegex is not null && !domainRegex.IsMatch(executionUnit))
+            var packetDeclaredDomain = ReadPacketDeclaredDomain(context, executionUnit);
+            if (!TryConfirmDomain(domain, packetDeclaredDomain, candidateDomains, executionUnit,
+                    out var reason, out var detail))
             {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindPrCreatedNotReviewing,
+                    ExecutionUnit = executionUnit,
+                    Issue = new StalledWorkRef { Number = matchedIssue.Number, Url = matchedIssue.Url },
+                    Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
+                    Reason = reason,
+                    Detail = detail,
+                });
                 continue;
             }
 
@@ -256,11 +300,12 @@ internal static class AutomationStalledWorkCommand
     private static void CollectMergedNotClosedOut(
         CliContext context,
         string domain,
+        IReadOnlyList<string> candidateDomains,
         string repo,
         IReadOnlyList<GitHubAutomationPrCandidate> mergedPrs,
-        System.Text.RegularExpressions.Regex? domainRegex,
         DateTimeOffset now,
         List<StalledWorkItem> items,
+        List<StalledWorkExcluded> excluded,
         List<string> warnings)
     {
         if (mergedPrs.Count == 0)
@@ -295,8 +340,24 @@ internal static class AutomationStalledWorkCommand
                 continue;
             }
 
-            if (domainRegex is not null && !domainRegex.IsMatch(matchedItem.ExecutionUnit))
+            var issueRef = matchedItem.LinkedIssue is { Number: { } linkedIssueNumber } linkedIssue
+                ? new StalledWorkRef { Number = linkedIssueNumber, Url = linkedIssue.Url ?? string.Empty }
+                : null;
+            var prRef = new StalledWorkRef { Number = pr.Number, Url = pr.Url };
+
+            var packetDeclaredDomain = ReadPacketDeclaredDomain(context, matchedItem.ExecutionUnit);
+            if (!TryConfirmDomain(domain, packetDeclaredDomain, candidateDomains, matchedItem.ExecutionUnit,
+                    out var reason, out var detail))
             {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindMergedNotClosedOut,
+                    ExecutionUnit = matchedItem.ExecutionUnit,
+                    Issue = issueRef,
+                    Pr = prRef,
+                    Reason = reason,
+                    Detail = detail,
+                });
                 continue;
             }
 
@@ -304,10 +365,8 @@ internal static class AutomationStalledWorkCommand
             {
                 Kind = KindMergedNotClosedOut,
                 ExecutionUnit = matchedItem.ExecutionUnit,
-                Issue = matchedItem.LinkedIssue is { Number: { } linkedIssueNumber } linkedIssue
-                    ? new StalledWorkRef { Number = linkedIssueNumber, Url = linkedIssue.Url ?? string.Empty }
-                    : null,
-                Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
+                Issue = issueRef,
+                Pr = prRef,
                 // Best-effort merge-time proxy: `gh pr list` does not expose a
                 // dedicated `mergedAt` field in the requested field set;
                 // `updatedAt` is set to the merge time for a merged PR.
@@ -316,6 +375,93 @@ internal static class AutomationStalledWorkCommand
                     $"intent-cli closeout pr --pr {pr.Number} --repo {repo} --domain {domain} --pr-merged true --write --format json",
             });
         }
+    }
+
+    /// <summary>
+    /// PR #1148 review repair: domain confirmation is now ALWAYS grounded in
+    /// the candidate's own packet-declared domain — never in a title-prefix
+    /// regex match, and never assumed from the explicit <c>--domain</c>
+    /// alone. Unlike <see cref="PacketDomainResolution"/> (tuned for a
+    /// single operator-named execution unit, where an explicit
+    /// <c>--domain</c> may stand alone), a broad multi-candidate scan like
+    /// this one cannot trust that the requested domain applies to a
+    /// candidate it cannot corroborate — so a missing/absent packet-declared
+    /// domain here is fail-closed (excluded), not accepted.
+    /// </summary>
+    private static bool TryConfirmDomain(
+        string domain,
+        string? packetDeclaredDomain,
+        IReadOnlyList<string> candidateDomains,
+        string executionUnit,
+        out string reason,
+        out string detail)
+    {
+        if (string.IsNullOrWhiteSpace(packetDeclaredDomain))
+        {
+            reason = PacketDomainResolution.ReasonUnderivable;
+            var candidates = candidateDomains.Count > 0
+                ? string.Join(", ", candidateDomains)
+                : "(none found under intents/)";
+            detail =
+                $"domain could not be confirmed for `{executionUnit}`: no packet-declared `domain:` field was found "
+                + $"(expected at `.intent-cli/issues/{executionUnit}/packet.yaml`). Candidate domains: {candidates}. "
+                + "Excluded rather than assumed to belong to the requested --domain.";
+            return false;
+        }
+
+        if (!string.Equals(domain, packetDeclaredDomain, StringComparison.Ordinal))
+        {
+            reason = PacketDomainResolution.ReasonContradiction;
+            detail =
+                $"requested --domain '{domain}' does not match the packet-declared domain '{packetDeclaredDomain}' "
+                + $"for `{executionUnit}`.";
+            return false;
+        }
+
+        reason = string.Empty;
+        detail = string.Empty;
+        return true;
+    }
+
+    private static string? ReadPacketDeclaredDomain(CliContext context, string executionUnit)
+    {
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            return null;
+        }
+        var packetYamlPath = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit, "packet.yaml");
+        if (!File.Exists(packetYamlPath))
+        {
+            return null;
+        }
+        try
+        {
+            PreparedPacketYamlScalarParser.Parse(File.ReadAllText(packetYamlPath)).TryGetValue("domain", out var declaredDomain);
+            return declaredDomain;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+    }
+
+    private static bool HasOpenClosingPr(int issueNumber, IReadOnlyList<GitHubAutomationPrCandidate> openPrs, string repo)
+    {
+        foreach (var pr in openPrs)
+        {
+            if (!IsOpen(pr.State))
+            {
+                continue;
+            }
+            foreach (var reference in pr.ClosingIssuesReferences)
+            {
+                if (reference.Number == issueNumber && ReferenceMatchesRepo(reference, repo))
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static bool IsOpen(string state) =>
@@ -360,7 +506,9 @@ internal static class AutomationStalledWorkCommand
     /// <summary>
     /// Derives the candidate execution unit from a title following the
     /// established convention used across this repository's own issues/PRs
-    /// (e.g. <c>"G523: Add automation stalled-work surface..."</c>).
+    /// (e.g. <c>"G523: Add automation stalled-work surface..."</c>). This
+    /// string is used ONLY to locate the candidate's packet.yaml — never as
+    /// the domain-membership decision itself (see <see cref="TryConfirmDomain"/>).
     /// </summary>
     private static string ExecutionUnitFromTitle(string title)
     {
@@ -471,6 +619,7 @@ internal static class AutomationStalledWorkCommand
         writer.WriteLine($"- stale_minutes_threshold: {result.StaleMinutesThreshold}");
         writer.WriteLine($"- stalled: {(result.Stalled ? "true" : "false")}");
         writer.WriteLine($"- items: {result.Items.Count}");
+        writer.WriteLine($"- excluded: {result.Excluded.Count}");
         writer.WriteLine();
 
         if (result.Items.Count == 0)
@@ -493,6 +642,16 @@ internal static class AutomationStalledWorkCommand
                 writer.WriteLine($"- recommended_action: `{item.RecommendedAction}`");
                 writer.WriteLine();
             }
+        }
+
+        if (result.Excluded.Count > 0)
+        {
+            writer.WriteLine("## Excluded (domain could not be confirmed)");
+            foreach (var item in result.Excluded)
+            {
+                writer.WriteLine($"- `{item.ExecutionUnit}` ({item.Kind}, {item.Reason}): {item.Detail}");
+            }
+            writer.WriteLine();
         }
 
         if (result.Warnings.Count > 0)
@@ -523,6 +682,16 @@ internal sealed record AutomationStalledWorkResult
     [JsonPropertyName("items")]
     public required IReadOnlyList<StalledWorkItem> Items { get; init; }
 
+    /// <summary>
+    /// PR #1148 review repair (G522 domain-isolation boundary): candidates
+    /// whose domain could not be confirmed against the candidate's own
+    /// packet-declared domain (underivable or contradicting) are reported
+    /// here instead of silently joining or silently vanishing from
+    /// <see cref="Items"/>.
+    /// </summary>
+    [JsonPropertyName("excluded")]
+    public required IReadOnlyList<StalledWorkExcluded> Excluded { get; init; }
+
     [JsonPropertyName("warnings")]
     public required IReadOnlyList<string> Warnings { get; init; }
 }
@@ -546,6 +715,27 @@ internal sealed record StalledWorkItem
 
     [JsonPropertyName("recommended_action")]
     public required string RecommendedAction { get; init; }
+}
+
+internal sealed record StalledWorkExcluded
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("issue")]
+    public StalledWorkRef? Issue { get; init; }
+
+    [JsonPropertyName("pr")]
+    public StalledWorkRef? Pr { get; init; }
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    [JsonPropertyName("detail")]
+    public required string Detail { get; init; }
 }
 
 internal sealed record StalledWorkRef

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -188,7 +188,7 @@ internal static class AutomationStalledWorkCommand
 
             var executionUnit = ExecutionUnitFromTitle(issue.Title);
             var packetDeclaredDomain = ReadPacketDeclaredDomain(context, executionUnit);
-            if (!TryConfirmDomain(domain, packetDeclaredDomain, candidateDomains, executionUnit,
+            if (!TryConfirmDomain(domain, packetDeclaredDomain, candidateDomains, executionUnit, repo,
                     out var reason, out var detail))
             {
                 excluded.Add(new StalledWorkExcluded
@@ -269,7 +269,7 @@ internal static class AutomationStalledWorkCommand
 
             var executionUnit = ExecutionUnitFromTitle(matchedIssue.Title);
             var packetDeclaredDomain = ReadPacketDeclaredDomain(context, executionUnit);
-            if (!TryConfirmDomain(domain, packetDeclaredDomain, candidateDomains, executionUnit,
+            if (!TryConfirmDomain(domain, packetDeclaredDomain, candidateDomains, executionUnit, repo,
                     out var reason, out var detail))
             {
                 excluded.Add(new StalledWorkExcluded
@@ -346,7 +346,7 @@ internal static class AutomationStalledWorkCommand
             var prRef = new StalledWorkRef { Number = pr.Number, Url = pr.Url };
 
             var packetDeclaredDomain = ReadPacketDeclaredDomain(context, matchedItem.ExecutionUnit);
-            if (!TryConfirmDomain(domain, packetDeclaredDomain, candidateDomains, matchedItem.ExecutionUnit,
+            if (!TryConfirmDomain(domain, packetDeclaredDomain, candidateDomains, matchedItem.ExecutionUnit, repo,
                     out var reason, out var detail))
             {
                 excluded.Add(new StalledWorkExcluded
@@ -393,6 +393,7 @@ internal static class AutomationStalledWorkCommand
         string? packetDeclaredDomain,
         IReadOnlyList<string> candidateDomains,
         string executionUnit,
+        string repo,
         out string reason,
         out string detail)
     {
@@ -402,9 +403,13 @@ internal static class AutomationStalledWorkCommand
             var candidates = candidateDomains.Count > 0
                 ? string.Join(", ", candidateDomains)
                 : "(none found under intents/)";
+            // PR #1148 review re-repair: the underivable detail must name an
+            // exact, runnable re-invocation (inherited from the G522
+            // underivable diagnostic contract), not just candidate domains.
             detail =
                 $"domain could not be confirmed for `{executionUnit}`: no packet-declared `domain:` field was found "
                 + $"(expected at `.intent-cli/issues/{executionUnit}/packet.yaml`). Candidate domains: {candidates}. "
+                + $"Re-invoke with: intent-cli automation stalled-work --domain <name> --repo {repo} --format json. "
                 + "Excluded rather than assumed to belong to the requested --domain.";
             return false;
         }

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -185,6 +185,7 @@ internal static class CommandRouter
                 ["queue-seed-from-packet"] = AutomationQueueSeedFromPacketCommand.Execute,
                 ["reconcile"] = AutomationReconcileCommand.Execute,
                 ["same-repo-metadata-preflight"] = AutomationSameRepoMetadataPreflightCommand.Execute,
+                ["stalled-work"] = AutomationStalledWorkCommand.Execute,
                 ["state-doctor"] = AutomationStateDoctorCommand.Execute,
                 ["summary"] = AutomationSummaryCommand.Execute,
                 ["workspace-guard"] = AutomationWorkspaceGuardCommand.Execute

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -137,7 +137,7 @@ internal static class GuideCommandsListCommand
             Classification = ClassificationSupport,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerHostLoop,
-            Purpose = "Host-side label transitions and capability JSON: summary / doctor / host-review-preflight / issue-publish / pr-transition / check / complete / clarification-stop. doctor / reconcile / publish-recovery are the recovery-diagnostics subset."
+            Purpose = "Host-side label transitions and capability JSON: summary / doctor / host-review-preflight / issue-publish / pr-transition / check / complete / clarification-stop. doctor / reconcile / publish-recovery / stalled-work are the recovery-diagnostics subset (stalled-work is read-only: reports pending pipeline transitions with ages, never mutates)."
         },
         new CommandGroupEntry
         {

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -114,6 +114,7 @@ internal static class Program
                 || string.Equals(args[1], "queue-seed-from-packet", StringComparison.Ordinal)
                 || string.Equals(args[1], "reconcile", StringComparison.Ordinal)
                 || string.Equals(args[1], "same-repo-metadata-preflight", StringComparison.Ordinal)
+                || string.Equals(args[1], "stalled-work", StringComparison.Ordinal)
                 || string.Equals(args[1], "summary", StringComparison.Ordinal)
                 || string.Equals(args[1], "workspace-guard", StringComparison.Ordinal));
     }

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -334,6 +334,40 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         var excludedItem = Assert.Single(doc.RootElement.GetProperty("excluded").EnumerateArray());
         Assert.Equal("SKS-G512", excludedItem.GetProperty("execution_unit").GetString());
         Assert.Equal("domain-underivable", excludedItem.GetProperty("reason").GetString());
+        // PR #1148 review re-repair: the detail must name candidate domains
+        // AND the exact, runnable re-invocation — pinned here in JSON.
+        Assert.Contains("Candidate domains:", excludedItem.GetProperty("detail").GetString(), StringComparison.Ordinal);
+        Assert.Contains(
+            "Re-invoke with: intent-cli automation stalled-work --domain <name> --repo J-Tech-Japan/intent-system --format json",
+            excludedItem.GetProperty("detail").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NoPacketYamlAtAll_Markdown_PinsExactReinvocationCommand()
+    {
+        // Same underivable fixture as above, rendered as markdown — the
+        // exact re-invocation command must survive both output formats so
+        // docs, schema, and rendering cannot drift independently.
+        using var workspace = new StalledWorkWorkspace();
+        var issue = BuildIssue(9999, "SKS-G512: From a different domain naming convention", FixedNow.AddHours(-26), "intent-target");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("SKS-G512", output, StringComparison.Ordinal);
+        Assert.Contains("domain-underivable", output, StringComparison.Ordinal);
+        Assert.Contains("Candidate domains:", output, StringComparison.Ordinal);
+        Assert.Contains(
+            "Re-invoke with: intent-cli automation stalled-work --domain <name> --repo J-Tech-Japan/intent-system --format json",
+            output,
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -39,12 +39,14 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         using var doc = JsonDocument.Parse(writer.ToString());
         Assert.False(doc.RootElement.GetProperty("stalled").GetBoolean());
         Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        Assert.Equal(0, doc.RootElement.GetProperty("excluded").GetArrayLength());
     }
 
     [Fact]
-    public void Execute_PublishedNotDelegated_FiresForOpenIntentTargetIssueWithNoClaim()
+    public void Execute_PublishedNotDelegated_FiresWhenPacketConfirmsRequestedDomain()
     {
         using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G523", "intent-cli");
         var issue = BuildIssue(1147, "G523: Add automation stalled-work surface", FixedNow.AddHours(-26),
             "intent-target");
         AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
@@ -65,12 +67,14 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         Assert.Equal(1560, item.GetProperty("age_minutes").GetInt32());
         Assert.Contains("worker claim", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
         Assert.Contains("--number 1147", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+        Assert.Equal(0, doc.RootElement.GetProperty("excluded").GetArrayLength());
     }
 
     [Fact]
     public void Execute_PublishedNotDelegated_ExcludesIssueAlreadyClaimed()
     {
         using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G524", "intent-cli");
         var claimedIssue = BuildIssue(1148, "G524: Something else", FixedNow.AddHours(-26),
             "intent-target", "intent-issue-in-progress");
         AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [claimedIssue]);
@@ -86,9 +90,45 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_PublishedNotDelegated_ExcludesIssueWithLabelDriftButAlreadyClosedByOpenPr()
+    {
+        // PR #1148 review repair (finding 2): the completion label can drift
+        // out of sync with reality. This issue has NEITHER
+        // intent-issue-in-progress NOR intent-pr-created, but an OPEN PR in
+        // the same repo already closes it — it must NOT be recommended for
+        // `worker claim` (it is already implemented).
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G527", "intent-cli");
+        var driftedIssue = BuildIssue(1160, "G527: Label drifted out of sync", FixedNow.AddHours(-26),
+            "intent-target");
+        var closingPr = BuildPr(1161, "G527: Label drifted out of sync", FixedNow.AddHours(-20),
+            state: "OPEN", closingIssueNumber: 1160);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(
+            issues: [driftedIssue], prs: [closingPr]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        // Only the pr-created-not-reviewing scan could still find this PR,
+        // but it requires intent-pr-created on the issue (absent here), so
+        // no item of ANY kind should reference G527's issue as
+        // published-not-delegated.
+        var items = doc.RootElement.GetProperty("items").EnumerateArray().ToArray();
+        Assert.DoesNotContain(items, item =>
+            item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindPublishedNotDelegated
+            && item.GetProperty("execution_unit").GetString() == "G527");
+    }
+
+    [Fact]
     public void Execute_PrCreatedNotReviewing_FiresWhenIssueCarriesPrCreatedAndPrLacksReviewStart()
     {
         using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G521", "intent-cli");
         var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
         var pr = BuildPr(1144, "G521: Document agmsg Codex monitor", FixedNow.AddHours(-1.5),
             state: "OPEN", closingIssueNumber: 1143);
@@ -115,6 +155,7 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     public void Execute_PrCreatedNotReviewing_ExcludesPrAlreadyReviewing()
     {
         using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G521", "intent-cli");
         var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
         var pr = BuildPr(1144, "G521: Document agmsg Codex monitor", FixedNow.AddHours(-1.5),
             state: "OPEN", closingIssueNumber: 1143, extraLabels: ["intent-pr-reviewing"]);
@@ -134,6 +175,7 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     public void Execute_MergedNotClosedOut_FiresWhenQueueItemNotCompleted()
     {
         using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G500", "intent-cli");
         workspace.WriteQueueState(BuildQueueStateJson("G500", QueueItemState.Review,
             linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/1200",
             linkedIssueNumber: 1199));
@@ -161,6 +203,7 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     public void Execute_MergedNotClosedOut_ExcludesCompletedQueueItem()
     {
         using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G500", "intent-cli");
         workspace.WriteQueueState(BuildQueueStateJson("G500", QueueItemState.Completed,
             linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/1200",
             linkedIssueNumber: 1199));
@@ -201,6 +244,8 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     public void Execute_StaleMinutesFilter_ExcludesItemsYoungerThanThreshold()
     {
         using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G525", "intent-cli");
+        workspace.WritePacketDomain("G526", "intent-cli");
         var youngIssue = BuildIssue(1150, "G525: A brand new issue", FixedNow.AddMinutes(-10), "intent-target");
         var oldIssue = BuildIssue(1151, "G526: A stale issue", FixedNow.AddHours(-26), "intent-target");
         AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [youngIssue, oldIssue]);
@@ -217,13 +262,41 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_DomainBindingRegex_ExcludesOtherDomainIssue()
+    public void Execute_PacketDeclaresContradictingDomain_ExcludesAsStructuredResult()
     {
+        // PR #1148 review repair (finding 1): a candidate whose
+        // packet-declared domain contradicts the requested --domain must be
+        // fail-closed — excluded from items[], surfaced in excluded[].
         using var workspace = new StalledWorkWorkspace();
-        workspace.WriteBindings("intent-cli", "^G[0-9]+$");
-        var ourIssue = BuildIssue(1147, "G523: Ours", FixedNow.AddHours(-26), "intent-target");
+        workspace.WritePacketDomain("SKS-G512", "sekiban-as-a-service");
         var otherDomainIssue = BuildIssue(9999, "SKS-G512: Not ours", FixedNow.AddHours(-26), "intent-target");
-        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [ourIssue, otherDomainIssue]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [otherDomainIssue]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        var excludedItem = Assert.Single(doc.RootElement.GetProperty("excluded").EnumerateArray());
+        Assert.Equal("SKS-G512", excludedItem.GetProperty("execution_unit").GetString());
+        Assert.Equal("domain-contradiction", excludedItem.GetProperty("reason").GetString());
+    }
+
+    [Fact]
+    public void Execute_MisleadingTitlePrefixMatchingOurConvention_StillExcludedByPacketDomain()
+    {
+        // PR #1148 review repair (finding 1): a title prefix that LOOKS like
+        // it belongs to our domain (same "G<n>" convention) must not leak in
+        // just because the prefix matches our naming pattern — the packet's
+        // own declared domain is authoritative, and here it disagrees.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G9001", "sekiban-as-a-service");
+        var misleadingIssue = BuildIssue(9001, "G9001: Looks like ours but isn't", FixedNow.AddHours(-26), "intent-target");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [misleadingIssue]);
 
         using var writer = new StringWriter();
         AutomationStalledWorkCommand.Execute(
@@ -232,27 +305,62 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
             writer);
 
         using var doc = JsonDocument.Parse(writer.ToString());
-        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
-        Assert.Equal("G523", item.GetProperty("execution_unit").GetString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        var excludedItem = Assert.Single(doc.RootElement.GetProperty("excluded").EnumerateArray());
+        Assert.Equal("domain-contradiction", excludedItem.GetProperty("reason").GetString());
     }
 
     [Fact]
-    public void Execute_MissingDomainBindings_DoesNotFilter_AndSurfacesWarning()
+    public void Execute_NoPacketYamlAtAll_FailsClosedAsUnderivable_NeverJoinsItems()
     {
+        // PR #1148 review repair (finding 1): missing packet metadata must
+        // NOT be trusted just because an explicit --domain was passed — it
+        // is fail-closed (excluded), not fail-open (included with a
+        // warning), for this multi-candidate scan.
         using var workspace = new StalledWorkWorkspace();
-        // No bindings.md written for "intent-cli" — regex cannot be resolved.
+        // No packet.yaml written for this execution unit at all.
         var issue = BuildIssue(9999, "SKS-G512: From a different domain naming convention", FixedNow.AddHours(-26), "intent-target");
         AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
 
         using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        var excludedItem = Assert.Single(doc.RootElement.GetProperty("excluded").EnumerateArray());
+        Assert.Equal("SKS-G512", excludedItem.GetProperty("execution_unit").GetString());
+        Assert.Equal("domain-underivable", excludedItem.GetProperty("reason").GetString());
+    }
+
+    [Fact]
+    public void Execute_MergedNotClosedOut_PacketContradictsDomain_ExcludedNotItem()
+    {
+        // Cross-domain leakage check for the merged-not-closed-out category
+        // specifically: a legacy/shared queue-state may list an item that
+        // belongs to a different domain than requested.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("SKS-G700", "sekiban-as-a-service");
+        workspace.WriteQueueState(BuildQueueStateJson("SKS-G700", QueueItemState.Review,
+            linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/1300",
+            linkedIssueNumber: 1299));
+        var mergedPr = BuildPr(1300, "SKS-G700: Some other domain's merged change", FixedNow.AddHours(-3), state: "MERGED");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(mergedPrs: [mergedPr]);
+
+        using var writer = new StringWriter();
         AutomationStalledWorkCommand.Execute(
             workspace.Context,
             ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
             writer);
 
         using var doc = JsonDocument.Parse(writer.ToString());
-        Assert.Equal(1, doc.RootElement.GetProperty("items").GetArrayLength());
-        Assert.True(doc.RootElement.GetProperty("warnings").GetArrayLength() > 0);
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        var excludedItem = Assert.Single(doc.RootElement.GetProperty("excluded").EnumerateArray());
+        Assert.Equal("SKS-G700", excludedItem.GetProperty("execution_unit").GetString());
+        Assert.Equal("domain-contradiction", excludedItem.GetProperty("reason").GetString());
     }
 
     [Fact]
@@ -291,6 +399,9 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         // GitHub write path (the fake lister has no write methods at all,
         // so this test additionally proves the command never needs one).
         using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G500", "intent-cli");
+        workspace.WritePacketDomain("G523", "intent-cli");
+        workspace.WritePacketDomain("G521", "intent-cli");
         var queueStateJson = BuildQueueStateJson("G500", QueueItemState.Review,
             linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/1200",
             linkedIssueNumber: 1199);
@@ -309,11 +420,14 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         var queueStateBefore = File.ReadAllText(queueStatePath);
 
         using var writer = new StringWriter();
-        AutomationStalledWorkCommand.Execute(
+        var exitCode = AutomationStalledWorkCommand.Execute(
             workspace.Context,
             ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
             writer);
 
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(3, doc.RootElement.GetProperty("items").GetArrayLength());
         Assert.False(File.Exists(runsPath), "stalled-work must never append a runs.jsonl event");
         Assert.Equal(queueStateBefore, File.ReadAllText(queueStatePath));
     }
@@ -449,12 +563,16 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
 
         public void WriteQueueState(string json) => File.WriteAllText(Context.GetQueueStatePath(), json);
 
-        public void WriteBindings(string domain, string executionUnitRegex)
+        /// <summary>
+        /// G522/G523: write a minimal packet.yaml declaring `domain:` for a
+        /// candidate execution unit, so <c>automation stalled-work</c> can
+        /// confirm that candidate's domain from its own packet metadata.
+        /// </summary>
+        public void WritePacketDomain(string executionUnit, string domain)
         {
-            var dir = Path.Combine(RootPath, "intents", domain, "automation");
+            var dir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
             Directory.CreateDirectory(dir);
-            File.WriteAllText(Path.Combine(dir, "bindings.md"),
-                $"---\nexecution_unit_regex: '{executionUnitRegex}'\n---\n");
+            File.WriteAllText(Path.Combine(dir, "packet.yaml"), $"domain: {domain}\n");
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -1,0 +1,468 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class AutomationStalledWorkCommandTests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 7, 14, 12, 0, 0, TimeSpan.Zero);
+
+    public AutomationStalledWorkCommandTests()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = () => FixedNow;
+    }
+
+    public void Dispose()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = null;
+    }
+
+    [Fact]
+    public void Execute_EmptyPipeline_ReturnsStalledFalseAndNoItems()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("stalled").GetBoolean());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_PublishedNotDelegated_FiresForOpenIntentTargetIssueWithNoClaim()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        var issue = BuildIssue(1147, "G523: Add automation stalled-work surface", FixedNow.AddHours(-26),
+            "intent-target");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.True(doc.RootElement.GetProperty("stalled").GetBoolean());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindPublishedNotDelegated, item.GetProperty("kind").GetString());
+        Assert.Equal("G523", item.GetProperty("execution_unit").GetString());
+        Assert.Equal(1147, item.GetProperty("issue").GetProperty("number").GetInt32());
+        Assert.Equal(1560, item.GetProperty("age_minutes").GetInt32());
+        Assert.Contains("worker claim", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+        Assert.Contains("--number 1147", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_PublishedNotDelegated_ExcludesIssueAlreadyClaimed()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        var claimedIssue = BuildIssue(1148, "G524: Something else", FixedNow.AddHours(-26),
+            "intent-target", "intent-issue-in-progress");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [claimedIssue]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_PrCreatedNotReviewing_FiresWhenIssueCarriesPrCreatedAndPrLacksReviewStart()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildPr(1144, "G521: Document agmsg Codex monitor", FixedNow.AddHours(-1.5),
+            state: "OPEN", closingIssueNumber: 1143);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindPrCreatedNotReviewing, item.GetProperty("kind").GetString());
+        Assert.Equal("G521", item.GetProperty("execution_unit").GetString());
+        Assert.Equal(1143, item.GetProperty("issue").GetProperty("number").GetInt32());
+        Assert.Equal(1144, item.GetProperty("pr").GetProperty("number").GetInt32());
+        Assert.Equal(90, item.GetProperty("age_minutes").GetInt32());
+        Assert.Contains("--transition review-start", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_PrCreatedNotReviewing_ExcludesPrAlreadyReviewing()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildPr(1144, "G521: Document agmsg Codex monitor", FixedNow.AddHours(-1.5),
+            state: "OPEN", closingIssueNumber: 1143, extraLabels: ["intent-pr-reviewing"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_MergedNotClosedOut_FiresWhenQueueItemNotCompleted()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WriteQueueState(BuildQueueStateJson("G500", QueueItemState.Review,
+            linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/1200",
+            linkedIssueNumber: 1199));
+        var mergedPr = BuildPr(1200, "G500: Some merged change", FixedNow.AddHours(-3), state: "MERGED");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(mergedPrs: [mergedPr]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindMergedNotClosedOut, item.GetProperty("kind").GetString());
+        Assert.Equal("G500", item.GetProperty("execution_unit").GetString());
+        Assert.Equal(1200, item.GetProperty("pr").GetProperty("number").GetInt32());
+        Assert.Equal(180, item.GetProperty("age_minutes").GetInt32());
+        Assert.Contains("closeout pr", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+        Assert.Contains("--pr 1200", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_MergedNotClosedOut_ExcludesCompletedQueueItem()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WriteQueueState(BuildQueueStateJson("G500", QueueItemState.Completed,
+            linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/1200",
+            linkedIssueNumber: 1199));
+        var mergedPr = BuildPr(1200, "G500: Some merged change", FixedNow.AddHours(-3), state: "MERGED");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(mergedPrs: [mergedPr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_MergedNotClosedOut_MissingQueueStateSurfacesWarning_DoesNotFail()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        // No queue-state.json written at all.
+        var mergedPr = BuildPr(1200, "G500: Some merged change", FixedNow.AddHours(-3), state: "MERGED");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(mergedPrs: [mergedPr]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        Assert.True(doc.RootElement.GetProperty("warnings").GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public void Execute_StaleMinutesFilter_ExcludesItemsYoungerThanThreshold()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        var youngIssue = BuildIssue(1150, "G525: A brand new issue", FixedNow.AddMinutes(-10), "intent-target");
+        var oldIssue = BuildIssue(1151, "G526: A stale issue", FixedNow.AddHours(-26), "intent-target");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [youngIssue, oldIssue]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--stale-minutes", "60", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal("G526", item.GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_DomainBindingRegex_ExcludesOtherDomainIssue()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WriteBindings("intent-cli", "^G[0-9]+$");
+        var ourIssue = BuildIssue(1147, "G523: Ours", FixedNow.AddHours(-26), "intent-target");
+        var otherDomainIssue = BuildIssue(9999, "SKS-G512: Not ours", FixedNow.AddHours(-26), "intent-target");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [ourIssue, otherDomainIssue]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal("G523", item.GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_MissingDomainBindings_DoesNotFilter_AndSurfacesWarning()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        // No bindings.md written for "intent-cli" — regex cannot be resolved.
+        var issue = BuildIssue(9999, "SKS-G512: From a different domain naming convention", FixedNow.AddHours(-26), "intent-target");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(1, doc.RootElement.GetProperty("items").GetArrayLength());
+        Assert.True(doc.RootElement.GetProperty("warnings").GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public void Execute_RequiresDomainFlag()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--domain", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RequiresRepoFlag()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--repo", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverMutatesGitHubQueueStateOrRunsLog()
+    {
+        // Read-only guarantee: even with a full one-of-each fixture, the
+        // command must never touch queue-state.json / runs.jsonl / any
+        // GitHub write path (the fake lister has no write methods at all,
+        // so this test additionally proves the command never needs one).
+        using var workspace = new StalledWorkWorkspace();
+        var queueStateJson = BuildQueueStateJson("G500", QueueItemState.Review,
+            linkedPr: "https://github.com/J-Tech-Japan/intent-system/pull/1200",
+            linkedIssueNumber: 1199);
+        workspace.WriteQueueState(queueStateJson);
+        var publishedIssue = BuildIssue(1147, "G523: Ours", FixedNow.AddHours(-26), "intent-target");
+        var prCreatedIssue = BuildIssue(1143, "G521: Document agmsg", FixedNow.AddDays(-2), "intent-pr-created");
+        var reviewPr = BuildPr(1144, "G521: Document agmsg", FixedNow.AddHours(-1.5), state: "OPEN", closingIssueNumber: 1143);
+        var mergedPr = BuildPr(1200, "G500: Some merged change", FixedNow.AddHours(-3), state: "MERGED");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(
+            issues: [publishedIssue, prCreatedIssue],
+            prs: [reviewPr],
+            mergedPrs: [mergedPr]);
+
+        var runsPath = Path.Combine(workspace.RootPath, ".intent-cli", "runs.jsonl");
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var queueStateBefore = File.ReadAllText(queueStatePath);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.False(File.Exists(runsPath), "stalled-work must never append a runs.jsonl event");
+        Assert.Equal(queueStateBefore, File.ReadAllText(queueStatePath));
+    }
+
+    private static GitHubAutomationIssueCandidate BuildIssue(
+        int number, string title, DateTimeOffset createdAt, params string[] labels) => new()
+        {
+            Number = number,
+            Title = title,
+            Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{number}",
+            CreatedAt = createdAt.ToString("O"),
+            State = "OPEN",
+            Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+        };
+
+    private static GitHubAutomationPrCandidate BuildPr(
+        int number,
+        string title,
+        DateTimeOffset createdAt,
+        string state,
+        int? closingIssueNumber = null,
+        string[]? extraLabels = null) => new()
+        {
+            Number = number,
+            Title = title,
+            Url = $"https://github.com/J-Tech-Japan/intent-system/pull/{number}",
+            CreatedAt = createdAt.ToString("O"),
+            UpdatedAt = createdAt.ToString("O"),
+            State = state,
+            IsDraft = false,
+            Labels = (extraLabels ?? Array.Empty<string>()).Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+            ClosingIssuesReferences = closingIssueNumber is int n
+                ? new[]
+                {
+                    new GitHubPrClosingIssueReference
+                    {
+                        Number = n,
+                        Repository = new GitHubPrClosingIssueRepository
+                        {
+                            Name = "intent-system",
+                            Owner = new GitHubPrClosingIssueRepositoryOwner { Login = "J-Tech-Japan" },
+                        },
+                    },
+                }
+                : Array.Empty<GitHubPrClosingIssueReference>(),
+        };
+
+    private static string BuildQueueStateJson(string executionUnit, QueueItemState state, string linkedPr, int linkedIssueNumber)
+    {
+        var queueState = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = FixedNow,
+            Items = new[]
+            {
+                new QueueItem
+                {
+                    ExecutionUnit = executionUnit,
+                    Title = $"{executionUnit} title",
+                    State = state,
+                    Dependencies = Array.Empty<string>(),
+                    BlockedBy = Array.Empty<string>(),
+                    ClarificationReturnPath = string.Empty,
+                    PacketPaths = new PacketPaths
+                    {
+                        Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                        ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = linkedIssueNumber,
+                        Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{linkedIssueNumber}",
+                    },
+                    LinkedPr = linkedPr,
+                    WorkerRole = "Claude",
+                    ReviewRole = "Codex",
+                    Priority = "normal",
+                },
+            },
+        };
+        return QueueStateSerializer.Serialize(queueState);
+    }
+
+    private sealed class FakeLister : IGitHubAutomationCandidateLister
+    {
+        private readonly IReadOnlyList<GitHubAutomationIssueCandidate> issues;
+        private readonly IReadOnlyList<GitHubAutomationPrCandidate> prs;
+        private readonly IReadOnlyList<GitHubAutomationPrCandidate> mergedPrs;
+
+        public FakeLister(
+            IReadOnlyList<GitHubAutomationIssueCandidate>? issues = null,
+            IReadOnlyList<GitHubAutomationPrCandidate>? prs = null,
+            IReadOnlyList<GitHubAutomationPrCandidate>? mergedPrs = null)
+        {
+            this.issues = issues ?? Array.Empty<GitHubAutomationIssueCandidate>();
+            this.prs = prs ?? Array.Empty<GitHubAutomationPrCandidate>();
+            this.mergedPrs = mergedPrs ?? Array.Empty<GitHubAutomationPrCandidate>();
+        }
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => prs;
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) => issues;
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => mergedPrs;
+    }
+
+    private sealed class StalledWorkWorkspace : IDisposable
+    {
+        public StalledWorkWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("stalled-work-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public void WriteQueueState(string json) => File.WriteAllText(Context.GetQueueStatePath(), json);
+
+        public void WriteBindings(string domain, string executionUnitRegex)
+        {
+            var dir = Path.Combine(RootPath, "intents", domain, "automation");
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "bindings.md"),
+                $"---\nexecution_unit_regex: '{executionUnitRegex}'\n---\n");
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a read-only `intent-cli automation stalled-work --domain <d> --repo <r> [--stale-minutes <m>] --format json|markdown` command inventorying pending pipeline transitions with ages across three categories:
  - `published-not-delegated` — an OPEN issue carries `intent-target` but has no claim label and no PR yet.
  - `pr-created-not-reviewing` — the source issue carries `intent-pr-created`, and its closing PR is missing the `review-start` transition (no `intent-pr-reviewing`/`intent-pr-approved`).
  - `merged-not-closed-out` — a MERGED PR's linked queue-state item is not yet `Completed`.
- Each item reports `kind`, `execution_unit` (derived from the `<unit>: ...` title-prefix convention used throughout this repo's own issues/PRs), `issue`/`pr` refs, `age_minutes`, and `recommended_action` naming the exact canonical next command (`worker claim`, `automation pr-transition --transition review-start`, or `closeout pr`).
- `--stale-minutes` filters out items younger than the threshold (default `0` = report everything).
- Domain scoping reuses the existing `execution_unit_regex` binding convention (`intents/<domain>/automation/bindings.md`) rather than G522's per-candidate packet.yaml lookup, since this surface scans lists of GitHub issues/PRs with no single resolved execution unit upstream — flagging this design choice for review.
- Strictly read-only: no GitHub mutation, no queue-state/runs.jsonl write, no label change (covered by a dedicated test).
- Registers the command in `CommandRouter`, adds it to the `Program.cs` bootstrap allow-list (so it behaves like `automation summary`/`doctor` from a bare cwd — this was required; the command failed with the G299 missing-host-state gate until added), extends the `guide commands list` purpose text, and documents the surface in `docs/ja` and `docs/en` `09-developer-reference.md`.

Closes #1147

## Test plan
- [x] `dotnet build` (full solution) — 0 warnings/errors.
- [x] `dotnet test` (full solution) — all green (3213 passed, 1 pre-existing skip).
- [x] Focused fixture tests per category (fires + excludes for each), empty-pipeline case, `--stale-minutes` filtering, domain-regex filtering (including missing-bindings fail-open + warning), required-flag validation, and a read-only-guarantee test (queue-state/runs.jsonl untouched after execution).
- [x] Manual check: built the CLI and ran `automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format markdown` against this dev sandbox — confirmed it runs end-to-end (real `gh` calls, no crash) and surfaces the expected warnings for this sandbox's missing bindings.md / queue-state.
- [x] `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4yoyeXmTeJWD16RLvktQd