### PR TITLE
G524: Orchestrator wake contract — finish pending transitions in-wake

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -164,8 +164,28 @@ either trigger runs exactly one pass:
 - Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge
   state, closeout/label state.
 - Detect stale blockers and no-reply receivers.
-- Decide the single action this wake: delegate the next slice/PR, send one
-  repair message, or escalate one operator decision.
+- **Publish + delegate in the SAME wake (G524).** If you publish a ready
+  next-slice issue this wake, verify it exists, THEN delegate it to the
+  implementation thread within this same wake — never defer the delegation
+  to an unscheduled "next wake"; nothing else will ever trigger it (this was
+  the single largest measured stall class: ~60 hours across four slices in
+  one field trace).
+- **Per-wake cap is at most one delegation per receiver, not
+  at-most-one-message (G524).** A wake may include a publish + its
+  same-wake delegation, one repair message per stalled receiver, one
+  operator escalation, and handling of any pending receiver reports — all
+  together.
+- **Verify the recipient roster before dispatch (G524).** Before sending any
+  agmsg message, confirm the recipient id is on the team roster
+  (`agmsg team.sh`); agmsg accepts an unknown recipient silently, so treat an
+  off-roster id as an error, never a guess (a legacy `review` vs the
+  registered `reviewer` has silently lost messages in the field).
+- **End the wake with a stalled-work check (G523/G524).** Run
+  `intent-cli automation stalled-work --domain <domain> --repo <owner/repo>
+  --format json` and process every actionable item it reports before
+  sleeping — a wake must never end leaving an actionable transition for an
+  unscheduled next wake; escalate explicitly if an item is genuinely blocked
+  on an operator decision.
 
 ### Repair vs escalate
 
@@ -203,7 +223,10 @@ Routine next-slice issue publication is an **orchestrator responsibility**, not
 an operator question. When intent-cli reports a candidate as `issue-cut-ready`
 and all safety gates pass, the orchestrator publishes it itself through
 canonical intent-cli commands rather than stopping to ask the operator to create
-the GitHub issue. **At most one issue per wake.**
+the GitHub issue. **At most one issue per wake**, then verify, THEN **delegate
+that same issue to implementation in the SAME wake (G524)** — publish and
+delegate complete together; never defer the delegation to an unscheduled
+next wake.
 
 Publish only when **all** of these hold:
 
@@ -223,9 +246,44 @@ Publish through the canonical surfaces only — `intent-cli issue publish-flow`
 and `intent-cli automation issue-publish` — never raw `gh issue create` or
 `gh ... --add-label`. After publishing, verify via intent-cli / GitHub (not
 chat) that the issue exists with the expected body and the `intent-target`
-label and that durable state reflects it, then delegate implementation over
-agmsg. The implementation receiver still derives its target from
-`intent-cli worker next-action`, not the agmsg text.
+label and that durable state reflects it, then, **in this same wake**,
+delegate implementation over agmsg (G524) — do not stop after publishing to
+wait for a future wake. The implementation receiver still derives its target
+from `intent-cli worker next-action`, not the agmsg text.
+
+## End-of-wake check (G523/G524)
+
+Every orchestrator wake ends with a read-only stalled-work check — a wake
+must never end leaving an actionable pending transition for an unscheduled
+"next wake" that nothing would trigger. This closes the measured
+publish-then-sleep and silent-completion stall classes without adding any
+timer.
+
+```text
+intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json
+```
+
+- **Never defer** — process every actionable item the check reports in THIS
+  wake (delegate, repair, or route to closeout) before sleeping. Do not
+  announce work for a future wake unless an explicit fallback/legacy timer
+  is actually scheduled to run it; message-driven wakes have no other
+  trigger to pick deferred work back up.
+- **Escalate instead of defer** — if an item is genuinely blocked on an
+  external/operator decision, escalate it explicitly to the design thread
+  now via the design-thread escalation filter; do not silently defer it and
+  do not leave it unprocessed.
+
+## Dispatch verification (G524)
+
+Before sending ANY agmsg message, verify the recipient id is present in the
+team roster (agmsg `team.sh`). agmsg accepts an unknown recipient silently —
+there is no delivery error to notice. Treat a recipient id that is not on
+the roster as an error: fix the id or the roster registration before
+sending; never guess or approximate a role name.
+
+Field-observed loss: 8 dispatches addressed to `review` were silently lost
+when the registered role was `reviewer` — agmsg neither delivered nor
+reported the mismatch.
 
 ## Dependency planning
 
@@ -840,6 +898,25 @@ Implementation threads stay **GitHub-contract-only**: they do not read or
 mutate host metadata (`.intent-cli/**`, `intents/**`). All label transitions go
 through `intent-cli worker` / `intent-cli automation`.
 
+**Reporting completion or blocked status to the orchestrator is a REQUIRED
+FINAL STEP of every delegation (G524)** — it is not optional, and the
+orchestrator cannot discover a silent completion on its own (a PR opened
+with no report reaching the orchestrator is lost work from the
+orchestrator's perspective; one field case sat undiscovered for 88 minutes
+until a manual GitHub check found it). Send exactly this shape when done:
+
+```json
+{"status":"completed","thread":"implementation","ref":"pr#<n>","note":"PR opened, Closes #<n>, CI green"}
+```
+
+or the `blocked` shape naming one operator action. The same required-final-step
+rule applies to the review thread, whose `completed` reply additionally
+carries `design_alignment_checked` and the checked-source list:
+
+```json
+{"status":"completed","thread":"review","ref":"pr#<n>","note":"approved; closeout done","design_alignment_checked":true,"design_alignment_sources_checked":["packet","review-context","intent-tree","adr-decision-notes","relevant-docs"]}
+```
+
 ## Safety boundaries (summary)
 
 - agmsg is a signal layer only; intent-cli and GitHub are authoritative for all
@@ -853,3 +930,13 @@ through `intent-cli worker` / `intent-cli automation`.
   require explicit per-delegation routing.
 - Fail closed on duplicate orchestrators or when a signal conflicts with
   intent-cli/GitHub facts — stop and escalate, never guess.
+- Per-wake cap is **at most one delegation per receiver** (implementation,
+  review) — NOT at-most-one-message: a publish's same-wake delegation, repair
+  messages, an escalation, and receiver-report handling may all happen in one
+  wake (G524); never defer a publish's delegation to an unscheduled future
+  wake.
+- Verify the recipient id against the team roster (`agmsg team.sh`) before
+  every send; an id not on the roster is an error, not a guess (G524).
+- End every wake with a stalled-work check (`automation stalled-work`, G523)
+  and process any actionable item before sleeping; escalate explicitly
+  rather than deferring silently.

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -151,8 +151,27 @@ orchestrator がメッセージ駆動で動作する場合でも fallback/legacy
 - host レビュー準備状況を確認（`automation host-review-preflight`）。
 - GitHub の事実を直接検証: open PR、CI 結論、承認、マージ状態、closeout/label 状態。
 - 停滞ブロッカーと無返信の receiver を検知する。
-- この wake の単一アクションを決定する: 次の slice/PR を委譲、1 通の repair メッセージ送信、
-  または 1 件のオペレーター判断にエスカレーション。
+- **publish と delegate は SAME WAKE で行う（G524）。** この wake で next-slice issue を
+  publish した場合、存在を検証したうえで、その **同じ wake の中で** implementation
+  スレッドへ delegate する — delegate をスケジュールされていない「次の wake」に
+  先送りしてはいけない。他に何もそれをトリガーしないためです（フィールドトレースでは
+  4 slice にまたがり合計約 60 時間という、測定された中で最大の stall class でした）。
+- **1 wake あたりの上限は「receiver ごとに最大 1 件の delegation」であり、
+  「最大 1 メッセージ」ではありません（G524）。** 1 回の wake に、publish とその
+  同一 wake 内 delegation、停滞している receiver ごとに 1 通の repair メッセージ、
+  1 件のオペレーターエスカレーション、保留中の receiver report への対応が
+  すべて含まれてよい。
+- **送信前に受信者ロースターを検証する（G524）。** どの agmsg メッセージを送る前にも、
+  受信者 id が team roster（`agmsg team.sh`）に存在することを確認する — agmsg は
+  未知の受信者を黙って受け付けてしまうため、roster に無い id は推測せず、
+  エラーとして扱う（フィールドでは、登録済みロール `reviewer` に対して `review` と
+  誤指定し、メッセージが静かに失われた例があります）。
+- **stalled-work チェックで wake を終える（G523/G524）。**
+  `intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json`
+  を実行し、報告されたすべての actionable item を眠りにつく前に処理する — wake が
+  actionable な transition をスケジュールされていない次の wake に残したまま終わる
+  ことは決してない。オペレーターの判断に本当にブロックされている場合は、黙って
+  先送りせず明示的にエスカレーションする。
 
 ### repair と escalate
 
@@ -188,7 +207,10 @@ green は古くなっている可能性があります。
 ルーチンな next-slice issue の publish は **orchestrator の責務** であり、オペレーターへの
 質問ではありません。intent-cli が候補を `issue-cut-ready` と報告し、すべての安全ゲートを
 通過したら、orchestrator はオペレーターに GitHub issue 作成を依頼して止まるのではなく、
-canonical な intent-cli コマンドで自分で publish します。**1 wake につき最大 1 件** です。
+canonical な intent-cli コマンドで自分で publish します。**1 wake につき最大 1 件** で
+publish し、検証したうえで、**同じ wake の中で** その issue を implementation へ
+delegate します（G524）— publish と delegate は一緒に完了させ、delegate を
+スケジュールされていない次の wake に先送りしてはいけません。
 
 次の **すべて** が成り立つときのみ publish します:
 
@@ -208,8 +230,42 @@ publish は canonical な surface のみ — `intent-cli issue publish-flow` と
 `intent-cli automation issue-publish` — を使い、生の `gh issue create` や
 `gh ... --add-label` は使いません。publish 後は intent-cli / GitHub（チャットではなく）で
 issue が期待どおりの body と `intent-target` label を持つこと、durable state がそれを
-反映していることを検証し、その後 agmsg で実装を委譲します。実装 receiver は依然として
+反映していることを検証し、**その同じ wake の中で** agmsg で実装を委譲します（G524）—
+publish した後で止まって将来の wake を待つことはしません。実装 receiver は依然として
 `intent-cli worker next-action` からターゲットを得ます（agmsg テキストからではありません）。
+
+## end-of-wake チェック（G523/G524）
+
+すべての orchestrator wake は read-only な stalled-work チェックで終わります —
+wake は、何もトリガーしないスケジュールされていない「次の wake」に actionable な
+pending transition を残したまま終わってはいけません。これにより、測定された
+publish-then-sleep と silent-completion の stall class を、タイマーを追加することなく
+解消します。
+
+```text
+intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json
+```
+
+- **先送りしない** — このチェックが報告するすべての actionable item を、眠りにつく前に
+  この wake の中で処理する（delegate、repair、または closeout へのルーティング）。
+  明示的な fallback/legacy タイマーが実際にそれを実行するようスケジュールされていない
+  限り、将来の wake のために作業を告知しない。メッセージ駆動の wake には、先送りした
+  作業を拾い直す他のトリガーがありません。
+- **先送りせずエスカレーションする** — item が本当に外部/オペレーターの判断に
+  ブロックされている場合は、design スレッドのエスカレーションフィルターを通じて
+  今すぐ明示的にエスカレーションする。黙って先送りしたり未処理のまま残したりしない。
+
+## dispatch 検証（G524）
+
+どの agmsg メッセージを送る前にも、受信者 id が team roster（agmsg `team.sh`）に
+存在することを確認してください。agmsg は未知の受信者を黙って受け付けてしまいます —
+配信エラーとして気づく手段がありません。roster に無い受信者 id はエラーとして扱い、
+送信前に id か roster 登録を修正してください。ロール名を推測したり近似したり
+しないでください。
+
+フィールドで観測された損失: 登録済みロールが `reviewer` であったにもかかわらず
+`review` 宛に送られた 8 件の dispatch が、静かに失われました — agmsg は配信もせず、
+不一致を報告もしませんでした。
 
 ## 依存の計画（dependency planning）
 
@@ -767,6 +823,25 @@ host チェックアウトは正当に **複数** の intent ドメインを含�
 （`.intent-cli/**`、`intents/**`）を読んだり変更したりしません。すべての label 遷移は
 `intent-cli worker` / `intent-cli automation` を経由します。
 
+**orchestrator への completion または blocked の報告は、すべての delegation の
+REQUIRED FINAL STEP です（G524）** — これは任意ではなく、orchestrator が自力で
+silent completion を発見することはできません（orchestrator に報告が届かないまま
+PR が open された場合、それは orchestrator の視点では失われた作業です — フィールドの
+ある事例では、手動の GitHub チェックで発見されるまで 88 分間気づかれませんでした）。
+完了時は正確に次の shape を送ってください:
+
+```json
+{"status":"completed","thread":"implementation","ref":"pr#<n>","note":"PR opened, Closes #<n>, CI green"}
+```
+
+または 1 件のオペレーターアクションを名指しする `blocked` の shape。同じ
+required-final-step のルールは review スレッドにも適用され、その `completed` 返信は
+さらに `design_alignment_checked` とチェック済みソースのリストを持ちます:
+
+```json
+{"status":"completed","thread":"review","ref":"pr#<n>","note":"approved; closeout done","design_alignment_checked":true,"design_alignment_sources_checked":["packet","review-context","intent-tree","adr-decision-notes","relevant-docs"]}
+```
+
 ## セーフティ境界（まとめ）
 
 - agmsg はシグナル層のみ。intent-cli と GitHub がすべてのワークフロー状態の権威。
@@ -778,3 +853,13 @@ host チェックアウトは正当に **複数** の intent ドメインを含�
   を要求する。
 - orchestrator の重複や、シグナルが intent-cli/GitHub の事実と矛盾する場合は fail closed —
   推測せず、停止してエスカレーションする。
+- 1 wake あたりの上限は **receiver ごとに最大 1 件の delegation**（implementation、
+  review）— 「最大 1 メッセージ」ではない。publish の同一 wake 内 delegation、repair
+  メッセージ、1 件のエスカレーション、receiver report への対応は 1 回の wake に
+  すべて含まれてよい（G524）。publish の delegation をスケジュールされていない
+  将来の wake に先送りしない。
+- 送信の前に必ず受信者 id を team roster（`agmsg team.sh`）と照合する。roster に
+  無い id は推測ではなくエラーとして扱う（G524）。
+- すべての wake を stalled-work チェック（`automation stalled-work`、G523）で終え、
+  眠りにつく前に actionable な item を処理する。黙って先送りせず、明示的に
+  エスカレーションする。

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -263,10 +263,12 @@ internal static class GuideOrchestratorThreadCommand
                     "Classify each open PR's CI: pending = wait-and-recheck next wake (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate. Pending CI is normal progress, not a reason to message the operator.",
                     "Detect stale blockers and no-reply receivers: a delegation with no accepted/progress reply within the expected window, or a thread stuck off the official workflow.",
                     "On a no-reply receiver past the threshold (default 30m), run the SAFE stale-thread health check: send one non-destructive status-request, check read-only intent-cli/GitHub facts, keep watching if there is progress, treat waiting-permission as an operator notice (never auto-clear), and only after repeated no-reply with no progress send one idempotent re-entry or escalate.",
-                    "If intent-cli reports an `issue-cut-ready` candidate and all gates pass (same-domain or routed, complete contract, no open clarification, dependencies satisfied, under WIP, clean host-sync/preflight), publish ONE issue this wake via canonical publish-flow / issue-publish, then verify — do not ask the operator to create it.",
+                    "If intent-cli reports an `issue-cut-ready` candidate and all gates pass (same-domain or routed, complete contract, no open clarification, dependencies satisfied, under WIP, clean host-sync/preflight), publish ONE issue this wake via canonical publish-flow / issue-publish, verify it, THEN delegate that same issue to implementation in THIS SAME WAKE (G524) — do not ask the operator to create it, and do not stop after publishing to wait for a future wake to send the delegation.",
                     "If the candidate has unmet dependencies, plan the chain instead of pausing: act on the EARLIEST unmet resolvable dependency (publish or route it), keep the dependent held, and escalate only ambiguous/cycle/cross-domain-unrouted cases.",
-                    "Decide the single action for this wake: publish one ready next-slice issue, delegate the next slice/PR, send one repair message, or escalate one operator decision.",
+                    "The per-wake cap is AT MOST ONE DELEGATION PER RECEIVER (implementation, review) — NOT at-most-one-message overall (G524): this wake's actions may include a publish plus its same-wake delegation, one repair message per stalled receiver, one operator escalation, and handling any pending receiver reports, all together.",
+                    "Before sending any agmsg message this wake, verify the recipient id against the team roster (`agmsg team.sh`) — treat an id not on the roster as an error, never a guess (G524).",
                     "Apply the design-thread escalation filter: keep routine progress / CI-wait / success / closeout / idle internal; surface to the design thread ONLY human-needed decisions, with structured evidence and the exact decision needed. Never hide a failure that needs a human.",
+                    Apply("End this wake with the stalled-work check (G523): `intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json`, and process every actionable item it reports before sleeping — never leave one for an unscheduled next wake; escalate explicitly if it is genuinely blocked on an operator decision."),
                 },
                 RepairVsEscalate = new OrchestratorRepairEscalate
                 {
@@ -338,8 +340,11 @@ internal static class GuideOrchestratorThreadCommand
                     "Routine next-slice issue publication is an ORCHESTRATOR responsibility, not an operator question. "
                     + "When intent-cli reports a candidate as `issue-cut-ready` and ALL safety gates pass, the "
                     + "orchestrator publishes it itself through canonical intent-cli commands instead of stopping to ask "
-                    + "the operator to create the GitHub issue. Publish AT MOST ONE issue per wake, then verify before "
-                    + "delegating implementation.",
+                    + "the operator to create the GitHub issue. Publish AT MOST ONE issue per wake, then verify, THEN "
+                    + "delegate that same issue to the implementation thread in THE SAME WAKE (G524) — publish and "
+                    + "delegate complete together; never defer the delegation to an unscheduled \"next wake\", since no "
+                    + "other trigger will ever wake the orchestrator to send it (this was the single largest measured "
+                    + "stall class in message-driven orchestration, ~60 hours across G807/G809/G810/G812).",
                 OnePerWake = true,
                 Preconditions = new[]
                 {
@@ -369,8 +374,37 @@ internal static class GuideOrchestratorThreadCommand
                 {
                     "Confirm via intent-cli / GitHub (not chat) that the issue exists with the expected execution-unit body and the `intent-target` label.",
                     "Confirm the durable workflow state (queue-state / linkage / label) reflects the publish through intent-cli surfaces.",
-                    "Only after verification, delegate implementation over agmsg — and the implementation receiver still derives its target from `intent-cli worker next-action`, not the agmsg text.",
+                    "Immediately after verification, in THIS SAME WAKE, delegate implementation over agmsg (G524) — do not stop after publishing and wait for a future wake to send the delegation. The implementation receiver still derives its target from `intent-cli worker next-action`, not the agmsg text.",
                 },
+            },
+            EndOfWakeCheck = new OrchestratorEndOfWakeCheck
+            {
+                Summary =
+                    "G524: every orchestrator wake ends with a read-only stalled-work check (G523) — a wake must never "
+                    + "end leaving an actionable pending transition for an unscheduled \"next wake\" that nothing would "
+                    + "trigger. This closes the measured publish-then-sleep and silent-completion stall classes without "
+                    + "adding any timer.",
+                Command = Apply("intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json"),
+                NeverDeferRule =
+                    "Process every actionable item the check reports in THIS wake — delegate, repair, or route to "
+                    + "closeout — before sleeping. Do not announce work for a future wake unless an explicit "
+                    + "fallback/legacy timer is actually scheduled to run it; message-driven wakes have no other "
+                    + "trigger to pick the deferred work back up.",
+                EscalateInsteadOfDeferRule =
+                    "If an actionable item is genuinely blocked on an external/operator decision, escalate it "
+                    + "explicitly to the design thread now via the design-thread escalation filter — do not silently "
+                    + "defer it and do not leave it unprocessed.",
+            },
+            DispatchVerification = new OrchestratorDispatchVerification
+            {
+                Rule =
+                    "G524: before sending ANY agmsg message, verify the recipient id is present in the team roster "
+                    + "(agmsg `team.sh`). agmsg accepts an unknown recipient silently — there is no delivery error to "
+                    + "notice. Treat a recipient id that is not on the roster as an error: fix the id or the roster "
+                    + "registration before sending; never guess or approximate a role name.",
+                DeadAddressExample =
+                    "Field-observed loss: 8 dispatches addressed to `review` were silently lost when the registered "
+                    + "role was `reviewer` — agmsg neither delivered nor reported the mismatch.",
             },
             DependencyPlanning = new OrchestratorDependencyPlanning
             {
@@ -1068,13 +1102,20 @@ internal static class GuideOrchestratorThreadCommand
                         + "verify the GitHub facts that an agmsg reply claims (merged PR, CI, labels). Treat pending/"
                         + "running CI as an active wait state — re-check it on a later wake rather than asking the "
                         + "operator; delegate review/closeout only after required checks are green, route red checks to "
-                        + "repair or escalation by ownership, and escalate only stuck/ambiguous CI. Then take AT MOST "
-                        + "ONE forward action: publish one ready next-slice issue (when intent-cli reports it "
-                        + "`issue-cut-ready` and all gates pass — via canonical `intent-cli issue publish-flow` / "
-                        + "`automation issue-publish`, then verify), send one delegation (assign the next slice/PR), send "
-                        + "one repair request (point a stalled thread back to the official intent-cli workflow), or "
-                        + "escalate one operator decision. Unmet dependencies are normal work, not a stop: if the next "
-                        + "candidate depends on incomplete work, act on the EARLIEST unmet resolvable dependency "
+                        + "repair or escalation by ownership, and escalate only stuck/ambiguous CI. If you publish a "
+                        + "ready next-slice issue this wake (when intent-cli reports it `issue-cut-ready` and all gates "
+                        + "pass — via canonical `intent-cli issue publish-flow` / `automation issue-publish`), verify it "
+                        + "exists, THEN delegate that same issue to implementation in THIS SAME WAKE (G524) — never stop "
+                        + "after publishing to wait for an unscheduled future wake to send the delegation; no other "
+                        + "trigger will ever pick it back up. The per-wake cap is AT MOST ONE DELEGATION PER RECEIVER "
+                        + "(implementation, review), NOT at-most-one-message overall: alongside a publish+delegation you "
+                        + "may also send one repair request per stalled receiver (pointing it back to the official "
+                        + "intent-cli workflow), escalate one operator decision, and handle any pending receiver "
+                        + "reports. Before sending ANY agmsg message, verify the recipient id is present in the team "
+                        + "roster (agmsg `team.sh`) — agmsg accepts an unknown recipient silently, so treat an "
+                        + "off-roster id as an error, never a guess (a legacy `review` vs the registered `reviewer` has "
+                        + "silently lost messages in the field). Unmet dependencies are normal work, not a stop: if the "
+                        + "next candidate depends on incomplete work, act on the EARLIEST unmet resolvable dependency "
                         + "(publish or route it) and keep the dependent held, rather than pausing for the operator. For a "
                         + "no-reply receiver past the threshold (default 30m), run the SAFE stale-thread health check — "
                         + "send one non-destructive status-request and verify read-only intent-cli/GitHub facts before any "
@@ -1084,7 +1125,11 @@ internal static class GuideOrchestratorThreadCommand
                         + "release/publish, explicit policy); keep routine progress / CI-wait / success / closeout / idle "
                         + "internal — but never hide a failure that needs a human. Do "
                         + "NOT "
-                        + "launch recurring implement/review timers for this domain/repo while orchestrating. Fail "
+                        + "launch recurring implement/review timers for this domain/repo while orchestrating. End every "
+                        + "wake with the stalled-work check (G523): `intent-cli automation stalled-work --domain "
+                        + "<domain> --repo <owner/repo> --format json`, and process every actionable item it reports "
+                        + "before sleeping — a wake must never end leaving an actionable transition for an unscheduled "
+                        + "next wake; escalate explicitly if an item is genuinely blocked on an operator decision. Fail "
                         + "closed: if you detect a second orchestrator for this domain/repo, or agmsg replies conflict "
                         + "with GitHub/intent-cli facts, STOP and escalate rather than guessing. Your normal steady "
                         + "state is MESSAGE-DRIVEN: implementation/review agmsg replies wake you, so you do NOT need a "
@@ -1113,9 +1158,17 @@ internal static class GuideOrchestratorThreadCommand
                         + "signal — confirm via packet/domain metadata and the routing context, not the prefix. Then "
                         + "claim, implement, open the PR with a `Closes #<issue>` reference, and `worker complete` — all "
                         + "label transitions through intent-cli worker/automation only. intent-cli and GitHub remain "
-                        + "authoritative; agmsg is only how you receive the delegation and send back your reply. When "
-                        + "done or blocked, send ONE structured agmsg reply (accepted / progress / completed / blocked) "
-                        + "citing the GitHub facts (PR number, CI). Do NOT read host metadata (`.intent-cli/**`, "
+                        + "authoritative; agmsg is only how you receive the delegation and send back your reply. "
+                        + "Reporting completion or blocked status to the orchestrator is a REQUIRED FINAL STEP of "
+                        + "EVERY delegation (G524) — it is not optional and the orchestrator cannot discover a silent "
+                        + "completion on its own (a PR opened with no report reaching the orchestrator is LOST WORK "
+                        + "from the orchestrator's perspective, observed in the field for 88 minutes before a manual "
+                        + "check found it). When done or blocked, send ONE structured agmsg reply (accepted / progress "
+                        + "/ completed / blocked) in the exact shape "
+                        + "`{\"status\":\"completed\",\"thread\":\"implementation\",\"ref\":\"pr#<n>\",\"note\":\"PR "
+                        + "opened, Closes #<n>, CI green\"}` (or the `blocked` shape naming one operator action), "
+                        + "citing the GitHub facts (PR number, CI) — do not consider the delegation finished until this "
+                        + "reply is sent. Do NOT read host metadata (`.intent-cli/**`, "
                         + "`intents/**`)."),
                 },
                 new OrchestratorThreadPrompt
@@ -1142,8 +1195,15 @@ internal static class GuideOrchestratorThreadCommand
                         + "notes, and relevant docs, and your reply must set `design_alignment_checked: true` plus which "
                         + "of those sources you checked — the orchestrator treats a reply missing that evidence as an "
                         + "INCOMPLETE review unless an authoritative prior approval state already proves equivalent "
-                        + "review. Report ONE structured agmsg reply (accepted / progress / completed / blocked) citing "
-                        + "the intent-cli/GitHub facts. intent-cli and GitHub stay authoritative."),
+                        + "review. Reporting completion or blocked status to the orchestrator is a REQUIRED FINAL STEP "
+                        + "of EVERY delegation (G524) — report ONE structured agmsg reply (accepted / progress / "
+                        + "completed / blocked) in the exact shape "
+                        + "`{\"status\":\"completed\",\"thread\":\"review\",\"ref\":\"pr#<n>\",\"note\":\"approved; "
+                        + "closeout done\",\"design_alignment_checked\":true,\"design_alignment_sources_checked\":"
+                        + "[\"packet\",\"review-context\",\"intent-tree\",\"adr-decision-notes\",\"relevant-docs\"]}` "
+                        + "(or the `blocked` shape naming one operator action), citing the intent-cli/GitHub facts — do "
+                        + "not consider the delegation finished until this reply is sent. intent-cli and GitHub stay "
+                        + "authoritative."),
                 },
             },
             AgmsgReplyContract = new OrchestratorReplyContract
@@ -1174,8 +1234,10 @@ internal static class GuideOrchestratorThreadCommand
                 "Read pending agmsg replies from the implementation/review threads (signals only — do not trust them as state).",
                 Apply("Ask intent-cli for the real state: `intent-cli intent status --domain <domain> --format json` and `intent-cli worker next-action --repo <owner/repo> --github-only --format json`."),
                 "Verify every GitHub fact an agmsg reply claims (PR merged, CI concluded, labels) before acting on it.",
-                "Send AT MOST ONE message this wake: one delegation, one repair request, or one operator escalation — never a batch.",
+                "The per-wake cap is AT MOST ONE DELEGATION PER RECEIVER, not at-most-one-message overall (G524): a publish this wake must be delegated to implementation in this SAME wake — never defer that delegation to an unscheduled next wake — alongside any repair requests (one per stalled receiver) or one operator escalation.",
+                "Before sending any agmsg message, verify the recipient id against the team roster (`agmsg team.sh`); treat an id not on the roster as an error, never a guess (G524).",
                 "Do not launch implement/review recurring timers for this domain/repo while orchestrating.",
+                Apply("End this wake with the stalled-work check (G523): `intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json`, and process every actionable item before sleeping — never leave one for an unscheduled next wake; escalate explicitly if it is genuinely blocked on an operator decision."),
             },
             SafetyBoundaries = new[]
             {
@@ -1183,7 +1245,9 @@ internal static class GuideOrchestratorThreadCommand
                 "No raw label mutation (`gh ... --add-label`/`--remove-label`); every label transition goes through intent-cli worker/automation.",
                 "No hand-editing queue-state, runs.jsonl, packets, or any host metadata (`.intent-cli/**`, `intents/**`).",
                 "agmsg never replaces semantic review or authorizes a merge; review/closeout decisions run through intent-cli review surfaces (G480).",
-                "Process at most one delegation/repair/escalation per orchestrator wake; one delegated item per implementation/review wake.",
+                "Per-wake cap is AT MOST ONE DELEGATION PER RECEIVER (implementation, review) — NOT at-most-one-message: a publish's same-wake delegation, repair messages, an escalation, and receiver-report handling may all happen in one wake (G524); never defer a publish's delegation to an unscheduled future wake.",
+                "Verify the recipient id against the team roster (`agmsg team.sh`) before every send; an id not on the roster is an error, not a guess (G524).",
+                "End every wake with a stalled-work check (`automation stalled-work`, G523) and process any actionable item before sleeping; escalate explicitly rather than deferring silently.",
                 "Domain isolation: a host repo can hold several domains and one repo can serve several domains, so visibility is not authorization. Single-domain orchestrators ignore/escalate other-domain items; multi-domain orchestrators require explicit per-delegation routing. An execution-unit prefix mismatch alone is not a wrong-repo signal.",
                 "Fail closed on duplicate orchestrators for the same domain/repo, or when an agmsg reply conflicts with intent-cli/GitHub facts — STOP and escalate, never guess.",
                 "Allocate temporary worktrees under an allowlisted managed root and remove them with `git worktree remove`; never raw `rm -rf` of arbitrary temp paths, and `approval_policy=never`/`danger-full-access` is not a substitute for safe cleanup.",
@@ -1905,6 +1969,22 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## End-of-wake check (G523/G524)");
+        writer.WriteLine();
+        writer.WriteLine(guide.EndOfWakeCheck.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- command: `{guide.EndOfWakeCheck.Command}`");
+        writer.WriteLine($"- **never defer** — {guide.EndOfWakeCheck.NeverDeferRule}");
+        writer.WriteLine($"- **escalate instead of defer** — {guide.EndOfWakeCheck.EscalateInsteadOfDeferRule}");
+        writer.WriteLine();
+
+        writer.WriteLine("## Dispatch verification (G524)");
+        writer.WriteLine();
+        writer.WriteLine(guide.DispatchVerification.Rule);
+        writer.WriteLine();
+        writer.WriteLine($"- {guide.DispatchVerification.DeadAddressExample}");
+        writer.WriteLine();
+
         writer.WriteLine("## Dependency planning");
         writer.WriteLine();
         writer.WriteLine(guide.DependencyPlanning.Summary);
@@ -2320,6 +2400,12 @@ internal sealed record OrchestratorThreadGuide
 
     [JsonPropertyName("next_slice_publication")]
     public required OrchestratorNextSlicePublication NextSlicePublication { get; init; }
+
+    [JsonPropertyName("end_of_wake_check")]
+    public required OrchestratorEndOfWakeCheck EndOfWakeCheck { get; init; }
+
+    [JsonPropertyName("dispatch_verification")]
+    public required OrchestratorDispatchVerification DispatchVerification { get; init; }
 
     [JsonPropertyName("dependency_planning")]
     public required OrchestratorDependencyPlanning DependencyPlanning { get; init; }
@@ -2875,6 +2961,43 @@ internal sealed record OrchestratorNextSlicePublication
 
     [JsonPropertyName("post_publish_verification")]
     public required IReadOnlyList<string> PostPublishVerification { get; init; }
+}
+
+/// <summary>
+/// G524: every orchestrator wake ends with a read-only stalled-work check
+/// (G523) so a wake never ends leaving an actionable pending transition for
+/// an unscheduled "next wake" that nothing would trigger — this closes the
+/// measured publish-then-sleep / silent-completion stall classes.
+/// </summary>
+internal sealed record OrchestratorEndOfWakeCheck
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("command")]
+    public required string Command { get; init; }
+
+    [JsonPropertyName("never_defer_rule")]
+    public required string NeverDeferRule { get; init; }
+
+    [JsonPropertyName("escalate_instead_of_defer_rule")]
+    public required string EscalateInsteadOfDeferRule { get; init; }
+}
+
+/// <summary>
+/// G524: dispatch guidance requiring the recipient id to be verified
+/// against the agmsg team roster before every send — agmsg accepts an
+/// unknown recipient silently, so a typo'd/legacy id (e.g. `review` instead
+/// of the registered `reviewer`) loses the message with no error surfaced
+/// anywhere.
+/// </summary>
+internal sealed record OrchestratorDispatchVerification
+{
+    [JsonPropertyName("rule")]
+    public required string Rule { get; init; }
+
+    [JsonPropertyName("dead_address_example")]
+    public required string DeadAddressExample { get; init; }
 }
 
 internal sealed record OrchestratorThreadPrompt

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -60,9 +60,9 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("\"status\":\"completed\"", output, StringComparison.Ordinal);
         Assert.Contains("\"status\":\"blocked\"", output, StringComparison.Ordinal);
 
-        // First wake: read replies, ask intent-cli, verify GitHub, one message per wake.
+        // First wake: read replies, ask intent-cli, verify GitHub, per-receiver delegation cap (G524).
         Assert.Contains("## Orchestrator first wake", output, StringComparison.Ordinal);
-        Assert.Contains("Send AT MOST ONE message this wake", output, StringComparison.Ordinal);
+        Assert.Contains("AT MOST ONE DELEGATION PER RECEIVER", output, StringComparison.Ordinal);
 
         // Safety boundaries.
         Assert.Contains("## Safety boundaries", output, StringComparison.Ordinal);
@@ -552,11 +552,11 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.NotEmpty(publication.GetProperty("canonical_commands").EnumerateArray());
         Assert.NotEmpty(publication.GetProperty("post_publish_verification").EnumerateArray());
 
-        // The orchestrator prompt lists publication as a possible single action.
+        // The orchestrator prompt describes publish-then-same-wake-delegate (G524).
         var orchestrator = doc.RootElement.GetProperty("threads").EnumerateArray()
             .First(t => t.GetProperty("role").GetString() == "orchestrator")
             .GetProperty("prompt").GetString()!;
-        Assert.Contains("publish one ready next-slice issue", orchestrator, StringComparison.Ordinal);
+        Assert.Contains("publish a ready next-slice issue", orchestrator, StringComparison.Ordinal);
         Assert.Contains("issue-cut-ready", orchestrator, StringComparison.Ordinal);
     }
 
@@ -1542,6 +1542,127 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("guide orchestrator-thread", output, StringComparison.Ordinal);
         Assert.Contains("OPTIONAL", output, StringComparison.Ordinal);
         Assert.Contains("not replaced", output, StringComparison.Ordinal);
+    }
+
+    // ----- G524: orchestrator wake contract (finish pending transitions in-wake) -----
+
+    [Fact]
+    public void Execute_Markdown_PublishAndDelegate_HappenInSameWake_NoDeferToNextWakeWording()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        // AC: guide output states publish + delegate happen in the same wake.
+        Assert.Contains("THE SAME WAKE", output, StringComparison.Ordinal);
+        Assert.Contains("delegate that same issue to implementation", output, StringComparison.Ordinal);
+
+        // AC: no longer contains the defer-delegation-to-next-wake instruction.
+        Assert.DoesNotContain("delegation intentionally deferred to the next wake", output, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("deferred to the next wake", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Markdown_MessageCap_IsPerReceiverDelegation_NotAtMostOneMessage()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        // AC: the message cap reads "at most one delegation per receiver per wake"
+        // and explicitly permits publish + delegation + reports within one wake.
+        Assert.Contains("AT MOST ONE DELEGATION PER RECEIVER", output, StringComparison.Ordinal);
+        Assert.Contains("NOT at-most-one-message", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Send AT MOST ONE message this wake", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Decide the single action for this wake", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_EndOfWakeCheck_RequiresStalledWorkAndNeverDefers()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        // AC: guide output contains the end-of-wake stalled-work check (G523)
+        // and the never-end-with-unprocessed-actionable-transitions rule.
+        Assert.Contains("## End-of-wake check (G523/G524)", output, StringComparison.Ordinal);
+        Assert.Contains("automation stalled-work --domain", output, StringComparison.Ordinal);
+        Assert.Contains("never defer", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("escalate", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_Json_EndOfWakeCheck_HasCommandAndRules()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var check = doc.RootElement.GetProperty("end_of_wake_check");
+        Assert.Contains("stalled-work", check.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Contains("automation stalled-work", check.GetProperty("command").GetString(), StringComparison.Ordinal);
+        Assert.True(check.GetProperty("never_defer_rule").GetString()!.Length > 0);
+        Assert.True(check.GetProperty("escalate_instead_of_defer_rule").GetString()!.Length > 0);
+    }
+
+    [Fact]
+    public void Execute_Markdown_ReceiverPrompts_RequireCompletionOrBlockedReportAsFinalStep()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        // AC: implementation and review thread prompts contain the required
+        // completion-or-blocked report step with its expected shape.
+        Assert.Contains("REQUIRED FINAL STEP of EVERY delegation", output, StringComparison.Ordinal);
+        Assert.Contains("\"status\":\"completed\",\"thread\":\"implementation\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"status\":\"completed\",\"thread\":\"review\"", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_ReceiverPrompts_ContainRequiredReportStep()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var threads = doc.RootElement.GetProperty("threads").EnumerateArray().ToArray();
+        var implementation = threads.First(t => t.GetProperty("role").GetString() == "implementation").GetProperty("prompt").GetString()!;
+        var review = threads.First(t => t.GetProperty("role").GetString() == "review").GetProperty("prompt").GetString()!;
+
+        Assert.Contains("REQUIRED FINAL STEP", implementation, StringComparison.Ordinal);
+        Assert.Contains("REQUIRED FINAL STEP", review, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_DispatchVerification_RequiresRosterCheckBeforeSend()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        // AC: dispatch guidance requires team-roster verification of the
+        // recipient id before sending.
+        Assert.Contains("## Dispatch verification (G524)", output, StringComparison.Ordinal);
+        Assert.Contains("team roster", output, StringComparison.Ordinal);
+        Assert.Contains("team.sh", output, StringComparison.Ordinal);
+        Assert.Contains("`review`", output, StringComparison.Ordinal);
+        Assert.Contains("`reviewer`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_DispatchVerification_HasRuleAndDeadAddressExample()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var verification = doc.RootElement.GetProperty("dispatch_verification");
+        Assert.Contains("team.sh", verification.GetProperty("rule").GetString(), StringComparison.Ordinal);
+        Assert.True(verification.GetProperty("dead_address_example").GetString()!.Length > 0);
     }
 
     private static string RunMarkdown(string[] args)


### PR DESCRIPTION
## Summary
Rewrites the orchestrator-thread guide (wake procedure, thread prompts, safety boundaries) per field data (sekiban-as-a-service-orch, 2026-06-28..07-14: ~60h of publish-then-sleep stalls across G807/G809/G810/G812, an 88-minute silent completion on G814, and 8 messages lost to a dead `review` vs `reviewer` address).

Five required elements, all implemented and mirrored in ja/en docs:
1. **Publish + delegate in the SAME wake.** Removes every "deferred to the next wake" instruction — nothing else would ever wake the orchestrator to send a deferred delegation.
2. **Message cap restated as "at most one delegation per receiver per wake"**, not "at most one message" — explicitly permits publish + its delegation + repair messages + an escalation + receiver-report handling within one wake.
3. **End-of-wake stalled-work check (G523)** — new `EndOfWakeCheck` guide element with the exact `automation stalled-work` command, a never-defer rule, and an explicit escalate-instead-of-defer rule.
4. **Receiver completion-report required final step** — implementation and review thread prompts now state the completion-or-blocked report is a REQUIRED FINAL STEP of every delegation, with the exact expected JSON shape inline.
5. **Dispatch roster verification (G524)** — new `DispatchVerification` guide element requiring the recipient id be checked against the agmsg team roster (`team.sh`) before every send, citing the field-observed `review`/`reviewer` loss.

No CLI behavior changes, no timers, no agmsg code changes — this is guide-content only (`GuideOrchestratorThreadCommand.cs` + docs + tests).

Closes #1149

## Test plan
- [x] `dotnet build` (full solution) — 0 warnings/errors.
- [x] `dotnet test` (full solution) — all green (3225 passed, 1 pre-existing skip).
- [x] New focused tests pinning each of the five elements (markdown + JSON) in `GuideOrchestratorThreadCommandTests.cs`; updated the 2 pre-existing tests that asserted the old wording.
- [x] Manually rendered `intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --format markdown` and confirmed the new `## End-of-wake check (G523/G524)` and `## Dispatch verification (G524)` sections, plus the same-wake publish+delegate and per-receiver cap wording.
- [x] `git diff --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4yoyeXmTeJWD16RLvktQd