### PR TITLE
G527: Fix packet-yaml scalar parser rejection of apostrophes in double-quoted values

### DIFF
--- a/src/IntentSystem.Cli/Commands/PreparedPacketCommitReadyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PreparedPacketCommitReadyAnalyzer.cs
@@ -634,24 +634,34 @@ internal static class PreparedPacketYamlScalarParser
             }
             value = value.Trim();
 
-            // Fail closed on unbalanced quotes in the value scalar.
-            if (HasUnbalancedQuote(value, '\''))
+            // G527: quote-balance rules depend on the scalar's OWN delimiter
+            // (standard YAML behavior) — a quote character that is not the
+            // scalar's delimiter is literal content and must never trigger a
+            // balance check for the OTHER quote style. A double-quoted value
+            // containing an apostrophe (e.g. `"it's here"`) is valid YAML and
+            // must parse, not fail closed.
+            if (value.Length > 0 && value[0] == '"')
             {
-                throw new FormatException(
-                    $"line {lineNumber}: unbalanced single quote in value for `{key}`: `{rawValue.Trim()}`.");
-            }
-            if (HasUnbalancedQuote(value, '"'))
-            {
-                throw new FormatException(
-                    $"line {lineNumber}: unbalanced double quote in value for `{key}`: `{rawValue.Trim()}`.");
-            }
-
-            if (value.Length >= 2
-                && (value[0] == '"' && value[^1] == '"'
-                    || value[0] == '\'' && value[^1] == '\''))
-            {
+                if (!IsBalancedDoubleQuotedScalar(value))
+                {
+                    throw new FormatException(
+                        $"line {lineNumber}: unbalanced double quote in value for `{key}`: `{rawValue.Trim()}`.");
+                }
                 value = value.Substring(1, value.Length - 2);
             }
+            else if (value.Length > 0 && value[0] == '\'')
+            {
+                if (!IsBalancedSingleQuotedScalar(value))
+                {
+                    throw new FormatException(
+                        $"line {lineNumber}: unbalanced single quote in value for `{key}`: `{rawValue.Trim()}`.");
+                }
+                value = value.Substring(1, value.Length - 2);
+            }
+            // else: an unquoted plain scalar. Standard YAML gives quote
+            // characters no special meaning inside a plain scalar (they are
+            // only significant as the very first character, handled above),
+            // so no balance check applies here.
 
             while (pathStack.Count > 0 && pathStack[^1].Indent >= indent)
             {
@@ -679,20 +689,55 @@ internal static class PreparedPacketYamlScalarParser
         return fields;
     }
 
-    private static bool HasUnbalancedQuote(string value, char quote)
+    /// <summary>
+    /// G527: <paramref name="value"/> is known to start with <c>"</c>. Valid
+    /// only when it also ends with an unescaped <c>"</c> and no other
+    /// double quote appears in between — this lightweight reader does not
+    /// support a <c>\"</c> escape, so any interior double quote makes the
+    /// scalar's boundary genuinely ambiguous. A single quote (apostrophe)
+    /// anywhere inside is literal content and never affects this check.
+    /// </summary>
+    private static bool IsBalancedDoubleQuotedScalar(string value)
     {
-        if (string.IsNullOrEmpty(value))
+        if (value.Length < 2 || value[^1] != '"')
         {
             return false;
         }
-        var count = 0;
-        foreach (var ch in value)
+        for (var i = 1; i < value.Length - 1; i++)
         {
-            if (ch == quote)
+            if (value[i] == '"')
             {
-                count++;
+                return false;
             }
         }
-        return (count % 2) != 0;
+        return true;
+    }
+
+    /// <summary>
+    /// G527: <paramref name="value"/> is known to start with <c>'</c>. Valid
+    /// when scanning from the character after the opening quote finds an
+    /// unescaped closing <c>'</c> exactly at the last position — a doubled
+    /// <c>''</c> is the standard YAML escape for a literal single quote
+    /// inside a single-quoted scalar and is consumed as one escaped
+    /// character rather than treated as a delimiter. A double quote
+    /// anywhere inside is literal content and never affects this check.
+    /// </summary>
+    private static bool IsBalancedSingleQuotedScalar(string value)
+    {
+        var index = 1;
+        while (index < value.Length)
+        {
+            if (value[index] == '\'')
+            {
+                if (index + 1 < value.Length && value[index + 1] == '\'')
+                {
+                    index += 2;
+                    continue;
+                }
+                return index == value.Length - 1;
+            }
+            index++;
+        }
+        return false;
     }
 }

--- a/tests/IntentSystem.Cli.Tests/PreparedPacketCommitReadyAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PreparedPacketCommitReadyAnalyzerTests.cs
@@ -543,6 +543,36 @@ Demo.
     }
 
     [Fact]
+    public void Analyze_PacketYamlWithApostropheInDoubleQuotedValue_G527Regression_IsCommitReady()
+    {
+        // G527 regression: the 2026-07-10 field incident — a correctly
+        // double-quoted `placement_rationale` value containing an
+        // apostrophe was rejected as `packet-yaml-unparseable`. It must now
+        // be accepted end-to-end through the same analyzer
+        // `queue-seed-from-packet` uses.
+        const string packetYamlWithApostrophe = """
+implementation_issue_packet:
+  source_execution_unit: Z4R-G3
+  issue_title: Demo packet
+  target_repo: J-Tech-Creations/Zero4Racer
+placement_rationale: "This is Sekiban's core boundary and it's the right place."
+""";
+        var result = PreparedPacketCommitReadyAnalyzer.Analyze(new PreparedPacketCommitReadyInput
+        {
+            ExecutionUnit = "Z4R-G3",
+            PacketYaml = packetYamlWithApostrophe,
+            ImplementationMarkdown = CanonicalImplementation,
+            ReviewContextMarkdown = CanonicalReviewContext,
+            GithubBodyMarkdown = CanonicalGithubBody,
+            ExecutionUnitRegex = "^Z4R-G[0-9]+$",
+            RequestedTargetRepo = "J-Tech-Creations/Zero4Racer",
+            RequireDomainBinding = true,
+        });
+
+        Assert.Equal(PreparedPacketCommitReadyAnalyzer.ClassificationCommitReady, result.Classification);
+    }
+
+    [Fact]
     public void Analyze_MalformedPacketYaml_UnbalancedQuote_ReturnsUnsafeUnparseable()
     {
         // An operator typo that breaks scalar parsing (unbalanced

--- a/tests/IntentSystem.Cli.Tests/PreparedPacketYamlScalarParserTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PreparedPacketYamlScalarParserTests.cs
@@ -1,0 +1,129 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G527: focused coverage for <see cref="PreparedPacketYamlScalarParser"/>'s
+/// quote-handling — apostrophes inside double-quoted values must parse as
+/// literal content (standard YAML behavior), while genuinely unbalanced
+/// quotes still fail closed with a line number and quoting guidance.
+/// </summary>
+public sealed class PreparedPacketYamlScalarParserTests
+{
+    [Fact]
+    public void Parse_DoubleQuotedValueWithApostrophe_ParsesAsLiteralContent()
+    {
+        // 2026-07-10 field incident regression: a correctly double-quoted
+        // value containing an apostrophe must not be rejected.
+        var fields = PreparedPacketYamlScalarParser.Parse(
+            "placement_rationale: \"This is Sekiban's core boundary and it's the right place.\"\n");
+
+        Assert.Equal(
+            "This is Sekiban's core boundary and it's the right place.",
+            fields["placement_rationale"]);
+    }
+
+    [Fact]
+    public void Parse_DoubleQuotedValueWithApostrophe_NestedKey_ParsesAsLiteralContent()
+    {
+        // The second 2026-07-10 refusal was on a nested key
+        // (closeout_learning.expected).
+        var fields = PreparedPacketYamlScalarParser.Parse(
+            "closeout_learning:\n  expected: \"Author's summary won't need rewording anymore.\"\n");
+
+        Assert.Equal(
+            "Author's summary won't need rewording anymore.",
+            fields["closeout_learning.expected"]);
+    }
+
+    [Fact]
+    public void Parse_DoubleQuotedValueWithMultipleApostrophes_ParsesAsLiteralContent()
+    {
+        var fields = PreparedPacketYamlScalarParser.Parse(
+            "note: \"it's, don't, won't, can't\"\n");
+
+        Assert.Equal("it's, don't, won't, can't", fields["note"]);
+    }
+
+    [Fact]
+    public void Parse_UnquotedPlainScalarWithApostrophe_ParsesAsLiteralContent()
+    {
+        // Standard YAML gives quote characters no special meaning inside an
+        // unquoted plain scalar — an apostrophe here must not trigger the
+        // single-quote balance check either.
+        var fields = PreparedPacketYamlScalarParser.Parse(
+            "note: it's a plain unquoted value\n");
+
+        Assert.Equal("it's a plain unquoted value", fields["note"]);
+    }
+
+    [Fact]
+    public void Parse_SingleQuotedValueWithDoubledEscape_DoesNotThrow()
+    {
+        // Preserved behavior: single-quoted values using the YAML ''
+        // doubled-single-quote escape convention must keep parsing (this
+        // lightweight reader does not unescape '' to ' — it only strips the
+        // outer delimiters — so the doubled quote survives in the output,
+        // matching pre-G527 behavior).
+        var fields = PreparedPacketYamlScalarParser.Parse(
+            "title: 'it''s single-quoted'\n");
+
+        Assert.Equal("it''s single-quoted", fields["title"]);
+    }
+
+    [Fact]
+    public void Parse_SingleQuotedValueWithDoubleQuoteInside_ParsesAsLiteralContent()
+    {
+        // Symmetry: a double quote inside a single-quoted scalar is literal
+        // content and must never trigger the double-quote balance check.
+        var fields = PreparedPacketYamlScalarParser.Parse(
+            "title: 'she said \"hello\"'\n");
+
+        Assert.Equal("she said \"hello\"", fields["title"]);
+    }
+
+    [Fact]
+    public void Parse_UnquotedPlainScalar_StillParsesUnchanged()
+    {
+        var fields = PreparedPacketYamlScalarParser.Parse(
+            "target_repo: J-Tech-Creations/Zero4Racer\n");
+
+        Assert.Equal("J-Tech-Creations/Zero4Racer", fields["target_repo"]);
+    }
+
+    [Fact]
+    public void Parse_GenuinelyUnterminatedDoubleQuote_StillThrowsWithLineNumberAndGuidance()
+    {
+        // 2026-07-10 incident's ORIGINAL shape must still fail: a
+        // double-quoted value with no closing quote at all.
+        var exception = Assert.Throws<FormatException>(() =>
+            PreparedPacketYamlScalarParser.Parse(
+                "implementation_issue_packet:\n  source_execution_unit: Z4R-G3\n  target_repo: \"J-Tech-Creations/Zero4Racer\n"));
+
+        Assert.Contains("line 3", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("unbalanced double quote", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_DoubleQuotedValueWithStrayInteriorDoubleQuote_StillThrows()
+    {
+        // A genuinely ambiguous double-quoted scalar (an interior
+        // unescaped double quote before the true end) must still fail
+        // closed — this lightweight reader has no `\"` escape support.
+        var exception = Assert.Throws<FormatException>(() =>
+            PreparedPacketYamlScalarParser.Parse(
+                "title: \"broken \"quote\" here\"\n"));
+
+        Assert.Contains("unbalanced double quote", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_SingleQuotedValueWithGenuinelyUnbalancedQuote_StillThrows()
+    {
+        var exception = Assert.Throws<FormatException>(() =>
+            PreparedPacketYamlScalarParser.Parse(
+                "title: 'it's broken\n"));
+
+        Assert.Contains("unbalanced single quote", exception.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- Fixes `PreparedPacketYamlScalarParser` (shared by packet validation and `automation queue-seed-from-packet`) so quote-balance checks are delimiter-aware instead of counting every occurrence of a quote character across the value:
  - A double-quoted scalar's balance depends only on double quotes — an apostrophe inside is literal content (standard YAML) and never triggers the single-quote check.
  - A single-quoted scalar's balance depends only on single quotes, honoring the YAML `''` doubled-escape convention — a double quote inside is literal content.
  - An unquoted plain scalar has no quote-balance rule at all (matches standard YAML — quote characters are only significant as the very first character of a value).
  - Genuinely unterminated or ambiguous quoting (no closing quote, or an interior unescaped quote of the same delimiter — this lightweight reader has no `\"`/escape support beyond `''`) still fails closed with the line number and quoting guidance.
- Fixes the exact 2026-07-10 field incident: `automation queue-seed-from-packet` twice refused a valid packet (`placement_rationale`, then `closeout_learning.expected`) whose double-quoted values merely contained an apostrophe.

## Test plan
- [x] `dotnet build` (full solution) — 0 warnings/errors.
- [x] `dotnet test` (full solution) — all green (3236 passed, 1 pre-existing skip).
- [x] New `PreparedPacketYamlScalarParserTests.cs`: double-quoted apostrophe (top-level + nested key, reproducing both field-incident values), unquoted plain scalar with apostrophe, single-quoted `''` escape preserved, single-quoted value containing a double quote, unquoted plain scalar unchanged, and 3 still-fails-closed cases (unterminated double quote, interior stray double quote, genuinely unbalanced single quote).
- [x] New end-to-end regression test in `PreparedPacketCommitReadyAnalyzerTests.cs` confirming a packet with the field-incident value now classifies `commit-ready` through the same analyzer `queue-seed-from-packet` uses.
- [x] Manual check: built the CLI and ran `automation queue-seed-from-packet` against a fixture reproducing the exact field incident (`placement_rationale: "This is Sekiban's core boundary and it's the right place."`) — confirmed `classification: queue-seed-ready` (previously `unsafe-prepared-packet` / `packet-yaml-unparseable`).
- [x] `git diff --check` — clean.

Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4yoyeXmTeJWD16RLvktQd