### PR TITLE
G525: Add canonical automation issue-retire transition

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -303,7 +303,7 @@ wake procedure and from an external heartbeat are separate follow-up slices.
 
 ### Retiring a stuck published issue (G525)
 
-`intent-cli automation issue-retire --repo <r> --issue <n> --reason <superseded|decomposed|obsolete> [--note <text>] [--write]`
+`intent-cli automation issue-retire --repo <r> --issue <n> --reason <superseded|decomposed|obsolete> [--note <text>] [--domain <name>] [--write]`
 is the canonical, atomic transition for a published `intent-target` issue
 that can never be started as authored (e.g. a research pass proves the
 slice must be decomposed). Before this command existed, the only escape
@@ -314,7 +314,8 @@ GitHub close, manual label strip, hand-authored queue-state edit) that
 `--write` performs, in order:
 
 1. closes the GitHub issue as **not planned**, with a comment naming the
-   reason and the optional note;
+   reason and the optional note (skipped if the issue is already closed —
+   see partial-failure recovery below);
 2. removes `intent-target` and any other workflow labels present on the
    issue;
 3. marks the corresponding queue-state item's lifecycle `retired` (with the
@@ -331,12 +332,45 @@ It **fails closed** (no mutation at all) when:
   that PR first;
 - the issue carries `intent-issue-in-progress` — an active claim is in
   flight; release it first (e.g. `intent-cli worker complete --kind issue
-  --number <n> --outcome declined-contract-incomplete --write`).
+  --number <n> --outcome declined-contract-incomplete --write`);
+- the matched queue item is already `Completed` (merged/finished work) —
+  retirement only applies to work that was published but can never be
+  completed as authored; this refusal touches neither GitHub nor local
+  state;
+- the resolved domain is underivable or contradicts an explicit `--domain`
+  (see domain resolution below).
+
+**Partial-failure recovery**: the target issue is resolved via a direct
+per-issue GitHub lookup — regardless of open/closed state — instead of
+scanning the OPEN-issues list. If a `--write` dies mid-sequence (issue
+closed but label removal, the queue-state write, or the `runs.jsonl` append
+did not complete), simply re-running the same command finds the issue again
+and finishes the remaining steps instead of dead-ending on "not found among
+OPEN issues." Recovery for an already-CLOSED issue is only authorized when
+GitHub's own close reason is **not planned** (the exact reason this command
+uses) — a closed issue with any other reason (e.g. completed via merge) is
+left untouched.
+
+**Domain resolution (G522 boundary)**: queue-item matching requires an
+exact `(repo, issue number)` pair — a same-numbered issue in a different
+repo can never match this execution unit. The execution unit's domain is
+resolved in the same order as other execution-unit-resolving surfaces: an
+explicit `--domain` wins (it is an error if it contradicts the domain
+declared by the resolved packet.yaml); otherwise the packet-declared
+`domain:` field is used; otherwise the command fails loud, naming candidate
+domains and the exact `--domain` re-invocation. This applies to both an
+existing queue item and a brand-new one derived from the issue title — a
+misleading title prefix alone can never authorize queue creation without a
+packet.yaml (or an explicit operator-supplied `--domain`) confirming it.
 
 **Idempotent**: re-running on an execution unit whose queue-state entry is
 already `retired` is a safe no-op — durable state (not a fragile GitHub
-state re-check) is the source of truth for idempotency. Packet directories
-and the issue comment trail are never touched or deleted.
+state re-check) is the source of truth for idempotency. If `--write` is
+used and the queue-state was retired but the `runs.jsonl` event from a
+prior partial write is missing, the retry finishes exactly that missing
+step (with zero GitHub calls) instead of silently dropping it forever.
+Packet directories and the issue comment trail are never touched or
+deleted.
 
 Retired items clear WIP gating automatically: `automation
 host-review-preflight`'s in-flight scan reads OPEN, `intent-target`-labeled

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -301,6 +301,48 @@ and never silently disappears.
 This slice is detection only — consuming the surface from the orchestrator
 wake procedure and from an external heartbeat are separate follow-up slices.
 
+### Retiring a stuck published issue (G525)
+
+`intent-cli automation issue-retire --repo <r> --issue <n> --reason <superseded|decomposed|obsolete> [--note <text>] [--write]`
+is the canonical, atomic transition for a published `intent-target` issue
+that can never be started as authored (e.g. a research pass proves the
+slice must be decomposed). Before this command existed, the only escape
+from this deadlock was an operator-authorized noncanonical recovery (manual
+GitHub close, manual label strip, hand-authored queue-state edit) that
+`metadata validate` then failed to recognize.
+
+`--write` performs, in order:
+
+1. closes the GitHub issue as **not planned**, with a comment naming the
+   reason and the optional note;
+2. removes `intent-target` and any other workflow labels present on the
+   issue;
+3. marks the corresponding queue-state item's lifecycle `retired` (with the
+   reason) — **creating the entry if none existed yet**, since a
+   published-but-never-delegated issue commonly has no queue-state entry at
+   all; this is what lets `metadata validate` recognize the retired
+   lifecycle instead of reporting a missing queue entry;
+4. appends a `packet-retired` event to `runs.jsonl`.
+
+Without `--write` it is a dry-run that lists the exact planned mutations.
+It **fails closed** (no mutation at all) when:
+
+- an OPEN PR in the same repo closes the issue — merge, close, or release
+  that PR first;
+- the issue carries `intent-issue-in-progress` — an active claim is in
+  flight; release it first (e.g. `intent-cli worker complete --kind issue
+  --number <n> --outcome declined-contract-incomplete --write`).
+
+**Idempotent**: re-running on an execution unit whose queue-state entry is
+already `retired` is a safe no-op — durable state (not a fragile GitHub
+state re-check) is the source of truth for idempotency. Packet directories
+and the issue comment trail are never touched or deleted.
+
+Retired items clear WIP gating automatically: `automation
+host-review-preflight`'s in-flight scan reads OPEN, `intent-target`-labeled
+GitHub issues/PRs live, so a closed, unlabeled issue simply disappears from
+it — no separate code path needed.
+
 ---
 
 ## Version flow

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -295,6 +295,52 @@ candidate が黙って scan に紛れ込むことも、黙って消えること�
 このスライスは検出のみです — orchestrator wake procedure や外部
 heartbeat からこのサーフェスを利用する部分は、別の後続スライスです。
 
+### 行き詰まった published issue を retire する (G525)
+
+`intent-cli automation issue-retire --repo <r> --issue <n> --reason <superseded|decomposed|obsolete> [--note <text>] [--write]`
+は、authored 通りには決して開始できない published な `intent-target` issue
+（例: research pass によって slice を decompose する必要があると判明した場合）
+のための canonical かつ atomic な transition です。このコマンドが存在する
+以前は、このデッドロックからの唯一の逃げ道は、operator が承認する
+noncanonical なリカバリ（手動での GitHub close、手動での label 除去、
+手書きの queue-state 編集）であり、その後 `metadata validate` はそれを
+認識できませんでした。
+
+`--write` は次の順序で実行します:
+
+1. GitHub issue を **not planned** として close し、reason と任意の note
+   を記載したコメントを付ける;
+2. issue に付いている `intent-target` およびその他の workflow label を
+   すべて除去する;
+3. 対応する queue-state item の lifecycle を（reason 付きで）`retired`
+   としてマークする — **エントリが存在しなければ新規作成する**。
+   publish されたが一度も delegate されていない issue には queue-state
+   エントリが無いことが一般的なためです。これにより `metadata validate`
+   は queue entry の欠落を報告するのではなく、retired lifecycle を
+   認識できるようになります;
+4. `runs.jsonl` に `packet-retired` イベントを追記する。
+
+`--write` を付けない場合は、正確な planned mutation を一覧表示する
+dry-run になります。次の場合は **fail closed**（一切の変更なし）します:
+
+- 同じ repo の OPEN な PR がその issue を close する — 先にその PR を
+  merge・close、またはリリースしてください;
+- issue が `intent-issue-in-progress` を持つ — アクティブな claim が
+  進行中です。先にそれを解放してください（例:
+  `intent-cli worker complete --kind issue --number <n> --outcome
+  declined-contract-incomplete --write`）。
+
+**冪等**: queue-state エントリが既に `retired` になっている execution
+unit に対して再実行しても安全な no-op です — 冪等性の判断根拠は
+（不安定な GitHub 状態の再チェックではなく）durable state です。packet
+ディレクトリと issue のコメント履歴には一切触れず、削除もしません。
+
+retired になった item は自動的に WIP gating から外れます:
+`automation host-review-preflight` の in-flight スキャンは OPEN で
+`intent-target` ラベル付きの GitHub issue/PR をライブに読むため、close
+されて label が外れた issue は単にそこから消えるだけです — 別途コード
+パスは不要です。
+
 ---
 
 ## バージョンフロー

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -297,7 +297,7 @@ heartbeat からこのサーフェスを利用する部分は、別の後続ス�
 
 ### 行き詰まった published issue を retire する (G525)
 
-`intent-cli automation issue-retire --repo <r> --issue <n> --reason <superseded|decomposed|obsolete> [--note <text>] [--write]`
+`intent-cli automation issue-retire --repo <r> --issue <n> --reason <superseded|decomposed|obsolete> [--note <text>] [--domain <name>] [--write]`
 は、authored 通りには決して開始できない published な `intent-target` issue
 （例: research pass によって slice を decompose する必要があると判明した場合）
 のための canonical かつ atomic な transition です。このコマンドが存在する
@@ -309,7 +309,8 @@ noncanonical なリカバリ（手動での GitHub close、手動での label �
 `--write` は次の順序で実行します:
 
 1. GitHub issue を **not planned** として close し、reason と任意の note
-   を記載したコメントを付ける;
+   を記載したコメントを付ける(issue が既に close 済みの場合はスキップ
+   される — 下記の partial-failure recovery を参照);
 2. issue に付いている `intent-target` およびその他の workflow label を
    すべて除去する;
 3. 対応する queue-state item の lifecycle を（reason 付きで）`retired`
@@ -329,11 +330,44 @@ dry-run になります。次の場合は **fail closed**（一切の変更な�
   進行中です。先にそれを解放してください（例:
   `intent-cli worker complete --kind issue --number <n> --outcome
   declined-contract-incomplete --write`）。
+- マッチした queue item が既に `Completed`(merge/完了済みの作業)である
+  — retire は authored 通りには決して完了できない published work にのみ
+  適用されます。この refusal は GitHub にも local state にも一切触れません;
+- 解決された domain が導出不能、または明示的な `--domain` と矛盾する
+  (下記の domain resolution を参照)。
+
+**Partial-failure recovery**: 対象 issue は OPEN issue の一覧スキャンでは
+なく、open/closed を問わない直接の GitHub 参照で解決されます。`--write`
+がシーケンスの途中で失敗した場合(issue は close されたが label 除去・
+queue-state 書き込み・`runs.jsonl` 追記のいずれかが完了しなかった場合)、
+同じコマンドを再実行するだけで issue が再び見つかり、残りのステップが
+完了します — 「OPEN issues の中に見つからない」で行き詰まることは
+ありません。既に CLOSED な issue に対する recovery は、GitHub 自身の
+close reason が **not planned**(このコマンドが close 時に使う reason
+そのもの)である場合のみ許可されます — それ以外の reason(例: merge に
+よる completed)で close された issue には一切触れません。
+
+**Domain resolution (G522 boundary)**: queue item のマッチングは
+`(repo, issue number)` の完全一致を要求します — 別 repo の同番号 issue が
+この execution unit にマッチすることはありません。execution unit の
+domain は、他の execution-unit-resolving なサーフェスと同じ順序で解決
+されます: 明示的な `--domain` が優先されます(解決された packet.yaml が
+宣言する domain と矛盾する場合はエラー); それ以外の場合は
+packet-declared な `domain:` フィールドが使われます; どちらも無い場合は
+candidate domains と正確な `--domain` re-invocation を示して fail loud
+します。これは既存の queue item にも、issue タイトルから新規に導出される
+item にも適用されます — misleading な title prefix だけでは、packet.yaml
+(または operator が明示的に指定した `--domain`)による裏付けなしに queue
+を作成することは決してできません。
 
 **冪等**: queue-state エントリが既に `retired` になっている execution
 unit に対して再実行しても安全な no-op です — 冪等性の判断根拠は
-（不安定な GitHub 状態の再チェックではなく）durable state です。packet
-ディレクトリと issue のコメント履歴には一切触れず、削除もしません。
+（不安定な GitHub 状態の再チェックではなく）durable state です。`--write`
+を使った際、queue-state は既に retired だが直前の partial write による
+`runs.jsonl` イベントが欠落している場合、再実行はその欠落したステップ
+だけを(GitHub 呼び出しゼロで)完了させます — 永久に黙って失われることは
+ありません。packet ディレクトリと issue のコメント履歴には一切触れず、
+削除もしません。
 
 retired になった item は自動的に WIP gating から外れます:
 `automation host-review-preflight` の in-flight スキャンは OPEN で

--- a/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -275,18 +276,23 @@ internal static class AutomationIssueRetireCommand
                 + "If it was already fully processed (e.g. merged and closed out), no action is needed.");
             return 1;
         }
-        else if (!HasCanonicalRetireMarker(snapshot.Comments, executionUnit))
+        else if (!HasCanonicalRetireMarker(snapshot.Comments, executionUnit, reason!))
         {
             // Repair: `stateReason == NOT_PLANNED` alone is not durable
             // provenance — an issue closed manually/independently as "not
             // planned" would pass that check too. Require the canonical
             // marker comment this command itself posts alongside its close,
-            // tied to the exact candidate execution unit, before resuming.
+            // anchored to the exact candidate execution unit AND the exact
+            // requested reason, before resuming. A quoted/substring marker,
+            // a unit-prefix collision, or a marker recorded under a
+            // different reason all fail this check.
             writer.WriteLine(
                 $"refusing to retire issue #{issue}: it is CLOSED in {repo} with reason 'not planned', but no "
-                + $"canonical `automation issue-retire` marker comment for '{executionUnit}' was found — this does "
-                + "not look like a partial-failure recovery from a prior run of this command (e.g. a manual or "
-                + "unrelated 'not planned' closure). Refusing with zero GitHub or local mutation.");
+                + $"canonical `automation issue-retire` marker comment for '{executionUnit}' with reason "
+                + $"'{reason}' was found — this does not look like a partial-failure recovery from a prior run of "
+                + "this command with the same reason (e.g. a manual/unrelated 'not planned' closure, a marker for "
+                + "a different unit or reason, or a comment merely quoting the marker text). Refusing with zero "
+                + "GitHub or local mutation.");
             return 1;
         }
 
@@ -595,12 +601,25 @@ internal static class AutomationIssueRetireCommand
         }
     }
 
-    /// <summary>Prefix of the durable-provenance marker embedded in the close comment (see <see cref="HasCanonicalRetireMarker"/>).</summary>
-    private const string RetireMarkerPrefix = "[issue-retire:";
+    // Repair: the marker literals below are the SINGLE source of truth for
+    // both writing (BuildReasonComment) and reading (the compiled regex)
+    // the canonical provenance record, so the two can never drift apart. A
+    // naive substring `Contains` check on the prefix alone would accept a
+    // comment merely quoting the marker, a differently-reasoned marker, or
+    // an unrelated unit whose name happens to share a prefix — the regex is
+    // anchored to the WHOLE trimmed comment body and captures both the exact
+    // unit and reason for an equality check, closing all three gaps.
+    private const string RetireMarkerPrefixLiteral = "[issue-retire:";
+    private const string RetireMarkerMiddleLiteral = "] Retired via canonical `automation issue-retire` transition — reason: ";
+
+    private static readonly Regex CanonicalRetireMarkerPattern = new(
+        "^" + Regex.Escape(RetireMarkerPrefixLiteral) + "(?<unit>[^\\]]+)" + Regex.Escape(RetireMarkerMiddleLiteral)
+        + "(?<reason>" + string.Join("|", AllowedReasons.Select(Regex.Escape)) + @")\.(?: Note: .*)?$",
+        RegexOptions.Singleline);
 
     private static string BuildReasonComment(string executionUnit, string reason, string? note)
     {
-        var comment = $"{RetireMarkerPrefix}{executionUnit}] Retired via canonical `automation issue-retire` transition — reason: {reason}.";
+        var comment = $"{RetireMarkerPrefixLiteral}{executionUnit}{RetireMarkerMiddleLiteral}{reason}.";
         if (!string.IsNullOrWhiteSpace(note))
         {
             comment += $" Note: {note}";
@@ -610,19 +629,29 @@ internal static class AutomationIssueRetireCommand
 
     /// <summary>
     /// Repair: durable provenance that THIS command (not a manual/unrelated
-    /// closure) closed the issue as "not planned" for THIS candidate
-    /// execution unit — required before a CLOSED issue is treated as a
+    /// closure, and not merely a comment quoting the marker) closed the
+    /// issue as "not planned" for THIS candidate execution unit AND THIS
+    /// requested reason — required before a CLOSED issue is treated as a
     /// partial-failure recovery target, since <c>stateReason == NOT_PLANNED</c>
     /// alone is not sufficient authentication.
     /// </summary>
-    private static bool HasCanonicalRetireMarker(IReadOnlyList<string> comments, string executionUnit)
+    private static bool HasCanonicalRetireMarker(IReadOnlyList<string> comments, string executionUnit, string reason)
     {
         if (string.IsNullOrWhiteSpace(executionUnit))
         {
             return false;
         }
-        var marker = $"{RetireMarkerPrefix}{executionUnit}]";
-        return comments.Any(body => !string.IsNullOrEmpty(body) && body.Contains(marker, StringComparison.Ordinal));
+        return comments.Any(body =>
+        {
+            if (string.IsNullOrEmpty(body))
+            {
+                return false;
+            }
+            var match = CanonicalRetireMarkerPattern.Match(body.Trim());
+            return match.Success
+                && string.Equals(match.Groups["unit"].Value, executionUnit, StringComparison.Ordinal)
+                && string.Equals(match.Groups["reason"].Value, reason, StringComparison.Ordinal);
+        });
     }
 
     private static bool TryParseArguments(

--- a/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
@@ -229,6 +229,7 @@ internal static class AutomationIssueRetireCommand
 
         var currentLabels = snapshot.Labels.ToHashSet(StringComparer.Ordinal);
         var issueIsOpen = IsOpen(snapshot.State);
+        var executionUnit = existingItem?.ExecutionUnit ?? ExecutionUnitFromTitle(snapshot.Title);
 
         if (issueIsOpen)
         {
@@ -274,8 +275,21 @@ internal static class AutomationIssueRetireCommand
                 + "If it was already fully processed (e.g. merged and closed out), no action is needed.");
             return 1;
         }
+        else if (!HasCanonicalRetireMarker(snapshot.Comments, executionUnit))
+        {
+            // Repair: `stateReason == NOT_PLANNED` alone is not durable
+            // provenance — an issue closed manually/independently as "not
+            // planned" would pass that check too. Require the canonical
+            // marker comment this command itself posts alongside its close,
+            // tied to the exact candidate execution unit, before resuming.
+            writer.WriteLine(
+                $"refusing to retire issue #{issue}: it is CLOSED in {repo} with reason 'not planned', but no "
+                + $"canonical `automation issue-retire` marker comment for '{executionUnit}' was found — this does "
+                + "not look like a partial-failure recovery from a prior run of this command (e.g. a manual or "
+                + "unrelated 'not planned' closure). Refusing with zero GitHub or local mutation.");
+            return 1;
+        }
 
-        var executionUnit = existingItem?.ExecutionUnit ?? ExecutionUnitFromTitle(snapshot.Title);
         var candidateDomains = DomainCandidateScanner.Scan(context);
         var packetDeclaredDomain = ReadPacketDeclaredDomain(context, executionUnit);
         var noteSuffix = string.IsNullOrWhiteSpace(note) ? string.Empty : $" --note \"{note}\"";
@@ -294,7 +308,7 @@ internal static class AutomationIssueRetireCommand
         var resolvedDomain = domainResolution.Domain!;
 
         var labelsToRemove = KnownIssueWorkflowLabels.Where(currentLabels.Contains).ToArray();
-        var reasonComment = BuildReasonComment(reason!, note);
+        var reasonComment = BuildReasonComment(executionUnit, reason!, note);
 
         var plannedMutations = new List<string>();
         if (issueIsOpen)
@@ -581,14 +595,34 @@ internal static class AutomationIssueRetireCommand
         }
     }
 
-    private static string BuildReasonComment(string reason, string? note)
+    /// <summary>Prefix of the durable-provenance marker embedded in the close comment (see <see cref="HasCanonicalRetireMarker"/>).</summary>
+    private const string RetireMarkerPrefix = "[issue-retire:";
+
+    private static string BuildReasonComment(string executionUnit, string reason, string? note)
     {
-        var comment = $"Retired via canonical `automation issue-retire` transition — reason: {reason}.";
+        var comment = $"{RetireMarkerPrefix}{executionUnit}] Retired via canonical `automation issue-retire` transition — reason: {reason}.";
         if (!string.IsNullOrWhiteSpace(note))
         {
             comment += $" Note: {note}";
         }
         return comment;
+    }
+
+    /// <summary>
+    /// Repair: durable provenance that THIS command (not a manual/unrelated
+    /// closure) closed the issue as "not planned" for THIS candidate
+    /// execution unit — required before a CLOSED issue is treated as a
+    /// partial-failure recovery target, since <c>stateReason == NOT_PLANNED</c>
+    /// alone is not sufficient authentication.
+    /// </summary>
+    private static bool HasCanonicalRetireMarker(IReadOnlyList<string> comments, string executionUnit)
+    {
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            return false;
+        }
+        var marker = $"{RetireMarkerPrefix}{executionUnit}]";
+        return comments.Any(body => !string.IsNullOrEmpty(body) && body.Contains(marker, StringComparison.Ordinal));
     }
 
     private static bool TryParseArguments(
@@ -749,7 +783,7 @@ internal static class AutomationIssueRetireCommand
 /// a comment, and for reading a single issue's CURRENT state regardless of
 /// open/closed — the production implementation shells out to
 /// <c>gh issue close --reason "not planned" --comment &lt;text&gt;</c> /
-/// <c>gh issue view --json state,stateReason,title,url,labels</c>.
+/// <c>gh issue view --json state,stateReason,title,url,labels,comments</c>.
 /// </summary>
 internal interface IGitHubIssueRetirementMutator
 {
@@ -765,9 +799,12 @@ internal interface IGitHubIssueRetirementMutator
 
 /// <summary>
 /// G525 repair: point-in-time snapshot of a single GitHub issue, used to
-/// resolve the retire target and to detect a same-command partial-failure
-/// recovery (<see cref="StateReason"/> == <c>NOT_PLANNED</c> on a CLOSED
-/// issue).
+/// resolve the retire target and to authenticate a same-command
+/// partial-failure recovery — <see cref="StateReason"/> == <c>NOT_PLANNED</c>
+/// on a CLOSED issue is a necessary but NOT sufficient signal (a manual or
+/// unrelated "not planned" closure would also match it); <see cref="Comments"/>
+/// is required in addition to confirm the canonical retire marker this
+/// command itself posts (see <c>HasCanonicalRetireMarker</c>).
 /// </summary>
 internal sealed record IssueSnapshot
 {
@@ -780,6 +817,8 @@ internal sealed record IssueSnapshot
     public required string Url { get; init; }
 
     public required IReadOnlyList<string> Labels { get; init; }
+
+    public required IReadOnlyList<string> Comments { get; init; }
 }
 
 /// <summary>
@@ -808,7 +847,7 @@ internal sealed class GhCliGitHubIssueRetirementMutator : IGitHubIssueRetirement
             "issue", "view",
             issueNumber.ToString(CultureInfo.InvariantCulture),
             "--repo", repo,
-            "--json", "state,stateReason,title,url,labels",
+            "--json", "state,stateReason,title,url,labels,comments",
         };
         var stdout = RunGh(args, $"view issue #{issueNumber} in {repo}");
         return ParseSnapshot(stdout);
@@ -831,6 +870,18 @@ internal sealed class GhCliGitHubIssueRetirementMutator : IGitHubIssueRetirement
             }
         }
 
+        var comments = new List<string>();
+        if (root.TryGetProperty("comments", out var commentsElement) && commentsElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var comment in commentsElement.EnumerateArray())
+            {
+                if (comment.TryGetProperty("body", out var bodyElement) && bodyElement.ValueKind == JsonValueKind.String)
+                {
+                    comments.Add(bodyElement.GetString() ?? string.Empty);
+                }
+            }
+        }
+
         return new IssueSnapshot
         {
             State = root.TryGetProperty("state", out var stateElement) && stateElement.ValueKind == JsonValueKind.String
@@ -846,6 +897,7 @@ internal sealed class GhCliGitHubIssueRetirementMutator : IGitHubIssueRetirement
                 ? urlElement.GetString() ?? string.Empty
                 : string.Empty,
             Labels = labels,
+            Comments = comments,
         };
     }
 

--- a/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
@@ -9,10 +9,11 @@ namespace IntentSystem.Cli.Commands;
 
 /// <summary>
 /// G525: <c>intent-cli automation issue-retire --repo &lt;r&gt; --issue &lt;n&gt;
-/// --reason &lt;superseded|decomposed|obsolete&gt; [--note &lt;text&gt;]
-/// [--write]</c> — the canonical, atomic transition that supersedes a
-/// published <c>intent-target</c> issue that can never be started as
-/// authored (e.g. a research pass proves the slice must be decomposed).
+/// --reason &lt;superseded|decomposed|obsolete&gt; [--note &lt;text&gt;] [--domain
+/// &lt;name&gt;] [--write]</c> — the canonical, atomic transition that
+/// supersedes a published <c>intent-target</c> issue that can never be
+/// started as authored (e.g. a research pass proves the slice must be
+/// decomposed).
 ///
 /// <c>--write</c> performs, in order:
 /// <list type="number">
@@ -30,10 +31,33 @@ namespace IntentSystem.Cli.Commands;
 ///
 /// Without <c>--write</c> it is a dry-run that lists the exact planned
 /// mutations. Fails closed (no mutation) when the issue has an open linked
-/// PR or an active claim (<c>intent-issue-in-progress</c>), naming the
-/// release step to run first. Idempotent: re-running on an already-retired
-/// execution unit (queue-state already shows <see cref="QueueItemState.Retired"/>)
-/// is a safe no-op. Never deletes packet files.
+/// PR, an active claim (<c>intent-issue-in-progress</c>), or a matched queue
+/// item that is already <see cref="QueueItemState.Completed"/> (merged/
+/// finished work is out of scope for retirement). Idempotent: re-running on
+/// an already-retired execution unit is a safe no-op that also finishes any
+/// missing <c>runs.jsonl</c> event from a prior partial write. Never deletes
+/// packet files.
+///
+/// Partial-failure recovery (review repair): the target issue is resolved
+/// via a direct <c>gh issue view</c> snapshot — regardless of open/closed
+/// state — instead of scanning the OPEN-issues list. This means a retry
+/// after a mid-sequence failure (close succeeded but label removal or the
+/// durable-state write did not) can still find the issue and finish the
+/// remaining steps: the issue no longer needs to be OPEN for the retry to
+/// converge. Recovery for an already-CLOSED issue is only authorized when
+/// GitHub's own <c>stateReason</c> is <c>NOT_PLANNED</c> (the exact reason
+/// this command uses to close) — a closed issue with any other reason (e.g.
+/// completed via merge) is left untouched.
+///
+/// Domain/repo isolation (G522 boundary): queue-item matching requires an
+/// EXACT <c>(repo, issue number)</c> pair — a same-numbered issue in a
+/// different repo can never match. The execution unit's domain is resolved
+/// via <see cref="PacketDomainResolution"/> (explicit <c>--domain</c> &gt;
+/// packet-declared <c>domain:</c> &gt; fail loud with candidate domains and
+/// an exact <c>--domain</c> re-invocation) for BOTH an existing queue item
+/// and a brand-new one derived from the issue title — a misleading title
+/// prefix alone can never authorize queue creation without a packet.yaml
+/// (or an explicit operator-supplied <c>--domain</c>) confirming it.
 /// </summary>
 internal static class AutomationIssueRetireCommand
 {
@@ -45,6 +69,9 @@ internal static class AutomationIssueRetireCommand
     public const string ReasonObsolete = "obsolete";
 
     private static readonly string[] AllowedReasons = { ReasonSuperseded, ReasonDecomposed, ReasonObsolete };
+
+    /// <summary>GitHub's own reason for a CLOSED issue that this command uses when closing.</summary>
+    private const string StateReasonNotPlanned = "NOT_PLANNED";
 
     /// <summary>Issue-side workflow labels this command may remove.</summary>
     private static readonly string[] KnownIssueWorkflowLabels =
@@ -71,7 +98,7 @@ internal static class AutomationIssueRetireCommand
     };
 
     private const string UsageLine =
-        "Usage: intent-cli automation issue-retire --repo <owner/repo> --issue <n> --reason <superseded|decomposed|obsolete> [--note <text>] [--write] [--format json|markdown]";
+        "Usage: intent-cli automation issue-retire --repo <owner/repo> --issue <n> --reason <superseded|decomposed|obsolete> [--note <text>] [--domain <name>] [--write] [--format json|markdown]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -85,7 +112,7 @@ internal static class AutomationIssueRetireCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var repo, out var issue, out var reason, out var note, out var write, out var format, out var error))
+        if (!TryParseArguments(args, out var repo, out var issue, out var reason, out var note, out var domain, out var write, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -107,94 +134,184 @@ internal static class AutomationIssueRetireCommand
             }
         }
 
-        var existingItem = queueState?.Items.FirstOrDefault(item => MatchesLinkedIssue(item.LinkedIssue, issue!.Value));
+        var existingItem = queueState?.Items.FirstOrDefault(item => MatchesLinkedIssue(item.LinkedIssue, repo!, issue!.Value));
+
+        // Out of scope: retiring merged/completed work. Refuse before any
+        // GitHub call — zero GitHub or local mutation for this refusal.
+        if (existingItem is { State: QueueItemState.Completed })
+        {
+            writer.WriteLine(
+                $"refusing to retire issue #{issue}: queue item '{existingItem.ExecutionUnit}' is already "
+                + $"{QueueItemState.Completed} (merged/finished work) — `automation issue-retire` only applies to "
+                + "work that was published but can never be completed as authored. No GitHub or local state was "
+                + "touched.");
+            return 1;
+        }
 
         // Idempotency: durable state is the source of truth. If this
-        // execution unit is already retired, this is a safe no-op —
-        // never re-attempt the GitHub mutation (the issue is presumably
-        // already closed) and never error.
+        // execution unit is already retired, never re-attempt the GitHub
+        // mutation (the issue is presumably already closed). A dry-run
+        // always reports the no-op without touching anything; --write also
+        // finishes a missing runs.jsonl event left over from a prior
+        // partial write (queue-state persisted, but the audit-trail append
+        // that follows it did not) instead of silently dropping it forever.
         if (existingItem is { State: QueueItemState.Retired })
         {
-            var alreadyRetired = new AutomationIssueRetireResult
+            if (!write || RunsLogHasRetireEvent(context, existingItem.ExecutionUnit))
+            {
+                var alreadyRetired = new AutomationIssueRetireResult
+                {
+                    Repo = repo!,
+                    Issue = issue!.Value,
+                    Reason = reason!,
+                    Note = note,
+                    Domain = null,
+                    Mode = write ? "write" : "dry-run",
+                    Applied = false,
+                    AlreadyRetired = true,
+                    ExecutionUnit = existingItem.ExecutionUnit,
+                    PlannedMutations = Array.Empty<string>(),
+                    RefusalReason = null,
+                    Summary = $"'{existingItem.ExecutionUnit}' is already retired ({existingItem.RetirementReason}); no-op.",
+                };
+                EmitResult(writer, format, alreadyRetired);
+                return 0;
+            }
+
+            try
+            {
+                AppendRetireRunEvent(
+                    context,
+                    existingItem.ExecutionUnit,
+                    repo!,
+                    issue!.Value,
+                    existingItem.RetirementReason ?? reason!,
+                    (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime());
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException or UnauthorizedAccessException)
+            {
+                writer.WriteLine(
+                    $"'{existingItem.ExecutionUnit}' is already retired in queue-state, but appending the "
+                    + $"runs.jsonl event failed: {exception.Message}. Re-run `automation issue-retire --write` to retry.");
+                return 1;
+            }
+
+            var recovered = new AutomationIssueRetireResult
             {
                 Repo = repo!,
                 Issue = issue!.Value,
                 Reason = reason!,
                 Note = note,
-                Mode = write ? "write" : "dry-run",
-                Applied = false,
+                Domain = null,
+                Mode = "write",
+                Applied = true,
                 AlreadyRetired = true,
                 ExecutionUnit = existingItem.ExecutionUnit,
-                PlannedMutations = Array.Empty<string>(),
+                PlannedMutations = new[] { $"append missing `{RetireRunEventName}` event to runs.jsonl for '{existingItem.ExecutionUnit}'" },
                 RefusalReason = null,
-                Summary = $"'{existingItem.ExecutionUnit}' is already retired ({existingItem.RetirementReason}); no-op.",
+                Summary = $"'{existingItem.ExecutionUnit}' was already retired; completed a missing runs.jsonl event from a prior partial write.",
             };
-            EmitResult(writer, format, alreadyRetired);
+            EmitResult(writer, format, recovered);
             return 0;
         }
 
-        IGitHubAutomationCandidateLister lister;
-        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues;
-        IReadOnlyList<GitHubAutomationPrCandidate> openPrs;
+        IGitHubIssueRetirementMutator retirementMutator = RetirementMutatorFactory?.Invoke() ?? new GhCliGitHubIssueRetirementMutator();
+        IssueSnapshot snapshot;
         try
         {
-            lister = CandidateListerFactory?.Invoke() ?? new GhCliGitHubAutomationCandidateLister();
-            openIssues = lister.ListIssues(repo!, Array.Empty<string>());
-            openPrs = lister.ListPullRequests(repo!, Array.Empty<string>());
+            snapshot = retirementMutator.GetSnapshot(repo!, issue!.Value);
         }
         catch (Exception exception) when (exception is IOException or InvalidOperationException)
         {
-            writer.WriteLine($"failed to read GitHub state for {repo}: {exception.Message}");
+            writer.WriteLine($"issue #{issue} not found in {repo}, or GitHub could not be reached: {exception.Message}");
             return 1;
         }
 
-        var targetIssue = openIssues.FirstOrDefault(candidate => candidate.Number == issue!.Value);
-        if (targetIssue is null)
+        var currentLabels = snapshot.Labels.ToHashSet(StringComparer.Ordinal);
+        var issueIsOpen = IsOpen(snapshot.State);
+
+        if (issueIsOpen)
+        {
+            var lister = CandidateListerFactory?.Invoke() ?? new GhCliGitHubAutomationCandidateLister();
+            IReadOnlyList<GitHubAutomationPrCandidate> openPrs;
+            try
+            {
+                openPrs = lister.ListPullRequests(repo!, Array.Empty<string>());
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                writer.WriteLine($"failed to read GitHub state for {repo}: {exception.Message}");
+                return 1;
+            }
+
+            var openClosingPr = openPrs.FirstOrDefault(pr => IsOpen(pr.State) && HasClosingReference(pr, issue!.Value, repo!));
+            if (openClosingPr is not null)
+            {
+                writer.WriteLine(
+                    $"refusing to retire issue #{issue}: OPEN PR #{openClosingPr.Number} in {repo} closes it — work is in "
+                    + $"flight. Merge, close, or release PR #{openClosingPr.Number} first (e.g. `intent-cli automation "
+                    + "pr-transition` / `closeout pr` / `gh pr close`), then retry.");
+                return 1;
+            }
+
+            if (currentLabels.Contains(WorkerNextActionConstants.Labels.IntentIssueInProgress))
+            {
+                writer.WriteLine(
+                    $"refusing to retire issue #{issue}: it carries `{WorkerNextActionConstants.Labels.IntentIssueInProgress}` "
+                    + "— an active claim is in flight. Release the claim first (e.g. `intent-cli worker complete --kind "
+                    + "issue --number "
+                    + issue
+                    + " --outcome declined-contract-incomplete --write`), then retry.");
+                return 1;
+            }
+        }
+        else if (!string.Equals(snapshot.StateReason, StateReasonNotPlanned, StringComparison.OrdinalIgnoreCase))
         {
             writer.WriteLine(
-                $"issue #{issue} not found among OPEN issues in {repo}; either it does not exist, or it is already "
-                + "closed for a reason other than `automation issue-retire`. This command only retires OPEN "
-                + "issues that still carry workflow labels.");
+                $"refusing to retire issue #{issue}: it is CLOSED in {repo} with reason "
+                + $"'{(string.IsNullOrWhiteSpace(snapshot.StateReason) ? "(unknown)" : snapshot.StateReason)}', not "
+                + "'not planned' — this does not look like an `automation issue-retire` partial-failure recovery. "
+                + "If it was already fully processed (e.g. merged and closed out), no action is needed.");
             return 1;
         }
 
-        var openClosingPr = openPrs.FirstOrDefault(pr => IsOpen(pr.State) && HasClosingReference(pr, issue!.Value, repo!));
-        if (openClosingPr is not null)
+        var executionUnit = existingItem?.ExecutionUnit ?? ExecutionUnitFromTitle(snapshot.Title);
+        var candidateDomains = DomainCandidateScanner.Scan(context);
+        var packetDeclaredDomain = ReadPacketDeclaredDomain(context, executionUnit);
+        var noteSuffix = string.IsNullOrWhiteSpace(note) ? string.Empty : $" --note \"{note}\"";
+        var domainResolution = PacketDomainResolution.Resolve(
+            domain,
+            packetDeclaredDomain,
+            candidateDomains,
+            $"intent-cli automation issue-retire --repo {repo} --issue {issue} --reason {reason} --domain <name>{noteSuffix} --write");
+        if (domainResolution.IsError)
         {
             writer.WriteLine(
-                $"refusing to retire issue #{issue}: OPEN PR #{openClosingPr.Number} in {repo} closes it — work is in "
-                + $"flight. Merge, close, or release PR #{openClosingPr.Number} first (e.g. `intent-cli automation "
-                + "pr-transition` / `closeout pr` / `gh pr close`), then retry.");
+                $"refusing to retire issue #{issue}: {domainResolution.ErrorMessage} A misleading title prefix "
+                + "alone is never sufficient to create or mutate a queue entry.");
             return 1;
         }
+        var resolvedDomain = domainResolution.Domain!;
 
-        var currentLabels = targetIssue.Labels.Select(label => label.Name).ToHashSet(StringComparer.Ordinal);
-        if (currentLabels.Contains(WorkerNextActionConstants.Labels.IntentIssueInProgress))
-        {
-            writer.WriteLine(
-                $"refusing to retire issue #{issue}: it carries `{WorkerNextActionConstants.Labels.IntentIssueInProgress}` "
-                + "— an active claim is in flight. Release the claim first (e.g. `intent-cli worker complete --kind "
-                + "issue --number "
-                + issue
-                + " --outcome declined-contract-incomplete --write`), then retry.");
-            return 1;
-        }
-
-        var executionUnit = existingItem?.ExecutionUnit ?? ExecutionUnitFromTitle(targetIssue.Title);
         var labelsToRemove = KnownIssueWorkflowLabels.Where(currentLabels.Contains).ToArray();
         var reasonComment = BuildReasonComment(reason!, note);
 
-        var plannedMutations = new List<string>
+        var plannedMutations = new List<string>();
+        if (issueIsOpen)
         {
-            $"gh issue close #{issue} --repo {repo} --reason \"not planned\" --comment <reason comment>",
-        };
+            plannedMutations.Add($"gh issue close #{issue} --repo {repo} --reason \"not planned\" --comment <reason comment>");
+        }
+        else
+        {
+            plannedMutations.Add($"issue #{issue} already CLOSED (not planned) — resuming a partial prior --write");
+        }
         if (labelsToRemove.Length > 0)
         {
             plannedMutations.Add($"remove label(s) from issue #{issue}: {string.Join(", ", labelsToRemove)}");
         }
         plannedMutations.Add(
             existingItem is null
-                ? $"create queue-state entry for '{executionUnit}' with state=retired, reason={reason}"
+                ? $"create queue-state entry for '{executionUnit}' (domain: {resolvedDomain}) with state=retired, reason={reason}"
                 : $"update queue-state entry for '{executionUnit}': state=retired, reason={reason}");
         plannedMutations.Add($"append `{RetireRunEventName}` event to runs.jsonl for '{executionUnit}'");
 
@@ -206,6 +323,7 @@ internal static class AutomationIssueRetireCommand
                 Issue = issue!.Value,
                 Reason = reason!,
                 Note = note,
+                Domain = resolvedDomain,
                 Mode = "dry-run",
                 Applied = false,
                 AlreadyRetired = false,
@@ -218,34 +336,47 @@ internal static class AutomationIssueRetireCommand
             return 0;
         }
 
-        // --write: GitHub mutation first (close + label removal), then the
-        // durable-state mutation (queue-state + runs.jsonl). If the GitHub
-        // step fails, nothing durable changed — safe to retry as-is. If the
-        // durable-state step fails AFTER the GitHub step succeeded, the
-        // issue is already closed; retrying is still safe because the
-        // command is idempotent once queue-state reflects `retired` (and
-        // harmless to re-run before then, since the GitHub calls are
-        // themselves idempotent — closing an already-closed issue / removing
-        // an already-absent label is a no-op from gh's perspective).
-        try
+        // --write: GitHub mutation first (close, then labels), then the
+        // durable-state mutation (queue-state, then runs.jsonl). Each stage
+        // is isolated in its own try/catch so a mid-sequence failure yields
+        // an accurate, actionable recovery hint instead of a blanket "no
+        // durable state changed" claim that would be false once the issue
+        // is already closed. Every stage is safe to re-run: closing is
+        // skipped once the issue is already CLOSED (checked above via the
+        // snapshot), label removal only targets labels still present, and
+        // the queue-state upsert is idempotent by construction.
+        if (issueIsOpen)
         {
-            var retirementMutator = RetirementMutatorFactory?.Invoke() ?? new GhCliGitHubIssueRetirementMutator();
-            retirementMutator.CloseAsNotPlanned(repo!, issue!.Value, reasonComment);
+            try
+            {
+                retirementMutator.CloseAsNotPlanned(repo!, issue!.Value, reasonComment);
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                writer.WriteLine(
+                    $"failed to close issue #{issue} in {repo}: {exception.Message}. No durable state was "
+                    + "changed — re-run with --write to retry.");
+                return 1;
+            }
+        }
 
-            if (labelsToRemove.Length > 0)
+        if (labelsToRemove.Length > 0)
+        {
+            try
             {
                 var labelMutator = LabelMutatorFactory?.Invoke() ?? new GhCliGitHubLabelMutator();
                 labelMutator.ApplyLabelTransitions(
                     repo!, GhCliGitHubLabelMutator.Kinds.Issue, issue!.Value,
                     Array.Empty<string>(), labelsToRemove);
             }
-        }
-        catch (Exception exception) when (exception is IOException or InvalidOperationException)
-        {
-            writer.WriteLine(
-                $"failed to close/relabel issue #{issue} in {repo}: {exception.Message}. No durable state was "
-                + "changed — re-run with --write to retry.");
-            return 1;
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                writer.WriteLine(
+                    $"issue #{issue} in {repo} is closed (reason: not planned), but label removal failed: "
+                    + $"{exception.Message}. Re-run `automation issue-retire --write` — the issue is already "
+                    + "closed, so the retry will resume from label removal without re-closing it.");
+                return 1;
+            }
         }
 
         var now = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
@@ -270,7 +401,7 @@ internal static class AutomationIssueRetireCommand
                 updatedItems.Add(new QueueItem
                 {
                     ExecutionUnit = executionUnit,
-                    Title = targetIssue.Title,
+                    Title = snapshot.Title,
                     State = QueueItemState.Retired,
                     Dependencies = Array.Empty<string>(),
                     BlockedBy = Array.Empty<string>(),
@@ -281,7 +412,7 @@ internal static class AutomationIssueRetireCommand
                         Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
                         ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
                     },
-                    LinkedIssue = new LinkedIssue { Repo = repo!, Number = issue, Url = targetIssue.Url },
+                    LinkedIssue = new LinkedIssue { Repo = repo!, Number = issue, Url = snapshot.Url },
                     LinkedPr = null,
                     WorkerRole = CliRuntimeContracts.DefaultImplementRole,
                     ReviewRole = CliRuntimeContracts.DefaultReviewRole,
@@ -297,15 +428,27 @@ internal static class AutomationIssueRetireCommand
                 Items = updatedItems,
             };
             File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
-
-            AppendRetireRunEvent(context, executionUnit, repo!, issue!.Value, retirementReason, now);
         }
-        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException or UnauthorizedAccessException)
         {
             writer.WriteLine(
-                $"issue #{issue} in {repo} was closed and relabeled, but the queue-state/runs.jsonl update failed: "
-                + $"{exception.Message}. Re-run `automation issue-retire` with --write (idempotent) to retry the "
-                + "durable-state update.");
+                $"issue #{issue} in {repo} is closed and relabeled, but the queue-state update failed: "
+                + $"{exception.Message}. Re-run `automation issue-retire --write` (idempotent) to retry the "
+                + "queue-state and runs.jsonl update.");
+            return 1;
+        }
+
+        try
+        {
+            AppendRetireRunEvent(context, executionUnit, repo!, issue!.Value, retirementReason, now);
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException or UnauthorizedAccessException)
+        {
+            writer.WriteLine(
+                $"issue #{issue} in {repo} is closed, relabeled, and queue-state now shows it retired, but "
+                + $"appending the runs.jsonl event failed: {exception.Message}. Re-run `automation issue-retire "
+                + "--write` (idempotent) — it will detect the queue-state is already retired and finish only "
+                + "the missing runs.jsonl event.");
             return 1;
         }
 
@@ -315,6 +458,7 @@ internal static class AutomationIssueRetireCommand
             Issue = issue!.Value,
             Reason = reason!,
             Note = note,
+            Domain = resolvedDomain,
             Mode = "write",
             Applied = true,
             AlreadyRetired = false,
@@ -343,8 +487,36 @@ internal static class AutomationIssueRetireCommand
         File.AppendAllText(runsPath, RunLogSerializer.SerializeLine(runEvent) + "\n");
     }
 
-    private static bool MatchesLinkedIssue(LinkedIssue? linkedIssue, int issueNumber) =>
-        linkedIssue is { Number: { } number } && number == issueNumber;
+    private static bool RunsLogHasRetireEvent(CliContext context, string executionUnit)
+    {
+        var runsPath = context.GetRunLogPath();
+        if (!File.Exists(runsPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var events = RunLogSerializer.DeserializeAll(File.ReadAllText(runsPath));
+            return events.Any(runEvent =>
+                string.Equals(runEvent.Event, RetireRunEventName, StringComparison.Ordinal)
+                && string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+        }
+        catch (Exception exception) when (exception is JsonException or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// G522 repair: exact <c>(repo, issue number)</c> match — a same-numbered
+    /// issue in a different repo (a multi-repo host queue-state.json) must
+    /// never match this execution unit.
+    /// </summary>
+    private static bool MatchesLinkedIssue(LinkedIssue? linkedIssue, string repo, int issueNumber) =>
+        linkedIssue is { Number: { } number } linked
+        && number == issueNumber
+        && string.Equals(linked.Repo, repo, StringComparison.OrdinalIgnoreCase);
 
     private static bool IsOpen(string state) =>
         string.IsNullOrEmpty(state) || string.Equals(state, "OPEN", StringComparison.OrdinalIgnoreCase);
@@ -370,6 +542,13 @@ internal static class AutomationIssueRetireCommand
         return false;
     }
 
+    /// <summary>
+    /// Derives a CANDIDATE execution unit from the issue title. Used ONLY to
+    /// locate <c>.intent-cli/issues/&lt;unit&gt;/packet.yaml</c> for domain
+    /// confirmation via <see cref="PacketDomainResolution"/> — never trusted
+    /// on its own to authorize queue creation (see the domain resolution
+    /// call in <see cref="Execute"/>).
+    /// </summary>
     private static string ExecutionUnitFromTitle(string title)
     {
         if (string.IsNullOrWhiteSpace(title))
@@ -378,6 +557,28 @@ internal static class AutomationIssueRetireCommand
         }
         var colonIndex = title.IndexOf(':');
         return (colonIndex > 0 ? title[..colonIndex] : title).Trim();
+    }
+
+    private static string? ReadPacketDeclaredDomain(CliContext context, string executionUnit)
+    {
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            return null;
+        }
+        var packetYamlPath = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit, "packet.yaml");
+        if (!File.Exists(packetYamlPath))
+        {
+            return null;
+        }
+        try
+        {
+            PreparedPacketYamlScalarParser.Parse(File.ReadAllText(packetYamlPath)).TryGetValue("domain", out var declaredDomain);
+            return declaredDomain;
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
     }
 
     private static string BuildReasonComment(string reason, string? note)
@@ -396,6 +597,7 @@ internal static class AutomationIssueRetireCommand
         out int? issue,
         out string? reason,
         out string? note,
+        out string? domain,
         out bool write,
         out string format,
         out string error)
@@ -404,6 +606,7 @@ internal static class AutomationIssueRetireCommand
         issue = null;
         reason = null;
         note = null;
+        domain = null;
         write = false;
         format = FormatMarkdown;
         error = string.Empty;
@@ -452,6 +655,14 @@ internal static class AutomationIssueRetireCommand
                         return false;
                     }
                     note = args[++index];
+                    break;
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value.";
+                        return false;
+                    }
+                    domain = args[++index].Trim();
                     break;
                 case "--write":
                     write = true;
@@ -507,6 +718,10 @@ internal static class AutomationIssueRetireCommand
             writer.WriteLine($"# automation issue-retire — `{result.Repo}` #{result.Issue} ({result.Mode})");
             writer.WriteLine();
             writer.WriteLine($"- execution_unit: `{result.ExecutionUnit}`");
+            if (!string.IsNullOrWhiteSpace(result.Domain))
+            {
+                writer.WriteLine($"- domain: {result.Domain}");
+            }
             writer.WriteLine($"- reason: {result.Reason}");
             if (!string.IsNullOrWhiteSpace(result.Note))
             {
@@ -531,16 +746,45 @@ internal static class AutomationIssueRetireCommand
 
 /// <summary>
 /// G525: testability seam for closing a GitHub issue as "not planned" with
-/// a comment — the production implementation shells out to
-/// <c>gh issue close --reason "not planned" --comment &lt;text&gt;</c>.
+/// a comment, and for reading a single issue's CURRENT state regardless of
+/// open/closed — the production implementation shells out to
+/// <c>gh issue close --reason "not planned" --comment &lt;text&gt;</c> /
+/// <c>gh issue view --json state,stateReason,title,url,labels</c>.
 /// </summary>
 internal interface IGitHubIssueRetirementMutator
 {
     void CloseAsNotPlanned(string repo, int issueNumber, string comment);
+
+    /// <summary>
+    /// Repair: fetches the issue regardless of open/closed state, so a
+    /// retry after a partial <c>--write</c> failure (issue already closed)
+    /// can still locate it instead of dead-ending on an OPEN-only scan.
+    /// </summary>
+    IssueSnapshot GetSnapshot(string repo, int issueNumber);
 }
 
 /// <summary>
-/// G525: default retirement mutator backed by <c>gh issue close</c>.
+/// G525 repair: point-in-time snapshot of a single GitHub issue, used to
+/// resolve the retire target and to detect a same-command partial-failure
+/// recovery (<see cref="StateReason"/> == <c>NOT_PLANNED</c> on a CLOSED
+/// issue).
+/// </summary>
+internal sealed record IssueSnapshot
+{
+    public required string State { get; init; }
+
+    public required string StateReason { get; init; }
+
+    public required string Title { get; init; }
+
+    public required string Url { get; init; }
+
+    public required IReadOnlyList<string> Labels { get; init; }
+}
+
+/// <summary>
+/// G525: default retirement mutator backed by <c>gh issue close</c> /
+/// <c>gh issue view</c>.
 /// </summary>
 internal sealed class GhCliGitHubIssueRetirementMutator : IGitHubIssueRetirementMutator
 {
@@ -554,10 +798,58 @@ internal sealed class GhCliGitHubIssueRetirementMutator : IGitHubIssueRetirement
             "--reason", "not planned",
             "--comment", comment,
         };
-        RunGh(args, $"close issue #{issueNumber} in {repo} as not planned");
+        RunGh(args, $"close issue #{issueNumber} in {repo}");
     }
 
-    private static void RunGh(IReadOnlyList<string> arguments, string description)
+    public IssueSnapshot GetSnapshot(string repo, int issueNumber)
+    {
+        var args = new List<string>
+        {
+            "issue", "view",
+            issueNumber.ToString(CultureInfo.InvariantCulture),
+            "--repo", repo,
+            "--json", "state,stateReason,title,url,labels",
+        };
+        var stdout = RunGh(args, $"view issue #{issueNumber} in {repo}");
+        return ParseSnapshot(stdout);
+    }
+
+    private static IssueSnapshot ParseSnapshot(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        var labels = new List<string>();
+        if (root.TryGetProperty("labels", out var labelsElement) && labelsElement.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var label in labelsElement.EnumerateArray())
+            {
+                if (label.TryGetProperty("name", out var nameElement) && nameElement.ValueKind == JsonValueKind.String)
+                {
+                    labels.Add(nameElement.GetString() ?? string.Empty);
+                }
+            }
+        }
+
+        return new IssueSnapshot
+        {
+            State = root.TryGetProperty("state", out var stateElement) && stateElement.ValueKind == JsonValueKind.String
+                ? stateElement.GetString() ?? string.Empty
+                : string.Empty,
+            StateReason = root.TryGetProperty("stateReason", out var stateReasonElement) && stateReasonElement.ValueKind == JsonValueKind.String
+                ? stateReasonElement.GetString() ?? string.Empty
+                : string.Empty,
+            Title = root.TryGetProperty("title", out var titleElement) && titleElement.ValueKind == JsonValueKind.String
+                ? titleElement.GetString() ?? string.Empty
+                : string.Empty,
+            Url = root.TryGetProperty("url", out var urlElement) && urlElement.ValueKind == JsonValueKind.String
+                ? urlElement.GetString() ?? string.Empty
+                : string.Empty,
+            Labels = labels,
+        };
+    }
+
+    private static string RunGh(IReadOnlyList<string> arguments, string description)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -602,6 +894,8 @@ internal sealed class GhCliGitHubIssueRetirementMutator : IGitHubIssueRetirement
                 $"[{classification}] `gh` failed to {description} with exit {exitCode}: "
                 + GitHubCliJsonBoundary.SanitizePreview(errorBody));
         }
+
+        return stdout;
     }
 }
 
@@ -618,6 +912,14 @@ internal sealed record AutomationIssueRetireResult
 
     [JsonPropertyName("note")]
     public string? Note { get; init; }
+
+    /// <summary>
+    /// G522 repair: the resolved domain (explicit <c>--domain</c> or
+    /// packet-declared) this retirement was authorized under. Null for the
+    /// already-retired no-op paths, which never re-resolve it.
+    /// </summary>
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
 
     [JsonPropertyName("mode")]
     public required string Mode { get; init; }

--- a/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
@@ -1,0 +1,642 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G525: <c>intent-cli automation issue-retire --repo &lt;r&gt; --issue &lt;n&gt;
+/// --reason &lt;superseded|decomposed|obsolete&gt; [--note &lt;text&gt;]
+/// [--write]</c> — the canonical, atomic transition that supersedes a
+/// published <c>intent-target</c> issue that can never be started as
+/// authored (e.g. a research pass proves the slice must be decomposed).
+///
+/// <c>--write</c> performs, in order:
+/// <list type="number">
+/// <item>closes the GitHub issue as "not planned" with a comment carrying
+///   the reason, the optional note, and a canonical-transition marker;</item>
+/// <item>removes <c>intent-target</c> and any other workflow labels
+///   present on the issue;</item>
+/// <item>marks the corresponding queue-state item's lifecycle
+///   <see cref="QueueItemState.Retired"/> (creating the entry if none
+///   existed yet — a published-but-never-delegated issue commonly has no
+///   queue-state entry at all) so <c>metadata validate</c> never reports a
+///   missing entry for a legitimately retired unit;</item>
+/// <item>appends a <c>packet-retired</c> event to <c>runs.jsonl</c>.</item>
+/// </list>
+///
+/// Without <c>--write</c> it is a dry-run that lists the exact planned
+/// mutations. Fails closed (no mutation) when the issue has an open linked
+/// PR or an active claim (<c>intent-issue-in-progress</c>), naming the
+/// release step to run first. Idempotent: re-running on an already-retired
+/// execution unit (queue-state already shows <see cref="QueueItemState.Retired"/>)
+/// is a safe no-op. Never deletes packet files.
+/// </summary>
+internal static class AutomationIssueRetireCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    public const string ReasonSuperseded = "superseded";
+    public const string ReasonDecomposed = "decomposed";
+    public const string ReasonObsolete = "obsolete";
+
+    private static readonly string[] AllowedReasons = { ReasonSuperseded, ReasonDecomposed, ReasonObsolete };
+
+    /// <summary>Issue-side workflow labels this command may remove.</summary>
+    private static readonly string[] KnownIssueWorkflowLabels =
+    {
+        WorkerNextActionConstants.Labels.IntentTarget,
+        WorkerNextActionConstants.Labels.IntentIssueInProgress,
+        WorkerNextActionConstants.Labels.IntentPrCreated,
+    };
+
+    public const string RetireRunEventName = "packet-retired";
+
+    public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
+
+    public static Func<IGitHubLabelMutator>? LabelMutatorFactory { get; set; }
+
+    public static Func<IGitHubIssueRetirementMutator>? RetirementMutatorFactory { get; set; }
+
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    private const string UsageLine =
+        "Usage: intent-cli automation issue-retire --repo <owner/repo> --issue <n> --reason <superseded|decomposed|obsolete> [--note <text>] [--write] [--format json|markdown]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(UsageLine);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var repo, out var issue, out var reason, out var note, out var write, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var queueStatePath = context.GetQueueStatePath();
+        QueueState? queueState = null;
+        if (File.Exists(queueStatePath))
+        {
+            try
+            {
+                queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            }
+            catch (Exception exception) when (exception is JsonException or InvalidOperationException)
+            {
+                writer.WriteLine($"queue-state.json at '{queueStatePath}' could not be parsed: {exception.Message}");
+                return 1;
+            }
+        }
+
+        var existingItem = queueState?.Items.FirstOrDefault(item => MatchesLinkedIssue(item.LinkedIssue, issue!.Value));
+
+        // Idempotency: durable state is the source of truth. If this
+        // execution unit is already retired, this is a safe no-op —
+        // never re-attempt the GitHub mutation (the issue is presumably
+        // already closed) and never error.
+        if (existingItem is { State: QueueItemState.Retired })
+        {
+            var alreadyRetired = new AutomationIssueRetireResult
+            {
+                Repo = repo!,
+                Issue = issue!.Value,
+                Reason = reason!,
+                Note = note,
+                Mode = write ? "write" : "dry-run",
+                Applied = false,
+                AlreadyRetired = true,
+                ExecutionUnit = existingItem.ExecutionUnit,
+                PlannedMutations = Array.Empty<string>(),
+                RefusalReason = null,
+                Summary = $"'{existingItem.ExecutionUnit}' is already retired ({existingItem.RetirementReason}); no-op.",
+            };
+            EmitResult(writer, format, alreadyRetired);
+            return 0;
+        }
+
+        IGitHubAutomationCandidateLister lister;
+        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues;
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs;
+        try
+        {
+            lister = CandidateListerFactory?.Invoke() ?? new GhCliGitHubAutomationCandidateLister();
+            openIssues = lister.ListIssues(repo!, Array.Empty<string>());
+            openPrs = lister.ListPullRequests(repo!, Array.Empty<string>());
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException)
+        {
+            writer.WriteLine($"failed to read GitHub state for {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var targetIssue = openIssues.FirstOrDefault(candidate => candidate.Number == issue!.Value);
+        if (targetIssue is null)
+        {
+            writer.WriteLine(
+                $"issue #{issue} not found among OPEN issues in {repo}; either it does not exist, or it is already "
+                + "closed for a reason other than `automation issue-retire`. This command only retires OPEN "
+                + "issues that still carry workflow labels.");
+            return 1;
+        }
+
+        var openClosingPr = openPrs.FirstOrDefault(pr => IsOpen(pr.State) && HasClosingReference(pr, issue!.Value, repo!));
+        if (openClosingPr is not null)
+        {
+            writer.WriteLine(
+                $"refusing to retire issue #{issue}: OPEN PR #{openClosingPr.Number} in {repo} closes it — work is in "
+                + $"flight. Merge, close, or release PR #{openClosingPr.Number} first (e.g. `intent-cli automation "
+                + "pr-transition` / `closeout pr` / `gh pr close`), then retry.");
+            return 1;
+        }
+
+        var currentLabels = targetIssue.Labels.Select(label => label.Name).ToHashSet(StringComparer.Ordinal);
+        if (currentLabels.Contains(WorkerNextActionConstants.Labels.IntentIssueInProgress))
+        {
+            writer.WriteLine(
+                $"refusing to retire issue #{issue}: it carries `{WorkerNextActionConstants.Labels.IntentIssueInProgress}` "
+                + "— an active claim is in flight. Release the claim first (e.g. `intent-cli worker complete --kind "
+                + "issue --number "
+                + issue
+                + " --outcome declined-contract-incomplete --write`), then retry.");
+            return 1;
+        }
+
+        var executionUnit = existingItem?.ExecutionUnit ?? ExecutionUnitFromTitle(targetIssue.Title);
+        var labelsToRemove = KnownIssueWorkflowLabels.Where(currentLabels.Contains).ToArray();
+        var reasonComment = BuildReasonComment(reason!, note);
+
+        var plannedMutations = new List<string>
+        {
+            $"gh issue close #{issue} --repo {repo} --reason \"not planned\" --comment <reason comment>",
+        };
+        if (labelsToRemove.Length > 0)
+        {
+            plannedMutations.Add($"remove label(s) from issue #{issue}: {string.Join(", ", labelsToRemove)}");
+        }
+        plannedMutations.Add(
+            existingItem is null
+                ? $"create queue-state entry for '{executionUnit}' with state=retired, reason={reason}"
+                : $"update queue-state entry for '{executionUnit}': state=retired, reason={reason}");
+        plannedMutations.Add($"append `{RetireRunEventName}` event to runs.jsonl for '{executionUnit}'");
+
+        if (!write)
+        {
+            var dryRun = new AutomationIssueRetireResult
+            {
+                Repo = repo!,
+                Issue = issue!.Value,
+                Reason = reason!,
+                Note = note,
+                Mode = "dry-run",
+                Applied = false,
+                AlreadyRetired = false,
+                ExecutionUnit = executionUnit,
+                PlannedMutations = plannedMutations,
+                RefusalReason = null,
+                Summary = $"'{executionUnit}' (issue #{issue}) would be retired ({reason}). Re-run with --write to apply.",
+            };
+            EmitResult(writer, format, dryRun);
+            return 0;
+        }
+
+        // --write: GitHub mutation first (close + label removal), then the
+        // durable-state mutation (queue-state + runs.jsonl). If the GitHub
+        // step fails, nothing durable changed — safe to retry as-is. If the
+        // durable-state step fails AFTER the GitHub step succeeded, the
+        // issue is already closed; retrying is still safe because the
+        // command is idempotent once queue-state reflects `retired` (and
+        // harmless to re-run before then, since the GitHub calls are
+        // themselves idempotent — closing an already-closed issue / removing
+        // an already-absent label is a no-op from gh's perspective).
+        try
+        {
+            var retirementMutator = RetirementMutatorFactory?.Invoke() ?? new GhCliGitHubIssueRetirementMutator();
+            retirementMutator.CloseAsNotPlanned(repo!, issue!.Value, reasonComment);
+
+            if (labelsToRemove.Length > 0)
+            {
+                var labelMutator = LabelMutatorFactory?.Invoke() ?? new GhCliGitHubLabelMutator();
+                labelMutator.ApplyLabelTransitions(
+                    repo!, GhCliGitHubLabelMutator.Kinds.Issue, issue!.Value,
+                    Array.Empty<string>(), labelsToRemove);
+            }
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException)
+        {
+            writer.WriteLine(
+                $"failed to close/relabel issue #{issue} in {repo}: {exception.Message}. No durable state was "
+                + "changed — re-run with --write to retry.");
+            return 1;
+        }
+
+        var now = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var retirementReason = string.IsNullOrWhiteSpace(note) ? reason! : $"{reason}: {note}";
+        try
+        {
+            var updatedItems = (queueState?.Items ?? Array.Empty<QueueItem>()).ToList();
+            var indexToUpdate = existingItem is null
+                ? -1
+                : updatedItems.FindIndex(item => string.Equals(item.ExecutionUnit, existingItem.ExecutionUnit, StringComparison.Ordinal));
+
+            if (indexToUpdate >= 0)
+            {
+                updatedItems[indexToUpdate] = updatedItems[indexToUpdate] with
+                {
+                    State = QueueItemState.Retired,
+                    RetirementReason = retirementReason,
+                };
+            }
+            else
+            {
+                updatedItems.Add(new QueueItem
+                {
+                    ExecutionUnit = executionUnit,
+                    Title = targetIssue.Title,
+                    State = QueueItemState.Retired,
+                    Dependencies = Array.Empty<string>(),
+                    BlockedBy = Array.Empty<string>(),
+                    ClarificationReturnPath = string.Empty,
+                    PacketPaths = new PacketPaths
+                    {
+                        Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                        ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                    },
+                    LinkedIssue = new LinkedIssue { Repo = repo!, Number = issue, Url = targetIssue.Url },
+                    LinkedPr = null,
+                    WorkerRole = CliRuntimeContracts.DefaultImplementRole,
+                    ReviewRole = CliRuntimeContracts.DefaultReviewRole,
+                    Priority = "high",
+                    RetirementReason = retirementReason,
+                });
+            }
+
+            var updatedState = new QueueState
+            {
+                SchemaVersion = queueState?.SchemaVersion ?? "1",
+                UpdatedAt = now,
+                Items = updatedItems,
+            };
+            File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+
+            AppendRetireRunEvent(context, executionUnit, repo!, issue!.Value, retirementReason, now);
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+        {
+            writer.WriteLine(
+                $"issue #{issue} in {repo} was closed and relabeled, but the queue-state/runs.jsonl update failed: "
+                + $"{exception.Message}. Re-run `automation issue-retire` with --write (idempotent) to retry the "
+                + "durable-state update.");
+            return 1;
+        }
+
+        var applied = new AutomationIssueRetireResult
+        {
+            Repo = repo!,
+            Issue = issue!.Value,
+            Reason = reason!,
+            Note = note,
+            Mode = "write",
+            Applied = true,
+            AlreadyRetired = false,
+            ExecutionUnit = executionUnit,
+            PlannedMutations = plannedMutations,
+            RefusalReason = null,
+            Summary = $"'{executionUnit}' (issue #{issue}) retired ({reason}).",
+        };
+        EmitResult(writer, format, applied);
+        return 0;
+    }
+
+    private static void AppendRetireRunEvent(
+        CliContext context, string executionUnit, string repo, int issue, string reason, DateTimeOffset ts)
+    {
+        var runsPath = context.GetRunLogPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(runsPath)!);
+        var runEvent = new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = RetireRunEventName,
+            By = "intent-cli automation issue-retire (G525)",
+            Reason = reason,
+        };
+        File.AppendAllText(runsPath, RunLogSerializer.SerializeLine(runEvent) + "\n");
+    }
+
+    private static bool MatchesLinkedIssue(LinkedIssue? linkedIssue, int issueNumber) =>
+        linkedIssue is { Number: { } number } && number == issueNumber;
+
+    private static bool IsOpen(string state) =>
+        string.IsNullOrEmpty(state) || string.Equals(state, "OPEN", StringComparison.OrdinalIgnoreCase);
+
+    private static bool HasClosingReference(GitHubAutomationPrCandidate pr, int issueNumber, string repo)
+    {
+        foreach (var reference in pr.ClosingIssuesReferences)
+        {
+            if (reference.Number != issueNumber)
+            {
+                continue;
+            }
+            if (reference.Repository is not { Name.Length: > 0, Owner.Login.Length: > 0 } repository)
+            {
+                return true;
+            }
+            var candidateRepo = $"{repository.Owner!.Login}/{repository.Name}";
+            if (string.Equals(candidateRepo, repo, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static string ExecutionUnitFromTitle(string title)
+    {
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            return string.Empty;
+        }
+        var colonIndex = title.IndexOf(':');
+        return (colonIndex > 0 ? title[..colonIndex] : title).Trim();
+    }
+
+    private static string BuildReasonComment(string reason, string? note)
+    {
+        var comment = $"Retired via canonical `automation issue-retire` transition — reason: {reason}.";
+        if (!string.IsNullOrWhiteSpace(note))
+        {
+            comment += $" Note: {note}";
+        }
+        return comment;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out int? issue,
+        out string? reason,
+        out string? note,
+        out bool write,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        issue = null;
+        reason = null;
+        note = null;
+        write = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--repo requires a value (owner/repo).";
+                        return false;
+                    }
+                    repo = args[++index].Trim();
+                    break;
+                case "--issue":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1].TrimStart('#'), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedIssue)
+                        || parsedIssue <= 0)
+                    {
+                        error = "--issue requires a positive integer issue number.";
+                        return false;
+                    }
+                    issue = parsedIssue;
+                    index++;
+                    break;
+                case "--reason":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--reason requires a value (superseded, decomposed, or obsolete).";
+                        return false;
+                    }
+                    var requestedReason = args[++index].Trim();
+                    if (!AllowedReasons.Contains(requestedReason, StringComparer.Ordinal))
+                    {
+                        error = $"--reason must be one of: {string.Join(", ", AllowedReasons)} (got '{requestedReason}').";
+                        return false;
+                    }
+                    reason = requestedReason;
+                    break;
+                case "--note":
+                    if (index + 1 >= args.Length)
+                    {
+                        error = "--note requires a value.";
+                        return false;
+                    }
+                    note = args[++index];
+                    break;
+                case "--write":
+                    write = true;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[++index].Trim();
+                    if (!string.Equals(requestedFormat, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "automation issue-retire requires '--repo <owner/repo>'.";
+            return false;
+        }
+        if (issue is null)
+        {
+            error = "automation issue-retire requires '--issue <n>'.";
+            return false;
+        }
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            error = "automation issue-retire requires '--reason <superseded|decomposed|obsolete>'.";
+            return false;
+        }
+        return true;
+    }
+
+    private static void EmitResult(TextWriter writer, string format, AutomationIssueRetireResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+        }
+        else
+        {
+            writer.WriteLine($"# automation issue-retire — `{result.Repo}` #{result.Issue} ({result.Mode})");
+            writer.WriteLine();
+            writer.WriteLine($"- execution_unit: `{result.ExecutionUnit}`");
+            writer.WriteLine($"- reason: {result.Reason}");
+            if (!string.IsNullOrWhiteSpace(result.Note))
+            {
+                writer.WriteLine($"- note: {result.Note}");
+            }
+            writer.WriteLine($"- applied: {(result.Applied ? "true" : "false")}");
+            writer.WriteLine($"- already_retired: {(result.AlreadyRetired ? "true" : "false")}");
+            writer.WriteLine();
+            writer.WriteLine(result.Summary);
+            if (result.PlannedMutations.Count > 0)
+            {
+                writer.WriteLine();
+                writer.WriteLine(result.Applied ? "## Applied mutations" : "## Planned mutations");
+                foreach (var mutation in result.PlannedMutations)
+                {
+                    writer.WriteLine($"- {mutation}");
+                }
+            }
+        }
+    }
+}
+
+/// <summary>
+/// G525: testability seam for closing a GitHub issue as "not planned" with
+/// a comment — the production implementation shells out to
+/// <c>gh issue close --reason "not planned" --comment &lt;text&gt;</c>.
+/// </summary>
+internal interface IGitHubIssueRetirementMutator
+{
+    void CloseAsNotPlanned(string repo, int issueNumber, string comment);
+}
+
+/// <summary>
+/// G525: default retirement mutator backed by <c>gh issue close</c>.
+/// </summary>
+internal sealed class GhCliGitHubIssueRetirementMutator : IGitHubIssueRetirementMutator
+{
+    public void CloseAsNotPlanned(string repo, int issueNumber, string comment)
+    {
+        var args = new List<string>
+        {
+            "issue", "close",
+            issueNumber.ToString(CultureInfo.InvariantCulture),
+            "--repo", repo,
+            "--reason", "not planned",
+            "--comment", comment,
+        };
+        RunGh(args, $"close issue #{issueNumber} in {repo} as not planned");
+    }
+
+    private static void RunGh(IReadOnlyList<string> arguments, string description)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        string stdout;
+        string stderr;
+        int exitCode;
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException($"failed to start `gh` process to {description}");
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            exitCode = process.ExitCode;
+        }
+        catch (Exception exception) when (
+            exception is System.ComponentModel.Win32Exception
+            or InvalidOperationException
+            or IOException)
+        {
+            throw new InvalidOperationException($"could not invoke `gh` to {description}: {exception.Message}", exception);
+        }
+
+        if (exitCode != 0)
+        {
+            var classification = GitHubCliJsonBoundary.ClassifyProcessFailure(stderr, stdout);
+            var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+            throw new InvalidOperationException(
+                $"[{classification}] `gh` failed to {description} with exit {exitCode}: "
+                + GitHubCliJsonBoundary.SanitizePreview(errorBody));
+        }
+    }
+}
+
+internal sealed record AutomationIssueRetireResult
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("issue")]
+    public required int Issue { get; init; }
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    [JsonPropertyName("note")]
+    public string? Note { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("already_retired")]
+    public required bool AlreadyRetired { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("planned_mutations")]
+    public required IReadOnlyList<string> PlannedMutations { get; init; }
+
+    [JsonPropertyName("refusal_reason")]
+    public string? RefusalReason { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -177,6 +177,7 @@ internal static class CommandRouter
                 ["intent-target-gap-recovery"] = AutomationIntentTargetGapRecoveryCommand.Execute,
                 ["issue-publish"] = AutomationIssuePublishCommand.Execute,
                 ["issue-release"] = AutomationIssueReleaseCommand.Execute,
+                ["issue-retire"] = AutomationIssueRetireCommand.Execute,
                 ["label-palette-audit"] = AutomationLabelPaletteAuditCommand.Execute,
                 ["label-palette-sync"] = AutomationLabelPaletteSyncCommand.Execute,
                 ["pr-transition"] = AutomationPrTransitionCommand.Execute,

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -106,6 +106,7 @@ internal static class Program
                 || string.Equals(args[1], "host-sync-preflight", StringComparison.Ordinal)
                 || string.Equals(args[1], "issue-publish", StringComparison.Ordinal)
                 || string.Equals(args[1], "issue-release", StringComparison.Ordinal)
+                || string.Equals(args[1], "issue-retire", StringComparison.Ordinal)
                 || string.Equals(args[1], "label-palette-audit", StringComparison.Ordinal)
                 || string.Equals(args[1], "label-palette-sync", StringComparison.Ordinal)
                 || string.Equals(args[1], "pr-transition", StringComparison.Ordinal)

--- a/src/IntentSystem.Supervisor/Models/QueueItem.cs
+++ b/src/IntentSystem.Supervisor/Models/QueueItem.cs
@@ -29,4 +29,11 @@ public sealed record QueueItem
     public required string ReviewRole { get; init; }
 
     public required string Priority { get; init; }
+
+    /// <summary>
+    /// G525: set when <see cref="State"/> is <see cref="QueueItemState.Retired"/>
+    /// — one of <c>superseded</c>, <c>decomposed</c>, or <c>obsolete</c>,
+    /// optionally suffixed with an operator note. Null for every other state.
+    /// </summary>
+    public string? RetirementReason { get; init; }
 }

--- a/src/IntentSystem.Supervisor/Models/QueueItemState.cs
+++ b/src/IntentSystem.Supervisor/Models/QueueItemState.cs
@@ -8,5 +8,12 @@ public enum QueueItemState
     Fixing,
     ClarifyBlocked,
     Blocked,
-    Completed
+    Completed,
+
+    /// <summary>
+    /// G525: the item was atomically retired (superseded/decomposed/obsolete)
+    /// via <c>automation issue-retire</c> — it no longer counts toward WIP
+    /// and is a terminal state distinct from <see cref="Completed"/>.
+    /// </summary>
+    Retired
 }

--- a/src/IntentSystem.Supervisor/Serialization/QueueItemStateJsonConverter.cs
+++ b/src/IntentSystem.Supervisor/Serialization/QueueItemStateJsonConverter.cs
@@ -55,6 +55,7 @@ internal sealed class QueueItemStateJsonConverter : JsonConverter<QueueItemState
             "clarify-blocked" => QueueItemState.ClarifyBlocked,
             "blocked" => QueueItemState.Blocked,
             "completed" => QueueItemState.Completed,
+            "retired" => QueueItemState.Retired,
             _ => throw new JsonException(
                 $"Unrecognized queue item state value '{raw}'.")
         };
@@ -71,6 +72,7 @@ internal sealed class QueueItemStateJsonConverter : JsonConverter<QueueItemState
             QueueItemState.ClarifyBlocked => "clarify-blocked",
             QueueItemState.Blocked => "blocked",
             QueueItemState.Completed => "completed",
+            QueueItemState.Retired => "retired",
             _ => throw new JsonException(
                 $"Unrecognized queue item state value '{value}'.")
         };

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
@@ -77,6 +77,7 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         Assert.Equal(1744, closed.IssueNumber);
         Assert.Contains("decomposed", closed.Comment, StringComparison.Ordinal);
         Assert.Contains("oversized; split into successor slices", closed.Comment, StringComparison.Ordinal);
+        Assert.Contains("[issue-retire:SKS-G812]", closed.Comment, StringComparison.Ordinal);
         var transition = Assert.Single(labelMutator.Transitions);
         Assert.Equal("issue", transition.Kind);
         Assert.Equal(1744, transition.Number);
@@ -446,9 +447,14 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         Assert.Single(retirementMutator.Closed); // close DID happen — stage pinned after A, before B.
         Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
 
-        // Retry: the issue is now CLOSED (not planned) with labels still
-        // present — exactly what the first attempt's failure left behind.
-        retirementMutator.Snapshots[1744] = ClosedNotPlannedSnapshot(1744, "SKS-G812: Oversized single-slice contract", new[] { "intent-target" });
+        // Retry: the issue is now CLOSED (not planned), still carrying the
+        // canonical marker comment the first attempt's close posted (durable
+        // provenance this is OUR partial write, not an unrelated closure),
+        // with labels still present — exactly what the first attempt's
+        // failure left behind.
+        retirementMutator.Snapshots[1744] = ClosedNotPlannedSnapshot(
+            1744, "SKS-G812: Oversized single-slice contract", new[] { "intent-target" },
+            new[] { retirementMutator.Closed[0].Comment });
         labelMutator.ThrowOnApply = null;
 
         using var secondWriter = new StringWriter();
@@ -485,6 +491,7 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
             Title = "SKS-G812: Oversized single-slice contract",
             Url = $"https://github.com/{Repo}/issues/1744",
             Labels = Array.Empty<string>(),
+            Comments = Array.Empty<string>(),
         };
         AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
 
@@ -498,6 +505,42 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         Assert.Contains("COMPLETED", writer.ToString(), StringComparison.Ordinal);
         Assert.Empty(retirementMutator.Closed);
         Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+    }
+
+    [Fact]
+    public void Execute_Write_RefusesRecoveryWhenClosedNotPlannedButNoProvenanceMarker()
+    {
+        // Rereview repair: `stateReason == NOT_PLANNED` alone is NOT durable
+        // provenance — an issue closed manually or by an unrelated process
+        // with reason "not planned" must never be treated as THIS command's
+        // partial-failure recovery target just because the reason string
+        // happens to match. Only the canonical marker comment this command
+        // itself posts alongside its own close authenticates a resume.
+        using var workspace = new RetireWorkspace();
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = new IssueSnapshot
+        {
+            State = "CLOSED",
+            StateReason = "NOT_PLANNED",
+            Title = "SKS-G812: Oversized single-slice contract",
+            Url = $"https://github.com/{Repo}/issues/1744",
+            Labels = Array.Empty<string>(),
+            Comments = new[] { "Closing as not planned — this was a duplicate of #1700." },
+        };
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "obsolete", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("no canonical", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("marker comment", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(retirementMutator.Closed);
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+        Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
     }
 
     [Fact]
@@ -541,7 +584,8 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         File.SetUnixFileMode(
             queueStatePath,
             UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
-        retirementMutator.Snapshots[2001] = ClosedNotPlannedSnapshot(2001, "G600: Some slice", Array.Empty<string>());
+        retirementMutator.Snapshots[2001] = ClosedNotPlannedSnapshot(
+            2001, "G600: Some slice", Array.Empty<string>(), new[] { retirementMutator.Closed[0].Comment });
 
         using var secondWriter = new StringWriter();
         var secondExitCode = AutomationIssueRetireCommand.Execute(
@@ -680,15 +724,23 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         Title = title,
         Url = $"https://github.com/{Repo}/issues/{number}",
         Labels = labels,
+        Comments = Array.Empty<string>(),
     };
 
-    private static IssueSnapshot ClosedNotPlannedSnapshot(int number, string title, IReadOnlyList<string> labels) => new()
+    // `comments` should normally be seeded from the real close comment a
+    // prior successful attempt recorded (`retirementMutator.Closed[i].Comment`)
+    // so the marker text matches exactly what the command itself produces —
+    // pass an empty list to simulate an unrelated/manual "not planned"
+    // closure lacking any canonical provenance.
+    private static IssueSnapshot ClosedNotPlannedSnapshot(
+        int number, string title, IReadOnlyList<string> labels, IReadOnlyList<string>? comments = null) => new()
     {
         State = "CLOSED",
         StateReason = "NOT_PLANNED",
         Title = title,
         Url = $"https://github.com/{Repo}/issues/{number}",
         Labels = labels,
+        Comments = comments ?? Array.Empty<string>(),
     };
 
     private static string BuildRunEventLine(string executionUnit, string eventName) =>

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
@@ -461,6 +461,7 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
                     },
                 },
             };
+            WriteInstalledCliScript();
         }
 
         public string RootPath { get; }
@@ -468,6 +469,43 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         public CliContext Context { get; }
 
         public void WriteQueueState(string json) => File.WriteAllText(Context.GetQueueStatePath(), json);
+
+        // Without a cwd-local shim, AutomationInstalledCliSurfaceProbe falls back to
+        // searching PATH for a globally installed intent-cli — present on a dev
+        // machine but absent on CI runners, which made the WIP-gating test pass
+        // locally and fail in CI. Writing the shim here removes that environment
+        // dependency (mirrors AutomationHostReviewPreflightCommandTests's workspace).
+        private void WriteInstalledCliScript()
+        {
+            var binPath = Path.Combine(RootPath, ".intent-cli", "bin");
+            Directory.CreateDirectory(binPath);
+            var scriptPath = Path.Combine(binPath, "intent-cli");
+            File.WriteAllText(
+                scriptPath,
+                "#!/bin/sh\n"
+                + "case \"$*\" in\n"
+                + "  'automation summary') echo '--domain is required.'; exit 1 ;;\n"
+                + "  'automation host-review-preflight') echo '--repo is required.'; exit 1 ;;\n"
+                + "  'automation issue-publish') echo '--issue is required.'; exit 1 ;;\n"
+                + "  'automation pr-transition')\n"
+                + "    echo '--transition is required (review-start, request-update, or approved).'\n"
+                + "    exit 1\n"
+                + "    ;;\n"
+                + "  *) echo \"unexpected probe: $*\"; exit 1 ;;\n"
+                + "esac\n");
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    scriptPath,
+                    UnixFileMode.UserRead
+                    | UnixFileMode.UserWrite
+                    | UnixFileMode.UserExecute
+                    | UnixFileMode.GroupRead
+                    | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead
+                    | UnixFileMode.OtherExecute);
+            }
+        }
 
         public void Dispose()
         {

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
@@ -8,13 +8,19 @@ using IntentSystem.Supervisor.Serialization;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G525: focused coverage for <c>automation issue-retire</c> — the canonical
-/// atomic transition that supersedes a published <c>intent-target</c> issue
-/// that can never be started as authored.
+/// G525 (+ PR #1154 semantic re-review repair): focused coverage for
+/// <c>automation issue-retire</c> — the canonical atomic transition that
+/// supersedes a published <c>intent-target</c> issue that can never be
+/// started as authored. Covers partial-failure recovery (a retry must
+/// converge even after the issue is already closed), repo-exact queue
+/// linkage + authoritative domain resolution (G522 boundary — a title
+/// prefix alone must never create/mutate a queue entry), and a fail-closed
+/// refusal for already-Completed work.
 /// </summary>
 public sealed class AutomationIssueRetireCommandTests : IDisposable
 {
     private static readonly DateTimeOffset FixedNow = new(2026, 7, 14, 16, 0, 0, TimeSpan.Zero);
+    private const string Repo = "J-Tech-Japan/intent-system";
 
     public AutomationIssueRetireCommandTests()
     {
@@ -39,29 +45,28 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         // pre-existing queue-state entry — the command must derive the
         // execution unit from the title and CREATE the entry.
         using var workspace = new RetireWorkspace();
-        var issue = BuildIssue(1744, "SKS-G812: Oversized single-slice contract", ["intent-target"]);
-        var lister = new FakeLister(issues: [issue]);
-        AutomationIssueRetireCommand.CandidateListerFactory = () => lister;
         var labelMutator = new FakeLabelMutator(new[] { "intent-target" });
         AutomationIssueRetireCommand.LabelMutatorFactory = () => labelMutator;
         var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = OpenSnapshot(1744, "SKS-G812: Oversized single-slice contract", "intent-target");
         AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
 
         using var writer = new StringWriter();
         var exitCode = AutomationIssueRetireCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "decomposed",
-                "--note", "oversized; split into successor slices", "--write", "--format", "json"],
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed",
+                "--note", "oversized; split into successor slices", "--domain", "intent-cli", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
         var result = JsonSerializer.Deserialize<AutomationIssueRetireResult>(writer.ToString())!;
         Assert.True(result.Applied);
         Assert.Equal("SKS-G812", result.ExecutionUnit);
+        Assert.Equal("intent-cli", result.Domain);
 
         // GitHub mutation.
         var closed = Assert.Single(retirementMutator.Closed);
-        Assert.Equal("J-Tech-Japan/intent-system", closed.Repo);
+        Assert.Equal(Repo, closed.Repo);
         Assert.Equal(1744, closed.IssueNumber);
         Assert.Contains("decomposed", closed.Comment, StringComparison.Ordinal);
         Assert.Contains("oversized; split into successor slices", closed.Comment, StringComparison.Ordinal);
@@ -92,16 +97,16 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
     public void Execute_Write_ExistingQueueItem_UpdatesInPlace()
     {
         using var workspace = new RetireWorkspace();
-        workspace.WriteQueueState(BuildQueueStateJson("G600", QueueItemState.Queued, linkedIssueNumber: 2001));
-        var issue = BuildIssue(2001, "G600: Some slice", ["intent-target"]);
-        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+        workspace.WriteQueueState(BuildQueueStateJson("G600", QueueItemState.Queued, Repo, linkedIssueNumber: 2001));
         AutomationIssueRetireCommand.LabelMutatorFactory = () => new FakeLabelMutator(new[] { "intent-target" });
-        AutomationIssueRetireCommand.RetirementMutatorFactory = () => new FakeRetirementMutator();
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[2001] = OpenSnapshot(2001, "G600: Some slice", "intent-target");
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
 
         using var writer = new StringWriter();
         var exitCode = AutomationIssueRetireCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--issue", "2001", "--reason", "superseded", "--write", "--format", "json"],
+            ["--repo", Repo, "--issue", "2001", "--reason", "superseded", "--domain", "intent-cli", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -116,17 +121,16 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
     public void Execute_DryRun_ListsPlannedMutations_DoesNotMutateAnything()
     {
         using var workspace = new RetireWorkspace();
-        var issue = BuildIssue(1744, "SKS-G812: Oversized single-slice contract", ["intent-target"]);
-        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
         var labelMutator = new FakeLabelMutator(new[] { "intent-target" });
         AutomationIssueRetireCommand.LabelMutatorFactory = () => labelMutator;
         var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = OpenSnapshot(1744, "SKS-G812: Oversized single-slice contract", "intent-target");
         AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
 
         using var writer = new StringWriter();
         var exitCode = AutomationIssueRetireCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "obsolete", "--format", "json"],
+            ["--repo", Repo, "--issue", "1744", "--reason", "obsolete", "--domain", "intent-cli", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -144,16 +148,16 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
     public void Execute_RefusesWhenOpenLinkedPrExists()
     {
         using var workspace = new RetireWorkspace();
-        var issue = BuildIssue(1744, "SKS-G812: Oversized single-slice contract", ["intent-target"]);
         var pr = BuildPr(1900, closingIssueNumber: 1744);
-        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister(prs: [pr]);
         var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = OpenSnapshot(1744, "SKS-G812: Oversized single-slice contract", "intent-target");
         AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
 
         using var writer = new StringWriter();
         var exitCode = AutomationIssueRetireCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "superseded", "--write", "--format", "json"],
+            ["--repo", Repo, "--issue", "1744", "--reason", "superseded", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -166,15 +170,15 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
     public void Execute_RefusesWhenActiveClaimExists()
     {
         using var workspace = new RetireWorkspace();
-        var issue = BuildIssue(1744, "SKS-G812: Oversized single-slice contract", ["intent-target", "intent-issue-in-progress"]);
-        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister();
         var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = OpenSnapshot(1744, "SKS-G812: Oversized single-slice contract", "intent-target", "intent-issue-in-progress");
         AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
 
         using var writer = new StringWriter();
         var exitCode = AutomationIssueRetireCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "superseded", "--write", "--format", "json"],
+            ["--repo", Repo, "--issue", "1744", "--reason", "superseded", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
@@ -184,19 +188,18 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_Idempotent_AlreadyRetiredQueueItem_IsNoOp()
+    public void Execute_Idempotent_AlreadyRetiredWithRunsEventPresent_IsPureNoOp()
     {
         using var workspace = new RetireWorkspace();
-        var alreadyRetired = BuildQueueStateJson("SKS-G812", QueueItemState.Retired, linkedIssueNumber: 1744, retirementReason: "decomposed");
-        workspace.WriteQueueState(alreadyRetired);
+        workspace.WriteQueueState(BuildQueueStateJson("SKS-G812", QueueItemState.Retired, Repo, linkedIssueNumber: 1744, retirementReason: "decomposed"));
+        workspace.WriteRunsLog(BuildRunEventLine("SKS-G812", AutomationIssueRetireCommand.RetireRunEventName));
         var retirementMutator = new FakeRetirementMutator();
         AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
-        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister();
 
         using var writer = new StringWriter();
         var exitCode = AutomationIssueRetireCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "decomposed", "--write", "--format", "json"],
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -206,25 +209,80 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         // No GitHub mutation attempted at all — the durable state alone
         // proves idempotency without needing a closed-issue GitHub lookup.
         Assert.Empty(retirementMutator.Closed);
+        Assert.Single(RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.Context.GetRunLogPath())));
     }
 
     [Fact]
-    public void Execute_IssueNotFoundAmongOpenIssues_FailsClosedWithoutGuessing()
+    public void Execute_DryRun_AlreadyRetired_IsNoOpEvenWhenRunsEventMissing()
     {
+        // Dry-run must never mutate, even to "finish" a missing runs.jsonl
+        // event from a prior partial write.
         using var workspace = new RetireWorkspace();
-        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister();
+        workspace.WriteQueueState(BuildQueueStateJson("SKS-G812", QueueItemState.Retired, Repo, linkedIssueNumber: 1744, retirementReason: "decomposed"));
         var retirementMutator = new FakeRetirementMutator();
         AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
 
         using var writer = new StringWriter();
         var exitCode = AutomationIssueRetireCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--issue", "9999", "--reason", "obsolete", "--write", "--format", "json"],
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueRetireResult>(writer.ToString())!;
+        Assert.True(result.AlreadyRetired);
+        Assert.False(result.Applied);
+        Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
+    }
+
+    [Fact]
+    public void Execute_Write_AlreadyRetiredButRunsEventMissing_FinishesOnlyTheRunsAppend()
+    {
+        // Review repair (partial-failure recovery, stage 3->4): queue-state
+        // already shows Retired (a prior --write got that far) but
+        // runs.jsonl never got the event (process died / disk fault right
+        // after the queue write). A retry must not silently no-op forever —
+        // it finishes exactly the missing step, with zero GitHub calls.
+        using var workspace = new RetireWorkspace();
+        workspace.WriteQueueState(BuildQueueStateJson("SKS-G812", QueueItemState.Retired, Repo, linkedIssueNumber: 1744, retirementReason: "decomposed"));
+        var retirementMutator = new FakeRetirementMutator();
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueRetireResult>(writer.ToString())!;
+        Assert.True(result.AlreadyRetired);
+        Assert.True(result.Applied);
+        Assert.Empty(retirementMutator.Closed);
+
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.Context.GetRunLogPath()));
+        var runEvent = Assert.Single(events);
+        Assert.Equal("SKS-G812", runEvent.ExecutionUnit);
+        Assert.Equal(AutomationIssueRetireCommand.RetireRunEventName, runEvent.Event);
+    }
+
+    [Fact]
+    public void Execute_IssueNotFoundAtAll_FailsClosedWithoutGuessing()
+    {
+        using var workspace = new RetireWorkspace();
+        var retirementMutator = new FakeRetirementMutator();
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "9999", "--reason", "obsolete", "--write", "--format", "json"],
             writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("not found among OPEN issues", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("not found", writer.ToString(), StringComparison.Ordinal);
         Assert.Empty(retirementMutator.Closed);
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
     }
 
     [Fact]
@@ -234,11 +292,319 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         using var writer = new StringWriter();
         var exitCode = AutomationIssueRetireCommand.Execute(
             workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "cancelled", "--write"],
+            ["--repo", Repo, "--issue", "1744", "--reason", "cancelled", "--write"],
             writer);
 
         Assert.Equal(1, exitCode);
         Assert.Contains("--reason must be one of", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ── Semantic re-review finding #3: fail closed for Completed work ──────
+
+    [Fact]
+    public void Execute_RefusesToRetireCompletedQueueItem_ZeroMutation()
+    {
+        using var workspace = new RetireWorkspace();
+        var originalJson = BuildQueueStateJson("G500", QueueItemState.Completed, Repo, linkedIssueNumber: 1744);
+        workspace.WriteQueueState(originalJson);
+        // No factories are seeded at all — if the refusal reached any
+        // GitHub call, the default gh-cli-backed implementation would be
+        // constructed and attempt a real subprocess, which would fail loudly
+        // in this sandboxed test run. Reaching EmitResult without that
+        // happening is itself proof of zero GitHub interaction.
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "obsolete", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Completed", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(originalJson, File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
+    }
+
+    // ── Semantic re-review finding #2: repo-exact linkage + domain (G522) ──
+
+    [Fact]
+    public void Execute_SameIssueNumberDifferentRepo_NeverMatchesOtherRepoQueueItem()
+    {
+        using var workspace = new RetireWorkspace();
+        var otherRepoJson = BuildQueueStateJson("OTHER-UNIT", QueueItemState.Queued, "Other-Org/other-repo", linkedIssueNumber: 1744);
+        workspace.WriteQueueState(otherRepoJson);
+        AutomationIssueRetireCommand.LabelMutatorFactory = () => new FakeLabelMutator(new[] { "intent-target" });
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = OpenSnapshot(1744, "G999: unrelated slice in the actual target repo", "intent-target");
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "superseded", "--domain", "intent-cli", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueRetireResult>(writer.ToString())!;
+        // Derived from THIS repo's issue title, not the other repo's entry.
+        Assert.Equal("G999", result.ExecutionUnit);
+
+        var queueAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.Equal(2, queueAfter.Items.Count);
+        var otherItem = Assert.Single(queueAfter.Items, item => item.ExecutionUnit == "OTHER-UNIT");
+        Assert.Equal(QueueItemState.Queued, otherItem.State);
+        Assert.Equal("Other-Org/other-repo", otherItem.LinkedIssue!.Repo);
+        var newItem = Assert.Single(queueAfter.Items, item => item.ExecutionUnit == "G999");
+        Assert.Equal(QueueItemState.Retired, newItem.State);
+        Assert.Equal(Repo, newItem.LinkedIssue!.Repo);
+    }
+
+    [Fact]
+    public void Execute_UnderivableDomain_NoPacketNoExplicitDomain_FailsLoudWithCandidates()
+    {
+        using var workspace = new RetireWorkspace();
+        workspace.WriteIntentsDomainDirectory("intent-cli");
+        workspace.WriteIntentsDomainDirectory("other-domain");
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = OpenSnapshot(1744, "G777: a title prefix with no packet.yaml anywhere", "intent-target");
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "obsolete", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("could not be derived", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("other-domain", output, StringComparison.Ordinal);
+        Assert.Contains("--domain", output, StringComparison.Ordinal);
+        // Prefix alone must never create a queue entry.
+        Assert.Empty(retirementMutator.Closed);
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+    }
+
+    [Fact]
+    public void Execute_ContradictingDomain_PacketDeclaresDifferentDomainThanExplicitDomain_FailsLoud()
+    {
+        // Doubles as the "misleading title" defense: the title prefix looks
+        // like it belongs to the operator's intended domain, but the real
+        // packet.yaml on disk says otherwise — the packet, never the title,
+        // is authoritative.
+        using var workspace = new RetireWorkspace();
+        workspace.WritePacketYaml("G525", "billing");
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = OpenSnapshot(1744, "G525: looks like it belongs to intent-cli", "intent-target");
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "obsolete", "--domain", "intent-cli", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("contradicts", output, StringComparison.Ordinal);
+        Assert.Contains("billing", output, StringComparison.Ordinal);
+        Assert.Empty(retirementMutator.Closed);
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+    }
+
+    // ── Semantic re-review finding #1: partial-failure recovery ────────────
+
+    [Fact]
+    public void Execute_Write_RecoversAfterCloseSucceedsButLabelRemovalFails()
+    {
+        using var workspace = new RetireWorkspace();
+        var labelMutator = new FakeLabelMutator(new[] { "intent-target" })
+        {
+            ThrowOnApply = new InvalidOperationException("gh label remove: simulated transient failure"),
+        };
+        AutomationIssueRetireCommand.LabelMutatorFactory = () => labelMutator;
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = OpenSnapshot(1744, "SKS-G812: Oversized single-slice contract", "intent-target");
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var firstWriter = new StringWriter();
+        var firstExitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--domain", "intent-cli", "--write", "--format", "json"],
+            firstWriter);
+
+        Assert.Equal(1, firstExitCode);
+        Assert.Contains("already closed", firstWriter.ToString(), StringComparison.Ordinal);
+        Assert.Single(retirementMutator.Closed); // close DID happen — stage pinned after A, before B.
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+
+        // Retry: the issue is now CLOSED (not planned) with labels still
+        // present — exactly what the first attempt's failure left behind.
+        retirementMutator.Snapshots[1744] = ClosedNotPlannedSnapshot(1744, "SKS-G812: Oversized single-slice contract", new[] { "intent-target" });
+        labelMutator.ThrowOnApply = null;
+
+        using var secondWriter = new StringWriter();
+        var secondExitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--domain", "intent-cli", "--write", "--format", "json"],
+            secondWriter);
+
+        Assert.Equal(0, secondExitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueRetireResult>(secondWriter.ToString())!;
+        Assert.True(result.Applied);
+        // Not re-closed — the retry recognized the issue was already closed.
+        Assert.Single(retirementMutator.Closed);
+        Assert.Single(labelMutator.Transitions);
+
+        var queueAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        var item = Assert.Single(queueAfter.Items);
+        Assert.Equal(QueueItemState.Retired, item.State);
+        Assert.Single(RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.Context.GetRunLogPath())));
+    }
+
+    [Fact]
+    public void Execute_Write_RefusesRecoveryWhenClosedForAnUnrelatedReason()
+    {
+        // A CLOSED issue whose stateReason is NOT "not planned" (e.g. closed
+        // via a merge) must never be treated as an issue-retire recovery
+        // target — only this command's own close reason authorizes resuming.
+        using var workspace = new RetireWorkspace();
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = new IssueSnapshot
+        {
+            State = "CLOSED",
+            StateReason = "COMPLETED",
+            Title = "SKS-G812: Oversized single-slice contract",
+            Url = $"https://github.com/{Repo}/issues/1744",
+            Labels = Array.Empty<string>(),
+        };
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "obsolete", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("COMPLETED", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(retirementMutator.Closed);
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+    }
+
+    [Fact]
+    public void Execute_Write_QueueStateWriteFails_RecoversOnRetryWithoutReClosing()
+    {
+        // Fault injected AFTER close + label removal succeed, around queue
+        // persistence: make the pre-existing queue-state.json read-only so
+        // the overwrite throws, then retry after restoring write access.
+        using var workspace = new RetireWorkspace();
+        workspace.WriteQueueState(BuildQueueStateJson("G600", QueueItemState.Queued, Repo, linkedIssueNumber: 2001));
+        var queueStatePath = workspace.Context.GetQueueStatePath();
+        var labelMutator = new FakeLabelMutator(new[] { "intent-target" });
+        AutomationIssueRetireCommand.LabelMutatorFactory = () => labelMutator;
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[2001] = OpenSnapshot(2001, "G600: Some slice", "intent-target");
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(queueStatePath, UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        }
+
+        using var firstWriter = new StringWriter();
+        var firstExitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "2001", "--reason", "superseded", "--domain", "intent-cli", "--write", "--format", "json"],
+            firstWriter);
+
+        if (OperatingSystem.IsWindows())
+        {
+            // Read-only fault injection is unix-permission-specific; skip
+            // the assertions that depend on the write actually failing.
+            return;
+        }
+
+        Assert.Equal(1, firstExitCode);
+        Assert.Contains("queue-state update failed", firstWriter.ToString(), StringComparison.Ordinal);
+        Assert.Single(retirementMutator.Closed);
+        Assert.Single(labelMutator.Transitions);
+
+        File.SetUnixFileMode(
+            queueStatePath,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        retirementMutator.Snapshots[2001] = ClosedNotPlannedSnapshot(2001, "G600: Some slice", Array.Empty<string>());
+
+        using var secondWriter = new StringWriter();
+        var secondExitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "2001", "--reason", "superseded", "--domain", "intent-cli", "--write", "--format", "json"],
+            secondWriter);
+
+        Assert.Equal(0, secondExitCode);
+        Assert.Single(retirementMutator.Closed); // still not re-closed.
+        var queueAfter = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        var item = Assert.Single(queueAfter.Items);
+        Assert.Equal(QueueItemState.Retired, item.State);
+        Assert.Single(RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.Context.GetRunLogPath())));
+    }
+
+    [Fact]
+    public void Execute_Write_RunsAppendFails_RetryFinishesOnlyTheMissingEvent()
+    {
+        // Fault injected around the runs.jsonl append (after queue
+        // persistence succeeds): pre-seed runs.jsonl as read-only so the
+        // append throws even though the queue-state write already landed.
+        using var workspace = new RetireWorkspace();
+        AutomationIssueRetireCommand.LabelMutatorFactory = () => new FakeLabelMutator(new[] { "intent-target" });
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = OpenSnapshot(1744, "SKS-G812: Oversized single-slice contract", "intent-target");
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        var runsPath = workspace.Context.GetRunLogPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(runsPath)!);
+        File.WriteAllText(runsPath, string.Empty);
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(runsPath, UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+        }
+
+        using var firstWriter = new StringWriter();
+        var firstExitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--domain", "intent-cli", "--write", "--format", "json"],
+            firstWriter);
+
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Assert.Equal(1, firstExitCode);
+        Assert.Contains("runs.jsonl event failed", firstWriter.ToString(), StringComparison.Ordinal);
+        // Queue-state DID persist as Retired even though the runs append failed.
+        var queueAfterFirst = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.Equal(QueueItemState.Retired, Assert.Single(queueAfterFirst.Items).State);
+
+        File.SetUnixFileMode(runsPath, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+
+        using var secondWriter = new StringWriter();
+        var secondExitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--domain", "intent-cli", "--write", "--format", "json"],
+            secondWriter);
+
+        Assert.Equal(0, secondExitCode);
+        var secondResult = JsonSerializer.Deserialize<AutomationIssueRetireResult>(secondWriter.ToString())!;
+        Assert.True(secondResult.AlreadyRetired);
+        Assert.True(secondResult.Applied);
+        // The retry never re-attempted any GitHub mutation — still just the
+        // ONE close from the first attempt; queue-state already showed
+        // Retired, so only the missing runs event was finished.
+        Assert.Single(retirementMutator.Closed);
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(runsPath));
+        Assert.Single(events);
     }
 
     [Fact]
@@ -288,7 +654,7 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         // validate` unable to recognize the resulting state; the canonical
         // command always creates/updates a queue-state entry on retire so
         // this anomaly cannot recur.
-        var queueStateJson = BuildQueueStateJson("SKS-G812", QueueItemState.Retired, linkedIssueNumber: 1744, retirementReason: "decomposed");
+        var queueStateJson = BuildQueueStateJson("SKS-G812", QueueItemState.Retired, Repo, linkedIssueNumber: 1744, retirementReason: "decomposed");
 
         var result = MetadataValidateAnalyzer.Analyze(new MetadataValidateInputs
         {
@@ -300,15 +666,33 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         Assert.DoesNotContain(result.Errors, finding => finding.Code == MetadataValidateConstants.Codes.CompletedMissingClosure);
     }
 
-    private static GitHubAutomationIssueCandidate BuildIssue(int number, string title, string[] labels) => new()
+    private static IssueSnapshot OpenSnapshot(int number, string title, params string[] labels) => new()
     {
-        Number = number,
-        Title = title,
-        Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{number}",
-        CreatedAt = FixedNow.AddDays(-3).ToString("O"),
         State = "OPEN",
-        Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+        StateReason = string.Empty,
+        Title = title,
+        Url = $"https://github.com/{Repo}/issues/{number}",
+        Labels = labels,
     };
+
+    private static IssueSnapshot ClosedNotPlannedSnapshot(int number, string title, IReadOnlyList<string> labels) => new()
+    {
+        State = "CLOSED",
+        StateReason = "NOT_PLANNED",
+        Title = title,
+        Url = $"https://github.com/{Repo}/issues/{number}",
+        Labels = labels,
+    };
+
+    private static string BuildRunEventLine(string executionUnit, string eventName) =>
+        RunLogSerializer.SerializeLine(new RunEvent
+        {
+            Ts = FixedNow.AddMinutes(-5),
+            ExecutionUnit = executionUnit,
+            Event = eventName,
+            By = "intent-cli automation issue-retire (G525)",
+            Reason = "decomposed",
+        });
 
     private static GitHubAutomationPrCandidate BuildPr(int number, int closingIssueNumber) => new()
     {
@@ -333,7 +717,7 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
     };
 
     private static string BuildQueueStateJson(
-        string executionUnit, QueueItemState state, int linkedIssueNumber, string? retirementReason = null)
+        string executionUnit, QueueItemState state, string linkedIssueRepo, int linkedIssueNumber, string? retirementReason = null)
     {
         var queueState = new QueueState
         {
@@ -357,9 +741,9 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
                     },
                     LinkedIssue = new LinkedIssue
                     {
-                        Repo = "J-Tech-Japan/intent-system",
+                        Repo = linkedIssueRepo,
                         Number = linkedIssueNumber,
-                        Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{linkedIssueNumber}",
+                        Url = $"https://github.com/{linkedIssueRepo}/issues/{linkedIssueNumber}",
                     },
                     LinkedPr = null,
                     WorkerRole = "Claude",
@@ -395,26 +779,24 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
 
     private sealed class FakeLister : IGitHubAutomationCandidateLister
     {
-        private readonly IReadOnlyList<GitHubAutomationIssueCandidate> issues;
         private readonly IReadOnlyList<GitHubAutomationPrCandidate> prs;
 
-        public FakeLister(
-            IReadOnlyList<GitHubAutomationIssueCandidate>? issues = null,
-            IReadOnlyList<GitHubAutomationPrCandidate>? prs = null)
+        public FakeLister(IReadOnlyList<GitHubAutomationPrCandidate>? prs = null)
         {
-            this.issues = issues ?? Array.Empty<GitHubAutomationIssueCandidate>();
             this.prs = prs ?? Array.Empty<GitHubAutomationPrCandidate>();
         }
 
         public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => prs;
 
-        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) => issues;
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) =>
+            Array.Empty<GitHubAutomationIssueCandidate>();
     }
 
     private sealed class FakeLabelMutator : IGitHubLabelMutator
     {
         private readonly IReadOnlyList<string> labels;
         public List<Transition> Transitions { get; } = new();
+        public Exception? ThrowOnApply { get; set; }
 
         public FakeLabelMutator(IReadOnlyList<string> labels) => this.labels = labels;
 
@@ -422,8 +804,14 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
             labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
 
         public void ApplyLabelTransitions(string repo, string kind, int number,
-            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels)
+        {
+            if (ThrowOnApply is not null)
+            {
+                throw ThrowOnApply;
+            }
             Transitions.Add(new Transition(kind, number, addLabels.ToArray(), removeLabels.ToArray()));
+        }
 
         public void ApplyReconcileTransitions(string repo, string kind, int number,
             IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
@@ -435,9 +823,27 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
     private sealed class FakeRetirementMutator : IGitHubIssueRetirementMutator
     {
         public List<ClosedIssue> Closed { get; } = new();
+        public Dictionary<int, IssueSnapshot> Snapshots { get; } = new();
+        public Exception? ThrowOnClose { get; set; }
 
-        public void CloseAsNotPlanned(string repo, int issueNumber, string comment) =>
+        public void CloseAsNotPlanned(string repo, int issueNumber, string comment)
+        {
+            if (ThrowOnClose is not null)
+            {
+                throw ThrowOnClose;
+            }
             Closed.Add(new ClosedIssue(repo, issueNumber, comment));
+        }
+
+        public IssueSnapshot GetSnapshot(string repo, int issueNumber)
+        {
+            if (Snapshots.TryGetValue(issueNumber, out var snapshot))
+            {
+                return snapshot;
+            }
+            throw new InvalidOperationException(
+                $"[github-cli-generic] gh failed to view issue #{issueNumber} in {repo}: not found (fake).");
+        }
     }
 
     private sealed record ClosedIssue(string Repo, int IssueNumber, string Comment);
@@ -469,6 +875,25 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         public CliContext Context { get; }
 
         public void WriteQueueState(string json) => File.WriteAllText(Context.GetQueueStatePath(), json);
+
+        public void WriteRunsLog(string line)
+        {
+            var runsPath = Context.GetRunLogPath();
+            Directory.CreateDirectory(Path.GetDirectoryName(runsPath)!);
+            File.WriteAllText(runsPath, line + "\n");
+        }
+
+        public void WritePacketYaml(string executionUnit, string domain)
+        {
+            var packetDir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(packetDir);
+            File.WriteAllText(Path.Combine(packetDir, "packet.yaml"), $"domain: {domain}\n");
+        }
+
+        public void WriteIntentsDomainDirectory(string domain)
+        {
+            Directory.CreateDirectory(Path.Combine(RootPath, "intents", domain));
+        }
 
         // Without a cwd-local shim, AutomationInstalledCliSurfaceProbe falls back to
         // searching PATH for a globally installed intent-cli — present on a dev
@@ -511,6 +936,23 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         {
             if (Directory.Exists(RootPath))
             {
+                if (!OperatingSystem.IsWindows())
+                {
+                    var queueStatePath = Context.GetQueueStatePath();
+                    if (File.Exists(queueStatePath))
+                    {
+                        File.SetUnixFileMode(
+                            queueStatePath,
+                            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+                    }
+                    var runsPath = Context.GetRunLogPath();
+                    if (File.Exists(runsPath))
+                    {
+                        File.SetUnixFileMode(
+                            runsPath,
+                            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
+                    }
+                }
                 Directory.Delete(RootPath, recursive: true);
             }
         }

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
@@ -544,6 +544,132 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_Write_RecoversWhenExactMarkerFoundAmongMultipleComments()
+    {
+        using var workspace = new RetireWorkspace();
+        AutomationIssueRetireCommand.LabelMutatorFactory = () => new FakeLabelMutator(Array.Empty<string>());
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = new IssueSnapshot
+        {
+            State = "CLOSED",
+            StateReason = "NOT_PLANNED",
+            Title = "SKS-G812: Oversized single-slice contract",
+            Url = $"https://github.com/{Repo}/issues/1744",
+            Labels = Array.Empty<string>(),
+            Comments = new[]
+            {
+                "Closing as not planned — duplicate of #1700.",
+                CanonicalMarkerComment("SKS-G812", "obsolete"), // wrong reason — must not match either
+                CanonicalMarkerComment("SKS-G812", "decomposed"), // the exact match
+            },
+        };
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--domain", "intent-cli", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueRetireResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.Empty(retirementMutator.Closed); // already closed — not re-closed.
+        var item = Assert.Single(QueueStateSerializer.Deserialize(File.ReadAllText(workspace.Context.GetQueueStatePath())).Items);
+        Assert.Equal(QueueItemState.Retired, item.State);
+    }
+
+    [Fact]
+    public void Execute_Write_RefusesRecoveryWhenMarkerIsOnlyAQuotedSubstring()
+    {
+        // A comment merely QUOTING the marker text (e.g. someone pasting an
+        // example of the format) must not authenticate a recovery — the
+        // marker must anchor the WHOLE comment body, not appear as a
+        // substring inside unrelated surrounding text.
+        using var workspace = new RetireWorkspace();
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = new IssueSnapshot
+        {
+            State = "CLOSED",
+            StateReason = "NOT_PLANNED",
+            Title = "SKS-G812: Oversized single-slice contract",
+            Url = $"https://github.com/{Repo}/issues/1744",
+            Labels = Array.Empty<string>(),
+            Comments = new[] { $"For reference, the format looks like: {CanonicalMarkerComment("SKS-G812", "decomposed")} — that's it." },
+        };
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("no canonical", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(retirementMutator.Closed);
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+    }
+
+    [Fact]
+    public void Execute_Write_RefusesRecoveryWhenMarkerUnitIsAPrefixCollision()
+    {
+        // "G52" must never match the candidate unit "G525" — the marker's
+        // captured unit is compared for exact equality, not prefix/contains.
+        using var workspace = new RetireWorkspace();
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = new IssueSnapshot
+        {
+            State = "CLOSED",
+            StateReason = "NOT_PLANNED",
+            Title = "G525: some title deriving the candidate unit G525",
+            Url = $"https://github.com/{Repo}/issues/1744",
+            Labels = Array.Empty<string>(),
+            Comments = new[] { CanonicalMarkerComment("G52", "decomposed") },
+        };
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("no canonical", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(retirementMutator.Closed);
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+    }
+
+    [Fact]
+    public void Execute_Write_RefusesRecoveryWhenMarkerReasonDiffersFromRequestedReason()
+    {
+        using var workspace = new RetireWorkspace();
+        var retirementMutator = new FakeRetirementMutator();
+        retirementMutator.Snapshots[1744] = new IssueSnapshot
+        {
+            State = "CLOSED",
+            StateReason = "NOT_PLANNED",
+            Title = "SKS-G812: Oversized single-slice contract",
+            Url = $"https://github.com/{Repo}/issues/1744",
+            Labels = Array.Empty<string>(),
+            Comments = new[] { CanonicalMarkerComment("SKS-G812", "obsolete") },
+        };
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--issue", "1744", "--reason", "decomposed", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("no canonical", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(retirementMutator.Closed);
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+    }
+
+    [Fact]
     public void Execute_Write_QueueStateWriteFails_RecoversOnRetryWithoutReClosing()
     {
         // Fault injected AFTER close + label removal succeed, around queue
@@ -742,6 +868,20 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         Labels = labels,
         Comments = comments ?? Array.Empty<string>(),
     };
+
+    // Mirrors the exact canonical format AutomationIssueRetireCommand's
+    // BuildReasonComment/CanonicalRetireMarkerPattern produce and parse —
+    // used to hand-author fixture comments simulating what a prior close
+    // (or an unrelated/malicious comment) would look like.
+    private static string CanonicalMarkerComment(string executionUnit, string reason, string? note = null)
+    {
+        var comment = $"[issue-retire:{executionUnit}] Retired via canonical `automation issue-retire` transition — reason: {reason}.";
+        if (!string.IsNullOrWhiteSpace(note))
+        {
+            comment += $" Note: {note}";
+        }
+        return comment;
+    }
 
     private static string BuildRunEventLine(string executionUnit, string eventName) =>
         RunLogSerializer.SerializeLine(new RunEvent

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
@@ -1,0 +1,480 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G525: focused coverage for <c>automation issue-retire</c> — the canonical
+/// atomic transition that supersedes a published <c>intent-target</c> issue
+/// that can never be started as authored.
+/// </summary>
+public sealed class AutomationIssueRetireCommandTests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 7, 14, 16, 0, 0, TimeSpan.Zero);
+
+    public AutomationIssueRetireCommandTests()
+    {
+        AutomationIssueRetireCommand.CandidateListerFactory = null;
+        AutomationIssueRetireCommand.LabelMutatorFactory = null;
+        AutomationIssueRetireCommand.RetirementMutatorFactory = null;
+        AutomationIssueRetireCommand.UtcNowFactory = () => FixedNow;
+    }
+
+    public void Dispose()
+    {
+        AutomationIssueRetireCommand.CandidateListerFactory = null;
+        AutomationIssueRetireCommand.LabelMutatorFactory = null;
+        AutomationIssueRetireCommand.RetirementMutatorFactory = null;
+        AutomationIssueRetireCommand.UtcNowFactory = null;
+    }
+
+    [Fact]
+    public void Execute_Write_ClosesIssueRemovesLabelsRetiresQueueItem_AppendsRunsEvent()
+    {
+        // G525 field scenario: a published, never-delegated issue has NO
+        // pre-existing queue-state entry — the command must derive the
+        // execution unit from the title and CREATE the entry.
+        using var workspace = new RetireWorkspace();
+        var issue = BuildIssue(1744, "SKS-G812: Oversized single-slice contract", ["intent-target"]);
+        var lister = new FakeLister(issues: [issue]);
+        AutomationIssueRetireCommand.CandidateListerFactory = () => lister;
+        var labelMutator = new FakeLabelMutator(new[] { "intent-target" });
+        AutomationIssueRetireCommand.LabelMutatorFactory = () => labelMutator;
+        var retirementMutator = new FakeRetirementMutator();
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "decomposed",
+                "--note", "oversized; split into successor slices", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueRetireResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.Equal("SKS-G812", result.ExecutionUnit);
+
+        // GitHub mutation.
+        var closed = Assert.Single(retirementMutator.Closed);
+        Assert.Equal("J-Tech-Japan/intent-system", closed.Repo);
+        Assert.Equal(1744, closed.IssueNumber);
+        Assert.Contains("decomposed", closed.Comment, StringComparison.Ordinal);
+        Assert.Contains("oversized; split into successor slices", closed.Comment, StringComparison.Ordinal);
+        var transition = Assert.Single(labelMutator.Transitions);
+        Assert.Equal("issue", transition.Kind);
+        Assert.Equal(1744, transition.Number);
+        Assert.Contains("intent-target", transition.RemoveLabels);
+        Assert.Empty(transition.AddLabels);
+
+        // Durable state.
+        var queueAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        var item = Assert.Single(queueAfter.Items);
+        Assert.Equal("SKS-G812", item.ExecutionUnit);
+        Assert.Equal(QueueItemState.Retired, item.State);
+        Assert.Contains("decomposed", item.RetirementReason, StringComparison.Ordinal);
+        Assert.Equal(1744, item.LinkedIssue!.Number);
+
+        var runsPath = workspace.Context.GetRunLogPath();
+        Assert.True(File.Exists(runsPath));
+        var runLine = File.ReadAllText(runsPath).Trim();
+        var runEvent = RunLogSerializer.DeserializeLine(runLine);
+        Assert.Equal(AutomationIssueRetireCommand.RetireRunEventName, runEvent.Event);
+        Assert.Equal("SKS-G812", runEvent.ExecutionUnit);
+        Assert.Contains("decomposed", runEvent.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Write_ExistingQueueItem_UpdatesInPlace()
+    {
+        using var workspace = new RetireWorkspace();
+        workspace.WriteQueueState(BuildQueueStateJson("G600", QueueItemState.Queued, linkedIssueNumber: 2001));
+        var issue = BuildIssue(2001, "G600: Some slice", ["intent-target"]);
+        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+        AutomationIssueRetireCommand.LabelMutatorFactory = () => new FakeLabelMutator(new[] { "intent-target" });
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => new FakeRetirementMutator();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "2001", "--reason", "superseded", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var queueAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        var item = Assert.Single(queueAfter.Items);
+        Assert.Equal("G600", item.ExecutionUnit);
+        Assert.Equal(QueueItemState.Retired, item.State);
+        Assert.Equal("superseded", item.RetirementReason);
+    }
+
+    [Fact]
+    public void Execute_DryRun_ListsPlannedMutations_DoesNotMutateAnything()
+    {
+        using var workspace = new RetireWorkspace();
+        var issue = BuildIssue(1744, "SKS-G812: Oversized single-slice contract", ["intent-target"]);
+        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+        var labelMutator = new FakeLabelMutator(new[] { "intent-target" });
+        AutomationIssueRetireCommand.LabelMutatorFactory = () => labelMutator;
+        var retirementMutator = new FakeRetirementMutator();
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "obsolete", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueRetireResult>(writer.ToString())!;
+        Assert.False(result.Applied);
+        Assert.NotEmpty(result.PlannedMutations);
+
+        Assert.Empty(retirementMutator.Closed);
+        Assert.Empty(labelMutator.Transitions);
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+        Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
+    }
+
+    [Fact]
+    public void Execute_RefusesWhenOpenLinkedPrExists()
+    {
+        using var workspace = new RetireWorkspace();
+        var issue = BuildIssue(1744, "SKS-G812: Oversized single-slice contract", ["intent-target"]);
+        var pr = BuildPr(1900, closingIssueNumber: 1744);
+        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+        var retirementMutator = new FakeRetirementMutator();
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "superseded", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("OPEN PR #1900", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(retirementMutator.Closed);
+        Assert.False(File.Exists(workspace.Context.GetQueueStatePath()));
+    }
+
+    [Fact]
+    public void Execute_RefusesWhenActiveClaimExists()
+    {
+        using var workspace = new RetireWorkspace();
+        var issue = BuildIssue(1744, "SKS-G812: Oversized single-slice contract", ["intent-target", "intent-issue-in-progress"]);
+        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+        var retirementMutator = new FakeRetirementMutator();
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "superseded", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("intent-issue-in-progress", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("declined-contract-incomplete", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(retirementMutator.Closed);
+    }
+
+    [Fact]
+    public void Execute_Idempotent_AlreadyRetiredQueueItem_IsNoOp()
+    {
+        using var workspace = new RetireWorkspace();
+        var alreadyRetired = BuildQueueStateJson("SKS-G812", QueueItemState.Retired, linkedIssueNumber: 1744, retirementReason: "decomposed");
+        workspace.WriteQueueState(alreadyRetired);
+        var retirementMutator = new FakeRetirementMutator();
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "decomposed", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueRetireResult>(writer.ToString())!;
+        Assert.True(result.AlreadyRetired);
+        Assert.False(result.Applied);
+        // No GitHub mutation attempted at all — the durable state alone
+        // proves idempotency without needing a closed-issue GitHub lookup.
+        Assert.Empty(retirementMutator.Closed);
+    }
+
+    [Fact]
+    public void Execute_IssueNotFoundAmongOpenIssues_FailsClosedWithoutGuessing()
+    {
+        using var workspace = new RetireWorkspace();
+        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister();
+        var retirementMutator = new FakeRetirementMutator();
+        AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "9999", "--reason", "obsolete", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("not found among OPEN issues", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(retirementMutator.Closed);
+    }
+
+    [Fact]
+    public void Execute_RejectsUnrecognizedReason()
+    {
+        using var workspace = new RetireWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueRetireCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--issue", "1744", "--reason", "cancelled", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--reason must be one of", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RetiredIssue_ClearsWipGatingForHostReviewPreflight()
+    {
+        // G525 AC: retired items clear WIP gating. This exercises the SAME
+        // AutomationHostReviewPreflightCommand path G523/host-review-preflight
+        // uses, proving the "before retire" (blocked) vs. "after retire"
+        // (ready) transition — retiring removes intent-target and closes the
+        // issue, so it naturally disappears from the live GitHub scan that
+        // WIP gating already relies on (no host-review-preflight code change
+        // needed).
+        using var beforeWorkspace = new RetireWorkspace();
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => new HostPreflightFakeLister
+        {
+            Issues = [BuildHostPreflightIssue(1744, "wip", "https://github.com/J-Tech-Japan/intent-system/issues/1744",
+                "2026-07-14T00:00:00Z", ["intent-target"])],
+        };
+        using var beforeWriter = new StringWriter();
+        AutomationHostReviewPreflightCommand.Execute(
+            beforeWorkspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--candidate", "SKS-G814", "--format", "json"],
+            beforeWriter);
+        var beforeResult = JsonDocument.Parse(beforeWriter.ToString());
+        Assert.Equal("skip-next-slice-due-to-wip", beforeResult.RootElement.GetProperty("action").GetString());
+
+        // After retire: the issue is closed and intent-target removed, so
+        // it no longer appears in the live open-issues scan at all.
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = () => new HostPreflightFakeLister();
+        using var afterWriter = new StringWriter();
+        AutomationHostReviewPreflightCommand.Execute(
+            beforeWorkspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--candidate", "SKS-G814", "--format", "json"],
+            afterWriter);
+        var afterResult = JsonDocument.Parse(afterWriter.ToString());
+        Assert.Equal("candidate-ready", afterResult.RootElement.GetProperty("action").GetString());
+
+        AutomationHostReviewPreflightCommand.CandidateListerFactory = null;
+    }
+
+    [Fact]
+    public void MetadataValidate_RecognizesRetiredLifecycle_NoQueueEntryMissingAnomaly()
+    {
+        // G525 AC: metadata validate must not flag a retired unit's
+        // queue-state entry as missing/inconsistent. Field incident: a
+        // hand-authored noncanonical recovery previously left `metadata
+        // validate` unable to recognize the resulting state; the canonical
+        // command always creates/updates a queue-state entry on retire so
+        // this anomaly cannot recur.
+        var queueStateJson = BuildQueueStateJson("SKS-G812", QueueItemState.Retired, linkedIssueNumber: 1744, retirementReason: "decomposed");
+
+        var result = MetadataValidateAnalyzer.Analyze(new MetadataValidateInputs
+        {
+            ExecutionUnit = "SKS-G812",
+            QueueStateJson = queueStateJson,
+        });
+
+        Assert.DoesNotContain(result.Errors, finding => finding.Code == MetadataValidateConstants.Codes.QueueEntryMissing);
+        Assert.DoesNotContain(result.Errors, finding => finding.Code == MetadataValidateConstants.Codes.CompletedMissingClosure);
+    }
+
+    private static GitHubAutomationIssueCandidate BuildIssue(int number, string title, string[] labels) => new()
+    {
+        Number = number,
+        Title = title,
+        Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{number}",
+        CreatedAt = FixedNow.AddDays(-3).ToString("O"),
+        State = "OPEN",
+        Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+    };
+
+    private static GitHubAutomationPrCandidate BuildPr(int number, int closingIssueNumber) => new()
+    {
+        Number = number,
+        Title = "Some PR",
+        Url = $"https://github.com/J-Tech-Japan/intent-system/pull/{number}",
+        CreatedAt = FixedNow.AddDays(-1).ToString("O"),
+        UpdatedAt = FixedNow.AddDays(-1).ToString("O"),
+        State = "OPEN",
+        ClosingIssuesReferences = new[]
+        {
+            new GitHubPrClosingIssueReference
+            {
+                Number = closingIssueNumber,
+                Repository = new GitHubPrClosingIssueRepository
+                {
+                    Name = "intent-system",
+                    Owner = new GitHubPrClosingIssueRepositoryOwner { Login = "J-Tech-Japan" },
+                },
+            },
+        },
+    };
+
+    private static string BuildQueueStateJson(
+        string executionUnit, QueueItemState state, int linkedIssueNumber, string? retirementReason = null)
+    {
+        var queueState = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = FixedNow,
+            Items = new[]
+            {
+                new QueueItem
+                {
+                    ExecutionUnit = executionUnit,
+                    Title = $"{executionUnit} title",
+                    State = state,
+                    Dependencies = Array.Empty<string>(),
+                    BlockedBy = Array.Empty<string>(),
+                    ClarificationReturnPath = string.Empty,
+                    PacketPaths = new PacketPaths
+                    {
+                        Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                        Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                        ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                    },
+                    LinkedIssue = new LinkedIssue
+                    {
+                        Repo = "J-Tech-Japan/intent-system",
+                        Number = linkedIssueNumber,
+                        Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{linkedIssueNumber}",
+                    },
+                    LinkedPr = null,
+                    WorkerRole = "Claude",
+                    ReviewRole = "Codex",
+                    Priority = "normal",
+                    RetirementReason = retirementReason,
+                },
+            },
+        };
+        return QueueStateSerializer.Serialize(queueState);
+    }
+
+    private static GitHubAutomationIssueCandidate BuildHostPreflightIssue(
+        int number, string state, string url, string createdAt, string[] labels) => new()
+    {
+        Number = number,
+        Title = "wip issue",
+        Url = url,
+        CreatedAt = createdAt,
+        State = "OPEN",
+        Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+    };
+
+    private sealed class HostPreflightFakeLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationIssueCandidate> Issues { get; init; } = Array.Empty<GitHubAutomationIssueCandidate>();
+        public IReadOnlyList<GitHubAutomationPrCandidate> Prs { get; init; } = Array.Empty<GitHubAutomationPrCandidate>();
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => Prs;
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) => Issues;
+    }
+
+    private sealed class FakeLister : IGitHubAutomationCandidateLister
+    {
+        private readonly IReadOnlyList<GitHubAutomationIssueCandidate> issues;
+        private readonly IReadOnlyList<GitHubAutomationPrCandidate> prs;
+
+        public FakeLister(
+            IReadOnlyList<GitHubAutomationIssueCandidate>? issues = null,
+            IReadOnlyList<GitHubAutomationPrCandidate>? prs = null)
+        {
+            this.issues = issues ?? Array.Empty<GitHubAutomationIssueCandidate>();
+            this.prs = prs ?? Array.Empty<GitHubAutomationPrCandidate>();
+        }
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => prs;
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) => issues;
+    }
+
+    private sealed class FakeLabelMutator : IGitHubLabelMutator
+    {
+        private readonly IReadOnlyList<string> labels;
+        public List<Transition> Transitions { get; } = new();
+
+        public FakeLabelMutator(IReadOnlyList<string> labels) => this.labels = labels;
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+
+        public void ApplyLabelTransitions(string repo, string kind, int number,
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
+            Transitions.Add(new Transition(kind, number, addLabels.ToArray(), removeLabels.ToArray()));
+
+        public void ApplyReconcileTransitions(string repo, string kind, int number,
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed record Transition(string Kind, int Number, IReadOnlyList<string> AddLabels, IReadOnlyList<string> RemoveLabels);
+
+    private sealed class FakeRetirementMutator : IGitHubIssueRetirementMutator
+    {
+        public List<ClosedIssue> Closed { get; } = new();
+
+        public void CloseAsNotPlanned(string repo, int issueNumber, string comment) =>
+            Closed.Add(new ClosedIssue(repo, issueNumber, comment));
+    }
+
+    private sealed record ClosedIssue(string Repo, int IssueNumber, string Comment);
+
+    private sealed class RetireWorkspace : IDisposable
+    {
+        public RetireWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("issue-retire-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public void WriteQueueState(string json) => File.WriteAllText(Context.GetQueueStatePath(), json);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
@@ -24,7 +24,14 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
 
     public AutomationIssueRetireCommandTests()
     {
-        AutomationIssueRetireCommand.CandidateListerFactory = null;
+        // Default to an empty fake lister so tests that never override it
+        // (most: they only care about the issue snapshot / label / queue
+        // seams) cannot silently fall back to a REAL `gh pr list` subprocess
+        // for the open-linked-PR check — that fallback happens to succeed
+        // on a machine with an authenticated `gh` (e.g. a dev box) but fails
+        // in CI, which is exactly the class of environment-dependent test
+        // bug already hit once in this execution unit.
+        AutomationIssueRetireCommand.CandidateListerFactory = () => new FakeLister();
         AutomationIssueRetireCommand.LabelMutatorFactory = null;
         AutomationIssueRetireCommand.RetirementMutatorFactory = null;
         AutomationIssueRetireCommand.UtcNowFactory = () => FixedNow;


### PR DESCRIPTION
## Summary
Adds `intent-cli automation issue-retire --repo <r> --issue <n> --reason <superseded|decomposed|obsolete> [--note <text>] [--write]` — the missing atomic transition for a published `intent-target` issue that can never be started as authored.

Fixes the field deadlock from issue #1744 / SKS-G812 (2026-07-14): the WIP cap correctly blocked publishing an urgent fix, but intent-cli exposed no canonical way to retire the stuck issue (`automation complete` had no matching outcome; `declined-contract-incomplete` only released the claim, leaving the issue open with `intent-target` still attached). The only escape was an operator-authorized noncanonical recovery that `metadata validate` then failed to recognize.

`--write` atomically:
1. Closes the GitHub issue as **not planned** with a reason/note comment.
2. Removes `intent-target` and any other workflow labels present.
3. Marks the queue-state item's lifecycle `Retired` — **creating the entry if none existed yet** (a published-but-never-delegated issue commonly has none; this is exactly what lets `metadata validate` recognize the retired state instead of reporting a missing queue entry).
4. Appends a `packet-retired` event to `runs.jsonl`.

Fails closed (no mutation) when an OPEN linked PR or an active claim (`intent-issue-in-progress`) exists, naming the release step to run first. Idempotent via durable state (a re-run against an already-`Retired` execution unit is a safe no-op — no fragile GitHub-state re-check needed). Retired items clear WIP gating automatically since `host-review-preflight` already scans live, labeled GitHub state — no code change needed there. Packet files and the issue comment trail are never touched.

Adds `QueueItemState.Retired` and `QueueItem.RetirementReason` to the shared Supervisor models, registers the command in `CommandRouter` and the `Program.cs` bootstrap allow-list (learned from the G523 lesson), and documents the transition in `docs/ja`/`docs/en` `09-developer-reference.md`.

## Test plan
- [x] `dotnet build` (full solution) — 0 warnings/errors.
- [x] `dotnet test` (full solution) — all green (3246 passed, 1 pre-existing skip).
- [x] New `AutomationIssueRetireCommandTests.cs` (10 tests): full `--write` mutation sequence (deriving execution unit from title when no queue item exists, reproducing the field scenario), updating an existing queue item in place, dry-run (no mutation), refusal on open linked PR, refusal on active claim, idempotent no-op on an already-retired unit, fail-closed on an issue not found among OPEN issues, `--reason` validation, a WIP-clearing fixture through `AutomationHostReviewPreflightCommand` (before/after), and a `MetadataValidateAnalyzer` fixture proving a retired entry never trips `QueueEntryMissing`/`CompletedMissingClosure`.
- [x] Manual check: built the CLI, confirmed `--help`/argument validation, and ran a safe read-only dry-run against the real repo with a nonexistent issue number (`gh issue list` call succeeds, correctly reports "not found," no mutation attempted) — did not perform a real `--write` against the production repo, since that would durably close/retire a real issue.
- [x] `git diff --check` — clean.

Closes #1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4yoyeXmTeJWD16RLvktQd