### PR TITLE
G528: Prepare v0.4.0 minor release metadata for G520-G527

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -390,79 +390,104 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.3.14",
-  "nextVersion": "0.3.15"
+  "stableVersion": "0.3.15",
+  "nextVersion": "0.4.0"
 }
 ```
 
 | Stage | Version form | How it is derived |
 | --- | --- | --- |
-| Local pack / install | `0.3.15-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.3.15-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.3.15-rc.N` | Publishing the GitHub Release for tag `v0.3.15-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
-| Stable release | `0.3.15` | Publishing the GitHub Release for tag `v0.3.15` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.3.16-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.3.16` |
+| Local pack / install | `0.4.0-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.4.0-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.4.0-rc.N` | Publishing the GitHub Release for tag `v0.4.0-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
+| Stable release | `0.4.0` | Publishing the GitHub Release for tag `v0.4.0` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.4.1-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.4.1` |
 
-**After releasing `v0.3.15`**, bump both fields in `eng/version.json`:
+**After releasing `v0.4.0`**, bump both fields in `eng/version.json`:
 
 ```json
 {
-  "stableVersion": "0.3.15",
-  "nextVersion": "0.3.16"
+  "stableVersion": "0.4.0",
+  "nextVersion": "0.4.1"
 }
 ```
 
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.3.16-preview.<run>.<attempt>` / `0.3.16-<sha>-<G-unit>` rather than continuing to
-emit `0.3.15` (which would collide with the stable release version).
+`0.4.1-preview.<run>.<attempt>` / `0.4.1-<sha>-<G-unit>` rather than continuing to
+emit `0.4.0` (which would collide with the stable release version).
 
-### Next release readiness (v0.3.15)
+### Next release readiness (v0.4.0)
 
-**`v0.3.14` shipped** (GitHub Release + NuGet) and the version policy was bumped
-to the `0.3.15` development line. The repository is now on the in-development
-**`0.3.15`** `nextVersion`; G519 is **prepare-only** — it bumps the version
-metadata and docs and adds no publish steps. The version-bump merge does **not**
-create a GitHub Release or tag. After it merges and the
-[release-readiness gate](release-notes-v0.3.15.md#release-readiness-gate-g519)
+**`v0.3.15` shipped** (GitHub Release + NuGet) and the version policy was bumped
+to the `0.4.0` development line — a **minor** bump, not a patch: three new
+automation commands plus a visible fail-loud behavior change justify more than
+a patch release. The repository is now on the in-development **`0.4.0`**
+`nextVersion`; G528 is **prepare-only** — it bumps the version metadata and
+docs and adds no publish steps. The version-bump merge does **not** create a
+GitHub Release or tag. After it merges and the
+[release-readiness gate](release-notes-v0.4.0.md#release-readiness-gate-g528)
 holds, a **maintainer/operator (or external release automation) creates and
-publishes the GitHub Release** for `v0.3.15`; publishing that Release fires
+publishes the GitHub Release** for `v0.4.0`; publishing that Release fires
 `.github/workflows/release.yml` (`on: release: published`), which builds and
 publishes the NuGet package and the per-platform binary artifacts. Full
 changelog and operator checklist:
-[release-notes-v0.3.15.md](release-notes-v0.3.15.md).
+[release-notes-v0.4.0.md](release-notes-v0.4.0.md).
 
-**To ship in `v0.3.15` (changes since `v0.3.14`) — orchestrator/agmsg
-operational fixes:**
+**To ship in `v0.4.0` (changes since `v0.3.15`) — orchestrator stall-prevention
+batch, fail-loud domain resolution, and a parser fix:**
 
-- **Claude project-settings diagnosis for a missing agmsg Monitor** (G517) —
-  when `ToolSearch select:Monitor` finds no Claude Code `Monitor` tool at all
-  (a tool-surface problem, not the `1 shell` vs `1 monitor` delivery-mode
-  confusion), the guide adds a known-good comparison checklist, names suspect
-  project-level `env` overrides, and documents safe operator remediation.
-- **orchestrator-mode timers shift to a design-side watchdog** (G518) — the
-  normal steady state is now message-driven (implementation/review replies
-  wake the orchestrator), with an explicit orchestrator timer supported only
-  as a fallback/legacy polling option, and a new optional, low-frequency
-  design-side watchdog as the recommended safety net.
+- **Three new automation commands** — `automation stalled-work` (G523),
+  `automation heartbeat` (G526), and `automation issue-retire` (G525): a
+  read-only pending-transition inventory, a read-only wrapper of it that
+  emits a ready-to-send reconcile message for an external low-frequency
+  scheduler, and a canonical atomic transition to retire a published issue
+  that can never be started as authored.
+- **Fail-loud domain resolution** (G522) — execution-unit-resolving surfaces
+  (`automation queue-seed-from-packet`, `review closeout-plan`,
+  `automation publish-recovery`) now resolve domain as: explicit `--domain`
+  wins (erroring on contradiction with the packet's own `domain:` field) >
+  the packet-declared domain > fail loud naming candidate domains and the
+  exact re-invocation — never a silent fallback to the host's config-default
+  domain. **Migration:** any script or automation that relied on the previous
+  silent fallback must now either pass `--domain` explicitly or ensure the
+  resolved packet.yaml declares its `domain:` field.
+- **Orchestrator wake contract** (G524) — publish and delegate in the SAME
+  wake (no more "deferred to the next wake"); the message cap is reframed as
+  "at most one delegation per receiver per wake"; a new end-of-wake
+  `automation stalled-work` check with a never-defer rule; the receiver
+  completion-or-blocked report is now a REQUIRED FINAL STEP of every
+  delegation; and dispatch roster verification (`team.sh`) before every send.
+- **Managed review worktrees + design-alignment checks** (G520) — review
+  worktrees are enforced under the managed root
+  (`.intent-cli/worktrees/review-<unit>`), never `/tmp`; a review `completed`
+  reply missing design-alignment evidence (packet, review-context, intent
+  tree, ADR/decision notes) is now incomplete.
+- **Codex monitor (beta) guidance** (G521) — a setup preflight and three new
+  troubleshooting entries (silent launcher, static TUI, doubled responses)
+  for the agmsg Codex bridge.
+- **Packet-yaml parser fix** (G527) — `PreparedPacketYamlScalarParser`'s
+  quote-balance check is now delimiter-aware, fixing the exact field
+  incident where a double-quoted value merely containing an apostrophe was
+  wrongly rejected.
 - Orchestrator mode remains **preview/experimental**: opt-in, still being
   hardened, with the timer-loop mode fully supported and unchanged. See
   [Agent-message orchestration](12-agent-message-orchestration.md).
 
-**Release-readiness verification (run before merging the `v0.3.15` version
+**Release-readiness verification (run before merging the `v0.4.0` version
 bump):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.3.14 (published), nextVersion 0.3.15 (to release)
+cat eng/version.json   # stableVersion 0.3.15 (published), nextVersion 0.4.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.3.15-<sha>-G51x   (NOT a stale literal)
+#   expected shape: intent-cli 0.4.0-<sha>-G52x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.15.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.4.0.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -470,11 +495,11 @@ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
 ```
 
 After the version-bump merge lands on `main`, a maintainer/operator (or external
-release automation) creates and publishes the GitHub Release for `v0.3.15`;
+release automation) creates and publishes the GitHub Release for `v0.4.0`;
 publishing it triggers `release.yml` (`on: release: published`) to build and
 publish the NuGet package and the per-platform binary artifacts. Once it has
 published, apply the post-release `eng/version.json` bump above
-(`stableVersion → 0.3.15`, `nextVersion → 0.3.16`).
+(`stableVersion → 0.4.0`, `nextVersion → 0.4.1`).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.4.0.md
+++ b/docs/en/release-notes-v0.4.0.md
@@ -1,0 +1,233 @@
+# Release Notes — intent-cli v0.4.0
+
+> **Release model:** a maintainer/operator (or external release automation)
+> **creates and publishes the GitHub Release** for `v0.4.0` — the version-bump
+> merge does **not** create a Release or tag on its own. Publishing the GitHub
+> Release fires `.github/workflows/release.yml` (`on: release: published`), which
+> then builds and publishes the NuGet package and platform binary artifacts.
+> This packet is **prepare-only**: it bumps version metadata and docs and adds
+> **no** publish steps. See the
+> [pre-merge release-readiness gate](#release-readiness-gate-g528) and
+> [publishing v0.4.0](#publishing-v040).
+
+## What's in v0.4.0
+
+v0.4.0 is a **minor release** covering eight slices (G520–G527) completed
+after `v0.3.15`. It is a minor bump rather than a patch because it ships
+**three new automation commands** and a **visible fail-loud behavior change**
+in domain resolution — both are more than routine maintenance. The package id
+remains `JTechJapan.IntentSystem.Cli`; there are no package id, license, or
+workflow-semantics changes.
+
+> **Orchestrator mode is still preview/experimental.** It is opt-in, still
+> being hardened, and not the default workflow. intent-cli and GitHub remain
+> the authoritative source of truth; agmsg is only a message/progress/
+> completion signal layer.
+
+### New automation commands: stalled-work, heartbeat, issue-retire
+
+These three commands exist because an orchestrator-mode pilot
+(sekiban-as-a-service-orch, 2026-06-28..07-14) lost significant time to
+silent pipeline stalls with no built-in way to detect or recover from them.
+
+- **`automation stalled-work`** (G523) — a read-only inventory of pending
+  pipeline transitions with ages, across three categories: `published-not-
+  delegated` (an OPEN issue carries `intent-target` but has no claim and no
+  PR yet), `pr-created-not-reviewing` (the closing PR is missing the
+  `review-start` transition), and `merged-not-closed-out` (a MERGED PR's
+  linked queue item is not yet `Completed`). Each item reports its execution
+  unit, age, and the exact canonical next command to run. No GitHub
+  mutation, no queue-state/runs.jsonl write.
+- **`automation heartbeat`** (G526) — wraps `stalled-work` and, when
+  anything is stale, emits a ready-to-send reconcile message body naming
+  every stale item and its recommended action; silent JSON (`stale: false`,
+  no `message_body`) when healthy. Never sends a message or launches an
+  agent itself — the orchestrator-thread guide now documents this as the
+  **recommended safety net**: a session-independent external scheduler
+  (cron/launchd, 60-minute class) with a fail-closed copy-paste wrapper,
+  ahead of the design-side watchdog and the in-session fallback timer (both
+  of which showed measured weaknesses in the field trial — see the guide's
+  "External heartbeat" section for the full comparison).
+- **`automation issue-retire`** (G525) — the canonical, atomic transition
+  for a published `intent-target` issue that can never be started as
+  authored (e.g. a slice must be decomposed). Closes the issue as "not
+  planned", removes workflow labels, and marks the queue-state entry
+  `retired` — creating the entry if none existed, so `metadata validate`
+  never reports a missing queue entry for a legitimately retired unit.
+  Fails closed on an open linked PR, an active claim, or already-`Completed`
+  work; a partial-write retry converges safely via a durable provenance
+  marker rather than dead-ending.
+
+### Fail-loud domain resolution — migration note
+
+**(G522, tightened further across G523/G525)** Execution-unit-resolving
+surfaces — `automation queue-seed-from-packet`, `review closeout-plan`,
+`automation publish-recovery`, `automation stalled-work`, and `automation
+issue-retire` — now resolve the domain in a strict order:
+
+1. an explicit `--domain` wins (it is an error if it contradicts the domain
+   declared by the resolved packet.yaml's `domain:` field);
+2. otherwise the packet-declared `domain:` field is used;
+3. otherwise the surface **fails loud**, naming candidate domains (scanned
+   from `intents/*/`) and the exact `--domain` re-invocation.
+
+**This is a visible behavior change.** Previously some of these surfaces
+silently fell back to the host's config-default domain binding when neither
+signal was available — on a multi-domain host, this could misattribute an
+execution unit to the wrong domain. **If you have scripts or automation that
+relied on that silent fallback**, they will now fail loud instead of silently
+succeeding against the wrong domain. Adapt by either passing `--domain`
+explicitly, or ensuring the relevant packet.yaml declares its `domain:`
+field.
+
+### Orchestrator wake contract (G524)
+
+Field data showed ~60 hours of "publish-then-sleep" stalls and an 88-minute
+silent-completion gap. The orchestrator-thread guide now requires, every
+wake:
+
+- **publish and delegate in the same wake** — no more deferring a delegation
+  to "the next wake" (nothing else would reliably wake the orchestrator to
+  send it);
+- the message cap is reframed as **"at most one delegation per receiver per
+  wake"**, not a blanket one-message rule — publish + its delegation + repair
+  messages + an escalation + receiver-report handling are all permitted
+  within one wake;
+- a new **end-of-wake `automation stalled-work` check** with a never-defer,
+  escalate-instead-of-defer rule;
+- the receiver's completion-or-blocked report is now a **REQUIRED FINAL
+  STEP** of every delegation, stated with its exact expected JSON shape;
+- **dispatch roster verification** (`team.sh`) before every send, closing a
+  field-observed message loss to a dead `review` vs `reviewer` address.
+
+### Managed review worktrees + design-alignment checks (G520)
+
+Review worktrees are now enforced under the managed root
+(`.intent-cli/worktrees/review-<unit>`) — never a raw `/tmp/...` path — and a
+stale/dirty/unregistered worktree becomes a structured blocker reply, never
+an operator `rm -rf` approval prompt. A review `completed` reply is now
+**incomplete** unless it shows evidence that design alignment (packet,
+review-context, intent tree, ADR/decision notes) was actually checked.
+
+### Codex monitor (beta) guidance (G521)
+
+Adds a Codex monitor setup preflight and three troubleshooting entries for
+the agmsg Codex bridge: a silent launcher (multiple identities), a static
+TUI (stale app-server threads, with the full recovery sequence), and doubled
+responses (a doubled bridge).
+
+### Packet-yaml parser fix (G527)
+
+`PreparedPacketYamlScalarParser`'s quote-balance check is now
+delimiter-aware instead of counting every quote character in a value — a
+double-quoted scalar's balance depends only on double quotes (an apostrophe
+inside is ordinary content), and a single-quoted scalar's balance depends
+only on single quotes (honoring the YAML `''` escape). This fixes the exact
+field incident where `automation queue-seed-from-packet` twice refused a
+valid packet whose double-quoted values merely contained an apostrophe.
+Genuinely unterminated or ambiguous quoting still fails closed.
+
+> Version metadata note: `eng/version.json` records `stableVersion: 0.3.15`,
+> `nextVersion: 0.4.0`; G528 (this packet) is the release-prep metadata bump.
+> The post-v0.4.0 metadata advancement (`stableVersion → 0.4.0`, `nextVersion
+> → 0.4.1`) is the operator's post-release step and is out of scope for this
+> packet.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.4.0
+```
+
+Or download the self-contained binary from the
+[v0.4.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.4.0).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.3.15
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.4.0
+```
+
+**Read the fail-loud domain resolution migration note above before upgrading
+any automation that scripts these commands.** Everything else is additive:
+the three new commands are opt-in surfaces, and the orchestrator/review-guide
+changes only affect operators who have opted into orchestrator mode. Existing
+timer-loop setups are unaffected.
+
+## Release-readiness gate (G528)
+
+These items must hold **before the GitHub Release for `v0.4.0` is published**.
+This gate fails closed — if any item is unmet, do not publish the Release yet.
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G520, G521, G522, G523, G524, G525, G526, G527 (and this G528
+      release-notes prep). Confirm on the host/review side via the host
+      queue-state / GitHub PR state — the child implementation loop must not
+      read parent queue-state, so this is a host-owned precondition.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before
+      publishing).
+- [ ] `eng/version.json` `nextVersion` is `0.4.0` (the intended release
+      version). `release.yml` builds the package version from the published
+      Release/tag; `src/IntentSystem.Cli/IntentSystem.Cli.csproj` derives its
+      local default from the same policy.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] Release notes / README keep **orchestrator mode described as
+      preview/experimental** and opt-in, with timer-loop mode unchanged.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+
+## Publishing v0.4.0
+
+This packet does **not** publish the release and adds **no** publish steps. The
+version-bump merge does **not** create a GitHub Release or tag on its own.
+
+1. After this version bump is merged and the readiness gate above holds, a
+   **maintainer/operator (or external release automation) creates and publishes
+   the GitHub Release** for `v0.4.0` (tagging the release commit). This is a
+   post-merge host/operator/external action.
+2. Publishing that GitHub Release fires `.github/workflows/release.yml`
+   (`on: release: published`), which builds and publishes the NuGet package and
+   the per-platform binary archives (with `.sha256` checksums) and attaches them
+   to the triggering Release.
+
+Post-release verification (after the GitHub Release is published and
+`release.yml` has run):
+
+- [ ] NuGet.org package page links all resolve correctly.
+- [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+      accessible.
+- [ ] `.sha256` checksums match the downloaded artifacts.
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.4.0`)
+      then `intent-cli --version` reports `0.4.0`.
+- [ ] Binary artifact smoke check: download the platform archive, verify its
+      `.sha256`, extract, and run `./intent-cli --version` → `0.4.0`.
+- [ ] **New commands smoke**: `intent-cli automation stalled-work --domain <d>
+      --repo <r> --format json`, `intent-cli automation heartbeat --domain <d>
+      --repo <r> --format json`, and `intent-cli automation issue-retire --help`
+      all run against a real repo without crashing.
+- [ ] **Fail-loud domain migration smoke** (G522): running one of the affected
+      surfaces without `--domain` against a packet with no declared `domain:`
+      fails loud naming candidate domains, rather than silently resolving the
+      host's config-default domain.
+- [ ] **External heartbeat guide smoke** (G526): `intent-cli guide
+      orchestrator-thread --domain <d> --target-repo <repo> --agent <agent>
+      --format markdown` renders the **External heartbeat (recommended safety
+      net)** section (frequency, command, copy-paste wrapper, at-most-one-
+      message rule) ahead of the **Design-side watchdog (alternative safety
+      net)** section.
+- [ ] **Wake contract guide smoke** (G524): the same guide output renders the
+      end-of-wake `automation stalled-work` check, the "at most one delegation
+      per receiver per wake" framing, and the dispatch roster verification
+      step.
+- [ ] Local preview/dry-run version metadata uses the next development line
+      after `0.4.0` (bump `eng/version.json` per the post-release step in
+      [Version flow](09-developer-reference.md#version-flow)):
+      `stableVersion → 0.4.0`, `nextVersion → 0.4.1`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -387,78 +387,103 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.3.14",
-  "nextVersion": "0.3.15"
+  "stableVersion": "0.3.15",
+  "nextVersion": "0.4.0"
 }
 ```
 
 | ステージ | バージョン形式 | 導出方法 |
 | --- | --- | --- |
-| ローカル pack / install | `0.3.15-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.3.15-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.3.15-rc.N` | タグ `v0.3.15-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
-| 安定版リリース | `0.3.15` | タグ `v0.3.15` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.3.16-preview.<run>.<attempt>` | `nextVersion` を `0.3.16` にバンプ後 |
+| ローカル pack / install | `0.4.0-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.4.0-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.4.0-rc.N` | タグ `v0.4.0-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
+| 安定版リリース | `0.4.0` | タグ `v0.4.0` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.4.1-preview.<run>.<attempt>` | `nextVersion` を `0.4.1` にバンプ後 |
 
-**`v0.3.15` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+**`v0.4.0` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
 
 ```json
 {
-  "stableVersion": "0.3.15",
-  "nextVersion": "0.3.16"
+  "stableVersion": "0.4.0",
+  "nextVersion": "0.4.1"
 }
 ```
 
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.3.16-preview.<run>.<attempt>` / `0.3.16-<sha>-<G-unit>` を生成し、`0.3.15`（安定版
+`0.4.1-preview.<run>.<attempt>` / `0.4.1-<sha>-<G-unit>` を生成し、`0.4.0`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備（v0.3.15）
+### 次リリース準備（v0.4.0）
 
-**`v0.3.14` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
-`0.3.15` 開発ラインにバンプされました。リポジトリは現在 in-development の **`0.3.15`**
-`nextVersion` 上にあり、G519 は **prepare-only** です — version メタデータと docs をバンプするだけで
+**`v0.3.15` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
+`0.4.0` 開発ラインにバンプされました — これは patch ではなく **minor** バンプです:
+3 つの新しい automation コマンドに加えて、目に見える fail-loud な挙動変更があるため、
+patch リリース以上の扱いが妥当です。リポジトリは現在 in-development の **`0.4.0`**
+`nextVersion` 上にあり、G528 は **prepare-only** です — version メタデータと docs をバンプするだけで
 publish ステップを追加しません。version-bump マージ自体は GitHub Release やタグを作成しません。
 マージされ
-[リリース準備ゲート](release-notes-v0.3.15.md#リリース準備ゲート-g519)が成り立った後、
-**メンテナ/オペレーター（または外部のリリース automation）が `v0.3.15` の GitHub Release を作成・
+[リリース準備ゲート](release-notes-v0.4.0.md#リリース準備ゲート-g528)が成り立った後、
+**メンテナ/オペレーター（または外部のリリース automation）が `v0.4.0` の GitHub Release を作成・
 publish** します。その Release の publish が `.github/workflows/release.yml`（`on: release: published`）を
 発火させ、NuGet package とプラットフォームごとのバイナリ成果物を build・publish します。
 完全な changelog と operator チェックリスト:
-[release-notes-v0.3.15.md](release-notes-v0.3.15.md)。
+[release-notes-v0.4.0.md](release-notes-v0.4.0.md)。
 
-**`v0.3.15` で出荷予定（`v0.3.14` 以降の変更）— orchestrator/agmsg 運用修正:**
+**`v0.4.0` で出荷予定（`v0.3.15` 以降の変更）— orchestrator スタール防止バッチ、
+fail-loud な domain 解決、parser 修正:**
 
-- **agmsg Monitor 欠落時の Claude project-settings 診断**（G517）— `ToolSearch select:Monitor` が
-  Claude Code の `Monitor` ツールをまったく見つけられない場合（`1 shell` vs `1 monitor` の
-  delivery-mode 混同ではなく、ツールサーフェス問題）、ガイドに known-good 比較チェックリスト、
-  疑わしい project-level `env` override、安全なオペレーター修復手順を追加。
-- **orchestrator モードのタイマーを design-side watchdog へシフト**（G518）— 通常の定常状態が
-  メッセージ駆動になり（implementation/review の返信が orchestrator を起こす）、明示的な
-  orchestrator タイマーは fallback/legacy ポーリングオプションとしてのみサポートされ、新しい
-  任意・低頻度の design-side watchdog が推奨セーフティネットとして追加された。
+- **3 つの新しい automation コマンド** — `automation stalled-work`（G523）、
+  `automation heartbeat`（G526）、`automation issue-retire`（G525）: 保留中の
+  transition を一覧する read-only な棚卸しコマンド、それを外部の低頻度スケジューラ向けに
+  ラップして送信可能な reconcile メッセージを返す read-only コマンド、そして authored 通りには
+  決して開始できない published issue を retire する canonical かつ atomic な transition。
+- **fail-loud な domain 解決**（G522）— execution-unit を解決するサーフェス
+  （`automation queue-seed-from-packet`、`review closeout-plan`、
+  `automation publish-recovery`）は、明示的な `--domain` が優先され（packet 自身の
+  `domain:` フィールドと矛盾する場合はエラー）、次に packet-declared な domain、
+  どちらも無い場合は candidate domains と正確な re-invocation を示して fail loud する
+  ようになりました — host の config-default domain への黙ったフォールバックは
+  もうありません。**移行方法:** これまで黙ったフォールバックに依存していたスクリプトや
+  automation は、`--domain` を明示的に渡すか、解決対象の packet.yaml が `domain:`
+  フィールドを宣言していることを確認する必要があります。
+- **orchestrator wake contract**（G524）— publish と delegate を同じ wake 内で行う
+  (「次の wake に持ち越す」はもうありません); メッセージ上限は「wake ごと・receiver ごとに
+  最大 1 通の delegation」と再定義; 新しい end-of-wake の `automation stalled-work`
+  チェック（never-defer ルール付き）; receiver の completion/blocked レポートは
+  すべての delegation の REQUIRED FINAL STEP になりました; そして送信のたびに
+  dispatch roster を検証（`team.sh`）。
+- **managed review worktree + design-alignment チェック**（G520）— review worktree は
+  managed root（`.intent-cli/worktrees/review-<unit>`）配下で強制され、`/tmp` は
+  使われません; design-alignment のエビデンス（packet、review-context、intent tree、
+  ADR/decision note）が無い review completed 返信は incomplete 扱いになります。
+- **Codex monitor（beta）ガイダンス**（G521）— agmsg Codex bridge 向けの setup preflight
+  と 3 つの新しい troubleshooting エントリ（silent launcher、static TUI、doubled
+  responses）。
+- **packet-yaml parser 修正**（G527）— `PreparedPacketYamlScalarParser` の
+  quote-balance チェックが delimiter-aware になり、アポストロフィだけを含む
+  double-quoted 値が誤って拒否されていたフィールドインシデントを修正しました。
 - orchestrator モードは引き続き **preview/experimental** です: オプトインで、まだ hardening 中であり、
   timer-loop モードは完全サポート・不変です。
   [エージェントメッセージオーケストレーション](12-agent-message-orchestration.md) を参照。
 
-**リリース準備の検証（`v0.3.15` version bump のマージ前に実行）:**
+**リリース準備の検証（`v0.4.0` version bump のマージ前に実行）:**
 
 ```bash
-cat eng/version.json   # stableVersion 0.3.14（公開済み）, nextVersion 0.3.15（リリース対象）
+cat eng/version.json   # stableVersion 0.3.15（公開済み）, nextVersion 0.4.0（リリース対象）
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.3.15-<sha>-G51x （stale なリテラルではない）
+#   期待形: intent-cli 0.4.0-<sha>-G52x （stale なリテラルではない）
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.3.15.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.4.0.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
 version-bump マージが `main` に入った後、メンテナ/オペレーター（または外部のリリース automation）が
-`v0.3.15` の GitHub Release を作成・publish します。その publish が `release.yml`
+`v0.4.0` の GitHub Release を作成・publish します。その publish が `release.yml`
 （`on: release: published`）を発火させ、NuGet package とプラットフォームごとのバイナリ成果物を
 build・publish します。publish 後、上記のリリース後 `eng/version.json` バンプ
-（`stableVersion → 0.3.15`, `nextVersion → 0.3.16`）を適用します。
+（`stableVersion → 0.4.0`, `nextVersion → 0.4.1`）を適用します。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.4.0.md
+++ b/docs/ja/release-notes-v0.4.0.md
@@ -1,0 +1,215 @@
+# リリースノート — intent-cli v0.4.0
+
+> **リリースモデル:** メンテナ/オペレーター(または外部のリリース automation)が `v0.4.0` の
+> **GitHub Release を作成・publish** します — version-bump マージ自体は Release やタグを作成しません。
+> GitHub Release の publish が `.github/workflows/release.yml`(`on: release: published`)を発火させ、
+> NuGet package とプラットフォームバイナリ成果物を build・publish します。本パケットは
+> **prepare-only** で、version メタデータと docs をバンプするだけで publish ステップを **追加しません**。
+> [マージ前 リリース準備ゲート](#リリース準備ゲート-g528) と
+> [v0.4.0 の publish](#v040-の-publish) を参照。
+
+## v0.4.0 の内容
+
+v0.4.0 は **minor リリース** で、`v0.3.15` 以降に完了した 8 件のスライス(G520–G527)を
+カバーします。patch ではなく minor バンプなのは、**3 つの新しい automation コマンド**と、
+domain 解決における目に見える **fail-loud な挙動変更**を出荷するためで、どちらも通常の
+メンテナンス以上のものです。package id は `JTechJapan.IntentSystem.Cli` のままで、
+package id・ライセンス・workflow セマンティクスの変更はありません。
+
+> **orchestrator モードは引き続き preview/experimental です。** オプトインで、まだ hardening 中で
+> あり、デフォルトの workflow ではありません。intent-cli と GitHub が権威 source of truth であり
+> 続け、agmsg はメッセージ / 進捗 / 完了のシグナル層のみです。
+
+### 新しい automation コマンド: stalled-work, heartbeat, issue-retire
+
+これら 3 つのコマンドは、orchestrator モードのパイロット(sekiban-as-a-service-orch、
+2026-06-28..07-14)が、検知もリカバリもできないサイレントなパイプラインスタールに
+大きな時間を失ったことから生まれました。
+
+- **`automation stalled-work`**(G523)— 保留中のパイプライン transition を年齢付きで
+  一覧する read-only な棚卸しコマンドで、3 つのカテゴリがあります: `published-not-
+  delegated`(OPEN issue が `intent-target` を持つが claim も PR もまだ無い)、
+  `pr-created-not-reviewing`(closing PR に `review-start` transition が欠けている)、
+  `merged-not-closed-out`(MERGED PR の紐づく queue item がまだ `Completed` でない)。
+  各項目は execution unit・年齢・実行すべき正確な canonical な次のコマンドを報告します。
+  GitHub mutation も queue-state/runs.jsonl への書き込みもありません。
+- **`automation heartbeat`**(G526)— `stalled-work` をラップし、何かがスタールしている
+  場合はスタールした各項目とその推奨アクションを示す送信可能な reconcile メッセージを
+  返します。健全な場合は沈黙した JSON(`stale: false`、`message_body` なし)を返します。
+  自分でメッセージを送ったり agent を起動したりすることは一切ありません — orchestrator-
+  thread ガイドはこれを **推奨セーフティネット** として文書化しています: セッションに
+  依存しない外部スケジューラ(cron/launchd、60 分クラス)を fail-closed なコピペ用
+  ラッパーとともに使い、design-side watchdog と in-session の fallback タイマー
+  (どちらも同じフィールドトライアルで実測された弱点があります — 詳細な比較はガイドの
+  「External heartbeat」セクションを参照)よりも優先します。
+- **`automation issue-retire`**(G525)— authored 通りには決して開始できない
+  published `intent-target` issue(例: slice を decompose する必要が判明した場合)の
+  ための canonical かつ atomic な transition です。issue を「not planned」として
+  close し、workflow label を除去し、queue-state エントリを `retired` としてマーク
+  します — エントリが存在しなければ新規作成するため、正当に retire されたユニットに
+  ついて `metadata validate` が queue entry の欠落を報告することはありません。open な
+  紐づき PR、アクティブな claim、既に `Completed` な作業に対しては fail closed し、
+  partial write のリトライは行き詰まるのではなく、durable な provenance marker を
+  通じて安全に収束します。
+
+### fail-loud な domain 解決 — 移行に関する注記
+
+**(G522、G523/G525 でさらに強化)** execution-unit を解決するサーフェス —
+`automation queue-seed-from-packet`、`review closeout-plan`、
+`automation publish-recovery`、`automation stalled-work`、`automation
+issue-retire` — は、次の厳密な順序で domain を解決するようになりました:
+
+1. 明示的な `--domain` が優先されます(解決対象の packet.yaml の `domain:` フィールドと
+   矛盾する場合はエラー);
+2. それ以外の場合は packet-declared な `domain:` フィールドが使われます;
+3. どちらも無い場合、サーフェスは **fail loud** し、candidate domains(`intents/*/`
+   からスキャン)と正確な `--domain` re-invocation を示します。
+
+**これは目に見える挙動変更です。** 以前は、これらのサーフェスの一部は、どちらの
+シグナルも得られない場合に host の config-default domain binding へ黙って
+フォールバックしていました — マルチドメインの host では、これにより execution unit が
+誤った domain に帰属してしまう可能性がありました。**その黙ったフォールバックに
+依存していたスクリプトや automation がある場合**、それらは今後、誤った domain に
+対して黙って成功するのではなく、fail loud するようになります。`--domain` を明示的に
+渡すか、該当する packet.yaml が `domain:` フィールドを宣言していることを確認して
+対応してください。
+
+### orchestrator wake contract(G524)
+
+フィールドデータは約 60 時間の「publish してから sleep する」スタールと、88 分間の
+サイレントな completion のギャップを示しました。orchestrator-thread ガイドは、
+すべての wake で次を要求するようになりました:
+
+- **同じ wake 内で publish と delegate を行う** — delegation を「次の wake」に
+  持ち越すことはもうありません(他に何も、確実に orchestrator を起こして delegation を
+  送らせる仕組みはありません);
+- メッセージ上限は、一律の「1 通のみ」ルールではなく **「wake ごと・receiver ごとに
+  最大 1 通の delegation」** と再定義されました — publish + その delegation +
+  repair メッセージ + エスカレーション + receiver report の処理はすべて 1 回の
+  wake 内で許可されます;
+- 新しい **end-of-wake の `automation stalled-work` チェック**(never-defer・
+  escalate-instead-of-defer ルール付き);
+- receiver の completion/blocked レポートは、すべての delegation の
+  **REQUIRED FINAL STEP** になり、期待される正確な JSON 形状とともに明記されました;
+- 送信のたびに **dispatch roster を検証**(`team.sh`)し、死んだ `review` vs
+  `reviewer` アドレスへのフィールドで観測されたメッセージ損失を解消します。
+
+### managed review worktree + design-alignment チェック(G520)
+
+review worktree は managed root(`.intent-cli/worktrees/review-<unit>`)配下で
+強制されるようになり — 生の `/tmp/...` パスはもう使われません — stale/dirty/
+未登録の worktree は、オペレーターへの `rm -rf` 承認プロンプトではなく、構造化された
+blocker 返信になります。review completed 返信は、design alignment(packet、
+review-context、intent tree、ADR/decision note)が実際に確認されたエビデンスを
+示さない限り、incomplete 扱いになります。
+
+### Codex monitor(beta)ガイダンス(G521)
+
+agmsg Codex bridge 向けの Codex monitor setup preflight と、3 つの
+troubleshooting エントリ(silent launcher — 複数 identity、static TUI — 古い
+app-server thread とその完全なリカバリ手順、doubled responses — bridge の二重化)を
+追加しました。
+
+### packet-yaml parser 修正(G527)
+
+`PreparedPacketYamlScalarParser` の quote-balance チェックが、値中のすべての
+quote 文字を数える方式ではなく、delimiter-aware になりました — double-quoted
+scalar の balance は double quote のみに依存し(内部のアポストロフィは通常の
+コンテンツ)、single-quoted scalar の balance は single quote のみに依存します
+(YAML の `''` エスケープを尊重)。これにより、`automation queue-seed-from-packet`
+が、アポストロフィだけを含む double-quoted 値を持つ有効な packet を 2 回誤って
+拒否したフィールドインシデントを修正しました。本当に unterminated あるいは
+曖昧な quoting は引き続き fail closed します。
+
+> バージョンメタデータ注記: `eng/version.json` は `stableVersion: 0.3.15`,
+> `nextVersion: 0.4.0` を記録します。G528(本パケット)はリリース準備のメタデータ
+> バンプです。v0.4.0 リリース後のメタデータ前進(`stableVersion → 0.4.0`,
+> `nextVersion → 0.4.1`)はオペレーターのリリース後ステップであり、本パケットの
+> スコープ外です。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.4.0
+```
+
+または [v0.4.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.4.0)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを検証します。
+
+## v0.3.15 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.4.0
+```
+
+**アップグレード前に、上記の fail-loud な domain 解決の移行に関する注記を、これらの
+コマンドをスクリプト化している automation について必ず確認してください。** それ以外は
+すべて加算的な変更です: 3 つの新しいコマンドはオプトインのサーフェスであり、
+orchestrator/review ガイドの変更は orchestrator モードをオプトインしたオペレーターに
+のみ影響します。既存の timer-loop セットアップには影響しません。
+
+## リリース準備ゲート (G528)
+
+次の項目は **`v0.4.0` の GitHub Release が publish される前** に成り立っている必要があります。
+このゲートは fail closed です — 1 つでも未充足なら、まだ Release を publish しないでください。
+
+- [ ] リリース対象の各パケットが **完了し PR が `main` にマージ済み**: G520、G521、
+      G522、G523、G524、G525、G526、G527(および release-notes 準備の G528)。
+      host queue-state / GitHub PR 状態で host/review 側から確認する(child 実装
+      ループは parent queue-state を読まないため、これは host 所有の前提条件)。
+- [ ] 本リリース対象の open な intent-system PR や WIP パケットが誤ってスキップされて
+      いない(publish 前に host queue / open PR リストを確認)。
+- [ ] `eng/version.json` の `nextVersion` が `0.4.0`(意図したリリースバージョン)。
+      `release.yml` は publish された Release/タグから package バージョンをビルドし、
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` も同じポリシーからローカル
+      デフォルトを導出する。
+- [ ] package メタデータが正しい: `PackageId = JTechJapan.IntentSystem.Cli`、
+      `RepositoryUrl` / `PackageProjectUrl` が `https://github.com/J-Tech-Japan/intent-system` を指す、
+      `PackageLicenseExpression = Apache-2.0`、README/docs リンクが解決し、公式サービスサイト
+      `https://www.intent-driven-development.com/` が README からリンクされている。
+- [ ] リリースノート / README が **orchestrator モードは preview/experimental** かつオプトインで
+      あること、timer-loop モードが不変であることを保っている。
+- [ ] リリースコミットで **Main CI が green**(`Build and test (source contract)`)であり、
+      **preview-pack** workflow も green。
+
+## v0.4.0 の publish
+
+本パケットはリリースを publish せず、publish ステップを **追加しません**。version-bump マージ自体は
+GitHub Release やタグを作成しません。
+
+1. この version bump がマージされ上記の準備ゲートが成り立った後、**メンテナ/オペレーター(または
+   外部のリリース automation)が `v0.4.0` の GitHub Release を作成・publish** します
+   (リリースコミットにタグ付け)。これはマージ後の host/operator/外部リリースアクションです。
+2. その GitHub Release の publish が `.github/workflows/release.yml`(`on: release: published`)を
+   発火させ、NuGet package とプラットフォームごとのバイナリアーカイブ(`.sha256` チェックサム付き)を
+   build・publish し、トリガーとなった Release に添付します。
+
+リリース後の検証(GitHub Release が publish され `release.yml` が実行された後):
+
+- [ ] NuGet.org の package ページのリンクがすべて正しく解決する。
+- [ ] GitHub release アセットリンク(`.tar.gz`, `.zip`, `.exe`, `.nupkg`)にアクセスできる。
+- [ ] `.sha256` チェックサムがダウンロード成果物と一致する。
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`(または
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.4.0`)後、
+      `intent-cli --version` が `0.4.0` を報告する。
+- [ ] バイナリ成果物スモーク: プラットフォームアーカイブをダウンロードし `.sha256` を検証、
+      展開して `./intent-cli --version` → `0.4.0`。
+- [ ] **新コマンドスモーク**: `intent-cli automation stalled-work --domain <d>
+      --repo <r> --format json`、`intent-cli automation heartbeat --domain <d>
+      --repo <r> --format json`、`intent-cli automation issue-retire --help` が
+      実リポジトリに対してクラッシュせず実行できる。
+- [ ] **fail-loud な domain 移行スモーク**(G522): `domain:` を宣言していない packet に
+      対して、対象サーフェスを `--domain` なしで実行すると、host の config-default
+      domain へ黙って解決するのではなく、candidate domains を示して fail loud する。
+- [ ] **External heartbeat ガイドスモーク**(G526): `intent-cli guide
+      orchestrator-thread --domain <d> --target-repo <repo> --agent <agent>
+      --format markdown` が、**Design-side watchdog (alternative safety net)**
+      セクションより前に **External heartbeat (recommended safety net)**
+      セクション(頻度、コマンド、コピペ用ラッパー、1 回の実行につき最大 1 通の
+      ルール)をレンダリングする。
+- [ ] **wake contract ガイドスモーク**(G524): 同じガイド出力が、end-of-wake の
+      `automation stalled-work` チェック、「wake ごと・receiver ごとに最大 1 通の
+      delegation」という枠組み、dispatch roster 検証ステップをレンダリングする。
+- [ ] ローカル preview/dry-run のバージョンメタデータが `0.4.0` の次の開発ラインを使う
+      ([バージョンフロー](09-developer-reference.md#バージョンフロー) のリリース後ステップに従い
+      `eng/version.json` をバンプ): `stableVersion → 0.4.0`, `nextVersion → 0.4.1`。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.14",
-  "nextVersion": "0.3.15"
+  "stableVersion": "0.3.15",
+  "nextVersion": "0.4.0"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,10 +124,12 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.3.15 as the next development line
-        // (post-v0.3.14 release bump, see G519 — v0.3.14 was published to
+        // be parseable and must point to 0.4.0 as the next development line
+        // (post-v0.3.15 release bump, see G528 — v0.3.15 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.3.15 while recording 0.3.14 as the published stable).
+        // forward to 0.4.0 — a minor bump, since three new automation
+        // commands plus a visible fail-loud behavior change justify more
+        // than a patch — while recording 0.3.15 as the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -137,8 +139,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.3.15", policy.NextVersion);
-        Assert.Equal("0.3.14", policy.StableVersion);
+        Assert.Equal("0.4.0", policy.NextVersion);
+        Assert.Equal("0.3.15", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary
- Prepares the repository for an operator release of **v0.4.0**, a **minor** release bundling eight slices completed since `v0.3.15` (G520–G527) — three new automation commands plus a visible fail-loud behavior change justify more than a patch, per the design ruling in the packet. This packet is **prepare-only**: it bumps version metadata and docs and adds no publish steps; the GitHub Release is created/published by a maintainer/operator after merge.
- `eng/version.json` — advance to `stableVersion: 0.3.15` (published) / `nextVersion: 0.4.0` (release-to-cut). Verified: `intent-cli --version` reports `0.4.0-fdb3ffd-G527`, `dotnet pack` produces `JTechJapan.IntentSystem.Cli.0.4.0.nupkg` — artifact and NuGet version sources are consistent (both derive solely from `eng/version.json`'s `nextVersion`, no other hard-coded version literal exists in the csproj).
- New `docs/{en,ja}/release-notes-v0.4.0.md` summarizing all eight slices, with dedicated sections for:
  - the three new automation commands — `automation stalled-work` (G523), `automation heartbeat` (G526), `automation issue-retire` (G525);
  - the **G522 fail-loud domain-resolution migration note** — execution-unit-resolving surfaces no longer silently fall back to the host's config-default domain; scripts relying on that must now pass `--domain` explicitly or ensure the packet declares its domain;
  - the **G524 orchestrator wake-contract** change (publish+delegate same wake, end-of-wake stalled-work check, required completion report, dispatch roster verification);
  - G520 (managed review worktrees + design-alignment checks), G521 (Codex monitor guidance), and G527 (packet-yaml parser fix).
  - Uses the same prepare-only release model, fail-closed release-readiness gate, and post-release verification checklist as the G519 (`v0.3.15`) precedent.
- `docs/{en,ja}/09-developer-reference.md` — retargets the version-flow table and "Next release readiness" section to v0.4.0, links the release notes, documents the post-release bump (`stable → 0.4.0`, `next → 0.4.1`).
- `tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs` — updates the smoke assertion to `next 0.4.0` / `stable 0.3.15`.

No GitHub Release/tag is created, no `release.yml` trigger is changed, no CLI install/cron setup performed, and no raw `gh` / host-metadata edits are introduced.

## Test plan
- [x] `dotnet build` (full solution) — 0 errors.
- [x] `dotnet test` (full solution) — all green (3282 passed, 1 pre-existing skip).
- [x] `intent-cli --version` reports `0.4.0-<sha>-<G-unit>` (not a stale literal).
- [x] `dotnet pack` produces `JTechJapan.IntentSystem.Cli.0.4.0.nupkg`.
- [x] `dotnet test --filter FullyQualifiedName~ReleasePackageMetadataTests` (Release config) — 4 passed.
- [x] Manually rendered both release-notes files and confirmed ja/en parity of structure and content.
- [x] `git diff --check` — clean.

Closes #1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4yoyeXmTeJWD16RLvktQd