### PR TITLE
G529: Add semantic facet classification to intent-tree nodes

### DIFF
--- a/docs/en/03a-intent-tree-layout.md
+++ b/docs/en/03a-intent-tree-layout.md
@@ -95,6 +95,98 @@ features/
     links.md             # References
 ```
 
+## Facets
+
+Any node file can carry an optional `facets:` frontmatter field naming which
+of four "human-retained understanding" surfaces it documents — the minimal
+surface humans must keep understanding when coding is delegated to AI
+(operator input, [issue #1159](https://github.com/J-Tech-Japan/intent-system/issues/1159)).
+Projections and boilerplate are safely delegable; these four are not:
+
+- **`vocabulary`** — event/command vocabulary: what counts as a fact.
+- **`invariant`** — invariants and consistency boundaries.
+- **`decider`** — decider judgments: what a command decides.
+- **`acceptance-property`** — acceptance properties: what must not break.
+
+The value set is closed for now; extending it is future design work, not
+something a node's frontmatter can invent locally. `facets:` is entirely
+**optional** — a node without it is unannotated, which is legitimate, not an
+error. `intent lint-layout` rejects only an unrecognized value (naming the
+node, the bad value, and the allowed set); `intent search --facet <value>`
+filters to nodes carrying that facet; `intent analyze-tree` reports
+per-facet counts. Scaffolded node files (`init-tree`, `add-feature`,
+`draft-from-interview`) include a commented example explaining all four
+values — uncomment and edit the line to annotate a node:
+
+```markdown
+---
+# Optional semantic facets (G529) — closed set, one line each:
+#   vocabulary            — event/command vocabulary: what counts as a fact
+#   invariant              — invariants and consistency boundaries
+#   decider                — decider judgments: what a command decides
+#   acceptance-property    — what must not break
+# Uncomment and edit to annotate this node, e.g.:
+# facets: [vocabulary]
+---
+
+# Node title
+...
+```
+
+One example node per facet:
+
+- **vocabulary** — a glossary node defining the domain's event/command
+  vocabulary:
+
+  ```markdown
+  ---
+  facets: [vocabulary]
+  ---
+  # Glossary
+  **PaymentAuthorized** — a fact recorded once a payment provider confirms
+  funds capture; never reversed in place (see `PaymentRefunded`).
+  ```
+
+- **invariant** — a feature's consistency-boundary node:
+
+  ```markdown
+  ---
+  facets: [invariant]
+  ---
+  # Order — consistency boundary
+  An order's total must always equal the sum of its line items; this
+  invariant is enforced inside the `Order` aggregate boundary, never across
+  aggregates.
+  ```
+
+- **decider** — a node documenting what a command decides:
+
+  ```markdown
+  ---
+  facets: [decider]
+  ---
+  # ApproveRefund — decision
+  Given a refund request and the order's payment history, decides whether
+  to approve, partially approve, or reject the refund; the decision itself
+  (not the notification/projection side effects) is what must stay
+  human-reviewed.
+  ```
+
+- **acceptance-property** — an acceptance-criteria node stating what must
+  never break:
+
+  ```markdown
+  ---
+  facets: [acceptance-property]
+  ---
+  # Checkout — acceptance properties
+  - A completed checkout must never leave the cart non-empty.
+  - A payment must never be captured twice for the same order.
+  ```
+
+A node can carry more than one facet (e.g. `facets: [vocabulary, invariant]`)
+when it genuinely documents both.
+
 ## Cross-linking rules
 
 Cross-links keep the tree navigable and prevent duplication:

--- a/docs/ja/03a-intent-tree-layout.md
+++ b/docs/ja/03a-intent-tree-layout.md
@@ -87,6 +87,98 @@ features/
     links.md             # 参照リンク
 ```
 
+## facets(セマンティックファセット)
+
+どの node ファイルも、任意の `facets:` frontmatter フィールドで、その node が
+4 つの「人間が理解を保持し続けるべき」サーフェスのうちどれを文書化しているかを
+示すことができます — これは、コーディングを AI に委譲する際に人間が理解し続け
+なければならない最小限のサーフェスです(オペレーター入力、
+[issue #1159](https://github.com/J-Tech-Japan/intent-system/issues/1159))。
+projection や boilerplate は安全に委譲できますが、この 4 つは委譲できません:
+
+- **`vocabulary`** — event/command vocabulary: 何が fact として扱われるか。
+- **`invariant`** — invariant と consistency boundary。
+- **`decider`** — decider judgment: コマンドが何を決定するか。
+- **`acceptance-property`** — acceptance property: 何が壊れてはならないか。
+
+この値セットは現時点では closed set です。拡張は将来の design 作業であり、
+node の frontmatter がローカルに新しい値を作り出すことはできません。
+`facets:` は完全に **任意** です — 付与されていない node は unannotated
+であり、これは正当な状態であって error ではありません。`intent lint-layout`
+は認識できない値のみを拒否します(node・不正な値・許可されている値セットを
+明示)。`intent search --facet <value>` はその facet を持つ node に絞り込み、
+`intent analyze-tree` は facet ごとのカウントを報告します。scaffold される
+node ファイル(`init-tree`、`add-feature`、`draft-from-interview`)には、
+4 つの値すべてを説明するコメント付きの例が含まれます — 該当行のコメントを
+外して編集することで node に注釈を付けられます:
+
+```markdown
+---
+# Optional semantic facets (G529) — closed set, one line each:
+#   vocabulary            — event/command vocabulary: what counts as a fact
+#   invariant              — invariants and consistency boundaries
+#   decider                — decider judgments: what a command decides
+#   acceptance-property    — what must not break
+# Uncomment and edit to annotate this node, e.g.:
+# facets: [vocabulary]
+---
+
+# Node title
+...
+```
+
+facet ごとの例 node を 1 つずつ示します:
+
+- **vocabulary** — ドメインの event/command vocabulary を定義する glossary
+  node:
+
+  ```markdown
+  ---
+  facets: [vocabulary]
+  ---
+  # Glossary
+  **PaymentAuthorized** — 決済プロバイダが資金確保を確認した時点で記録される
+  fact。その場で取り消されることはない(`PaymentRefunded` を参照)。
+  ```
+
+- **invariant** — 機能の consistency boundary を示す node:
+
+  ```markdown
+  ---
+  facets: [invariant]
+  ---
+  # Order — consistency boundary
+  注文の合計は常にその明細行の合計と一致しなければならない。この invariant は
+  `Order` aggregate の境界内でのみ強制され、aggregate を横断しては強制しない。
+  ```
+
+- **decider** — コマンドが何を決定するかを文書化する node:
+
+  ```markdown
+  ---
+  facets: [decider]
+  ---
+  # ApproveRefund — decision
+  返金リクエストと注文の支払い履歴が与えられたとき、返金を承認・部分承認・
+  却下のいずれにするかを決定する。この決定そのもの(通知/projection の副作用
+  ではなく)が、人間によるレビューを維持すべき部分である。
+  ```
+
+- **acceptance-property** — 何が壊れてはならないかを述べる acceptance
+  criteria node:
+
+  ```markdown
+  ---
+  facets: [acceptance-property]
+  ---
+  # Checkout — acceptance properties
+  - 完了した checkout はカートを空でない状態のまま残してはならない。
+  - 同じ注文に対して決済が二重に capture されてはならない。
+  ```
+
+1 つの node が複数の facet を持つこともできます(例: `facets: [vocabulary,
+invariant]`)。本当に両方を文書化している場合に限ります。
+
 ## 相互リンクのルール
 
 相互リンクはツリーをナビゲートしやすくし、コンテンツの重複を防ぎます:

--- a/src/IntentSystem.Cli/Commands/IntentAddFeatureCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentAddFeatureCommand.cs
@@ -209,6 +209,16 @@ internal static class IntentAddFeatureCommand
 
     private static string RenderOverview(IntentAddFeatureRequest r) =>
         $"""
+        ---
+        # Optional semantic facets (G529) — closed set, one line each:
+        #   vocabulary            — event/command vocabulary: what counts as a fact
+        #   invariant              — invariants and consistency boundaries
+        #   decider                — decider judgments: what a command decides
+        #   acceptance-property    — what must not break
+        # Uncomment and edit to annotate this node, e.g.:
+        # facets: [vocabulary]
+        ---
+
         # {r.FeatureName} — overview
 
         > **Ask intent-cli first:** `intent-cli guide intent-work setup --kind tree-layout --domain {r.Domain} --format markdown`

--- a/src/IntentSystem.Cli/Commands/IntentAnalyzeTreeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentAnalyzeTreeCommand.cs
@@ -159,6 +159,7 @@ internal static class IntentAnalyzeTreeCommand
         }
 
         var nextSteps = BuildNextSteps(request, flatFiles, proposals, backups.Count, written.Count);
+        var facetCoverage = ComputeFacetCoverage(domainRoot);
 
         return new IntentAnalyzeTreeResult
         {
@@ -170,8 +171,57 @@ internal static class IntentAnalyzeTreeCommand
             DetectedReferences = detectedRefs,
             BackupPaths = backups,
             WrittenPaths = written,
+            FacetCoverage = facetCoverage,
             NextSteps = nextSteps
         };
+    }
+
+    // ── Facet coverage (G529) ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Counts, across every Markdown file in the whole domain tree (not just
+    /// the top-level flat files this command otherwise analyzes), how many
+    /// nodes carry each facet. Only facets with at least one node are
+    /// included — an unannotated node is legitimate, so there is no
+    /// "facet-less nodes" list, and an unused facet is simply absent rather
+    /// than reported as zero.
+    /// </summary>
+    private static IReadOnlyDictionary<string, int> ComputeFacetCoverage(string domainRoot)
+    {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        if (!Directory.Exists(domainRoot))
+        {
+            return counts;
+        }
+
+        foreach (var file in Directory.GetFiles(domainRoot, "*.md", SearchOption.AllDirectories))
+        {
+            string content;
+            try
+            {
+                content = File.ReadAllText(file);
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            foreach (var facet in IntentNodeFacets.ExtractRawFacets(content).Distinct(StringComparer.Ordinal))
+            {
+                if (!IntentNodeFacets.IsAllowedValue(facet))
+                {
+                    // Invalid values are `lint-layout`'s concern, not counted here.
+                    continue;
+                }
+                counts[facet] = counts.GetValueOrDefault(facet) + 1;
+            }
+        }
+
+        return counts;
     }
 
     // ── Discovery ────────────────────────────────────────────────────────────
@@ -522,6 +572,20 @@ internal static class IntentAnalyzeTreeCommand
             writer.WriteLine();
         }
 
+        if (result.FacetCoverage.Count > 0)
+        {
+            writer.WriteLine("## Facet coverage");
+            writer.WriteLine();
+            foreach (var facet in IntentNodeFacets.AllowedValues)
+            {
+                if (result.FacetCoverage.TryGetValue(facet, out var count))
+                {
+                    writer.WriteLine($"- {facet}: {count}");
+                }
+            }
+            writer.WriteLine();
+        }
+
         writer.WriteLine("## Next steps");
         writer.WriteLine();
         foreach (var step in result.NextSteps)
@@ -555,6 +619,7 @@ internal sealed record IntentAnalyzeTreeResult
     public required IReadOnlyList<DetectedReference> DetectedReferences { get; init; }
     public required IReadOnlyList<string> BackupPaths { get; init; }
     public required IReadOnlyList<string> WrittenPaths { get; init; }
+    public required IReadOnlyDictionary<string, int> FacetCoverage { get; init; }
     public required IReadOnlyList<string> NextSteps { get; init; }
 }
 

--- a/src/IntentSystem.Cli/Commands/IntentAnalyzeTreeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentAnalyzeTreeCommand.cs
@@ -210,7 +210,18 @@ internal static class IntentAnalyzeTreeCommand
                 continue;
             }
 
-            foreach (var facet in IntentNodeFacets.ExtractRawFacets(content).Distinct(StringComparer.Ordinal))
+            var parsed = IntentNodeFacets.ParseFacets(content);
+            if (parsed.Kind != FacetsParseKind.Present)
+            {
+                // Absent: nothing to count. Malformed: `lint-layout`'s
+                // concern to report as an error, not counted here.
+                continue;
+            }
+
+            // parsed.Values is already deduplicated (stable, first-seen
+            // order) by the shared parser, so every caller — lint, search,
+            // and this coverage count — agrees on how a duplicate "counts".
+            foreach (var facet in parsed.Values)
             {
                 if (!IntentNodeFacets.IsAllowedValue(facet))
                 {

--- a/src/IntentSystem.Cli/Commands/IntentDraftFromInterviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentDraftFromInterviewCommand.cs
@@ -107,6 +107,16 @@ internal static class IntentDraftFromInterviewCommand
     private static string BuildDraftMarkdown(string domain, string session, IReadOnlyList<InterviewQuestion> accepted, IReadOnlyList<InterviewQuestion> open)
     {
         var builder = new StringBuilder();
+        builder.AppendLine("---");
+        builder.AppendLine("# Optional semantic facets (G529) — closed set, one line each:");
+        builder.AppendLine("#   vocabulary            — event/command vocabulary: what counts as a fact");
+        builder.AppendLine("#   invariant              — invariants and consistency boundaries");
+        builder.AppendLine("#   decider                — decider judgments: what a command decides");
+        builder.AppendLine("#   acceptance-property    — what must not break");
+        builder.AppendLine("# Uncomment and edit to annotate this node, e.g.:");
+        builder.AppendLine("# facets: [vocabulary]");
+        builder.AppendLine("---");
+        builder.AppendLine();
         builder.AppendLine($"# Draft intent — {domain} / session {session}");
         builder.AppendLine();
         builder.AppendLine("> Compiled from accepted interview answers. Operator must accept this draft before any source-of-truth mutation.");

--- a/src/IntentSystem.Cli/Commands/IntentInitTreeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentInitTreeCommand.cs
@@ -292,6 +292,16 @@ internal static class IntentInitTreeCommand
     private static string RenderMissionStarter(IntentInitTreeRequest request)
     {
         return $"""
+        ---
+        # Optional semantic facets (G529) — closed set, one line each:
+        #   vocabulary            — event/command vocabulary: what counts as a fact
+        #   invariant              — invariants and consistency boundaries
+        #   decider                — decider judgments: what a command decides
+        #   acceptance-property    — what must not break
+        # Uncomment and edit to annotate this node, e.g.:
+        # facets: [vocabulary]
+        ---
+
         # Mission
 
         > Ask intent-cli for guidance before editing:

--- a/src/IntentSystem.Cli/Commands/IntentLintLayoutCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentLintLayoutCommand.cs
@@ -27,6 +27,12 @@ internal static class IntentLintLayoutCommand
     private const string FormatJson = "json";
     private const string FormatMarkdown = "markdown";
 
+    /// <summary>Non-fatal (exit 0) — every pre-existing layout check.</summary>
+    public const string SeverityWarning = "warning";
+
+    /// <summary>Fatal (nonzero exit) — currently only <c>facets:</c> findings.</summary>
+    public const string SeverityError = "error";
+
     private const string UsageLine =
         "Usage: intent-cli intent lint-layout --domain <name> [--format markdown|json]";
 
@@ -54,7 +60,11 @@ internal static class IntentLintLayoutCommand
         {
             var result = ExecuteCore(context.RepoRoot, request);
             WriteOutput(writer, request.Format, result);
-            return result.Warnings.Count > 0 ? 0 : 0; // always exit 0; warnings surfaced in output
+            // G529 rereview repair: legacy layout warnings stay non-fatal
+            // (exit 0, backward compatible with every pre-existing check),
+            // but a facets: error (malformed declaration or an unknown
+            // value) is a real contract violation — nonzero exit.
+            return result.HasErrors ? 1 : 0;
         }
         catch (InvalidOperationException exception)
         {
@@ -285,10 +295,17 @@ internal static class IntentLintLayoutCommand
     // ── Facet check (G529) ────────────────────────────────────────────────────
 
     /// <summary>
-    /// A node's optional <c>facets:</c> frontmatter must draw only from the
-    /// closed set (<see cref="IntentNodeFacets.AllowedValues"/>). A node with
-    /// no frontmatter, or frontmatter with no <c>facets:</c> line, is
+    /// A node's optional <c>facets:</c> frontmatter must parse as a genuine
+    /// YAML list (block or flow form) and draw only from the closed set
+    /// (<see cref="IntentNodeFacets.AllowedValues"/>). A node with no
+    /// frontmatter, or frontmatter with no <c>facets:</c> key, is
     /// unaffected — unannotated nodes are legitimate and stay lint-clean.
+    /// A <c>facets:</c> key that is present but does not parse (a bare
+    /// scalar, an unterminated list, an unbalanced quote) is a
+    /// <see cref="IntentLintLayoutCommand.SeverityError"/> finding — it is
+    /// never silently treated as absent. An unknown value from an
+    /// otherwise-valid list is likewise an error, naming the node, the bad
+    /// value, and the allowed set.
     /// </summary>
     private static void CheckFacetValues(
         string domainRoot,
@@ -296,6 +313,7 @@ internal static class IntentLintLayoutCommand
         List<LintWarning> warnings)
     {
         var allMarkdown = Directory.GetFiles(domainRoot, "*.md", SearchOption.AllDirectories);
+        var allowed = string.Join(", ", IntentNodeFacets.AllowedValues);
 
         foreach (var mdFile in allMarkdown)
         {
@@ -313,23 +331,34 @@ internal static class IntentLintLayoutCommand
                 continue;
             }
 
-            var rawFacets = IntentNodeFacets.ExtractRawFacets(content);
-            if (rawFacets.Count == 0)
+            var parsed = IntentNodeFacets.ParseFacets(content);
+            if (parsed.Kind == FacetsParseKind.Absent)
             {
                 continue;
             }
 
             var rel = $"intents/{domain}/" + Path.GetRelativePath(domainRoot, mdFile).Replace(Path.DirectorySeparatorChar, '/');
-            var allowed = string.Join(", ", IntentNodeFacets.AllowedValues);
 
-            foreach (var value in rawFacets.Distinct(StringComparer.Ordinal))
+            if (parsed.Kind == FacetsParseKind.Malformed)
+            {
+                warnings.Add(new LintWarning(
+                    Code: "MALFORMED-FACETS",
+                    Message: $"Node '{rel}' has a malformed 'facets:' declaration: {parsed.MalformedReason}.",
+                    Fix: $"Use a YAML list, e.g. `facets: [{IntentNodeFacets.Vocabulary}]` or a block list with "
+                        + $"'- item' entries, drawing only from: {allowed}.",
+                    Severity: SeverityError));
+                continue;
+            }
+
+            foreach (var value in parsed.Values)
             {
                 if (!IntentNodeFacets.IsAllowedValue(value))
                 {
                     warnings.Add(new LintWarning(
                         Code: "INVALID-FACET",
                         Message: $"Node '{rel}' has invalid facet '{value}' (allowed: {allowed}).",
-                        Fix: $"Use one of: {allowed}, or remove '{value}' from the 'facets:' line in '{rel}'."));
+                        Fix: $"Use one of: {allowed}, or remove '{value}' from the 'facets:' line in '{rel}'.",
+                        Severity: SeverityError));
                 }
             }
         }
@@ -346,7 +375,8 @@ internal static class IntentLintLayoutCommand
             Domain = request.Domain,
             IsTreeDomain = isTreeDomain,
             Warnings = warnings,
-            Clean = warnings.Count == 0
+            Clean = warnings.Count == 0,
+            HasErrors = warnings.Any(w => string.Equals(w.Severity, SeverityError, StringComparison.Ordinal))
         };
 
     private static void EnsureNotChildWorktree(string hostRepoRoot)
@@ -439,12 +469,15 @@ internal static class IntentLintLayoutCommand
 
     private static void WriteMarkdown(TextWriter writer, IntentLintLayoutResult result)
     {
-        var status = result.Clean ? "clean" : $"{result.Warnings.Count} warning(s)";
+        var errorCount = result.Warnings.Count(w => string.Equals(w.Severity, SeverityError, StringComparison.Ordinal));
+        var warnCount = result.Warnings.Count - errorCount;
+        var status = result.Clean ? "clean" : $"{errorCount} error(s), {warnCount} warning(s)";
         writer.WriteLine($"# intent lint-layout — {result.Domain} ({status})");
         writer.WriteLine();
         writer.WriteLine($"- domain: {result.Domain}");
         writer.WriteLine($"- tree-domain: {result.IsTreeDomain}");
         writer.WriteLine($"- warnings: {result.Warnings.Count}");
+        writer.WriteLine($"- has-errors: {result.HasErrors}");
         writer.WriteLine();
 
         if (result.Clean)
@@ -459,6 +492,7 @@ internal static class IntentLintLayoutCommand
         {
             writer.WriteLine($"### [{w.Code}] {w.Message}");
             writer.WriteLine();
+            writer.WriteLine($"**Severity:** {w.Severity}");
             writer.WriteLine($"**Fix:** {w.Fix}");
             writer.WriteLine();
         }
@@ -483,10 +517,27 @@ internal sealed record IntentLintLayoutResult
     public required string Domain { get; init; }
     public required bool IsTreeDomain { get; init; }
     public required bool Clean { get; init; }
+
+    /// <summary>
+    /// G529 rereview repair: true when at least one finding carries
+    /// <c>Severity == "error"</c> (currently only <c>facets:</c>
+    /// malformed/unknown-value findings) — drives the command's exit code.
+    /// Every pre-existing layout check stays "warning" severity (exit 0),
+    /// so this is purely additive, not a behavior change for legacy checks.
+    /// </summary>
+    public required bool HasErrors { get; init; }
+
     public required IReadOnlyList<LintWarning> Warnings { get; init; }
 }
 
+/// <summary>
+/// <paramref name="Severity"/> defaults to <c>"warning"</c> so every
+/// pre-existing call site (all positional/named constructions that predate
+/// G529) keeps its non-fatal, exit-0 behavior unchanged. Only the G529
+/// facets checks pass <c>Severity: "error"</c> explicitly.
+/// </summary>
 internal sealed record LintWarning(
     string Code,
     string Message,
-    string Fix);
+    string Fix,
+    string Severity = IntentLintLayoutCommand.SeverityWarning);

--- a/src/IntentSystem.Cli/Commands/IntentLintLayoutCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentLintLayoutCommand.cs
@@ -112,6 +112,9 @@ internal static class IntentLintLayoutCommand
         // Check features/index.md
         CheckFeaturesIndex(domainRoot, request.Domain, warnings);
 
+        // G529: validate any facets: frontmatter against the closed value set
+        CheckFacetValues(domainRoot, request.Domain, warnings);
+
         return BuildResult(request, warnings, isTreeDomain);
     }
 
@@ -275,6 +278,59 @@ internal static class IntentLintLayoutCommand
                     Code: "MISSING-FEATURE-OVERVIEW",
                     Message: $"Feature folder 'intents/{domain}/features/{featureName}/' is missing 'overview.md'.",
                     Fix: $"Add 'intents/{domain}/features/{featureName}/overview.md' with goals and acceptance criteria."));
+            }
+        }
+    }
+
+    // ── Facet check (G529) ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A node's optional <c>facets:</c> frontmatter must draw only from the
+    /// closed set (<see cref="IntentNodeFacets.AllowedValues"/>). A node with
+    /// no frontmatter, or frontmatter with no <c>facets:</c> line, is
+    /// unaffected — unannotated nodes are legitimate and stay lint-clean.
+    /// </summary>
+    private static void CheckFacetValues(
+        string domainRoot,
+        string domain,
+        List<LintWarning> warnings)
+    {
+        var allMarkdown = Directory.GetFiles(domainRoot, "*.md", SearchOption.AllDirectories);
+
+        foreach (var mdFile in allMarkdown)
+        {
+            string content;
+            try
+            {
+                content = File.ReadAllText(mdFile);
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                continue;
+            }
+
+            var rawFacets = IntentNodeFacets.ExtractRawFacets(content);
+            if (rawFacets.Count == 0)
+            {
+                continue;
+            }
+
+            var rel = $"intents/{domain}/" + Path.GetRelativePath(domainRoot, mdFile).Replace(Path.DirectorySeparatorChar, '/');
+            var allowed = string.Join(", ", IntentNodeFacets.AllowedValues);
+
+            foreach (var value in rawFacets.Distinct(StringComparer.Ordinal))
+            {
+                if (!IntentNodeFacets.IsAllowedValue(value))
+                {
+                    warnings.Add(new LintWarning(
+                        Code: "INVALID-FACET",
+                        Message: $"Node '{rel}' has invalid facet '{value}' (allowed: {allowed}).",
+                        Fix: $"Use one of: {allowed}, or remove '{value}' from the 'facets:' line in '{rel}'."));
+                }
             }
         }
     }

--- a/src/IntentSystem.Cli/Commands/IntentNodeFacets.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNodeFacets.cs
@@ -1,31 +1,48 @@
-using System.Text.RegularExpressions;
+using System.Text;
 
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G529: shared reader for the optional <c>facets:</c> frontmatter field on
-/// intent-tree node Markdown files. Facets name which of the four
-/// "human-retained understanding" surfaces (Operator input, issue #1159) a
-/// node documents — event/command vocabulary, invariants and consistency
-/// boundaries, decider judgments, and acceptance properties. The value set
-/// is closed for now; extending it is future design work.
+/// G529 (+ rereview repair): shared reader for the optional <c>facets:</c>
+/// frontmatter field on intent-tree node Markdown files. Facets name which
+/// of the four "human-retained understanding" surfaces (Operator input,
+/// issue #1159) a node documents — event/command vocabulary, invariants and
+/// consistency boundaries, decider judgments, and acceptance properties.
+/// The value set is closed for now; extending it is future design work.
 ///
 /// A node opts in with a <c>---</c>-delimited frontmatter block at the very
-/// start of the file, e.g.:
+/// start of the file, using a genuine YAML list — either flow form:
 /// <code>
 /// ---
 /// facets: [vocabulary, invariant]
 /// ---
-/// # Node title
-/// ...
+/// </code>
+/// or block form:
+/// <code>
+/// ---
+/// facets:
+///   - vocabulary
+///   - invariant
+/// ---
 /// </code>
 ///
+/// <see cref="ParseFacets"/> supports both forms, quoted scalars
+/// (<c>"vocabulary"</c> / <c>'vocabulary'</c>), inline <c>#</c> comments, a
+/// flow list spanning multiple physical lines, and duplicate values
+/// (deduplicated once, centrally, preserving first-seen order — every
+/// caller sees the same deduplicated list, so lint/search/analyze can never
+/// disagree on how many times a facet "counts"). A <c>facets:</c>
+/// declaration that is present but does not parse as a YAML list (a bare
+/// scalar, an unterminated flow list, an unbalanced quote, tab indentation)
+/// is reported as <see cref="FacetsParseKind.Malformed"/> — it is never
+/// silently treated as absent. Only a genuinely missing <c>facets:</c> key
+/// (or no frontmatter block at all) is <see cref="FacetsParseKind.Absent"/>,
+/// which is fully backward compatible: the node is simply unannotated.
+///
 /// This reader is intentionally narrow: it extracts and validates ONLY the
-/// <c>facets:</c> line. Any other frontmatter fields a node file may carry
-/// (e.g. <c>intent_id</c>, <c>intent_type</c>) are untouched — parsing and
-/// validating those is out of scope for this slice. A node with no
-/// frontmatter block, or a frontmatter block with no <c>facets:</c> line,
-/// is fully backward compatible: it simply has zero facets.
+/// top-level <c>facets:</c> key. Any other frontmatter fields a node file
+/// may carry (e.g. <c>intent_id</c>, <c>intent_type</c>) are untouched —
+/// parsing and validating those is out of scope for this slice.
 /// </summary>
 internal static class IntentNodeFacets
 {
@@ -43,36 +60,364 @@ internal static class IntentNodeFacets
         AcceptanceProperty,
     };
 
-    private static readonly Regex FacetsLinePattern = new(
-        @"^facets:\s*\[(?<values>[^\]]*)\]\s*$",
-        RegexOptions.Multiline | RegexOptions.Compiled);
+    private const string FacetsKeyPrefix = "facets:";
 
     /// <summary>
-    /// Extracts the raw (unvalidated) facet tokens from a node's <c>facets:</c>
-    /// frontmatter line, or an empty list when the file has no frontmatter
-    /// block, or the block has no <c>facets:</c> line. Tokens are returned
-    /// exactly as written (trimmed) — callers validate against
-    /// <see cref="AllowedValues"/> via <see cref="IsAllowedValue"/>.
+    /// Parses the node's <c>facets:</c> frontmatter field. See the type
+    /// doc-comment for the exact forms supported and the absent/malformed/
+    /// present distinction.
     /// </summary>
-    public static IReadOnlyList<string> ExtractRawFacets(string fileContent)
+    public static FacetsParseResult ParseFacets(string fileContent)
     {
         ArgumentNullException.ThrowIfNull(fileContent);
 
         if (!TryExtractFrontmatterBlock(fileContent, out var frontmatter))
         {
-            return Array.Empty<string>();
+            return FacetsParseResult.AbsentResult;
         }
 
-        var match = FacetsLinePattern.Match(frontmatter);
-        if (!match.Success)
+        var lines = frontmatter.Split('\n');
+
+        // Top-level key only: must start at column 0. A "facets:" appearing
+        // under some other key's indentation is out of scope (narrow reader).
+        var facetsLineIndex = Array.FindIndex(lines, line => line.StartsWith(FacetsKeyPrefix, StringComparison.Ordinal));
+        if (facetsLineIndex < 0)
         {
-            return Array.Empty<string>();
+            return FacetsParseResult.AbsentResult;
         }
 
-        return match.Groups["values"].Value
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Where(value => value.Length > 0)
-            .ToArray();
+        if (lines[facetsLineIndex].Contains('\t'))
+        {
+            return FacetsParseResult.Malformed("tab character is invalid YAML indentation");
+        }
+
+        var rest = lines[facetsLineIndex][FacetsKeyPrefix.Length..];
+        var (restBeforeComment, _) = StripInlineComment(rest);
+        var trimmedRest = restBeforeComment.Trim();
+
+        if (trimmedRest.Length == 0)
+        {
+            return ParseBlockForm(lines, facetsLineIndex + 1);
+        }
+
+        if (trimmedRest[0] == '[')
+        {
+            return ParseFlowForm(lines, facetsLineIndex, trimmedRest);
+        }
+
+        return FacetsParseResult.Malformed(
+            $"expected a YAML list after 'facets:' (flow '[item, ...]' or block '- item' form), found scalar '{trimmedRest}'");
+    }
+
+    // ── Block form: "facets:" alone, followed by indented "- item" lines ──
+
+    private static FacetsParseResult ParseBlockForm(string[] frontmatterLines, int startIndex)
+    {
+        var items = new List<string>();
+
+        for (var i = startIndex; i < frontmatterLines.Length; i++)
+        {
+            var rawLine = frontmatterLines[i];
+            if (rawLine.Contains('\t'))
+            {
+                return FacetsParseResult.Malformed("tab character is invalid YAML indentation");
+            }
+
+            var trimmed = rawLine.TrimStart();
+            if (trimmed.Length == 0)
+            {
+                continue; // blank line inside the block list is allowed
+            }
+            if (trimmed.StartsWith('#'))
+            {
+                continue; // whole-line comment
+            }
+            if (!rawLine.StartsWith(' '))
+            {
+                // Not indented under the key: a new top-level entry — the
+                // block list has ended (not an error, just its boundary).
+                break;
+            }
+            if (!(trimmed.StartsWith("- ", StringComparison.Ordinal) || trimmed == "-"))
+            {
+                return FacetsParseResult.Malformed($"expected a '- item' list entry, found '{trimmed}'");
+            }
+
+            var rawItem = trimmed == "-" ? string.Empty : trimmed[2..];
+            var (beforeComment, _) = StripInlineComment(rawItem);
+            var token = beforeComment.Trim();
+            if (!TryUnquote(token, out var unquoted))
+            {
+                return FacetsParseResult.Malformed($"unbalanced quote in list item '{token}'");
+            }
+            if (unquoted.Length == 0)
+            {
+                return FacetsParseResult.Malformed("empty list item under 'facets:'");
+            }
+            items.Add(unquoted);
+        }
+
+        if (items.Count == 0)
+        {
+            return FacetsParseResult.Malformed(
+                "'facets:' has no value — use '[]' for an explicitly empty list, or list values with '- item' entries");
+        }
+
+        return FacetsParseResult.Present(Deduplicate(items));
+    }
+
+    // ── Flow form: "facets: [a, b]", possibly spanning multiple lines ─────
+
+    private static FacetsParseResult ParseFlowForm(string[] frontmatterLines, int facetsLineIndex, string firstSegment)
+    {
+        var inner = new StringBuilder();
+        var depth = 0;
+        var inSingle = false;
+        var inDouble = false;
+        var closed = false;
+
+        bool ScanSegment(string segment)
+        {
+            foreach (var c in segment)
+            {
+                if (inSingle)
+                {
+                    inner.Append(c);
+                    if (c == '\'')
+                    {
+                        inSingle = false;
+                    }
+                    continue;
+                }
+                if (inDouble)
+                {
+                    inner.Append(c);
+                    if (c == '"')
+                    {
+                        inDouble = false;
+                    }
+                    continue;
+                }
+                if (c == '\'')
+                {
+                    inSingle = true;
+                    inner.Append(c);
+                    continue;
+                }
+                if (c == '"')
+                {
+                    inDouble = true;
+                    inner.Append(c);
+                    continue;
+                }
+                if (c == '[')
+                {
+                    depth++;
+                    if (depth == 1)
+                    {
+                        continue; // exclude the outermost opening bracket
+                    }
+                    inner.Append(c);
+                    continue;
+                }
+                if (c == ']')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        closed = true;
+                        return true;
+                    }
+                    inner.Append(c);
+                    continue;
+                }
+                inner.Append(c);
+            }
+            return false;
+        }
+
+        if (!ScanSegment(firstSegment))
+        {
+            inner.Append(' ');
+
+            var lineIndex = facetsLineIndex;
+            while (!closed)
+            {
+                lineIndex++;
+                if (lineIndex >= frontmatterLines.Length)
+                {
+                    return FacetsParseResult.Malformed("unterminated '[' list under 'facets:' (missing closing ']')");
+                }
+                if (frontmatterLines[lineIndex].Contains('\t'))
+                {
+                    return FacetsParseResult.Malformed("tab character is invalid YAML indentation");
+                }
+
+                var (beforeComment, _) = StripInlineComment(frontmatterLines[lineIndex]);
+                if (ScanSegment(beforeComment))
+                {
+                    break;
+                }
+                inner.Append(' ');
+            }
+        }
+
+        if (inSingle || inDouble)
+        {
+            return FacetsParseResult.Malformed("unterminated quoted string in 'facets:' list");
+        }
+
+        return FinishFlowForm(inner.ToString());
+    }
+
+    private static FacetsParseResult FinishFlowForm(string inner)
+    {
+        var items = new List<string>();
+        foreach (var rawToken in SplitTopLevelCommas(inner))
+        {
+            var token = rawToken.Trim();
+            if (token.Length == 0)
+            {
+                continue; // tolerate a trailing comma, e.g. "[a, b,]"
+            }
+            if (!TryUnquote(token, out var unquoted))
+            {
+                return FacetsParseResult.Malformed($"unbalanced quote in list item '{token}'");
+            }
+            if (unquoted.Length == 0)
+            {
+                return FacetsParseResult.Malformed("empty list item in 'facets:' list");
+            }
+            items.Add(unquoted);
+        }
+
+        return FacetsParseResult.Present(Deduplicate(items));
+    }
+
+    // ── Shared token helpers ────────────────────────────────────────────────
+
+    /// <summary>Splits on top-level commas only — a comma inside a quoted scalar does not split.</summary>
+    private static IReadOnlyList<string> SplitTopLevelCommas(string text)
+    {
+        var result = new List<string>();
+        var current = new StringBuilder();
+        var inSingle = false;
+        var inDouble = false;
+
+        foreach (var c in text)
+        {
+            if (inSingle)
+            {
+                current.Append(c);
+                if (c == '\'')
+                {
+                    inSingle = false;
+                }
+                continue;
+            }
+            if (inDouble)
+            {
+                current.Append(c);
+                if (c == '"')
+                {
+                    inDouble = false;
+                }
+                continue;
+            }
+            if (c == '\'')
+            {
+                inSingle = true;
+                current.Append(c);
+                continue;
+            }
+            if (c == '"')
+            {
+                inDouble = true;
+                current.Append(c);
+                continue;
+            }
+            if (c == ',')
+            {
+                result.Add(current.ToString());
+                current.Clear();
+                continue;
+            }
+            current.Append(c);
+        }
+        result.Add(current.ToString());
+        return result;
+    }
+
+    /// <summary>
+    /// Strips a matching pair of surrounding quotes from a token. Returns
+    /// <see langword="false"/> when the token opens a quote but does not
+    /// close it with the same delimiter (a genuine syntax error, never
+    /// silently treated as a literal value).
+    /// </summary>
+    private static bool TryUnquote(string token, out string value)
+    {
+        value = token;
+        if (token.Length == 0)
+        {
+            return true;
+        }
+
+        var quote = token[0];
+        if (quote != '"' && quote != '\'')
+        {
+            return true; // unquoted plain scalar
+        }
+        if (token.Length < 2 || token[^1] != quote)
+        {
+            return false;
+        }
+
+        value = token[1..^1];
+        return true;
+    }
+
+    /// <summary>
+    /// Strips a <c>#</c> comment from a single physical line, respecting
+    /// quotes — a <c>#</c> inside an open quote is literal content, not a
+    /// comment marker.
+    /// </summary>
+    private static (string Before, bool HadComment) StripInlineComment(string line)
+    {
+        var inSingle = false;
+        var inDouble = false;
+
+        for (var i = 0; i < line.Length; i++)
+        {
+            var c = line[i];
+            if (c == '\'' && !inDouble)
+            {
+                inSingle = !inSingle;
+            }
+            else if (c == '"' && !inSingle)
+            {
+                inDouble = !inDouble;
+            }
+            else if (c == '#' && !inSingle && !inDouble)
+            {
+                return (line[..i], true);
+            }
+        }
+        return (line, false);
+    }
+
+    /// <summary>Stable dedup: first-seen order preserved, ordinal comparison — the single dedup point every caller shares.</summary>
+    private static IReadOnlyList<string> Deduplicate(IReadOnlyList<string> items)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<string>(items.Count);
+        foreach (var item in items)
+        {
+            if (seen.Add(item))
+            {
+                result.Add(item);
+            }
+        }
+        return result;
     }
 
     /// <summary>
@@ -107,4 +452,43 @@ internal static class IntentNodeFacets
 
     public static bool IsAllowedValue(string value) =>
         AllowedValues.Contains(value, StringComparer.Ordinal);
+}
+
+/// <summary>Discriminates the three possible outcomes of <see cref="IntentNodeFacets.ParseFacets"/>.</summary>
+internal enum FacetsParseKind
+{
+    /// <summary>No frontmatter block, or a frontmatter block with no <c>facets:</c> key — fully backward compatible.</summary>
+    Absent,
+
+    /// <summary>A <c>facets:</c> key is present but does not parse as a valid YAML list — a lint ERROR, never silently absent.</summary>
+    Malformed,
+
+    /// <summary>A <c>facets:</c> key parsed successfully; <see cref="Values"/> holds the deduplicated tokens (not yet validated against the closed set).</summary>
+    Present,
+}
+
+internal sealed record FacetsParseResult
+{
+    public required FacetsParseKind Kind { get; init; }
+    public required IReadOnlyList<string> Values { get; init; }
+    public string? MalformedReason { get; init; }
+
+    public static readonly FacetsParseResult AbsentResult = new()
+    {
+        Kind = FacetsParseKind.Absent,
+        Values = Array.Empty<string>(),
+    };
+
+    public static FacetsParseResult Malformed(string reason) => new()
+    {
+        Kind = FacetsParseKind.Malformed,
+        Values = Array.Empty<string>(),
+        MalformedReason = reason,
+    };
+
+    public static FacetsParseResult Present(IReadOnlyList<string> values) => new()
+    {
+        Kind = FacetsParseKind.Present,
+        Values = values,
+    };
 }

--- a/src/IntentSystem.Cli/Commands/IntentNodeFacets.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNodeFacets.cs
@@ -1,9 +1,10 @@
-using System.Text;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
 
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G529 (+ rereview repair): shared reader for the optional <c>facets:</c>
+/// G529 (+ rereview repairs): shared reader for the optional <c>facets:</c>
 /// frontmatter field on intent-tree node Markdown files. Facets name which
 /// of the four "human-retained understanding" surfaces (Operator input,
 /// issue #1159) a node documents — event/command vocabulary, invariants and
@@ -26,23 +27,28 @@ namespace IntentSystem.Cli.Commands;
 /// ---
 /// </code>
 ///
-/// <see cref="ParseFacets"/> supports both forms, quoted scalars
-/// (<c>"vocabulary"</c> / <c>'vocabulary'</c>), inline <c>#</c> comments, a
-/// flow list spanning multiple physical lines, and duplicate values
-/// (deduplicated once, centrally, preserving first-seen order — every
-/// caller sees the same deduplicated list, so lint/search/analyze can never
-/// disagree on how many times a facet "counts"). A <c>facets:</c>
-/// declaration that is present but does not parse as a YAML list (a bare
-/// scalar, an unterminated flow list, an unbalanced quote, tab indentation)
-/// is reported as <see cref="FacetsParseKind.Malformed"/> — it is never
+/// <see cref="ParseFacets"/> hands the <c>facets:</c> value off to
+/// <b>YamlDotNet</b> — a real YAML parser — rather than a hand-rolled
+/// scanner. Two prior repair rounds each found a fresh correctness gap in a
+/// bespoke tokenizer (single-line-only flow, then unescaped/non-trailing-
+/// junk-aware scanning); a real parser resolves escaping, doubled-single-
+/// quote semantics, comments, multi-line flow, and trailing-content
+/// rejection correctly by construction instead of by ad hoc patching.
+///
+/// A <c>facets:</c> declaration that is present but does not parse as a
+/// YAML list (a bare scalar, an unterminated flow list, an unbalanced
+/// quote, non-comment trailing content after the list, tab indentation) is
+/// reported as <see cref="FacetsParseKind.Malformed"/> — it is never
 /// silently treated as absent. Only a genuinely missing <c>facets:</c> key
 /// (or no frontmatter block at all) is <see cref="FacetsParseKind.Absent"/>,
 /// which is fully backward compatible: the node is simply unannotated.
 ///
-/// This reader is intentionally narrow: it extracts and validates ONLY the
-/// top-level <c>facets:</c> key. Any other frontmatter fields a node file
-/// may carry (e.g. <c>intent_id</c>, <c>intent_type</c>) are untouched —
-/// parsing and validating those is out of scope for this slice.
+/// This reader is intentionally narrow: it locates and validates ONLY the
+/// top-level <c>facets:</c> key (and, from that line onward, hands YamlDotNet
+/// just enough of the frontmatter to resolve that one key — never the
+/// portion before it). Any other frontmatter fields a node file may carry
+/// (e.g. <c>intent_id</c>, <c>intent_type</c>) are untouched — parsing and
+/// validating those is out of scope for this slice.
 /// </summary>
 internal static class IntentNodeFacets
 {
@@ -61,6 +67,7 @@ internal static class IntentNodeFacets
     };
 
     private const string FacetsKeyPrefix = "facets:";
+    private const string FacetsKeyName = "facets";
 
     /// <summary>
     /// Parses the node's <c>facets:</c> frontmatter field. See the type
@@ -71,338 +78,98 @@ internal static class IntentNodeFacets
     {
         ArgumentNullException.ThrowIfNull(fileContent);
 
-        if (!TryExtractFrontmatterBlock(fileContent, out var frontmatter))
+        if (!TryExtractFrontmatterBlock(fileContent, out var frontmatter, out _))
         {
             return FacetsParseResult.AbsentResult;
         }
 
         var lines = frontmatter.Split('\n');
 
-        // Top-level key only: must start at column 0. A "facets:" appearing
-        // under some other key's indentation is out of scope (narrow reader).
+        // Top-level key only: must start at column 0 with no leading
+        // whitespace at all. A "facets:" appearing under some other key's
+        // indentation is out of scope (narrow reader) — UNLESS it was
+        // clearly intended as the top-level declaration but mis-indented
+        // with a tab, which is never silently absent (see below).
         var facetsLineIndex = Array.FindIndex(lines, line => line.StartsWith(FacetsKeyPrefix, StringComparison.Ordinal));
         if (facetsLineIndex < 0)
         {
-            return FacetsParseResult.AbsentResult;
-        }
-
-        if (lines[facetsLineIndex].Contains('\t'))
-        {
-            return FacetsParseResult.Malformed("tab character is invalid YAML indentation");
-        }
-
-        var rest = lines[facetsLineIndex][FacetsKeyPrefix.Length..];
-        var (restBeforeComment, _) = StripInlineComment(rest);
-        var trimmedRest = restBeforeComment.Trim();
-
-        if (trimmedRest.Length == 0)
-        {
-            return ParseBlockForm(lines, facetsLineIndex + 1);
-        }
-
-        if (trimmedRest[0] == '[')
-        {
-            return ParseFlowForm(lines, facetsLineIndex, trimmedRest);
-        }
-
-        return FacetsParseResult.Malformed(
-            $"expected a YAML list after 'facets:' (flow '[item, ...]' or block '- item' form), found scalar '{trimmedRest}'");
-    }
-
-    // ── Block form: "facets:" alone, followed by indented "- item" lines ──
-
-    private static FacetsParseResult ParseBlockForm(string[] frontmatterLines, int startIndex)
-    {
-        var items = new List<string>();
-
-        for (var i = startIndex; i < frontmatterLines.Length; i++)
-        {
-            var rawLine = frontmatterLines[i];
-            if (rawLine.Contains('\t'))
+            if (Array.Exists(lines, LooksLikeTabIndentedFacetsDeclaration))
             {
                 return FacetsParseResult.Malformed("tab character is invalid YAML indentation");
             }
-
-            var trimmed = rawLine.TrimStart();
-            if (trimmed.Length == 0)
-            {
-                continue; // blank line inside the block list is allowed
-            }
-            if (trimmed.StartsWith('#'))
-            {
-                continue; // whole-line comment
-            }
-            if (!rawLine.StartsWith(' '))
-            {
-                // Not indented under the key: a new top-level entry — the
-                // block list has ended (not an error, just its boundary).
-                break;
-            }
-            if (!(trimmed.StartsWith("- ", StringComparison.Ordinal) || trimmed == "-"))
-            {
-                return FacetsParseResult.Malformed($"expected a '- item' list entry, found '{trimmed}'");
-            }
-
-            var rawItem = trimmed == "-" ? string.Empty : trimmed[2..];
-            var (beforeComment, _) = StripInlineComment(rawItem);
-            var token = beforeComment.Trim();
-            if (!TryUnquote(token, out var unquoted))
-            {
-                return FacetsParseResult.Malformed($"unbalanced quote in list item '{token}'");
-            }
-            if (unquoted.Length == 0)
-            {
-                return FacetsParseResult.Malformed("empty list item under 'facets:'");
-            }
-            items.Add(unquoted);
+            return FacetsParseResult.AbsentResult;
         }
 
-        if (items.Count == 0)
+        // Hand YamlDotNet everything from the "facets:" line to the end of
+        // the frontmatter block — real block/flow-list boundary resolution,
+        // multi-line flow, quoting/escaping, and comments, all per actual
+        // YAML grammar. Content BEFORE this line (other fields) is excluded
+        // so an unrelated field's own syntax issue can never masquerade as
+        // a facets: problem.
+        var fragment = string.Join('\n', lines[facetsLineIndex..]);
+        return ParseFacetsFragment(fragment);
+    }
+
+    private static bool LooksLikeTabIndentedFacetsDeclaration(string line) =>
+        line.Contains('\t') && line.TrimStart('\t', ' ').StartsWith(FacetsKeyPrefix, StringComparison.Ordinal);
+
+    private static FacetsParseResult ParseFacetsFragment(string fragment)
+    {
+        YamlMappingNode mapping;
+        try
         {
+            var yaml = new YamlStream();
+            using var reader = new StringReader(fragment);
+            yaml.Load(reader);
+
+            if (yaml.Documents.Count == 0 || yaml.Documents[0].RootNode is not YamlMappingNode rootMapping)
+            {
+                return FacetsParseResult.Malformed("'facets:' did not parse as a YAML mapping entry");
+            }
+            mapping = rootMapping;
+        }
+        catch (YamlException exception)
+        {
+            // Covers every hand-rolled failure mode from prior rounds for
+            // free: unterminated flow lists, unbalanced/unescaped quotes,
+            // non-comment trailing content after a flow list's closing
+            // bracket, and tab indentation — all genuine YAML syntax
+            // errors that a real parser rejects by construction.
+            return FacetsParseResult.Malformed($"invalid YAML: {exception.Message}");
+        }
+
+        if (!mapping.Children.TryGetValue(new YamlScalarNode(FacetsKeyName), out var facetsNode))
+        {
+            // Should not happen — the caller only reaches here after
+            // locating a "facets:" line itself — but stay defensive.
+            return FacetsParseResult.AbsentResult;
+        }
+
+        if (facetsNode is YamlSequenceNode sequence)
+        {
+            var items = new List<string>();
+            foreach (var child in sequence.Children)
+            {
+                if (child is not YamlScalarNode { Value: { Length: > 0 } scalarValue })
+                {
+                    return FacetsParseResult.Malformed("'facets:' list contains a non-scalar or empty item");
+                }
+                items.Add(scalarValue);
+            }
+            return FacetsParseResult.Present(Deduplicate(items));
+        }
+
+        if (facetsNode is YamlScalarNode { Value: null or "" })
+        {
+            // "facets:" with nothing after it and no block items either
+            // (YAML null) — use "[]" for an intentionally empty list.
             return FacetsParseResult.Malformed(
                 "'facets:' has no value — use '[]' for an explicitly empty list, or list values with '- item' entries");
         }
 
-        return FacetsParseResult.Present(Deduplicate(items));
-    }
-
-    // ── Flow form: "facets: [a, b]", possibly spanning multiple lines ─────
-
-    private static FacetsParseResult ParseFlowForm(string[] frontmatterLines, int facetsLineIndex, string firstSegment)
-    {
-        var inner = new StringBuilder();
-        var depth = 0;
-        var inSingle = false;
-        var inDouble = false;
-        var closed = false;
-
-        bool ScanSegment(string segment)
-        {
-            foreach (var c in segment)
-            {
-                if (inSingle)
-                {
-                    inner.Append(c);
-                    if (c == '\'')
-                    {
-                        inSingle = false;
-                    }
-                    continue;
-                }
-                if (inDouble)
-                {
-                    inner.Append(c);
-                    if (c == '"')
-                    {
-                        inDouble = false;
-                    }
-                    continue;
-                }
-                if (c == '\'')
-                {
-                    inSingle = true;
-                    inner.Append(c);
-                    continue;
-                }
-                if (c == '"')
-                {
-                    inDouble = true;
-                    inner.Append(c);
-                    continue;
-                }
-                if (c == '[')
-                {
-                    depth++;
-                    if (depth == 1)
-                    {
-                        continue; // exclude the outermost opening bracket
-                    }
-                    inner.Append(c);
-                    continue;
-                }
-                if (c == ']')
-                {
-                    depth--;
-                    if (depth == 0)
-                    {
-                        closed = true;
-                        return true;
-                    }
-                    inner.Append(c);
-                    continue;
-                }
-                inner.Append(c);
-            }
-            return false;
-        }
-
-        if (!ScanSegment(firstSegment))
-        {
-            inner.Append(' ');
-
-            var lineIndex = facetsLineIndex;
-            while (!closed)
-            {
-                lineIndex++;
-                if (lineIndex >= frontmatterLines.Length)
-                {
-                    return FacetsParseResult.Malformed("unterminated '[' list under 'facets:' (missing closing ']')");
-                }
-                if (frontmatterLines[lineIndex].Contains('\t'))
-                {
-                    return FacetsParseResult.Malformed("tab character is invalid YAML indentation");
-                }
-
-                var (beforeComment, _) = StripInlineComment(frontmatterLines[lineIndex]);
-                if (ScanSegment(beforeComment))
-                {
-                    break;
-                }
-                inner.Append(' ');
-            }
-        }
-
-        if (inSingle || inDouble)
-        {
-            return FacetsParseResult.Malformed("unterminated quoted string in 'facets:' list");
-        }
-
-        return FinishFlowForm(inner.ToString());
-    }
-
-    private static FacetsParseResult FinishFlowForm(string inner)
-    {
-        var items = new List<string>();
-        foreach (var rawToken in SplitTopLevelCommas(inner))
-        {
-            var token = rawToken.Trim();
-            if (token.Length == 0)
-            {
-                continue; // tolerate a trailing comma, e.g. "[a, b,]"
-            }
-            if (!TryUnquote(token, out var unquoted))
-            {
-                return FacetsParseResult.Malformed($"unbalanced quote in list item '{token}'");
-            }
-            if (unquoted.Length == 0)
-            {
-                return FacetsParseResult.Malformed("empty list item in 'facets:' list");
-            }
-            items.Add(unquoted);
-        }
-
-        return FacetsParseResult.Present(Deduplicate(items));
-    }
-
-    // ── Shared token helpers ────────────────────────────────────────────────
-
-    /// <summary>Splits on top-level commas only — a comma inside a quoted scalar does not split.</summary>
-    private static IReadOnlyList<string> SplitTopLevelCommas(string text)
-    {
-        var result = new List<string>();
-        var current = new StringBuilder();
-        var inSingle = false;
-        var inDouble = false;
-
-        foreach (var c in text)
-        {
-            if (inSingle)
-            {
-                current.Append(c);
-                if (c == '\'')
-                {
-                    inSingle = false;
-                }
-                continue;
-            }
-            if (inDouble)
-            {
-                current.Append(c);
-                if (c == '"')
-                {
-                    inDouble = false;
-                }
-                continue;
-            }
-            if (c == '\'')
-            {
-                inSingle = true;
-                current.Append(c);
-                continue;
-            }
-            if (c == '"')
-            {
-                inDouble = true;
-                current.Append(c);
-                continue;
-            }
-            if (c == ',')
-            {
-                result.Add(current.ToString());
-                current.Clear();
-                continue;
-            }
-            current.Append(c);
-        }
-        result.Add(current.ToString());
-        return result;
-    }
-
-    /// <summary>
-    /// Strips a matching pair of surrounding quotes from a token. Returns
-    /// <see langword="false"/> when the token opens a quote but does not
-    /// close it with the same delimiter (a genuine syntax error, never
-    /// silently treated as a literal value).
-    /// </summary>
-    private static bool TryUnquote(string token, out string value)
-    {
-        value = token;
-        if (token.Length == 0)
-        {
-            return true;
-        }
-
-        var quote = token[0];
-        if (quote != '"' && quote != '\'')
-        {
-            return true; // unquoted plain scalar
-        }
-        if (token.Length < 2 || token[^1] != quote)
-        {
-            return false;
-        }
-
-        value = token[1..^1];
-        return true;
-    }
-
-    /// <summary>
-    /// Strips a <c>#</c> comment from a single physical line, respecting
-    /// quotes — a <c>#</c> inside an open quote is literal content, not a
-    /// comment marker.
-    /// </summary>
-    private static (string Before, bool HadComment) StripInlineComment(string line)
-    {
-        var inSingle = false;
-        var inDouble = false;
-
-        for (var i = 0; i < line.Length; i++)
-        {
-            var c = line[i];
-            if (c == '\'' && !inDouble)
-            {
-                inSingle = !inSingle;
-            }
-            else if (c == '"' && !inSingle)
-            {
-                inDouble = !inDouble;
-            }
-            else if (c == '#' && !inSingle && !inDouble)
-            {
-                return (line[..i], true);
-            }
-        }
-        return (line, false);
+        var foundValue = facetsNode is YamlScalarNode scalarNode ? scalarNode.Value : facetsNode.ToString();
+        return FacetsParseResult.Malformed(
+            $"expected a YAML list after 'facets:' (flow '[item, ...]' or block '- item' form), found scalar '{foundValue}'");
     }
 
     /// <summary>Stable dedup: first-seen order preserved, ordinal comparison — the single dedup point every caller shares.</summary>
@@ -421,34 +188,49 @@ internal static class IntentNodeFacets
     }
 
     /// <summary>
-    /// Extracts the raw text between an opening <c>---</c> line at the very
-    /// start of the file and the next <c>---</c> line. Returns
-    /// <see langword="false"/> when the file does not start with a
-    /// frontmatter block at all (the common case for a node with no facets).
+    /// Extracts the raw text between an opening <c>---</c> delimiter line at
+    /// the very start of the file and the next exact <c>---</c> delimiter
+    /// line, plus the remaining body text after that closing delimiter.
+    /// Delimiter lines must match exactly (trailing whitespace tolerated) —
+    /// a line like <c>---junk</c> is never mistaken for the closing
+    /// delimiter. Returns <see langword="false"/> when the file does not
+    /// start with a frontmatter block at all (the common case for a node
+    /// with no facets).
     /// </summary>
-    public static bool TryExtractFrontmatterBlock(string fileContent, out string frontmatter)
+    public static bool TryExtractFrontmatterBlock(string fileContent, out string frontmatter, out string body)
     {
         frontmatter = string.Empty;
+        body = fileContent ?? string.Empty;
         if (string.IsNullOrEmpty(fileContent))
         {
             return false;
         }
 
         var normalized = fileContent.Replace("\r\n", "\n", StringComparison.Ordinal);
-        if (!normalized.StartsWith("---\n", StringComparison.Ordinal))
+        var lines = normalized.Split('\n');
+        if (lines.Length == 0 || lines[0].TrimEnd() != "---")
         {
             return false;
         }
 
-        var closingIndex = normalized.IndexOf("\n---", 4, StringComparison.Ordinal);
-        if (closingIndex < 0)
+        for (var i = 1; i < lines.Length; i++)
         {
-            return false;
+            if (lines[i].TrimEnd() != "---")
+            {
+                continue;
+            }
+
+            frontmatter = string.Join('\n', lines[1..i]);
+            body = string.Join('\n', lines[(i + 1)..]);
+            return true;
         }
 
-        frontmatter = normalized[4..closingIndex];
-        return true;
+        return false;
     }
+
+    /// <summary>Convenience overload for callers that only need the frontmatter text itself.</summary>
+    public static bool TryExtractFrontmatterBlock(string fileContent, out string frontmatter) =>
+        TryExtractFrontmatterBlock(fileContent, out frontmatter, out _);
 
     public static bool IsAllowedValue(string value) =>
         AllowedValues.Contains(value, StringComparer.Ordinal);

--- a/src/IntentSystem.Cli/Commands/IntentNodeFacets.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNodeFacets.cs
@@ -1,5 +1,6 @@
+using System.Text.RegularExpressions;
 using YamlDotNet.Core;
-using YamlDotNet.RepresentationModel;
+using YamlDotNet.Core.Events;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -29,11 +30,19 @@ namespace IntentSystem.Cli.Commands;
 ///
 /// <see cref="ParseFacets"/> hands the <c>facets:</c> value off to
 /// <b>YamlDotNet</b> — a real YAML parser — rather than a hand-rolled
-/// scanner. Two prior repair rounds each found a fresh correctness gap in a
-/// bespoke tokenizer (single-line-only flow, then unescaped/non-trailing-
-/// junk-aware scanning); a real parser resolves escaping, doubled-single-
-/// quote semantics, comments, multi-line flow, and trailing-content
-/// rejection correctly by construction instead of by ad hoc patching.
+/// scanner. Prior repair rounds each found a fresh correctness gap in a
+/// bespoke tokenizer; a real parser resolves escaping, doubled-single-quote
+/// semantics, comments, multi-line flow, and trailing-content rejection
+/// correctly by construction instead of by ad hoc patching.
+///
+/// Extraction is narrow in BOTH directions: content before the top-level
+/// <c>facets:</c> line is never fed to the parser at all (excluded from the
+/// input text), and parsing STOPS the instant the facets value itself is
+/// fully consumed — YamlDotNet's low-level event parser is lazy/streaming,
+/// so a later, unrelated key's own malformed value is never even
+/// tokenized, let alone attributed to <c>facets:</c>. (A duplicate
+/// top-level <c>facets:</c> key is instead detected up front via a cheap
+/// line-level scan, deterministically, before any parsing is attempted.)
 ///
 /// A <c>facets:</c> declaration that is present but does not parse as a
 /// YAML list (a bare scalar, an unterminated flow list, an unbalanced
@@ -43,12 +52,11 @@ namespace IntentSystem.Cli.Commands;
 /// (or no frontmatter block at all) is <see cref="FacetsParseKind.Absent"/>,
 /// which is fully backward compatible: the node is simply unannotated.
 ///
-/// This reader is intentionally narrow: it locates and validates ONLY the
-/// top-level <c>facets:</c> key (and, from that line onward, hands YamlDotNet
-/// just enough of the frontmatter to resolve that one key — never the
-/// portion before it). Any other frontmatter fields a node file may carry
-/// (e.g. <c>intent_id</c>, <c>intent_type</c>) are untouched — parsing and
-/// validating those is out of scope for this slice.
+/// This reader is intentionally narrow in scope too: it locates and
+/// validates ONLY the top-level <c>facets:</c> key. Any other frontmatter
+/// fields a node file may carry (e.g. <c>intent_id</c>, <c>intent_type</c>)
+/// are untouched — parsing and validating those is out of scope for this
+/// slice, and (per the above) their own syntax is never even inspected.
 /// </summary>
 internal static class IntentNodeFacets
 {
@@ -90,8 +98,16 @@ internal static class IntentNodeFacets
         // indentation is out of scope (narrow reader) — UNLESS it was
         // clearly intended as the top-level declaration but mis-indented
         // with a tab, which is never silently absent (see below).
-        var facetsLineIndex = Array.FindIndex(lines, line => line.StartsWith(FacetsKeyPrefix, StringComparison.Ordinal));
-        if (facetsLineIndex < 0)
+        var facetsLineIndices = new List<int>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (lines[i].StartsWith(FacetsKeyPrefix, StringComparison.Ordinal))
+            {
+                facetsLineIndices.Add(i);
+            }
+        }
+
+        if (facetsLineIndices.Count == 0)
         {
             if (Array.Exists(lines, LooksLikeTabIndentedFacetsDeclaration))
             {
@@ -100,13 +116,24 @@ internal static class IntentNodeFacets
             return FacetsParseResult.AbsentResult;
         }
 
+        if (facetsLineIndices.Count > 1)
+        {
+            // Deterministic, cheap, and parser-independent: a second
+            // top-level "facets:" key is unambiguously a contract
+            // violation regardless of whether either declaration is
+            // otherwise well-formed YAML.
+            return FacetsParseResult.Malformed(
+                $"multiple top-level 'facets:' keys found in frontmatter (lines {string.Join(", ", facetsLineIndices.Select(i => i + 1))}); only one is allowed");
+        }
+
         // Hand YamlDotNet everything from the "facets:" line to the end of
-        // the frontmatter block — real block/flow-list boundary resolution,
-        // multi-line flow, quoting/escaping, and comments, all per actual
-        // YAML grammar. Content BEFORE this line (other fields) is excluded
-        // so an unrelated field's own syntax issue can never masquerade as
-        // a facets: problem.
-        var fragment = string.Join('\n', lines[facetsLineIndex..]);
+        // the frontmatter block as the INPUT TEXT — but the low-level event
+        // parser below only reads as far as needed to fully consume the
+        // facets value itself, then stops. Content before this line (other
+        // fields) is excluded from the input text entirely; content after
+        // it is included in the input text but is never actually parsed,
+        // so neither can surface as a facets: problem.
+        var fragment = string.Join('\n', lines[facetsLineIndices[0]..]);
         return ParseFacetsFragment(fragment);
     }
 
@@ -115,18 +142,43 @@ internal static class IntentNodeFacets
 
     private static FacetsParseResult ParseFacetsFragment(string fragment)
     {
-        YamlMappingNode mapping;
         try
         {
-            var yaml = new YamlStream();
             using var reader = new StringReader(fragment);
-            yaml.Load(reader);
+            IParser parser = new Parser(reader);
 
-            if (yaml.Documents.Count == 0 || yaml.Documents[0].RootNode is not YamlMappingNode rootMapping)
+            parser.Consume<StreamStart>();
+            parser.Consume<DocumentStart>();
+            if (!parser.TryConsume<MappingStart>(out _))
             {
                 return FacetsParseResult.Malformed("'facets:' did not parse as a YAML mapping entry");
             }
-            mapping = rootMapping;
+
+            var key = parser.Consume<Scalar>();
+            if (!string.Equals(key.Value, FacetsKeyName, StringComparison.Ordinal))
+            {
+                // Should not happen — the caller only reaches here after
+                // locating a "facets:" line itself — but stay defensive.
+                return FacetsParseResult.AbsentResult;
+            }
+
+            var result = ConsumeFacetsValue(parser);
+
+            // One more look-ahead only: confirm the value's own line ends
+            // cleanly (either the mapping ends here, or a new key starts).
+            // This is what catches non-comment trailing content on the
+            // SAME declaration (e.g. "facets: [a] junk") without ever
+            // parsing — or risking an exception from — anything belonging
+            // to a genuinely separate, later key.
+            if (result.Kind == FacetsParseKind.Present
+                && !parser.Accept<MappingEnd>(out _)
+                && !parser.Accept<Scalar>(out _))
+            {
+                parser.MoveNext(); // force tokenization to surface the real diagnostic
+                return FacetsParseResult.Malformed("unexpected content immediately after the 'facets:' declaration");
+            }
+
+            return result;
         }
         catch (YamlException exception)
         {
@@ -134,42 +186,61 @@ internal static class IntentNodeFacets
             // free: unterminated flow lists, unbalanced/unescaped quotes,
             // non-comment trailing content after a flow list's closing
             // bracket, and tab indentation — all genuine YAML syntax
-            // errors that a real parser rejects by construction.
-            return FacetsParseResult.Malformed($"invalid YAML: {exception.Message}");
+            // errors that a real parser rejects by construction. The
+            // message is sanitized: no absolute paths (none are ever
+            // legitimately present, parsing an in-memory fragment, but
+            // this is defense in depth against library internals) and
+            // capped in length so a pathological input can't flood output.
+            return FacetsParseResult.Malformed($"invalid YAML: {SanitizeYamlDiagnostic(exception)}");
         }
+    }
 
-        if (!mapping.Children.TryGetValue(new YamlScalarNode(FacetsKeyName), out var facetsNode))
-        {
-            // Should not happen — the caller only reaches here after
-            // locating a "facets:" line itself — but stay defensive.
-            return FacetsParseResult.AbsentResult;
-        }
-
-        if (facetsNode is YamlSequenceNode sequence)
+    private static FacetsParseResult ConsumeFacetsValue(IParser parser)
+    {
+        if (parser.TryConsume<SequenceStart>(out _))
         {
             var items = new List<string>();
-            foreach (var child in sequence.Children)
+            while (!parser.Accept<SequenceEnd>(out _))
             {
-                if (child is not YamlScalarNode { Value: { Length: > 0 } scalarValue })
+                if (!parser.TryConsume<Scalar>(out var itemScalar) || itemScalar.Value.Length == 0)
                 {
                     return FacetsParseResult.Malformed("'facets:' list contains a non-scalar or empty item");
                 }
-                items.Add(scalarValue);
+                items.Add(itemScalar.Value);
             }
+            parser.Consume<SequenceEnd>();
             return FacetsParseResult.Present(Deduplicate(items));
         }
 
-        if (facetsNode is YamlScalarNode { Value: null or "" })
+        if (parser.TryConsume<Scalar>(out var scalar))
         {
-            // "facets:" with nothing after it and no block items either
-            // (YAML null) — use "[]" for an intentionally empty list.
+            if (scalar.Value.Length == 0)
+            {
+                // "facets:" with nothing after it and no block items either
+                // (YAML null) — use "[]" for an intentionally empty list.
+                return FacetsParseResult.Malformed(
+                    "'facets:' has no value — use '[]' for an explicitly empty list, or list values with '- item' entries");
+            }
             return FacetsParseResult.Malformed(
-                "'facets:' has no value — use '[]' for an explicitly empty list, or list values with '- item' entries");
+                $"expected a YAML list after 'facets:' (flow '[item, ...]' or block '- item' form), found scalar '{scalar.Value}'");
         }
 
-        var foundValue = facetsNode is YamlScalarNode scalarNode ? scalarNode.Value : facetsNode.ToString();
-        return FacetsParseResult.Malformed(
-            $"expected a YAML list after 'facets:' (flow '[item, ...]' or block '- item' form), found scalar '{foundValue}'");
+        return FacetsParseResult.Malformed("'facets:' value did not parse as a YAML list or scalar");
+    }
+
+    private static readonly Regex PathLikeFragmentPattern = new(
+        @"[A-Za-z]:\\[^\s""']+|/(?:[^\s""'/]+/)+[^\s""']*",
+        RegexOptions.Compiled);
+
+    private const int MaxDiagnosticLength = 300;
+
+    private static string SanitizeYamlDiagnostic(YamlException exception)
+    {
+        var message = string.IsNullOrWhiteSpace(exception.Message) ? "malformed YAML" : exception.Message;
+        message = PathLikeFragmentPattern.Replace(message, "<redacted>");
+        return message.Length > MaxDiagnosticLength
+            ? message[..MaxDiagnosticLength] + "…"
+            : message;
     }
 
     /// <summary>Stable dedup: first-seen order preserved, ordinal comparison — the single dedup point every caller shares.</summary>

--- a/src/IntentSystem.Cli/Commands/IntentNodeFacets.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNodeFacets.cs
@@ -1,0 +1,110 @@
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G529: shared reader for the optional <c>facets:</c> frontmatter field on
+/// intent-tree node Markdown files. Facets name which of the four
+/// "human-retained understanding" surfaces (Operator input, issue #1159) a
+/// node documents — event/command vocabulary, invariants and consistency
+/// boundaries, decider judgments, and acceptance properties. The value set
+/// is closed for now; extending it is future design work.
+///
+/// A node opts in with a <c>---</c>-delimited frontmatter block at the very
+/// start of the file, e.g.:
+/// <code>
+/// ---
+/// facets: [vocabulary, invariant]
+/// ---
+/// # Node title
+/// ...
+/// </code>
+///
+/// This reader is intentionally narrow: it extracts and validates ONLY the
+/// <c>facets:</c> line. Any other frontmatter fields a node file may carry
+/// (e.g. <c>intent_id</c>, <c>intent_type</c>) are untouched — parsing and
+/// validating those is out of scope for this slice. A node with no
+/// frontmatter block, or a frontmatter block with no <c>facets:</c> line,
+/// is fully backward compatible: it simply has zero facets.
+/// </summary>
+internal static class IntentNodeFacets
+{
+    public const string Vocabulary = "vocabulary";
+    public const string Invariant = "invariant";
+    public const string Decider = "decider";
+    public const string AcceptanceProperty = "acceptance-property";
+
+    /// <summary>The closed set of recognized facet values, in the canonical order used for docs/scaffolds.</summary>
+    public static readonly IReadOnlyList<string> AllowedValues = new[]
+    {
+        Vocabulary,
+        Invariant,
+        Decider,
+        AcceptanceProperty,
+    };
+
+    private static readonly Regex FacetsLinePattern = new(
+        @"^facets:\s*\[(?<values>[^\]]*)\]\s*$",
+        RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Extracts the raw (unvalidated) facet tokens from a node's <c>facets:</c>
+    /// frontmatter line, or an empty list when the file has no frontmatter
+    /// block, or the block has no <c>facets:</c> line. Tokens are returned
+    /// exactly as written (trimmed) — callers validate against
+    /// <see cref="AllowedValues"/> via <see cref="IsAllowedValue"/>.
+    /// </summary>
+    public static IReadOnlyList<string> ExtractRawFacets(string fileContent)
+    {
+        ArgumentNullException.ThrowIfNull(fileContent);
+
+        if (!TryExtractFrontmatterBlock(fileContent, out var frontmatter))
+        {
+            return Array.Empty<string>();
+        }
+
+        var match = FacetsLinePattern.Match(frontmatter);
+        if (!match.Success)
+        {
+            return Array.Empty<string>();
+        }
+
+        return match.Groups["values"].Value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Where(value => value.Length > 0)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// Extracts the raw text between an opening <c>---</c> line at the very
+    /// start of the file and the next <c>---</c> line. Returns
+    /// <see langword="false"/> when the file does not start with a
+    /// frontmatter block at all (the common case for a node with no facets).
+    /// </summary>
+    public static bool TryExtractFrontmatterBlock(string fileContent, out string frontmatter)
+    {
+        frontmatter = string.Empty;
+        if (string.IsNullOrEmpty(fileContent))
+        {
+            return false;
+        }
+
+        var normalized = fileContent.Replace("\r\n", "\n", StringComparison.Ordinal);
+        if (!normalized.StartsWith("---\n", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var closingIndex = normalized.IndexOf("\n---", 4, StringComparison.Ordinal);
+        if (closingIndex < 0)
+        {
+            return false;
+        }
+
+        frontmatter = normalized[4..closingIndex];
+        return true;
+    }
+
+    public static bool IsAllowedValue(string value) =>
+        AllowedValues.Contains(value, StringComparer.Ordinal);
+}

--- a/src/IntentSystem.Cli/Commands/IntentNodeFacets.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNodeFacets.cs
@@ -122,8 +122,14 @@ internal static class IntentNodeFacets
             // top-level "facets:" key is unambiguously a contract
             // violation regardless of whether either declaration is
             // otherwise well-formed YAML.
+            //
+            // `frontmatter` is everything BETWEEN the opening "---" line
+            // and the closing one (see TryExtractFrontmatterBlock), so its
+            // own line 0 is already file line 2 — translate a frontmatter
+            // index back to a 1-based FILE line by adding 2, not 1, or the
+            // reported location is one line short of the actual file.
             return FacetsParseResult.Malformed(
-                $"multiple top-level 'facets:' keys found in frontmatter (lines {string.Join(", ", facetsLineIndices.Select(i => i + 1))}); only one is allowed");
+                $"multiple top-level 'facets:' keys found in frontmatter (lines {string.Join(", ", facetsLineIndices.Select(i => i + 2))}); only one is allowed");
         }
 
         // Hand YamlDotNet everything from the "facets:" line to the end of

--- a/src/IntentSystem.Cli/Commands/IntentSearchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentSearchCommand.cs
@@ -10,6 +10,13 @@ namespace IntentSystem.Cli.Commands;
 /// (<c>intents/&lt;domain&gt;/</c>) and emits the matching file paths,
 /// 1-based line numbers, and a trimmed snippet. Never mutates state and
 /// never launches an AI provider.
+///
+/// G529: an optional <c>--facet &lt;value&gt;</c> filter (one of
+/// <see cref="IntentNodeFacets.AllowedValues"/>) restricts results to files
+/// whose <c>facets:</c> frontmatter carries that value, combinable with
+/// <c>--query</c>. When <c>--facet</c> is given without <c>--query</c>, each
+/// matching file is reported once (its <c>facets:</c> line as the snippet)
+/// rather than doing line-level substring matching.
 /// </summary>
 internal static class IntentSearchCommand
 {
@@ -20,7 +27,7 @@ internal static class IntentSearchCommand
     private const int SnippetMaxLength = 240;
 
     private const string UsageLine =
-        "Usage: intent-cli intent search --query <text> [--domain <name>] [--format markdown|json]";
+        "Usage: intent-cli intent search [--query <text>] [--domain <name>] [--facet vocabulary|invariant|decider|acceptance-property] [--format markdown|json]";
 
     private static readonly string[] SearchableExtensions =
         new[] { ".md", ".yaml", ".yml", ".json", ".txt" };
@@ -37,14 +44,14 @@ internal static class IntentSearchCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var query, out var domainOverride, out var format, out var error))
+        if (!TryParseArguments(args, out var query, out var domainOverride, out var facet, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
             return 1;
         }
 
-        var result = Search(context, query!, domainOverride);
+        var result = Search(context, query, domainOverride, facet);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -59,7 +66,7 @@ internal static class IntentSearchCommand
         return 0;
     }
 
-    internal static IntentSearchResult Search(CliContext context, string query, string? domainOverride)
+    internal static IntentSearchResult Search(CliContext context, string? query, string? domainOverride, string? facet)
     {
         var domain = string.IsNullOrWhiteSpace(domainOverride)
             ? context.Config.Project.Domain
@@ -70,26 +77,27 @@ internal static class IntentSearchCommand
         var packetRoot = Path.Combine(context.RepoRoot, ".intent-cli", "issues");
         if (Directory.Exists(packetRoot))
         {
-            CollectMatches(packetRoot, query, hits);
+            CollectMatches(packetRoot, query, facet, hits);
         }
 
         var domainRoot = Path.Combine(context.RepoRoot, "intents", domain);
         if (Directory.Exists(domainRoot))
         {
-            CollectMatches(domainRoot, query, hits);
+            CollectMatches(domainRoot, query, facet, hits);
         }
 
         return new IntentSearchResult
         {
             Domain = domain,
             Query = query,
+            Facet = facet,
             PacketRoot = packetRoot,
             DomainRoot = domainRoot,
             Hits = hits
         };
     }
 
-    private static void CollectMatches(string root, string query, List<IntentSearchHit> hits)
+    private static void CollectMatches(string root, string? query, string? facet, List<IntentSearchHit> hits)
     {
         var files = Directory
             .EnumerateFiles(root, "*", SearchOption.AllDirectories)
@@ -100,10 +108,10 @@ internal static class IntentSearchCommand
 
         foreach (var file in files)
         {
-            string[] lines;
+            string content;
             try
             {
-                lines = File.ReadAllLines(file);
+                content = File.ReadAllText(file);
             }
             catch (IOException)
             {
@@ -114,6 +122,41 @@ internal static class IntentSearchCommand
                 continue;
             }
 
+            // G529: when --facet is given, restrict to files carrying that
+            // facet in their frontmatter before any text matching happens.
+            if (facet is not null
+                && !IntentNodeFacets.ExtractRawFacets(content).Contains(facet, StringComparer.Ordinal))
+            {
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(query))
+            {
+                // G529: facet-only mode — report the file once rather than
+                // doing line-level substring matching with an empty query.
+                // Skip past any frontmatter block so the snippet shows the
+                // node's actual title/prose, not the "---" delimiter.
+                // Both the frontmatter extraction and the line split operate
+                // on the same normalized (LF-only) text, so the offset math
+                // stays correct regardless of the file's original line endings.
+                var normalizedContent = content.Replace("\r\n", "\n", StringComparison.Ordinal);
+                var body = IntentNodeFacets.TryExtractFrontmatterBlock(normalizedContent, out var frontmatter)
+                    ? normalizedContent[(4 + frontmatter.Length + 4)..]
+                    : normalizedContent;
+                var firstLine = body
+                    .Split('\n')
+                    .Select(line => line.Trim())
+                    .FirstOrDefault(line => line.Length > 0) ?? string.Empty;
+                hits.Add(new IntentSearchHit
+                {
+                    Path = file,
+                    Line = 1,
+                    Snippet = TrimSnippet(firstLine)
+                });
+                continue;
+            }
+
+            var lines = content.Split('\n');
             var matchesInFile = 0;
             for (var index = 0; index < lines.Length && matchesInFile < MatchesPerFile; index++)
             {
@@ -149,7 +192,14 @@ internal static class IntentSearchCommand
     {
         writer.WriteLine($"# Intent search — {result.Domain}");
         writer.WriteLine();
-        writer.WriteLine($"- query: `{result.Query}`");
+        if (!string.IsNullOrEmpty(result.Query))
+        {
+            writer.WriteLine($"- query: `{result.Query}`");
+        }
+        if (!string.IsNullOrEmpty(result.Facet))
+        {
+            writer.WriteLine($"- facet: `{result.Facet}`");
+        }
         writer.WriteLine($"- packet root: {result.PacketRoot}");
         writer.WriteLine($"- domain root: {result.DomainRoot}");
         writer.WriteLine($"- matches: {result.Hits.Count}");
@@ -172,11 +222,13 @@ internal static class IntentSearchCommand
         string[] args,
         out string? query,
         out string? domainOverride,
+        out string? facet,
         out string format,
         out string error)
     {
         query = null;
         domainOverride = null;
+        facet = null;
         format = FormatMarkdown;
         error = string.Empty;
 
@@ -207,6 +259,24 @@ internal static class IntentSearchCommand
                     index++;
                     break;
 
+                case "--facet":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--facet requires a value.";
+                        return false;
+                    }
+
+                    var requestedFacet = args[index + 1];
+                    if (!IntentNodeFacets.IsAllowedValue(requestedFacet))
+                    {
+                        error = $"--facet must be one of: {string.Join(", ", IntentNodeFacets.AllowedValues)} (got '{requestedFacet}').";
+                        return false;
+                    }
+
+                    facet = requestedFacet;
+                    index++;
+                    break;
+
                 case "--format":
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
                     {
@@ -232,9 +302,9 @@ internal static class IntentSearchCommand
             }
         }
 
-        if (string.IsNullOrWhiteSpace(query))
+        if (string.IsNullOrWhiteSpace(query) && string.IsNullOrWhiteSpace(facet))
         {
-            error = "--query is required.";
+            error = "intent search requires --query and/or --facet.";
             return false;
         }
 
@@ -246,6 +316,7 @@ internal static class IntentSearchCommand
         writer.WriteLine("intent search");
         writer.WriteLine(UsageLine);
         writer.WriteLine("Read-only substring search across packets and the per-domain intent tree.");
+        writer.WriteLine("--facet filters to files whose facets: frontmatter carries that value; combinable with --query.");
     }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
@@ -262,7 +333,10 @@ internal sealed record IntentSearchResult
     public required string Domain { get; init; }
 
     [JsonPropertyName("query")]
-    public required string Query { get; init; }
+    public string? Query { get; init; }
+
+    [JsonPropertyName("facet")]
+    public string? Facet { get; init; }
 
     [JsonPropertyName("packet_root")]
     public required string PacketRoot { get; init; }

--- a/src/IntentSystem.Cli/Commands/IntentSearchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentSearchCommand.cs
@@ -122,12 +122,20 @@ internal static class IntentSearchCommand
                 continue;
             }
 
-            // G529: when --facet is given, restrict to files carrying that
-            // facet in their frontmatter before any text matching happens.
-            if (facet is not null
-                && !IntentNodeFacets.ExtractRawFacets(content).Contains(facet, StringComparer.Ordinal))
+            // G529: when --facet is given, restrict to files that PARSE a
+            // present, valid facets: list carrying that value. A malformed
+            // facets: declaration is `lint-layout`'s concern to flag as an
+            // error — search simply excludes it, the same as a node with no
+            // facets: at all, since it cannot be confirmed to carry the
+            // requested facet.
+            if (facet is not null)
             {
-                continue;
+                var parsed = IntentNodeFacets.ParseFacets(content);
+                if (parsed.Kind != FacetsParseKind.Present
+                    || !parsed.Values.Contains(facet, StringComparer.Ordinal))
+                {
+                    continue;
+                }
             }
 
             if (string.IsNullOrEmpty(query))

--- a/src/IntentSystem.Cli/Commands/IntentSearchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentSearchCommand.cs
@@ -144,13 +144,9 @@ internal static class IntentSearchCommand
                 // doing line-level substring matching with an empty query.
                 // Skip past any frontmatter block so the snippet shows the
                 // node's actual title/prose, not the "---" delimiter.
-                // Both the frontmatter extraction and the line split operate
-                // on the same normalized (LF-only) text, so the offset math
-                // stays correct regardless of the file's original line endings.
-                var normalizedContent = content.Replace("\r\n", "\n", StringComparison.Ordinal);
-                var body = IntentNodeFacets.TryExtractFrontmatterBlock(normalizedContent, out var frontmatter)
-                    ? normalizedContent[(4 + frontmatter.Length + 4)..]
-                    : normalizedContent;
+                var body = IntentNodeFacets.TryExtractFrontmatterBlock(content, out _, out var bodyAfterFrontmatter)
+                    ? bodyAfterFrontmatter
+                    : content;
                 var firstLine = body
                     .Split('\n')
                     .Select(line => line.Trim())

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -175,6 +175,7 @@
 
   <ItemGroup>
     <PackageReference Include="Tomlyn" Version="2.3.0" />
+    <PackageReference Include="YamlDotNet" Version="18.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/IntentSystem.Cli.Tests/IntentAnalyzeTreeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentAnalyzeTreeCommandTests.cs
@@ -392,6 +392,61 @@ public sealed class IntentAnalyzeTreeCommandTests
     }
 
     [Fact]
+    public void Execute_BlockFormFacetsAndDuplicateValues_CountedConsistentlyWithFlowForm()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        var featuresDir = Path.Combine(hostRoot, "intents", "auth", "features", "login");
+        Directory.CreateDirectory(featuresDir);
+        // Block form.
+        File.WriteAllText(
+            Path.Combine(featuresDir, "overview.md"),
+            "---\nfacets:\n  - vocabulary\n  - invariant\n---\n# Login overview\n");
+        // Flow form with a duplicate value — a duplicate within ONE node
+        // must count as ONE occurrence of that facet, not two.
+        File.WriteAllText(
+            Path.Combine(featuresDir, "decisions.md"),
+            "---\nfacets: [invariant, invariant]\n---\n# Login decisions\n");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        var coverage = document.RootElement.GetProperty("facet_coverage");
+        Assert.Equal(1, coverage.GetProperty("vocabulary").GetInt32());
+        // One from overview.md (block form) + one from decisions.md (the
+        // duplicate collapses to a single occurrence) = 2, not 3.
+        Assert.Equal(2, coverage.GetProperty("invariant").GetInt32());
+    }
+
+    [Fact]
+    public void Execute_MalformedFacetsNode_ExcludedFromCoverage_NotCounted()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        var identityDir = Path.Combine(hostRoot, "intents", "auth", "identity");
+        Directory.CreateDirectory(identityDir);
+        File.WriteAllText(
+            Path.Combine(identityDir, "mission.md"),
+            "---\nfacets: invariant\n---\n# Mission\n");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        var coverage = document.RootElement.GetProperty("facet_coverage");
+        Assert.False(coverage.TryGetProperty("invariant", out _));
+    }
+
+    [Fact]
     public void Execute_NoNodesWithFacets_FacetCoverageIsEmpty()
     {
         using var tmp = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntentAnalyzeTreeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentAnalyzeTreeCommandTests.cs
@@ -354,6 +354,82 @@ public sealed class IntentAnalyzeTreeCommandTests
     }
 
     // ──────────────────────────────────────────────
+    // Facet coverage (G529)
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_NodesWithFacets_ReportsPerFacetCounts()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        var featuresDir = Path.Combine(hostRoot, "intents", "auth", "features", "login");
+        Directory.CreateDirectory(featuresDir);
+        File.WriteAllText(
+            Path.Combine(featuresDir, "overview.md"),
+            "---\nfacets: [vocabulary, invariant]\n---\n# Login overview\n");
+        File.WriteAllText(
+            Path.Combine(featuresDir, "decisions.md"),
+            "---\nfacets: [invariant]\n---\n# Login decisions\n");
+        File.WriteAllText(
+            Path.Combine(featuresDir, "requirements.md"),
+            "# Login requirements\n\nNo facets frontmatter.\n");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        var coverage = document.RootElement.GetProperty("facet_coverage");
+        Assert.Equal(1, coverage.GetProperty("vocabulary").GetInt32());
+        Assert.Equal(2, coverage.GetProperty("invariant").GetInt32());
+        // "decider" and "acceptance-property" have zero nodes — only
+        // positive counts are reported, so they must be absent entirely.
+        Assert.False(coverage.TryGetProperty("decider", out _));
+        Assert.False(coverage.TryGetProperty("acceptance-property", out _));
+    }
+
+    [Fact]
+    public void Execute_NoNodesWithFacets_FacetCoverageIsEmpty()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateFlatFile(hostRoot, "auth", "intent.md", "# Auth\n\n## Mission\nWe auth.");
+        using var writer = new StringWriter();
+
+        var exitCode = IntentAnalyzeTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        var coverage = document.RootElement.GetProperty("facet_coverage");
+        Assert.Equal(0, coverage.EnumerateObject().Count());
+    }
+
+    [Fact]
+    public void Execute_Markdown_RendersFacetCoverageSection()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        var identityDir = Path.Combine(hostRoot, "intents", "auth", "identity");
+        Directory.CreateDirectory(identityDir);
+        File.WriteAllText(
+            Path.Combine(identityDir, "mission.md"),
+            "---\nfacets: [decider]\n---\n# Mission\n");
+        using var writer = new StringWriter();
+
+        IntentAnalyzeTreeCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        var output = writer.ToString();
+        Assert.Contains("## Facet coverage", output, StringComparison.Ordinal);
+        Assert.Contains("decider: 1", output, StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
     // Helpers
     // ──────────────────────────────────────────────
 

--- a/tests/IntentSystem.Cli.Tests/IntentInitTreeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentInitTreeCommandTests.cs
@@ -472,6 +472,35 @@ public sealed class IntentInitTreeCommandTests
     }
 
     // ──────────────────────────────────────────────
+    // Facets scaffold comment (G529)
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_WithWrite_MissionStarterIncludesCommentedFacetsExample_AndLintStaysClean()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+
+        IntentInitTreeCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "auth", "--write"],
+            TextWriter.Null);
+
+        var missionContent = File.ReadAllText(Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"));
+        // Present as a comment (explaining all four values), not a live field.
+        Assert.Contains("# facets: [vocabulary]", missionContent, StringComparison.Ordinal);
+        Assert.Contains("vocabulary", missionContent, StringComparison.Ordinal);
+        Assert.Contains("invariant", missionContent, StringComparison.Ordinal);
+        Assert.Contains("decider", missionContent, StringComparison.Ordinal);
+        Assert.Contains("acceptance-property", missionContent, StringComparison.Ordinal);
+        Assert.DoesNotContain("\nfacets:", missionContent, StringComparison.Ordinal);
+
+        using var lintWriter = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], lintWriter);
+        Assert.DoesNotContain("INVALID-FACET", lintWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
     // Helpers
     // ──────────────────────────────────────────────
 

--- a/tests/IntentSystem.Cli.Tests/IntentLintLayoutCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentLintLayoutCommandTests.cs
@@ -413,6 +413,48 @@ public sealed class IntentLintLayoutCommandTests
     }
 
     [Fact]
+    public void Execute_NodeWithValidFacets_UnrelatedMalformedFieldAfterFacets_DoesNotReportMalformedFacets_ExitsZero()
+    {
+        // Second rereview repair: an unrelated field's own YAML syntax
+        // error, appearing AFTER a perfectly well-formed facets: value,
+        // must never be misattributed to facets: — the streaming parser
+        // stops reading once the facets value is consumed.
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\nfacets: [vocabulary]\nother_field: \"unterminated\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.DoesNotContain("MALFORMED-FACETS", output, StringComparison.Ordinal);
+        Assert.Contains("clean", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_NodeWithDuplicateTopLevelFacetsKeys_ReportsMalformedFacetsAndExitsNonzero()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\nfacets: [vocabulary]\nfacets: [invariant]\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.NotEqual(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("MALFORMED-FACETS", output, StringComparison.Ordinal);
+        Assert.Contains("multiple", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Execute_NodeWithTabIndentedFacetsDeclaration_ReportsErrorNeverSilentlyClean()
     {
         using var tmp = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntentLintLayoutCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentLintLayoutCommandTests.cs
@@ -396,6 +396,65 @@ public sealed class IntentLintLayoutCommandTests
     }
 
     [Fact]
+    public void Execute_NodeWithTrailingJunkAfterFlowList_ReportsErrorAndExitsNonzero()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\nfacets: [vocabulary] trailing-junk\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("MALFORMED-FACETS", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NodeWithTabIndentedFacetsDeclaration_ReportsErrorNeverSilentlyClean()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\n\tfacets: [vocabulary]\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.NotEqual(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("MALFORMED-FACETS", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("clean", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_NodeWithEscapedQuoteInFacetValue_ParsesAndValidatesTheDecodedValue()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        // Decodes to `vocabulary"quoted` — not one of the four allowed
+        // values, so this must surface as an INVALID-FACET error naming the
+        // DECODED value, proving the escape was actually resolved rather
+        // than corrupting the scan.
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\nfacets: [\"vocabulary\\\"quoted\"]\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.NotEqual(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("INVALID-FACET", output, StringComparison.Ordinal);
+        Assert.Contains("vocabulary\"quoted", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_NodeWithNoFacetsFrontmatter_StaysBackwardCompatible()
     {
         using var tmp = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/IntentLintLayoutCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentLintLayoutCommandTests.cs
@@ -270,6 +270,89 @@ public sealed class IntentLintLayoutCommandTests
     }
 
     // ──────────────────────────────────────────────
+    // Facets (G529)
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_NodeWithValidFacets_ReportsNoInvalidFacetWarning()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\nfacets: [vocabulary, invariant]\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        var output = writer.ToString();
+        Assert.DoesNotContain("INVALID-FACET", output, StringComparison.Ordinal);
+        Assert.Contains("clean", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_NodeWithUnknownFacetValue_ReportsInvalidFacetWarningNamingNodeValueAndAllowedSet()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\nfacets: [projection]\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        var output = writer.ToString();
+        Assert.Contains("INVALID-FACET", output, StringComparison.Ordinal);
+        Assert.Contains("intents/auth/identity/mission.md", output, StringComparison.Ordinal);
+        Assert.Contains("projection", output, StringComparison.Ordinal);
+        Assert.Contains("vocabulary", output, StringComparison.Ordinal);
+        Assert.Contains("invariant", output, StringComparison.Ordinal);
+        Assert.Contains("decider", output, StringComparison.Ordinal);
+        Assert.Contains("acceptance-property", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NodeWithMixOfValidAndInvalidFacets_ReportsOnlyTheInvalidOne()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\nfacets: [decider, projection]\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        var output = writer.ToString();
+        Assert.Single(System.Text.RegularExpressions.Regex.Matches(output, "INVALID-FACET"));
+        Assert.Contains("projection", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NodeWithNoFacetsFrontmatter_StaysBackwardCompatible()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        // No frontmatter at all — the pre-G529 default shape.
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "# Mission\n\nNo frontmatter here.\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.DoesNotContain("INVALID-FACET", output, StringComparison.Ordinal);
+        Assert.Contains("clean", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ──────────────────────────────────────────────
     // Mixed flat/tree compatibility
     // ──────────────────────────────────────────────
 

--- a/tests/IntentSystem.Cli.Tests/IntentLintLayoutCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentLintLayoutCommandTests.cs
@@ -274,7 +274,7 @@ public sealed class IntentLintLayoutCommandTests
     // ──────────────────────────────────────────────
 
     [Fact]
-    public void Execute_NodeWithValidFacets_ReportsNoInvalidFacetWarning()
+    public void Execute_NodeWithValidFacets_FlowForm_ExitsZeroCleanNoInvalidFacetWarning()
     {
         using var tmp = new TemporaryDirectory();
         var hostRoot = tmp.CreateDirectory("host");
@@ -284,15 +284,36 @@ public sealed class IntentLintLayoutCommandTests
             "---\nfacets: [vocabulary, invariant]\n---\n# Mission\n");
 
         using var writer = new StringWriter();
-        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
 
+        Assert.Equal(0, exitCode);
         var output = writer.ToString();
         Assert.DoesNotContain("INVALID-FACET", output, StringComparison.Ordinal);
         Assert.Contains("clean", output, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void Execute_NodeWithUnknownFacetValue_ReportsInvalidFacetWarningNamingNodeValueAndAllowedSet()
+    public void Execute_NodeWithValidFacets_BlockForm_ExitsZeroClean()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\nfacets:\n  - vocabulary\n  - invariant\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.DoesNotContain("INVALID-FACET", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("MALFORMED-FACETS", output, StringComparison.Ordinal);
+        Assert.Contains("clean", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_NodeWithUnknownFacetValue_ReportsErrorSeverity_NamesNodeValueAndAllowedSet_ExitsNonzero()
     {
         using var tmp = new TemporaryDirectory();
         var hostRoot = tmp.CreateDirectory("host");
@@ -302,8 +323,9 @@ public sealed class IntentLintLayoutCommandTests
             "---\nfacets: [projection]\n---\n# Mission\n");
 
         using var writer = new StringWriter();
-        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
 
+        Assert.NotEqual(0, exitCode);
         var output = writer.ToString();
         Assert.Contains("INVALID-FACET", output, StringComparison.Ordinal);
         Assert.Contains("intents/auth/identity/mission.md", output, StringComparison.Ordinal);
@@ -312,10 +334,12 @@ public sealed class IntentLintLayoutCommandTests
         Assert.Contains("invariant", output, StringComparison.Ordinal);
         Assert.Contains("decider", output, StringComparison.Ordinal);
         Assert.Contains("acceptance-property", output, StringComparison.Ordinal);
+        Assert.Contains("**Severity:** error", output, StringComparison.Ordinal);
+        Assert.Contains("has-errors: True", output, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Execute_NodeWithMixOfValidAndInvalidFacets_ReportsOnlyTheInvalidOne()
+    public void Execute_NodeWithMixOfValidAndInvalidFacets_ReportsOnlyTheInvalidOne_ExitsNonzero()
     {
         using var tmp = new TemporaryDirectory();
         var hostRoot = tmp.CreateDirectory("host");
@@ -325,11 +349,50 @@ public sealed class IntentLintLayoutCommandTests
             "---\nfacets: [decider, projection]\n---\n# Mission\n");
 
         using var writer = new StringWriter();
-        IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
 
+        Assert.NotEqual(0, exitCode);
         var output = writer.ToString();
         Assert.Single(System.Text.RegularExpressions.Regex.Matches(output, "INVALID-FACET"));
         Assert.Contains("projection", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NodeWithMalformedFacets_BareScalar_ReportsErrorNeverAbsent_ExitsNonzero()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\nfacets: projection\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.NotEqual(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("MALFORMED-FACETS", output, StringComparison.Ordinal);
+        Assert.Contains("**Severity:** error", output, StringComparison.Ordinal);
+        // Must never be silently treated as "no facets" (absent).
+        Assert.DoesNotContain("clean", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_NodeWithMalformedFacets_UnterminatedFlowList_ReportsErrorAndExitsNonzero()
+    {
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        CreateMinimalTreeDomain(hostRoot, "auth");
+        File.WriteAllText(
+            Path.Combine(hostRoot, "intents", "auth", "identity", "mission.md"),
+            "---\nfacets: [vocabulary, invariant\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("MALFORMED-FACETS", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -350,6 +413,45 @@ public sealed class IntentLintLayoutCommandTests
         var output = writer.ToString();
         Assert.DoesNotContain("INVALID-FACET", output, StringComparison.Ordinal);
         Assert.Contains("clean", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_LegacyWarningWithNoFacetsIssue_StaysNonfatal_ExitsZero()
+    {
+        // G529 rereview repair: a facets: error must not make unrelated,
+        // pre-existing layout warnings fatal. A missing manifest (a
+        // legacy, non-facet finding) must still exit 0 on its own.
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        Directory.CreateDirectory(Path.Combine(hostRoot, "intents", "auth"));
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("MISSING-MANIFEST", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_LegacyWarningAndFacetsError_OnlyFacetsErrorDrivesNonzeroExit()
+    {
+        // Both a legacy warning (missing manifest) and a facets error are
+        // present simultaneously — the facets error alone must drive the
+        // nonzero exit; the legacy warning stays reported but non-fatal on
+        // its own merits.
+        using var tmp = new TemporaryDirectory();
+        var hostRoot = tmp.CreateDirectory("host");
+        var domainDir = Path.Combine(hostRoot, "intents", "auth");
+        Directory.CreateDirectory(domainDir);
+        File.WriteAllText(Path.Combine(domainDir, "note.md"), "---\nfacets: [projection]\n---\n# Note\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentLintLayoutCommand.Execute(CreateContext(hostRoot), ["--domain", "auth"], writer);
+
+        Assert.NotEqual(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("MISSING-MANIFEST", output, StringComparison.Ordinal);
+        Assert.Contains("INVALID-FACET", output, StringComparison.Ordinal);
     }
 
     // ──────────────────────────────────────────────

--- a/tests/IntentSystem.Cli.Tests/IntentNodeFacetsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNodeFacetsTests.cs
@@ -431,6 +431,23 @@ public sealed class IntentNodeFacetsTests
     }
 
     [Fact]
+    public void ParseFacets_DuplicateTopLevelFacetsKeys_DiagnosticReportsFileAccurateLineNumbers_NotFrontmatterRelative()
+    {
+        // Third rereview repair: `frontmatter` (as extracted by
+        // TryExtractFrontmatterBlock) is everything AFTER the opening
+        // "---" line, so its own line 0 is already file line 2. A field
+        // preceding "facets:" shifts the two declarations to file lines 3
+        // and 4 — the diagnostic must report those file-accurate numbers,
+        // not the frontmatter-relative 2 and 3.
+        var content = "---\nintent_id: I.TEST\nfacets: [vocabulary]\nfacets: [invariant]\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+        Assert.Contains("lines 3, 4", result.MalformedReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ParseFacets_DuplicateTopLevelFacetsKeys_BlockForm_IsMalformed()
     {
         var content = "---\nfacets:\n  - vocabulary\nfacets:\n  - invariant\n---\n";

--- a/tests/IntentSystem.Cli.Tests/IntentNodeFacetsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNodeFacetsTests.cs
@@ -1,0 +1,259 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G529 rereview repair: direct unit coverage for
+/// <see cref="IntentNodeFacets.ParseFacets"/> — the real YAML-list parser
+/// (block + flow forms, quoted scalars, comments, multiline, duplicates,
+/// malformed detection) that replaced the original single-line-flow-only
+/// regex, which silently treated every other valid YAML shape as absent.
+/// </summary>
+public sealed class IntentNodeFacetsTests
+{
+    // ── Absent ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseFacets_NoFrontmatterBlock_IsAbsent()
+    {
+        var result = IntentNodeFacets.ParseFacets("# Mission\n\nNo frontmatter at all.\n");
+
+        Assert.Equal(FacetsParseKind.Absent, result.Kind);
+        Assert.Empty(result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_FrontmatterWithNoFacetsKey_IsAbsent()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nintent_id: G1\n---\n# Node\n");
+
+        Assert.Equal(FacetsParseKind.Absent, result.Kind);
+    }
+
+    // ── Flow form ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseFacets_FlowForm_SingleLine_Parses()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [vocabulary, invariant]\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary", "invariant" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_FlowForm_MultiLine_Parses()
+    {
+        var content = "---\nfacets: [\n  vocabulary,\n  invariant\n]\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary", "invariant" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_FlowForm_QuotedScalars_DoubleAndSingle_Parses()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [\"vocabulary\", 'invariant']\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary", "invariant" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_FlowForm_InlineCommentAfterList_Parses()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [vocabulary, invariant]  # the two vocabulary facets\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary", "invariant" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_FlowForm_ExtraWhitespaceAndTrailingComma_Parses()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets:   [  vocabulary ,   invariant ,  ]\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary", "invariant" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_FlowForm_EmptyList_ParsesAsPresentWithNoValues()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: []\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Empty(result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_FlowForm_DuplicateValues_DedupedPreservingFirstSeenOrder()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [invariant, vocabulary, invariant]\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "invariant", "vocabulary" }, result.Values);
+    }
+
+    // ── Block form ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseFacets_BlockForm_Parses()
+    {
+        var content = "---\nfacets:\n  - vocabulary\n  - invariant\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary", "invariant" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_BlockForm_QuotedItems_Parses()
+    {
+        var content = "---\nfacets:\n  - \"vocabulary\"\n  - 'invariant'\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary", "invariant" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_BlockForm_InlineCommentsPerItem_Parses()
+    {
+        var content = "---\nfacets:\n  - vocabulary  # the glossary facet\n  - invariant  # consistency boundary\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary", "invariant" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_BlockForm_BlankLineBetweenItems_Parses()
+    {
+        var content = "---\nfacets:\n  - vocabulary\n\n  - invariant\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary", "invariant" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_BlockForm_DuplicateValues_DedupedPreservingFirstSeenOrder()
+    {
+        var content = "---\nfacets:\n  - decider\n  - vocabulary\n  - decider\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "decider", "vocabulary" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_BlockForm_OtherFrontmatterFieldsAfterBlock_AreIgnoredAsBlockBoundary()
+    {
+        var content = "---\nfacets:\n  - vocabulary\nintent_id: G1\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary" }, result.Values);
+    }
+
+    // ── Malformed: must never be silently treated as absent ────────────────
+
+    [Fact]
+    public void ParseFacets_BareScalar_IsMalformedNotAbsent()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: projection\n---\n");
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+        Assert.NotNull(result.MalformedReason);
+        Assert.Empty(result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_UnterminatedFlowList_IsMalformed()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [vocabulary, invariant\n---\n");
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+    }
+
+    [Fact]
+    public void ParseFacets_UnbalancedQuoteInFlowList_IsMalformed()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [\"vocabulary]\n---\n");
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+    }
+
+    [Fact]
+    public void ParseFacets_UnbalancedQuoteInBlockItem_IsMalformed()
+    {
+        var content = "---\nfacets:\n  - \"vocabulary\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+    }
+
+    [Fact]
+    public void ParseFacets_TabIndentedFacetsKey_IsNotRecognizedAsTopLevel_IsAbsent()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\n\tfacets: [vocabulary]\n---\n");
+
+        // A tab-indented "facets:" is not column-0, so it is not recognized
+        // as the top-level key at all — absent, not malformed. This case
+        // instead pins that a tab appearing WITHIN the recognized facets
+        // line/block is rejected; see the block-form variant below for the
+        // block-list indentation case.
+        Assert.Equal(FacetsParseKind.Absent, result.Kind);
+    }
+
+    [Fact]
+    public void ParseFacets_TabInBlockItemIndentation_IsMalformed()
+    {
+        var content = "---\nfacets:\n\t- vocabulary\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+    }
+
+    [Fact]
+    public void ParseFacets_FacetsKeyWithNoValueAndNoBlockItems_IsMalformed()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets:\nintent_id: G1\n---\n");
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+    }
+
+    [Fact]
+    public void ParseFacets_BlockFormWithNonListItemLine_IsMalformed()
+    {
+        var content = "---\nfacets:\n  vocabulary\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+    }
+
+    // ── Unknown-value validation stays a separate concern from parsing ─────
+
+    [Fact]
+    public void ParseFacets_UnknownValue_StillParsesAsPresent_ValidationIsCallersJob()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [vocabulary, projection]\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary", "projection" }, result.Values);
+        Assert.True(IntentNodeFacets.IsAllowedValue("vocabulary"));
+        Assert.False(IntentNodeFacets.IsAllowedValue("projection"));
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentNodeFacetsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNodeFacetsTests.cs
@@ -364,4 +364,97 @@ public sealed class IntentNodeFacetsTests
         Assert.True(IntentNodeFacets.IsAllowedValue("vocabulary"));
         Assert.False(IntentNodeFacets.IsAllowedValue("projection"));
     }
+
+    // ── Second rereview repair: narrow in both directions, duplicate keys ──
+
+    [Fact]
+    public void ParseFacets_MalformedUnrelatedFieldBeforeFacets_DoesNotAffectFacetsParsing()
+    {
+        // The malformed field is entirely excluded from the fed fragment —
+        // parsing starts at the "facets:" line itself, by construction.
+        var content = "---\nother_field: [unterminated\nfacets: [vocabulary]\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_MalformedUnrelatedFieldAfterFacets_DoesNotAffectFacetsParsing()
+    {
+        // The low-level streaming parser stops consuming events the moment
+        // the facets value (and its one-line trailing-junk check) is done —
+        // a later key's own malformed VALUE is never tokenized at all.
+        var content = "---\nfacets: [vocabulary]\nother_field: \"unterminated\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_MalformedUnrelatedFieldAfterFacets_BlockForm_DoesNotAffectFacetsParsing()
+    {
+        var content = "---\nfacets:\n  - vocabulary\nother_field: [unterminated\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_NestedFacetsKeyUnderAnotherKey_IsNotCaptured_IsAbsent()
+    {
+        // Indented "facets:" is not a top-level key — the narrow reader
+        // only recognizes column-0 declarations, so this node has no
+        // top-level facets: at all.
+        var content = "---\nmetadata:\n  facets: [vocabulary]\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Absent, result.Kind);
+    }
+
+    [Fact]
+    public void ParseFacets_DuplicateTopLevelFacetsKeys_IsMalformed()
+    {
+        var content = "---\nfacets: [vocabulary]\nfacets: [invariant]\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+        Assert.Contains("multiple", result.MalformedReason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("facets:", result.MalformedReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ParseFacets_DuplicateTopLevelFacetsKeys_BlockForm_IsMalformed()
+    {
+        var content = "---\nfacets:\n  - vocabulary\nfacets:\n  - invariant\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+        Assert.Contains("multiple", result.MalformedReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ParseFacets_MalformedYamlDiagnostic_IsSanitizedAndBounded()
+    {
+        // A large, genuinely invalid fragment must still produce a
+        // Malformed result with a bounded, non-empty diagnostic — never an
+        // unbounded dump of parser-internal detail.
+        var junk = new string('"', 5000);
+        var content = $"---\nfacets: [{junk}\n---\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+        Assert.NotNull(result.MalformedReason);
+        Assert.True(result.MalformedReason!.Length <= 320, $"diagnostic was {result.MalformedReason.Length} chars: {result.MalformedReason}");
+        Assert.DoesNotContain("/Users", result.MalformedReason, StringComparison.Ordinal);
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/IntentNodeFacetsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNodeFacetsTests.cs
@@ -204,16 +204,17 @@ public sealed class IntentNodeFacetsTests
     }
 
     [Fact]
-    public void ParseFacets_TabIndentedFacetsKey_IsNotRecognizedAsTopLevel_IsAbsent()
+    public void ParseFacets_TabIndentedFacetsKey_IsMalformedNeverAbsent()
     {
+        // Rereview repair: a tab-indented "facets:" is not column-0, so it
+        // is not recognized as the strict top-level key — but it clearly
+        // LOOKS like an attempted facets declaration, so it must never be
+        // silently swallowed as "no facets here" (Absent). It is Malformed,
+        // which lint reports as a nonzero-exit error.
         var result = IntentNodeFacets.ParseFacets("---\n\tfacets: [vocabulary]\n---\n");
 
-        // A tab-indented "facets:" is not column-0, so it is not recognized
-        // as the top-level key at all — absent, not malformed. This case
-        // instead pins that a tab appearing WITHIN the recognized facets
-        // line/block is rejected; see the block-form variant below for the
-        // block-list indentation case.
-        Assert.Equal(FacetsParseKind.Absent, result.Kind);
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+        Assert.Contains("tab", result.MalformedReason, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -245,6 +246,113 @@ public sealed class IntentNodeFacetsTests
     }
 
     // ── Unknown-value validation stays a separate concern from parsing ─────
+
+    // ── Rereview repair: escape-aware scanning, trailing junk, exact delimiters ──
+
+    [Fact]
+    public void ParseFacets_DoubleQuotedScalar_EscapedQuote_DecodedCorrectly_NotSplitEarly()
+    {
+        // The escaped quote must not be treated as the closing delimiter —
+        // if scanning were not escape-aware, this would either split the
+        // value early or fail to find the list's closing bracket at all.
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [\"vocabulary\\\"quoted\", invariant]\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(2, result.Values.Count);
+        Assert.Equal("vocabulary\"quoted", result.Values[0]);
+        Assert.Equal("invariant", result.Values[1]);
+    }
+
+    [Fact]
+    public void ParseFacets_DoubleQuotedScalar_EscapedBackslash_DecodedCorrectly()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [\"back\\\\slash\"]\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "back\\slash" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_SingleQuotedScalar_DoubledQuoteEscape_DecodedToOneLiteralQuote()
+    {
+        // YAML single-quote scalars escape an embedded quote by doubling
+        // it ('') — not backslash-escaping. "it''s" decodes to "it's".
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: ['it''s vocabulary']\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "it's vocabulary" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_QuotedScalar_ContainingHashAndComma_TreatedAsLiteralContentNotDelimiters()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [\"a, b # not a comment\", invariant]\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(2, result.Values.Count);
+        Assert.Equal("a, b # not a comment", result.Values[0]);
+        Assert.Equal("invariant", result.Values[1]);
+    }
+
+    [Fact]
+    public void ParseFacets_FlowForm_NonCommentTrailingContentAfterClosingBracket_IsMalformed()
+    {
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [vocabulary] trailing-junk\n---\n");
+
+        Assert.Equal(FacetsParseKind.Malformed, result.Kind);
+    }
+
+    [Fact]
+    public void ParseFacets_FlowForm_CommentAfterClosingBracket_StillParses()
+    {
+        // A genuine comment (not other content) after the closing bracket
+        // is valid YAML and must still parse — distinguishing this from
+        // the trailing-junk case above.
+        var result = IntentNodeFacets.ParseFacets("---\nfacets: [vocabulary] # trailing comment is fine\n---\n");
+
+        Assert.Equal(FacetsParseKind.Present, result.Kind);
+        Assert.Equal(new[] { "vocabulary" }, result.Values);
+    }
+
+    [Fact]
+    public void ParseFacets_OpeningDelimiter_NearMissNotExactDashes_IsAbsent()
+    {
+        // "---junk" is not a valid frontmatter opening delimiter — the file
+        // has no recognized frontmatter block at all, so this is Absent
+        // (not a false-positive empty frontmatter match).
+        var result = IntentNodeFacets.ParseFacets("---junk\nfacets: [vocabulary]\n---\n# Title\n");
+
+        Assert.Equal(FacetsParseKind.Absent, result.Kind);
+    }
+
+    [Fact]
+    public void ParseFacets_ClosingDelimiter_NearMissNotExactDashes_TreatedAsUnterminatedFrontmatter()
+    {
+        // "---junk" mid-file must never be mistaken for the closing "---"
+        // delimiter (the prior IndexOf("\n---")-based implementation would
+        // have accepted it). With no exact closing delimiter anywhere, the
+        // file has no recognized frontmatter block at all — Absent, not a
+        // corrupted partial parse.
+        var content = "---\nfacets: [vocabulary]\n---junk\nmore text\n";
+
+        var result = IntentNodeFacets.ParseFacets(content);
+
+        Assert.Equal(FacetsParseKind.Absent, result.Kind);
+    }
+
+    [Fact]
+    public void TryExtractFrontmatterBlock_ExactClosingDelimiter_NotConfusedByNearMissEarlier()
+    {
+        // A "---junk" line must be skipped when searching for the closing
+        // delimiter; the real, exact "---" further down is what closes it.
+        var content = "---\nfacets: [vocabulary]\n---junk\n---\n# Title\n";
+
+        var found = IntentNodeFacets.TryExtractFrontmatterBlock(content, out var frontmatter, out var body);
+
+        Assert.True(found);
+        Assert.Contains("---junk", frontmatter, StringComparison.Ordinal);
+        Assert.Equal("# Title", body.Trim());
+    }
 
     [Fact]
     public void ParseFacets_UnknownValue_StillParsesAsPresent_ValidationIsCallersJob()

--- a/tests/IntentSystem.Cli.Tests/IntentSearchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentSearchCommandTests.cs
@@ -157,6 +157,51 @@ public sealed class IntentSearchCommandTests
     }
 
     [Fact]
+    public void Execute_FacetFilter_MatchesBlockFormFrontmatter()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        workspace.WriteFile(
+            "intents/intent-cli/features/auth/overview.md",
+            "---\nfacets:\n  - vocabulary\n  - invariant\n---\n# Auth overview\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--facet", "invariant", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var hits = document.RootElement.GetProperty("hits");
+        Assert.Equal(1, hits.GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_FacetFilter_MalformedFacetsNode_IsExcludedNotErrored()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        workspace.WriteFile(
+            "intents/intent-cli/features/auth/broken.md",
+            "---\nfacets: invariant\n---\n# Broken facets declaration\n");
+        workspace.WriteFile(
+            "intents/intent-cli/features/auth/overview.md",
+            "---\nfacets: [invariant]\n---\n# Auth overview\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--facet", "invariant", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var paths = document.RootElement.GetProperty("hits").EnumerateArray()
+            .Select(h => h.GetProperty("path").GetString()).ToArray();
+        Assert.Contains(paths, p => p!.EndsWith("overview.md", StringComparison.Ordinal));
+        Assert.DoesNotContain(paths, p => p!.EndsWith("broken.md", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Execute_FacetFilterCombinedWithQuery_RestrictsToBothConditions()
     {
         using var workspace = new IntentSearchWorkspace();

--- a/tests/IntentSystem.Cli.Tests/IntentSearchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentSearchCommandTests.cs
@@ -109,7 +109,7 @@ public sealed class IntentSearchCommandTests
     }
 
     [Fact]
-    public void Execute_MissingQuery_ReturnsUsageError()
+    public void Execute_MissingQueryAndFacet_ReturnsUsageError()
     {
         using var workspace = new IntentSearchWorkspace();
         using var writer = new StringWriter();
@@ -120,7 +120,80 @@ public sealed class IntentSearchCommandTests
             writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("--query is required.", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("requires --query and/or --facet", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ──────────────────────────────────────────────
+    // Facet filter (G529)
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_FacetFilterAlone_ReturnsOnlyNodesCarryingThatFacet()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        workspace.WriteFile(
+            "intents/intent-cli/features/auth/overview.md",
+            "---\nfacets: [invariant]\n---\n# Auth overview\n");
+        workspace.WriteFile(
+            "intents/intent-cli/features/auth/decisions.md",
+            "---\nfacets: [decider]\n---\n# Auth decisions\n");
+        workspace.WriteFile(
+            "intents/intent-cli/README.md",
+            "No facets here.");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--facet", "invariant", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var hits = document.RootElement.GetProperty("hits");
+        var paths = hits.EnumerateArray().Select(h => h.GetProperty("path").GetString()).ToArray();
+        Assert.Contains(paths, p => p!.EndsWith("overview.md", StringComparison.Ordinal));
+        Assert.DoesNotContain(paths, p => p!.EndsWith("decisions.md", StringComparison.Ordinal));
+        Assert.DoesNotContain(paths, p => p!.EndsWith("README.md", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_FacetFilterCombinedWithQuery_RestrictsToBothConditions()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        workspace.WriteFile(
+            "intents/intent-cli/features/auth/overview.md",
+            "---\nfacets: [invariant]\n---\n# Auth overview\nDescribes the login invariant.\n");
+        workspace.WriteFile(
+            "intents/intent-cli/features/auth/requirements.md",
+            "---\nfacets: [invariant]\n---\n# Auth requirements\nNo matching keyword here.\n");
+
+        using var writer = new StringWriter();
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--query", "login invariant", "--facet", "invariant", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var hits = document.RootElement.GetProperty("hits");
+        var paths = hits.EnumerateArray().Select(h => h.GetProperty("path").GetString()).ToArray();
+        Assert.Contains(paths, p => p!.EndsWith("overview.md", StringComparison.Ordinal));
+        Assert.DoesNotContain(paths, p => p!.EndsWith("requirements.md", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_UnknownFacetValue_ReturnsUsageError()
+    {
+        using var workspace = new IntentSearchWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = IntentSearchCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--facet", "projection"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--facet must be one of", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Gives intent-tree nodes an optional `facets:` frontmatter field with a closed set of four values — `vocabulary`, `invariant`, `decider`, `acceptance-property` — naming which of the "human-retained understanding" surfaces (operator input, #1159) a node documents. Projections and boilerplate are safely delegable to AI; these four are not.
- New `IntentNodeFacets.cs`: a shared, deliberately narrow reader that extracts an optional `facets:` line from a node's `---`-delimited frontmatter (bracket-list syntax, e.g. `facets: [vocabulary, invariant]`). It reads only the `facets:` line — any other frontmatter a node may carry is untouched — and is fully backward compatible: a node with no frontmatter, or frontmatter with no `facets:` line, has zero facets and stays valid.
- `intent lint-layout` — new `CheckFacetValues` check: an unrecognized facet value is a warning naming the node, the bad value, and the allowed set; nodes without `facets:` are unaffected.
- `intent search` — new `--facet <value>` filter, combinable with `--query`; `--query` is now optional when `--facet` is given (a facet-only search reports each matching file once, skipping past its frontmatter block so the snippet shows the node's actual title).
- `intent analyze-tree` — new per-facet coverage counts computed across the whole domain tree (not just the top-level flat files the restructuring analysis itself scans); only facets with at least one node are reported, since an unannotated node is legitimate (no "facet-less nodes" list).
- Scaffold templates (`init-tree` mission starter, `add-feature` `overview.md`, `draft-from-interview` draft) now include a commented `facets:` example explaining all four values in one line each — inert until an author uncomments and edits it.
- New "Facets" section in `docs/{en,ja}/03a-intent-tree-layout.md`: the four values, their origin, authoring guidance, and one example node per facet.

Backward compatible throughout: every existing tree (with no `facets:` anywhere) stays valid and lint-clean, and non-facet callers/output are unchanged. Tree layout rules, `intent_type` vocabulary, and all non-facet validation are unchanged. No context-supply prioritization or change-proposal cross-checking — that's G530/G531.

## Test plan
- [x] `dotnet build` (full solution) — 0 errors.
- [x] `dotnet test` (full solution) — all green (3293 passed, 1 pre-existing skip).
- [x] New/updated focused tests: valid facets parse without warning; an unknown facet value fails lint naming the node/value/allowed set (and only the invalid one, when mixed with a valid one); a node with no `facets:` frontmatter stays valid and lint-clean; `--facet` alone and combined with `--query` filter correctly; an unknown `--facet` value is a usage error; `analyze-tree` reports positive-only per-facet counts (JSON + markdown); scaffolded mission.md carries the commented example and stays lint-clean.
- [x] Manual fixture run against a real repo (bypassing the test harness): `intent lint-layout` correctly flagged an invalid facet naming the node/value/allowed-set; `intent search --facet invariant` returned only the matching node with a clean title snippet; `intent analyze-tree` reported `vocabulary: 1`, `invariant: 1`, `decider: 1` (the invalid `projection` value correctly excluded from counts).
- [x] `git diff --check` — clean.

Closes #1160

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4yoyeXmTeJWD16RLvktQd