### PR TITLE
G530: Prioritize semantic-facet nodes in AI context supply

### DIFF
--- a/docs/en/04-packets-issues.md
+++ b/docs/en/04-packets-issues.md
@@ -6,7 +6,7 @@ This is **host/design** work. When your intent is clear enough to act on, the de
 
 ## What a packet is
 
-A **packet** is a focused, reviewable slice of intent that becomes an executable task. The design thread scaffolds a canonical set of files (`packet.yaml`, `implementation.md`, `review-context.md`, `github-body.md`) that describe exactly what needs to be built.
+A **packet** is a focused, reviewable slice of intent that becomes an executable task. The design thread scaffolds a canonical set of files (`packet.yaml`, `implementation.md`, `review-context.md`, `github-body.md`) that describe exactly what needs to be built. `review-context.md` includes a generated **Facet context** section listing the G529 semantic-facet nodes (vocabulary/invariant/decider/acceptance-property) overlapping the packet's `intent_references` — see [Facet-aware context supply (G530)](09-developer-reference.md#facet-aware-context-supply-g530).
 
 **Issue publish** turns a reviewed packet into a GitHub Issue with a **Standalone Child Issue Contract** — the only source of truth a child implementation agent needs to do the work. The child agent reads the issue body and the repository code; it does not access host metadata.
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -484,6 +484,14 @@ intent-cli context collect --domain <d> --scope intents/<d>/means,identity/missi
   entirely returns every domain facet node; passing `--scope` with hints
   that all turn out invalid or outside the domain matches NOTHING — it
   never silently falls back to "no scoping requested".
+- A rejected `--scope` hint is never silent either: it produces a
+  `facet_context_scope_warnings` entry (`hint`, `reason`) naming the exact
+  hint and why it was rejected (outside the domain root, a `..` traversal,
+  etc.) — so "matched nothing because every hint was invalid" is never
+  indistinguishable from "matched nothing because a genuinely valid hint
+  just didn't overlap any node". A mixed list still applies the valid
+  hints while reporting every rejected one; `facet_context_all_scope_hints_rejected`
+  is `true` only when every requested hint was rejected.
 - A domain with ZERO facet-annotated nodes at all (not merely a
   `--scope`/`--facets` query that matched nothing) sets `facet_context_note`
   and renders an explicit note instead of an empty section — graceful
@@ -498,16 +506,19 @@ intent-cli context collect --domain <d> --scope intents/<d>/means,identity/missi
 - JSON shape: `facet_context: [{facet, nodes: [{id, facets, summary,
   path}]}]` (always 4 entries, or fewer when `--facets` is passed),
   `facet_context_note: string | null`, `facet_context_warnings: [{path,
-  reason}]`.
+  reason}]`, `facet_context_scope_warnings: [{hint, reason}]`,
+  `facet_context_all_scope_hints_rejected: bool`.
 
 **`intent-cli packet draft`** generates a `## Facet context` section inside
 the scaffolded `review-context.md`, listing the facet nodes overlapping the
 packet's own `implementation_issue_packet.intent_references` — the exact
-same overlap logic `context collect`'s `--scope` uses, so the two surfaces
-can never disagree about what "overlaps". The generated content lives
-between two HTML-comment markers
-(`<!-- BEGIN/END GENERATED FACET CONTEXT (G530) -->`); the rest of
-`review-context.md` is hand-owned and untouched:
+same overlap logic `context collect`'s `--scope` uses (including the same
+rejected-reference visibility above), so the two surfaces can never
+disagree about what "overlaps". The generated content lives between two
+HTML-comment markers (`<!-- BEGIN/END GENERATED FACET CONTEXT (G530) -->`);
+the rest of `review-context.md` is hand-owned and untouched. Marker
+handling is fail-closed — mutation is attempted ONLY when the file carries
+EXACTLY one begin marker and one end marker in that order:
 
 - **File does not exist yet**: written fresh, in full, with the current
   `intent_references` (read from an EXISTING `packet.yaml` on disk if one
@@ -515,21 +526,30 @@ between two HTML-comment markers
   `packet draft` run — never the freshly-templated empty `[]` this same
   invocation might otherwise write for `packet.yaml` itself). Reported as
   `created`.
-- **File exists AND carries both markers**: only the content strictly
-  BETWEEN them is recomputed from the packet's CURRENT `intent_references`
-  and replaced — this is what keeps the section current through the
-  ordinary workflow (scaffold with empty references → operator adds real
-  references to `packet.yaml` → rerun `packet draft` → the block reflects
-  them). Everything before the begin marker and after the end marker,
-  including any hand-written prose around the block, is preserved
-  byte-for-byte. Reported as `updated` when the recomputed content differs
-  from what is already there, `skipped` when it doesn't (a genuine no-op,
-  not a spurious update).
-- **File exists but has no recognizable markers** (predates this feature,
-  or an operator removed them): left completely untouched, exactly like
-  the other three scaffold files' plain skip-if-exists behavior. The
-  markers are never retroactively injected into hand-owned content.
-  Reported as `skipped`.
+- **File exists AND carries exactly one correctly-ordered marker pair**:
+  only the content strictly BETWEEN them is recomputed from the packet's
+  CURRENT `intent_references` and replaced, using the FILE'S OWN existing
+  newline convention (CRLF or LF — never hardcoded, so an existing CRLF
+  file is never left with mixed line endings) — this is what keeps the
+  section current through the ordinary workflow (scaffold with empty
+  references → operator adds real references to `packet.yaml` → rerun
+  `packet draft` → the block reflects them). Everything before the begin
+  marker and after the end marker, including any hand-written prose around
+  the block, is preserved byte-for-byte. Reported as `updated` when the
+  recomputed content differs from what is already there, `skipped` when it
+  doesn't (a genuine no-op, not a spurious update).
+- **File exists but has NO markers at all** (predates this feature, or an
+  operator removed them): left completely untouched, exactly like the
+  other three scaffold files' plain skip-if-exists behavior. The markers
+  are never retroactively injected into hand-owned content. Reported as
+  `skipped`.
+- **File exists with markers in any OTHER shape** — duplicate begin and/or
+  end markers, an end marker appearing before its begin, or only one of the
+  two present: also left completely untouched (never a silent partial
+  update, never guessing which pair is "the real one"), but reported
+  distinctly as `markers-malformed` with a `detail` string naming exactly
+  what shape was found — this state must never look like the healthy
+  no-markers-at-all case.
 
 An empty `intent_references` list is itself a meaningful scope — "this
 packet references nothing (yet)" — so the block shows every facet group as

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -440,6 +440,71 @@ it — no separate code path needed.
 
 ---
 
+### Facet-aware context supply (G530)
+
+Building on G529's four semantic facets (`vocabulary`, `invariant`,
+`decider`, `acceptance-property`), two read-only surfaces now supply
+facet-classified nodes as the preferred, localized semantic context a
+change must respect — instead of an implement/review agent reconstructing
+that surface by hand.
+
+**`intent-cli context collect`** gains a `## Facet context` section,
+rendered AHEAD of the unclassified queue-state/clarification/automation-
+bindings/recent-events context below it (it is the semantic core, not an
+afterthought). The section holds one group per facet, always in the
+canonical order `vocabulary → invariant → decider → acceptance-property`,
+each node reported as `id`, `facets` (all of that node's facet values, not
+just the current group's), `summary` (first non-blank line after
+frontmatter), and `path` (`intents/<domain>/...`):
+
+```bash
+intent-cli context collect --domain <d> --format json
+intent-cli context collect --domain <d> --facets invariant,decider   # restrict to these facets only
+intent-cli context collect --domain <d> --scope intents/<d>/means,identity/mission.md  # narrow by overlap
+```
+
+- `--facets <comma-separated>` restricts which facet groups appear at all
+  (still rendered in canonical order); an unrecognized facet name is a
+  usage error (mirrors `intent search --facet`'s validation).
+- `--scope <comma-separated paths>` narrows every group to nodes whose path
+  overlaps a hint — an exact match, a hint naming an ancestor directory, or
+  the shorter domain-relative id form (no `intents/<domain>/` prefix, no
+  `.md`) all count as overlap. Omitting `--scope` returns every domain
+  facet node.
+- A domain with ZERO facet-annotated nodes at all (not merely a
+  `--scope`/`--facets` query that matched nothing) sets `facet_context_note`
+  and renders an explicit note instead of an empty section — graceful
+  degradation, never an error. Facets are optional; this is the norm before
+  a tree adopts them.
+- JSON shape: `facet_context: [{facet, nodes: [{id, facets, summary,
+  path}]}]` (always 4 entries, or fewer when `--facets` is passed),
+  `facet_context_note: string | null`.
+
+**`intent-cli packet draft`** generates a `## Facet context` section inside
+the scaffolded `review-context.md`, listing the facet nodes overlapping the
+packet's own `implementation_issue_packet.intent_references` — the exact
+same overlap logic `context collect`'s `--scope` uses, so the two surfaces
+can never disagree about what "overlaps". Because `packet draft` never
+overwrites an existing file, this only applies the first time
+`review-context.md` is written: if `packet.yaml` already exists (e.g. an
+operator hand-edited its `intent_references` after an earlier `packet
+draft` run, before `review-context.md` was ever generated), that packet.yaml
+ON DISK — never the freshly-templated empty `intent_references: []` this
+same invocation might otherwise write — is what gets read. Once
+`review-context.md` exists, re-running `packet draft` never touches it,
+preserving hand-edits exactly as it already does for the other three
+scaffold files.
+
+Both surfaces share one selector (`FacetContextSelector`) for scanning,
+classifying, grouping, and scope-overlap matching, so ordering, filtering,
+and degradation semantics can't drift apart between them. Only VALID facet
+values (the closed G529 set) are ever bucketed; a malformed `facets:`
+declaration is excluded from every group exactly like an absent one is —
+validating and reporting malformed/unknown values is `lint-layout`'s job,
+not these consumption surfaces'.
+
+---
+
 ## Version flow
 
 The repository version policy lives in `eng/version.json` — the single source of

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -465,43 +465,81 @@ intent-cli context collect --domain <d> --scope intents/<d>/means,identity/missi
 
 - `--facets <comma-separated>` restricts which facet groups appear at all
   (still rendered in canonical order); an unrecognized facet name is a
-  usage error (mirrors `intent search --facet`'s validation).
+  usage error (mirrors `intent search --facet`'s validation). Every
+  comma-separated option (`--facets` and `--scope` alike) requires each
+  element to be non-empty after trimming and dedupes repeats in first-seen
+  order — `--scope ","` or `--facets "vocabulary,,decider"` (an empty
+  element) is a usage error, never silently "no scope" / a dropped element.
 - `--scope <comma-separated paths>` narrows every group to nodes whose path
-  overlaps a hint — an exact match, a hint naming an ancestor directory, or
-  the shorter domain-relative id form (no `intents/<domain>/` prefix, no
-  `.md`) all count as overlap. Omitting `--scope` returns every domain
-  facet node.
+  OVERLAPS a hint, checked symmetrically in BOTH directions — a hint naming
+  an ancestor directory of a node, or a node whose own path is an ancestor
+  of a (more specific) hint, both count, on top of an exact match. Every
+  hint form reduces to the same domain-relative segment list a node's own
+  id already uses before comparing, so these are all equivalent: an
+  absolute filesystem path under the domain root, the repo-relative
+  `intents/<domain>/...` form, and the short domain-relative id form (with
+  or without a trailing `.md`). A `..` segment is rejected (never silently
+  resolved — it could otherwise walk a hint outside the domain it claims to
+  scope); comparison is case-sensitive throughout. Omitting `--scope`
+  entirely returns every domain facet node; passing `--scope` with hints
+  that all turn out invalid or outside the domain matches NOTHING — it
+  never silently falls back to "no scoping requested".
 - A domain with ZERO facet-annotated nodes at all (not merely a
   `--scope`/`--facets` query that matched nothing) sets `facet_context_note`
   and renders an explicit note instead of an empty section — graceful
   degradation, never an error. Facets are optional; this is the norm before
   a tree adopts them.
+- A malformed `facets:` declaration, or a Present declaration carrying an
+  unknown value, is never silently dropped: both produce a `facet_context_warnings`
+  entry (`path`, `reason`) in JSON and a `Warnings` list in Markdown, naming
+  exactly what was excluded and why — so "genuinely no facets here" never
+  looks identical to "facets were present but excluded". An unknown value
+  does not disqualify a node from its OTHER valid facets.
 - JSON shape: `facet_context: [{facet, nodes: [{id, facets, summary,
   path}]}]` (always 4 entries, or fewer when `--facets` is passed),
-  `facet_context_note: string | null`.
+  `facet_context_note: string | null`, `facet_context_warnings: [{path,
+  reason}]`.
 
 **`intent-cli packet draft`** generates a `## Facet context` section inside
 the scaffolded `review-context.md`, listing the facet nodes overlapping the
 packet's own `implementation_issue_packet.intent_references` — the exact
 same overlap logic `context collect`'s `--scope` uses, so the two surfaces
-can never disagree about what "overlaps". Because `packet draft` never
-overwrites an existing file, this only applies the first time
-`review-context.md` is written: if `packet.yaml` already exists (e.g. an
-operator hand-edited its `intent_references` after an earlier `packet
-draft` run, before `review-context.md` was ever generated), that packet.yaml
-ON DISK — never the freshly-templated empty `intent_references: []` this
-same invocation might otherwise write — is what gets read. Once
-`review-context.md` exists, re-running `packet draft` never touches it,
-preserving hand-edits exactly as it already does for the other three
-scaffold files.
+can never disagree about what "overlaps". The generated content lives
+between two HTML-comment markers
+(`<!-- BEGIN/END GENERATED FACET CONTEXT (G530) -->`); the rest of
+`review-context.md` is hand-owned and untouched:
+
+- **File does not exist yet**: written fresh, in full, with the current
+  `intent_references` (read from an EXISTING `packet.yaml` on disk if one
+  is already present — e.g. an operator hand-edited it after an earlier
+  `packet draft` run — never the freshly-templated empty `[]` this same
+  invocation might otherwise write for `packet.yaml` itself). Reported as
+  `created`.
+- **File exists AND carries both markers**: only the content strictly
+  BETWEEN them is recomputed from the packet's CURRENT `intent_references`
+  and replaced — this is what keeps the section current through the
+  ordinary workflow (scaffold with empty references → operator adds real
+  references to `packet.yaml` → rerun `packet draft` → the block reflects
+  them). Everything before the begin marker and after the end marker,
+  including any hand-written prose around the block, is preserved
+  byte-for-byte. Reported as `updated` when the recomputed content differs
+  from what is already there, `skipped` when it doesn't (a genuine no-op,
+  not a spurious update).
+- **File exists but has no recognizable markers** (predates this feature,
+  or an operator removed them): left completely untouched, exactly like
+  the other three scaffold files' plain skip-if-exists behavior. The
+  markers are never retroactively injected into hand-owned content.
+  Reported as `skipped`.
+
+An empty `intent_references` list is itself a meaningful scope — "this
+packet references nothing (yet)" — so the block shows every facet group as
+empty, never the whole domain's facet nodes; only a domain with zero facet
+nodes AT ALL renders the graceful-degradation note.
 
 Both surfaces share one selector (`FacetContextSelector`) for scanning,
 classifying, grouping, and scope-overlap matching, so ordering, filtering,
-and degradation semantics can't drift apart between them. Only VALID facet
-values (the closed G529 set) are ever bucketed; a malformed `facets:`
-declaration is excluded from every group exactly like an absent one is —
-validating and reporting malformed/unknown values is `lint-layout`'s job,
-not these consumption surfaces'.
+warning, and degradation semantics can't drift apart between them. Only
+VALID facet values (the closed G529 set) are ever bucketed.
 
 ---
 

--- a/docs/ja/04-packets-issues.md
+++ b/docs/ja/04-packets-issues.md
@@ -6,7 +6,7 @@
 
 ## packet とは
 
-**packet** は、intent から切り出された焦点の絞られた実装スライスです。デザインスレッドが正本ファイル一式（`packet.yaml`、`implementation.md`、`review-context.md`、`github-body.md`）を scaffold します。これにより、何を作るかが明確に定義されます。
+**packet** は、intent から切り出された焦点の絞られた実装スライスです。デザインスレッドが正本ファイル一式（`packet.yaml`、`implementation.md`、`review-context.md`、`github-body.md`）を scaffold します。これにより、何を作るかが明確に定義されます。`review-context.md` には、その packet の `intent_references` と overlap する G529 semantic-facet node（vocabulary/invariant/decider/acceptance-property）を一覧化した、生成済みの **Facet context** セクションが含まれます — 詳細は [facet を意識した context 供給 (G530)](09-developer-reference.md#facet-を意識した-context-供給-g530) を参照してください。
 
 **issue 公開**はレビュー済みの packet を GitHub Issue に変換します。この issue は **Standalone Child Issue Contract** であり、child implementation agent が実装に必要な唯一の情報源です。child agent は issue 本文とリポジトリのコードを参照するだけです。host metadata にはアクセスしません。
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -500,6 +500,16 @@ intent-cli context collect --domain <d> --scope intents/<d>/means,identity/missi
   すべてのヒントが無効または domain 外だった場合は、何にもマッチ
   しません — 黙って「scope 要求なし」にフォールバックすることは
   ありません。
+- 拒否された `--scope` ヒントも、決して黙って消えることはありません:
+  `facet_context_scope_warnings` エントリ（`hint`、`reason`）を生成し、
+  どのヒントが・なぜ拒否されたか（domain root の外側、`..` トラバーサル
+  など）を正確に示します — そのため「すべてのヒントが無効だったので
+  何にもマッチしなかった」場合と、「本物の有効なヒントがたまたま
+  どの node とも overlap しなかった」場合が、区別できないまま同じに
+  見えることがなくなります。混在したリストでも、有効なヒントは
+  そのまま適用されつつ、拒否されたヒントはすべて報告されます。
+  `facet_context_all_scope_hints_rejected` は、要求されたヒントが
+  すべて拒否された場合にのみ `true` になります。
 - domain に facet-annotated な node が 1 つも無い場合（`--scope`/
   `--facets` のクエリがたまたま何にもマッチしなかっただけの場合とは
   異なります）は、`facet_context_note` が設定され、空のセクションの
@@ -517,18 +527,23 @@ intent-cli context collect --domain <d> --scope intents/<d>/means,identity/missi
 - JSON の形: `facet_context: [{facet, nodes: [{id, facets, summary,
   path}]}]`（常に 4 要素。`--facets` を渡した場合はそれより少なくなる
   こともあります）、`facet_context_note: string | null`、
-  `facet_context_warnings: [{path, reason}]`。
+  `facet_context_warnings: [{path, reason}]`、
+  `facet_context_scope_warnings: [{hint, reason}]`、
+  `facet_context_all_scope_hints_rejected: bool`。
 
 **`intent-cli packet draft`** は、scaffold される `review-context.md`
 の中に `## Facet context` セクションを生成するようになりました。
 これは、その packet 自身の
 `implementation_issue_packet.intent_references` と overlap する
 facet node を一覧化します — `context collect` の `--scope` が使うのと
-全く同じ overlap ロジックなので、2 つのサーフェスが「overlap」の
-意味について食い違うことはありません。生成される内容は、2 つの
-HTML コメントマーカー（`<!-- BEGIN/END GENERATED FACET CONTEXT
-(G530) -->`）の間に存在します。`review-context.md` の残りの部分は
-手による所有物であり、一切触れられません:
+全く同じ overlap ロジック（上記の拒否ヒントの可視化を含む）なので、
+2 つのサーフェスが「overlap」の意味について食い違うことはありません。
+生成される内容は、2 つの HTML コメントマーカー（`<!-- BEGIN/END
+GENERATED FACET CONTEXT (G530) -->`）の間に存在します。
+`review-context.md` の残りの部分は手による所有物であり、一切触れられ
+ません。マーカーの扱いは fail-closed です — 変更が試みられるのは、
+ファイルが「開始マーカー 1 つ、終了マーカー 1 つ、その順序」を
+正確に持つ場合のみです:
 
 - **ファイルがまだ存在しない場合**: 現在の `intent_references`
   （既に `packet.yaml` が存在していれば、そのディスク上の値を
@@ -536,23 +551,33 @@ HTML コメントマーカー（`<!-- BEGIN/END GENERATED FACET CONTEXT
   手で編集していた場合。この同じ呼び出しが別途書き込むかもしれない、
   テンプレートの空の `[]` では決してありません）を使って、ファイル
   全体が新規に書き込まれます。`created` として報告されます。
-- **ファイルが存在し、かつ両方のマーカーを持つ場合**: マーカーの
-  「間」にある内容だけが、packet の現在の `intent_references` から
-  再計算され、置き換えられます — これにより、通常のワークフロー
-  （空の references で scaffold → operator が `packet.yaml` に
-  本物の references を追加 → `packet draft` を再実行 → block に
-  それが反映される）を通して、セクションが最新に保たれます。
-  開始マーカーより前、終了マーカーより後のすべて（block の周りに
-  手で書かれた文章を含む）は、バイト単位でそのまま保持されます。
-  再計算された内容が既存のものと異なる場合は `updated`、異ならない
-  場合は `skipped`（本物の no-op であり、見せかけの update では
-  ない）として報告されます。
-- **ファイルが存在するが、認識できるマーカーが無い場合**（この機能
-  より前に作られたか、operator がマーカーを削除した場合）: 他の
-  3 つの scaffold ファイルの、単純な「存在すればスキップ」の挙動と
-  全く同じように、完全に触れられないままになります。マーカーが
-  手による所有物の中に後から注入されることは決してありません。
-  `skipped` として報告されます。
+- **ファイルが存在し、かつ正確に 1 組の正しい順序のマーカーを持つ
+  場合**: マーカーの「間」にある内容だけが、packet の現在の
+  `intent_references` から再計算され、ファイル自身の既存の改行規則
+  （CRLF か LF か — 決してハードコードしません。既存の CRLF ファイルが
+  改行スタイル混在になることはありません）を使って置き換えられます —
+  これにより、通常のワークフロー（空の references で scaffold →
+  operator が `packet.yaml` に本物の references を追加 → `packet
+  draft` を再実行 → block にそれが反映される）を通して、セクションが
+  最新に保たれます。開始マーカーより前、終了マーカーより後のすべて
+  （block の周りに手で書かれた文章を含む）は、バイト単位でそのまま
+  保持されます。再計算された内容が既存のものと異なる場合は
+  `updated`、異ならない場合は `skipped`（本物の no-op であり、
+  見せかけの update ではない）として報告されます。
+- **ファイルが存在するが、マーカーが全く無い場合**（この機能より前に
+  作られたか、operator がマーカーを削除した場合）: 他の 3 つの
+  scaffold ファイルの、単純な「存在すればスキップ」の挙動と全く
+  同じように、完全に触れられないままになります。マーカーが手による
+  所有物の中に後から注入されることは決してありません。`skipped`
+  として報告されます。
+- **ファイルが存在し、マーカーが他のいずれかの形（開始・終了の
+  どちらか、または両方が重複している、終了マーカーがその開始マーカー
+  より前に現れる、どちらか片方しか無い）である場合**: これも完全に
+  触れられないままになります（黙った部分的な update や、「どちらが
+  本物のペアか」を勝手に推測することは決してありません）が、
+  `markers-malformed` として明確に区別して報告され、正確にどのような
+  形が見つかったかを示す `detail` 文字列が付きます — この状態が、
+  健全な「マーカーが全く無い」場合と同じに見えることはありません。
 
 空の `intent_references` リストそれ自体が、意味のある scope です —
 「この packet は（今のところ）何も参照していない」— そのため block は

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -449,6 +449,80 @@ retired になった item は自動的に WIP gating から外れます:
 
 ---
 
+### facet を意識した context 供給 (G530)
+
+G529 の 4 つの semantic facet（`vocabulary`、`invariant`、`decider`、
+`acceptance-property`）を土台に、2 つの read-only サーフェスが、
+facet で分類された node を「変更が尊重すべき、局所化された semantic
+context」として優先的に供給するようになりました — implement/review
+エージェントが手作業でその surface を再構築する代わりに。
+
+**`intent-cli context collect`** は `## Facet context` セクションを
+追加で持つようになりました。これは、その下にある未分類の
+queue-state/clarification/automation-bindings/recent-events の
+context より AHEAD（前）にレンダリングされます（これは
+おまけではなく semantic の核だからです）。このセクションは facet
+ごとに 1 グループを持ち、常に正規の順序
+`vocabulary → invariant → decider → acceptance-property` で並び、
+各 node は `id`、`facets`（現在のグループだけでなく、その node の
+全 facet 値）、`summary`（frontmatter 後の最初の空でない行）、
+`path`（`intents/<domain>/...`）として報告されます:
+
+```bash
+intent-cli context collect --domain <d> --format json
+intent-cli context collect --domain <d> --facets invariant,decider   # これらの facet だけに絞る
+intent-cli context collect --domain <d> --scope intents/<d>/means,identity/mission.md  # overlap で絞り込む
+```
+
+- `--facets <カンマ区切り>` は、そもそもどの facet グループが現れるかを
+  制限します（それでも正規の順序でレンダリングされます）。認識できない
+  facet 名は usage error になります（`intent search --facet` の
+  バリデーションと同様）。
+- `--scope <カンマ区切りのパス>` は、各グループを、パスがヒントと
+  overlap する node だけに絞り込みます — 完全一致、祖先ディレクトリを
+  指すヒント、または（`intents/<domain>/` prefix も `.md` も無い）
+  より短い domain-relative の id 形式、いずれも overlap とみなされます。
+  `--scope` を省略した場合は、domain の facet node すべてが返されます。
+- domain に facet-annotated な node が 1 つも無い場合（`--scope`/
+  `--facets` のクエリがたまたま何にもマッチしなかっただけの場合とは
+  異なります）は、`facet_context_note` が設定され、空のセクションの
+  代わりに明示的なノートがレンダリングされます — graceful な
+  degradation であり、決して error にはなりません。facets は
+  optional であり、tree がまだ採用していない段階ではこれが通常です。
+- JSON の形: `facet_context: [{facet, nodes: [{id, facets, summary,
+  path}]}]`（常に 4 要素。`--facets` を渡した場合はそれより少なくなる
+  こともあります）、`facet_context_note: string | null`。
+
+**`intent-cli packet draft`** は、scaffold される `review-context.md`
+の中に `## Facet context` セクションを生成するようになりました。
+これは、その packet 自身の
+`implementation_issue_packet.intent_references` と overlap する
+facet node を一覧化します — `context collect` の `--scope` が使うのと
+全く同じ overlap ロジックなので、2 つのサーフェスが「overlap」の
+意味について食い違うことはありません。`packet draft` は既存の
+ファイルを決して上書きしないため、これが適用されるのは
+`review-context.md` が初めて書き込まれる時だけです: もし
+`packet.yaml` が既に存在していれば（例えば、以前の `packet draft`
+実行の後、`review-context.md` がまだ生成されていない段階で
+operator が `intent_references` を手で編集していた場合）、
+読まれるのはディスク上のその packet.yaml です — この同じ呼び出しが
+別途書き込むかもしれない、テンプレートの空の
+`intent_references: []` では決してありません。`review-context.md`
+が一度存在すれば、`packet draft` を再実行してもそれには一切
+触れません。これは他の 3 つの scaffold ファイルで既にそうなっている
+のと全く同じように、手による編集を保持します。
+
+両サーフェスは 1 つのセレクター（`FacetContextSelector`）を共有して
+スキャン・分類・グループ化・scope-overlap のマッチングを行うため、
+順序付け・フィルタリング・degradation のセマンティクスが両者の間で
+食い違うことはあり得ません。バケット分けされるのは有効な facet 値
+（G529 の閉じた集合）だけです。壊れた `facets:` 宣言は、存在しない
+場合と全く同じように、すべてのグループから除外されます —
+壊れた/未知の値を検証・報告するのは `lint-layout` の仕事であり、
+これらの消費側サーフェスの仕事ではありません。
+
+---
+
 ## バージョンフロー
 
 リポジトリのバージョンポリシーは `eng/version.json` に記載されています。`stableVersion`

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -477,21 +477,47 @@ intent-cli context collect --domain <d> --scope intents/<d>/means,identity/missi
 - `--facets <カンマ区切り>` は、そもそもどの facet グループが現れるかを
   制限します（それでも正規の順序でレンダリングされます）。認識できない
   facet 名は usage error になります（`intent search --facet` の
-  バリデーションと同様）。
+  バリデーションと同様）。カンマ区切りのオプションはすべて（`--facets`
+  も `--scope` も）、trim 後の各要素が非空であることを要求し、
+  先勝ちの順序で重複を除去します — `--scope ","` や `--facets
+  "vocabulary,,decider"`（空の要素）は usage error であり、黙って
+  「scope なし」になったり、要素が黙って捨てられたりすることは
+  ありません。
 - `--scope <カンマ区切りのパス>` は、各グループを、パスがヒントと
-  overlap する node だけに絞り込みます — 完全一致、祖先ディレクトリを
-  指すヒント、または（`intents/<domain>/` prefix も `.md` も無い）
-  より短い domain-relative の id 形式、いずれも overlap とみなされます。
-  `--scope` を省略した場合は、domain の facet node すべてが返されます。
+  overlap する node だけに対称的に（両方向で）絞り込みます — ヒントが
+  node の祖先ディレクトリを指す場合に加えて、node 自身のパスが
+  （より具体的な）ヒントの祖先である場合も、両方とも overlap と
+  みなされます。完全一致も同様です。どのヒントの形式も、比較の前に
+  node 自身の id が既に使っている domain-relative なセグメント列に
+  正規化されます — そのため、domain root 配下の絶対ファイルシステム
+  パス、repo-relative な `intents/<domain>/...` 形式、そして短い
+  domain-relative の id 形式（末尾の `.md` の有無を問わず）は、
+  すべて等価です。`..` セグメントは拒否されます（黙って解決される
+  ことはありません — そうしないと、ヒントが自身の scope 対象で
+  あるはずの domain の外へ抜け出してしまう可能性があるためです）。
+  比較は常に大文字小文字を区別します。`--scope` を省略した場合は、
+  domain の facet node すべてが返されます。`--scope` を渡したが、
+  すべてのヒントが無効または domain 外だった場合は、何にもマッチ
+  しません — 黙って「scope 要求なし」にフォールバックすることは
+  ありません。
 - domain に facet-annotated な node が 1 つも無い場合（`--scope`/
   `--facets` のクエリがたまたま何にもマッチしなかっただけの場合とは
   異なります）は、`facet_context_note` が設定され、空のセクションの
   代わりに明示的なノートがレンダリングされます — graceful な
   degradation であり、決して error にはなりません。facets は
   optional であり、tree がまだ採用していない段階ではこれが通常です。
+- 壊れた `facets:` 宣言、または Present な宣言に未知の値が含まれる
+  場合、それが黙って消えることはありません: どちらも
+  `facet_context_warnings` エントリ（`path`、`reason`）を JSON に、
+  Markdown では `Warnings` リストを生成し、何が・なぜ除外されたのかを
+  正確に示します — これにより「そもそも facets が無い」場合と
+  「facets はあったが除外された」場合が、区別できないまま同じに
+  見えることがなくなります。未知の値があっても、その node の他の
+  有効な facet からその node が除外されることはありません。
 - JSON の形: `facet_context: [{facet, nodes: [{id, facets, summary,
   path}]}]`（常に 4 要素。`--facets` を渡した場合はそれより少なくなる
-  こともあります）、`facet_context_note: string | null`。
+  こともあります）、`facet_context_note: string | null`、
+  `facet_context_warnings: [{path, reason}]`。
 
 **`intent-cli packet draft`** は、scaffold される `review-context.md`
 の中に `## Facet context` セクションを生成するようになりました。
@@ -499,27 +525,47 @@ intent-cli context collect --domain <d> --scope intents/<d>/means,identity/missi
 `implementation_issue_packet.intent_references` と overlap する
 facet node を一覧化します — `context collect` の `--scope` が使うのと
 全く同じ overlap ロジックなので、2 つのサーフェスが「overlap」の
-意味について食い違うことはありません。`packet draft` は既存の
-ファイルを決して上書きしないため、これが適用されるのは
-`review-context.md` が初めて書き込まれる時だけです: もし
-`packet.yaml` が既に存在していれば（例えば、以前の `packet draft`
-実行の後、`review-context.md` がまだ生成されていない段階で
-operator が `intent_references` を手で編集していた場合）、
-読まれるのはディスク上のその packet.yaml です — この同じ呼び出しが
-別途書き込むかもしれない、テンプレートの空の
-`intent_references: []` では決してありません。`review-context.md`
-が一度存在すれば、`packet draft` を再実行してもそれには一切
-触れません。これは他の 3 つの scaffold ファイルで既にそうなっている
-のと全く同じように、手による編集を保持します。
+意味について食い違うことはありません。生成される内容は、2 つの
+HTML コメントマーカー（`<!-- BEGIN/END GENERATED FACET CONTEXT
+(G530) -->`）の間に存在します。`review-context.md` の残りの部分は
+手による所有物であり、一切触れられません:
+
+- **ファイルがまだ存在しない場合**: 現在の `intent_references`
+  （既に `packet.yaml` が存在していれば、そのディスク上の値を
+  読みます — 例えば、以前の `packet draft` 実行の後に operator が
+  手で編集していた場合。この同じ呼び出しが別途書き込むかもしれない、
+  テンプレートの空の `[]` では決してありません）を使って、ファイル
+  全体が新規に書き込まれます。`created` として報告されます。
+- **ファイルが存在し、かつ両方のマーカーを持つ場合**: マーカーの
+  「間」にある内容だけが、packet の現在の `intent_references` から
+  再計算され、置き換えられます — これにより、通常のワークフロー
+  （空の references で scaffold → operator が `packet.yaml` に
+  本物の references を追加 → `packet draft` を再実行 → block に
+  それが反映される）を通して、セクションが最新に保たれます。
+  開始マーカーより前、終了マーカーより後のすべて（block の周りに
+  手で書かれた文章を含む）は、バイト単位でそのまま保持されます。
+  再計算された内容が既存のものと異なる場合は `updated`、異ならない
+  場合は `skipped`（本物の no-op であり、見せかけの update では
+  ない）として報告されます。
+- **ファイルが存在するが、認識できるマーカーが無い場合**（この機能
+  より前に作られたか、operator がマーカーを削除した場合）: 他の
+  3 つの scaffold ファイルの、単純な「存在すればスキップ」の挙動と
+  全く同じように、完全に触れられないままになります。マーカーが
+  手による所有物の中に後から注入されることは決してありません。
+  `skipped` として報告されます。
+
+空の `intent_references` リストそれ自体が、意味のある scope です —
+「この packet は（今のところ）何も参照していない」— そのため block は
+すべての facet グループを空として表示します。domain 全体の facet
+node を表示することは決してありません。domain に facet node が
+1 つも存在しない場合にのみ、graceful-degradation のノートが
+レンダリングされます。
 
 両サーフェスは 1 つのセレクター（`FacetContextSelector`）を共有して
 スキャン・分類・グループ化・scope-overlap のマッチングを行うため、
-順序付け・フィルタリング・degradation のセマンティクスが両者の間で
-食い違うことはあり得ません。バケット分けされるのは有効な facet 値
-（G529 の閉じた集合）だけです。壊れた `facets:` 宣言は、存在しない
-場合と全く同じように、すべてのグループから除外されます —
-壊れた/未知の値を検証・報告するのは `lint-layout` の仕事であり、
-これらの消費側サーフェスの仕事ではありません。
+順序付け・フィルタリング・warning・degradation のセマンティクスが
+両者の間で食い違うことはあり得ません。バケット分けされるのは有効な
+facet 値（G529 の閉じた集合）だけです。
 
 ---
 

--- a/src/IntentSystem.Cli/Commands/ContextCollectAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectAnalyzer.cs
@@ -15,7 +15,11 @@ internal static class ContextCollectAnalyzer
     private const int RecentEventLimit = 5;
     private const int MarkdownExcerptCharLimit = 1500;
 
-    public static ContextCollectPacket Analyze(CliContext context, string? domainOverride)
+    public static ContextCollectPacket Analyze(
+        CliContext context,
+        string? domainOverride,
+        IReadOnlyList<string>? scopeHints = null,
+        IReadOnlyCollection<string>? facetFilter = null)
     {
         ArgumentNullException.ThrowIfNull(context);
 
@@ -24,6 +28,19 @@ internal static class ContextCollectAnalyzer
             : domainOverride;
 
         var notes = new List<string>();
+
+        // G530: same domain-root resolution the rest of this analyzer
+        // already uses for clarification/automation-bindings paths (parent
+        // host root when configured, else the local repo) — a child
+        // implementation workspace's `intent_references`/`--scope` hints
+        // and facet nodes both live under the PARENT host's intent tree.
+        var facetDomainRoot = ResolveDomainPath(context, domain);
+        var facetSelection = facetDomainRoot is null
+            ? new FacetContextSelection { Groups = Array.Empty<FacetContextGroup>(), DomainHasAnyFacetNodes = false }
+            : FacetContextSelector.Select(facetDomainRoot, domain, scopeHints, facetFilter);
+        var facetContextNote = facetSelection.DomainHasAnyFacetNodes
+            ? null
+            : $"no facet-annotated nodes found under intents/{domain}/ — facets (G529) are optional and this is the norm before a tree adopts them.";
 
         var queueStatePath = context.GetQueueStatePath();
         var queueStatePresent = File.Exists(queueStatePath);
@@ -130,6 +147,8 @@ internal static class ContextCollectAnalyzer
         return new ContextCollectPacket
         {
             Domain = domain,
+            FacetContext = facetSelection.Groups,
+            FacetContextNote = facetContextNote,
             QueueStatePath = queueStatePath,
             QueueStatePresent = queueStatePresent,
             QueueStateReadable = queueStateReadable,

--- a/src/IntentSystem.Cli/Commands/ContextCollectAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectAnalyzer.cs
@@ -36,7 +36,7 @@ internal static class ContextCollectAnalyzer
         // and facet nodes both live under the PARENT host's intent tree.
         var facetDomainRoot = ResolveDomainPath(context, domain);
         var facetSelection = facetDomainRoot is null
-            ? new FacetContextSelection { Groups = Array.Empty<FacetContextGroup>(), DomainHasAnyFacetNodes = false }
+            ? new FacetContextSelection { Groups = Array.Empty<FacetContextGroup>(), DomainHasAnyFacetNodes = false, Warnings = Array.Empty<FacetContextWarning>() }
             : FacetContextSelector.Select(facetDomainRoot, domain, scopeHints, facetFilter);
         var facetContextNote = facetSelection.DomainHasAnyFacetNodes
             ? null
@@ -148,6 +148,7 @@ internal static class ContextCollectAnalyzer
         {
             Domain = domain,
             FacetContext = facetSelection.Groups,
+            FacetContextWarnings = facetSelection.Warnings,
             FacetContextNote = facetContextNote,
             QueueStatePath = queueStatePath,
             QueueStatePresent = queueStatePresent,

--- a/src/IntentSystem.Cli/Commands/ContextCollectAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectAnalyzer.cs
@@ -36,7 +36,14 @@ internal static class ContextCollectAnalyzer
         // and facet nodes both live under the PARENT host's intent tree.
         var facetDomainRoot = ResolveDomainPath(context, domain);
         var facetSelection = facetDomainRoot is null
-            ? new FacetContextSelection { Groups = Array.Empty<FacetContextGroup>(), DomainHasAnyFacetNodes = false, Warnings = Array.Empty<FacetContextWarning>() }
+            ? new FacetContextSelection
+              {
+                  Groups = Array.Empty<FacetContextGroup>(),
+                  DomainHasAnyFacetNodes = false,
+                  Warnings = Array.Empty<FacetContextWarning>(),
+                  ScopeWarnings = Array.Empty<FacetScopeWarning>(),
+                  AllScopeHintsRejected = false,
+              }
             : FacetContextSelector.Select(facetDomainRoot, domain, scopeHints, facetFilter);
         var facetContextNote = facetSelection.DomainHasAnyFacetNodes
             ? null
@@ -149,6 +156,8 @@ internal static class ContextCollectAnalyzer
             Domain = domain,
             FacetContext = facetSelection.Groups,
             FacetContextWarnings = facetSelection.Warnings,
+            FacetContextScopeWarnings = facetSelection.ScopeWarnings,
+            FacetContextAllScopeHintsRejected = facetSelection.AllScopeHintsRejected,
             FacetContextNote = facetContextNote,
             QueueStatePath = queueStatePath,
             QueueStatePresent = queueStatePresent,

--- a/src/IntentSystem.Cli/Commands/ContextCollectCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectCommand.cs
@@ -96,7 +96,12 @@ internal static class ContextCollectCommand
                         return false;
                     }
 
-                    scopeHints = SplitCommaList(args[index + 1]);
+                    if (!TrySplitCommaList(args[index + 1], "--scope", out var splitScope, out error))
+                    {
+                        return false;
+                    }
+
+                    scopeHints = splitScope;
                     index++;
                     break;
 
@@ -109,7 +114,11 @@ internal static class ContextCollectCommand
                         return false;
                     }
 
-                    var requestedFacets = SplitCommaList(args[index + 1]);
+                    if (!TrySplitCommaList(args[index + 1], "--facets", out var requestedFacets, out error))
+                    {
+                        return false;
+                    }
+
                     var unknownFacet = requestedFacets.FirstOrDefault(facet => !IntentNodeFacets.IsAllowedValue(facet));
                     if (unknownFacet is not null)
                     {
@@ -130,6 +139,36 @@ internal static class ContextCollectCommand
         return true;
     }
 
-    private static IReadOnlyList<string> SplitCommaList(string value) =>
-        value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    /// <summary>
+    /// G530 review repair: a comma-separated option value must never
+    /// silently weaken narrowing — <c>--scope ","</c> or <c>--facets
+    /// "vocabulary,,decider"</c> (an empty element) is a usage error, not
+    /// "no scope"/"drop the empty one". Every element is trimmed; a
+    /// duplicate (after trimming) is kept only once, first-seen order
+    /// preserved.
+    /// </summary>
+    private static bool TrySplitCommaList(string value, string optionName, out IReadOnlyList<string> values, out string error)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var result = new List<string>();
+        foreach (var rawElement in value.Split(','))
+        {
+            var element = rawElement.Trim();
+            if (element.Length == 0)
+            {
+                values = Array.Empty<string>();
+                error = $"{optionName} value '{value}' contains an empty element — every comma-separated value must be non-empty.";
+                return false;
+            }
+
+            if (seen.Add(element))
+            {
+                result.Add(element);
+            }
+        }
+
+        values = result;
+        error = string.Empty;
+        return true;
+    }
 }

--- a/src/IntentSystem.Cli/Commands/ContextCollectCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectCommand.cs
@@ -18,13 +18,13 @@ internal static class ContextCollectCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (!TryParseArguments(args, out var domainOverride, out var format, out var error))
+        if (!TryParseArguments(args, out var domainOverride, out var format, out var scopeHints, out var facetFilter, out var error))
         {
             writer.WriteLine(error);
             return 1;
         }
 
-        var packet = ContextCollectAnalyzer.Analyze(context, domainOverride);
+        var packet = ContextCollectAnalyzer.Analyze(context, domainOverride, scopeHints, facetFilter);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -42,10 +42,14 @@ internal static class ContextCollectCommand
         string[] args,
         out string? domainOverride,
         out string format,
+        out IReadOnlyList<string>? scopeHints,
+        out IReadOnlyCollection<string>? facetFilter,
         out string error)
     {
         domainOverride = null;
         format = FormatMarkdown;
+        scopeHints = null;
+        facetFilter = null;
         error = string.Empty;
 
         for (var index = 0; index < args.Length; index++)
@@ -83,12 +87,49 @@ internal static class ContextCollectCommand
                     index++;
                     break;
 
+                // G530: narrows the facet section to nodes overlapping the
+                // given path/intent-reference hints — see FacetContextSelector.
+                case "--scope":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--scope requires a value (comma-separated paths).";
+                        return false;
+                    }
+
+                    scopeHints = SplitCommaList(args[index + 1]);
+                    index++;
+                    break;
+
+                // G530: restricts the facet section to the requested facet
+                // values, still rendered in the canonical facet order.
+                case "--facets":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--facets requires a value (comma-separated facet names).";
+                        return false;
+                    }
+
+                    var requestedFacets = SplitCommaList(args[index + 1]);
+                    var unknownFacet = requestedFacets.FirstOrDefault(facet => !IntentNodeFacets.IsAllowedValue(facet));
+                    if (unknownFacet is not null)
+                    {
+                        error = $"--facets must be a comma-separated subset of: {string.Join(", ", IntentNodeFacets.AllowedValues)} (got '{unknownFacet}').";
+                        return false;
+                    }
+
+                    facetFilter = requestedFacets;
+                    index++;
+                    break;
+
                 default:
-                    error = $"Unknown argument '{argument}'. Supported: --domain <name> --format markdown|json.";
+                    error = $"Unknown argument '{argument}'. Supported: --domain <name> --format markdown|json --scope <paths> --facets <names>.";
                     return false;
             }
         }
 
         return true;
     }
+
+    private static IReadOnlyList<string> SplitCommaList(string value) =>
+        value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 }

--- a/src/IntentSystem.Cli/Commands/ContextCollectPacket.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectPacket.cs
@@ -43,6 +43,25 @@ internal sealed record ContextCollectPacket
     [JsonPropertyName("facet_context_warnings")]
     public required IReadOnlyList<FacetContextWarning> FacetContextWarnings { get; init; }
 
+    /// <summary>
+    /// G530 review repair: every requested <c>--scope</c> hint that was
+    /// rejected (outside the domain root, a <c>..</c> traversal, or
+    /// otherwise unresolvable), verbatim, with the reason — never silent,
+    /// so "matched nothing because every hint was invalid" is
+    /// distinguishable from "matched nothing because a valid hint just
+    /// didn't overlap any node".
+    /// </summary>
+    [JsonPropertyName("facet_context_scope_warnings")]
+    public required IReadOnlyList<FacetScopeWarning> FacetContextScopeWarnings { get; init; }
+
+    /// <summary>
+    /// G530 review repair: true only when every <c>--scope</c> hint the
+    /// caller passed was rejected — an explicit summary flag so a renderer
+    /// doesn't have to infer it by comparing counts.
+    /// </summary>
+    [JsonPropertyName("facet_context_all_scope_hints_rejected")]
+    public required bool FacetContextAllScopeHintsRejected { get; init; }
+
     [JsonPropertyName("queue_state_path")]
     public required string QueueStatePath { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/ContextCollectPacket.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectPacket.cs
@@ -14,6 +14,26 @@ internal sealed record ContextCollectPacket
     [JsonPropertyName("domain")]
     public required string Domain { get; init; }
 
+    /// <summary>
+    /// G530: the four G529 semantic-facet groups (<c>vocabulary</c>,
+    /// <c>invariant</c>, <c>decider</c>, <c>acceptance-property</c>, in that
+    /// order), each carrying every domain node classified under it —
+    /// narrowed by <c>--scope</c> when passed, restricted to the requested
+    /// subset by <c>--facets</c> when passed. Rendered AHEAD of the
+    /// unclassified queue/clarification/automation-bindings/events context
+    /// below, since this is the semantic core a change must respect.
+    /// </summary>
+    [JsonPropertyName("facet_context")]
+    public required IReadOnlyList<FacetContextGroup> FacetContext { get; init; }
+
+    /// <summary>
+    /// G530: set only when the DOMAIN has zero facet-annotated nodes at all
+    /// (not merely when a <c>--scope</c>/<c>--facets</c> query matched
+    /// nothing) — explicit graceful-degradation note, never an error.
+    /// </summary>
+    [JsonPropertyName("facet_context_note")]
+    public string? FacetContextNote { get; init; }
+
     [JsonPropertyName("queue_state_path")]
     public required string QueueStatePath { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/ContextCollectPacket.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectPacket.cs
@@ -34,6 +34,15 @@ internal sealed record ContextCollectPacket
     [JsonPropertyName("facet_context_note")]
     public string? FacetContextNote { get; init; }
 
+    /// <summary>
+    /// G530 review repair: every node excluded from <see cref="FacetContext"/>
+    /// because its own <c>facets:</c> declaration was malformed, or that
+    /// carried at least one unknown value — never silent, so an agent can
+    /// tell "omitted with a reason" apart from "never had facets at all".
+    /// </summary>
+    [JsonPropertyName("facet_context_warnings")]
+    public required IReadOnlyList<FacetContextWarning> FacetContextWarnings { get; init; }
+
     [JsonPropertyName("queue_state_path")]
     public required string QueueStatePath { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/ContextCollectRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectRenderer.cs
@@ -22,6 +22,36 @@ internal static class ContextCollectRenderer
         writer.WriteLine($"# Context packet: {packet.Domain}");
         writer.WriteLine();
 
+        // G530: the facet section is rendered AHEAD of the unclassified
+        // queue/clarification/automation-bindings/events context below —
+        // it is the semantic core (vocabulary/invariant/decider/
+        // acceptance-property nodes) a change must respect, localized
+        // instead of buried at the end of the packet.
+        writer.WriteLine("## Facet context");
+        if (packet.FacetContextNote is not null)
+        {
+            writer.WriteLine($"- {packet.FacetContextNote}");
+        }
+        else
+        {
+            foreach (var group in packet.FacetContext)
+            {
+                writer.WriteLine($"### {group.Facet}");
+                if (group.Nodes.Count == 0)
+                {
+                    writer.WriteLine("- (none)");
+                    continue;
+                }
+
+                foreach (var node in group.Nodes)
+                {
+                    writer.WriteLine(
+                        $"- `{node.Id}` [{string.Join(", ", node.Facets)}] {node.Summary} — `{node.Path}`");
+                }
+            }
+        }
+        writer.WriteLine();
+
         writer.WriteLine("## Queue state");
         writer.WriteLine($"- Path: `{packet.QueueStatePath}`");
         writer.WriteLine(

--- a/src/IntentSystem.Cli/Commands/ContextCollectRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectRenderer.cs
@@ -63,6 +63,20 @@ internal static class ContextCollectRenderer
                 writer.WriteLine($"  - `{warning.Path}`: {warning.Reason}");
             }
         }
+
+        // G530 review repair: a rejected --scope hint must never look like
+        // a valid scope that simply matched nothing.
+        if (packet.FacetContextScopeWarnings.Count > 0)
+        {
+            writer.WriteLine(
+                packet.FacetContextAllScopeHintsRejected
+                    ? "- Scope warnings (ALL requested --scope hints were rejected — nothing was scoped in):"
+                    : "- Scope warnings (these --scope hints were rejected; other valid hints were still applied):");
+            foreach (var warning in packet.FacetContextScopeWarnings)
+            {
+                writer.WriteLine($"  - `{warning.Hint}`: {warning.Reason}");
+            }
+        }
         writer.WriteLine();
 
         writer.WriteLine("## Queue state");

--- a/src/IntentSystem.Cli/Commands/ContextCollectRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/ContextCollectRenderer.cs
@@ -50,6 +50,19 @@ internal static class ContextCollectRenderer
                 }
             }
         }
+
+        // G530 review repair: malformed/unknown-value exclusions are never
+        // silent — surfaced regardless of whether the note above fired, so
+        // "genuinely no facets" and "facets excluded for a reason" never
+        // look identical.
+        if (packet.FacetContextWarnings.Count > 0)
+        {
+            writer.WriteLine("- Warnings (excluded from the facet context above):");
+            foreach (var warning in packet.FacetContextWarnings)
+            {
+                writer.WriteLine($"  - `{warning.Path}`: {warning.Reason}");
+            }
+        }
         writer.WriteLine();
 
         writer.WriteLine("## Queue state");

--- a/src/IntentSystem.Cli/Commands/FacetContextSelector.cs
+++ b/src/IntentSystem.Cli/Commands/FacetContextSelector.cs
@@ -1,0 +1,200 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G530: shared, read-only selection of G529 semantic-facet nodes
+/// (<c>vocabulary</c>, <c>invariant</c>, <c>decider</c>,
+/// <c>acceptance-property</c>) for a domain's intent tree, used by both
+/// <c>context collect</c> (a <c>--scope</c> hint list, narrowing by overlap)
+/// and <c>packet draft</c> (the packet's own <c>intent_references</c> as the
+/// scope hints) so the two surfaces can never disagree on what "overlaps".
+/// Never mutates state; a missing/unreadable node is skipped rather than
+/// failing the whole selection.
+/// </summary>
+internal static class FacetContextSelector
+{
+    /// <summary>
+    /// Scans every <c>.md</c> file under <paramref name="domainRoot"/>
+    /// (already resolved by the caller — <c>context collect</c> and
+    /// <c>packet draft</c> each follow their own established parent-host /
+    /// local-repo resolution), classifies each by its G529 <c>facets:</c>
+    /// frontmatter, and groups the result into one entry per facet in the
+    /// canonical order (<see cref="IntentNodeFacets.AllowedValues"/>).
+    ///
+    /// <paramref name="scopeHints"/> (paths, either the full displayed
+    /// <c>intents/&lt;domain&gt;/...</c> form or the shorter domain-relative
+    /// id form) narrow the result to nodes whose path equals a hint, sits
+    /// under a hint treated as a directory prefix, or vice versa. A null or
+    /// empty hint list applies no narrowing — every domain facet node is
+    /// returned. <paramref name="facetFilter"/> (a subset of
+    /// <see cref="IntentNodeFacets.AllowedValues"/>) restricts which facet
+    /// groups are returned at all; null/empty returns all four.
+    ///
+    /// Only VALID facet values (per <see cref="IntentNodeFacets.IsAllowedValue"/>)
+    /// are ever bucketed — an unknown value on an otherwise-Present node is
+    /// silently excluded from the facet groups it doesn't belong to
+    /// (validating and reporting unknown values is `lint-layout`'s job, not
+    /// this consumption surface's). A node carrying more than one facet
+    /// appears once in each matching group.
+    /// </summary>
+    public static FacetContextSelection Select(
+        string domainRoot,
+        string domain,
+        IReadOnlyList<string>? scopeHints,
+        IReadOnlyCollection<string>? facetFilter)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(domainRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+
+        var nodes = new List<(string RepoRelativePath, string DomainRelativeId, IReadOnlyList<string> Facets, string Summary)>();
+
+        if (Directory.Exists(domainRoot))
+        {
+            foreach (var file in Directory
+                         .EnumerateFiles(domainRoot, "*.md", SearchOption.AllDirectories)
+                         .OrderBy(path => path, StringComparer.Ordinal))
+            {
+                string content;
+                try
+                {
+                    content = File.ReadAllText(file);
+                }
+                catch (IOException)
+                {
+                    continue;
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    continue;
+                }
+
+                var parsed = IntentNodeFacets.ParseFacets(content);
+                if (parsed.Kind != FacetsParseKind.Present)
+                {
+                    continue;
+                }
+
+                var validFacets = parsed.Values.Where(IntentNodeFacets.IsAllowedValue).ToArray();
+                if (validFacets.Length == 0)
+                {
+                    continue;
+                }
+
+                var domainRelativeId = ToDomainRelativeId(domainRoot, file);
+                var repoRelativePath = $"intents/{domain}/{domainRelativeId}.md";
+                var summary = ExtractSummary(content);
+                nodes.Add((repoRelativePath, domainRelativeId, validFacets, summary));
+            }
+        }
+
+        var domainHasAnyFacetNodes = nodes.Count > 0;
+
+        var scoped = scopeHints is { Count: > 0 }
+            ? nodes.Where(node => scopeHints.Any(hint => HintOverlapsNode(hint, node.RepoRelativePath, node.DomainRelativeId))).ToArray()
+            : nodes.ToArray();
+
+        var groups = new List<FacetContextGroup>();
+        foreach (var facet in IntentNodeFacets.AllowedValues)
+        {
+            if (facetFilter is { Count: > 0 } && !facetFilter.Contains(facet, StringComparer.Ordinal))
+            {
+                continue;
+            }
+
+            var nodeRefs = scoped
+                .Where(node => node.Facets.Contains(facet, StringComparer.Ordinal))
+                .Select(node => new FacetContextNodeRef
+                {
+                    Id = node.DomainRelativeId,
+                    Facets = node.Facets,
+                    Summary = node.Summary,
+                    Path = node.RepoRelativePath,
+                })
+                .ToArray();
+
+            groups.Add(new FacetContextGroup { Facet = facet, Nodes = nodeRefs });
+        }
+
+        return new FacetContextSelection
+        {
+            Groups = groups,
+            DomainHasAnyFacetNodes = domainHasAnyFacetNodes,
+        };
+    }
+
+    /// <summary>The domain-relative id — path under the domain root, slashes normalized, without the `.md` extension (e.g. `identity/mission`).</summary>
+    private static string ToDomainRelativeId(string domainRoot, string fullPath)
+    {
+        var relative = Path.GetRelativePath(domainRoot, fullPath).Replace('\\', '/');
+        return relative.EndsWith(".md", StringComparison.OrdinalIgnoreCase)
+            ? relative[..^3]
+            : relative;
+    }
+
+    private static string ExtractSummary(string content)
+    {
+        var body = IntentNodeFacets.TryExtractFrontmatterBlock(content, out _, out var bodyAfterFrontmatter)
+            ? bodyAfterFrontmatter
+            : content;
+        var firstLine = body
+            .Split('\n')
+            .Select(line => line.Trim())
+            .FirstOrDefault(line => line.Length > 0) ?? string.Empty;
+        return firstLine.TrimStart('#').Trim();
+    }
+
+    private static bool HintOverlapsNode(string hint, string repoRelativePath, string domainRelativeId) =>
+        HintMatchesPath(hint, repoRelativePath) || HintMatchesPath(hint, domainRelativeId);
+
+    private static bool HintMatchesPath(string hint, string candidate)
+    {
+        var normalizedHint = hint.Replace('\\', '/').Trim().TrimEnd('/');
+        if (normalizedHint.Length == 0)
+        {
+            return false;
+        }
+
+        var normalizedCandidate = candidate.Replace('\\', '/');
+        return string.Equals(normalizedCandidate, normalizedHint, StringComparison.Ordinal)
+            || normalizedCandidate.StartsWith(normalizedHint + "/", StringComparison.Ordinal);
+    }
+}
+
+internal sealed record FacetContextSelection
+{
+    public required IReadOnlyList<FacetContextGroup> Groups { get; init; }
+
+    /// <summary>
+    /// True when the DOMAIN has at least one facet-annotated node, ignoring
+    /// any <c>--scope</c>/<c>--facets</c> narrowing — used to distinguish
+    /// "this domain has no facet nodes at all" (graceful-degradation note)
+    /// from "this query's filter/scope happened to match nothing" (an
+    /// ordinary empty result, not a degradation case).
+    /// </summary>
+    public required bool DomainHasAnyFacetNodes { get; init; }
+}
+
+internal sealed record FacetContextGroup
+{
+    [JsonPropertyName("facet")]
+    public required string Facet { get; init; }
+
+    [JsonPropertyName("nodes")]
+    public required IReadOnlyList<FacetContextNodeRef> Nodes { get; init; }
+}
+
+internal sealed record FacetContextNodeRef
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("facets")]
+    public required IReadOnlyList<string> Facets { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("path")]
+    public required string Path { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/FacetContextSelector.cs
+++ b/src/IntentSystem.Cli/Commands/FacetContextSelector.cs
@@ -22,20 +22,26 @@ internal static class FacetContextSelector
     /// frontmatter, and groups the result into one entry per facet in the
     /// canonical order (<see cref="IntentNodeFacets.AllowedValues"/>).
     ///
-    /// <paramref name="scopeHints"/> (paths, either the full displayed
-    /// <c>intents/&lt;domain&gt;/...</c> form or the shorter domain-relative
-    /// id form) narrow the result to nodes whose path equals a hint, sits
-    /// under a hint treated as a directory prefix, or vice versa. A null or
-    /// empty hint list applies no narrowing — every domain facet node is
-    /// returned. <paramref name="facetFilter"/> (a subset of
-    /// <see cref="IntentNodeFacets.AllowedValues"/>) restricts which facet
-    /// groups are returned at all; null/empty returns all four.
+    /// <paramref name="scopeHints"/> narrow the result to nodes overlapping
+    /// at least one hint (see <see cref="NormalizeHintSegments"/> for every
+    /// accepted hint form and <see cref="SegmentsOverlap"/> for the
+    /// symmetric overlap rule). A null or empty hint list applies no
+    /// narrowing — every domain facet node is returned. <paramref
+    /// name="facetFilter"/> (a subset of <see cref="IntentNodeFacets.AllowedValues"/>)
+    /// restricts which facet groups are returned at all; null/empty returns
+    /// all four.
     ///
     /// Only VALID facet values (per <see cref="IntentNodeFacets.IsAllowedValue"/>)
-    /// are ever bucketed — an unknown value on an otherwise-Present node is
-    /// silently excluded from the facet groups it doesn't belong to
-    /// (validating and reporting unknown values is `lint-layout`'s job, not
-    /// this consumption surface's). A node carrying more than one facet
+    /// are ever bucketed. Unlike the first G530 round, neither a malformed
+    /// <c>facets:</c> declaration nor an unknown facet value is silent: both
+    /// produce a <see cref="FacetContextWarning"/> (path + reason) so an
+    /// agent can tell "genuinely no facets here" apart from "facets were
+    /// present but excluded" — <see cref="FacetContextSelection.DomainHasAnyFacetNodes"/>
+    /// reflects only nodes that contributed at least one VALID facet: a
+    /// domain whose every facets: declaration is malformed or entirely
+    /// unknown-valued still reports <c>false</c>, but the accompanying
+    /// warnings explain why, rather than looking identical to a domain that
+    /// never adopted facets at all. A node carrying more than one facet
     /// appears once in each matching group.
     /// </summary>
     public static FacetContextSelection Select(
@@ -48,6 +54,7 @@ internal static class FacetContextSelector
         ArgumentException.ThrowIfNullOrWhiteSpace(domain);
 
         var nodes = new List<(string RepoRelativePath, string DomainRelativeId, IReadOnlyList<string> Facets, string Summary)>();
+        var warnings = new List<FacetContextWarning>();
 
         if (Directory.Exists(domainRoot))
         {
@@ -69,20 +76,43 @@ internal static class FacetContextSelector
                     continue;
                 }
 
+                var domainRelativeId = ToDomainRelativeId(domainRoot, file);
+                var repoRelativePath = $"intents/{domain}/{domainRelativeId}.md";
+
                 var parsed = IntentNodeFacets.ParseFacets(content);
+                if (parsed.Kind == FacetsParseKind.Malformed)
+                {
+                    warnings.Add(new FacetContextWarning
+                    {
+                        Path = repoRelativePath,
+                        Reason = $"malformed 'facets:' declaration excluded from facet context: {parsed.MalformedReason}",
+                    });
+                    continue;
+                }
+
                 if (parsed.Kind != FacetsParseKind.Present)
                 {
                     continue;
                 }
 
                 var validFacets = parsed.Values.Where(IntentNodeFacets.IsAllowedValue).ToArray();
+                var unknownFacets = parsed.Values.Where(value => !IntentNodeFacets.IsAllowedValue(value)).ToArray();
+                if (unknownFacets.Length > 0)
+                {
+                    warnings.Add(new FacetContextWarning
+                    {
+                        Path = repoRelativePath,
+                        Reason =
+                            $"unknown facet value(s) ignored: {string.Join(", ", unknownFacets)} "
+                            + $"(closed set: {string.Join(", ", IntentNodeFacets.AllowedValues)})",
+                    });
+                }
+
                 if (validFacets.Length == 0)
                 {
                     continue;
                 }
 
-                var domainRelativeId = ToDomainRelativeId(domainRoot, file);
-                var repoRelativePath = $"intents/{domain}/{domainRelativeId}.md";
                 var summary = ExtractSummary(content);
                 nodes.Add((repoRelativePath, domainRelativeId, validFacets, summary));
             }
@@ -90,8 +120,23 @@ internal static class FacetContextSelector
 
         var domainHasAnyFacetNodes = nodes.Count > 0;
 
-        var scoped = scopeHints is { Count: > 0 }
-            ? nodes.Where(node => scopeHints.Any(hint => HintOverlapsNode(hint, node.RepoRelativePath, node.DomainRelativeId))).ToArray()
+        var normalizedHints = (scopeHints ?? Array.Empty<string>())
+            .Select(hint => NormalizeHintSegments(hint, domain, domainRoot))
+            .Where(segments => segments is not null)
+            .Select(segments => segments!)
+            .ToArray();
+
+        // Narrowing is requested whenever the caller passed a scope-hint
+        // LIST AT ALL — including an EXPLICITLY EMPTY one (e.g. a packet
+        // that declares zero `intent_references`, which must scope to
+        // NOTHING, not to "no scoping requested" — a fresh, unreferenced
+        // packet is not entitled to the whole domain's facet nodes). Only
+        // a null scopeHints (the caller genuinely omitted --scope) applies
+        // no narrowing at all. Within a requested-but-empty-or-fully-
+        // invalid hint set, every node fails to match — matches nothing,
+        // never falls back to "show everything".
+        var scoped = scopeHints is not null
+            ? nodes.Where(node => normalizedHints.Any(hint => SegmentsOverlap(hint, node.DomainRelativeId.Split('/')))).ToArray()
             : nodes.ToArray();
 
         var groups = new List<FacetContextGroup>();
@@ -120,6 +165,7 @@ internal static class FacetContextSelector
         {
             Groups = groups,
             DomainHasAnyFacetNodes = domainHasAnyFacetNodes,
+            Warnings = warnings,
         };
     }
 
@@ -144,20 +190,137 @@ internal static class FacetContextSelector
         return firstLine.TrimStart('#').Trim();
     }
 
-    private static bool HintOverlapsNode(string hint, string repoRelativePath, string domainRelativeId) =>
-        HintMatchesPath(hint, repoRelativePath) || HintMatchesPath(hint, domainRelativeId);
-
-    private static bool HintMatchesPath(string hint, string candidate)
+    /// <summary>
+    /// Normalizes a scope hint into a domain-relative segment list, or
+    /// <see langword="null"/> when the hint is empty/whitespace, resolves
+    /// outside <paramref name="domainRoot"/> entirely, or attempts to
+    /// escape the domain via a <c>..</c> segment. Accepted hint forms —
+    /// all reduced to the SAME canonical segment list a node's own
+    /// domain-relative id already uses, so comparison is always
+    /// apples-to-apples:
+    /// <list type="bullet">
+    /// <item>an absolute filesystem path under <paramref name="domainRoot"/>
+    ///   (reduced by subtracting the domain root, exactly like a node's own
+    ///   path is derived);</item>
+    /// <item>the repo-relative <c>intents/&lt;domain&gt;/...</c> form (the
+    ///   prefix is stripped);</item>
+    /// <item>the short domain-relative id form with no prefix (e.g.
+    ///   <c>identity/mission</c>);</item>
+    /// <item>any of the above WITH a trailing <c>.md</c> (stripped, so the
+    ///   documented short file form <c>identity/mission.md</c> matches the
+    ///   extension-less node id <c>identity/mission</c>).</item>
+    /// </list>
+    /// A leading/trailing <c>/</c> and any <c>.</c> (no-op) segment are
+    /// tolerated and dropped; a <c>..</c> segment is rejected outright
+    /// (returns null) rather than silently resolved, since it could
+    /// otherwise walk a hint outside the domain it claims to scope.
+    /// Comparison is case-sensitive (<see cref="StringComparison.Ordinal"/>)
+    /// throughout, matching every other path-handling surface in this
+    /// codebase (case-sensitive filesystem semantics) — pinned explicitly
+    /// here since path overlap has no other natural default.
+    /// </summary>
+    private static IReadOnlyList<string>? NormalizeHintSegments(string hint, string domain, string domainRoot)
     {
-        var normalizedHint = hint.Replace('\\', '/').Trim().TrimEnd('/');
-        if (normalizedHint.Length == 0)
+        if (string.IsNullOrWhiteSpace(hint))
         {
-            return false;
+            return null;
         }
 
-        var normalizedCandidate = candidate.Replace('\\', '/');
-        return string.Equals(normalizedCandidate, normalizedHint, StringComparison.Ordinal)
-            || normalizedCandidate.StartsWith(normalizedHint + "/", StringComparison.Ordinal);
+        var normalized = hint.Trim().Replace('\\', '/');
+
+        if (Path.IsPathRooted(normalized))
+        {
+            string fullHintPath;
+            string fullDomainRoot;
+            try
+            {
+                fullHintPath = Path.GetFullPath(normalized).Replace('\\', '/');
+                fullDomainRoot = Path.GetFullPath(domainRoot).Replace('\\', '/').TrimEnd('/');
+            }
+            catch (Exception exception) when (exception is ArgumentException or NotSupportedException or PathTooLongException)
+            {
+                return null;
+            }
+
+            if (string.Equals(fullHintPath, fullDomainRoot, StringComparison.Ordinal))
+            {
+                normalized = string.Empty;
+            }
+            else if (fullHintPath.StartsWith(fullDomainRoot + "/", StringComparison.Ordinal))
+            {
+                normalized = fullHintPath[(fullDomainRoot.Length + 1)..];
+            }
+            else
+            {
+                return null; // outside the domain root entirely — never matches
+            }
+        }
+        else
+        {
+            var domainPrefix = $"intents/{domain}/";
+            if (normalized.StartsWith(domainPrefix, StringComparison.Ordinal))
+            {
+                normalized = normalized[domainPrefix.Length..];
+            }
+            else if (string.Equals(normalized.TrimEnd('/'), $"intents/{domain}", StringComparison.Ordinal))
+            {
+                normalized = string.Empty;
+            }
+            // else: already the short domain-relative form — used as-is.
+        }
+
+        normalized = normalized.Trim('/');
+        if (normalized.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[..^3];
+        }
+
+        if (normalized.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        var segments = new List<string>();
+        foreach (var segment in normalized.Split('/'))
+        {
+            if (segment.Length == 0 || segment == ".")
+            {
+                continue;
+            }
+            if (segment == "..")
+            {
+                return null; // reject traversal outside the domain
+            }
+            segments.Add(segment);
+        }
+
+        return segments;
+    }
+
+    /// <summary>
+    /// Symmetric segment-boundary overlap: true when either segment list is
+    /// a whole-segment prefix of the other (covers an exact match, a hint
+    /// naming an ancestor directory of a node, AND the reverse — a node
+    /// whose own segments are a prefix of a more specific hint). An empty
+    /// segment list (a hint that normalized to the domain root itself) is a
+    /// prefix of everything, so it matches every node — a deliberate "scope
+    /// to the whole domain" hint, not a bug. Never a bare string-prefix
+    /// comparison, so a hint like <c>means</c> can never spuriously match a
+    /// node <c>means-2/flow</c> ("means" is not a whole segment of
+    /// "means-2").
+    /// </summary>
+    private static bool SegmentsOverlap(IReadOnlyList<string> a, IReadOnlyList<string> b)
+    {
+        var shorter = a.Count <= b.Count ? a : b;
+        var longer = a.Count <= b.Count ? b : a;
+        for (var i = 0; i < shorter.Count; i++)
+        {
+            if (!string.Equals(shorter[i], longer[i], StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+        return true;
     }
 }
 
@@ -166,13 +329,28 @@ internal sealed record FacetContextSelection
     public required IReadOnlyList<FacetContextGroup> Groups { get; init; }
 
     /// <summary>
-    /// True when the DOMAIN has at least one facet-annotated node, ignoring
-    /// any <c>--scope</c>/<c>--facets</c> narrowing — used to distinguish
-    /// "this domain has no facet nodes at all" (graceful-degradation note)
-    /// from "this query's filter/scope happened to match nothing" (an
-    /// ordinary empty result, not a degradation case).
+    /// True when the DOMAIN has at least one node contributing a VALID
+    /// facet, ignoring any <c>--scope</c>/<c>--facets</c> narrowing — used
+    /// to distinguish "this domain has no usable facet nodes at all"
+    /// (graceful-degradation note) from "this query's filter/scope happened
+    /// to match nothing" (an ordinary empty result, not a degradation
+    /// case). A domain whose only <c>facets:</c> declarations are malformed
+    /// or entirely unknown-valued is still <see langword="false"/> here —
+    /// check <see cref="Warnings"/> to tell that apart from a domain that
+    /// never adopted facets at all.
     /// </summary>
     public required bool DomainHasAnyFacetNodes { get; init; }
+
+    /// <summary>
+    /// G530 review repair: every node excluded from the facet groups
+    /// because its own <c>facets:</c> declaration was malformed, plus every
+    /// node whose Present declaration carried at least one unknown value
+    /// (that node may still appear in <see cref="Groups"/> under its OTHER
+    /// valid facets — the warning only concerns the unknown value itself).
+    /// Never silent: both JSON and Markdown renderers surface this list so
+    /// an agent can tell omitted-with-a-reason apart from never-existed.
+    /// </summary>
+    public required IReadOnlyList<FacetContextWarning> Warnings { get; init; }
 }
 
 internal sealed record FacetContextGroup
@@ -197,4 +375,13 @@ internal sealed record FacetContextNodeRef
 
     [JsonPropertyName("path")]
     public required string Path { get; init; }
+}
+
+internal sealed record FacetContextWarning
+{
+    [JsonPropertyName("path")]
+    public required string Path { get; init; }
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/FacetContextSelector.cs
+++ b/src/IntentSystem.Cli/Commands/FacetContextSelector.cs
@@ -258,6 +258,25 @@ internal static class FacetContextSelector
 
         var normalized = hint.Trim().Replace('\\', '/');
 
+        // G530 review repair: reject a literal ".." segment on the
+        // NORMALIZED ORIGINAL hint text — before any filesystem
+        // canonicalization. For an absolute hint, Path.GetFullPath below
+        // would silently RESOLVE (and thereby hide) a traversal such as
+        // "<domainRoot>/identity/../identity/mission.md" before the old
+        // post-canonicalization segment loop ever saw it, so an absolute
+        // hint using ".." syntax was wrongly accepted while the identical
+        // RELATIVE hint text was correctly rejected. Checking here — on the
+        // slash-unified text, which already folds backslash separators in,
+        // so a mixed-separator traversal can't hide either — applies the
+        // same rejection uniformly to both hint forms, and never flags a
+        // benign segment that merely contains a dot (only a segment that is
+        // LITERALLY "..").
+        if (normalized.Split('/').Any(segment => segment == ".."))
+        {
+            rejectionReason = "contains a '..' traversal segment, which is rejected rather than resolved";
+            return null;
+        }
+
         if (Path.IsPathRooted(normalized))
         {
             string fullHintPath;

--- a/src/IntentSystem.Cli/Commands/FacetContextSelector.cs
+++ b/src/IntentSystem.Cli/Commands/FacetContextSelector.cs
@@ -120,11 +120,23 @@ internal static class FacetContextSelector
 
         var domainHasAnyFacetNodes = nodes.Count > 0;
 
-        var normalizedHints = (scopeHints ?? Array.Empty<string>())
-            .Select(hint => NormalizeHintSegments(hint, domain, domainRoot))
-            .Where(segments => segments is not null)
-            .Select(segments => segments!)
-            .ToArray();
+        // G530 review repair: a hint that NormalizeHintSegments rejects
+        // (outside the domain root, a `..` traversal, or otherwise
+        // unresolvable) still safely matches nothing — but that must never
+        // look identical to a valid scope that simply matched no nodes.
+        // Every rejected hint is captured here, verbatim, with the reason.
+        var scopeWarnings = new List<FacetScopeWarning>();
+        var normalizedHints = new List<IReadOnlyList<string>>();
+        foreach (var hint in scopeHints ?? Array.Empty<string>())
+        {
+            var segments = NormalizeHintSegments(hint, domain, domainRoot, out var rejectionReason);
+            if (segments is null)
+            {
+                scopeWarnings.Add(new FacetScopeWarning { Hint = hint, Reason = rejectionReason! });
+                continue;
+            }
+            normalizedHints.Add(segments);
+        }
 
         // Narrowing is requested whenever the caller passed a scope-hint
         // LIST AT ALL — including an EXPLICITLY EMPTY one (e.g. a packet
@@ -138,6 +150,13 @@ internal static class FacetContextSelector
         var scoped = scopeHints is not null
             ? nodes.Where(node => normalizedHints.Any(hint => SegmentsOverlap(hint, node.DomainRelativeId.Split('/')))).ToArray()
             : nodes.ToArray();
+
+        // "All requested hints were rejected" is only true, by definition,
+        // when the caller requested at least one hint AND every one of
+        // them ended up in scopeWarnings (none survived into
+        // normalizedHints) — computed rather than tracked separately so it
+        // can never drift out of sync with the two lists above.
+        var allScopeHintsRejected = scopeHints is { Count: > 0 } && normalizedHints.Count == 0;
 
         var groups = new List<FacetContextGroup>();
         foreach (var facet in IntentNodeFacets.AllowedValues)
@@ -166,6 +185,8 @@ internal static class FacetContextSelector
             Groups = groups,
             DomainHasAnyFacetNodes = domainHasAnyFacetNodes,
             Warnings = warnings,
+            ScopeWarnings = scopeWarnings,
+            AllScopeHintsRejected = allScopeHintsRejected,
         };
     }
 
@@ -192,12 +213,18 @@ internal static class FacetContextSelector
 
     /// <summary>
     /// Normalizes a scope hint into a domain-relative segment list, or
-    /// <see langword="null"/> when the hint is empty/whitespace, resolves
-    /// outside <paramref name="domainRoot"/> entirely, or attempts to
-    /// escape the domain via a <c>..</c> segment. Accepted hint forms —
-    /// all reduced to the SAME canonical segment list a node's own
-    /// domain-relative id already uses, so comparison is always
-    /// apples-to-apples:
+    /// <see langword="null"/> (with <paramref name="rejectionReason"/> set)
+    /// when the hint is empty/whitespace, resolves outside
+    /// <paramref name="domainRoot"/> entirely, or attempts to escape the
+    /// domain via a <c>..</c> segment. G530 review repair: a rejection is
+    /// NEVER silent — the caller (<see cref="Select"/>) surfaces every
+    /// rejected hint, verbatim, with this reason, as a
+    /// <see cref="FacetScopeWarning"/>, so "--scope matched nothing because
+    /// every hint was invalid" is never indistinguishable from "--scope
+    /// matched nothing because no node happened to overlap a genuinely
+    /// valid hint". Accepted hint forms — all reduced to the SAME canonical
+    /// segment list a node's own domain-relative id already uses, so
+    /// comparison is always apples-to-apples:
     /// <list type="bullet">
     /// <item>an absolute filesystem path under <paramref name="domainRoot"/>
     ///   (reduced by subtracting the domain root, exactly like a node's own
@@ -219,10 +246,13 @@ internal static class FacetContextSelector
     /// codebase (case-sensitive filesystem semantics) — pinned explicitly
     /// here since path overlap has no other natural default.
     /// </summary>
-    private static IReadOnlyList<string>? NormalizeHintSegments(string hint, string domain, string domainRoot)
+    private static IReadOnlyList<string>? NormalizeHintSegments(string hint, string domain, string domainRoot, out string? rejectionReason)
     {
+        rejectionReason = null;
+
         if (string.IsNullOrWhiteSpace(hint))
         {
+            rejectionReason = "hint is empty or whitespace-only";
             return null;
         }
 
@@ -239,6 +269,7 @@ internal static class FacetContextSelector
             }
             catch (Exception exception) when (exception is ArgumentException or NotSupportedException or PathTooLongException)
             {
+                rejectionReason = $"could not be resolved as a filesystem path: {exception.Message}";
                 return null;
             }
 
@@ -252,7 +283,9 @@ internal static class FacetContextSelector
             }
             else
             {
-                return null; // outside the domain root entirely — never matches
+                // outside the domain root entirely — never matches
+                rejectionReason = $"resolves to '{fullHintPath}', which is outside the domain root '{fullDomainRoot}'";
+                return null;
             }
         }
         else
@@ -289,7 +322,9 @@ internal static class FacetContextSelector
             }
             if (segment == "..")
             {
-                return null; // reject traversal outside the domain
+                // reject traversal outside the domain — never silently resolved
+                rejectionReason = "contains a '..' traversal segment, which is rejected rather than resolved";
+                return null;
             }
             segments.Add(segment);
         }
@@ -351,6 +386,26 @@ internal sealed record FacetContextSelection
     /// an agent can tell omitted-with-a-reason apart from never-existed.
     /// </summary>
     public required IReadOnlyList<FacetContextWarning> Warnings { get; init; }
+
+    /// <summary>
+    /// G530 review repair: every requested <c>--scope</c>/<c>intent_references</c>
+    /// hint that <see cref="FacetContextSelector.NormalizeHintSegments"/>
+    /// rejected (outside the domain root, a <c>..</c> traversal, or
+    /// otherwise unresolvable), verbatim, with the reason. A rejected hint
+    /// still safely contributes zero matches — but never silently, so
+    /// "matched nothing because every hint was invalid" is distinguishable
+    /// from "matched nothing because a valid hint just didn't overlap any
+    /// node".
+    /// </summary>
+    public required IReadOnlyList<FacetScopeWarning> ScopeWarnings { get; init; }
+
+    /// <summary>
+    /// True only when the caller requested at least one scope hint AND
+    /// every single one of them was rejected (none survived into the
+    /// actual narrowing) — lets a renderer say so explicitly rather than
+    /// leaving the reader to infer it by counting <see cref="ScopeWarnings"/>.
+    /// </summary>
+    public required bool AllScopeHintsRejected { get; init; }
 }
 
 internal sealed record FacetContextGroup
@@ -381,6 +436,15 @@ internal sealed record FacetContextWarning
 {
     [JsonPropertyName("path")]
     public required string Path { get; init; }
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+}
+
+internal sealed record FacetScopeWarning
+{
+    [JsonPropertyName("hint")]
+    public required string Hint { get; init; }
 
     [JsonPropertyName("reason")]
     public required string Reason { get; init; }

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -25,6 +25,30 @@ internal static class PacketDraftCommand
     private const string FileSkipped = "skipped";
     private const string FilePlanned = "planned";
 
+    /// <summary>
+    /// G530 review repair: review-context.md's Facet context block is
+    /// selectively regenerated (not merely created-once-or-skipped like the
+    /// other three scaffold files) — this status distinguishes "the
+    /// existing file's generated block was refreshed" from a fresh
+    /// <see cref="FileCreated"/> or an untouched <see cref="FileSkipped"/>.
+    /// </summary>
+    private const string FileUpdated = "updated";
+
+    /// <summary>
+    /// G530 review repair: delimits the machine-owned Facet context block
+    /// inside review-context.md. Content between these markers is fully
+    /// regenerated on every `packet draft` run (never hand-edited content —
+    /// treat it as codegen output); content OUTSIDE the markers — including
+    /// everything before/after them in the file — is NEVER touched. A
+    /// review-context.md that predates this feature (or had the markers
+    /// manually removed) has neither marker, so it is left alone entirely,
+    /// exactly like the other three scaffold files' plain skip-if-exists
+    /// behavior — the markers are never retroactively injected into
+    /// hand-owned content.
+    /// </summary>
+    private const string FacetContextBeginMarker = "<!-- BEGIN GENERATED FACET CONTEXT (G530) -->";
+    private const string FacetContextEndMarker = "<!-- END GENERATED FACET CONTEXT (G530) -->";
+
     private const string UsageLine =
         "Usage: intent-cli packet draft --execution-unit <id> [--domain <name>] [--target-repo <owner/repo>] [--dry-run] [--format markdown|json]";
 
@@ -108,15 +132,16 @@ internal static class PacketDraftCommand
             ? BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy)
             : CliRuntimeContracts.DirectMainBaseBranch;
 
-        // G530: review-context.md's generated "Facet context" section scopes
+        // G530: review-context.md's generated "Facet context" block scopes
         // to whatever `intent_references` an EXISTING packet.yaml on disk
         // already declares — never the freshly-templated `[]` this same
         // call may be about to write for packet.yaml itself (that write
         // happens below, after this read). This is what makes
         // "regenerating an existing packet" meaningful: packet.yaml can
         // already carry hand-edited references (added after an earlier
-        // `packet draft` run) even though review-context.md does not yet
-        // exist, and the section reflects those real references.
+        // `packet draft` run), and every subsequent `packet draft` run
+        // refreshes the generated block to match current references —
+        // never the surrounding hand-owned content.
         var packetYamlPath = Path.Combine(packetDirectory, "packet.yaml");
         var intentReferences = ReadIntentReferences(packetYamlPath);
         var facetDomainRoot = ResolveFacetDomainRoot(context, domain);
@@ -126,7 +151,6 @@ internal static class PacketDraftCommand
         {
             ("packet.yaml", BuildPacketYaml(executionUnit, domain, targetRepo)),
             ("implementation.md", BuildImplementationMd(executionUnit)),
-            ("review-context.md", BuildReviewContextMd(executionUnit, facetSelection)),
             ("github-body.md", BuildGithubBodyMd(executionUnit, baseBranchPolicy, expectedBaseBranch))
         };
 
@@ -158,6 +182,11 @@ internal static class PacketDraftCommand
                 Status = status
             });
         }
+
+        // Inserted at its original position (between implementation.md and
+        // github-body.md) so the reported file order matches the canonical
+        // four-file layout regardless of the dedicated handling below.
+        files.Insert(2, WriteOrUpdateReviewContext(packetDirectory, executionUnit, facetSelection, dryRun));
 
         // Validate contract sections against whatever github-body.md ends up on disk
         // (skeleton if newly written, existing content if previously authored).
@@ -289,6 +318,14 @@ internal static class PacketDraftCommand
             """;
     }
 
+    /// <summary>
+    /// G530 review repair: the review-context.md scaffold, once created,
+    /// gets its Facet context block selectively refreshed on every later
+    /// `packet draft` run rather than the whole file being locked at
+    /// creation time — see <see cref="WriteOrUpdateReviewContext"/>. Content
+    /// is only ever written by that method; this helper produces the FULL
+    /// file for the fresh-create case.
+    /// </summary>
     private static string BuildReviewContextMd(string executionUnit, FacetContextSelection facetSelection)
     {
         return $"""
@@ -305,7 +342,9 @@ internal static class PacketDraftCommand
 
             ## Facet context
 
-            {BuildFacetContextSection(facetSelection)}
+            {FacetContextBeginMarker}
+            {BuildFacetContextBlockContent(facetSelection)}
+            {FacetContextEndMarker}
 
             ## Knowledge Writeback Expectation (G461)
 
@@ -317,36 +356,110 @@ internal static class PacketDraftCommand
     }
 
     /// <summary>
-    /// G530: the four G529 semantic-facet nodes (vocabulary/invariant/
-    /// decider/acceptance-property) overlapping this packet's own declared
-    /// `intent_references` — the semantic core the implementation must
-    /// respect, surfaced directly in the review contract rather than left
-    /// for a reviewer to reconstruct by hand.
+    /// G530 (review-repaired): the four G529 semantic-facet nodes
+    /// (vocabulary/invariant/decider/acceptance-property) overlapping this
+    /// packet's own declared `intent_references` — the semantic core the
+    /// implementation must respect, surfaced directly in the review
+    /// contract rather than left for a reviewer to reconstruct by hand.
+    /// This is exactly the content written BETWEEN the generated-block
+    /// markers — see <see cref="WriteOrUpdateReviewContext"/> — so it is
+    /// entirely machine-owned and safe to regenerate on every run. Malformed
+    /// or unknown-valued `facets:` declarations are never silently dropped:
+    /// they surface as trailing warning lines naming the excluded path and
+    /// reason.
     /// </summary>
-    private static string BuildFacetContextSection(FacetContextSelection facetSelection)
+    private static string BuildFacetContextBlockContent(FacetContextSelection facetSelection)
     {
+        var lines = new List<string>();
         if (!facetSelection.DomainHasAnyFacetNodes)
         {
-            return "No facet-annotated nodes found for this domain — facets (G529) are optional and this is the norm before a tree adopts them.";
+            lines.Add("No facet-annotated nodes found for this domain — facets (G529) are optional and this is the norm before a tree adopts them.");
+        }
+        else
+        {
+            foreach (var group in facetSelection.Groups)
+            {
+                lines.Add($"### {group.Facet}");
+                if (group.Nodes.Count == 0)
+                {
+                    lines.Add("- (none overlapping this packet's intent_references)");
+                    continue;
+                }
+
+                foreach (var node in group.Nodes)
+                {
+                    lines.Add($"- `{node.Id}` [{string.Join(", ", node.Facets)}] {node.Summary} — `{node.Path}`");
+                }
+            }
         }
 
-        var lines = new List<string>();
-        foreach (var group in facetSelection.Groups)
+        if (facetSelection.Warnings.Count > 0)
         {
-            lines.Add($"### {group.Facet}");
-            if (group.Nodes.Count == 0)
+            lines.Add(string.Empty);
+            lines.Add("Warnings (excluded from the facet context above):");
+            foreach (var warning in facetSelection.Warnings)
             {
-                lines.Add("- (none overlapping this packet's intent_references)");
-                continue;
-            }
-
-            foreach (var node in group.Nodes)
-            {
-                lines.Add($"- `{node.Id}` [{string.Join(", ", node.Facets)}] {node.Summary} — `{node.Path}`");
+                lines.Add($"- `{warning.Path}`: {warning.Reason}");
             }
         }
 
         return string.Join('\n', lines);
+    }
+
+    /// <summary>
+    /// G530 review repair: creates review-context.md fresh (matching the
+    /// other three scaffold files' first-write behavior) when it does not
+    /// yet exist. When it DOES exist, the file as a whole is never
+    /// overwritten — but if it carries the generated-block markers (see
+    /// <see cref="FacetContextBeginMarker"/>), the content strictly BETWEEN
+    /// them is replaced with a freshly-computed <see cref="FacetContextSelection"/>
+    /// while everything before/after the markers (all hand-owned content)
+    /// is preserved byte-for-byte. A review-context.md with no recognizable
+    /// markers (predates this feature, or an operator removed them) is left
+    /// completely untouched — the markers are never retroactively injected.
+    /// </summary>
+    private static PacketDraftFile WriteOrUpdateReviewContext(
+        string packetDirectory, string executionUnit, FacetContextSelection facetSelection, bool dryRun)
+    {
+        const string name = "review-context.md";
+        var path = Path.Combine(packetDirectory, name);
+
+        if (!File.Exists(path))
+        {
+            var status = dryRun ? FilePlanned : FileCreated;
+            if (!dryRun)
+            {
+                File.WriteAllText(path, BuildReviewContextMd(executionUnit, facetSelection));
+            }
+            return new PacketDraftFile { Name = name, Path = path, Status = status };
+        }
+
+        var existing = File.ReadAllText(path);
+        var beginIndex = existing.IndexOf(FacetContextBeginMarker, StringComparison.Ordinal);
+        var endIndex = beginIndex < 0
+            ? -1
+            : existing.IndexOf(FacetContextEndMarker, beginIndex, StringComparison.Ordinal);
+
+        if (beginIndex < 0 || endIndex < 0)
+        {
+            return new PacketDraftFile { Name = name, Path = path, Status = FileSkipped };
+        }
+
+        var beforeAndBeginMarker = existing[..(beginIndex + FacetContextBeginMarker.Length)];
+        var endMarkerOnward = existing[endIndex..];
+        var updatedContent = $"{beforeAndBeginMarker}\n{BuildFacetContextBlockContent(facetSelection)}\n{endMarkerOnward}";
+
+        if (string.Equals(updatedContent, existing, StringComparison.Ordinal))
+        {
+            return new PacketDraftFile { Name = name, Path = path, Status = FileSkipped };
+        }
+
+        var updateStatus = dryRun ? FilePlanned : FileUpdated;
+        if (!dryRun)
+        {
+            File.WriteAllText(path, updatedContent);
+        }
+        return new PacketDraftFile { Name = name, Path = path, Status = updateStatus };
     }
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -108,11 +108,25 @@ internal static class PacketDraftCommand
             ? BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy)
             : CliRuntimeContracts.DirectMainBaseBranch;
 
+        // G530: review-context.md's generated "Facet context" section scopes
+        // to whatever `intent_references` an EXISTING packet.yaml on disk
+        // already declares — never the freshly-templated `[]` this same
+        // call may be about to write for packet.yaml itself (that write
+        // happens below, after this read). This is what makes
+        // "regenerating an existing packet" meaningful: packet.yaml can
+        // already carry hand-edited references (added after an earlier
+        // `packet draft` run) even though review-context.md does not yet
+        // exist, and the section reflects those real references.
+        var packetYamlPath = Path.Combine(packetDirectory, "packet.yaml");
+        var intentReferences = ReadIntentReferences(packetYamlPath);
+        var facetDomainRoot = ResolveFacetDomainRoot(context, domain);
+        var facetSelection = FacetContextSelector.Select(facetDomainRoot, domain, intentReferences, facetFilter: null);
+
         var planned = new[]
         {
             ("packet.yaml", BuildPacketYaml(executionUnit, domain, targetRepo)),
             ("implementation.md", BuildImplementationMd(executionUnit)),
-            ("review-context.md", BuildReviewContextMd(executionUnit)),
+            ("review-context.md", BuildReviewContextMd(executionUnit, facetSelection)),
             ("github-body.md", BuildGithubBodyMd(executionUnit, baseBranchPolicy, expectedBaseBranch))
         };
 
@@ -275,7 +289,7 @@ internal static class PacketDraftCommand
             """;
     }
 
-    private static string BuildReviewContextMd(string executionUnit)
+    private static string BuildReviewContextMd(string executionUnit, FacetContextSelection facetSelection)
     {
         return $"""
             # {executionUnit} Review Context
@@ -289,6 +303,10 @@ internal static class PacketDraftCommand
             - mutates GitHub or parent state when the issue is read-only;
             - skips required contract sections.
 
+            ## Facet context
+
+            {BuildFacetContextSection(facetSelection)}
+
             ## Knowledge Writeback Expectation (G461)
 
             If the packet's `closeout_learning.write_back_required` is `true`, confirm the
@@ -296,6 +314,98 @@ internal static class PacketDraftCommand
             captured as a follow-up packet. If the packet declined all knowledge maintenance,
             that is acceptable — note it rather than blocking.
             """;
+    }
+
+    /// <summary>
+    /// G530: the four G529 semantic-facet nodes (vocabulary/invariant/
+    /// decider/acceptance-property) overlapping this packet's own declared
+    /// `intent_references` — the semantic core the implementation must
+    /// respect, surfaced directly in the review contract rather than left
+    /// for a reviewer to reconstruct by hand.
+    /// </summary>
+    private static string BuildFacetContextSection(FacetContextSelection facetSelection)
+    {
+        if (!facetSelection.DomainHasAnyFacetNodes)
+        {
+            return "No facet-annotated nodes found for this domain — facets (G529) are optional and this is the norm before a tree adopts them.";
+        }
+
+        var lines = new List<string>();
+        foreach (var group in facetSelection.Groups)
+        {
+            lines.Add($"### {group.Facet}");
+            if (group.Nodes.Count == 0)
+            {
+                lines.Add("- (none overlapping this packet's intent_references)");
+                continue;
+            }
+
+            foreach (var node in group.Nodes)
+            {
+                lines.Add($"- `{node.Id}` [{string.Join(", ", node.Facets)}] {node.Summary} — `{node.Path}`");
+            }
+        }
+
+        return string.Join('\n', lines);
+    }
+
+    /// <summary>
+    /// G530: reads the `implementation_issue_packet.intent_references` list
+    /// from an EXISTING packet.yaml on disk (never the in-memory template
+    /// this same invocation may be about to write). Tolerant — a missing
+    /// file, missing section, or malformed YAML all degrade to an empty
+    /// list rather than an error, consistent with the rest of this
+    /// scaffolding command's never-fail posture.
+    /// </summary>
+    private static IReadOnlyList<string> ReadIntentReferences(string packetYamlPath)
+    {
+        if (!File.Exists(packetYamlPath))
+        {
+            return Array.Empty<string>();
+        }
+
+        try
+        {
+            var yaml = new YamlDotNet.RepresentationModel.YamlStream();
+            using var reader = new StringReader(File.ReadAllText(packetYamlPath));
+            yaml.Load(reader);
+
+            if (yaml.Documents.Count == 0
+                || yaml.Documents[0].RootNode is not YamlDotNet.RepresentationModel.YamlMappingNode root
+                || !root.Children.TryGetValue(
+                    new YamlDotNet.RepresentationModel.YamlScalarNode("implementation_issue_packet"), out var implementationNode)
+                || implementationNode is not YamlDotNet.RepresentationModel.YamlMappingNode implementationMapping
+                || !implementationMapping.Children.TryGetValue(
+                    new YamlDotNet.RepresentationModel.YamlScalarNode("intent_references"), out var referencesNode)
+                || referencesNode is not YamlDotNet.RepresentationModel.YamlSequenceNode referencesSequence)
+            {
+                return Array.Empty<string>();
+            }
+
+            return referencesSequence.Children
+                .OfType<YamlDotNet.RepresentationModel.YamlScalarNode>()
+                .Select(scalar => scalar.Value ?? string.Empty)
+                .Where(value => value.Length > 0)
+                .ToArray();
+        }
+        catch (YamlDotNet.Core.YamlException)
+        {
+            return Array.Empty<string>();
+        }
+    }
+
+    /// <summary>
+    /// G530: same parent-host-aware domain root resolution
+    /// <c>context collect</c> already uses for clarification/automation-
+    /// bindings paths — a child implementation workspace's intent tree
+    /// (and therefore its facet nodes) lives under the PARENT host root
+    /// when one is configured, else the local repo.
+    /// </summary>
+    private static string ResolveFacetDomainRoot(CliContext context, string domain)
+    {
+        var parentRoot = context.ResolveParentIntentRepoRootPath();
+        var baseRoot = string.IsNullOrWhiteSpace(parentRoot) ? context.RepoRoot : parentRoot;
+        return Path.Combine(baseRoot!, "intents", domain);
     }
 
     private static string BuildGithubBodyMd(string executionUnit, string baseBranchPolicy, string expectedBaseBranch)

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -35,6 +35,17 @@ internal static class PacketDraftCommand
     private const string FileUpdated = "updated";
 
     /// <summary>
+    /// G530 review repair: distinct from <see cref="FileSkipped"/> (which
+    /// also covers the genuinely healthy "no markers at all, a legacy file"
+    /// case). This status means the file HAS marker text but not in the one
+    /// safe shape (exactly one begin, exactly one end, begin before end) —
+    /// fail-closed: the file is never mutated, but the caller must be able
+    /// to tell "untouched because healthy" apart from "untouched because
+    /// something is wrong with the markers" (see <see cref="PacketDraftFile.Detail"/>).
+    /// </summary>
+    private const string FileMarkersMalformed = "markers-malformed";
+
+    /// <summary>
     /// G530 review repair: delimits the machine-owned Facet context block
     /// inside review-context.md. Content between these markers is fully
     /// regenerated on every `packet draft` run (never hand-edited content —
@@ -403,6 +414,23 @@ internal static class PacketDraftCommand
             }
         }
 
+        // G530 review repair: an intent_references entry that could not be
+        // resolved to a domain-relative path must never look like "this
+        // packet simply references nothing overlapping" — it is reported
+        // exactly like context collect's rejected --scope hints.
+        if (facetSelection.ScopeWarnings.Count > 0)
+        {
+            lines.Add(string.Empty);
+            lines.Add(
+                facetSelection.AllScopeHintsRejected
+                    ? "Scope warnings (ALL of this packet's intent_references were rejected — nothing was scoped in):"
+                    : "Scope warnings (these intent_references entries were rejected; other valid entries were still applied):");
+            foreach (var warning in facetSelection.ScopeWarnings)
+            {
+                lines.Add($"- `{warning.Hint}`: {warning.Reason}");
+            }
+        }
+
         return string.Join('\n', lines);
     }
 
@@ -410,13 +438,21 @@ internal static class PacketDraftCommand
     /// G530 review repair: creates review-context.md fresh (matching the
     /// other three scaffold files' first-write behavior) when it does not
     /// yet exist. When it DOES exist, the file as a whole is never
-    /// overwritten — but if it carries the generated-block markers (see
-    /// <see cref="FacetContextBeginMarker"/>), the content strictly BETWEEN
-    /// them is replaced with a freshly-computed <see cref="FacetContextSelection"/>
-    /// while everything before/after the markers (all hand-owned content)
-    /// is preserved byte-for-byte. A review-context.md with no recognizable
-    /// markers (predates this feature, or an operator removed them) is left
-    /// completely untouched — the markers are never retroactively injected.
+    /// overwritten — but if it carries EXACTLY ONE correctly-ordered pair of
+    /// generated-block markers (see <see cref="FacetContextBeginMarker"/>),
+    /// the content strictly BETWEEN them is replaced with a
+    /// freshly-computed <see cref="FacetContextSelection"/> while
+    /// everything before/after the markers (all hand-owned content) is
+    /// preserved byte-for-byte, using the FILE'S OWN existing newline style
+    /// (CRLF or LF) rather than hardcoding one. A review-context.md with NO
+    /// markers at all (predates this feature, or an operator removed them)
+    /// is left completely untouched — <see cref="FileSkipped"/>, the
+    /// markers are never retroactively injected. A review-context.md with
+    /// markers in any OTHER shape (duplicates, reversed order, only a begin
+    /// or only an end) is ALSO left completely untouched — but reported
+    /// distinctly as <see cref="FileMarkersMalformed"/> with a diagnostic
+    /// <see cref="PacketDraftFile.Detail"/>, so that state is never
+    /// indistinguishable from the genuinely healthy no-markers-at-all case.
     /// </summary>
     private static PacketDraftFile WriteOrUpdateReviewContext(
         string packetDirectory, string executionUnit, FacetContextSelection facetSelection, bool dryRun)
@@ -435,19 +471,39 @@ internal static class PacketDraftCommand
         }
 
         var existing = File.ReadAllText(path);
-        var beginIndex = existing.IndexOf(FacetContextBeginMarker, StringComparison.Ordinal);
-        var endIndex = beginIndex < 0
-            ? -1
-            : existing.IndexOf(FacetContextEndMarker, beginIndex, StringComparison.Ordinal);
+        var markerShape = ClassifyGeneratedBlockMarkers(existing);
 
-        if (beginIndex < 0 || endIndex < 0)
+        if (markerShape.Kind == GeneratedBlockMarkerKind.None)
         {
             return new PacketDraftFile { Name = name, Path = path, Status = FileSkipped };
         }
 
-        var beforeAndBeginMarker = existing[..(beginIndex + FacetContextBeginMarker.Length)];
-        var endMarkerOnward = existing[endIndex..];
-        var updatedContent = $"{beforeAndBeginMarker}\n{BuildFacetContextBlockContent(facetSelection)}\n{endMarkerOnward}";
+        if (markerShape.Kind == GeneratedBlockMarkerKind.Malformed)
+        {
+            return new PacketDraftFile
+            {
+                Name = name,
+                Path = path,
+                Status = FileMarkersMalformed,
+                Detail = markerShape.Diagnostic,
+            };
+        }
+
+        // Preserve the FILE'S OWN newline convention for both the newly
+        // inserted separators and the block content's internal newlines —
+        // never hardcode "\n", which would mix line-ending styles into an
+        // existing CRLF file.
+        var usesCrlf = existing.Contains("\r\n", StringComparison.Ordinal);
+        var newline = usesCrlf ? "\r\n" : "\n";
+        var blockContent = BuildFacetContextBlockContent(facetSelection);
+        if (usesCrlf)
+        {
+            blockContent = blockContent.Replace("\n", "\r\n", StringComparison.Ordinal);
+        }
+
+        var beforeAndBeginMarker = existing[..(markerShape.BeginIndex + FacetContextBeginMarker.Length)];
+        var endMarkerOnward = existing[markerShape.EndIndex..];
+        var updatedContent = $"{beforeAndBeginMarker}{newline}{blockContent}{newline}{endMarkerOnward}";
 
         if (string.Equals(updatedContent, existing, StringComparison.Ordinal))
         {
@@ -460,6 +516,83 @@ internal static class PacketDraftCommand
             File.WriteAllText(path, updatedContent);
         }
         return new PacketDraftFile { Name = name, Path = path, Status = updateStatus };
+    }
+
+    private enum GeneratedBlockMarkerKind
+    {
+        /// <summary>No begin marker and no end marker anywhere — a healthy legacy file (or one never scaffolded by this feature).</summary>
+        None,
+
+        /// <summary>Exactly one begin marker, exactly one end marker, begin strictly before end — safe to regenerate.</summary>
+        ValidPair,
+
+        /// <summary>Any other shape: duplicates, reversed order, or only one of the two markers present.</summary>
+        Malformed,
+    }
+
+    private readonly record struct GeneratedBlockMarkerShape(
+        GeneratedBlockMarkerKind Kind, int BeginIndex, int EndIndex, string? Diagnostic);
+
+    /// <summary>
+    /// G530 review repair: classifies review-context.md's marker state
+    /// before any mutation is attempted — fail-closed. Only the single
+    /// unambiguous "exactly one begin, exactly one end, begin before end"
+    /// shape is safe to regenerate; every other shape (duplicate markers of
+    /// either kind, an end appearing before its begin, or only one of the
+    /// two present) is reported as <see cref="GeneratedBlockMarkerKind.Malformed"/>
+    /// with a human-readable diagnostic rather than silently doing nothing
+    /// OR silently picking an arbitrary pair.
+    /// </summary>
+    private static GeneratedBlockMarkerShape ClassifyGeneratedBlockMarkers(string content)
+    {
+        var beginPositions = AllIndicesOf(content, FacetContextBeginMarker);
+        var endPositions = AllIndicesOf(content, FacetContextEndMarker);
+
+        if (beginPositions.Count == 0 && endPositions.Count == 0)
+        {
+            return new GeneratedBlockMarkerShape(GeneratedBlockMarkerKind.None, -1, -1, null);
+        }
+
+        if (beginPositions.Count == 1 && endPositions.Count == 1 && endPositions[0] > beginPositions[0])
+        {
+            return new GeneratedBlockMarkerShape(GeneratedBlockMarkerKind.ValidPair, beginPositions[0], endPositions[0], null);
+        }
+
+        string diagnostic;
+        if (beginPositions.Count == 0)
+        {
+            diagnostic = $"found {endPositions.Count} end marker(s) but no begin marker — expected exactly one of each.";
+        }
+        else if (endPositions.Count == 0)
+        {
+            diagnostic = $"found {beginPositions.Count} begin marker(s) but no end marker — expected exactly one of each.";
+        }
+        else if (beginPositions.Count > 1 || endPositions.Count > 1)
+        {
+            diagnostic = $"found {beginPositions.Count} begin marker(s) and {endPositions.Count} end marker(s) — expected exactly one of each.";
+        }
+        else
+        {
+            diagnostic = "the end marker appears before the begin marker.";
+        }
+
+        return new GeneratedBlockMarkerShape(GeneratedBlockMarkerKind.Malformed, -1, -1, diagnostic);
+    }
+
+    private static List<int> AllIndicesOf(string content, string marker)
+    {
+        var indices = new List<int>();
+        var searchStart = 0;
+        while (true)
+        {
+            var index = content.IndexOf(marker, searchStart, StringComparison.Ordinal);
+            if (index < 0)
+            {
+                return indices;
+            }
+            indices.Add(index);
+            searchStart = index + marker.Length;
+        }
     }
 
     /// <summary>
@@ -632,6 +765,10 @@ internal static class PacketDraftCommand
         foreach (var file in result.Files)
         {
             writer.WriteLine($"- {file.Name}: {file.Status}");
+            if (file.Detail is not null)
+            {
+                writer.WriteLine($"  - {file.Detail}");
+            }
         }
         writer.WriteLine();
 
@@ -801,4 +938,14 @@ internal sealed record PacketDraftFile
 
     [JsonPropertyName("status")]
     public required string Status { get; init; }
+
+    /// <summary>
+    /// G530 review repair: set only for review-context.md's <c>markers-malformed</c>
+    /// status — a human-readable diagnostic explaining exactly what shape
+    /// the generated-block markers were found in (duplicates, reversed
+    /// order, one-sided), so the fail-closed "left untouched" outcome is
+    /// actionable rather than a bare status string.
+    /// </summary>
+    [JsonPropertyName("detail")]
+    public string? Detail { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/ContextCollectCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ContextCollectCommandTests.cs
@@ -379,6 +379,73 @@ public sealed class ContextCollectCommandTests
         Assert.Single(vocabularyNodes);
     }
 
+    // ── Review repair: rejected --scope hints are never silent ──────────
+
+    [Fact]
+    public void Execute_ScopeHintOutsideDomainRoot_SurfacesScopeWarningInMarkdown()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var outsideHint = Path.Combine(Path.GetTempPath(), "definitely-outside", "file.md");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--scope", outsideHint], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Scope warnings", output, StringComparison.Ordinal);
+        Assert.Contains("ALL requested --scope hints were rejected", output, StringComparison.Ordinal);
+        Assert.Contains(outsideHint, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_FacetContextScopeWarningsShapeIsStableSnakeCase()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var outsideHint = Path.Combine(Path.GetTempPath(), "definitely-outside", "file.md");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--scope", outsideHint, "--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        var scopeWarnings = root.GetProperty("facet_context_scope_warnings").EnumerateArray().ToArray();
+        var warning = Assert.Single(scopeWarnings);
+        Assert.Equal(outsideHint, warning.GetProperty("hint").GetString());
+        Assert.Contains("outside", warning.GetProperty("reason").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.True(root.GetProperty("facet_context_all_scope_hints_rejected").GetBoolean());
+        // Rejected, so the node never appears — never silently "shown anyway".
+        var vocabularyNodes = root.GetProperty("facet_context")[0].GetProperty("nodes").EnumerateArray().ToArray();
+        Assert.Empty(vocabularyNodes);
+    }
+
+    [Fact]
+    public void Execute_MixedValidAndInvalidScopeHints_NotAllRejected_ValidHintStillApplied()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var outsideHint = Path.Combine(Path.GetTempPath(), "definitely-outside", "file.md");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context,
+            ["--scope", $"intents/intent-cli/identity,{outsideHint}", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("facet_context_all_scope_hints_rejected").GetBoolean());
+        var scopeWarnings = root.GetProperty("facet_context_scope_warnings").EnumerateArray().ToArray();
+        Assert.Single(scopeWarnings);
+        var vocabularyNodes = root.GetProperty("facet_context")[0].GetProperty("nodes").EnumerateArray().ToArray();
+        Assert.Single(vocabularyNodes);
+    }
+
     [Fact]
     public void Execute_GivenUnknownArgument_ReturnsErrorExitCode()
     {

--- a/tests/IntentSystem.Cli.Tests/ContextCollectCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ContextCollectCommandTests.cs
@@ -424,6 +424,54 @@ public sealed class ContextCollectCommandTests
     }
 
     [Fact]
+    public void Execute_AbsoluteScopeHintWithTraversalSegment_RejectedNotSilentlyCanonicalized()
+    {
+        // Round-4 review repair: an ABSOLUTE --scope value containing ".."
+        // that resolves right back to a real in-domain node must still be
+        // rejected — the traversal check must run on the original hint text
+        // before Path.GetFullPath canonicalizes the ".." away.
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var domainRoot = Path.Combine(workspace.Context.RepoRoot, "intents", "intent-cli");
+        var traversalHint = Path.Combine(domainRoot, "identity", "..", "identity", "mission.md");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--scope", traversalHint, "--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        var scopeWarnings = root.GetProperty("facet_context_scope_warnings").EnumerateArray().ToArray();
+        var warning = Assert.Single(scopeWarnings);
+        Assert.Equal(traversalHint, warning.GetProperty("hint").GetString());
+        Assert.Contains("traversal", warning.GetProperty("reason").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.True(root.GetProperty("facet_context_all_scope_hints_rejected").GetBoolean());
+        var vocabularyNodes = root.GetProperty("facet_context")[0].GetProperty("nodes").EnumerateArray().ToArray();
+        Assert.Empty(vocabularyNodes);
+    }
+
+    [Fact]
+    public void Execute_AbsoluteScopeHintWithMixedSeparatorTraversal_SurfacesScopeWarningInMarkdown()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var domainRoot = Path.Combine(workspace.Context.RepoRoot, "intents", "intent-cli");
+        var traversalHint = Path.Combine(domainRoot, "identity") + @"\..\identity\mission.md";
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--scope", traversalHint], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Scope warnings", output, StringComparison.Ordinal);
+        Assert.Contains("ALL requested --scope hints were rejected", output, StringComparison.Ordinal);
+        Assert.Contains(traversalHint, output, StringComparison.Ordinal);
+        Assert.Contains("traversal", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void Execute_MixedValidAndInvalidScopeHints_NotAllRejected_ValidHintStillApplied()
     {
         using var workspace = new ContextCollectWorkspace();

--- a/tests/IntentSystem.Cli.Tests/ContextCollectCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ContextCollectCommandTests.cs
@@ -178,6 +178,119 @@ public sealed class ContextCollectCommandTests
         Assert.Contains("Current Open Blockers", excerpt!, StringComparison.Ordinal);
     }
 
+    // ── G530: facet context section ─────────────────────────────────────
+
+    [Fact]
+    public void Execute_DomainWithFacetNodes_RendersFacetSectionAheadOfQueueStateInCanonicalOrder()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        workspace.WriteFacetNode("decisions/adr-1.md", ["decider"], "Decision One");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("## Facet context", output, StringComparison.Ordinal);
+        var facetIndex = output.IndexOf("## Facet context", StringComparison.Ordinal);
+        var queueIndex = output.IndexOf("## Queue state", StringComparison.Ordinal);
+        Assert.True(facetIndex >= 0 && queueIndex > facetIndex, "Facet context must render ahead of Queue state.");
+        var vocabularyIndex = output.IndexOf("### vocabulary", StringComparison.Ordinal);
+        var deciderIndex = output.IndexOf("### decider", StringComparison.Ordinal);
+        Assert.True(vocabularyIndex >= 0 && deciderIndex > vocabularyIndex, "vocabulary must render before decider.");
+        Assert.Contains("identity/mission", output, StringComparison.Ordinal);
+        Assert.Contains("Mission", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_FacetsFilter_RestrictsSectionToRequestedFacetsOnly()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        workspace.WriteFacetNode("decisions/adr-1.md", ["decider"], "Decision One");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--facets", "decider"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("### decider", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("### vocabulary", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_FacetsFilterUnknownValue_ReturnsErrorExitCode()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--facets", "not-a-real-facet"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--facets", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ScopeHint_NarrowsFacetSectionToOverlappingNodesOnly()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        workspace.WriteFacetNode("decisions/adr-1.md", ["vocabulary"], "Decision One");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--scope", "intents/intent-cli/identity"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("identity/mission", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("decisions/adr-1", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NoFacetAnnotatedNodesInDomain_EmitsGracefulDegradationNoteNeverAnError()
+    {
+        using var workspace = new ContextCollectWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("## Facet context", output, StringComparison.Ordinal);
+        Assert.Contains("no facet-annotated nodes found", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_FacetContextShapeIsStableSnakeCase()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary", "invariant"], "Mission");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        var facetContext = root.GetProperty("facet_context").EnumerateArray().ToArray();
+        Assert.Equal(4, facetContext.Length);
+        Assert.Equal("vocabulary", facetContext[0].GetProperty("facet").GetString());
+        var vocabularyNodes = facetContext[0].GetProperty("nodes").EnumerateArray().ToArray();
+        var node = Assert.Single(vocabularyNodes);
+        Assert.Equal("identity/mission", node.GetProperty("id").GetString());
+        Assert.Equal("intents/intent-cli/identity/mission.md", node.GetProperty("path").GetString());
+        Assert.Equal("Mission", node.GetProperty("summary").GetString());
+        var facets = node.GetProperty("facets").EnumerateArray().Select(f => f.GetString()).ToArray();
+        Assert.Equal(new[] { "vocabulary", "invariant" }, facets);
+        Assert.True(root.TryGetProperty("facet_context_note", out var note));
+        Assert.Equal(JsonValueKind.Null, note.ValueKind);
+    }
+
     [Fact]
     public void Execute_GivenUnknownArgument_ReturnsErrorExitCode()
     {
@@ -302,6 +415,15 @@ public sealed class ContextCollectCommandTests
             var path = Path.Combine(rootPath, "intents", Context.Config.Project.Domain, "automation");
             Directory.CreateDirectory(path);
             File.WriteAllText(Path.Combine(path, "bindings.md"), content);
+        }
+
+        /// <summary>G530: writes a facet-annotated intent-tree node under `intents/&lt;domain&gt;/&lt;relativePath&gt;`.</summary>
+        public void WriteFacetNode(string relativePath, IReadOnlyList<string> facets, string title)
+        {
+            var fullPath = Path.Combine(
+                rootPath, "intents", Context.Config.Project.Domain, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            File.WriteAllText(fullPath, $"---\nfacets: [{string.Join(", ", facets)}]\n---\n# {title}\n");
         }
 
         public void WritePacketFile(string executionUnit, string fileName, string content)

--- a/tests/IntentSystem.Cli.Tests/ContextCollectCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ContextCollectCommandTests.cs
@@ -291,6 +291,94 @@ public sealed class ContextCollectCommandTests
         Assert.Equal(JsonValueKind.Null, note.ValueKind);
     }
 
+    // ── Review repair: strict comma-list validation ─────────────────────
+
+    [Fact]
+    public void Execute_ScopeValueIsBareComma_ReturnsErrorRatherThanDisablingScope()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ContextCollectCommand.Execute(workspace.Context, ["--scope", ","], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--scope", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("empty element", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_FacetsValueHasEmptyMiddleElement_ReturnsErrorRatherThanDiscardingIt()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--facets", "vocabulary,,decider"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--facets", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("empty element", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_FacetsDuplicateElements_DedupedFirstSeenOrder_StillValidatesAndFilters()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        workspace.WriteFacetNode("decisions/adr-1.md", ["decider"], "Decision One");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--facets", "decider,vocabulary,decider"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("### vocabulary", output, StringComparison.Ordinal);
+        Assert.Contains("### decider", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("### invariant", output, StringComparison.Ordinal);
+    }
+
+    // ── Review repair: malformed/unknown-facet warning visibility ───────
+
+    [Fact]
+    public void Execute_MalformedFacetsNode_SurfacesWarningInMarkdown_NeverSilent()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteRawIntentFile("identity/mission.md", "---\nfacets: not-a-list\n---\n# Mission\n");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(workspace.Context, [], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("no facet-annotated nodes found", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Warnings", output, StringComparison.Ordinal);
+        Assert.Contains("intents/intent-cli/identity/mission.md", output, StringComparison.Ordinal);
+        Assert.Contains("malformed", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_JsonFormat_FacetContextWarningsShapeIsStableSnakeCase()
+    {
+        using var workspace = new ContextCollectWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary", "projection"], "Mission");
+
+        using var writer = new StringWriter();
+        var exitCode = ContextCollectCommand.Execute(
+            workspace.Context, ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        var warnings = root.GetProperty("facet_context_warnings").EnumerateArray().ToArray();
+        var warning = Assert.Single(warnings);
+        Assert.Equal("intents/intent-cli/identity/mission.md", warning.GetProperty("path").GetString());
+        Assert.Contains("projection", warning.GetProperty("reason").GetString(), StringComparison.Ordinal);
+        // The node still appears under its own valid facet despite the warning.
+        var vocabularyNodes = root.GetProperty("facet_context")[0].GetProperty("nodes").EnumerateArray().ToArray();
+        Assert.Single(vocabularyNodes);
+    }
+
     [Fact]
     public void Execute_GivenUnknownArgument_ReturnsErrorExitCode()
     {
@@ -424,6 +512,15 @@ public sealed class ContextCollectCommandTests
                 rootPath, "intents", Context.Config.Project.Domain, relativePath.Replace('/', Path.DirectorySeparatorChar));
             Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
             File.WriteAllText(fullPath, $"---\nfacets: [{string.Join(", ", facets)}]\n---\n# {title}\n");
+        }
+
+        /// <summary>G530 review repair: writes arbitrary raw content under `intents/&lt;domain&gt;/&lt;relativePath&gt;` — used to pin a malformed `facets:` declaration.</summary>
+        public void WriteRawIntentFile(string relativePath, string content)
+        {
+            var fullPath = Path.Combine(
+                rootPath, "intents", Context.Config.Project.Domain, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            File.WriteAllText(fullPath, content);
         }
 
         public void WritePacketFile(string executionUnit, string fileName, string content)

--- a/tests/IntentSystem.Cli.Tests/FacetContextSelectorTests.cs
+++ b/tests/IntentSystem.Cli.Tests/FacetContextSelectorTests.cs
@@ -1,0 +1,198 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G530: direct unit coverage for <see cref="FacetContextSelector"/> — the
+/// shared node scan/group/scope logic behind both `context collect`'s
+/// facet section and `packet draft`'s generated "Facet context" section.
+/// </summary>
+public sealed class FacetContextSelectorTests : IDisposable
+{
+    private readonly string domainRoot = Directory.CreateTempSubdirectory("facet-context-selector-tests-").FullName;
+
+    public void Dispose()
+    {
+        if (Directory.Exists(domainRoot))
+        {
+            Directory.Delete(domainRoot, recursive: true);
+        }
+    }
+
+    private void WriteNode(string relativePath, IReadOnlyList<string> facets, string title = "Node")
+    {
+        var fullPath = Path.Combine(domainRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        var facetsLine = facets.Count == 0 ? string.Empty : $"facets: [{string.Join(", ", facets)}]\n";
+        File.WriteAllText(fullPath, $"---\n{facetsLine}---\n# {title}\nBody text.\n");
+    }
+
+    [Fact]
+    public void Select_NoScopeNoFilter_ReturnsAllFourGroupsInCanonicalOrder()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        WriteNode("decisions/adr-1.md", ["decider"]);
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        Assert.True(selection.DomainHasAnyFacetNodes);
+        Assert.Equal(4, selection.Groups.Count);
+        Assert.Equal(
+            new[] { "vocabulary", "invariant", "decider", "acceptance-property" },
+            selection.Groups.Select(g => g.Facet));
+    }
+
+    [Fact]
+    public void Select_NodeCarriesMultipleFacets_AppearsInEachMatchingGroup()
+    {
+        WriteNode("identity/mission.md", ["vocabulary", "invariant"]);
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        var vocabularyGroup = selection.Groups.Single(g => g.Facet == "vocabulary");
+        var invariantGroup = selection.Groups.Single(g => g.Facet == "invariant");
+        Assert.Single(vocabularyGroup.Nodes);
+        Assert.Single(invariantGroup.Nodes);
+        Assert.Equal(vocabularyGroup.Nodes[0].Id, invariantGroup.Nodes[0].Id);
+        Assert.Equal(new[] { "vocabulary", "invariant" }, vocabularyGroup.Nodes[0].Facets);
+    }
+
+    [Fact]
+    public void Select_FacetFilter_RestrictsToRequestedFacetsOnly_StillCanonicalOrder()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        WriteNode("decisions/adr-1.md", ["decider"]);
+        WriteNode("means/flow.md", ["invariant"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: null, facetFilter: ["decider", "invariant"]);
+
+        Assert.Equal(new[] { "invariant", "decider" }, selection.Groups.Select(g => g.Facet));
+    }
+
+    [Fact]
+    public void Select_ScopeHintExactPathMatch_IncludesOnlyThatNode()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        WriteNode("decisions/adr-1.md", ["vocabulary"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: ["intents/intent-cli/identity/mission.md"], facetFilter: null);
+
+        var vocabularyGroup = selection.Groups.Single(g => g.Facet == "vocabulary");
+        var node = Assert.Single(vocabularyGroup.Nodes);
+        Assert.Equal("identity/mission", node.Id);
+    }
+
+    [Fact]
+    public void Select_ScopeHintDirectoryPrefix_IncludesEveryNodeUnderIt()
+    {
+        WriteNode("means/a.md", ["decider"]);
+        WriteNode("means/b.md", ["decider"]);
+        WriteNode("identity/mission.md", ["decider"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: ["intents/intent-cli/means"], facetFilter: null);
+
+        var deciderGroup = selection.Groups.Single(g => g.Facet == "decider");
+        Assert.Equal(2, deciderGroup.Nodes.Count);
+        Assert.All(deciderGroup.Nodes, node => Assert.StartsWith("means/", node.Id, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Select_ScopeHintDomainRelativeShortForm_AlsoMatches()
+    {
+        // The short "identity/mission" form (no "intents/<domain>/" prefix,
+        // no ".md" extension) — as intent_references may realistically be
+        // authored — must also overlap.
+        WriteNode("identity/mission.md", ["vocabulary"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: ["identity/mission"], facetFilter: null);
+
+        var vocabularyGroup = selection.Groups.Single(g => g.Facet == "vocabulary");
+        Assert.Single(vocabularyGroup.Nodes);
+    }
+
+    [Fact]
+    public void Select_ScopeHintMatchingNothing_ReturnsEmptyGroupsButDomainStillHasFacetNodes()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: ["intents/intent-cli/unrelated"], facetFilter: null);
+
+        Assert.True(selection.DomainHasAnyFacetNodes);
+        Assert.All(selection.Groups, group => Assert.Empty(group.Nodes));
+    }
+
+    [Fact]
+    public void Select_NoFacetAnnotatedNodesInDomain_DomainHasAnyFacetNodesIsFalse()
+    {
+        WriteNode("identity/mission.md", facets: []);
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        Assert.False(selection.DomainHasAnyFacetNodes);
+        Assert.All(selection.Groups, group => Assert.Empty(group.Nodes));
+    }
+
+    [Fact]
+    public void Select_MissingDomainDirectory_DegradesGracefullyToEmpty()
+    {
+        var missingRoot = Path.Combine(domainRoot, "does-not-exist");
+
+        var selection = FacetContextSelector.Select(missingRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        Assert.False(selection.DomainHasAnyFacetNodes);
+        Assert.All(selection.Groups, group => Assert.Empty(group.Nodes));
+    }
+
+    [Fact]
+    public void Select_MalformedFacetsDeclaration_ExcludedFromEveryGroup()
+    {
+        var path = Path.Combine(domainRoot, "identity", "mission.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "---\nfacets: not-a-list\n---\n# Mission\n");
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        Assert.False(selection.DomainHasAnyFacetNodes);
+        Assert.All(selection.Groups, group => Assert.Empty(group.Nodes));
+    }
+
+    [Fact]
+    public void Select_UnknownFacetValueAlongsideValidOne_OnlyValidFacetBucketed()
+    {
+        WriteNode("identity/mission.md", ["vocabulary", "projection"]);
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        var vocabularyGroup = selection.Groups.Single(g => g.Facet == "vocabulary");
+        var node = Assert.Single(vocabularyGroup.Nodes);
+        Assert.DoesNotContain("projection", node.Facets);
+        Assert.All(selection.Groups.Where(g => g.Facet != "vocabulary"), group => Assert.Empty(group.Nodes));
+    }
+
+    [Fact]
+    public void Select_NodeSummary_IsFirstNonBlankLineAfterFrontmatterWithHashStripped()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"], title: "Mission Statement");
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        var node = selection.Groups.Single(g => g.Facet == "vocabulary").Nodes.Single();
+        Assert.Equal("Mission Statement", node.Summary);
+    }
+
+    [Fact]
+    public void Select_NodePath_UsesIntentsDomainPrefixConvention()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        var node = selection.Groups.Single(g => g.Facet == "vocabulary").Nodes.Single();
+        Assert.Equal("intents/intent-cli/identity/mission.md", node.Path);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/FacetContextSelectorTests.cs
+++ b/tests/IntentSystem.Cli.Tests/FacetContextSelectorTests.cs
@@ -195,4 +195,170 @@ public sealed class FacetContextSelectorTests : IDisposable
         var node = selection.Groups.Single(g => g.Facet == "vocabulary").Nodes.Single();
         Assert.Equal("intents/intent-cli/identity/mission.md", node.Path);
     }
+
+    // ── Review repair: symmetric, normalized scope overlap ──────────────
+
+    [Fact]
+    public void Select_ScopeHintShortFormWithMdExtension_Matches()
+    {
+        // The documented short domain-relative FILE form carries ".md";
+        // the node's own id does not. Both must be recognized as the same
+        // logical path.
+        WriteNode("identity/mission.md", ["vocabulary"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: ["identity/mission.md"], facetFilter: null);
+
+        Assert.Single(selection.Groups.Single(g => g.Facet == "vocabulary").Nodes);
+    }
+
+    [Fact]
+    public void Select_ScopeHintAbsoluteFilesystemPath_ReducedToDomainRelativeForm()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        var absoluteHint = Path.Combine(domainRoot, "identity", "mission.md");
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: [absoluteHint], facetFilter: null);
+
+        Assert.Single(selection.Groups.Single(g => g.Facet == "vocabulary").Nodes);
+    }
+
+    [Fact]
+    public void Select_ScopeHintAbsolutePathOutsideDomainRoot_NeverMatches()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        var outsideHint = Path.Combine(Path.GetTempPath(), "definitely-not-under-domain-root", "file.md");
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: [outsideHint], facetFilter: null);
+
+        Assert.Empty(selection.Groups.Single(g => g.Facet == "vocabulary").Nodes);
+    }
+
+    [Fact]
+    public void Select_ScopeHintDeeperThanNodePath_ReverseAncestorOverlapMatches()
+    {
+        // Symmetric overlap: a hint MORE SPECIFIC than a node's own path
+        // (the node's segments are a prefix of the hint's) must also count
+        // as overlap, not just the already-covered "hint is an ancestor
+        // directory of the node" direction.
+        WriteNode("means/flow.md", ["decider"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: ["intents/intent-cli/means/flow/deeper-anchor"], facetFilter: null);
+
+        Assert.Single(selection.Groups.Single(g => g.Facet == "decider").Nodes);
+    }
+
+    [Fact]
+    public void Select_MultipleScopeHints_UnionsMatchingNodesAcrossAllHints()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        WriteNode("decisions/adr-1.md", ["vocabulary"]);
+        WriteNode("means/flow.md", ["vocabulary"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli",
+            scopeHints: ["intents/intent-cli/identity", "intents/intent-cli/decisions"],
+            facetFilter: null);
+
+        var vocabularyGroup = selection.Groups.Single(g => g.Facet == "vocabulary");
+        Assert.Equal(2, vocabularyGroup.Nodes.Count);
+        Assert.DoesNotContain(vocabularyGroup.Nodes, n => n.Id == "means/flow");
+    }
+
+    [Fact]
+    public void Select_ScopeHintWithBackslashSeparators_NormalizedAndMatches()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: [@"intents\intent-cli\identity\mission.md"], facetFilter: null);
+
+        Assert.Single(selection.Groups.Single(g => g.Facet == "vocabulary").Nodes);
+    }
+
+    [Fact]
+    public void Select_ScopeHintWithParentTraversalSegment_RejectedNeverMatches()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: ["intents/intent-cli/identity/../identity/mission.md"], facetFilter: null);
+
+        Assert.Empty(selection.Groups.Single(g => g.Facet == "vocabulary").Nodes);
+    }
+
+    [Fact]
+    public void Select_ScopeHintCaseMismatch_NeverMatches_CaseSensitivePinned()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: ["intents/intent-cli/IDENTITY/MISSION.md"], facetFilter: null);
+
+        Assert.Empty(selection.Groups.Single(g => g.Facet == "vocabulary").Nodes);
+    }
+
+    [Fact]
+    public void Select_ScopeHintPrefixCollision_DoesNotMatchSimilarlyNamedSibling()
+    {
+        // "means" must never match "means-2/flow" via a bare string-prefix
+        // check — only a whole path SEGMENT match counts.
+        WriteNode("means-2/flow.md", ["decider"]);
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: ["intents/intent-cli/means"], facetFilter: null);
+
+        Assert.Empty(selection.Groups.Single(g => g.Facet == "decider").Nodes);
+    }
+
+    // ── Review repair: malformed/unknown-value visibility ───────────────
+
+    [Fact]
+    public void Select_MalformedFacetsDeclaration_ProducesWarningWithPathAndReason()
+    {
+        var path = Path.Combine(domainRoot, "identity", "mission.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, "---\nfacets: not-a-list\n---\n# Mission\n");
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        var warning = Assert.Single(selection.Warnings);
+        Assert.Equal("intents/intent-cli/identity/mission.md", warning.Path);
+        Assert.Contains("malformed", warning.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Select_UnknownFacetValue_ProducesWarning_NodeStillAppearsUnderItsValidFacets()
+    {
+        WriteNode("identity/mission.md", ["vocabulary", "projection"]);
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        var warning = Assert.Single(selection.Warnings);
+        Assert.Equal("intents/intent-cli/identity/mission.md", warning.Path);
+        Assert.Contains("projection", warning.Reason, StringComparison.Ordinal);
+        Assert.Single(selection.Groups.Single(g => g.Facet == "vocabulary").Nodes);
+    }
+
+    [Fact]
+    public void Select_DomainWhereEveryDeclarationIsMalformedOrUnknownOnly_DistinguishableFromGenuinelyEmptyDomain()
+    {
+        // DomainHasAnyFacetNodes stays false (no VALID facet was ever
+        // bucketed), but Warnings is non-empty — this is what lets a
+        // consumer tell "excluded for a reason" apart from "never adopted
+        // facets at all", which look identical without the warnings list.
+        var malformedPath = Path.Combine(domainRoot, "identity", "mission.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(malformedPath)!);
+        File.WriteAllText(malformedPath, "---\nfacets: not-a-list\n---\n# Mission\n");
+        WriteNode("decisions/adr-1.md", ["projection"]); // unknown-only, nothing valid
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        Assert.False(selection.DomainHasAnyFacetNodes);
+        Assert.Equal(2, selection.Warnings.Count);
+        Assert.All(selection.Groups, group => Assert.Empty(group.Nodes));
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/FacetContextSelectorTests.cs
+++ b/tests/IntentSystem.Cli.Tests/FacetContextSelectorTests.cs
@@ -406,6 +406,40 @@ public sealed class FacetContextSelectorTests : IDisposable
     }
 
     [Fact]
+    public void Select_AbsoluteHintWithTraversalSegment_RejectedNotSilentlyCanonicalized()
+    {
+        // Round-4 review repair: an ABSOLUTE hint containing ".." must be
+        // rejected on its ORIGINAL text before Path.GetFullPath gets a
+        // chance to canonicalize the traversal away — this hint resolves
+        // right back to the real node's path, so if the traversal check ran
+        // AFTER canonicalization (the prior bug) it would wrongly match.
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        var hint = Path.Combine(domainRoot, "identity", "..", "identity", "mission.md");
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: [hint], facetFilter: null);
+
+        var warning = Assert.Single(selection.ScopeWarnings);
+        Assert.Equal(hint, warning.Hint);
+        Assert.Contains("traversal", warning.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.True(selection.AllScopeHintsRejected);
+        Assert.Empty(selection.Groups.Single(g => g.Facet == "vocabulary").Nodes);
+    }
+
+    [Fact]
+    public void Select_AbsoluteHintWithMixedSeparatorTraversal_RejectedNotSilentlyCanonicalized()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        var hint = Path.Combine(domainRoot, "identity") + @"\..\identity\mission.md";
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: [hint], facetFilter: null);
+
+        var warning = Assert.Single(selection.ScopeWarnings);
+        Assert.Equal(hint, warning.Hint);
+        Assert.Contains("traversal", warning.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(selection.Groups.Single(g => g.Facet == "vocabulary").Nodes);
+    }
+
+    [Fact]
     public void Select_MixedValidAndInvalidScopeHints_UsesValidOnes_ReportsOnlyTheRejectedOnes()
     {
         WriteNode("identity/mission.md", ["vocabulary"]);

--- a/tests/IntentSystem.Cli.Tests/FacetContextSelectorTests.cs
+++ b/tests/IntentSystem.Cli.Tests/FacetContextSelectorTests.cs
@@ -361,4 +361,93 @@ public sealed class FacetContextSelectorTests : IDisposable
         Assert.Equal(2, selection.Warnings.Count);
         Assert.All(selection.Groups, group => Assert.Empty(group.Nodes));
     }
+
+    // ── Review repair: rejected scope hints are never silent ────────────
+
+    [Fact]
+    public void Select_ScopeHintOutsideDomainRoot_ProducesScopeWarningNamingHintAndReason()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        var outsideHint = Path.Combine(Path.GetTempPath(), "definitely-not-under-domain-root", "file.md");
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: [outsideHint], facetFilter: null);
+
+        var warning = Assert.Single(selection.ScopeWarnings);
+        Assert.Equal(outsideHint, warning.Hint);
+        Assert.Contains("outside the domain root", warning.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.True(selection.AllScopeHintsRejected);
+    }
+
+    [Fact]
+    public void Select_ScopeHintWithTraversalSegment_ProducesScopeWarning()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        const string hint = "intents/intent-cli/identity/../identity/mission.md";
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: [hint], facetFilter: null);
+
+        var warning = Assert.Single(selection.ScopeWarnings);
+        Assert.Equal(hint, warning.Hint);
+        Assert.Contains("traversal", warning.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.True(selection.AllScopeHintsRejected);
+    }
+
+    [Fact]
+    public void Select_MixedSeparatorsWithTraversal_StillDetectedAndRejected()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        const string hint = @"intents\intent-cli\identity\..\..\etc";
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: [hint], facetFilter: null);
+
+        var warning = Assert.Single(selection.ScopeWarnings);
+        Assert.Equal(hint, warning.Hint);
+        Assert.Contains("traversal", warning.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Select_MixedValidAndInvalidScopeHints_UsesValidOnes_ReportsOnlyTheRejectedOnes()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        WriteNode("decisions/adr-1.md", ["vocabulary"]);
+        const string invalidHint = "intents/intent-cli/identity/../../outside";
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli",
+            scopeHints: ["intents/intent-cli/identity", invalidHint],
+            facetFilter: null);
+
+        var scopeWarning = Assert.Single(selection.ScopeWarnings);
+        Assert.Equal(invalidHint, scopeWarning.Hint);
+        Assert.False(selection.AllScopeHintsRejected);
+        var vocabularyGroup = selection.Groups.Single(g => g.Facet == "vocabulary");
+        var node = Assert.Single(vocabularyGroup.Nodes);
+        Assert.Equal("identity/mission", node.Id);
+    }
+
+    [Fact]
+    public void Select_AllScopeHintsInvalid_AllScopeHintsRejectedTrue_MatchesNothing()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+        var outsideHint1 = Path.Combine(Path.GetTempPath(), "outside-one", "a.md");
+        var outsideHint2 = Path.Combine(Path.GetTempPath(), "outside-two", "b.md");
+
+        var selection = FacetContextSelector.Select(
+            domainRoot, "intent-cli", scopeHints: [outsideHint1, outsideHint2], facetFilter: null);
+
+        Assert.True(selection.AllScopeHintsRejected);
+        Assert.Equal(2, selection.ScopeWarnings.Count);
+        Assert.All(selection.Groups, group => Assert.Empty(group.Nodes));
+    }
+
+    [Fact]
+    public void Select_NoScopeHintsPassed_NoScopeWarnings_NotAllRejected()
+    {
+        WriteNode("identity/mission.md", ["vocabulary"]);
+
+        var selection = FacetContextSelector.Select(domainRoot, "intent-cli", scopeHints: null, facetFilter: null);
+
+        Assert.Empty(selection.ScopeWarnings);
+        Assert.False(selection.AllScopeHintsRejected);
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
@@ -202,6 +202,188 @@ public sealed class PacketDraftCommandTests
             File.ReadAllText(Path.Combine(packetDir, "review-context.md")));
     }
 
+    // ── Review repair: the Facet context block stays current across the
+    // ── ordinary workflow (scaffold → add references → rerun) ──────────
+
+    [Fact]
+    public void Execute_OrdinaryWorkflow_ScaffoldThenAddReferencesThenRerun_RefreshesFacetContextBlock()
+    {
+        // The realistic sequence the first G530 round's positive test did
+        // NOT cover: a fresh `packet draft` scaffolds packet.yaml with
+        // EMPTY intent_references — the domain DOES have a facet node, but
+        // this packet references none of them yet, so the block correctly
+        // shows every facet group as empty (never the whole domain's facet
+        // nodes just because references happen to be empty — an empty
+        // scope is "scoped to nothing", not "no scoping requested"). The
+        // operator then edits packet.yaml to add a real reference;
+        // rerunning `packet draft` must refresh the block to reflect it,
+        // not skip the whole file because it already exists.
+        using var workspace = new PacketDraftWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G530");
+
+        using (var firstWriter = new StringWriter())
+        {
+            var firstExit = PacketDraftCommand.Execute(
+                workspace.Context, ["--execution-unit", "G530", "--target-repo", "J-Tech-Japan/intent-system"], firstWriter);
+            Assert.Equal(0, firstExit);
+            Assert.Contains("review-context.md: created", firstWriter.ToString(), StringComparison.Ordinal);
+        }
+
+        var initialReviewContext = File.ReadAllText(Path.Combine(packetDir, "review-context.md"));
+        Assert.Contains("(none overlapping this packet's intent_references)", initialReviewContext, StringComparison.Ordinal);
+        Assert.DoesNotContain("identity/mission", initialReviewContext, StringComparison.Ordinal);
+
+        // Operator hand-edits packet.yaml to add a real reference — append
+        // rather than replace, since packet.yaml itself must stay untouched
+        // by `packet draft` from this point on.
+        var packetYamlPath = Path.Combine(packetDir, "packet.yaml");
+        var packetYaml = File.ReadAllText(packetYamlPath)
+            .Replace("intent_references: []", "intent_references:\n  - intents/intent-cli/identity/mission.md", StringComparison.Ordinal);
+        File.WriteAllText(packetYamlPath, packetYaml);
+
+        using var secondWriter = new StringWriter();
+        var secondExit = PacketDraftCommand.Execute(
+            workspace.Context, ["--execution-unit", "G530"], secondWriter);
+
+        Assert.Equal(0, secondExit);
+        var secondOutput = secondWriter.ToString();
+        Assert.Contains("packet.yaml: skipped", secondOutput, StringComparison.Ordinal);
+        Assert.Contains("review-context.md: updated", secondOutput, StringComparison.Ordinal);
+
+        var refreshedReviewContext = File.ReadAllText(Path.Combine(packetDir, "review-context.md"));
+        Assert.Contains("### vocabulary", refreshedReviewContext, StringComparison.Ordinal);
+        Assert.Contains("identity/mission", refreshedReviewContext, StringComparison.Ordinal);
+        Assert.DoesNotContain("No facet-annotated nodes found", refreshedReviewContext, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RegenerationWithUnchangedReferences_StatusIsSkippedNotSpuriouslyUpdated()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G530");
+        Directory.CreateDirectory(packetDir);
+        File.WriteAllText(
+            Path.Combine(packetDir, "packet.yaml"),
+            """
+            implementation_issue_packet:
+              source_execution_unit: G530
+              domain: intent-cli
+              intent_references:
+                - intents/intent-cli/identity/mission.md
+            """);
+
+        using (var firstWriter = new StringWriter())
+        {
+            PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], firstWriter);
+        }
+
+        using var secondWriter = new StringWriter();
+        PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], secondWriter);
+
+        Assert.Contains("review-context.md: skipped", secondWriter.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RegenerationAfterReferenceRemoved_NodeNoLongerAppearsInFacetContextBlock()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G530");
+        Directory.CreateDirectory(packetDir);
+        var packetYamlPath = Path.Combine(packetDir, "packet.yaml");
+        File.WriteAllText(
+            packetYamlPath,
+            """
+            implementation_issue_packet:
+              source_execution_unit: G530
+              domain: intent-cli
+              intent_references:
+                - intents/intent-cli/identity/mission.md
+            """);
+
+        using (var firstWriter = new StringWriter())
+        {
+            PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], firstWriter);
+        }
+        Assert.Contains(
+            "identity/mission",
+            File.ReadAllText(Path.Combine(packetDir, "review-context.md")),
+            StringComparison.Ordinal);
+
+        File.WriteAllText(
+            packetYamlPath,
+            """
+            implementation_issue_packet:
+              source_execution_unit: G530
+              domain: intent-cli
+              intent_references: []
+            """);
+
+        using var secondWriter = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], secondWriter);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review-context.md: updated", secondWriter.ToString(), StringComparison.Ordinal);
+        var reviewContext = File.ReadAllText(Path.Combine(packetDir, "review-context.md"));
+        Assert.DoesNotContain("identity/mission", reviewContext, StringComparison.Ordinal);
+        // The domain still HAS a facet node — it is simply no longer
+        // referenced by this packet, so each group is empty ("scoped to
+        // nothing"), not the domain-wide "No facet-annotated nodes found"
+        // note (that note is reserved for a domain with zero facet nodes).
+        Assert.Contains("(none overlapping this packet's intent_references)", reviewContext, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_HandEditsBeforeAndAfterGeneratedBlock_PreservedAcrossRegeneration()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G530");
+        Directory.CreateDirectory(packetDir);
+        File.WriteAllText(
+            Path.Combine(packetDir, "packet.yaml"),
+            """
+            implementation_issue_packet:
+              source_execution_unit: G530
+              domain: intent-cli
+              intent_references: []
+            """);
+
+        using (var firstWriter = new StringWriter())
+        {
+            PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], firstWriter);
+        }
+
+        var reviewContextPath = Path.Combine(packetDir, "review-context.md");
+        var scaffolded = File.ReadAllText(reviewContextPath);
+        var handEdited = "Reviewer note: pay close attention to the event ordering invariant.\n\n" + scaffolded
+            + "\n\nAppended reviewer note: also double-check the closeout learning writeback.\n";
+        File.WriteAllText(reviewContextPath, handEdited);
+
+        // Now the operator adds a real reference and reruns.
+        File.WriteAllText(
+            Path.Combine(packetDir, "packet.yaml"),
+            """
+            implementation_issue_packet:
+              source_execution_unit: G530
+              domain: intent-cli
+              intent_references:
+                - intents/intent-cli/identity/mission.md
+            """);
+
+        using var secondWriter = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], secondWriter);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review-context.md: updated", secondWriter.ToString(), StringComparison.Ordinal);
+        var updated = File.ReadAllText(reviewContextPath);
+        Assert.StartsWith("Reviewer note: pay close attention to the event ordering invariant.", updated, StringComparison.Ordinal);
+        Assert.EndsWith("Appended reviewer note: also double-check the closeout learning writeback.\n", updated, StringComparison.Ordinal);
+        Assert.Contains("identity/mission", updated, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Execute_GivenDryRun_DoesNotWriteFilesAndReportsPlanned()
     {

--- a/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
@@ -258,6 +258,43 @@ public sealed class PacketDraftCommandTests
     }
 
     [Fact]
+    public void Execute_IntentReferenceIsAbsolutePathWithTraversalSegment_RejectedNotSilentlyCanonicalized()
+    {
+        // Round-4 review repair: an intent_references entry that is an
+        // ABSOLUTE path containing ".." — resolving right back to a real
+        // in-domain node — must still be rejected as a scope hint, not
+        // silently canonicalized into a match, and must surface in the
+        // generated block's Scope warnings.
+        using var workspace = new PacketDraftWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G530");
+        Directory.CreateDirectory(packetDir);
+        var domainRoot = Path.Combine(workspace.RepoRoot, "intents", "intent-cli");
+        var traversalReference = Path.Combine(domainRoot, "identity", "..", "identity", "mission.md").Replace('\\', '/');
+        File.WriteAllText(
+            Path.Combine(packetDir, "packet.yaml"),
+            $"""
+            implementation_issue_packet:
+              source_execution_unit: G530
+              domain: intent-cli
+              intent_references:
+                - {traversalReference}
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], writer);
+
+        Assert.Equal(0, exitCode);
+        var reviewContext = File.ReadAllText(Path.Combine(packetDir, "review-context.md"));
+        Assert.Contains("Scope warnings", reviewContext, StringComparison.Ordinal);
+        Assert.Contains(traversalReference, reviewContext, StringComparison.Ordinal);
+        Assert.Contains("traversal", reviewContext, StringComparison.OrdinalIgnoreCase);
+        // Rejected, so the node it would otherwise canonicalize to is never
+        // matched — each facet group falls back to the "no overlap" note.
+        Assert.Contains("(none overlapping this packet's intent_references)", reviewContext, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_RegenerationWithUnchangedReferences_StatusIsSkippedNotSpuriouslyUpdated()
     {
         using var workspace = new PacketDraftWorkspace();

--- a/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
@@ -107,6 +107,101 @@ public sealed class PacketDraftCommandTests
         Assert.Equal("existing content", File.ReadAllText(Path.Combine(packetDir, "packet.yaml")));
     }
 
+    // ── G530: Facet context section in review-context.md ────────────────
+
+    [Fact]
+    public void Execute_FreshScaffold_ReviewContextGetsGracefulNoFacetContextNote()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G530", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var reviewContext = File.ReadAllText(
+            Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G530", "review-context.md"));
+        Assert.Contains("## Facet context", reviewContext, StringComparison.Ordinal);
+        Assert.Contains("No facet-annotated nodes found", reviewContext, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ExistingPacketYamlDeclaresIntentReferences_ReviewContextListsOverlappingFacetNodes()
+    {
+        // G530: "regenerating an existing packet preserves hand-edits" —
+        // packet.yaml already exists (hand-edited with real
+        // intent_references) but review-context.md does not yet; running
+        // `packet draft` again must not touch the existing packet.yaml, but
+        // DOES generate review-context.md fresh, using packet.yaml's real
+        // on-disk intent_references (never the template's empty `[]`).
+        using var workspace = new PacketDraftWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        workspace.WriteFacetNode("decisions/adr-1.md", ["decider"], "Unrelated decision");
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G530");
+        Directory.CreateDirectory(packetDir);
+        File.WriteAllText(
+            Path.Combine(packetDir, "packet.yaml"),
+            """
+            implementation_issue_packet:
+              source_execution_unit: G530
+              domain: intent-cli
+              intent_references:
+                - intents/intent-cli/identity/mission.md
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G530"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("packet.yaml: skipped", output, StringComparison.Ordinal);
+        Assert.Contains("review-context.md: created", output, StringComparison.Ordinal);
+
+        var reviewContext = File.ReadAllText(Path.Combine(packetDir, "review-context.md"));
+        Assert.Contains("### vocabulary", reviewContext, StringComparison.Ordinal);
+        Assert.Contains("identity/mission", reviewContext, StringComparison.Ordinal);
+        Assert.Contains("Mission", reviewContext, StringComparison.Ordinal);
+        // The unrelated decision node does not overlap intent_references —
+        // it must not leak into the section.
+        Assert.DoesNotContain("decisions/adr-1", reviewContext, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ExistingReviewContextMd_NeverOverwritten_PreservesHandEditsRegardlessOfFacetNodes()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G530");
+        Directory.CreateDirectory(packetDir);
+        File.WriteAllText(
+            Path.Combine(packetDir, "packet.yaml"),
+            """
+            implementation_issue_packet:
+              source_execution_unit: G530
+              domain: intent-cli
+              intent_references:
+                - intents/intent-cli/identity/mission.md
+            """);
+        File.WriteAllText(Path.Combine(packetDir, "review-context.md"), "hand-edited review context, do not touch");
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G530"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review-context.md: skipped", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(
+            "hand-edited review context, do not touch",
+            File.ReadAllText(Path.Combine(packetDir, "review-context.md")));
+    }
+
     [Fact]
     public void Execute_GivenDryRun_DoesNotWriteFilesAndReportsPlanned()
     {
@@ -340,6 +435,15 @@ public sealed class PacketDraftCommandTests
         public string RepoRoot { get; }
 
         public CliContext Context { get; }
+
+        /// <summary>G530: writes a facet-annotated intent-tree node under `intents/&lt;domain&gt;/&lt;relativePath&gt;`.</summary>
+        public void WriteFacetNode(string relativePath, IReadOnlyList<string> facets, string title)
+        {
+            var fullPath = Path.Combine(
+                RepoRoot, "intents", Context.Config.Project.Domain, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+            File.WriteAllText(fullPath, $"---\nfacets: [{string.Join(", ", facets)}]\n---\n# {title}\n");
+        }
 
         public void Dispose()
         {

--- a/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
@@ -384,6 +384,153 @@ public sealed class PacketDraftCommandTests
         Assert.Contains("identity/mission", updated, StringComparison.Ordinal);
     }
 
+    // ── Review repair: fail-closed marker classification, never a silent
+    // ── partial/arbitrary update on a malformed marker shape ────────────
+
+    private const string BeginMarker = "<!-- BEGIN GENERATED FACET CONTEXT (G530) -->";
+    private const string EndMarker = "<!-- END GENERATED FACET CONTEXT (G530) -->";
+
+    private static (PacketDraftWorkspace Workspace, string PacketDir, string ReviewContextPath) SetUpPacketWithRawReviewContext(
+        string reviewContextContent)
+    {
+        var workspace = new PacketDraftWorkspace();
+        workspace.WriteFacetNode("identity/mission.md", ["vocabulary"], "Mission");
+        var packetDir = Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G530");
+        Directory.CreateDirectory(packetDir);
+        File.WriteAllText(
+            Path.Combine(packetDir, "packet.yaml"),
+            """
+            implementation_issue_packet:
+              source_execution_unit: G530
+              domain: intent-cli
+              intent_references:
+                - intents/intent-cli/identity/mission.md
+            """);
+        var reviewContextPath = Path.Combine(packetDir, "review-context.md");
+        File.WriteAllText(reviewContextPath, reviewContextContent);
+        return (workspace, packetDir, reviewContextPath);
+    }
+
+    [Fact]
+    public void Execute_DuplicateBeginMarkers_ReportsMarkersMalformed_FileUntouched()
+    {
+        var original = $"Intro\n{BeginMarker}\nold A\n{EndMarker}\nMiddle\n{BeginMarker}\nold B\n{EndMarker}\nOutro\n";
+        var (workspace, _, reviewContextPath) = SetUpPacketWithRawReviewContext(original);
+        using var workspaceDisposable = workspace;
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review-context.md: markers-malformed", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("expected exactly one", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(reviewContextPath));
+    }
+
+    [Fact]
+    public void Execute_ReversedMarkerOrder_ReportsMarkersMalformed_FileUntouched()
+    {
+        var original = $"Intro\n{EndMarker}\nstray content\n{BeginMarker}\nOutro\n";
+        var (workspace, _, reviewContextPath) = SetUpPacketWithRawReviewContext(original);
+        using var workspaceDisposable = workspace;
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review-context.md: markers-malformed", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("before the begin marker", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(reviewContextPath));
+    }
+
+    [Fact]
+    public void Execute_BeginMarkerOnlyNoEndMarker_ReportsMarkersMalformed_FileUntouched()
+    {
+        var original = $"Intro\n{BeginMarker}\nold content with no closing marker\nOutro\n";
+        var (workspace, _, reviewContextPath) = SetUpPacketWithRawReviewContext(original);
+        using var workspaceDisposable = workspace;
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review-context.md: markers-malformed", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("no end marker", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(reviewContextPath));
+    }
+
+    [Fact]
+    public void Execute_EndMarkerOnlyNoBeginMarker_ReportsMarkersMalformed_FileUntouched()
+    {
+        var original = $"Intro\n{EndMarker}\nOutro\n";
+        var (workspace, _, reviewContextPath) = SetUpPacketWithRawReviewContext(original);
+        using var workspaceDisposable = workspace;
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review-context.md: markers-malformed", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("no begin marker", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(original, File.ReadAllText(reviewContextPath));
+    }
+
+    [Fact]
+    public void Execute_MalformedMarkers_DryRun_ReportsSameStatus_NeverWrites()
+    {
+        var original = $"Intro\n{BeginMarker}\nold\n{BeginMarker}\nold2\n{EndMarker}\nOutro\n";
+        var (workspace, _, reviewContextPath) = SetUpPacketWithRawReviewContext(original);
+        using var workspaceDisposable = workspace;
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530", "--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review-context.md: markers-malformed", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(original, File.ReadAllText(reviewContextPath));
+    }
+
+    [Fact]
+    public void Execute_ZeroMarkers_StillPlainSkipped_NotMarkersMalformed()
+    {
+        // A genuinely healthy legacy file (no markers at all) must remain
+        // distinguishable from the malformed-marker-shape case — plain
+        // "skipped", never "markers-malformed".
+        var original = "hand-edited review context with no generated block markers at all\n";
+        var (workspace, _, reviewContextPath) = SetUpPacketWithRawReviewContext(original);
+        using var workspaceDisposable = workspace;
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review-context.md: skipped", writer.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("markers-malformed", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(original, File.ReadAllText(reviewContextPath));
+    }
+
+    [Fact]
+    public void Execute_ExistingFileUsesCrlf_RegeneratedBlockUsesCrlfNotMixedLineEndings()
+    {
+        var original =
+            $"Intro\r\n{BeginMarker}\r\n### vocabulary\r\n- (none overlapping this packet's intent_references)\r\n{EndMarker}\r\nOutro\r\n";
+        var (workspace, packetDir, reviewContextPath) = SetUpPacketWithRawReviewContext(original);
+        using var workspaceDisposable = workspace;
+
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(workspace.Context, ["--execution-unit", "G530"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("review-context.md: updated", writer.ToString(), StringComparison.Ordinal);
+        var updated = File.ReadAllText(reviewContextPath);
+        Assert.Contains("identity/mission", updated, StringComparison.Ordinal);
+        // No bare LF anywhere — every line ending is CRLF, matching the
+        // file's own pre-existing convention.
+        var withoutCrlf = updated.Replace("\r\n", string.Empty, StringComparison.Ordinal);
+        Assert.DoesNotContain('\n', withoutCrlf);
+        Assert.DoesNotContain('\r', withoutCrlf);
+    }
+
     [Fact]
     public void Execute_GivenDryRun_DoesNotWriteFilesAndReportsPlanned()
     {


### PR DESCRIPTION
## Summary

- Adds a shared `FacetContextSelector` — scans a domain's intent tree, classifies nodes by their G529 `facets:` frontmatter, groups them in the canonical `vocabulary → invariant → decider → acceptance-property` order, and narrows by path/intent-reference scope overlap — used identically by both surfaces below so they can never disagree on what "overlaps".
- `context collect --domain <d>` gains a `## Facet context` section rendered **ahead of** the unclassified queue-state/clarification/automation-bindings/recent-events context, a `--facets <list>` filter (validated against the closed G529 set, matching `intent search --facet`'s existing validation pattern), and a `--scope <paths>` narrowing flag (exact path, ancestor-directory prefix, or the shorter domain-relative id form all count as overlap). A domain with zero facet-annotated nodes at all gets an explicit graceful-degradation note — never an error.
- `packet draft` gains a generated `## Facet context` section inside the scaffolded `review-context.md`, listing the facet nodes overlapping the packet's own `implementation_issue_packet.intent_references` — read from an **existing** `packet.yaml` on disk (never the freshly-templated empty list this same invocation might otherwise write), so a packet whose `packet.yaml` was already hand-edited with real references produces a genuinely useful section the first time `review-context.md` is generated, while the "never overwrite an existing file" scaffold semantics stay exactly as before.

Closes #1164

## Test plan

- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Debug` — succeeds
- [x] New `FacetContextSelectorTests` (13 tests: canonical ordering, facet filter, scope-overlap in all three hint forms, multi-facet nodes appearing once per matching group, malformed/unknown-value exclusion, missing-domain and no-facet-nodes graceful degradation, summary/path/id derivation)
- [x] New `ContextCollectCommandTests` facet fixtures (6 tests: section ordering ahead of Queue state, `--facets` filter, `--facets` validation error, `--scope` narrowing, graceful degradation note, stable snake_case JSON shape)
- [x] New `PacketDraftCommandTests` facet fixtures (3 tests: fresh scaffold degradation note, regeneration from an existing hand-edited `packet.yaml`'s `intent_references`, existing `review-context.md` never overwritten regardless of facet nodes)
- [x] Full solution test suite — 3386 passed / 1 pre-existing unrelated skip / 0 failed
- [x] `git diff --check` — clean
- [x] Manual end-to-end check on a fixture tree with one node per facet: `context collect` ordering/filter/scope all verified against the real CLI binary; `packet draft` regeneration verified to correctly include only the two intent_references-overlapping nodes and exclude the other two
- [x] ja/en `docs/09-developer-reference.md` (new section) and `docs/04-packets-issues.md` (cross-reference) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)