### PR TITLE
G533: Fix stalled-work classification for repair states, add claimed-but-silent

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -249,38 +249,77 @@ All three surfaces apply the full order strictly — none of them fall back to
 
 ### Stalled-work detection (G523)
 
-`intent-cli automation stalled-work --domain <d> --repo <r> [--stale-minutes <m>] --format json|markdown`
+`intent-cli automation stalled-work --domain <d> --repo <r> [--stale-minutes <m>] [--claimed-silent-minutes <m>] --format json|markdown`
 is a **read-only** inventory of pending pipeline transitions with ages, so a
 single orchestrator wake (or an external heartbeat) can detect and recover a
 stalled pipeline without a human cross-checking GitHub labels, PR state, and
 queue-state by hand. It never mutates GitHub labels, queue-state, or
-`runs.jsonl`.
+`runs.jsonl` — and an informational kind never sends the status-check it
+recommends; that remains a human/orchestrator action.
 
-Categories:
+Every item carries `is_informational` (`bool`) distinguishing two families:
+
+**Actionable categories** (`is_informational: false` — `recommended_action`
+is always a runnable `intent-cli` command):
 
 - `published-not-delegated` — an OPEN issue carries `intent-target` but has
   no claim label (`intent-issue-in-progress` / `intent-pr-created`) yet, and
   no PR was ever created for it.
-- `pr-created-not-reviewing` — the source issue carries `intent-pr-created`
-  and its closing PR has not had the `review-start` transition applied (no
-  `intent-pr-reviewing` / `intent-pr-approved` on the PR).
+- `pr-created-not-reviewing` — the source issue carries `intent-pr-created`,
+  its closing PR has not had the `review-start` transition applied (no
+  `intent-pr-reviewing` / `intent-pr-approved` on the PR), AND the PR is not
+  already in the repair or rereview lifecycle (see below — a PR in either of
+  those states is reported under its own informational kind instead).
 - `merged-not-closed-out` — a MERGED PR's linked queue-state item is not yet
   `Completed` (closeout — `pr-merged` + `closeout-recorded` runs events —
   has not been recorded).
 
+**Informational categories (G533)** — `is_informational: true`,
+`recommended_action` is descriptive prose (never a transition command), age
+is reported for visibility only:
+
+- `repair-pending` — a PR carrying `intent-pr-request-update` and/or
+  `intent-pr-update-in-progress`. Field finding: an OPEN PR in exactly this
+  state (PR #1750) was previously misreported as `pr-created-not-reviewing`
+  with a `review-start` recommendation — semantically wrong mid-repair; a
+  detector whose recommendation must be second-guessed loses its value.
+  `age_minutes` is measured from the PR's own `updatedAt` (since entering
+  the repair state), not from PR creation.
+- `rereview-pending` — a PR carrying `intent-pr-rereview-ready` (repair
+  pushed, awaiting re-review). Same `updatedAt`-based age convention as
+  `repair-pending`.
+- `claimed-but-silent` — an issue carrying `intent-issue-in-progress` with
+  **no PR created yet** and no observable activity for longer than
+  `--claimed-silent-minutes` (default **720** minutes / 12 hours — chosen so
+  an ordinary work session never trips it). "Observable activity" is
+  approximated as the more recent of the issue's own `updatedAt` (GitHub
+  bumps this on any label change, comment, or other timeline event — the
+  closest available proxy without a dedicated per-issue timeline-events
+  fetch) and the `updatedAt` of any open PR whose closing references name
+  the issue (a linked PR's own activity counts too, even before
+  `intent-pr-created` is applied). `recommended_action` always reads as a
+  status-check request to the assigned worker — it never assumes
+  completion, failure, or any transition from silence alone. Once a PR
+  exists for the issue (`intent-pr-created`), the PR-lifecycle kinds take
+  over instead; detecting a repair-state PR that is itself stale beyond a
+  threshold is an explicit out-of-scope follow-up.
+
 Each item reports `kind`, `execution_unit`, `issue` and/or `pr` (number +
-url), `age_minutes`, and `recommended_action` — the exact canonical command
-to run next (`worker claim`, `automation pr-transition --transition
-review-start`, or `closeout pr`, respectively). `--stale-minutes` filters
-out items younger than the given threshold (default `0` — report everything
-with its age; callers pick their own threshold). `age_minutes` is
-approximated from the relevant GitHub entity's `createdAt`/`updatedAt`
-timestamp, since GitHub does not expose per-label-application timestamps.
-`published-not-delegated` also checks the already-fetched PR closing
-references independently of issue labels, so a completion label that has
-drifted out of sync with reality (an open PR already closes the issue, but
-`intent-pr-created` was never applied or was removed) never produces a
-false `worker claim` recommendation.
+url), `age_minutes`, `is_informational`, and `recommended_action`.
+`--stale-minutes` filters out items younger than the given threshold
+(default `0` — report everything with its age; callers pick their own
+threshold) — this applies uniformly across all six kinds; `claimed-but-silent`
+additionally gates on its OWN `--claimed-silent-minutes` threshold before an
+item is even considered (so raising `--stale-minutes` alone can never make a
+`claimed-but-silent` item appear earlier than its own threshold allows).
+`age_minutes` is approximated from the relevant GitHub entity's
+`createdAt`/`updatedAt` timestamp, since GitHub does not expose
+per-label-application timestamps or per-issue timeline events without a
+dedicated per-issue fetch this slice does not add. `published-not-delegated`
+also checks the already-fetched PR closing references independently of issue
+labels, so a completion label that has drifted out of sync with reality (an
+open PR already closes the issue, but `intent-pr-created` was never applied
+or was removed) never produces a false `worker claim` recommendation.
 
 **Execution-unit and domain identification (G532)**
 
@@ -361,6 +400,14 @@ packet.yaml path), `domain-underivable` (uncorroborated execution unit), or
 
 This slice is detection only — consuming the surface from the orchestrator
 wake procedure and from an external heartbeat are separate follow-up slices.
+
+`automation heartbeat` (G526) wraps this same analyzer and reflects
+`is_informational` into its `message_body`: the summary line splits into
+"`N` pending transition(s)" and, when any informational item is present,
+"`M` informational note(s)"; each per-item line ends with `— recommended:
+` command `` for an actionable kind or `— FYI: ` prose `` for an
+informational one, so a reader (human or orchestrator) can never mistake
+"no transition needed" for an actionable next command.
 
 ### Retiring a stuck published issue (G525)
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -283,10 +283,14 @@ is reported for visibility only:
   state (PR #1750) was previously misreported as `pr-created-not-reviewing`
   with a `review-start` recommendation — semantically wrong mid-repair; a
   detector whose recommendation must be second-guessed loses its value.
-  `age_minutes` is measured from the PR's own `updatedAt` (since entering
-  the repair state), not from PR creation.
+  `age_minutes` is measured from the PR's own `updatedAt` rather than PR
+  creation — a CONSERVATIVE approximation of "since entering the repair
+  state", not the exact label-application moment: GitHub does not expose
+  per-label-application timestamps, and `updatedAt` reflects the PR's most
+  recent modification of any kind (which may postdate the specific label
+  change) unless a dedicated label-event fetch is added.
 - `rereview-pending` — a PR carrying `intent-pr-rereview-ready` (repair
-  pushed, awaiting re-review). Same `updatedAt`-based age convention as
+  pushed, awaiting re-review). Same `updatedAt`-based age approximation as
   `repair-pending`.
 - `claimed-but-silent` — an issue carrying `intent-issue-in-progress` with
   **no PR created yet** and no observable activity for longer than
@@ -297,7 +301,15 @@ is reported for visibility only:
   closest available proxy without a dedicated per-issue timeline-events
   fetch) and the `updatedAt` of any open PR whose closing references name
   the issue (a linked PR's own activity counts too, even before
-  `intent-pr-created` is applied). `recommended_action` always reads as a
+  `intent-pr-created` is applied). A missing or malformed `updatedAt` — on
+  the issue OR a linked PR — is NEVER treated as "old activity" by falling
+  back to `createdAt` (which measures issue/PR OPEN time, not claim
+  acquisition or last touch, and could manufacture a misleadingly old
+  silence interval); it fails closed into `excluded[]`
+  (`activity-data-unusable`, naming exactly which timestamp was unusable)
+  instead. A parsed timestamp somehow in the future (clock skew) is
+  clamped to "now" rather than trusted, which can only ever make a
+  candidate look less silent. `recommended_action` always reads as a
   status-check request to the assigned worker — it never assumes
   completion, failure, or any transition from silence alone. Once a PR
   exists for the issue (`intent-pr-created`), the PR-lifecycle kinds take

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -241,39 +241,84 @@ binding fallback は、packet 自身の `domain:` フィールドが別の値を
 
 ### stalled-work 検出 (G523)
 
-`intent-cli automation stalled-work --domain <d> --repo <r> [--stale-minutes <m>] --format json|markdown`
+`intent-cli automation stalled-work --domain <d> --repo <r> [--stale-minutes <m>] [--claimed-silent-minutes <m>] --format json|markdown`
 は、保留中の pipeline transition を age 付きで一覧化する **read-only** な
 サーフェスです。これにより、1 回の orchestrator wake（あるいは外部の
 heartbeat）だけで、人間が GitHub label・PR state・queue-state を手で
 突き合わせることなく stall を検出・復旧できます。GitHub label、
-queue-state、`runs.jsonl` を変更することは一切ありません。
+queue-state、`runs.jsonl` を変更することは一切ありません — informational
+な kind も、それが推奨する status check を自分で送ることはありません。
+それは人間/orchestrator の行動として残ります。
 
-カテゴリ:
+すべての item は `is_informational`（`bool`）を持ち、2 つのグループを
+区別します:
+
+**actionable なカテゴリ**（`is_informational: false` —
+`recommended_action` は常に実行可能な `intent-cli` コマンド）:
 
 - `published-not-delegated` — OPEN の issue が `intent-target` を持つが、
   claim label（`intent-issue-in-progress` / `intent-pr-created`）がまだ無く、
   PR も一度も作成されていない。
 - `pr-created-not-reviewing` — 元の issue が `intent-pr-created` を持ち、
   その issue を close する PR に `review-start` transition がまだ適用
-  されていない（PR に `intent-pr-reviewing` / `intent-pr-approved` が無い）。
+  されておらず（PR に `intent-pr-reviewing` / `intent-pr-approved` が無い）、
+  かつその PR が repair/rereview lifecycle に既に入っていない場合（下記
+  参照 — いずれかの状態にある PR は、それぞれ独自の informational な
+  kind として報告されます）。
 - `merged-not-closed-out` — MERGED 状態の PR に紐づく queue-state item が
   まだ `Completed` になっていない（closeout — `pr-merged` +
   `closeout-recorded` の runs event — がまだ記録されていない）。
 
+**informational なカテゴリ (G533)** — `is_informational: true`、
+`recommended_action` は（transition コマンドではなく）説明的な prose、
+age は可視性のためだけに報告されます:
+
+- `repair-pending` — `intent-pr-request-update` および/または
+  `intent-pr-update-in-progress` を持つ PR。field finding: まさにこの
+  状態にあった OPEN PR（PR #1750）が、以前は `pr-created-not-reviewing`
+  として誤報告され、`review-start` が推奨されていました — repair の
+  最中としては意味的に間違っています。推奨を毎回疑ってかからなければ
+  ならない detector は、その価値を失います。`age_minutes` は、PR の
+  作成時刻ではなく PR 自身の `updatedAt`（repair 状態に入った時点）から
+  計測されます。
+- `rereview-pending` — `intent-pr-rereview-ready` を持つ PR（repair が
+  push され、re-review 待ち）。`repair-pending` と同じ `updatedAt` ベース
+  の age 規約です。
+- `claimed-but-silent` — `intent-issue-in-progress` を持つが **まだ PR が
+  作成されていない** issue で、`--claimed-silent-minutes`（デフォルトは
+  **720** 分 / 12 時間 — 通常の作業セッションでは決して発火しないよう
+  選ばれています）を超えて observable な活動が無いもの。「observable な
+  活動」は、issue 自身の `updatedAt`（GitHub は label 変更・コメント・
+  その他の timeline event でこれを更新します — 専用の per-issue
+  timeline-events fetch を持たないこの slice にとって、最も近い
+  proxy です）と、その issue を close する closing reference を持つ
+  OPEN な PR の `updatedAt`（`intent-pr-created` が付与される前でも、
+  紐づく PR 自身の活動はカウントされます）の、より新しい方として
+  近似されます。`recommended_action` は常に、assigned worker への
+  status check request として読めるテキストです — 沈黙だけから
+  completion・failure・いかなる transition も決して仮定しません。
+  issue に PR が作成されると（`intent-pr-created`）、代わりに
+  PR-lifecycle の kind が引き継ぎます。repair 状態の PR 自体が
+  閾値を超えて stale であることを検出するのは、明示的に out-of-scope の
+  follow-up です。
+
 各 item は `kind`、`execution_unit`、`issue` および/または `pr`
-（番号 + url）、`age_minutes`、`recommended_action`（次に実行すべき
-正確な canonical コマンド — それぞれ `worker claim`、`automation
-pr-transition --transition review-start`、`closeout pr`）を報告します。
-`--stale-minutes` は、指定した閾値より新しい item を除外します
-（デフォルトは `0` — すべてを age 付きで報告し、閾値は呼び出し側が選ぶ）。
-`age_minutes` は、GitHub が label 適用時刻を公開していないため、
-該当する GitHub entity の `createdAt`/`updatedAt` タイムスタンプからの
-近似値です。`published-not-delegated` は、既に取得済みの PR closing
-reference も issue label とは独立にチェックします — そのため、
-completion label が実態とずれてしまっていても（intent-pr-created が
-一度も付与されていない、または削除されてしまったが、OPEN の PR が
-既にその issue を close している場合）、誤って `worker claim` を推奨する
-ことはありません。
+（番号 + url）、`age_minutes`、`is_informational`、`recommended_action`
+を報告します。`--stale-minutes` は、指定した閾値より新しい item を
+除外します（デフォルトは `0` — すべてを age 付きで報告し、閾値は
+呼び出し側が選ぶ）— これは 6 つすべての kind に一律に適用されます。
+`claimed-but-silent` は、そもそも item が検討される前に、それ自身の
+`--claimed-silent-minutes` 閾値でも追加でゲートされます（そのため
+`--stale-minutes` を上げるだけでは、`claimed-but-silent` の item が
+自身の閾値より早く現れることは決してありません）。`age_minutes` は、
+GitHub が label 適用時刻や、専用の per-issue fetch 無しでの timeline
+event を公開していないため、該当する GitHub entity の
+`createdAt`/`updatedAt` タイムスタンプからの近似値です。
+`published-not-delegated` は、既に取得済みの PR closing reference も
+issue label とは独立にチェックします — そのため、completion label が
+実態とずれてしまっていても（intent-pr-created が一度も付与されていない、
+または削除されてしまったが、OPEN の PR が既にその issue を close して
+いる場合）、誤って `worker claim` を推奨することはありません。
 
 **execution unit と domain の特定 (G532)**
 
@@ -366,6 +411,15 @@ packet.yaml が存在せず、かつどの packet の `source_execution_unit`
 
 このスライスは検出のみです — orchestrator wake procedure や外部
 heartbeat からこのサーフェスを利用する部分は、別の後続スライスです。
+
+`automation heartbeat` (G526) はこの同じ analyzer をラップし、
+`is_informational` を `message_body` に反映します: サマリー行は
+「`N` pending transition(s)」と、informational な item が 1 つでも
+あれば「`M` informational note(s)」に分かれます。各 item の行は、
+actionable な kind では `— recommended:` コマンド ``、informational な
+kind では `— FYI:` prose `` で終わります — そのため読み手（人間でも
+orchestrator でも）が「transition は不要」を actionable な次コマンドと
+取り違えることはありません。
 
 ### 行き詰まった published issue を retire する (G525)
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -279,11 +279,15 @@ age は可視性のためだけに報告されます:
   として誤報告され、`review-start` が推奨されていました — repair の
   最中としては意味的に間違っています。推奨を毎回疑ってかからなければ
   ならない detector は、その価値を失います。`age_minutes` は、PR の
-  作成時刻ではなく PR 自身の `updatedAt`（repair 状態に入った時点）から
-  計測されます。
+  作成時刻ではなく PR 自身の `updatedAt` から計測されます — これは
+  「repair 状態に入った時点」の CONSERVATIVE な近似であり、正確な
+  label 付与の瞬間ではありません: GitHub は per-label-application の
+  タイムスタンプを公開しておらず、`updatedAt` は（専用の label-event
+  fetch を追加しない限り）その label の変更より後になり得る、PR への
+  あらゆる種類の最新の変更を反映します。
 - `rereview-pending` — `intent-pr-rereview-ready` を持つ PR（repair が
   push され、re-review 待ち）。`repair-pending` と同じ `updatedAt` ベース
-  の age 規約です。
+  の age 近似です。
 - `claimed-but-silent` — `intent-issue-in-progress` を持つが **まだ PR が
   作成されていない** issue で、`--claimed-silent-minutes`（デフォルトは
   **720** 分 / 12 時間 — 通常の作業セッションでは決して発火しないよう
@@ -294,11 +298,20 @@ age は可視性のためだけに報告されます:
   proxy です）と、その issue を close する closing reference を持つ
   OPEN な PR の `updatedAt`（`intent-pr-created` が付与される前でも、
   紐づく PR 自身の活動はカウントされます）の、より新しい方として
-  近似されます。`recommended_action` は常に、assigned worker への
-  status check request として読めるテキストです — 沈黙だけから
-  completion・failure・いかなる transition も決して仮定しません。
-  issue に PR が作成されると（`intent-pr-created`）、代わりに
-  PR-lifecycle の kind が引き継ぎます。repair 状態の PR 自体が
+  近似されます。issue または紐づく PR の `updatedAt` が欠落・不正な
+  場合、それを「古い活動」として `createdAt`（claim 取得時刻や最終
+  タッチ時刻ではなく、issue/PR が開かれた時刻を表す）にフォールバック
+  することは決してありません — 誤解を招くほど古い silence interval を
+  作り出してしまう可能性があるためです。代わりに、`excluded[]`
+  （`activity-data-unusable`、どのタイムスタンプが使用不能だったかを
+  明示）に入り fail closed します。パースされたタイムスタンプが
+  （clock skew などで）未来の時刻になっている場合は、そのまま信頼せず
+  「今」にクランプされます — これは candidate をより silent でなく
+  見せる方向にしか作用しません。`recommended_action` は常に、
+  assigned worker への status check request として読めるテキストです
+  — 沈黙だけから completion・failure・いかなる transition も決して
+  仮定しません。issue に PR が作成されると（`intent-pr-created`）、
+  代わりに PR-lifecycle の kind が引き継ぎます。repair 状態の PR 自体が
   閾値を超えて stale であることを検出するのは、明示的に out-of-scope の
   follow-up です。
 

--- a/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
@@ -109,14 +109,30 @@ internal static class AutomationHeartbeatCommand
     /// contract, a single message is sufficient to trigger a full recovery
     /// wake — this body is meant to be sent once per heartbeat run, verbatim,
     /// by the external wrapper.
+    ///
+    /// G533: the summary line and per-item framing distinguish ACTIONABLE
+    /// items (a runnable command is recommended) from INFORMATIONAL ones
+    /// (<see cref="StalledWorkItem.IsInformational"/> — repair-pending,
+    /// rereview-pending, claimed-but-silent) so a reader — human or
+    /// orchestrator — never mistakes "FYI, no transition needed" for
+    /// "pending transition(s)".
     /// </summary>
     private static string BuildMessageBody(AutomationStalledWorkResult stalledWork)
     {
+        var actionableCount = stalledWork.Items.Count(item => !item.IsInformational);
+        var informationalCount = stalledWork.Items.Count(item => item.IsInformational);
+
         var builder = new StringBuilder();
         builder
             .Append("WAKE (heartbeat): ")
-            .Append(stalledWork.Items.Count)
-            .Append(" pending transition(s) stale >= ")
+            .Append(actionableCount)
+            .Append(" pending transition(s)");
+        if (informationalCount > 0)
+        {
+            builder.Append(", ").Append(informationalCount).Append(" informational note(s)");
+        }
+        builder
+            .Append(" stale >= ")
             .Append(stalledWork.StaleMinutesThreshold)
             .Append("m in ")
             .Append(stalledWork.Repo)
@@ -143,7 +159,15 @@ internal static class AutomationHeartbeatCommand
                 builder.Append(", pr #").Append(pr.Number);
             }
 
-            builder.Append(") — recommended: `").Append(item.RecommendedAction).Append('`');
+            builder.Append(')');
+            if (item.IsInformational)
+            {
+                builder.Append(" — FYI: ").Append(item.RecommendedAction);
+            }
+            else
+            {
+                builder.Append(" — recommended: `").Append(item.RecommendedAction).Append('`');
+            }
         }
 
         return builder.ToString();
@@ -246,7 +270,8 @@ internal static class AutomationHeartbeatCommand
         {
             foreach (var item in result.Items)
             {
-                writer.WriteLine($"## `{item.ExecutionUnit}` — {item.Kind} ({item.AgeMinutes}m)");
+                var kindLabel = item.IsInformational ? $"{item.Kind}, informational" : item.Kind;
+                writer.WriteLine($"## `{item.ExecutionUnit}` — {kindLabel} ({item.AgeMinutes}m)");
                 if (item.Issue is { } issue)
                 {
                     writer.WriteLine($"- issue: #{issue.Number} — {issue.Url}");
@@ -255,7 +280,14 @@ internal static class AutomationHeartbeatCommand
                 {
                     writer.WriteLine($"- pr: #{pr.Number} — {pr.Url}");
                 }
-                writer.WriteLine($"- recommended_action: `{item.RecommendedAction}`");
+                if (item.IsInformational)
+                {
+                    writer.WriteLine($"- status: {item.RecommendedAction}");
+                }
+                else
+                {
+                    writer.WriteLine($"- recommended_action: `{item.RecommendedAction}`");
+                }
                 writer.WriteLine();
             }
         }

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -7,12 +7,14 @@ namespace IntentSystem.Cli.Commands;
 
 /// <summary>
 /// G523: <c>intent-cli automation stalled-work --domain &lt;d&gt; --repo &lt;r&gt;
-/// [--stale-minutes &lt;m&gt;] [--format json|markdown]</c> — read-only
-/// inventory of pending pipeline transitions with ages, so a single
-/// orchestrator wake (or an external heartbeat) can detect a stall without a
-/// human cross-checking GitHub labels, PR state, and queue-state by hand.
+/// [--stale-minutes &lt;m&gt;] [--claimed-silent-minutes &lt;m&gt;]
+/// [--format json|markdown]</c> — read-only inventory of pending pipeline
+/// transitions with ages, so a single orchestrator wake (or an external
+/// heartbeat) can detect a stall without a human cross-checking GitHub
+/// labels, PR state, and queue-state by hand.
 ///
-/// Categories:
+/// Actionable categories (carry a runnable <c>recommended_action</c> command,
+/// <see cref="StalledWorkItem.IsInformational"/> is <see langword="false"/>):
 /// <list type="bullet">
 /// <item><c>published-not-delegated</c> — an OPEN issue carries
 ///   <c>intent-target</c>, has no claim label
@@ -22,18 +24,42 @@ namespace IntentSystem.Cli.Commands;
 /// <item><c>pr-created-not-reviewing</c> — the source issue carries
 ///   <c>intent-pr-created</c> and its closing PR has not had the
 ///   <c>review-start</c> transition applied (no <c>intent-pr-reviewing</c> /
-///   <c>intent-pr-approved</c> on the PR).</item>
+///   <c>intent-pr-approved</c> on the PR), and the PR is NOT already in the
+///   repair or rereview lifecycle (see <c>repair-pending</c>/
+///   <c>rereview-pending</c> below — G533 review repair, field finding: PR
+///   #1750 was misreported this way with a wrong review-start
+///   recommendation mid-repair).</item>
 /// <item><c>merged-not-closed-out</c> — a MERGED PR's linked queue item is
 ///   not <see cref="QueueItemState.Completed"/>.</item>
 /// </list>
 ///
+/// Informational categories (G533 — age for visibility only,
+/// <c>recommended_action</c> is descriptive prose, never a transition,
+/// <see cref="StalledWorkItem.IsInformational"/> is <see langword="true"/>):
+/// <list type="bullet">
+/// <item><c>repair-pending</c> — a PR carrying <c>intent-pr-request-update</c>
+///   and/or <c>intent-pr-update-in-progress</c>; a review-start transition
+///   would be actively wrong mid-repair.</item>
+/// <item><c>rereview-pending</c> — a PR carrying
+///   <c>intent-pr-rereview-ready</c>; repair pushed, awaiting re-review.</item>
+/// <item><c>claimed-but-silent</c> — an issue carrying
+///   <c>intent-issue-in-progress</c> (no PR yet) with no observable activity
+///   for longer than <c>--claimed-silent-minutes</c> (default
+///   <see cref="DefaultClaimedSilentMinutes"/> minutes) — the third measured
+///   field stall class (silent completion / dead worker after claim).
+///   Recommends a worker status check, never assumes completion or
+///   failure from silence alone.</item>
+/// </list>
+///
 /// Age is approximated from the relevant GitHub entity's `createdAt` /
 /// `updatedAt` timestamp (GitHub does not expose per-label-application
-/// timestamps), which is the closest available proxy for "how long has this
-/// been pending".
+/// timestamps, or per-issue timeline events without a dedicated per-issue
+/// fetch this slice does not add), which is the closest available proxy for
+/// "how long has this been pending" / "how long has this been silent".
 ///
 /// Strictly read-only: no GitHub mutation, no queue-state/runs.jsonl write,
-/// no label change.
+/// no label change, no message sent — informational kinds recommend a
+/// status check but never send one themselves.
 ///
 /// Execution-unit and domain identification (G532, review-repaired):
 /// <list type="bullet">
@@ -83,6 +109,42 @@ internal static class AutomationStalledWorkCommand
     public const string KindMergedNotClosedOut = "merged-not-closed-out";
 
     /// <summary>
+    /// G533: a PR whose source issue carries <c>intent-pr-created</c> but
+    /// which is itself already in the repair lifecycle (<c>intent-pr-
+    /// request-update</c> and/or <c>intent-pr-update-in-progress</c>) —
+    /// informational, since a review-start transition would be wrong
+    /// mid-repair (field finding: PR #1750 was misreported as
+    /// <see cref="KindPrCreatedNotReviewing"/> with that exact wrong
+    /// recommendation).
+    /// </summary>
+    public const string KindRepairPending = "repair-pending";
+
+    /// <summary>
+    /// G533: a PR carrying <c>intent-pr-rereview-ready</c> — repair pushed,
+    /// awaiting re-review. Informational, same reasoning as
+    /// <see cref="KindRepairPending"/>.
+    /// </summary>
+    public const string KindRereviewPending = "rereview-pending";
+
+    /// <summary>
+    /// G533: an issue claimed via <c>intent-issue-in-progress</c> (with no
+    /// PR yet created) showing no observable activity for longer than the
+    /// conservative default threshold — the third measured stall class
+    /// from the field analysis (silent completion / dead worker after
+    /// claim). Informational: recommends a worker status check, never a
+    /// state transition (this command never assumes completion or failure
+    /// from silence alone).
+    /// </summary>
+    public const string KindClaimedButSilent = "claimed-but-silent";
+
+    /// <summary>
+    /// G533: conservative default for <c>--claimed-silent-minutes</c> (12
+    /// hours) — chosen so <c>claimed-but-silent</c> does not fire on an
+    /// ordinary work session; only a genuinely long silence after claim.
+    /// </summary>
+    public const int DefaultClaimedSilentMinutes = 720;
+
+    /// <summary>
     /// G532 review repair: a title matched more than one distinct packet's
     /// declared <c>source_execution_unit</c> as a token — the execution unit
     /// cannot be picked without guessing, so it is reported here instead of
@@ -101,7 +163,7 @@ internal static class AutomationStalledWorkCommand
     };
 
     private const string UsageLine =
-        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--stale-minutes <m>] [--format json|markdown]";
+        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--stale-minutes <m>] [--claimed-silent-minutes <m>] [--format json|markdown]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -115,7 +177,7 @@ internal static class AutomationStalledWorkCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var domain, out var repo, out var staleMinutes, out var format, out var error))
+        if (!TryParseArguments(args, out var domain, out var repo, out var staleMinutes, out var claimedSilentMinutes, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -125,7 +187,7 @@ internal static class AutomationStalledWorkCommand
         AutomationStalledWorkResult result;
         try
         {
-            result = Analyze(context, domain!, repo!, staleMinutes);
+            result = Analyze(context, domain!, repo!, staleMinutes, claimedSilentMinutes);
         }
         catch (Exception exception) when (exception is IOException or InvalidOperationException)
         {
@@ -154,8 +216,13 @@ internal static class AutomationStalledWorkCommand
     /// round-tripping through this command's own JSON output. Throws
     /// <see cref="IOException"/> / <see cref="InvalidOperationException"/>
     /// on a GitHub read failure — callers decide how to report it.
+    /// <paramref name="claimedSilentMinutes"/> defaults to
+    /// <see cref="DefaultClaimedSilentMinutes"/> so existing callers (e.g.
+    /// <c>automation heartbeat</c>) keep compiling and get the conservative
+    /// default without needing their own override plumbing.
     /// </summary>
-    public static AutomationStalledWorkResult Analyze(CliContext context, string domain, string repo, int staleMinutes)
+    public static AutomationStalledWorkResult Analyze(
+        CliContext context, string domain, string repo, int staleMinutes, int claimedSilentMinutes = DefaultClaimedSilentMinutes)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(domain);
@@ -175,6 +242,7 @@ internal static class AutomationStalledWorkCommand
         CollectPublishedNotDelegated(context, domain, candidateDomains, openIssues, openPrs, repo, now, items, excluded);
         CollectPrCreatedNotReviewing(context, domain, candidateDomains, openIssues, openPrs, repo, now, items, excluded);
         CollectMergedNotClosedOut(context, domain, candidateDomains, repo, mergedPrs, now, items, excluded, warnings);
+        CollectClaimedButSilent(context, domain, candidateDomains, openIssues, openPrs, repo, now, claimedSilentMinutes, items, excluded);
 
         var filtered = items
             .Where(item => item.AgeMinutes >= staleMinutes)
@@ -259,6 +327,7 @@ internal static class AutomationStalledWorkCommand
                 Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
                 Pr = null,
                 AgeMinutes = ComputeAgeMinutes(issue.CreatedAt, now),
+                IsInformational = false,
                 RecommendedAction =
                     $"intent-cli worker claim --repo {repo} --kind issue --number {issue.Number} --github-only --write",
             });
@@ -316,6 +385,40 @@ internal static class AutomationStalledWorkCommand
                 continue;
             }
 
+            // G533: a PR already in the repair or rereview lifecycle is NOT
+            // a "review hasn't started" stall — recommending review-start
+            // mid-repair is actively wrong (field finding: PR #1750 was
+            // misreported this way). Report it as an informational kind
+            // with age and no transition recommendation, rather than
+            // silently excluding it or misreporting it.
+            string kind;
+            bool isInformational;
+            string recommendedAction;
+            if (prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrRequestUpdate)
+                || prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress))
+            {
+                kind = KindRepairPending;
+                isInformational = true;
+                recommendedAction =
+                    "none — PR is in the repair lifecycle (change requested or repair in progress); "
+                    + "no transition is recommended until the repair completes.";
+            }
+            else if (prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrRereviewReady))
+            {
+                kind = KindRereviewPending;
+                isInformational = true;
+                recommendedAction =
+                    "none — PR has a repair pushed and is awaiting re-review; "
+                    + "no transition is recommended until a reviewer or automation re-reviews it.";
+            }
+            else
+            {
+                kind = KindPrCreatedNotReviewing;
+                isInformational = false;
+                recommendedAction =
+                    $"intent-cli automation pr-transition --repo {repo} --pr {pr.Number} --transition review-start --write";
+            }
+
             var resolution = ResolveExecutionUnit(context, matchedIssue.Title);
             var packetDeclaredDomain = resolution.Corroborated ? ReadPacketDeclaredDomain(context, resolution.ExecutionUnit) : null;
             if (!TryConfirmDomain(domain, resolution, packetDeclaredDomain, candidateDomains, repo,
@@ -323,7 +426,7 @@ internal static class AutomationStalledWorkCommand
             {
                 excluded.Add(new StalledWorkExcluded
                 {
-                    Kind = KindPrCreatedNotReviewing,
+                    Kind = kind,
                     ExecutionUnit = resolution.ExecutionUnit,
                     Issue = new StalledWorkRef { Number = matchedIssue.Number, Url = matchedIssue.Url },
                     Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
@@ -333,15 +436,23 @@ internal static class AutomationStalledWorkCommand
                 continue;
             }
 
+            // G533: repair-pending/rereview-pending age is best approximated
+            // by the PR's own `updatedAt` (bumped when the request-update/
+            // update-in-progress/rereview-ready label was applied) rather
+            // than `createdAt` — these are POST-creation lifecycle states,
+            // so "how long has this been pending" means "since entering
+            // this state", not "since the PR was opened".
+            var ageSource = isInformational ? pr.UpdatedAt : pr.CreatedAt;
+
             items.Add(new StalledWorkItem
             {
-                Kind = KindPrCreatedNotReviewing,
+                Kind = kind,
                 ExecutionUnit = resolution.ExecutionUnit,
                 Issue = new StalledWorkRef { Number = matchedIssue.Number, Url = matchedIssue.Url },
                 Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
-                AgeMinutes = ComputeAgeMinutes(pr.CreatedAt, now),
-                RecommendedAction =
-                    $"intent-cli automation pr-transition --repo {repo} --pr {pr.Number} --transition review-start --write",
+                AgeMinutes = ComputeAgeMinutes(ageSource, now),
+                IsInformational = isInformational,
+                RecommendedAction = recommendedAction,
             });
         }
     }
@@ -494,8 +605,125 @@ internal static class AutomationStalledWorkCommand
                 // dedicated `mergedAt` field in the requested field set;
                 // `updatedAt` is set to the merge time for a merged PR.
                 AgeMinutes = ComputeAgeMinutes(pr.UpdatedAt, now),
+                IsInformational = false,
                 RecommendedAction =
                     $"intent-cli closeout pr --pr {pr.Number} --repo {repo} --domain {domain} --pr-merged true --write --format json",
+            });
+        }
+    }
+
+    /// <summary>
+    /// G533: an issue claimed via <c>intent-issue-in-progress</c> that has
+    /// produced no observable activity for longer than
+    /// <paramref name="claimedSilentMinutes"/> — the third measured field
+    /// stall class (silent completion / dead worker after claim). Scoped to
+    /// issues WITHOUT <c>intent-pr-created</c> yet — once a PR exists, the
+    /// PR-lifecycle kinds (<see cref="KindPrCreatedNotReviewing"/>,
+    /// <see cref="KindRepairPending"/>, <see cref="KindRereviewPending"/>)
+    /// take over; detecting a repair-state PR that is itself stale is a
+    /// deliberately separate, out-of-scope follow-up.
+    ///
+    /// "Observable activity" is approximated as the MORE RECENT of the
+    /// issue's own <c>updatedAt</c> (GitHub bumps this on any label change,
+    /// comment, or other timeline event — the closest available proxy
+    /// without a dedicated per-issue timeline-events fetch) and the
+    /// <c>updatedAt</c> of any open PR whose closing references name this
+    /// issue (a linked PR's own activity counts too, even before
+    /// <c>intent-pr-created</c> is applied — e.g. a freshly-opened draft).
+    /// Conservative by construction: the default 720-minute threshold means
+    /// an ordinary work session never fires this kind.
+    /// </summary>
+    private static void CollectClaimedButSilent(
+        CliContext context,
+        string domain,
+        IReadOnlyList<string> candidateDomains,
+        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues,
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
+        string repo,
+        DateTimeOffset now,
+        int claimedSilentMinutes,
+        List<StalledWorkItem> items,
+        List<StalledWorkExcluded> excluded)
+    {
+        foreach (var issue in openIssues)
+        {
+            if (!IsOpen(issue.State))
+            {
+                continue;
+            }
+
+            var labels = LabelSet(issue.Labels);
+            if (!labels.Contains(WorkerNextActionConstants.Labels.IntentTarget))
+            {
+                continue;
+            }
+            if (!labels.Contains(WorkerNextActionConstants.Labels.IntentIssueInProgress))
+            {
+                continue;
+            }
+            if (labels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated))
+            {
+                // A PR already exists — the PR-lifecycle kinds cover this
+                // issue's ongoing state now, not the claim-silence check.
+                continue;
+            }
+
+            var lastActivity = ParseTimestampOrFallback(issue.UpdatedAt, issue.CreatedAt);
+            foreach (var pr in openPrs)
+            {
+                if (!IsOpen(pr.State))
+                {
+                    continue;
+                }
+                foreach (var reference in pr.ClosingIssuesReferences)
+                {
+                    if (reference.Number == issue.Number && ReferenceMatchesRepo(reference, repo))
+                    {
+                        var prActivity = ParseTimestampOrFallback(pr.UpdatedAt, pr.CreatedAt);
+                        if (prActivity > lastActivity)
+                        {
+                            lastActivity = prActivity;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            var silentMinutes = ComputeAgeMinutesFromInstant(lastActivity, now);
+            if (silentMinutes < claimedSilentMinutes)
+            {
+                continue;
+            }
+
+            var resolution = ResolveExecutionUnit(context, issue.Title);
+            var packetDeclaredDomain = resolution.Corroborated ? ReadPacketDeclaredDomain(context, resolution.ExecutionUnit) : null;
+            if (!TryConfirmDomain(domain, resolution, packetDeclaredDomain, candidateDomains, repo,
+                    out var reason, out var detail))
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindClaimedButSilent,
+                    ExecutionUnit = resolution.ExecutionUnit,
+                    Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
+                    Pr = null,
+                    Reason = reason,
+                    Detail = detail,
+                });
+                continue;
+            }
+
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindClaimedButSilent,
+                ExecutionUnit = resolution.ExecutionUnit,
+                Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
+                Pr = null,
+                AgeMinutes = silentMinutes,
+                IsInformational = true,
+                RecommendedAction =
+                    $"status check: no observable activity on `{resolution.ExecutionUnit}` (issue #{issue.Number}) "
+                    + $"for {silentMinutes}m since claim — ask the assigned worker for a status update; "
+                    + "do not assume completion, failure, or transition state from silence alone.",
             });
         }
     }
@@ -896,17 +1124,54 @@ internal static class AutomationStalledWorkCommand
         return minutes > 0 ? (int)minutes : 0;
     }
 
+    /// <summary>
+    /// G533: parses <paramref name="primary"/> (typically an entity's own
+    /// <c>updatedAt</c>), falling back to <paramref name="fallback"/>
+    /// (typically its <c>createdAt</c>) when <paramref name="primary"/> is
+    /// missing/unparseable — callers that pre-date the <c>updatedAt</c>
+    /// field, or a genuinely empty value, still get a usable "last known
+    /// activity" instant rather than an epoch-zero distortion.
+    /// </summary>
+    private static DateTimeOffset ParseTimestampOrFallback(string primary, string fallback)
+    {
+        if (!string.IsNullOrWhiteSpace(primary)
+            && DateTimeOffset.TryParse(primary, System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AssumeUniversal, out var parsedPrimary))
+        {
+            return parsedPrimary;
+        }
+        if (!string.IsNullOrWhiteSpace(fallback)
+            && DateTimeOffset.TryParse(fallback, System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AssumeUniversal, out var parsedFallback))
+        {
+            return parsedFallback;
+        }
+        return DateTimeOffset.MinValue;
+    }
+
+    private static int ComputeAgeMinutesFromInstant(DateTimeOffset instant, DateTimeOffset now)
+    {
+        if (instant == DateTimeOffset.MinValue)
+        {
+            return 0;
+        }
+        var minutes = (now - instant).TotalMinutes;
+        return minutes > 0 ? (int)minutes : 0;
+    }
+
     private static bool TryParseArguments(
         string[] args,
         out string? domain,
         out string? repo,
         out int staleMinutes,
+        out int claimedSilentMinutes,
         out string format,
         out string error)
     {
         domain = null;
         repo = null;
         staleMinutes = 0;
+        claimedSilentMinutes = DefaultClaimedSilentMinutes;
         format = FormatMarkdown;
         error = string.Empty;
 
@@ -940,6 +1205,18 @@ internal static class AutomationStalledWorkCommand
                         return false;
                     }
                     staleMinutes = parsedMinutes;
+                    index++;
+                    break;
+                case "--claimed-silent-minutes":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture, out var parsedSilentMinutes)
+                        || parsedSilentMinutes < 0)
+                    {
+                        error = "--claimed-silent-minutes requires a non-negative integer.";
+                        return false;
+                    }
+                    claimedSilentMinutes = parsedSilentMinutes;
                     index++;
                     break;
                 case "--format":
@@ -994,7 +1271,8 @@ internal static class AutomationStalledWorkCommand
         {
             foreach (var item in result.Items)
             {
-                writer.WriteLine($"## `{item.ExecutionUnit}` — {item.Kind} ({item.AgeMinutes}m)");
+                var kindLabel = item.IsInformational ? $"{item.Kind}, informational" : item.Kind;
+                writer.WriteLine($"## `{item.ExecutionUnit}` — {kindLabel} ({item.AgeMinutes}m)");
                 if (item.Issue is { } issue)
                 {
                     writer.WriteLine($"- issue: #{issue.Number} — {issue.Url}");
@@ -1003,7 +1281,18 @@ internal static class AutomationStalledWorkCommand
                 {
                     writer.WriteLine($"- pr: #{pr.Number} — {pr.Url}");
                 }
-                writer.WriteLine($"- recommended_action: `{item.RecommendedAction}`");
+                // G533: informational kinds never recommend a transition —
+                // rendered as `status` (descriptive prose) rather than
+                // `recommended_action` (always a runnable command) so a
+                // reader never mistakes one for the other.
+                if (item.IsInformational)
+                {
+                    writer.WriteLine($"- status: {item.RecommendedAction}");
+                }
+                else
+                {
+                    writer.WriteLine($"- recommended_action: `{item.RecommendedAction}`");
+                }
                 writer.WriteLine();
             }
         }
@@ -1094,6 +1383,19 @@ internal sealed record StalledWorkItem
 
     [JsonPropertyName("age_minutes")]
     public required int AgeMinutes { get; init; }
+
+    /// <summary>
+    /// G533: <see langword="true"/> for <see cref="AutomationStalledWorkCommand.KindRepairPending"/>,
+    /// <see cref="AutomationStalledWorkCommand.KindRereviewPending"/>, and
+    /// <see cref="AutomationStalledWorkCommand.KindClaimedButSilent"/> —
+    /// these kinds carry age for visibility but never recommend a state
+    /// transition (<see cref="RecommendedAction"/> is descriptive prose, not
+    /// an executable command). <see langword="false"/> for the original
+    /// three actionable kinds, where <see cref="RecommendedAction"/> is
+    /// always a runnable <c>intent-cli</c> command.
+    /// </summary>
+    [JsonPropertyName("is_informational")]
+    public required bool IsInformational { get; init; }
 
     [JsonPropertyName("recommended_action")]
     public required string RecommendedAction { get; init; }

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -152,6 +152,16 @@ internal static class AutomationStalledWorkCommand
     /// </summary>
     public const string ReasonExecutionUnitAmbiguous = "execution-unit-ambiguous";
 
+    /// <summary>
+    /// G533 review repair: <see cref="KindClaimedButSilent"/>'s own
+    /// last-activity timestamp (the issue's own <c>updatedAt</c>, or a
+    /// linked open PR's <c>updatedAt</c>) is missing or malformed —
+    /// silence can never be reliably established, so the candidate is
+    /// excluded rather than substituting a different field (e.g.
+    /// <c>createdAt</c>) that measures a different event entirely.
+    /// </summary>
+    public const string ReasonActivityDataUnusable = "activity-data-unusable";
+
     public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
 
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
@@ -436,12 +446,16 @@ internal static class AutomationStalledWorkCommand
                 continue;
             }
 
-            // G533: repair-pending/rereview-pending age is best approximated
-            // by the PR's own `updatedAt` (bumped when the request-update/
-            // update-in-progress/rereview-ready label was applied) rather
-            // than `createdAt` — these are POST-creation lifecycle states,
-            // so "how long has this been pending" means "since entering
-            // this state", not "since the PR was opened".
+            // G533 review repair: repair-pending/rereview-pending age uses
+            // the PR's own `updatedAt` rather than `createdAt` — these are
+            // POST-creation lifecycle states, so "how long has this been
+            // pending" should mean "since entering this state", not "since
+            // the PR was opened". `updatedAt` is only a CONSERVATIVE
+            // approximation of that, though, not the exact label-application
+            // moment: GitHub does not expose per-label-application
+            // timestamps, and `updatedAt` reflects the PR's most recent
+            // modification of ANY kind (which may postdate the specific
+            // label change) unless a dedicated label-event fetch is added.
             var ageSource = isInformational ? pr.UpdatedAt : pr.CreatedAt;
 
             items.Add(new StalledWorkItem
@@ -632,6 +646,22 @@ internal static class AutomationStalledWorkCommand
     /// <c>intent-pr-created</c> is applied — e.g. a freshly-opened draft).
     /// Conservative by construction: the default 720-minute threshold means
     /// an ordinary work session never fires this kind.
+    ///
+    /// G533 review repair: a missing or malformed <c>updatedAt</c> — on
+    /// either the issue OR a linked PR — is never silently treated as "old
+    /// activity" by falling back to <c>createdAt</c>. <c>createdAt</c>
+    /// measures a DIFFERENT event (issue open time / PR open time, not
+    /// claim acquisition or the linked PR's own last touch) and could
+    /// manufacture a silence interval that begins long before the claim
+    /// was ever made, firing this kind on unusable evidence rather than
+    /// genuine silence. Unusable activity data fails closed into
+    /// <c>excluded[]</c> (never <c>items[]</c>) with a structured
+    /// diagnostic naming exactly which timestamp was unusable and why. A
+    /// parsed timestamp that is somehow in the future relative to
+    /// <paramref name="now"/> (clock skew, bad data) is clamped to
+    /// <paramref name="now"/> — conservative in the same direction as
+    /// everything else here: it can only ever make the candidate look
+    /// LESS silent, never manufacture a false positive.
     /// </summary>
     private static void CollectClaimedButSilent(
         CliContext context,
@@ -668,7 +698,35 @@ internal static class AutomationStalledWorkCommand
                 continue;
             }
 
-            var lastActivity = ParseTimestampOrFallback(issue.UpdatedAt, issue.CreatedAt);
+            // Best-effort execution-unit naming for diagnostics below —
+            // used regardless of whether corroboration/domain confirmation
+            // ultimately succeeds, matching the pattern every other
+            // collector in this file already follows.
+            var resolution = ResolveExecutionUnit(context, issue.Title);
+            var issueRef = new StalledWorkRef { Number = issue.Number, Url = issue.Url };
+
+            if (!TryParseActivityTimestamp(issue.UpdatedAt, out var issueActivity, out var issueProblem))
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindClaimedButSilent,
+                    ExecutionUnit = resolution.ExecutionUnit,
+                    Issue = issueRef,
+                    Pr = null,
+                    Reason = ReasonActivityDataUnusable,
+                    Detail =
+                        $"issue #{issue.Number}'s updatedAt is {issueProblem} — claimed-but-silent requires a "
+                        + "valid last-activity timestamp and never substitutes createdAt (issue OPEN time, not "
+                        + "claim acquisition time) as a stand-in, since that could manufacture a misleadingly old "
+                        + "silence interval.",
+                });
+                continue;
+            }
+
+            var lastActivity = ClampToNow(issueActivity, now);
+            var linkedPrActivityUnusable = false;
+            string? linkedPrProblemDetail = null;
+
             foreach (var pr in openPrs)
             {
                 if (!IsOpen(pr.State))
@@ -679,14 +737,39 @@ internal static class AutomationStalledWorkCommand
                 {
                     if (reference.Number == issue.Number && ReferenceMatchesRepo(reference, repo))
                     {
-                        var prActivity = ParseTimestampOrFallback(pr.UpdatedAt, pr.CreatedAt);
-                        if (prActivity > lastActivity)
+                        if (!TryParseActivityTimestamp(pr.UpdatedAt, out var prActivity, out var prProblem))
                         {
-                            lastActivity = prActivity;
+                            linkedPrActivityUnusable = true;
+                            linkedPrProblemDetail =
+                                $"linked PR #{pr.Number}'s updatedAt is {prProblem} — its real activity could not "
+                                + "be verified, so this candidate is conservatively excluded rather than risking "
+                                + "an under-counted (falsely silent) result.";
+                        }
+                        else
+                        {
+                            var clampedPrActivity = ClampToNow(prActivity, now);
+                            if (clampedPrActivity > lastActivity)
+                            {
+                                lastActivity = clampedPrActivity;
+                            }
                         }
                         break;
                     }
                 }
+            }
+
+            if (linkedPrActivityUnusable)
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindClaimedButSilent,
+                    ExecutionUnit = resolution.ExecutionUnit,
+                    Issue = issueRef,
+                    Pr = null,
+                    Reason = ReasonActivityDataUnusable,
+                    Detail = linkedPrProblemDetail!,
+                });
+                continue;
             }
 
             var silentMinutes = ComputeAgeMinutesFromInstant(lastActivity, now);
@@ -695,7 +778,6 @@ internal static class AutomationStalledWorkCommand
                 continue;
             }
 
-            var resolution = ResolveExecutionUnit(context, issue.Title);
             var packetDeclaredDomain = resolution.Corroborated ? ReadPacketDeclaredDomain(context, resolution.ExecutionUnit) : null;
             if (!TryConfirmDomain(domain, resolution, packetDeclaredDomain, candidateDomains, repo,
                     out var reason, out var detail))
@@ -704,7 +786,7 @@ internal static class AutomationStalledWorkCommand
                 {
                     Kind = KindClaimedButSilent,
                     ExecutionUnit = resolution.ExecutionUnit,
-                    Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
+                    Issue = issueRef,
                     Pr = null,
                     Reason = reason,
                     Detail = detail,
@@ -716,7 +798,7 @@ internal static class AutomationStalledWorkCommand
             {
                 Kind = KindClaimedButSilent,
                 ExecutionUnit = resolution.ExecutionUnit,
-                Issue = new StalledWorkRef { Number = issue.Number, Url = issue.Url },
+                Issue = issueRef,
                 Pr = null,
                 AgeMinutes = silentMinutes,
                 IsInformational = true,
@@ -1125,36 +1207,52 @@ internal static class AutomationStalledWorkCommand
     }
 
     /// <summary>
-    /// G533: parses <paramref name="primary"/> (typically an entity's own
-    /// <c>updatedAt</c>), falling back to <paramref name="fallback"/>
-    /// (typically its <c>createdAt</c>) when <paramref name="primary"/> is
-    /// missing/unparseable — callers that pre-date the <c>updatedAt</c>
-    /// field, or a genuinely empty value, still get a usable "last known
-    /// activity" instant rather than an epoch-zero distortion.
+    /// G533 review repair: parses <paramref name="timestamp"/> (an entity's
+    /// own <c>updatedAt</c>) for <see cref="KindClaimedButSilent"/>'s
+    /// activity determination — deliberately NEVER falls back to a
+    /// different field (e.g. <c>createdAt</c>) on failure, unlike
+    /// <see cref="ComputeAgeMinutes"/>'s "unparseable means age zero"
+    /// convention used by the other (actionable) kinds. Those other kinds
+    /// treat a missing timestamp as "just happened" (age 0, never
+    /// over-reports staleness); doing the same here — or worse, falling
+    /// back to <c>createdAt</c> — would let claimed-but-silent fire (or
+    /// under-fire) on evidence that was never actually observed. Returns
+    /// <see langword="false"/> with a human-readable <paramref name="problem"/>
+    /// string ("missing" or "malformed (could not parse '...')") on
+    /// failure, so the caller can fail closed with a structured diagnostic
+    /// instead of guessing.
     /// </summary>
-    private static DateTimeOffset ParseTimestampOrFallback(string primary, string fallback)
+    private static bool TryParseActivityTimestamp(string timestamp, out DateTimeOffset instant, out string? problem)
     {
-        if (!string.IsNullOrWhiteSpace(primary)
-            && DateTimeOffset.TryParse(primary, System.Globalization.CultureInfo.InvariantCulture,
-                System.Globalization.DateTimeStyles.AssumeUniversal, out var parsedPrimary))
+        if (string.IsNullOrWhiteSpace(timestamp))
         {
-            return parsedPrimary;
+            instant = default;
+            problem = "missing";
+            return false;
         }
-        if (!string.IsNullOrWhiteSpace(fallback)
-            && DateTimeOffset.TryParse(fallback, System.Globalization.CultureInfo.InvariantCulture,
-                System.Globalization.DateTimeStyles.AssumeUniversal, out var parsedFallback))
+        if (!DateTimeOffset.TryParse(timestamp, System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AssumeUniversal, out instant))
         {
-            return parsedFallback;
+            problem = $"malformed (could not parse '{timestamp}')";
+            return false;
         }
-        return DateTimeOffset.MinValue;
+        problem = null;
+        return true;
     }
+
+    /// <summary>
+    /// G533 review repair: a parsed activity timestamp that is somehow in
+    /// the future relative to <paramref name="now"/> (clock skew, bad
+    /// data) is clamped to <paramref name="now"/> rather than trusted
+    /// verbatim — this can only ever make a candidate look LESS silent
+    /// (conservative), never manufacture a false <see cref="KindClaimedButSilent"/>
+    /// positive from an implausible timestamp.
+    /// </summary>
+    private static DateTimeOffset ClampToNow(DateTimeOffset instant, DateTimeOffset now) =>
+        instant > now ? now : instant;
 
     private static int ComputeAgeMinutesFromInstant(DateTimeOffset instant, DateTimeOffset now)
     {
-        if (instant == DateTimeOffset.MinValue)
-        {
-            return 0;
-        }
         var minutes = (now - instant).TotalMinutes;
         return minutes > 0 ? (int)minutes : 0;
     }

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -100,6 +100,17 @@ internal sealed record GitHubAutomationIssueCandidate
     [JsonPropertyName("createdAt")]
     public string CreatedAt { get; init; } = string.Empty;
 
+    /// <summary>
+    /// G533: GitHub's own "last modified" timestamp — bumped by any
+    /// label change, comment, or other timeline event on the issue, so it
+    /// is the closest available proxy for "last observable activity"
+    /// without a dedicated per-issue timeline-events fetch. Empty for
+    /// callers that pre-date the field; treated as unknown (falls back to
+    /// <see cref="CreatedAt"/>) by consumers.
+    /// </summary>
+    [JsonPropertyName("updatedAt")]
+    public string UpdatedAt { get; init; } = string.Empty;
+
     [JsonPropertyName("labels")]
     public IReadOnlyList<GitHubAutomationLabel> Labels { get; init; }
         = Array.Empty<GitHubAutomationLabel>();
@@ -136,7 +147,11 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
     // G289: also request `state` so the analyzer can defensively filter
     // closed issues / PRs from WIP detection even when callers (e.g. test
     // fakes) don't pre-apply `--state open`.
-    internal const string ListJsonFields = "number,title,url,createdAt,labels,state";
+    // G533: also request `updatedAt` — the closest available proxy for
+    // "last observable issue activity" (label change, comment, etc.)
+    // without a dedicated per-issue timeline-events fetch, used by
+    // `automation stalled-work`'s claimed-but-silent detection.
+    internal const string ListJsonFields = "number,title,url,createdAt,updatedAt,labels,state";
 
     // G319: also request `isDraft` so the host-loop-next-action analyzer
     // can map an approved-but-draft PR to `approved-pr-draft-blocked`

--- a/tests/IntentSystem.Cli.Tests/AutomationHeartbeatCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHeartbeatCommandTests.cs
@@ -243,6 +243,36 @@ public sealed class AutomationHeartbeatCommandTests : IDisposable
         Assert.Contains("WAKE (heartbeat)", output, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_RepairPendingItem_MessageBodyFramesAsFyiNotRecommended()
+    {
+        // G533: an informational kind (repair-pending here) must render as
+        // "FYI: ..." prose in message_body, never "recommended: `<command>`"
+        // — a reader (human or orchestrator) must never mistake "no
+        // transition needed" for an actionable next command.
+        using var workspace = new HeartbeatWorkspace();
+        workspace.WritePacketDomain("G521", "intent-cli");
+        var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildOpenPrClosingIssue(1750, FixedNow.AddHours(-3), 1143, "intent-pr-request-update");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHeartbeatCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--stale-minutes", "0", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var messageBody = doc.RootElement.GetProperty("message_body").GetString();
+        Assert.NotNull(messageBody);
+        Assert.Contains("repair-pending", messageBody, StringComparison.Ordinal);
+        Assert.Contains("FYI:", messageBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("recommended: `", messageBody, StringComparison.Ordinal);
+        Assert.Contains("informational note(s)", messageBody, StringComparison.Ordinal);
+        Assert.Contains("0 pending transition(s)", messageBody, StringComparison.Ordinal);
+    }
+
     private static GitHubAutomationIssueCandidate BuildIssue(
         int number, string title, DateTimeOffset createdAt, params string[] labels) => new()
         {
@@ -265,6 +295,34 @@ public sealed class AutomationHeartbeatCommandTests : IDisposable
         UpdatedAt = createdAt.ToString("O"),
         State = "MERGED",
         IsDraft = false,
+    };
+
+    /// <summary>G533: an OPEN PR closing a given issue, carrying arbitrary
+    /// extra labels — used for repair-pending/rereview-pending message_body
+    /// framing fixtures.</summary>
+    private static GitHubAutomationPrCandidate BuildOpenPrClosingIssue(
+        int number, DateTimeOffset createdAt, int closingIssueNumber, params string[] extraLabels) => new()
+    {
+        Number = number,
+        Title = "Some open PR",
+        Url = $"https://github.com/J-Tech-Japan/intent-system/pull/{number}",
+        CreatedAt = createdAt.ToString("O"),
+        UpdatedAt = createdAt.ToString("O"),
+        State = "OPEN",
+        IsDraft = false,
+        Labels = extraLabels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+        ClosingIssuesReferences = new[]
+        {
+            new GitHubPrClosingIssueReference
+            {
+                Number = closingIssueNumber,
+                Repository = new GitHubPrClosingIssueRepository
+                {
+                    Name = "intent-system",
+                    Owner = new GitHubPrClosingIssueRepositoryOwner { Login = "J-Tech-Japan" },
+                },
+            },
+        },
     };
 
     private sealed class FakeLister : IGitHubAutomationCandidateLister

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -74,9 +74,15 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     [Fact]
     public void Execute_PublishedNotDelegated_ExcludesIssueAlreadyClaimed()
     {
+        // G533: kept RECENT (well under the claimed-but-silent default
+        // 720-minute threshold) so this fixture stays narrowly scoped to
+        // its original purpose — published-not-delegated's own exclusion
+        // logic for an already-claimed issue — without incidentally also
+        // tripping the new claimed-but-silent kind (that scenario is
+        // covered by its own dedicated fixtures below).
         using var workspace = new StalledWorkWorkspace();
         workspace.WritePacketDomain("G524", "intent-cli");
-        var claimedIssue = BuildIssue(1148, "G524: Something else", FixedNow.AddHours(-26),
+        var claimedIssue = BuildIssue(1148, "G524: Something else", FixedNow.AddMinutes(-30),
             "intent-target", "intent-issue-in-progress");
         AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [claimedIssue]);
 
@@ -161,6 +167,247 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         var pr = BuildPr(1144, "G521: Document agmsg Codex monitor", FixedNow.AddHours(-1.5),
             state: "OPEN", closingIssueNumber: 1143, extraLabels: ["intent-pr-reviewing"]);
         AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+    }
+
+    // ── G533: repair-pending / rereview-pending / claimed-but-silent ────
+
+    [Fact]
+    public void Execute_RepairPending_FiresForPrWithRequestUpdateLabel_ReproducesPr1750Finding()
+    {
+        // Field finding #2: an OPEN PR with intent-target + intent-pr-
+        // request-update was reported pr-created-not-reviewing with a
+        // review-start recommendation — semantically wrong mid-repair.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G521", "intent-cli");
+        var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildPr(1750, "G521: Document agmsg Codex monitor", FixedNow.AddHours(-5),
+            state: "OPEN", closingIssueNumber: 1143, extraLabels: ["intent-pr-request-update"],
+            updatedAt: FixedNow.AddHours(-2));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindRepairPending, item.GetProperty("kind").GetString());
+        Assert.NotEqual(AutomationStalledWorkCommand.KindPrCreatedNotReviewing, item.GetProperty("kind").GetString());
+        Assert.True(item.GetProperty("is_informational").GetBoolean());
+        Assert.Equal(1750, item.GetProperty("pr").GetProperty("number").GetInt32());
+        // Age is since the repair state was entered (PR's own updatedAt),
+        // not since PR creation.
+        Assert.Equal(120, item.GetProperty("age_minutes").GetInt32());
+        Assert.DoesNotContain("--transition", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RepairPending_FiresForPrWithUpdateInProgressLabel()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G521", "intent-cli");
+        var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildPr(1144, "G521: Document agmsg Codex monitor", FixedNow.AddHours(-5),
+            state: "OPEN", closingIssueNumber: 1143,
+            extraLabels: ["intent-pr-request-update", "intent-pr-update-in-progress"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindRepairPending, item.GetProperty("kind").GetString());
+    }
+
+    [Fact]
+    public void Execute_RereviewPending_FiresForPrWithRereviewReadyLabel()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G521", "intent-cli");
+        var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildPr(1144, "G521: Document agmsg Codex monitor", FixedNow.AddHours(-5),
+            state: "OPEN", closingIssueNumber: 1143, extraLabels: ["intent-pr-rereview-ready"],
+            updatedAt: FixedNow.AddMinutes(-45));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindRereviewPending, item.GetProperty("kind").GetString());
+        Assert.True(item.GetProperty("is_informational").GetBoolean());
+        Assert.Equal(45, item.GetProperty("age_minutes").GetInt32());
+        Assert.DoesNotContain("--transition", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_FiresPastDefaultThreshold()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        // 25h silent claim, matching field finding #3 exactly.
+        var issue = BuildIssue(1200, "G540: Something claimed and gone quiet", FixedNow.AddHours(-25),
+            updatedAt: FixedNow.AddHours(-25), labels: ["intent-target", "intent-issue-in-progress"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindClaimedButSilent, item.GetProperty("kind").GetString());
+        Assert.True(item.GetProperty("is_informational").GetBoolean());
+        Assert.Equal("G540", item.GetProperty("execution_unit").GetString());
+        Assert.Equal(1200, item.GetProperty("issue").GetProperty("number").GetInt32());
+        Assert.Equal(1500, item.GetProperty("age_minutes").GetInt32());
+        Assert.DoesNotContain("--transition", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+        Assert.Contains("status check", item.GetProperty("recommended_action").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_FreshClaimUnderThreshold_ReportsNothing()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        var issue = BuildIssue(1200, "G540: Something freshly claimed", FixedNow.AddMinutes(-10),
+            updatedAt: FixedNow.AddMinutes(-10), labels: ["intent-target", "intent-issue-in-progress"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_ThresholdOverride_FiresEarlierThanDefault()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        // 90 minutes silent — well under the 720-minute default, but past a
+        // 60-minute override.
+        var issue = BuildIssue(1200, "G540: Something claimed 90 minutes ago", FixedNow.AddMinutes(-90),
+            updatedAt: FixedNow.AddMinutes(-90), labels: ["intent-target", "intent-issue-in-progress"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var defaultWriter = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            defaultWriter);
+        using var defaultDoc = JsonDocument.Parse(defaultWriter.ToString());
+        Assert.Equal(0, defaultDoc.RootElement.GetProperty("items").GetArrayLength());
+
+        using var overrideWriter = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--claimed-silent-minutes", "60", "--format", "json"],
+            overrideWriter);
+        using var overrideDoc = JsonDocument.Parse(overrideWriter.ToString());
+        var item = Assert.Single(overrideDoc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindClaimedButSilent, item.GetProperty("kind").GetString());
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_ExcludedOnceIssueHasPrCreated_PrLifecycleTakesOver()
+    {
+        // Even a very long silence must NOT fire claimed-but-silent once a
+        // PR exists for the issue — that lifecycle is covered by the
+        // pr-created-not-reviewing / repair-pending / rereview-pending
+        // kinds instead (detecting a stale repair-state PR itself is an
+        // explicit out-of-scope follow-up).
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        var issue = BuildIssue(1200, "G540: Already has a PR", FixedNow.AddDays(-10),
+            updatedAt: FixedNow.AddDays(-10), labels: ["intent-target", "intent-issue-in-progress", "intent-pr-created"]);
+        var pr = BuildPr(1201, "G540: Already has a PR", FixedNow.AddDays(-9),
+            state: "OPEN", closingIssueNumber: 1200, extraLabels: ["intent-pr-reviewing"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.DoesNotContain(
+            doc.RootElement.GetProperty("items").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindClaimedButSilent);
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_LinkedOpenPrActivityCountsAsObservableActivity()
+    {
+        // A linked open PR's own updatedAt counts as activity even before
+        // intent-pr-created is applied (e.g. a freshly-opened draft) — the
+        // issue itself looks silent, but the linked PR was touched recently.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        var issue = BuildIssue(1200, "G540: Draft PR opened quietly", FixedNow.AddHours(-25),
+            updatedAt: FixedNow.AddHours(-25), labels: ["intent-target", "intent-issue-in-progress"]);
+        var pr = BuildPr(1201, "G540: Draft PR opened quietly", FixedNow.AddHours(-25),
+            state: "OPEN", closingIssueNumber: 1200, updatedAt: FixedNow.AddMinutes(-10));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.DoesNotContain(
+            doc.RootElement.GetProperty("items").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindClaimedButSilent);
+    }
+
+    [Fact]
+    public void Execute_MergedPr_NeverTreatedAsPrCreatedNotReviewingOrClaimedButSilent()
+    {
+        // False-positive fixture: a MERGED PR (fetched via the separate
+        // merged-PR lister call, never appearing in openPrs) must never be
+        // treated as "not reviewing", and its source issue (already
+        // carrying intent-pr-created) must never trip claimed-but-silent.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        var issue = BuildIssue(1200, "G540: Already merged", FixedNow.AddDays(-10),
+            updatedAt: FixedNow.AddDays(-1), labels: ["intent-target", "intent-issue-in-progress", "intent-pr-created"]);
+        // Defensive: even if a MERGED-state PR were mistakenly present in
+        // the openPrs fake list (never a real `gh pr list --state open`
+        // result), it must still be filtered out by the existing IsOpen
+        // check rather than misreported.
+        var mergedLookingOpenPr = BuildPr(1201, "G540: Already merged", FixedNow.AddDays(-9),
+            state: "MERGED", closingIssueNumber: 1200, extraLabels: ["intent-pr-request-update"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [mergedLookingOpenPr]);
 
         using var writer = new StringWriter();
         AutomationStalledWorkCommand.Execute(
@@ -941,12 +1188,18 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     }
 
     private static GitHubAutomationIssueCandidate BuildIssue(
-        int number, string title, DateTimeOffset createdAt, params string[] labels) => new()
+        int number, string title, DateTimeOffset createdAt, params string[] labels) =>
+        BuildIssue(number, title, createdAt, updatedAt: null, labels);
+
+    /// <summary>G533: overload accepting an independent <c>updatedAt</c> for claimed-but-silent fixtures — defaults to <paramref name="createdAt"/> when omitted, matching the pre-G533 fixture shape.</summary>
+    private static GitHubAutomationIssueCandidate BuildIssue(
+        int number, string title, DateTimeOffset createdAt, DateTimeOffset? updatedAt, params string[] labels) => new()
         {
             Number = number,
             Title = title,
             Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{number}",
             CreatedAt = createdAt.ToString("O"),
+            UpdatedAt = (updatedAt ?? createdAt).ToString("O"),
             State = "OPEN",
             Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
         };
@@ -957,13 +1210,14 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         DateTimeOffset createdAt,
         string state,
         int? closingIssueNumber = null,
-        string[]? extraLabels = null) => new()
+        string[]? extraLabels = null,
+        DateTimeOffset? updatedAt = null) => new()
         {
             Number = number,
             Title = title,
             Url = $"https://github.com/J-Tech-Japan/intent-system/pull/{number}",
             CreatedAt = createdAt.ToString("O"),
-            UpdatedAt = createdAt.ToString("O"),
+            UpdatedAt = (updatedAt ?? createdAt).ToString("O"),
             State = state,
             IsDraft = false,
             Labels = (extraLabels ?? Array.Empty<string>()).Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -390,6 +390,171 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
             item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindClaimedButSilent);
     }
 
+    // ── G533 review repair: fail closed on unusable activity data ────
+
+    [Fact]
+    public void Execute_ClaimedButSilent_MissingUpdatedAt_NeverFallsBackToOldCreatedAt_ExcludedNotFired()
+    {
+        // The core defect: an old createdAt must NEVER be substituted for
+        // a missing updatedAt — that would manufacture a silence interval
+        // that begins long before the claim was ever made. Excluded, not
+        // reported as a finding.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        var issue = new GitHubAutomationIssueCandidate
+        {
+            Number = 1200,
+            Title = "G540: Old issue, missing updatedAt",
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/1200",
+            CreatedAt = FixedNow.AddDays(-100).ToString("O"),
+            UpdatedAt = string.Empty,
+            State = "OPEN",
+            Labels = [new GitHubAutomationLabel { Name = "intent-target" }, new GitHubAutomationLabel { Name = "intent-issue-in-progress" }],
+        };
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        var excludedItem = Assert.Single(
+            doc.RootElement.GetProperty("excluded").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindClaimedButSilent);
+        Assert.Equal(AutomationStalledWorkCommand.ReasonActivityDataUnusable, excludedItem.GetProperty("reason").GetString());
+        Assert.Contains("missing", excludedItem.GetProperty("detail").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("1200", excludedItem.GetProperty("detail").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_MalformedUpdatedAt_NeverFallsBackToOldCreatedAt_ExcludedNotFired()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        var issue = new GitHubAutomationIssueCandidate
+        {
+            Number = 1200,
+            Title = "G540: Old issue, malformed updatedAt",
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/1200",
+            CreatedAt = FixedNow.AddDays(-100).ToString("O"),
+            UpdatedAt = "not-a-real-timestamp",
+            State = "OPEN",
+            Labels = [new GitHubAutomationLabel { Name = "intent-target" }, new GitHubAutomationLabel { Name = "intent-issue-in-progress" }],
+        };
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        var excludedItem = Assert.Single(
+            doc.RootElement.GetProperty("excluded").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindClaimedButSilent);
+        Assert.Equal(AutomationStalledWorkCommand.ReasonActivityDataUnusable, excludedItem.GetProperty("reason").GetString());
+        Assert.Contains("malformed", excludedItem.GetProperty("detail").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_LinkedPrMissingUpdatedAt_ConservativelyExcluded()
+    {
+        // Same fail-closed treatment for a linked PR's own activity
+        // timestamp — never risk under-counting real (unverifiable) PR
+        // activity as silence.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        var issue = BuildIssue(1200, "G540: Linked PR has bad updatedAt", FixedNow.AddDays(-100),
+            updatedAt: FixedNow.AddDays(-100), labels: ["intent-target", "intent-issue-in-progress"]);
+        var pr = new GitHubAutomationPrCandidate
+        {
+            Number = 1201,
+            Title = "G540: Linked PR has bad updatedAt",
+            Url = "https://github.com/J-Tech-Japan/intent-system/pull/1201",
+            CreatedAt = FixedNow.AddDays(-99).ToString("O"),
+            UpdatedAt = string.Empty,
+            State = "OPEN",
+            IsDraft = false,
+            ClosingIssuesReferences =
+            [
+                new GitHubPrClosingIssueReference
+                {
+                    Number = 1200,
+                    Repository = new GitHubPrClosingIssueRepository
+                    {
+                        Name = "intent-system",
+                        Owner = new GitHubPrClosingIssueRepositoryOwner { Login = "J-Tech-Japan" },
+                    },
+                },
+            ],
+        };
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        var excludedItem = Assert.Single(
+            doc.RootElement.GetProperty("excluded").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindClaimedButSilent);
+        Assert.Equal(AutomationStalledWorkCommand.ReasonActivityDataUnusable, excludedItem.GetProperty("reason").GetString());
+        Assert.Contains("1201", excludedItem.GetProperty("detail").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_OldCreatedAtButRecentUpdatedAt_PostClaimActivityResetsThreshold()
+    {
+        // Proves createdAt is NEVER consulted for this kind: an issue open
+        // for 100 days, but its updatedAt (the ONLY signal this kind uses)
+        // is recent — must not fire.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        var issue = BuildIssue(1200, "G540: Old issue, recently active", FixedNow.AddDays(-100),
+            updatedAt: FixedNow.AddMinutes(-10), labels: ["intent-target", "intent-issue-in-progress"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        Assert.DoesNotContain(
+            doc.RootElement.GetProperty("excluded").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindClaimedButSilent);
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_FutureUpdatedAt_ClampedToNow_NeverFires()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        var issue = BuildIssue(1200, "G540: Clock-skewed future updatedAt", FixedNow.AddDays(-100),
+            updatedAt: FixedNow.AddHours(2), labels: ["intent-target", "intent-issue-in-progress"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+    }
+
     [Fact]
     public void Execute_MergedPr_NeverTreatedAsPrCreatedNotReviewingOrClaimedButSilent()
     {


### PR DESCRIPTION
## Summary
- Corrects `automation stalled-work` category semantics per two live field findings against sekiban-as-a-service (2026-07-17):
  - **Finding #2 (PR #1750)**: a PR already in the repair lifecycle (`intent-pr-request-update` and/or `intent-pr-update-in-progress`) was misreported as `pr-created-not-reviewing` with a `review-start` recommendation — semantically wrong mid-repair. Such a PR now reports as informational `repair-pending` (age, no transition recommendation). A PR carrying `intent-pr-rereview-ready` gets the same treatment under `rereview-pending`.
  - **Finding #3**: claimed issues (`intent-issue-in-progress`, no PR yet) were never considered stalled regardless of silence. Adds `claimed-but-silent`: fires when an issue shows no observable activity (issue `updatedAt`, or a linked open PR's `updatedAt`) for longer than a conservative default threshold (720 minutes, `--claimed-silent-minutes` override), recommending a worker status check, never a state transition.
- `StalledWorkItem` gains `is_informational` (bool) distinguishing the two new informational kinds from the three original actionable ones.
- `automation heartbeat`'s `message_body` renders informational items as `FYI: <prose>` instead of `recommended: \`<command>\``, and splits its summary line into pending-transition-count vs informational-note-count.
- ja/en developer-reference category tables updated.

Closes #1168

## Test plan
- [x] `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj` — succeeds
- [x] `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~AutomationStalledWorkCommandTests\|FullyQualifiedName~AutomationHeartbeatCommandTests` — 55/55 pass, including a regression fixture reproducing the exact PR #1750 finding, rereview-pending, claimed-but-silent (past threshold / fresh claim under threshold / threshold override / PR-lifecycle takeover / linked-PR activity counts), and a merged-PR false-positive fixture
- [x] Full suite: 3531 passed, 1 skipped (up from 3521 baseline)
- [x] `git diff --check` — clean
- [x] Manual E2E against the built CLI binary through the real `gh` CLI shell-out path (stubbed `gh` binary on PATH, not just the test seam): reproduced the exact PR #1750 scenario end-to-end for both `automation stalled-work` and `automation heartbeat`, confirming `repair-pending`/`is_informational: true`/no transition recommendation, and the heartbeat `message_body`'s "0 pending transition(s), 1 informational note(s)" + "FYI:" framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)