### PR TITLE
G534: Queue robustness — list parsing, retired transition, lifecycle-aware selection

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -499,6 +499,62 @@ it — no separate code path needed.
 
 ---
 
+### Queue robustness: list parsing, retired backfill, lifecycle-aware selection (G534)
+
+Three related field findings against real, hand-authored packets and queue
+state are fixed together here.
+
+**`queue enqueue` accepts both YAML list-item conventions.** The packet
+readers (`ProjectionPacketSerializer` for the current
+`implementation_issue_packet` / `review_context_packet` schema, and
+`ProjectionPacketRuntimeReader`'s legacy `execution_unit` /
+`implementation_issue` fallback) previously recognized a block-sequence list
+item only when indented with exactly 4 spaces plus `"- "` — the renderer's
+own self-generated convention. A hand-authored (or foreign-tool-authored)
+packet using the more common 2-space convention, where each list item sits
+at the same column as its parent key, was rejected outright with `field
+line is missing ':''` on every item, quoted or unquoted. Both readers now
+detect a list item by content (a line that, after stripping leading
+whitespace, starts with `"- "` or is exactly `"-"`) rather than by counting
+columns, so either convention parses — and the two conventions may even be
+mixed across different fields within the same file.
+
+**`queue transition --to retired` backfills a queue-state entry.** A packet
+retired via `intent-cli packet retire` (which writes only `lifecycle.yaml`,
+never touches `queue-state.json`) or via `automation issue-retire`
+predating queue tracking sometimes needs its queue-state item marked
+`retired` directly, without hand-editing the JSON file. `retired` is now
+accepted as a transition target — `queue transition <execution-unit>
+retired [--reason <text>]` — through the same generic, permissive
+transition path used by every other non-blocking target (`queued`,
+`active`, `review`, `fixing`, `completed`); the item must already exist in
+queue-state (create it first via `queue enqueue` if it doesn't). Naming an
+unsupported target still refuses and lists the full allowed set, which now
+includes `retired`.
+
+**The publish selector excludes units retired either way, even with no
+queue entry at all.** `intent next-slice` already correctly skipped a unit
+whose packet directory carries a `lifecycle.yaml` marking it
+`retired`/`absorbed`/`superseded` — including one with no queue-state entry
+whatsoever, via its fallback scan over every packet directory under
+`.intent-cli/issues/`. It did not, however, exclude a unit that was
+`Retired` purely in `queue-state.json` (e.g. via `automation issue-retire`,
+or now via `queue transition --to retired`) with no `lifecycle.yaml`
+sidecar: the state-bucketing switch had no case for `QueueItemState.Retired`,
+so such a unit fell into no bucket, and the fallback loop's only
+queue-state-derived exclusion was `completed`. Retired units are now
+tracked and excluded the same way completed ones are, so either retirement
+signal — packet-level `lifecycle.yaml` or queue-state `Retired` — reliably
+removes a unit from next-slice candidate selection and lets the next real
+candidate surface instead.
+
+Together, these three fixes let a repo recover from a stuck or
+pre-queue-tracking retirement entirely through `queue enqueue` / `queue
+transition` / `intent next-slice`, with zero manual `queue-state.json`
+edits.
+
+---
+
 ### Facet-aware context supply (G530)
 
 Building on G529's four semantic facets (`vocabulary`, `invariant`,

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -519,34 +519,60 @@ whitespace, starts with `"- "` or is exactly `"-"`) rather than by counting
 columns, so either convention parses — and the two conventions may even be
 mixed across different fields within the same file.
 
-**`queue transition --to retired` backfills a queue-state entry.** A packet
-retired via `intent-cli packet retire` (which writes only `lifecycle.yaml`,
-never touches `queue-state.json`) or via `automation issue-retire`
-predating queue tracking sometimes needs its queue-state item marked
-`retired` directly, without hand-editing the JSON file. `retired` is now
-accepted as a transition target — `queue transition <execution-unit>
-retired [--reason <text>]` — through the same generic, permissive
-transition path used by every other non-blocking target (`queued`,
-`active`, `review`, `fixing`, `completed`); the item must already exist in
-queue-state (create it first via `queue enqueue` if it doesn't). Naming an
-unsupported target still refuses and lists the full allowed set, which now
-includes `retired`.
+**`queue transition --to retired` backfills a queue-state entry — as a
+guarded, idempotent, terminal transition.** A packet retired via
+`intent-cli packet retire` (which writes only `lifecycle.yaml`, never
+touches `queue-state.json`) or via `automation issue-retire` predating
+queue tracking sometimes needs its queue-state item marked `retired`
+directly, without hand-editing the JSON file. `retired` is now accepted as
+a transition target — `queue transition <execution-unit> retired` — but,
+unlike every other non-blocking target, it does **not** route through the
+generic, source-state-agnostic transition path; it has its own guarded
+entry point (`QueueManager.Retire`) consistent with `automation
+issue-retire`'s own refusal (G525):
 
-**The publish selector excludes units retired either way, even with no
-queue entry at all.** `intent next-slice` already correctly skipped a unit
-whose packet directory carries a `lifecycle.yaml` marking it
-`retired`/`absorbed`/`superseded` — including one with no queue-state entry
-whatsoever, via its fallback scan over every packet directory under
-`.intent-cli/issues/`. It did not, however, exclude a unit that was
-`Retired` purely in `queue-state.json` (e.g. via `automation issue-retire`,
-or now via `queue transition --to retired`) with no `lifecycle.yaml`
-sidecar: the state-bucketing switch had no case for `QueueItemState.Retired`,
-so such a unit fell into no bucket, and the fallback loop's only
-queue-state-derived exclusion was `completed`. Retired units are now
-tracked and excluded the same way completed ones are, so either retirement
-signal — packet-level `lifecycle.yaml` or queue-state `Retired` — reliably
-removes a unit from next-slice candidate selection and lets the next real
-candidate surface instead.
+- legal from any state except `Completed` — a completed item (merged or
+  otherwise finished work, including one that still carries a linked PR)
+  refuses retirement with zero mutation and zero run event, since
+  retirement only ever applies to work that can never be completed as
+  authored;
+- idempotent when the item is already `Retired` — a no-op that changes
+  nothing and never appends a duplicate `retired` run event, however many
+  times it is re-run;
+- terminal once applied — a retired item can never be transitioned to any
+  other state (`queued`, `active`, `completed`, `blocked`, …) through
+  `queue transition`; the generic non-blocking/blocking transition paths
+  now refuse outright when the current state is `Retired`, closing what
+  was previously a silent reactivation path.
+
+The item must already exist in queue-state (create it first via `queue
+enqueue` if it doesn't). Naming an unsupported target still refuses and
+lists the full allowed set, which now includes `retired`.
+
+**The publish selector combines queue-state and packet-lifecycle evidence
+explicitly, and fails closed on ambiguous lifecycle metadata.** `intent
+next-slice` reads each candidate's `lifecycle.yaml` (if any) into one of
+four explicit states — absent (no sidecar; not an error), valid-active
+(`lifecycle: ready`), valid-retired (`absorbed`/`retired`/`superseded`), or
+invalid (unreadable, missing the `lifecycle` key, blank, or an
+unrecognized value) — and combines that with the queue-state `Retired`
+signal:
+
+- either signal alone recording retirement excludes the unit — this holds
+  even when there is no queue-state entry whatsoever (a lifecycle-only
+  retirement) or no `lifecycle.yaml` at all (a queue-only retirement, e.g.
+  via `automation issue-retire` or `queue transition --to retired`);
+- an explicit `lifecycle: ready` does **not** override a queue-state
+  `Retired` record — that combination is a contradiction, still excluded,
+  and surfaced as an actionable diagnostic (`lifecycle-metadata-diagnostic`
+  warning, with a note naming the unit and the sidecar path) so it can be
+  reconciled instead of silently resolved either direction;
+- invalid lifecycle metadata (unreadable, blank, missing key, or an
+  unrecognized value) excludes the unit and raises the same diagnostic
+  regardless of queue state — ambiguous retirement evidence must never
+  resolve to "publishable," so a malformed sidecar can never let its
+  packet quietly surface as the next candidate, even when it is the only
+  packet directory available.
 
 Together, these three fixes let a repo recover from a stuck or
 pre-queue-tracking retirement entirely through `queue enqueue` / `queue

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -531,11 +531,21 @@ generic, source-state-agnostic transition path; it has its own guarded
 entry point (`QueueManager.Retire`) consistent with `automation
 issue-retire`'s own refusal (G525):
 
-- legal from any state except `Completed` — a completed item (merged or
-  otherwise finished work, including one that still carries a linked PR)
-  refuses retirement with zero mutation and zero run event, since
-  retirement only ever applies to work that can never be completed as
-  authored;
+- legal from any state except `Completed` — a completed item refuses
+  retirement with zero mutation and zero run event, since retirement only
+  ever applies to work that can never be completed as authored;
+- **the linked PR is the authoritative evidence, not queue-state itself** —
+  queue-state can be stale, so before mutating anything the CLI boundary
+  resolves the item's `linked_pr` (if any) via `gh pr view` and refuses
+  retirement outright when that PR is confirmed **merged or closed**, even
+  for a `Queued`/`Review`/`Fixing` item that queue-state still calls
+  non-`Completed`. When the linked PR's state cannot be resolved (lookup
+  failure, unparseable/wrong-repo URL, an ambiguous response) retirement
+  also refuses — fail closed, never presumed open. An item with no linked
+  PR at all skips this check entirely (nothing to verify). This lookup is
+  the one place in the retirement path permitted to reach GitHub;
+  `QueueManager.Retire` itself stays network-free and simply receives the
+  already-verified evidence;
 - idempotent when the item is already `Retired` — a no-op that changes
   nothing and never appends a duplicate `retired` run event, however many
   times it is re-run;
@@ -563,10 +573,17 @@ signal:
   retirement) or no `lifecycle.yaml` at all (a queue-only retirement, e.g.
   via `automation issue-retire` or `queue transition --to retired`);
 - an explicit `lifecycle: ready` does **not** override a queue-state
-  `Retired` record — that combination is a contradiction, still excluded,
-  and surfaced as an actionable diagnostic (`lifecycle-metadata-diagnostic`
-  warning, with a note naming the unit and the sidecar path) so it can be
-  reconciled instead of silently resolved either direction;
+  `Retired` record, and a non-publishable `lifecycle.yaml` does **not** get
+  overridden by a *present* queue-state entry that is not `Retired`
+  (`queued`/`active`/`review`/`fixing`/…) — both directions are
+  contradictions, still excluded, and both are now surfaced as an
+  actionable diagnostic (`lifecycle-metadata-diagnostic` warning, with a
+  note naming the unit, the sidecar path, and both states) instead of
+  either direction resolving silently — a later, unrelated candidate can
+  never hide an earlier unit's inconsistent evidence;
+- agreement (both signals retired) and a lifecycle-only retirement with
+  **no queue entry at all** are not contradictions and stay silent —
+  exactly as before;
 - invalid lifecycle metadata (unreadable, blank, missing key, or an
   unrecognized value) excludes the unit and raises the same diagnostic
   regardless of queue state — ambiguous retirement evidence must never

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -516,6 +516,67 @@ retired になった item は自動的に WIP gating から外れます:
 
 ---
 
+### Queue の堅牢化: list parsing・retired backfill・lifecycle を考慮した selection (G534)
+
+実際の hand-authored な packet と queue state に対する、関連する 3 つの
+field finding をここでまとめて修正します。
+
+**`queue enqueue` が両方の YAML list-item convention を受け付ける。**
+packet reader(現行の `implementation_issue_packet` /
+`review_context_packet` schema 用の `ProjectionPacketSerializer`、および
+legacy な `execution_unit` / `implementation_issue` fallback 用の
+`ProjectionPacketRuntimeReader`)は、これまで block-sequence の list item
+を「4 スペース + `"- "`」というちょうど renderer 自身が生成する形式に
+インデントされている場合にのみ list item として認識していました。より
+一般的な、各 list item が親 key と同じカラムに置かれる 2 スペース
+convention を使う hand-authored(または他ツールが生成した)packet は、
+quoted / unquoted を問わずすべての item で `field line is missing ':''`
+として全面的に拒否されていました。両方の reader は、カラム数を数える
+のではなく内容(先頭の空白を除去した行が `"- "` で始まる、または
+ちょうど `"-"` である)で list item を検出するようになったため、どちら
+の convention でもパースできます — さらに同じファイル内で異なる field
+ごとに convention を混在させることも可能です。
+
+**`queue transition --to retired` が queue-state エントリを backfill
+する。** `intent-cli packet retire`(`lifecycle.yaml` のみを書き込み、
+`queue-state.json` には一切触れない)で retire された packet や、queue
+tracking より前に `automation issue-retire` で retire された packet は、
+JSON ファイルを手編集することなく、その queue-state item を直接
+`retired` としてマークする必要が生じることがあります。`retired` は
+transition target として受け付けられるようになりました —
+`queue transition <execution-unit> retired [--reason <text>]` — 他の
+すべての non-blocking target(`queued`、`active`、`review`、`fixing`、
+`completed`)と同じ、汎用的で許容的な transition path を通ります。item
+は queue-state に既に存在している必要があります(存在しなければ先に
+`queue enqueue` で作成してください)。サポートされていない target を
+指定した場合は引き続き refuse され、許可されている target の完全な一覧
+(今回 `retired` を含むようになったもの)が表示されます。
+
+**publish selector は、queue entry が一切無い場合も含め、どちらの方法で
+retire された unit も除外する。** `intent next-slice` は、packet
+directory が `lifecycle.yaml` を持ち `retired`/`absorbed`/`superseded`
+とマークされている unit を、`.intent-cli/issues/` 配下の全 packet
+directory を走査する fallback scan 経由で、queue-state エントリが
+一切無い場合も含めて既に正しく skip していました。しかし、
+`lifecycle.yaml` サイドカーが無く、`queue-state.json` の中だけで
+`Retired`(例えば `automation issue-retire` 経由、あるいは今回追加された
+`queue transition --to retired` 経由)になっている unit は除外して
+いませんでした: state-bucketing の switch に `QueueItemState.Retired`
+用の case が無かったため、そのような unit はどの bucket にも入らず、
+fallback loop の唯一の queue-state 由来の除外条件は `completed` だけ
+だったためです。retired な unit は completed な unit と同じ方法で
+追跡・除外されるようになったため、packet レベルの `lifecycle.yaml` と
+queue-state の `Retired` のどちらの retirement signal でも、その unit
+は next-slice の candidate selection から確実に除外され、代わりに次の
+本当の candidate が浮上するようになります。
+
+これら 3 つの修正を組み合わせることで、repo は `queue enqueue` /
+`queue transition` / `intent next-slice` だけを使って、行き詰まった
+retirement や queue tracking 以前の retirement から、`queue-state.json`
+を一切手編集することなく完全に復旧できます。
+
+---
+
 ### facet を意識した context 供給 (G530)
 
 G529 の 4 つの semantic facet（`vocabulary`、`invariant`、`decider`、

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -538,37 +538,65 @@ quoted / unquoted を問わずすべての item で `field line is missing ':''`
 ごとに convention を混在させることも可能です。
 
 **`queue transition --to retired` が queue-state エントリを backfill
-する。** `intent-cli packet retire`(`lifecycle.yaml` のみを書き込み、
+する — guarded・idempotent・terminal な transition として。**
+`intent-cli packet retire`(`lifecycle.yaml` のみを書き込み、
 `queue-state.json` には一切触れない)で retire された packet や、queue
 tracking より前に `automation issue-retire` で retire された packet は、
 JSON ファイルを手編集することなく、その queue-state item を直接
 `retired` としてマークする必要が生じることがあります。`retired` は
-transition target として受け付けられるようになりました —
-`queue transition <execution-unit> retired [--reason <text>]` — 他の
-すべての non-blocking target(`queued`、`active`、`review`、`fixing`、
-`completed`)と同じ、汎用的で許容的な transition path を通ります。item
-は queue-state に既に存在している必要があります(存在しなければ先に
-`queue enqueue` で作成してください)。サポートされていない target を
-指定した場合は引き続き refuse され、許可されている target の完全な一覧
-(今回 `retired` を含むようになったもの)が表示されます。
+transition target として受け付けられるようになりましたが —
+`queue transition <execution-unit> retired` — 他の non-blocking target と
+異なり、汎用的で source state を問わない transition path は通りません。
+`automation issue-retire` 自身の refusal(G525)と一貫した、専用の
+guarded な entry point(`QueueManager.Retire`)を持ちます:
 
-**publish selector は、queue entry が一切無い場合も含め、どちらの方法で
-retire された unit も除外する。** `intent next-slice` は、packet
-directory が `lifecycle.yaml` を持ち `retired`/`absorbed`/`superseded`
-とマークされている unit を、`.intent-cli/issues/` 配下の全 packet
-directory を走査する fallback scan 経由で、queue-state エントリが
-一切無い場合も含めて既に正しく skip していました。しかし、
-`lifecycle.yaml` サイドカーが無く、`queue-state.json` の中だけで
-`Retired`(例えば `automation issue-retire` 経由、あるいは今回追加された
-`queue transition --to retired` 経由)になっている unit は除外して
-いませんでした: state-bucketing の switch に `QueueItemState.Retired`
-用の case が無かったため、そのような unit はどの bucket にも入らず、
-fallback loop の唯一の queue-state 由来の除外条件は `completed` だけ
-だったためです。retired な unit は completed な unit と同じ方法で
-追跡・除外されるようになったため、packet レベルの `lifecycle.yaml` と
-queue-state の `Retired` のどちらの retirement signal でも、その unit
-は next-slice の candidate selection から確実に除外され、代わりに次の
-本当の candidate が浮上するようになります。
+- `Completed` 以外のどの state からも legal です — completed な item
+  (merge 済み、あるいは何らかの形で完了済みの作業。linked PR を持つ
+  ものも含む)は、mutation も run event もゼロのまま retirement を
+  refuse します。retirement は authored 通りには決して完了できない作業
+  にのみ適用されるためです;
+- 既に `Retired` な item に対しては idempotent です — 何も変更しない
+  no-op であり、何度再実行しても重複した `retired` run event が追記
+  されることはありません;
+- 一度適用されると terminal です — retired な item は `queue
+  transition` を通じて他のどの state(`queued`、`active`、`completed`、
+  `blocked` など)にも二度と transition できません。汎用的な
+  non-blocking/blocking transition path は、現在の state が `Retired`
+  の場合には即座に refuse するようになり、以前は静かに許されていた
+  reactivation の抜け道を塞ぎました。
+
+item は queue-state に既に存在している必要があります(存在しなければ
+先に `queue enqueue` で作成してください)。サポートされていない target
+を指定した場合は引き続き refuse され、許可されている target の完全な
+一覧(今回 `retired` を含むようになったもの)が表示されます。
+
+**publish selector は queue-state と packet-lifecycle の evidence を
+明示的に組み合わせ、曖昧な lifecycle metadata に対しては fail closed
+する。** `intent next-slice` は各 candidate の `lifecycle.yaml`(存在
+すれば)を、4 つの明示的な state のいずれかとして読み取ります —
+absent(sidecar が無い。エラーではない)、valid-active
+(`lifecycle: ready`)、valid-retired
+(`absorbed`/`retired`/`superseded`)、invalid(unreadable、`lifecycle`
+key の欠落、blank、または未知の値)— そしてそれを queue-state の
+`Retired` signal と組み合わせます:
+
+- どちらか一方の signal だけでも retirement を記録していれば unit は
+  除外されます — これは queue-state エントリが一切無い場合(lifecycle
+  のみによる retirement)や、`lifecycle.yaml` が一切無い場合(例えば
+  `automation issue-retire` や `queue transition --to retired` 経由の
+  queue のみによる retirement)でも成り立ちます;
+- 明示的な `lifecycle: ready` は queue-state の `Retired` レコードを
+  上書き**しません** — その組み合わせは contradiction であり、それでも
+  除外され、actionable な diagnostic
+  (`lifecycle-metadata-diagnostic` warning。unit 名と sidecar path を
+  記した note 付き)として表示されます。どちらの方向にも黙って解決
+  されるのではなく、reconcile できるようにするためです;
+- invalid な lifecycle metadata(unreadable、blank、key の欠落、または
+  未知の値)は、queue state に関わらず unit を除外し、同じ diagnostic
+  を発生させます — 曖昧な retirement evidence は決して
+  「publishable」に解決されてはならないためです。したがって malformed
+  な sidecar は、それが唯一の packet directory であっても、次の
+  candidate として静かに浮上することは決してありません。
 
 これら 3 つの修正を組み合わせることで、repo は `queue enqueue` /
 `queue transition` / `intent next-slice` だけを使って、行き詰まった

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -550,11 +550,24 @@ transition target として受け付けられるようになりましたが —
 `automation issue-retire` 自身の refusal(G525)と一貫した、専用の
 guarded な entry point(`QueueManager.Retire`)を持ちます:
 
-- `Completed` 以外のどの state からも legal です — completed な item
-  (merge 済み、あるいは何らかの形で完了済みの作業。linked PR を持つ
-  ものも含む)は、mutation も run event もゼロのまま retirement を
-  refuse します。retirement は authored 通りには決して完了できない作業
-  にのみ適用されるためです;
+- `Completed` 以外のどの state からも legal です — completed な item は
+  mutation も run event もゼロのまま retirement を refuse します。
+  retirement は authored 通りには決して完了できない作業にのみ適用され
+  るためです;
+- **linked PR こそが authoritative な evidence であり、queue-state
+  自体ではありません** — queue-state は stale になり得るため、何かを
+  mutate する前に CLI boundary がその item の `linked_pr`(存在すれば)
+  を `gh pr view` 経由で解決し、その PR が **merged または closed**
+  であると確認された場合は retirement を拒否します — queue-state が
+  まだ非 `Completed`(`Queued`/`Review`/`Fixing`)と言っている item で
+  あってもです。linked PR の state が解決できない場合(lookup 失敗、
+  parse 不能・誤った repo の URL、曖昧な response)も retirement は
+  refuse します — fail closed であり、open だと推定することは決してあり
+  ません。linked PR が一切無い item は、この check を完全にスキップし
+  ます(検証するものが無いため)。この lookup が retirement path の中で
+  GitHub に到達することが許されている唯一の場所です —
+  `QueueManager.Retire` 自体は network-free のままで、既に検証済みの
+  evidence を受け取るだけです;
 - 既に `Retired` な item に対しては idempotent です — 何も変更しない
   no-op であり、何度再実行しても重複した `retired` run event が追記
   されることはありません;
@@ -586,11 +599,19 @@ key の欠落、blank、または未知の値)— そしてそれを queue-state
   `automation issue-retire` や `queue transition --to retired` 経由の
   queue のみによる retirement)でも成り立ちます;
 - 明示的な `lifecycle: ready` は queue-state の `Retired` レコードを
-  上書き**しません** — その組み合わせは contradiction であり、それでも
-  除外され、actionable な diagnostic
-  (`lifecycle-metadata-diagnostic` warning。unit 名と sidecar path を
-  記した note 付き)として表示されます。どちらの方向にも黙って解決
-  されるのではなく、reconcile できるようにするためです;
+  上書き**せず**、また non-publishable な `lifecycle.yaml` も、
+  *存在する* queue-state エントリが `Retired` ではない
+  (`queued`/`active`/`review`/`fixing`/…)からといって上書きされること
+  は**ありません** — どちらの方向も contradiction であり、それでも
+  除外されます。そして今回、どちらの方向も actionable な diagnostic
+  (`lifecycle-metadata-diagnostic` warning。unit 名・sidecar path・
+  両方の state を記した note 付き)として表示されるようになりました —
+  以前はどちらの方向も黙って解決されていました。後続の、無関係な
+  candidate が、先行する unit の矛盾した evidence を隠してしまうことは
+  もう決してありません;
+- agreement(両方の signal が retired)や、queue エントリが**一切無い**
+  lifecycle のみによる retirement は contradiction ではなく、以前と
+  同じく黙って除外されます;
 - invalid な lifecycle metadata(unreadable、blank、key の欠落、または
   未知の値)は、queue state に関わらず unit を除外し、同じ diagnostic
   を発生させます — 曖昧な retirement evidence は決して

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -55,6 +55,15 @@ internal static class IntentNextSliceCommand
     // convert it via `intent-cli packet retire` instead of publishing it.
     internal const string WarningLegacyRetirementMarker = "legacy-retirement-marker-needs-machine-metadata";
 
+    // G534 review repair: a packet's lifecycle.yaml is unreadable, blank,
+    // missing its required key, carries an unrecognized value, or
+    // contradicts queue-state (queue says Retired but lifecycle explicitly
+    // says ready). The packet is excluded from selection (fail closed —
+    // ambiguous/contradictory retirement evidence must never resolve to
+    // "publishable") and the operator/agent is told to repair or reconcile
+    // the sidecar instead of publishing the packet as-is.
+    internal const string WarningLifecycleMetadataDiagnostic = "lifecycle-metadata-diagnostic";
+
     private const string UsageLine =
         "Usage: intent-cli intent next-slice --dry-run [--domain <name>] [--target-repo <owner/repo>] [--runtime-creation-allowed] [--format json|markdown]";
 
@@ -323,6 +332,12 @@ internal static class IntentNextSliceCommand
         // candidates. Stale human-only markers (STATUS: ABSORBED) are excluded
         // from selection too and surfaced as a repair recommendation.
         var legacyRetirementMarkerUnits = new List<string>();
+        // G534 review repair: diagnostics for unreadable/blank/unknown
+        // lifecycle.yaml sidecars and queue-vs-lifecycle contradictions —
+        // surfaced the same way legacy human markers are, so the operator
+        // knows exactly which packet needs a repair and why, instead of the
+        // selector silently resolving ambiguous evidence either direction.
+        var lifecycleDiagnostics = new List<string>();
 
         if (Directory.Exists(packetRoot) && !bindingsFailedClosed)
         {
@@ -358,7 +373,7 @@ internal static class IntentNextSliceCommand
                     continue;
                 }
 
-                if (PacketLifecycle.IsRetired(directory))
+                if (IsExcludedByLifecycle(executionUnit, directory, retired, lifecycleDiagnostics))
                 {
                     continue;
                 }
@@ -380,10 +395,18 @@ internal static class IntentNextSliceCommand
                     .OrderBy(path => path, StringComparer.Ordinal))
                 {
                     var executionUnit = Path.GetFileName(directory)!;
-                    if (completed.Contains(executionUnit) || retired.Contains(executionUnit))
+                    if (completed.Contains(executionUnit))
                     {
                         continue;
                     }
+
+                    // G534 review repair: queue-Retired exclusion (with any
+                    // lifecycle contradiction/diagnostic) is now handled
+                    // exclusively inside IsExcludedByLifecycle below, so a
+                    // unit that's Retired only in queue-state still reaches
+                    // that check instead of being filtered out here first
+                    // (which would make ValidActive+queueRetired
+                    // contradiction diagnostics unreachable).
 
                     if (!MatchesExecutionUnitRegex(executionUnitRegex, executionUnit))
                     {
@@ -395,7 +418,7 @@ internal static class IntentNextSliceCommand
                         continue;
                     }
 
-                    if (PacketLifecycle.IsRetired(directory))
+                    if (IsExcludedByLifecycle(executionUnit, directory, retired, lifecycleDiagnostics))
                     {
                         continue;
                     }
@@ -448,6 +471,17 @@ internal static class IntentNextSliceCommand
             }
         }
 
+        if (lifecycleDiagnostics.Count > 0)
+        {
+            // G534 review repair: unreadable/blank/unknown lifecycle.yaml or a
+            // queue-vs-lifecycle contradiction. Fail closed — the packet is
+            // excluded from selection above; surface the exact reason here so
+            // the operator/agent can repair or reconcile it instead of the
+            // selector silently resolving ambiguous evidence either direction.
+            warnings.Add(WarningLifecycleMetadataDiagnostic);
+            notes.AddRange(lifecycleDiagnostics);
+        }
+
         return new IntentNextSliceResult
         {
             Domain = domain,
@@ -468,6 +502,63 @@ internal static class IntentNextSliceCommand
             Warnings = warnings,
             Notes = notes
         };
+    }
+
+    /// <summary>
+    /// G534 review repair: combines queue-state retirement evidence
+    /// (<paramref name="queueRetiredUnits"/>) with the packet's own
+    /// <c>lifecycle.yaml</c> evidence explicitly, instead of consulting only
+    /// one signal or treating an unreadable/malformed sidecar as if no
+    /// sidecar existed:
+    /// <list type="bullet">
+    /// <item>either signal alone recording retirement excludes the unit;</item>
+    /// <item>an explicit <c>lifecycle: ready</c> does NOT override a
+    /// queue-state <c>Retired</c> record — that combination is a
+    /// contradiction, still excluded, and surfaced as a diagnostic so it can
+    /// be reconciled;</item>
+    /// <item>an unreadable, blank, missing-key, or unrecognized lifecycle
+    /// value is <see cref="PacketLifecycleState.Invalid"/> — excluded and
+    /// diagnosed (fail closed) regardless of queue state, since ambiguous
+    /// retirement evidence must never resolve to "publishable";</item>
+    /// <item>no sidecar at all (<see cref="PacketLifecycleState.Absent"/>) is
+    /// not an error — it defers entirely to the queue-state signal.</item>
+    /// </list>
+    /// </summary>
+    private static bool IsExcludedByLifecycle(
+        string executionUnit,
+        string directory,
+        HashSet<string> queueRetiredUnits,
+        List<string> lifecycleDiagnostics)
+    {
+        var outcome = PacketLifecycle.ReadState(directory);
+        var isQueueRetired = queueRetiredUnits.Contains(executionUnit);
+
+        switch (outcome.State)
+        {
+            case PacketLifecycleState.Invalid:
+                lifecycleDiagnostics.Add(
+                    $"packet '{executionUnit}' has unreadable or malformed lifecycle metadata at "
+                    + $"{outcome.SidecarPath} ({outcome.Detail}); excluded from next-slice selection "
+                    + "until the sidecar is repaired or removed (ambiguous retirement evidence fails closed).");
+                return true;
+
+            case PacketLifecycleState.ValidRetired:
+                return true;
+
+            case PacketLifecycleState.ValidActive when isQueueRetired:
+                lifecycleDiagnostics.Add(
+                    $"packet '{executionUnit}' has contradictory retirement evidence: queue-state records "
+                    + $"it as retired but {outcome.SidecarPath} declares 'lifecycle: ready'; excluded from "
+                    + "next-slice selection until the contradiction is reconciled.");
+                return true;
+
+            case PacketLifecycleState.ValidActive:
+                return false;
+
+            case PacketLifecycleState.Absent:
+            default:
+                return isQueueRetired;
+        }
     }
 
     private static IntentNextSliceCandidate BuildCandidate(string executionUnit, string directory)

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -227,6 +227,17 @@ internal static class IntentNextSliceCommand
         var wip = new List<string>();
         var queued = new List<string>();
         var completed = new HashSet<string>(StringComparer.Ordinal);
+        // G534 review repair: a unit already transitioned to Retired purely
+        // in queue-state.json (e.g. via `queue transition --to retired`,
+        // now that G534 makes that a valid target — or historically via
+        // `automation issue-retire`, which writes queue-state only, never
+        // packet.yaml's lifecycle.yaml sidecar) fell through this switch
+        // with NO bucket at all, so the fallback (all-directories) loop
+        // below — whose ONLY queue-state-derived exclusion check was
+        // `completed.Contains(...)` — never excluded it and could
+        // re-surface it as a next-slice candidate. Track retired units
+        // explicitly and exclude them the same way completed ones are.
+        var retired = new HashSet<string>(StringComparer.Ordinal);
         if (queueState is not null)
         {
             foreach (var item in queueState.Items)
@@ -256,6 +267,10 @@ internal static class IntentNextSliceCommand
 
                     case QueueItemState.Completed:
                         completed.Add(item.ExecutionUnit);
+                        break;
+
+                    case QueueItemState.Retired:
+                        retired.Add(item.ExecutionUnit);
                         break;
                 }
             }
@@ -365,7 +380,7 @@ internal static class IntentNextSliceCommand
                     .OrderBy(path => path, StringComparer.Ordinal))
                 {
                     var executionUnit = Path.GetFileName(directory)!;
-                    if (completed.Contains(executionUnit))
+                    if (completed.Contains(executionUnit) || retired.Contains(executionUnit))
                     {
                         continue;
                     }

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -373,7 +373,7 @@ internal static class IntentNextSliceCommand
                     continue;
                 }
 
-                if (IsExcludedByLifecycle(executionUnit, directory, retired, lifecycleDiagnostics))
+                if (IsExcludedByLifecycle(executionUnit, directory, queueState, lifecycleDiagnostics))
                 {
                     continue;
                 }
@@ -418,7 +418,7 @@ internal static class IntentNextSliceCommand
                         continue;
                     }
 
-                    if (IsExcludedByLifecycle(executionUnit, directory, retired, lifecycleDiagnostics))
+                    if (IsExcludedByLifecycle(executionUnit, directory, queueState, lifecycleDiagnostics))
                     {
                         continue;
                     }
@@ -505,17 +505,22 @@ internal static class IntentNextSliceCommand
     }
 
     /// <summary>
-    /// G534 review repair: combines queue-state retirement evidence
-    /// (<paramref name="queueRetiredUnits"/>) with the packet's own
-    /// <c>lifecycle.yaml</c> evidence explicitly, instead of consulting only
-    /// one signal or treating an unreadable/malformed sidecar as if no
-    /// sidecar existed:
+    /// G534 review repair: combines queue-state retirement evidence with the
+    /// packet's own <c>lifecycle.yaml</c> evidence explicitly, instead of
+    /// consulting only one signal or treating an unreadable/malformed
+    /// sidecar as if no sidecar existed:
     /// <list type="bullet">
     /// <item>either signal alone recording retirement excludes the unit;</item>
     /// <item>an explicit <c>lifecycle: ready</c> does NOT override a
-    /// queue-state <c>Retired</c> record — that combination is a
-    /// contradiction, still excluded, and surfaced as a diagnostic so it can
-    /// be reconciled;</item>
+    /// queue-state <c>Retired</c> record, and a non-publishable
+    /// <c>lifecycle.yaml</c> does NOT get overridden by a queue-state entry
+    /// that is present but NOT <c>Retired</c> (queued/active/review/fixing/
+    /// blocked/etc.) — both directions are contradictions, still excluded,
+    /// and surfaced as a diagnostic naming both the lifecycle path/state and
+    /// the queue path/state so they can be reconciled;</item>
+    /// <item>agreement (both signals retired) and a lifecycle-only
+    /// retirement with NO queue entry at all are NOT contradictions — they
+    /// exclude silently, exactly as before;</item>
     /// <item>an unreadable, blank, missing-key, or unrecognized lifecycle
     /// value is <see cref="PacketLifecycleState.Invalid"/> — excluded and
     /// diagnosed (fail closed) regardless of queue state, since ambiguous
@@ -527,11 +532,13 @@ internal static class IntentNextSliceCommand
     private static bool IsExcludedByLifecycle(
         string executionUnit,
         string directory,
-        HashSet<string> queueRetiredUnits,
+        QueueState? queueState,
         List<string> lifecycleDiagnostics)
     {
         var outcome = PacketLifecycle.ReadState(directory);
-        var isQueueRetired = queueRetiredUnits.Contains(executionUnit);
+        var queueItem = queueState?.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+        var isQueueRetired = queueItem?.State == QueueItemState.Retired;
 
         switch (outcome.State)
         {
@@ -543,6 +550,21 @@ internal static class IntentNextSliceCommand
                 return true;
 
             case PacketLifecycleState.ValidRetired:
+                if (queueItem is not null && queueItem.State != QueueItemState.Retired)
+                {
+                    // Reverse-direction contradiction: lifecycle says
+                    // non-publishable, but a queue entry exists and is NOT
+                    // Retired — the unit is still excluded (lifecycle wins
+                    // for exclusion purposes, same as G474/G525 predate
+                    // this fix), but the disagreement is diagnosed so a
+                    // later, unrelated candidate cannot silently hide it.
+                    lifecycleDiagnostics.Add(
+                        $"packet '{executionUnit}' has contradictory retirement evidence: lifecycle.yaml at "
+                        + $"{outcome.SidecarPath} declares it non-publishable ('{outcome.Metadata?.Lifecycle}') "
+                        + $"but queue-state records it as '{FormatQueueStateForDiagnostic(queueItem.State)}'; "
+                        + "excluded from next-slice selection until the contradiction is reconciled.");
+                }
+
                 return true;
 
             case PacketLifecycleState.ValidActive when isQueueRetired:
@@ -559,6 +581,15 @@ internal static class IntentNextSliceCommand
             default:
                 return isQueueRetired;
         }
+    }
+
+    private static string FormatQueueStateForDiagnostic(QueueItemState state)
+    {
+        return state switch
+        {
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            _ => state.ToString().ToLowerInvariant()
+        };
     }
 
     private static IntentNextSliceCandidate BuildCandidate(string executionUnit, string directory)

--- a/src/IntentSystem.Cli/Commands/PacketLifecycle.cs
+++ b/src/IntentSystem.Cli/Commands/PacketLifecycle.cs
@@ -99,6 +99,125 @@ internal static class PacketLifecycle
     }
 
     /// <summary>
+    /// G534 review repair: <see cref="TryRead"/> collapses "no sidecar",
+    /// "sidecar present but unreadable/blank/unknown", and "sidecar present
+    /// and valid" into the same null-vs-non-null shape, so a caller like
+    /// the old <see cref="IsRetired"/> treats an unreadable or malformed
+    /// <c>lifecycle.yaml</c> exactly like an absent one — the unsafe
+    /// direction for ambiguous retirement evidence, since it lets a
+    /// malformed sidecar's packet stay publishable. This reads the sidecar
+    /// into an explicit <see cref="PacketLifecycleState"/> so a caller can
+    /// fail closed on <see cref="PacketLifecycleState.Invalid"/> instead of
+    /// silently treating it as <see cref="PacketLifecycleState.Absent"/>.
+    /// </summary>
+    internal static PacketLifecycleReadOutcome ReadState(string packetDirectory)
+    {
+        var sidecarPath = SidecarPath(packetDirectory);
+        if (Directory.Exists(sidecarPath))
+        {
+            return new PacketLifecycleReadOutcome
+            {
+                State = PacketLifecycleState.Invalid,
+                SidecarPath = sidecarPath,
+                Detail = "unreadable (path is a directory, not a file)"
+            };
+        }
+
+        if (!File.Exists(sidecarPath))
+        {
+            return new PacketLifecycleReadOutcome
+            {
+                State = PacketLifecycleState.Absent,
+                SidecarPath = sidecarPath
+            };
+        }
+
+        string text;
+        try
+        {
+            text = File.ReadAllText(sidecarPath);
+        }
+        catch (IOException exception)
+        {
+            return new PacketLifecycleReadOutcome
+            {
+                State = PacketLifecycleState.Invalid,
+                SidecarPath = sidecarPath,
+                Detail = $"unreadable ({exception.Message})"
+            };
+        }
+        catch (UnauthorizedAccessException exception)
+        {
+            return new PacketLifecycleReadOutcome
+            {
+                State = PacketLifecycleState.Invalid,
+                SidecarPath = sidecarPath,
+                Detail = $"unreadable ({exception.Message})"
+            };
+        }
+
+        var fields = ParseFlatYaml(text);
+        if (!fields.TryGetValue("lifecycle", out var lifecycle))
+        {
+            return new PacketLifecycleReadOutcome
+            {
+                State = PacketLifecycleState.Invalid,
+                SidecarPath = sidecarPath,
+                Detail = "missing required 'lifecycle' key"
+            };
+        }
+
+        var trimmedLifecycle = lifecycle.Trim();
+        if (trimmedLifecycle.Length == 0)
+        {
+            return new PacketLifecycleReadOutcome
+            {
+                State = PacketLifecycleState.Invalid,
+                SidecarPath = sidecarPath,
+                Detail = "blank 'lifecycle' value"
+            };
+        }
+
+        var metadata = new PacketLifecycleMetadata
+        {
+            Lifecycle = trimmedLifecycle,
+            AbsorbedBy = fields.GetValueOrDefault("absorbed_by"),
+            SupersededBy = fields.GetValueOrDefault("superseded_by"),
+            RetiredReason = fields.GetValueOrDefault("retired_reason"),
+            RetiredAt = fields.GetValueOrDefault("retired_at")
+        };
+
+        if (trimmedLifecycle == LifecycleReady)
+        {
+            return new PacketLifecycleReadOutcome
+            {
+                State = PacketLifecycleState.ValidActive,
+                SidecarPath = sidecarPath,
+                Metadata = metadata
+            };
+        }
+
+        if (IsNonPublishable(metadata))
+        {
+            return new PacketLifecycleReadOutcome
+            {
+                State = PacketLifecycleState.ValidRetired,
+                SidecarPath = sidecarPath,
+                Metadata = metadata
+            };
+        }
+
+        return new PacketLifecycleReadOutcome
+        {
+            State = PacketLifecycleState.Invalid,
+            SidecarPath = sidecarPath,
+            Metadata = metadata,
+            Detail = $"unknown lifecycle value '{trimmedLifecycle}' "
+                + $"(expected one of: {LifecycleReady}, {LifecycleAbsorbed}, {LifecycleRetired}, {LifecycleSuperseded})"
+        };
+    }
+
+    /// <summary>
     /// Detects a stale human-only retirement marker (e.g.
     /// <c>STATUS: ABSORBED</c>) in any packet content file. Used to recommend
     /// converting to machine-readable metadata instead of publishing.
@@ -233,4 +352,48 @@ internal sealed record PacketLifecycleMetadata
     public string? RetiredReason { get; init; }
 
     public string? RetiredAt { get; init; }
+}
+
+/// <summary>
+/// G534 review repair: the structured outcome of reading a packet's
+/// <c>lifecycle.yaml</c> sidecar, distinguishing "no sidecar" (a normal,
+/// non-alarming state — most packets never carry one) from "sidecar
+/// present but unreadable/blank/unknown" (an ambiguous state a caller
+/// must fail closed on, never treat as equivalent to absence).
+/// </summary>
+internal enum PacketLifecycleState
+{
+    /// <summary>No <c>lifecycle.yaml</c> sidecar exists. Not an error.</summary>
+    Absent,
+
+    /// <summary>Sidecar exists and explicitly declares <c>lifecycle: ready</c>.</summary>
+    ValidActive,
+
+    /// <summary>Sidecar exists and declares a non-publishable lifecycle
+    /// (<c>absorbed</c>/<c>retired</c>/<c>superseded</c>).</summary>
+    ValidRetired,
+
+    /// <summary>Sidecar exists but is unreadable, missing the required
+    /// <c>lifecycle</c> key, blank, or carries an unrecognized value. A
+    /// caller must fail closed rather than treat this like
+    /// <see cref="Absent"/>.</summary>
+    Invalid
+}
+
+/// <summary>
+/// G534 review repair: result of <see cref="PacketLifecycle.ReadState"/>.
+/// </summary>
+internal sealed record PacketLifecycleReadOutcome
+{
+    public required PacketLifecycleState State { get; init; }
+
+    public required string SidecarPath { get; init; }
+
+    /// <summary>Human-readable diagnostic detail. Populated only for <see cref="PacketLifecycleState.Invalid"/>.</summary>
+    public string? Detail { get; init; }
+
+    /// <summary>Parsed metadata. Populated for <see cref="PacketLifecycleState.ValidActive"/> and
+    /// <see cref="PacketLifecycleState.ValidRetired"/> (and, best-effort, when the only defect is an
+    /// unrecognized lifecycle value).</summary>
+    public PacketLifecycleMetadata? Metadata { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/ProjectionPacketRuntimeReader.cs
+++ b/src/IntentSystem.Cli/Commands/ProjectionPacketRuntimeReader.cs
@@ -85,7 +85,13 @@ internal static class ProjectionPacketRuntimeReader
                     "Projection packet YAML must declare a section before its nested fields.");
             }
 
-            if (line.StartsWith("    - ", StringComparison.Ordinal))
+            // G534 review repair: accept a list item indented at the SAME
+            // column as its parent key (the common convention) or nested
+            // one level deeper — see the identical fix and rationale in
+            // ProjectionPacketSerializer.ParseSections (IntentSystem.Projection),
+            // which this legacy fallback parser mirrors.
+            var listItemCandidate = line.TrimStart(' ');
+            if (listItemCandidate.StartsWith("- ", StringComparison.Ordinal) || listItemCandidate == "-")
             {
                 if (currentListKey is null
                     || !currentSection.TryGetValue(currentListKey, out var listValue)
@@ -95,7 +101,8 @@ internal static class ProjectionPacketRuntimeReader
                         $"Projection packet YAML contains list item without a list field: '{line.Trim()}'.");
                 }
 
-                list.Add(ParseScalar(line[6..]));
+                var itemText = listItemCandidate.Length > 1 ? listItemCandidate[2..] : string.Empty;
+                list.Add(ParseScalar(itemText));
                 continue;
             }
 

--- a/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
@@ -31,7 +31,7 @@ internal static class QueueTransitionCommand
         if (!TryParseTargetState(args[1], out var targetState))
         {
             writer.WriteLine(
-                "Unsupported queue transition target state. Supported states: queued, active, review, fixing, completed, blocked, clarify-blocked.");
+                "Unsupported queue transition target state. Supported states: queued, active, review, fixing, completed, retired, blocked, clarify-blocked.");
             return 1;
         }
 
@@ -100,6 +100,14 @@ internal static class QueueTransitionCommand
                 return true;
             case "completed":
                 state = QueueItemState.Completed;
+                return true;
+            case "retired":
+                // G534: backfill target for a packet already retired
+                // outside queue tracking (G525 lifecycle) — e.g. a packet
+                // predating queue-state that must be recorded without a
+                // hand-edit. QueueManager.MapNonBlockingEventName carries
+                // the matching "retired" run-event case.
+                state = QueueItemState.Retired;
                 return true;
             case "blocked":
                 state = QueueItemState.Blocked;

--- a/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
 using IntentSystem.Supervisor;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
@@ -7,6 +9,23 @@ namespace IntentSystem.Cli.Commands;
 internal static class QueueTransitionCommand
 {
     private const string TransitionActor = "intent-cli";
+
+    // G534 review repair: matches a GitHub PR URL as stored in
+    // QueueItem.LinkedPr (e.g. "https://github.com/org/repo/pull/42"),
+    // capturing the owner/repo and PR number so the linked PR's
+    // authoritative state can be looked up before a retirement mutates
+    // queue-state, independent of (and not trusting) queue-state's own
+    // possibly-stale item state.
+    private static readonly Regex LinkedPrUrlPattern = new(
+        @"^https://github\.com/(?<repo>[^/]+/[^/]+)/pull/(?<number>\d+)/?$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// G534 review repair test seam: tests inject a fake
+    /// <see cref="IGitHubPrLookup"/> to avoid GitHub network access when
+    /// verifying a linked PR's state before allowing retirement.
+    /// </summary>
+    public static Func<IGitHubPrLookup>? PrLookupFactory { get; set; }
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -62,11 +81,14 @@ internal static class QueueTransitionCommand
             // path, which never asserted a source state at all.
             if (targetState == QueueItemState.Retired)
             {
+                var linkedPrVerification = ResolveLinkedPrVerification(queueState, args[0]);
+
                 var retireResult = QueueManager.Retire(
                     queueState,
                     args[0],
                     TransitionActor,
-                    DateTimeOffset.UtcNow);
+                    DateTimeOffset.UtcNow,
+                    linkedPrVerification);
 
                 if (!retireResult.WasRetired)
                 {
@@ -177,6 +199,75 @@ internal static class QueueTransitionCommand
 
         error = null;
         return true;
+    }
+
+    /// <summary>
+    /// G534 review repair: resolves the authoritative linked-PR state for a
+    /// retirement candidate BEFORE any mutation, since queue-state alone
+    /// (a stale `Queued`/`Review`/`Fixing` item) is not trustworthy
+    /// evidence that the work is actually still open. This is the only
+    /// place in the retirement path permitted to reach GitHub — the result
+    /// is a plain <see cref="LinkedPrVerification"/> value handed to the
+    /// network-free <see cref="QueueManager.Retire"/>.
+    /// </summary>
+    private static LinkedPrVerification ResolveLinkedPrVerification(QueueState queueState, string executionUnit)
+    {
+        var existingItem = queueState.Items.FirstOrDefault(item =>
+            string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        // Unknown execution unit: let QueueManager.Retire's own "not found"
+        // refusal handle it — no GitHub call needed.
+        if (existingItem is null || string.IsNullOrWhiteSpace(existingItem.LinkedPr))
+        {
+            return LinkedPrVerification.NotLinked;
+        }
+
+        var match = LinkedPrUrlPattern.Match(existingItem.LinkedPr.Trim());
+        if (!match.Success || !int.TryParse(
+                match.Groups["number"].Value,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var prNumber))
+        {
+            // Malformed/unparseable linked-PR reference — there IS a link,
+            // but its state cannot be resolved. Fail closed rather than
+            // treating it as unlinked.
+            return LinkedPrVerification.Unverifiable;
+        }
+
+        var repo = match.Groups["repo"].Value;
+
+        IGitHubPrLookup prLookup;
+        GitHubPrLookupResult lookupResult;
+        try
+        {
+            prLookup = PrLookupFactory?.Invoke() ?? new GhCliGitHubPrLookup();
+            lookupResult = prLookup.Lookup(repo, prNumber);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            // Lookup failure (network error, wrong repo, PR not found,
+            // malformed gh response, etc.) — ambiguous evidence must never
+            // be presumed open.
+            return LinkedPrVerification.Unverifiable;
+        }
+
+        if (lookupResult.Merged
+            || string.Equals(lookupResult.State, "MERGED", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(lookupResult.State, "CLOSED", StringComparison.OrdinalIgnoreCase))
+        {
+            return LinkedPrVerification.ConfirmedMergedOrClosed;
+        }
+
+        if (string.Equals(lookupResult.State, "OPEN", StringComparison.OrdinalIgnoreCase))
+        {
+            return LinkedPrVerification.ConfirmedOpen;
+        }
+
+        // Unexpected/empty state string from GitHub — ambiguous.
+        return LinkedPrVerification.Unverifiable;
     }
 
     private static bool IsBlockingTargetState(QueueItemState state)

--- a/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
@@ -55,6 +55,35 @@ internal static class QueueTransitionCommand
 
         try
         {
+            // G534 review repair: `retired` is a guarded, idempotent,
+            // terminal transition (refuses Completed, no-ops on an
+            // already-Retired item) — routed through the dedicated
+            // QueueManager.Retire rather than the generic non-blocking
+            // path, which never asserted a source state at all.
+            if (targetState == QueueItemState.Retired)
+            {
+                var retireResult = QueueManager.Retire(
+                    queueState,
+                    args[0],
+                    TransitionActor,
+                    DateTimeOffset.UtcNow);
+
+                if (!retireResult.WasRetired)
+                {
+                    writer.WriteLine($"{args[0]} is already retired; no changes made (idempotent).");
+                    return 0;
+                }
+
+                PersistTransition(context, new QueueTransitionResult
+                {
+                    UpdatedState = retireResult.UpdatedState,
+                    Event = retireResult.Event!
+                });
+
+                writer.WriteLine($"Transitioned {args[0]} to retired.");
+                return 0;
+            }
+
             var result = IsBlockingTargetState(targetState)
                 ? QueueManager.TransitionBlocking(
                     queueState,

--- a/src/IntentSystem.Projection/Serialization/ProjectionPacketSerializer.cs
+++ b/src/IntentSystem.Projection/Serialization/ProjectionPacketSerializer.cs
@@ -137,7 +137,21 @@ public static class ProjectionPacketSerializer
                     "Projection packet YAML must declare a section before its fields.");
             }
 
-            if (line.StartsWith("    - ", StringComparison.Ordinal))
+            // G534 review repair: a YAML block-sequence item may be
+            // indented at the SAME column as its parent key (the common
+            // convention, e.g. "  intent_references:\n  - foo") or nested
+            // one level deeper (this project's own renderer convention,
+            // "    - foo") — both are valid YAML. Detect a list item by
+            // its CONTENT ("- " once leading spaces are stripped), not by
+            // a fixed column count, so either convention — and any mix of
+            // the two across different fields in the same file — parses
+            // identically. Previously only the 4-space form was accepted;
+            // a 2-space list item fell through to the generic field-line
+            // branch below and failed with "field line is missing ':'"
+            // (no colon in "- foo"), rejecting every hand-authored packet
+            // using the more common convention.
+            var listItemCandidate = line.TrimStart(' ');
+            if (listItemCandidate.StartsWith("- ", StringComparison.Ordinal) || listItemCandidate == "-")
             {
                 if (currentListKey is null
                     || !currentSection.TryGetValue(currentListKey, out var listValue)
@@ -147,7 +161,8 @@ public static class ProjectionPacketSerializer
                         $"Projection packet YAML contains list item without a list field: '{line.Trim()}'.");
                 }
 
-                list.Add(ParseScalar(line[6..]));
+                var itemText = listItemCandidate.Length > 1 ? listItemCandidate[2..] : string.Empty;
+                list.Add(ParseScalar(itemText));
                 continue;
             }
 

--- a/src/IntentSystem.Supervisor/Models/LinkedPrVerification.cs
+++ b/src/IntentSystem.Supervisor/Models/LinkedPrVerification.cs
@@ -1,0 +1,30 @@
+namespace IntentSystem.Supervisor.Models;
+
+/// <summary>
+/// G534 review repair: authoritative verification of a queue item's linked
+/// PR state, resolved by a CLI boundary that has GitHub access (e.g. via
+/// `gh pr view`) and passed into the domain-pure <see cref="QueueManager.Retire"/>
+/// so retirement can refuse a merged/closed linked PR even when queue-state
+/// itself is stale and still reports a non-<see cref="QueueItemState.Completed"/>
+/// state (<c>Queued</c>/<c>Review</c>/<c>Fixing</c>/etc.). Queue-state alone is
+/// not authoritative for "is this work actually done" — the linked PR is.
+/// <see cref="QueueManager"/> never performs the lookup itself (no network
+/// logic in the domain core); the caller resolves this value first.
+/// </summary>
+public enum LinkedPrVerification
+{
+    /// <summary>The item has no linked PR at all — nothing to verify.</summary>
+    NotLinked,
+
+    /// <summary>The linked PR was confirmed OPEN — retirement may proceed.</summary>
+    ConfirmedOpen,
+
+    /// <summary>The linked PR was confirmed MERGED or CLOSED — retirement refuses;
+    /// completed/finished work can never be reclassified as retired.</summary>
+    ConfirmedMergedOrClosed,
+
+    /// <summary>The linked PR's state could not be resolved (lookup failure,
+    /// malformed/unparseable URL, wrong repo, ambiguous response, etc.).
+    /// Retirement refuses — ambiguous evidence must never be presumed open.</summary>
+    Unverifiable
+}

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -144,11 +144,24 @@ public static class QueueManager
     /// in <see cref="TransitionNonBlocking"/> / <see cref="TransitionBlocking"/>,
     /// which refuses every other transition away from it.
     /// </summary>
+    /// <param name="linkedPrVerification">
+    /// G534 review repair: queue-state alone is not authoritative for
+    /// whether an item's linked PR is actually done — a stale
+    /// <c>Queued</c>/<c>Review</c>/<c>Fixing</c> item whose linked PR was
+    /// separately merged or closed must refuse retirement exactly like a
+    /// <see cref="QueueItemState.Completed"/> item does, and an
+    /// unverifiable linked PR must fail closed rather than being presumed
+    /// open. The caller resolves this (e.g. via <c>gh pr view</c>) before
+    /// calling — <see cref="QueueManager"/> never performs the lookup
+    /// itself. Defaults to <see cref="LinkedPrVerification.NotLinked"/> for
+    /// callers that already know the item has no linked PR.
+    /// </param>
     public static QueueRetireResult Retire(
         QueueState state,
         string executionUnit,
         string by,
-        DateTimeOffset ts)
+        DateTimeOffset ts,
+        LinkedPrVerification linkedPrVerification = LinkedPrVerification.NotLinked)
     {
         ArgumentNullException.ThrowIfNull(state);
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
@@ -172,6 +185,25 @@ public static class QueueManager
                 WasRetired = false,
                 Event = null
             };
+        }
+
+        // G534 review repair: queue-state can be stale — a Queued/Review/
+        // Fixing/etc. item whose linked PR was separately merged or closed
+        // must refuse retirement exactly like a Completed item does, and an
+        // unverifiable linked PR must fail closed rather than being
+        // presumed open.
+        if (linkedPrVerification == LinkedPrVerification.ConfirmedMergedOrClosed)
+        {
+            throw new InvalidOperationException(
+                $"Cannot retire execution unit '{executionUnit}': its linked PR is merged or closed "
+                + "(queue-state is stale); retirement only applies to work that can never be completed as authored.");
+        }
+
+        if (linkedPrVerification == LinkedPrVerification.Unverifiable)
+        {
+            throw new InvalidOperationException(
+                $"Cannot retire execution unit '{executionUnit}': its linked PR state could not be verified; "
+                + "refusing to retire on unverifiable evidence (fail closed).");
         }
 
         var runEvent = new RunEvent

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -492,6 +492,10 @@ public static class QueueManager
             QueueItemState.Review => "review-started",
             QueueItemState.Fixing => "fix-requested",
             QueueItemState.Completed => "completed",
+            // G534: retired is a valid terminal transition target (G525
+            // lifecycle) — backfills a packet retired outside queue
+            // tracking without a hand-edited queue-state.json.
+            QueueItemState.Retired => "retired",
             _ => throw new InvalidOperationException(
                 $"Unsupported queue transition target state '{FormatState(targetState)}'.")
         };

--- a/src/IntentSystem.Supervisor/QueueManager.cs
+++ b/src/IntentSystem.Supervisor/QueueManager.cs
@@ -83,7 +83,8 @@ public static class QueueManager
         ArgumentException.ThrowIfNullOrWhiteSpace(by);
 
         ValidateNonBlockingTargetState(targetState);
-        FindItem(state, executionUnit);
+        var item = FindItem(state, executionUnit);
+        AssertNotRetired(item, targetState);
 
         return ApplyTransition(state, executionUnit, targetState, new RunEvent
         {
@@ -108,7 +109,8 @@ public static class QueueManager
         ArgumentException.ThrowIfNullOrWhiteSpace(by);
 
         ValidateBlockingTargetState(targetState);
-        FindItem(state, executionUnit);
+        var item = FindItem(state, executionUnit);
+        AssertNotRetired(item, targetState);
 
         return ApplyTransition(
             state,
@@ -123,6 +125,72 @@ public static class QueueManager
                 By = by,
                 Reason = reason
             });
+    }
+
+    /// <summary>
+    /// G534 review repair: retire a queue item as a canonical backfill for a
+    /// packet retired outside queue tracking (packet-level
+    /// <c>lifecycle.yaml</c>, or historically via <c>automation
+    /// issue-retire</c>) — never as a way to reclassify completed or
+    /// in-flight work. Consistent with <c>automation issue-retire</c>'s own
+    /// refusal (G525): legal from any state except <see
+    /// cref="QueueItemState.Completed"/> (merged/finished work — retirement
+    /// only applies to work that can never be completed as authored), and
+    /// idempotent when the item is already <see cref="QueueItemState.Retired"/>
+    /// (no state churn, no duplicate run event — <see
+    /// cref="QueueRetireResult.WasRetired"/> is <see langword="false"/> so
+    /// the caller knows nothing changed). Once retired, the item becomes
+    /// terminal: see the <see cref="QueueItemState.Retired"/> source guard
+    /// in <see cref="TransitionNonBlocking"/> / <see cref="TransitionBlocking"/>,
+    /// which refuses every other transition away from it.
+    /// </summary>
+    public static QueueRetireResult Retire(
+        QueueState state,
+        string executionUnit,
+        string by,
+        DateTimeOffset ts)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(by);
+
+        var item = FindItem(state, executionUnit);
+
+        if (item.State == QueueItemState.Completed)
+        {
+            throw new InvalidOperationException(
+                $"Cannot retire execution unit '{executionUnit}': item is completed (merged/finished work); "
+                + "retirement only applies to work that can never be completed as authored.");
+        }
+
+        if (item.State == QueueItemState.Retired)
+        {
+            return new QueueRetireResult
+            {
+                UpdatedState = state,
+                QueueItem = item,
+                WasRetired = false,
+                Event = null
+            };
+        }
+
+        var runEvent = new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = "retired",
+            By = by
+        };
+
+        var result = ApplyTransition(state, executionUnit, QueueItemState.Retired, runEvent);
+
+        return new QueueRetireResult
+        {
+            UpdatedState = result.UpdatedState,
+            QueueItem = FindItem(result.UpdatedState, executionUnit),
+            WasRetired = true,
+            Event = result.Event
+        };
     }
 
     /// <summary>
@@ -467,10 +535,34 @@ public static class QueueManager
 
     private static void ValidateNonBlockingTargetState(QueueItemState targetState)
     {
-        if (targetState is QueueItemState.Blocked or QueueItemState.ClarifyBlocked)
+        // G534 review repair: `retired` is no longer routed through the
+        // generic, source-state-agnostic non-blocking path — it has its own
+        // guarded entry point (see Retire) that refuses Completed and is
+        // idempotent on an already-Retired item. Excluding it here means a
+        // caller can never bypass that guard via TransitionNonBlocking.
+        if (targetState is QueueItemState.Blocked or QueueItemState.ClarifyBlocked or QueueItemState.Retired)
         {
             throw new InvalidOperationException(
                 $"Unsupported queue transition target state '{FormatState(targetState)}'.");
+        }
+    }
+
+    /// <summary>
+    /// G534 review repair: <see cref="QueueItemState.Retired"/> is terminal
+    /// (G525) — once an item is retired it must never be transitioned to any
+    /// other state through the generic non-blocking/blocking surfaces
+    /// (previously a Retired item could be silently reactivated to
+    /// <c>queued</c>/<c>active</c>/etc., since neither path asserted a
+    /// source state at all). The dedicated <see cref="Retire"/> method
+    /// handles the one legal exception (Retired → Retired, idempotent).
+    /// </summary>
+    private static void AssertNotRetired(QueueItem item, QueueItemState targetState)
+    {
+        if (item.State == QueueItemState.Retired)
+        {
+            throw new InvalidOperationException(
+                $"Cannot transition execution unit '{item.ExecutionUnit}' to '{FormatState(targetState)}': "
+                + "item is retired (G525 terminal state) and can never be reclassified through this surface.");
         }
     }
 
@@ -492,10 +584,9 @@ public static class QueueManager
             QueueItemState.Review => "review-started",
             QueueItemState.Fixing => "fix-requested",
             QueueItemState.Completed => "completed",
-            // G534: retired is a valid terminal transition target (G525
-            // lifecycle) — backfills a packet retired outside queue
-            // tracking without a hand-edited queue-state.json.
-            QueueItemState.Retired => "retired",
+            // G534 review repair: Retired now routes through the dedicated
+            // Retire method exclusively (see ValidateNonBlockingTargetState);
+            // it is never a legal target here.
             _ => throw new InvalidOperationException(
                 $"Unsupported queue transition target state '{FormatState(targetState)}'.")
         };

--- a/src/IntentSystem.Supervisor/QueueRetireResult.cs
+++ b/src/IntentSystem.Supervisor/QueueRetireResult.cs
@@ -1,0 +1,22 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Supervisor;
+
+/// <summary>
+/// G534 review repair: result of <see cref="QueueManager.Retire"/>. Mirrors
+/// <see cref="QueueEnqueueResult"/>'s "may be a safe no-op" shape —
+/// <see cref="WasRetired"/> is <see langword="false"/> and <see cref="Event"/>
+/// is <see langword="null"/> when the item was already retired, so the
+/// caller can skip persisting a no-op state write and never appends a
+/// duplicate run event.
+/// </summary>
+public sealed record QueueRetireResult
+{
+    public required QueueState UpdatedState { get; init; }
+
+    public required QueueItem QueueItem { get; init; }
+
+    public required bool WasRetired { get; init; }
+
+    public RunEvent? Event { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -461,12 +461,15 @@ public sealed class IntentNextSliceCommandTests
     }
 
     [Fact]
-    public void Execute_LifecycleRetiredContradictsQueueNotRetired_ExcludedRegardless()
+    public void Execute_LifecycleRetiredContradictsQueueNotRetired_ExcludedWithDiagnostic()
     {
-        // G534 review repair: "active-vs-retired", direction 2 — a packet
-        // lifecycle already marked retired excludes the unit even though
-        // queue-state does not (yet) agree. This direction pre-dates G534
-        // (G474/G525) and must keep working unchanged.
+        // G534 review repair (round 2): "active-vs-retired", direction 2 —
+        // a packet lifecycle already marked retired excludes the unit even
+        // though a PRESENT queue entry does not (yet) agree. Exclusion
+        // itself pre-dates G534 (G474/G525) and must keep working
+        // unchanged — but this contradiction must now ALSO be diagnosed
+        // (previously silent), so a later, unrelated candidate can never
+        // hide the inconsistent earlier unit.
         using var workspace = new IntentNextSliceWorkspace();
         workspace.WriteFile(
             ".intent-cli/issues/G244/github-body.md",
@@ -507,6 +510,114 @@ public sealed class IntentNextSliceCommandTests
         var root = document.RootElement;
         Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
         Assert.Equal("G245", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+        var warnings = root.GetProperty("warnings").EnumerateArray().Select(w => w.GetString()).ToArray();
+        Assert.Contains("lifecycle-metadata-diagnostic", warnings);
+        var notes = root.GetProperty("notes").EnumerateArray().Select(n => n.GetString()).ToArray();
+        Assert.Contains(notes, note => note!.Contains("G244", StringComparison.Ordinal)
+            && note.Contains("contradict", StringComparison.OrdinalIgnoreCase)
+            && note.Contains("queued", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_LifecycleRetiredContradictsQueueActive_MarkdownFormat_IncludesDiagnostic()
+    {
+        // G534 review repair (round 2): the same reverse-direction
+        // contradiction, verified in the `--format markdown` renderer too
+        // — the Markdown output must not silently omit the diagnostic
+        // note/warning that the JSON output carries.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/lifecycle.yaml",
+            "lifecycle: retired\n");
+        workspace.WriteFile(
+            ".intent-cli/issues/G245/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G244",
+                  "title": "lifecycle retired, queue active",
+                  "state": "active",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var markdown = writer.ToString();
+        Assert.Contains("lifecycle-metadata-diagnostic", markdown, StringComparison.Ordinal);
+        Assert.Contains("G244", markdown, StringComparison.Ordinal);
+        Assert.Contains("contradict", markdown, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_LifecycleActiveContradictsQueueRetired_MarkdownFormat_IncludesDiagnostic()
+    {
+        // G534 review repair (round 2): direction 1's diagnostic, verified
+        // in the `--format markdown` renderer too.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/lifecycle.yaml",
+            "lifecycle: ready\n");
+        workspace.WriteFile(
+            ".intent-cli/issues/G245/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G244",
+                  "title": "contradiction: queue retired, lifecycle ready",
+                  "state": "retired",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var markdown = writer.ToString();
+        Assert.Contains("lifecycle-metadata-diagnostic", markdown, StringComparison.Ordinal);
+        Assert.Contains("G244", markdown, StringComparison.Ordinal);
+        Assert.Contains("contradict", markdown, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -256,6 +258,253 @@ public sealed class IntentNextSliceCommandTests
         var root = document.RootElement;
         Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
         Assert.Equal("G245", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_LifecycleRetiredPacket_NoQueueEntryAtAll_ExcludedAndNextRealCandidateSelected()
+    {
+        // G534 field finding: the SKS-G812 case — a packet retired via
+        // lifecycle.yaml with NO queue-state entry whatsoever (not even a
+        // "retired" queue item) was returned as the next-slice candidate
+        // instead of the next real one, because the selector's
+        // fallback loop only had a packet directory to go on. This is
+        // the "even when no queue entry exists" boundary the fix must
+        // hold — G244 has no queue-state item at all here.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/lifecycle.yaml",
+            "lifecycle: retired\nretired_reason: \"retired before queue tracking existed\"\n");
+        workspace.WriteFile(
+            ".intent-cli/issues/G245/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": []
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G245", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_QueueStateRetiredWithNoLifecycleYaml_ExcludedAndNextRealCandidateSelected()
+    {
+        // G534 review repair: a unit already transitioned to Retired
+        // purely in queue-state.json (e.g. backfilled via the new
+        // `queue transition --to retired`) previously fell through the
+        // state-bucketing switch with NO bucket at all — the fallback
+        // (all-directories) loop's only queue-state-derived exclusion was
+        // `completed.Contains(...)`, so a queue-Retired-but-no-
+        // lifecycle.yaml unit was never excluded and could be
+        // re-surfaced. No lifecycle.yaml exists for G244 here — only the
+        // queue-state Retired entry is the signal.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G245/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G244",
+                  "title": "retired via queue transition",
+                  "state": "retired",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G245", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_EndToEnd_EnqueueThenRetiredBackfillThenSelection_RequiresNoManualQueueStateEdits()
+    {
+        // G534 end-to-end fixture: proves all three field-finding fixes work
+        // together through the real command surface, with the only
+        // queue-state.json write being the initial empty schema skeleton
+        // every repo bootstraps with before any queue command has ever run
+        // (not a hand-authored queue entry). Every subsequent queue-state
+        // mutation goes through `queue enqueue` / `queue transition` only:
+        //   1. `queue enqueue` on a 2-space-list-item packet (SKS-G824 shape,
+        //      defect a) enqueues G900 as Queued.
+        //   2. `queue transition --to retired` (defect b) backfills G900 to
+        //      Retired without ever hand-editing queue-state.json.
+        //   3. `queue enqueue` enqueues a second unit, G901, as Queued.
+        //   4. `intent next-slice` (defect c, the publish selector) must
+        //      skip the queue-Retired G900 and select G901 as the real next
+        //      candidate.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-19T00:00:00Z",
+              "items": []
+            }
+            """);
+
+        workspace.WriteFile(
+            ".intent-cli/issues/G900/packet.yaml",
+            BuildTwoSpaceListPacketYaml("G900", "G900 Retirement Candidate"));
+        workspace.WriteFile(
+            ".intent-cli/issues/G900/github-body.md",
+            BuildCompleteContractBody());
+
+        using (var enqueueFirstWriter = new StringWriter())
+        {
+            var enqueueFirstExitCode = QueueEnqueueCommand.Execute(
+                workspace.Context,
+                ["G900"],
+                enqueueFirstWriter);
+            Assert.Equal(0, enqueueFirstExitCode);
+            Assert.Contains(
+                "Queue enqueue processed for execution unit 'G900'.",
+                enqueueFirstWriter.ToString(),
+                StringComparison.Ordinal);
+        }
+
+        using (var transitionWriter = new StringWriter())
+        {
+            var transitionExitCode = QueueTransitionCommand.Execute(
+                workspace.Context,
+                ["G900", "retired"],
+                transitionWriter);
+            Assert.Equal(0, transitionExitCode);
+            Assert.Contains(
+                "Transitioned G900 to retired",
+                transitionWriter.ToString(),
+                StringComparison.Ordinal);
+        }
+
+        workspace.WriteFile(
+            ".intent-cli/issues/G901/packet.yaml",
+            BuildTwoSpaceListPacketYaml("G901", "G901 Next Real Candidate"));
+        workspace.WriteFile(
+            ".intent-cli/issues/G901/github-body.md",
+            BuildCompleteContractBody());
+
+        using (var enqueueSecondWriter = new StringWriter())
+        {
+            var enqueueSecondExitCode = QueueEnqueueCommand.Execute(
+                workspace.Context,
+                ["G901"],
+                enqueueSecondWriter);
+            Assert.Equal(0, enqueueSecondExitCode);
+            Assert.Contains(
+                "Queue enqueue processed for execution unit 'G901'.",
+                enqueueSecondWriter.ToString(),
+                StringComparison.Ordinal);
+        }
+
+        using var nextSliceWriter = new StringWriter();
+        var nextSliceExitCode = IntentNextSliceCommand.Execute(
+            workspace.Context,
+            ["--dry-run"],
+            nextSliceWriter);
+
+        Assert.Equal(0, nextSliceExitCode);
+        using var document = JsonDocument.Parse(nextSliceWriter.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G901", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+
+        var finalQueueState = QueueStateSerializer.Deserialize(
+            File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.Equal(
+            QueueItemState.Retired,
+            finalQueueState.Items.Single(item => item.ExecutionUnit == "G900").State);
+        Assert.Equal(
+            QueueItemState.Queued,
+            finalQueueState.Items.Single(item => item.ExecutionUnit == "G901").State);
+    }
+
+    private static string BuildTwoSpaceListPacketYaml(string executionUnit, string title)
+    {
+        // G534: the documented (new-schema) packet format, with list items
+        // indented at the SAME column as their parent key (the common,
+        // previously-rejected convention) — quoted and unquoted scalars.
+        return $"""
+        implementation_issue_packet:
+          issue_title: "{title}"
+          issue_kind: "feature"
+          source_execution_unit: "{executionUnit}"
+          goal: "goal"
+          in_scope:
+          - "in scope item"
+          out_of_scope:
+          - out of scope item
+          target_repo: "J-Tech-Japan/intent-system"
+          target_path: "."
+          target_part: "part"
+          dependencies: []
+          technical_baseline:
+          - "C# / .NET"
+          project_local_guide:
+          - "AGENTS.md"
+          intent_baseline:
+          - "queue insertion stays thin"
+          intent_references:
+          - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs: []
+          acceptance_criteria:
+          - acceptance criterion
+          verification_evidence:
+          - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "{executionUnit}"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+          - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs: []
+          acceptance_criteria:
+          - acceptance criterion
+          deterministic_review_checks: []
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -357,6 +357,230 @@ public sealed class IntentNextSliceCommandTests
     }
 
     [Fact]
+    public void Execute_QueueRetiredAndLifecycleRetired_Agreement_ExcludedAndNextRealCandidateSelected()
+    {
+        // G534 review repair: "agreement" case — both signals say retired.
+        // Ordinary exclusion, no lifecycle-metadata-diagnostic warning (this
+        // is not a contradiction; nothing needs reconciling).
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/lifecycle.yaml",
+            "lifecycle: retired\n");
+        workspace.WriteFile(
+            ".intent-cli/issues/G245/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G244",
+                  "title": "retired via both signals",
+                  "state": "retired",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G245", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+        var warnings = root.GetProperty("warnings").EnumerateArray().Select(w => w.GetString()).ToArray();
+        Assert.DoesNotContain("lifecycle-metadata-diagnostic", warnings);
+    }
+
+    [Fact]
+    public void Execute_LifecycleActiveContradictsQueueRetired_ExcludedWithDiagnostic()
+    {
+        // G534 review repair: "active-vs-retired", direction 1 — an explicit
+        // `lifecycle: ready` does NOT override a queue-state Retired record.
+        // This is a genuine contradiction: still excluded, and surfaced as an
+        // actionable diagnostic so it can be reconciled.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/lifecycle.yaml",
+            "lifecycle: ready\n");
+        workspace.WriteFile(
+            ".intent-cli/issues/G245/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G244",
+                  "title": "contradiction: queue retired, lifecycle ready",
+                  "state": "retired",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G245", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+        var warnings = root.GetProperty("warnings").EnumerateArray().Select(w => w.GetString()).ToArray();
+        Assert.Contains("lifecycle-metadata-diagnostic", warnings);
+        var notes = root.GetProperty("notes").EnumerateArray().Select(n => n.GetString()).ToArray();
+        Assert.Contains(notes, note => note!.Contains("G244", StringComparison.Ordinal)
+            && note.Contains("contradict", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Execute_LifecycleRetiredContradictsQueueNotRetired_ExcludedRegardless()
+    {
+        // G534 review repair: "active-vs-retired", direction 2 — a packet
+        // lifecycle already marked retired excludes the unit even though
+        // queue-state does not (yet) agree. This direction pre-dates G534
+        // (G474/G525) and must keep working unchanged.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/lifecycle.yaml",
+            "lifecycle: retired\n");
+        workspace.WriteFile(
+            ".intent-cli/issues/G245/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G244",
+                  "title": "lifecycle retired, queue not yet caught up",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G245", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_UnknownLifecycleValue_MalformedSksG812NeverSelectedEvenAsOnlyCandidate()
+    {
+        // G534 review repair: the literal field-finding shape — an
+        // unrecognized (e.g. typo'd) lifecycle value must fail closed and
+        // never silently become publishable, even when it is the only
+        // packet directory available (no other candidate to fall back to).
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/SKS-G812/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/SKS-G812/lifecycle.yaml",
+            "lifecycle: retird\n");
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": []
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.NotEqual("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.False(root.TryGetProperty("candidate", out _), "no candidate should be selected");
+        var warnings = root.GetProperty("warnings").EnumerateArray().Select(w => w.GetString()).ToArray();
+        Assert.Contains("lifecycle-metadata-diagnostic", warnings);
+        var notes = root.GetProperty("notes").EnumerateArray().Select(n => n.GetString()).ToArray();
+        Assert.Contains(notes, note => note!.Contains("SKS-G812", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_BlankLifecycleValue_ExcludedWithDiagnostic()
+    {
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/lifecycle.yaml",
+            "lifecycle: \n");
+        workspace.WriteFile(
+            ".intent-cli/issues/G245/github-body.md",
+            BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-04-28T23:00:00Z",
+              "items": []
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G245", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+        var warnings = root.GetProperty("warnings").EnumerateArray().Select(w => w.GetString()).ToArray();
+        Assert.Contains("lifecycle-metadata-diagnostic", warnings);
+    }
+
+    [Fact]
     public void Execute_EndToEnd_EnqueueThenRetiredBackfillThenSelection_RequiresNoManualQueueStateEdits()
     {
         // G534 end-to-end fixture: proves all three field-finding fixes work

--- a/tests/IntentSystem.Cli.Tests/PacketLifecycleTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketLifecycleTests.cs
@@ -1,0 +1,132 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class PacketLifecycleTests
+{
+    [Fact]
+    public void ReadState_GivenNoSidecar_ReturnsAbsent()
+    {
+        using var workspace = new PacketDirectoryWorkspace();
+
+        var outcome = PacketLifecycle.ReadState(workspace.PacketDirectory);
+
+        Assert.Equal(PacketLifecycleState.Absent, outcome.State);
+        Assert.Null(outcome.Metadata);
+        Assert.Null(outcome.Detail);
+    }
+
+    [Fact]
+    public void ReadState_GivenReadyLifecycle_ReturnsValidActive()
+    {
+        using var workspace = new PacketDirectoryWorkspace();
+        workspace.WriteSidecar("lifecycle: ready\n");
+
+        var outcome = PacketLifecycle.ReadState(workspace.PacketDirectory);
+
+        Assert.Equal(PacketLifecycleState.ValidActive, outcome.State);
+        Assert.Equal("ready", outcome.Metadata?.Lifecycle);
+    }
+
+    [Theory]
+    [InlineData("absorbed")]
+    [InlineData("retired")]
+    [InlineData("superseded")]
+    public void ReadState_GivenNonPublishableLifecycle_ReturnsValidRetired(string lifecycle)
+    {
+        using var workspace = new PacketDirectoryWorkspace();
+        workspace.WriteSidecar($"lifecycle: {lifecycle}\n");
+
+        var outcome = PacketLifecycle.ReadState(workspace.PacketDirectory);
+
+        Assert.Equal(PacketLifecycleState.ValidRetired, outcome.State);
+        Assert.Equal(lifecycle, outcome.Metadata?.Lifecycle);
+    }
+
+    [Fact]
+    public void ReadState_GivenMissingLifecycleKey_ReturnsInvalid()
+    {
+        // G534 review repair: a sidecar that exists but never declares the
+        // required `lifecycle` key must fail closed (Invalid), not be
+        // treated the same as no sidecar at all (Absent).
+        using var workspace = new PacketDirectoryWorkspace();
+        workspace.WriteSidecar("retired_reason: \"some note\"\n");
+
+        var outcome = PacketLifecycle.ReadState(workspace.PacketDirectory);
+
+        Assert.Equal(PacketLifecycleState.Invalid, outcome.State);
+        Assert.Contains("lifecycle", outcome.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ReadState_GivenBlankLifecycleValue_ReturnsInvalid()
+    {
+        using var workspace = new PacketDirectoryWorkspace();
+        workspace.WriteSidecar("lifecycle: \n");
+
+        var outcome = PacketLifecycle.ReadState(workspace.PacketDirectory);
+
+        Assert.Equal(PacketLifecycleState.Invalid, outcome.State);
+        Assert.Contains("blank", outcome.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ReadState_GivenUnknownLifecycleValue_ReturnsInvalid()
+    {
+        // G534 review repair: the literal SKS-G812 field-finding shape — a
+        // typo'd or unrecognized lifecycle value must never silently be
+        // treated as "not retired" (i.e. publishable).
+        using var workspace = new PacketDirectoryWorkspace();
+        workspace.WriteSidecar("lifecycle: retird\n");
+
+        var outcome = PacketLifecycle.ReadState(workspace.PacketDirectory);
+
+        Assert.Equal(PacketLifecycleState.Invalid, outcome.State);
+        Assert.Contains("unknown lifecycle value", outcome.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ReadState_GivenEmptyFile_ReturnsInvalid()
+    {
+        using var workspace = new PacketDirectoryWorkspace();
+        workspace.WriteSidecar(string.Empty);
+
+        var outcome = PacketLifecycle.ReadState(workspace.PacketDirectory);
+
+        Assert.Equal(PacketLifecycleState.Invalid, outcome.State);
+    }
+
+    [Fact]
+    public void ReadState_GivenSidecarPathIsADirectory_ReturnsInvalidUnreadable()
+    {
+        // G534 review repair: an unreadable sidecar (here: a directory
+        // occupying the expected file path) must fail closed as Invalid,
+        // never silently fall back to Absent.
+        using var workspace = new PacketDirectoryWorkspace();
+        Directory.CreateDirectory(Path.Combine(workspace.PacketDirectory, PacketLifecycle.SidecarFileName));
+
+        var outcome = PacketLifecycle.ReadState(workspace.PacketDirectory);
+
+        Assert.Equal(PacketLifecycleState.Invalid, outcome.State);
+        Assert.Contains("unreadable", outcome.Detail, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class PacketDirectoryWorkspace : IDisposable
+    {
+        public string PacketDirectory { get; } =
+            Directory.CreateTempSubdirectory("intent-cli-packet-lifecycle-tests-").FullName;
+
+        public void WriteSidecar(string content)
+        {
+            File.WriteAllText(Path.Combine(PacketDirectory, PacketLifecycle.SidecarFileName), content);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(PacketDirectory))
+            {
+                Directory.Delete(PacketDirectory, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/QueueEnqueueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueEnqueueCommandTests.cs
@@ -57,6 +57,36 @@ public sealed class QueueEnqueueCommandTests
     }
 
     [Fact]
+    public void Execute_GivenTwoSpaceListItemPacket_EnqueuesSuccessfully()
+    {
+        // G534 field finding: a verbatim previously-failing packet shape —
+        // the documented `implementation_issue_packet` schema with YAML
+        // list items indented at the SAME column as their parent key
+        // (quoted AND unquoted scalars) — used to throw "field line is
+        // missing ':''" on every list item, rejecting every real
+        // hand-authored packet using this common convention.
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "issues", "G38", "packet.yaml"),
+            CreateTwoSpaceListItemPacketYaml());
+        using var writer = new StringWriter();
+
+        var exitCode = QueueEnqueueCommand.Execute(CreateContext(repoRoot), ["G38"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Queue enqueue processed for execution unit 'G38'.", writer.ToString(), StringComparison.Ordinal);
+        var updatedState = QueueStateSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+        var selectedItem = updatedState.Items.Single(item => item.ExecutionUnit == "G38");
+        Assert.Equal(QueueItemState.Queued, selectedItem.State);
+        Assert.Equal(["G3", "G4"], selectedItem.Dependencies);
+    }
+
+    [Fact]
     public void Execute_GivenExistingQueueItem_SkipsWithoutMutatingFiles()
     {
         using var tempDirectory = new TemporaryDirectory();
@@ -222,6 +252,61 @@ public sealed class QueueEnqueueCommandTests
           require_explicit_contract_check: true
           required_checks:
             - "queue insertion remains thin"
+        """;
+    }
+
+    /// <summary>G534: the documented (new-schema) packet format, with list
+    /// items indented at the SAME column as their parent key — quoted and
+    /// unquoted — the exact shape that previously threw "field line is
+    /// missing ':''" before this fix.</summary>
+    private static string CreateTwoSpaceListItemPacketYaml()
+    {
+        return """
+        implementation_issue_packet:
+          issue_title: "G38 Queue Enqueue Command"
+          issue_kind: "feature"
+          source_execution_unit: "G38"
+          goal: "Enqueue issue packet into queue artifacts."
+          in_scope:
+          - "queue enqueue command"
+          out_of_scope:
+          - workflow execution
+          target_repo: "submodules/intent-system"
+          target_path: "."
+          target_part: "cli queue enqueue command"
+          dependencies:
+          - "G4"
+          - G3
+          technical_baseline:
+          - "C# / .NET"
+          project_local_guide:
+          - "AGENTS.md"
+          intent_baseline:
+          - "queue insertion stays thin"
+          intent_references:
+          - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+          - "intents/intent-cli/specs/03-queue-json-and-jsonl-schema.md"
+          acceptance_criteria:
+          - queue item inserted
+          verification_evidence:
+          - "tests-passing"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G38"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+          - "ICL.P.PRODUCT_GOAL"
+          rules_and_specs:
+          - "intents/intent-cli/specs/03-queue-json-and-jsonl-schema.md"
+          acceptance_criteria:
+          - queue item inserted
+          deterministic_review_checks:
+          - "queue insertion remains thin"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
         """;
     }
 

--- a/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
@@ -280,6 +280,190 @@ public sealed class QueueTransitionCommandTests
         Assert.Empty(File.ReadAllText(runLogPath));
     }
 
+    // ─── G534 review repair: authoritative linked-PR preflight ───────────────
+
+    [Theory]
+    [InlineData("queued", "MERGED", false)]
+    [InlineData("queued", "CLOSED", false)]
+    [InlineData("review", "MERGED", false)]
+    [InlineData("review", "CLOSED", false)]
+    [InlineData("fixing", "MERGED", false)]
+    [InlineData("fixing", "CLOSED", false)]
+    public void Execute_GivenRetiredTargetOnStaleNonCompletedItemWithMergedOrClosedLinkedPr_RefusesWithoutMutation(
+        string sourceState, string linkedPrState, bool merged)
+    {
+        // G534 review repair (round 2): queue-state alone is stale
+        // evidence — a Queued/Review/Fixing item whose LINKED PR is
+        // already MERGED or CLOSED must refuse retirement exactly like a
+        // Completed item does, with zero queue/run mutation.
+        var targetState = sourceState switch
+        {
+            "queued" => QueueItemState.Queued,
+            "review" => QueueItemState.Review,
+            "fixing" => QueueItemState.Fixing,
+            _ => throw new InvalidOperationException("unexpected state")
+        };
+
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items = [CreateItem("A2", targetState) with { LinkedPr = "https://github.com/org/repo/pull/42" }]
+        });
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(runLogPath, string.Empty);
+        using var writer = new StringWriter();
+
+        QueueTransitionCommand.PrLookupFactory = () => new StubLinkedPrLookup
+        {
+            State = linkedPrState,
+            Merged = merged
+        };
+        try
+        {
+            var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("merged or closed", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+        }
+        finally
+        {
+            QueueTransitionCommand.PrLookupFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenRetiredTargetWithVerifiedOpenLinkedPr_Succeeds()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+                Items = [CreateItem("A2", QueueItemState.Queued) with { LinkedPr = "https://github.com/org/repo/pull/42" }]
+            }));
+        using var writer = new StringWriter();
+
+        QueueTransitionCommand.PrLookupFactory = () => new StubLinkedPrLookup { State = "OPEN" };
+        try
+        {
+            var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+
+            Assert.Equal(0, exitCode);
+            var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            Assert.Equal(QueueItemState.Retired, updatedState.Items.Single(item => item.ExecutionUnit == "A2").State);
+        }
+        finally
+        {
+            QueueTransitionCommand.PrLookupFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenRetiredTargetWithUnresolvableLinkedPrLookup_RefusesWithoutMutation()
+    {
+        // G534 review repair: a lookup failure (network error, PR/repo not
+        // found, etc.) must fail closed — never presumed open.
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items = [CreateItem("A2", QueueItemState.Queued) with { LinkedPr = "https://github.com/some-other-org/some-other-repo/pull/7" }]
+        });
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(runLogPath, string.Empty);
+        using var writer = new StringWriter();
+
+        string? observedRepo = null;
+        QueueTransitionCommand.PrLookupFactory = () => new StubLinkedPrLookup
+        {
+            OnLookup = repo => observedRepo = repo,
+            ThrowOnLookup = new InvalidOperationException("`gh pr view` failed: no such PR in that repo")
+        };
+        try
+        {
+            var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains("could not be verified", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+            Assert.Empty(File.ReadAllText(runLogPath));
+            // The repo/PR were resolved from the linked-PR URL itself (not
+            // assumed same-repo) before the lookup was attempted.
+            Assert.Equal("some-other-org/some-other-repo", observedRepo);
+        }
+        finally
+        {
+            QueueTransitionCommand.PrLookupFactory = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_GivenRetiredTargetWithMalformedLinkedPrUrl_RefusesWithoutMutation()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items = [CreateItem("A2", QueueItemState.Queued) with { LinkedPr = "not-a-valid-url" }]
+        });
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(runLogPath, string.Empty);
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("could not be verified", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenRetiredTargetWithNoLinkedPr_SkipsLookupAndSucceeds()
+    {
+        // Pins that an item with NO linked PR never triggers a GitHub call
+        // at all — PrLookupFactory is left unset (would throw if invoked
+        // since GhCliGitHubPrLookup shells to a real `gh` binary that may
+        // not exist in this environment).
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        tempDirectory.CreateFile(
+            queueStatePath,
+            QueueStateSerializer.Serialize(new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+                Items = [CreateItem("A2", QueueItemState.Queued)]
+            }));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+
+        Assert.Equal(0, exitCode);
+        var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        Assert.Equal(QueueItemState.Retired, updatedState.Items.Single(item => item.ExecutionUnit == "A2").State);
+    }
+
     [Fact]
     public void Execute_GivenMissingRunLog_CreatesRunLogFile()
     {
@@ -463,6 +647,42 @@ public sealed class QueueTransitionCommandTests
             ReviewRole = "reviewer",
             Priority = "normal"
         };
+    }
+
+    /// <summary>
+    /// G534 review repair: parametric <see cref="IGitHubPrLookup"/> fake for
+    /// verifying a linked PR's state before retirement, without shelling out
+    /// to a real <c>gh</c> binary. <see cref="ThrowOnLookup"/> simulates a
+    /// lookup failure (network error, wrong repo, PR not found, etc.).
+    /// <see cref="OnLookup"/> optionally captures the resolved
+    /// <c>repo</c> argument for assertions.
+    /// </summary>
+    private sealed class StubLinkedPrLookup : IGitHubPrLookup
+    {
+        public string State { get; init; } = "OPEN";
+
+        public bool Merged { get; init; }
+
+        public Exception? ThrowOnLookup { get; init; }
+
+        public Action<string>? OnLookup { get; init; }
+
+        public GitHubPrLookupResult Lookup(string repo, int prNumber)
+        {
+            OnLookup?.Invoke(repo);
+
+            if (ThrowOnLookup is not null)
+            {
+                throw ThrowOnLookup;
+            }
+
+            return new GitHubPrLookupResult
+            {
+                Number = prNumber,
+                State = State,
+                Merged = Merged
+            };
+        }
     }
 
     private sealed class TemporaryDirectory : IDisposable

--- a/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
@@ -110,6 +110,37 @@ public sealed class QueueTransitionCommandTests
     }
 
     [Fact]
+    public void Execute_GivenRetiredTarget_BackfillsRetiredStateWithoutHandEditingQueueState()
+    {
+        // G534 field finding: the SKS-G815 case — a packet retired outside
+        // queue tracking (G525 lifecycle) needed to be backfilled into
+        // queue-state.json, but `retired` was rejected as a transition
+        // target, forcing the field workaround of hand-editing
+        // queue-state.json directly (the exact mutation class this
+        // tooling exists to prevent).
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(CreateQueueState()));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("Transitioned A2 to retired", writer.ToString(), StringComparison.Ordinal);
+
+        var updatedState = QueueStateSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+        Assert.Equal(QueueItemState.Retired, updatedState.Items.Single(item => item.ExecutionUnit == "A2").State);
+
+        var runEvents = RunLogSerializer.DeserializeAll(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "runs.jsonl")));
+        Assert.Equal("retired", runEvents[^1].Event);
+        Assert.Equal("A2", runEvents[^1].ExecutionUnit);
+    }
+
+    [Fact]
     public void Execute_GivenMissingRunLog_CreatesRunLogFile()
     {
         using var tempDirectory = new TemporaryDirectory();

--- a/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
@@ -140,6 +140,146 @@ public sealed class QueueTransitionCommandTests
         Assert.Equal("A2", runEvents[^1].ExecutionUnit);
     }
 
+    // ─── G534 review repair: guarded/idempotent/terminal `retired` ───────────
+
+    [Fact]
+    public void Execute_GivenRetiredTargetOnQueuedItem_Succeeds()
+    {
+        // Pins the "queued" legal source state alongside the existing
+        // "review" legal source state (Execute_GivenRetiredTarget...above).
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+                Items = [CreateItem("A2", QueueItemState.Queued)]
+            }));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+
+        Assert.Equal(0, exitCode);
+        var updatedState = QueueStateSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+        Assert.Equal(QueueItemState.Retired, updatedState.Items.Single(item => item.ExecutionUnit == "A2").State);
+    }
+
+    [Fact]
+    public void Execute_GivenRetiredTargetOnCompletedItem_RefusesWithoutMutation()
+    {
+        // G534 review repair (blocker #1): a Completed item (merged/finished
+        // work) must never be reclassified as retired — retirement only
+        // applies to work that can never be completed as authored.
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items = [CreateItem("A2", QueueItemState.Completed)]
+        });
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(runLogPath, string.Empty);
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("completed", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenRetiredTargetOnCompletedItemWithMergedLinkedPr_RefusesWithoutMutation()
+    {
+        // G534 review repair: pins the "merged-linked" phrasing explicitly —
+        // a Completed item carrying a linked (merged) PR refuses exactly
+        // like any other Completed item.
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items = [CreateItem("A2", QueueItemState.Completed) with { LinkedPr = "https://github.com/org/repo/pull/42" }]
+        });
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(runLogPath, string.Empty);
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenRetiredTargetOnAlreadyRetiredItem_IsIdempotentWithNoDuplicateEvent()
+    {
+        // G534 review repair: Retired -> Retired must be a safe no-op — no
+        // state churn, and critically no duplicate run event on repeated
+        // calls (a naive re-run must never grow runs.jsonl).
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items = [CreateItem("A2", QueueItemState.Retired)]
+        });
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(runLogPath, string.Empty);
+        using var writer = new StringWriter();
+
+        var firstExitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+        var secondExitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "retired"], writer);
+
+        Assert.Equal(0, firstExitCode);
+        Assert.Equal(0, secondExitCode);
+        Assert.Contains("already retired", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
+    [Fact]
+    public void Execute_GivenReactivationAttemptOnRetiredItem_RefusesWithoutMutation()
+    {
+        // G534 review repair (blocker #1): Retired is terminal — a retired
+        // item can never be transitioned back to queued/active/etc through
+        // this surface.
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueStatePath = Path.Combine(repoRoot, ".intent-cli", "queue-state.json");
+        var queueStateContents = QueueStateSerializer.Serialize(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.Parse("2026-04-03T10:12:34Z"),
+            Items = [CreateItem("A2", QueueItemState.Retired)]
+        });
+        tempDirectory.CreateFile(queueStatePath, queueStateContents);
+        var runLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
+        tempDirectory.CreateFile(runLogPath, string.Empty);
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "active"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("terminal", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(queueStateContents, File.ReadAllText(queueStatePath));
+        Assert.Empty(File.ReadAllText(runLogPath));
+    }
+
     [Fact]
     public void Execute_GivenMissingRunLog_CreatesRunLogFile()
     {

--- a/tests/IntentSystem.Projection.Tests/ProjectionPacketSerializerTests.cs
+++ b/tests/IntentSystem.Projection.Tests/ProjectionPacketSerializerTests.cs
@@ -147,6 +147,112 @@ public sealed class ProjectionPacketSerializerTests
     }
 
     [Fact]
+    public void Deserialize_GivenTwoSpaceListItemIndentation_ParsesSuccessfully()
+    {
+        // G534 field finding: a hand-authored packet using the common
+        // "list item at the SAME column as its parent key" YAML
+        // convention (2-space, not this renderer's own 4-space nested
+        // convention) previously threw "field line is missing ':''" on
+        // every list item — quoted or unquoted. Both forms are pinned
+        // here, mixed within the same packet, matching the real
+        // previously-failing shape.
+        var packet = ProjectionPacketSerializer.Deserialize(
+            """
+            implementation_issue_packet:
+              issue_title: "G2 Projection Generate Command"
+              issue_kind: "feature"
+              source_execution_unit: "G2"
+              goal: "goal"
+              in_scope:
+              - "quoted scope item"
+              out_of_scope:
+              - unquoted scope item
+              target_repo: "repo"
+              target_path: "."
+              target_part: "part"
+              dependencies:
+              - "G1"
+              technical_baseline: []
+              project_local_guide: []
+              intent_baseline: []
+              intent_references:
+              - intents/foo/bar.md
+              - "intents/baz/qux.md"
+              rules_and_specs: []
+              acceptance_criteria:
+              - unquoted criterion
+              verification_evidence: []
+              review_mode: "deterministic-review"
+              completion_action: "wait-for-deterministic-review"
+              landing_policy: "merge-after-review"
+
+            review_context_packet:
+              source_execution_unit: "G2"
+              parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+              intent_references:
+              - intents/foo/bar.md
+              - "intents/baz/qux.md"
+              rules_and_specs: []
+              acceptance_criteria:
+              - unquoted criterion
+              deterministic_review_checks: []
+              clarification_return_path: "path.md"
+            """);
+
+        Assert.Equal("G2", packet.ImplementationIssuePacket.SourceExecutionUnit);
+        Assert.Equal(["quoted scope item"], packet.ImplementationIssuePacket.InScope);
+        Assert.Equal(["unquoted scope item"], packet.ImplementationIssuePacket.OutOfScope);
+        Assert.Equal(["G1"], packet.ImplementationIssuePacket.Dependencies);
+        Assert.Equal(["intents/foo/bar.md", "intents/baz/qux.md"], packet.ImplementationIssuePacket.IntentReferences);
+        Assert.Equal(["unquoted criterion"], packet.ImplementationIssuePacket.AcceptanceCriteria);
+    }
+
+    [Fact]
+    public void Deserialize_GivenMixedTwoAndFourSpaceListIndentationAcrossFields_BothParseIdentically()
+    {
+        // Different fields in the SAME file may use either convention —
+        // the parser must not require file-wide consistency.
+        var packet = ProjectionPacketSerializer.Deserialize(
+            """
+            implementation_issue_packet:
+              issue_title: "G2 Projection Generate Command"
+              issue_kind: "feature"
+              source_execution_unit: "G2"
+              goal: "goal"
+              in_scope:
+                - "four-space item"
+              out_of_scope:
+              - "two-space item"
+              target_repo: "repo"
+              target_path: "."
+              target_part: "part"
+              dependencies: []
+              technical_baseline: []
+              project_local_guide: []
+              intent_baseline: []
+              intent_references: []
+              rules_and_specs: []
+              acceptance_criteria: []
+              verification_evidence: []
+              review_mode: "deterministic-review"
+              completion_action: "wait-for-deterministic-review"
+              landing_policy: "merge-after-review"
+
+            review_context_packet:
+              source_execution_unit: "G2"
+              parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+              intent_references: []
+              rules_and_specs: []
+              acceptance_criteria: []
+              deterministic_review_checks: []
+              clarification_return_path: "path.md"
+            """);
+
+        Assert.Equal(["four-space item"], packet.ImplementationIssuePacket.InScope);
+        Assert.Equal(["two-space item"], packet.ImplementationIssuePacket.OutOfScope);
+    }
+
+    [Fact]
     public void Deserialize_GivenMissingRequiredField_ThrowsInvalidOperationException()
     {
         var exception = Assert.Throws<InvalidOperationException>(

--- a/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/QueueManagerTests.cs
@@ -536,6 +536,178 @@ public sealed class QueueManagerTests
                 BaseTime));
     }
 
+    // ─── G534 review repair: guarded/idempotent/terminal Retire ──────────────
+
+    [Fact]
+    public void Retire_GivenQueuedItem_TransitionsToRetiredAndEmitsRetiredEvent()
+    {
+        var state = CreateState(QueueItemState.Queued);
+
+        var result = QueueManager.Retire(state, "A1", "intent-cli", BaseTime);
+
+        Assert.True(result.WasRetired);
+        Assert.Equal(QueueItemState.Retired, FindItem(result.UpdatedState, "A1").State);
+        Assert.NotNull(result.Event);
+        Assert.Equal("retired", result.Event!.Event);
+        Assert.Equal("A1", result.Event.ExecutionUnit);
+        Assert.Equal("intent-cli", result.Event.By);
+    }
+
+    [Fact]
+    public void Retire_GivenActiveOrBlockedItem_TransitionsToRetired()
+    {
+        var activeState = CreateState(QueueItemState.Active);
+        var activeResult = QueueManager.Retire(activeState, "A1", "intent-cli", BaseTime);
+        Assert.True(activeResult.WasRetired);
+        Assert.Equal(QueueItemState.Retired, FindItem(activeResult.UpdatedState, "A1").State);
+
+        var blockedItem = CreateItem("A1", QueueItemState.Blocked) with
+        {
+            BlockedBy = ["dependency-incomplete: B1"]
+        };
+        var blockedState = CreateState([blockedItem]);
+        var blockedResult = QueueManager.Retire(blockedState, "A1", "intent-cli", BaseTime);
+        Assert.True(blockedResult.WasRetired);
+        Assert.Equal(QueueItemState.Retired, FindItem(blockedResult.UpdatedState, "A1").State);
+    }
+
+    [Fact]
+    public void Retire_GivenCompletedItem_ThrowsWithoutMutation()
+    {
+        var state = CreateState(QueueItemState.Completed);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => QueueManager.Retire(state, "A1", "intent-cli", BaseTime));
+
+        Assert.Contains("completed", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(QueueItemState.Completed, FindItem(state, "A1").State);
+    }
+
+    [Fact]
+    public void Retire_GivenCompletedItemWithLinkedPr_ThrowsWithoutMutation()
+    {
+        // G534 review repair: a Completed item carrying merged/linked-PR
+        // evidence must refuse retirement exactly like any other Completed
+        // item — retirement never reclassifies finished work.
+        var mergedItem = CreateItem("A1", QueueItemState.Completed) with
+        {
+            LinkedPr = "https://github.com/org/repo/pull/42"
+        };
+        var state = CreateState([mergedItem]);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => QueueManager.Retire(state, "A1", "intent-cli", BaseTime));
+
+        Assert.Contains("completed", exception.Message, StringComparison.OrdinalIgnoreCase);
+        var unchangedItem = FindItem(state, "A1");
+        Assert.Equal(QueueItemState.Completed, unchangedItem.State);
+        Assert.Equal("https://github.com/org/repo/pull/42", unchangedItem.LinkedPr);
+    }
+
+    [Fact]
+    public void Retire_GivenAlreadyRetiredItem_IsIdempotentWithNoMutationOrDuplicateEvent()
+    {
+        var retiredItem = CreateItem("A1", QueueItemState.Retired);
+        var state = CreateState([retiredItem]);
+
+        var result = QueueManager.Retire(state, "A1", "intent-cli", BaseTime);
+
+        Assert.False(result.WasRetired);
+        Assert.Null(result.Event);
+        Assert.Same(state, result.UpdatedState);
+        Assert.Equal(QueueItemState.Retired, FindItem(result.UpdatedState, "A1").State);
+
+        // Calling it again produces the exact same no-op — no event ever
+        // appears on a re-run, however many times it is retried.
+        var secondResult = QueueManager.Retire(result.UpdatedState, "A1", "intent-cli", BaseTime);
+        Assert.False(secondResult.WasRetired);
+        Assert.Null(secondResult.Event);
+    }
+
+    [Fact]
+    public void Retire_GivenUnknownExecutionUnit_ThrowsInvalidOperationException()
+    {
+        var state = CreateState(QueueItemState.Queued);
+
+        Assert.Throws<InvalidOperationException>(
+            () => QueueManager.Retire(state, "does-not-exist", "intent-cli", BaseTime));
+    }
+
+    [Fact]
+    public void TransitionNonBlocking_GivenRetiredTargetState_ThrowsUnsupported()
+    {
+        // G534 review repair: `retired` is exclusively reached via the
+        // dedicated, guarded Retire method now — the generic non-blocking
+        // path must never accept it as a target, even for a non-retired
+        // source item.
+        var state = CreateState(QueueItemState.Queued);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => QueueManager.TransitionNonBlocking(
+                state,
+                "A1",
+                QueueItemState.Retired,
+                "intent-cli",
+                BaseTime));
+
+        Assert.Contains("Unsupported queue transition target state 'retired'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TransitionNonBlocking_GivenRetiredItem_RefusesReactivationToActive()
+    {
+        var retiredItem = CreateItem("A1", QueueItemState.Retired);
+        var state = CreateState([retiredItem]);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => QueueManager.TransitionNonBlocking(
+                state,
+                "A1",
+                QueueItemState.Active,
+                "intent-cli",
+                BaseTime));
+
+        Assert.Contains("retired", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("terminal", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(QueueItemState.Retired, FindItem(state, "A1").State);
+    }
+
+    [Fact]
+    public void TransitionNonBlocking_GivenRetiredItem_RefusesReactivationToQueued()
+    {
+        var retiredItem = CreateItem("A1", QueueItemState.Retired);
+        var state = CreateState([retiredItem]);
+
+        Assert.Throws<InvalidOperationException>(
+            () => QueueManager.TransitionNonBlocking(
+                state,
+                "A1",
+                QueueItemState.Queued,
+                "intent-cli",
+                BaseTime));
+
+        Assert.Equal(QueueItemState.Retired, FindItem(state, "A1").State);
+    }
+
+    [Fact]
+    public void TransitionBlocking_GivenRetiredItem_RefusesReclassificationToBlocked()
+    {
+        var retiredItem = CreateItem("A1", QueueItemState.Retired);
+        var state = CreateState([retiredItem]);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => QueueManager.TransitionBlocking(
+                state,
+                "A1",
+                QueueItemState.Blocked,
+                "reason",
+                "intent-cli",
+                BaseTime));
+
+        Assert.Contains("retired", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(QueueItemState.Retired, FindItem(state, "A1").State);
+    }
+
     private static QueueState CreateState(QueueItemState itemState)
     {
         return CreateState([CreateItem("A1", itemState)]);


### PR DESCRIPTION
## Summary

Fixes three field-found queue-surface defects (field finding #6, design@sekiban-as-a-service-orch, 2026-07-19) that combined to force a hand-edited `queue-state.json`:

- **`queue enqueue`** now parses YAML list items indented at either the common 2-space (same column as parent key) convention or the renderer's own 4-space convention — in both `ProjectionPacketSerializer` (current schema) and `ProjectionPacketRuntimeReader` (legacy schema fallback). Detection is now content-based (`"- "` after stripping leading whitespace) instead of column-count-based, and the two conventions may be mixed within the same file.
- **`queue transition`** now accepts `retired` as a valid terminal target, wired through `QueueTransitionCommand.TryParseTargetState` and `QueueManager.MapNonBlockingEventName` — backfilling a queue-state entry for a packet already retired via `lifecycle.yaml` or via `automation issue-retire`, without hand-editing `queue-state.json`.
- **`intent next-slice`** (the publish selector) now excludes a unit that is `Retired` purely in `queue-state.json` with no `lifecycle.yaml` sidecar — its state-bucketing switch previously had no case for `QueueItemState.Retired`, so such a unit fell through every exclusion bucket and could resurface as the next candidate. The pre-existing `lifecycle.yaml`-based exclusion (including units with no queue entry at all) was already correct and is unchanged.

## Test plan

- [x] New unit tests: `ProjectionPacketSerializerTests` (2-space and mixed 2/4-space list items), `QueueEnqueueCommandTests` (2-space packet enqueues successfully), `QueueTransitionCommandTests` (`--to retired` backfill, invalid-target refusal message updated), `IntentNextSliceCommandTests` (lifecycle-retired-no-queue-entry and queue-retired-no-lifecycle-yaml both correctly excluded)
- [x] New end-to-end fixture (`IntentNextSliceCommandTests`) chaining `queue enqueue` → `queue transition --to retired` → `intent next-slice`, proving zero manual `queue-state.json` edits are required
- [x] Full solution test suite: 3541 passed, 1 pre-existing skip, 0 failures
- [x] `git diff --check` clean
- [x] Manual verification against the built CLI binary in a scratch fixture, reproducing all three field scenarios (SKS-G824 enqueue-parse, SKS-G815-style retired-backfill, SKS-G812-style mis-selection)
- [x] ja/en developer-reference docs updated with a new G534 section

Closes #1170