### PR TITLE
G535: request-update supersedes a stale intent-pr-rereview-ready

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -612,17 +612,38 @@ with no installed command able to proceed. The only escape was a non-obvious
 `review-start` → `request-update` detour.
 
 `request-update` now clears `intent-pr-rereview-ready` (and its legacy
-`rereview-ready` string form) in the **same** label write that adds
+`rereview-ready` string form) in the **same** write that adds
 `intent-pr-request-update` and removes `intent-pr-reviewing` — a repair
-request always supersedes pending rereview-readiness. As with the other
-transitions that clear multiple labels (`review-start`, `approved`,
-`review-release`), `--write` mode only removes labels that are actually
-present, so a rerun (or a PR that was never rereview-ready) stays
-idempotent; `--dry-run` still reports the full planned removal set
-regardless of presence, matching the existing convention. Because the
-add/remove edit is issued as a single `gh` call, the transition stays atomic
-— a failure leaves the PR's labels completely untouched, never a
-half-applied state. No other transition's label set changed.
+request always supersedes pending rereview-readiness.
+
+**Truthful audit output in both modes.** Unlike `review-start`/`approved`/
+`review-release` (whose `--dry-run` intentionally reports the *full*
+planned removal set regardless of presence), `request-update`'s reported
+`remove_labels` — in **both** `--dry-run` and `--write` — is always derived
+from the already-fetched current labels: a PR carrying only
+`intent-pr-rereview-ready` is reported as superseding exactly that label,
+never an absent `intent-pr-reviewing` or absent legacy `rereview-ready`
+alongside it. A rerun (or a PR that was never rereview-ready) reports and
+applies an empty removal set — genuinely idempotent, not merely
+non-erroring.
+
+**One atomic GitHub request, not sequential add/remove.** `gh <kind> edit
+--add-label --remove-label` is a CLI convenience wrapper — its atomicity
+from GitHub's perspective is not guaranteed. `request-update`'s `--write`
+path instead computes the full desired label set (every current label
+minus the ones being superseded, plus `intent-pr-request-update`) and
+replaces it in **one** GitHub REST call — `PUT
+/repos/{repo}/issues/{number}/labels` — via the internal
+`IGitHubLabelSetReplacer.ReplaceLabelSet` seam. A failure in that single
+call leaves the PR's labels completely untouched; there is no window where
+one label lands and another doesn't. GitHub's "Set labels" endpoint has no
+conditional/If-Match support for optimistic concurrency, so a concurrent
+label change racing the read-then-write cannot be prevented outright —
+instead, the adapter re-reads the labels immediately after the PUT and
+throws if the result doesn't match the desired set exactly, rather than
+silently claiming success on a lost update. This atomic-replace path is
+used only by `request-update`; every other transition keeps using the
+pre-existing `ApplyLabelTransitions` add/remove path, unchanged.
 
 With this landed, the SKS-G824 recovery sequence (`review-start` then
 `request-update` to clear a stuck rereview-ready) is no longer necessary —

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -634,16 +634,49 @@ path instead computes the full desired label set (every current label
 minus the ones being superseded, plus `intent-pr-request-update`) and
 replaces it in **one** GitHub REST call — `PUT
 /repos/{repo}/issues/{number}/labels` — via the internal
-`IGitHubLabelSetReplacer.ReplaceLabelSet` seam. A failure in that single
-call leaves the PR's labels completely untouched; there is no window where
-one label lands and another doesn't. GitHub's "Set labels" endpoint has no
-conditional/If-Match support for optimistic concurrency, so a concurrent
-label change racing the read-then-write cannot be prevented outright —
-instead, the adapter re-reads the labels immediately after the PUT and
-throws if the result doesn't match the desired set exactly, rather than
-silently claiming success on a lost update. This atomic-replace path is
+`IGitHubLabelSetReplacer.ReplaceLabelSet` seam. If the desired set already
+equals the current set (order-insensitive), this is a genuine no-op — zero
+GitHub calls, not merely an empty removal list. This atomic-replace path is
 used only by `request-update`; every other transition keeps using the
 pre-existing `ApplyLabelTransitions` add/remove path, unchanged.
+
+**Phase-aware failure reporting — stated honestly, never overclaiming
+safety.** A single HTTP call means there is no window where *this call's
+own actions* land half-applied — but that is not the same as every failure
+being known-harmless, and the command's error reporting reflects that
+distinction precisely:
+
+- if the `gh` process for the PUT never starts (e.g. the executable can't
+  be launched), nothing was transmitted — reported as a plain failure,
+  `applied: false`, `may_have_applied: false`;
+- once that process has started, ANY failure (non-zero exit, a
+  write/read error, a timeout) is ambiguous — `gh` may already have
+  transmitted the request and GitHub may already have applied it before
+  the failure surfaced. Reported as `applied: false`, **`may_have_applied:
+  true`**, with the `intended_labels` the mutation was attempting to
+  establish and an exact `recovery_command` (`gh <kind> view <n> --repo
+  <repo> --json labels`) to resolve the ambiguity — never a false "nothing
+  changed" claim;
+- if the PUT itself reports success but the post-write verification read
+  fails, or succeeds but reads back a mismatched set, both are *also*
+  reported as `may_have_applied: true` with the same recovery info — never
+  as a rollback or "no mutation" signal, since the PUT very likely applied
+  in both cases.
+
+**Bounded concurrency model — the honest limit of the post-write
+verification.** GitHub's "Set labels" endpoint has no conditional/If-Match
+support for optimistic concurrency, so a label change racing between the
+caller's initial read (used to compute the desired set) and the PUT cannot
+be prevented outright. The post-write verification read only detects a
+mismatch that is *still present at the moment of that read*. A label added
+by another process **after** the initial read but **before** the PUT — and
+therefore never reflected in the desired set — can be silently overwritten
+by the PUT; if nothing else changes labels between the PUT and the
+verification read, that read will equal the intended set exactly and the
+command will report success even though a concurrent addition was just
+lost. This race is fundamentally undetectable by a read-after-write check
+alone, and the docs and code say so explicitly rather than implying full
+protection.
 
 With this landed, the SKS-G824 recovery sequence (`review-start` then
 `request-update` to clear a stuck rereview-ready) is no longer necessary —

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -598,6 +598,40 @@ edits.
 
 ---
 
+### `request-update` supersedes a stale `intent-pr-rereview-ready` (G535)
+
+Field finding #5 (SKS-G824 / PR #1760): `intent-cli automation pr-transition
+--transition request-update` added its repair labels (`intent-pr-request-update`,
+and cleared `intent-pr-reviewing`) but left a pre-existing
+`intent-pr-rereview-ready` in place. `worker claim` correctly refuses any PR
+still carrying `intent-pr-rereview-ready` (a rereview-ready PR is the
+reviewer's to pick up, not the worker's) — so a design amendment arriving
+while a PR was rereview-ready produced a PR that `request-update` marked for
+repair but `claim` refused to touch: a deadlock between two canonical rules,
+with no installed command able to proceed. The only escape was a non-obvious
+`review-start` → `request-update` detour.
+
+`request-update` now clears `intent-pr-rereview-ready` (and its legacy
+`rereview-ready` string form) in the **same** label write that adds
+`intent-pr-request-update` and removes `intent-pr-reviewing` — a repair
+request always supersedes pending rereview-readiness. As with the other
+transitions that clear multiple labels (`review-start`, `approved`,
+`review-release`), `--write` mode only removes labels that are actually
+present, so a rerun (or a PR that was never rereview-ready) stays
+idempotent; `--dry-run` still reports the full planned removal set
+regardless of presence, matching the existing convention. Because the
+add/remove edit is issued as a single `gh` call, the transition stays atomic
+— a failure leaves the PR's labels completely untouched, never a
+half-applied state. No other transition's label set changed.
+
+With this landed, the SKS-G824 recovery sequence (`review-start` then
+`request-update` to clear a stuck rereview-ready) is no longer necessary —
+`request-update` alone now leaves the PR in a state `worker claim` accepts.
+`worker claim` itself is unchanged: it still refuses a rereview-ready PR
+that has not been through `request-update`.
+
+---
+
 ### Facet-aware context supply (G530)
 
 Building on G529's four semantic facets (`vocabulary`, `invariant`,

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -667,17 +667,50 @@ desired label set(現在の label のうち supersede される label を除い�
 もの、プラス `intent-pr-request-update`)を計算し、内部の
 `IGitHubLabelSetReplacer.ReplaceLabelSet` seam 経由で、**1 回**の
 GitHub REST call — `PUT /repos/{repo}/issues/{number}/labels` — として
-置き換えます。この単一の call が失敗した場合、PR の label は完全に
-手つかずのまま残ります — 一方の label は反映され他方は反映されない、
-という window は存在しません。GitHub の「Set labels」endpoint には
-optimistic concurrency 用の conditional/If-Match support が無いため、
-read してから write するまでの間の並行した label 変更を完全に防ぐ
-ことはできません — その代わり、adapter は PUT 直後に label を
-re-read し、結果が desired set と完全に一致しない場合は throw します。
-lost update に対して黙って success を claim することは決してありません。
-この atomic-replace path を使うのは `request-update` のみであり、他の
-すべての transition は既存の `ApplyLabelTransitions` による add/remove
-path を変更なく使い続けます。
+置き換えます。desired set が current set と(順序を問わず)既に一致
+している場合は、真の no-op です — 単に removal list が空になるだけで
+はなく、GitHub 呼び出しがゼロになります。この atomic-replace path を
+使うのは `request-update` のみであり、他のすべての transition は既存の
+`ApplyLabelTransitions` による add/remove path を変更なく使い続けます。
+
+**Phase-aware な failure report — safety を過大に主張しない、正直な
+記述。** 1 回の HTTP call であるということは、*この call 自身の action*
+が中途半端に反映される window は無い、という意味であり、すべての
+failure が「無害だと分かっている」という意味では**ありません**。
+コマンドの error report はこの違いを正確に反映します:
+
+- PUT 用の `gh` process 自体が起動しなかった場合(例えば実行ファイルを
+  起動できない)、何も送信されていません — 単純な failure として、
+  `applied: false`、`may_have_applied: false` で報告されます;
+- その process が起動した後は、いかなる failure(non-zero exit、
+  write/read error、timeout)も曖昧です — `gh` は既に request を
+  送信済みで、GitHub は failure が表面化する前に既に適用済みかも
+  しれません。`applied: false`、**`may_have_applied: true`** として
+  報告され、mutation が確立しようとしていた `intended_labels` と、
+  曖昧さを解消するための正確な `recovery_command`(`gh <kind> view
+  <n> --repo <repo> --json labels`)が付きます — 「何も変わらな
+  かった」という誤った claim は決してしません;
+- PUT 自体は success を報告したが post-write の verification read が
+  失敗した場合、あるいは success したが read back した set が一致
+  しない場合、どちらも同じく `may_have_applied: true` と同じ recovery
+  情報として報告されます — rollback や「no mutation」の signal として
+  では**ありません**。どちらの場合も PUT 自体はかなりの確率で適用
+  されているためです。
+
+**Bounded concurrency model — post-write verification の正直な限界。**
+GitHub の「Set labels」endpoint には optimistic concurrency 用の
+conditional/If-Match support が無いため、caller の初回 read(desired
+set の計算に使われる)と PUT の間で競合する label 変更を完全に防ぐ
+ことはできません。post-write の verification read は、*その read の
+瞬間にまだ残っている*不一致だけを検出します。初回 read の**後**、
+PUT の**前**に別プロセスが追加した label は — desired set には決して
+反映されないため — PUT によって黙って上書きされる可能性があります。
+PUT と verification read の間に他に何も label を変更しなければ、その
+read は intended set と完全に一致し、コマンドは concurrent な追加が
+まさに失われたにもかかわらず success を報告します。この race は
+read-after-write check だけでは原理的に検出不能であり、doc とコード
+はそれを「完全に保護されている」かのように暗示するのではなく、明示的
+にそう述べています。
 
 これが landed したことで、SKS-G824 の recovery sequence(行き詰まった
 rereview-ready を除去するための `review-start` の後の `request-update`)

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -642,19 +642,42 @@ Field finding #5(SKS-G824 / PR #1760): `intent-cli automation pr-transition
 という非自明な迂回策でした。
 
 `request-update` は、`intent-pr-request-update` を追加し
-`intent-pr-reviewing` を除去するのと**同じ** label write の中で、
+`intent-pr-reviewing` を除去するのと**同じ** write の中で、
 `intent-pr-rereview-ready`(および legacy な `rereview-ready` 文字列
 形式)を除去するようになりました — repair request は常に pending な
-rereview-readiness を supersede するためです。複数の label を除去する
-他の transition(`review-start`、`approved`、`review-release`)と同様、
-`--write` mode は実際に存在する label のみを除去するため、再実行(や、
-一度も rereview-ready になったことのない PR)は idempotent なままです。
-`--dry-run` は既存の convention と同様、存在有無に関わらず完全な
-planned removal set を引き続き報告します。add/remove の edit は 1 回の
-`gh` 呼び出しとして発行されるため、transition は atomic のままです —
-失敗した場合、PR の label は完全に手つかずのまま残り、half-applied な
-状態には決してなりません。他のどの transition の label set も変更
-されていません。
+rereview-readiness を supersede するためです。
+
+**両方の mode で truthful な audit output。** `--dry-run` が存在有無に
+関わらず常に完全な planned removal set を報告する
+`review-start`/`approved`/`review-release` とは異なり、
+`request-update` が報告する `remove_labels` は `--dry-run` と
+`--write` の**両方**で、既に fetch 済みの current label から常に
+導出されます。`intent-pr-rereview-ready` のみを持つ PR は、その label
+のみを supersede すると報告され、存在しない `intent-pr-reviewing` や
+存在しない legacy `rereview-ready` を一緒に claim することは決して
+ありません。再実行(や、一度も rereview-ready になったことのない PR)
+は空の removal set を報告・適用します — 単にエラーにならないだけでは
+なく、真に idempotent です。
+
+**逐次的な add/remove ではなく、1 回の atomic GitHub request。**
+`gh <kind> edit --add-label --remove-label` は `gh` CLI の
+convenience wrapper であり、GitHub 視点での atomicity は保証されて
+いません。`request-update` の `--write` path は、代わりに完全な
+desired label set(現在の label のうち supersede される label を除いた
+もの、プラス `intent-pr-request-update`)を計算し、内部の
+`IGitHubLabelSetReplacer.ReplaceLabelSet` seam 経由で、**1 回**の
+GitHub REST call — `PUT /repos/{repo}/issues/{number}/labels` — として
+置き換えます。この単一の call が失敗した場合、PR の label は完全に
+手つかずのまま残ります — 一方の label は反映され他方は反映されない、
+という window は存在しません。GitHub の「Set labels」endpoint には
+optimistic concurrency 用の conditional/If-Match support が無いため、
+read してから write するまでの間の並行した label 変更を完全に防ぐ
+ことはできません — その代わり、adapter は PUT 直後に label を
+re-read し、結果が desired set と完全に一致しない場合は throw します。
+lost update に対して黙って success を claim することは決してありません。
+この atomic-replace path を使うのは `request-update` のみであり、他の
+すべての transition は既存の `ApplyLabelTransitions` による add/remove
+path を変更なく使い続けます。
 
 これが landed したことで、SKS-G824 の recovery sequence(行き詰まった
 rereview-ready を除去するための `review-start` の後の `request-update`)

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -626,6 +626,45 @@ retirement や queue tracking 以前の retirement から、`queue-state.json`
 
 ---
 
+### `request-update` が stale な `intent-pr-rereview-ready` を supersede する (G535)
+
+Field finding #5(SKS-G824 / PR #1760): `intent-cli automation pr-transition
+--transition request-update` は自身の repair label(`intent-pr-request-update`
+を追加し、`intent-pr-reviewing` を除去)を適用していましたが、既存の
+`intent-pr-rereview-ready` はそのまま残していました。`worker claim` は
+`intent-pr-rereview-ready` を持つ PR を正しく refuse します(rereview-ready
+な PR は reviewer が拾うべきものであり、worker のものではないため)—
+そのため、PR が rereview-ready の間に design amendment が到着すると、
+`request-update` によって repair 対象としてマークされたにもかかわらず
+`claim` が触れることを拒否する PR が生まれていました。2 つの canonical
+な rule 同士の deadlock であり、インストール済みのどのコマンドも先に
+進めない状態でした。唯一の脱出策は、`review-start` → `request-update`
+という非自明な迂回策でした。
+
+`request-update` は、`intent-pr-request-update` を追加し
+`intent-pr-reviewing` を除去するのと**同じ** label write の中で、
+`intent-pr-rereview-ready`(および legacy な `rereview-ready` 文字列
+形式)を除去するようになりました — repair request は常に pending な
+rereview-readiness を supersede するためです。複数の label を除去する
+他の transition(`review-start`、`approved`、`review-release`)と同様、
+`--write` mode は実際に存在する label のみを除去するため、再実行(や、
+一度も rereview-ready になったことのない PR)は idempotent なままです。
+`--dry-run` は既存の convention と同様、存在有無に関わらず完全な
+planned removal set を引き続き報告します。add/remove の edit は 1 回の
+`gh` 呼び出しとして発行されるため、transition は atomic のままです —
+失敗した場合、PR の label は完全に手つかずのまま残り、half-applied な
+状態には決してなりません。他のどの transition の label set も変更
+されていません。
+
+これが landed したことで、SKS-G824 の recovery sequence(行き詰まった
+rereview-ready を除去するための `review-start` の後の `request-update`)
+はもはや不要です — `request-update` 単体で、`worker claim` が受け入れる
+状態に PR を残すようになりました。`worker claim` 自体は変更ありません
+— `request-update` を経ていない rereview-ready な PR は引き続き
+refuse されます。
+
+---
+
 ### facet を意識した context 供給 (G530)
 
 G529 の 4 つの semantic facet（`vocabulary`、`invariant`、`decider`、

--- a/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
@@ -108,12 +108,43 @@ internal static class AutomationPrTransitionCommand
         {
             try
             {
-                mutator.ApplyLabelTransitions(
-                    repo!,
-                    GhCliGitHubLabelMutator.Kinds.Pr,
-                    pr!.Value,
-                    plan.AddLabels,
-                    removeLabels);
+                if (string.Equals(transition, TransitionRequestUpdate, StringComparison.Ordinal))
+                {
+                    // G535 review repair: request-update must never apply as
+                    // sequential add/remove gh calls — a failure between the
+                    // two would leave a half-transitioned PR (e.g. rereview-ready
+                    // removed but request-update not yet added, or vice versa).
+                    // Compute the full desired label set (every current label
+                    // minus the ones actually being superseded, plus the ones
+                    // being added) and replace it atomically in one GitHub
+                    // request via IGitHubLabelSetReplacer.
+                    if (mutator is not IGitHubLabelSetReplacer replacer)
+                    {
+                        writer.WriteLine(
+                            "the configured GitHub mutator does not support atomic label-set replacement, "
+                            + "required for the request-update transition (G535).");
+                        return 1;
+                    }
+
+                    var removeLabelSet = new HashSet<string>(removeLabels, StringComparer.Ordinal);
+                    var desiredLabels = currentLabels
+                        .Where(label => !removeLabelSet.Contains(label))
+                        .Concat(plan.AddLabels)
+                        .Distinct(StringComparer.Ordinal)
+                        .ToArray();
+
+                    replacer.ReplaceLabelSet(repo!, GhCliGitHubLabelMutator.Kinds.Pr, pr!.Value, desiredLabels);
+                }
+                else
+                {
+                    mutator.ApplyLabelTransitions(
+                        repo!,
+                        GhCliGitHubLabelMutator.Kinds.Pr,
+                        pr!.Value,
+                        plan.AddLabels,
+                        removeLabels);
+                }
+
                 applied = true;
             }
             catch (Exception exception) when (
@@ -224,22 +255,34 @@ internal static class AutomationPrTransitionCommand
         IReadOnlyList<string> plannedRemoveLabels,
         IReadOnlyList<string> currentLabels)
     {
+        // G535 review repair: request-update's audit output must be
+        // truthful in BOTH modes, never other transitions'. A PR carrying
+        // only intent-pr-rereview-ready must not be reported (dry-run OR
+        // write) as also superseding an absent intent-pr-reviewing or
+        // legacy "rereview-ready" — that would claim a removal that never
+        // happens. Filter to present-only regardless of mode, computed
+        // from the already-fetched current labels (no extra GitHub call).
+        if (string.Equals(transition, TransitionRequestUpdate, StringComparison.Ordinal))
+        {
+            var requestUpdateCurrentLabelSet = new HashSet<string>(currentLabels, StringComparer.Ordinal);
+            return plannedRemoveLabels
+                .Where(label => requestUpdateCurrentLabelSet.Contains(label))
+                .ToArray();
+        }
+
         // G292: review-release is also defensive about stale labels — only
         // remove labels that are actually present, so the dry-run plan
         // matches what gh will actually mutate.
         // G503: approved joins this set so clearing rereview-ready /
         // request-update / update-in-progress stays idempotent when those
         // labels are absent.
-        // G535: request-update joins this set too — the new
-        // intent-pr-rereview-ready / "rereview-ready" supersession removal
-        // must only be reported/applied when the label is actually present,
-        // so a rerun (or a PR that was never rereview-ready) stays
-        // idempotent and the reported plan matches what gh actually mutates.
+        // Unlike request-update above, these three transitions intentionally
+        // report the FULL planned removal set in dry-run (pre-existing,
+        // unchanged behavior) and only filter to present-only in --write.
         if (string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal)
             && (string.Equals(transition, TransitionReviewStart, StringComparison.Ordinal)
                 || string.Equals(transition, TransitionReviewRelease, StringComparison.Ordinal)
-                || string.Equals(transition, TransitionApproved, StringComparison.Ordinal)
-                || string.Equals(transition, TransitionRequestUpdate, StringComparison.Ordinal)))
+                || string.Equals(transition, TransitionApproved, StringComparison.Ordinal)))
         {
             var currentLabelSet = new HashSet<string>(currentLabels, StringComparer.Ordinal);
             return plannedRemoveLabels

--- a/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
@@ -104,38 +104,75 @@ internal static class AutomationPrTransitionCommand
         var removeLabels = ResolveRemoveLabelsForMode(transition!, mode, plan.RemoveLabels, currentLabels);
 
         var applied = false;
+        var mayHaveApplied = false;
+        IReadOnlyList<string>? intendedLabels = null;
+        string? recoveryCommand = null;
+        string? failureMessage = null;
+
         if (string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal))
         {
-            try
+            if (string.Equals(transition, TransitionRequestUpdate, StringComparison.Ordinal))
             {
-                if (string.Equals(transition, TransitionRequestUpdate, StringComparison.Ordinal))
+                // G535 review repair: request-update must never apply as
+                // sequential add/remove gh calls — a failure between the
+                // two would leave a half-transitioned PR (e.g. rereview-ready
+                // removed but request-update not yet added, or vice versa).
+                // Compute the full desired label set (every current label
+                // minus the ones actually being superseded, plus the ones
+                // being added) and replace it atomically in one GitHub
+                // request via IGitHubLabelSetReplacer.
+                if (mutator is not IGitHubLabelSetReplacer replacer)
                 {
-                    // G535 review repair: request-update must never apply as
-                    // sequential add/remove gh calls — a failure between the
-                    // two would leave a half-transitioned PR (e.g. rereview-ready
-                    // removed but request-update not yet added, or vice versa).
-                    // Compute the full desired label set (every current label
-                    // minus the ones actually being superseded, plus the ones
-                    // being added) and replace it atomically in one GitHub
-                    // request via IGitHubLabelSetReplacer.
-                    if (mutator is not IGitHubLabelSetReplacer replacer)
-                    {
-                        writer.WriteLine(
-                            "the configured GitHub mutator does not support atomic label-set replacement, "
-                            + "required for the request-update transition (G535).");
-                        return 1;
-                    }
-
-                    var removeLabelSet = new HashSet<string>(removeLabels, StringComparer.Ordinal);
-                    var desiredLabels = currentLabels
-                        .Where(label => !removeLabelSet.Contains(label))
-                        .Concat(plan.AddLabels)
-                        .Distinct(StringComparer.Ordinal)
-                        .ToArray();
-
-                    replacer.ReplaceLabelSet(repo!, GhCliGitHubLabelMutator.Kinds.Pr, pr!.Value, desiredLabels);
+                    writer.WriteLine(
+                        "the configured GitHub mutator does not support atomic label-set replacement, "
+                        + "required for the request-update transition (G535).");
+                    return 1;
                 }
-                else
+
+                var removeLabelSet = new HashSet<string>(removeLabels, StringComparer.Ordinal);
+                var desiredLabels = currentLabels
+                    .Where(label => !removeLabelSet.Contains(label))
+                    .Concat(plan.AddLabels)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToArray();
+                intendedLabels = desiredLabels.OrderBy(label => label, StringComparer.Ordinal).ToArray();
+
+                try
+                {
+                    // The replacer itself treats an already-converged desired
+                    // set as a genuine no-op (zero GitHub calls) — see
+                    // GhCliGitHubLabelMutator.ReplaceLabelSet.
+                    replacer.ReplaceLabelSet(
+                        repo!, GhCliGitHubLabelMutator.Kinds.Pr, pr!.Value, currentLabels, desiredLabels);
+                    applied = true;
+                }
+                catch (LabelSetReplacementException replacementException)
+                {
+                    failureMessage = replacementException.Message;
+                    if (replacementException.Certainty != LabelSetReplacementFailureCertainty.KnownUnapplied)
+                    {
+                        // G535 review repair: once the request may have
+                        // reached GitHub (transmitted, or the PUT itself
+                        // succeeded but verification could not confirm the
+                        // result), this is NOT a "nothing changed" failure —
+                        // report it as ambiguous and tell the operator
+                        // exactly how to resolve it, never a false "safe"
+                        // claim.
+                        mayHaveApplied = true;
+                        recoveryCommand =
+                            $"gh {GhCliGitHubLabelMutator.Kinds.Pr} view {pr} --repo {repo} --json labels";
+                    }
+                }
+                catch (Exception exception) when (
+                    exception is InvalidOperationException
+                    or IOException)
+                {
+                    failureMessage = exception.Message;
+                }
+            }
+            else
+            {
+                try
                 {
                     mutator.ApplyLabelTransitions(
                         repo!,
@@ -143,17 +180,48 @@ internal static class AutomationPrTransitionCommand
                         pr!.Value,
                         plan.AddLabels,
                         removeLabels);
+                    applied = true;
                 }
+                catch (Exception exception) when (
+                    exception is InvalidOperationException
+                    or IOException)
+                {
+                    failureMessage = exception.Message;
+                }
+            }
+        }
 
-                applied = true;
-            }
-            catch (Exception exception) when (
-                exception is InvalidOperationException
-                or IOException)
+        if (failureMessage is not null)
+        {
+            var failureResult = new AutomationPrTransitionResult
             {
-                writer.WriteLine($"failed to apply PR transition on PR #{pr} in {repo}: {exception.Message}");
-                return 1;
+                Repo = repo!,
+                Pr = pr!.Value,
+                Transition = transition!,
+                Mode = mode,
+                Applied = false,
+                AddLabels = plan.AddLabels,
+                RemoveLabels = removeLabels,
+                CurrentLabels = currentLabels,
+                Summary = BuildSummary(transition!, plan.AddLabels, removeLabels),
+                MayHaveApplied = mayHaveApplied,
+                IntendedLabels = mayHaveApplied ? intendedLabels : null,
+                RecoveryCommand = recoveryCommand,
+                Error = mayHaveApplied
+                    ? $"failed to confirm PR transition on PR #{pr} in {repo} (the mutation may already have applied — do not assume it did not): {failureMessage}"
+                    : $"failed to apply PR transition on PR #{pr} in {repo}: {failureMessage}",
+            };
+
+            if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+            {
+                writer.WriteLine(JsonSerializer.Serialize(failureResult, JsonOptions));
             }
+            else
+            {
+                WriteText(writer, failureResult);
+            }
+
+            return 1;
         }
 
         var result = new AutomationPrTransitionResult
@@ -453,11 +521,21 @@ internal static class AutomationPrTransitionCommand
 
     private static void WriteText(TextWriter writer, AutomationPrTransitionResult result)
     {
-        writer.WriteLine(result.Summary);
+        writer.WriteLine(result.Error ?? result.Summary);
         writer.WriteLine($"mode: {result.Mode}");
         writer.WriteLine($"repo: {result.Repo}");
         writer.WriteLine($"pr: {result.Pr.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
         writer.WriteLine($"applied: {result.Applied.ToString().ToLowerInvariant()}");
+
+        // G535 review repair: phase-aware ambiguity reporting — only ever
+        // emitted for a failed mutation whose outcome on GitHub is unknown.
+        if (result.MayHaveApplied)
+        {
+            writer.WriteLine("may_have_applied: true");
+            writer.WriteLine(
+                $"intended_labels: {string.Join(", ", result.IntendedLabels ?? Array.Empty<string>())}");
+            writer.WriteLine($"recovery_command: {result.RecoveryCommand}");
+        }
     }
 
     private static void WriteHelp(TextWriter writer)
@@ -513,4 +591,46 @@ internal sealed record AutomationPrTransitionResult
 
     [JsonPropertyName("summary")]
     public required string Summary { get; init; }
+
+    /// <summary>
+    /// G535 review repair: true when a mutation attempt failed at a point
+    /// where GitHub may already have applied it (the request was
+    /// transmitted, or a post-write verification read failed/mismatched) —
+    /// distinct from a failure known to have applied nothing at all (e.g.
+    /// the `gh` process never started). Always false when <see cref="Applied"/>
+    /// is true. Never omitted so callers can distinguish "definitely safe"
+    /// (both false) from "must re-check" (this true).
+    /// </summary>
+    [JsonPropertyName("may_have_applied")]
+    public bool MayHaveApplied { get; init; }
+
+    [JsonPropertyName("mayHaveApplied")]
+    public bool MayHaveAppliedCamel => MayHaveApplied;
+
+    /// <summary>
+    /// G535 review repair: the full label set the failed mutation was
+    /// attempting to establish, so an operator re-reading current labels
+    /// knows exactly what to compare against. Populated only alongside
+    /// <see cref="MayHaveApplied"/>.
+    /// </summary>
+    [JsonPropertyName("intended_labels")]
+    public IReadOnlyList<string>? IntendedLabels { get; init; }
+
+    [JsonPropertyName("intendedLabels")]
+    public IReadOnlyList<string>? IntendedLabelsCamel => IntendedLabels;
+
+    /// <summary>
+    /// G535 review repair: the exact command an operator should run to
+    /// read the PR's actual current labels and resolve the ambiguity.
+    /// Populated only alongside <see cref="MayHaveApplied"/>.
+    /// </summary>
+    [JsonPropertyName("recovery_command")]
+    public string? RecoveryCommand { get; init; }
+
+    [JsonPropertyName("recoveryCommand")]
+    public string? RecoveryCommandCamel => RecoveryCommand;
+
+    /// <summary>G535 review repair: the failure message, populated only when <see cref="Applied"/> is false.</summary>
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
@@ -183,6 +183,16 @@ internal static class AutomationPrTransitionCommand
                     WorkerPrReviewPreflightConstants.Labels.IntentPrRequestUpdate,
                     WorkerPrReviewPreflightConstants.Labels.IntentPrUpdateInProgress,
                 ]),
+            // G535: request-update supersedes a stale intent-pr-rereview-ready
+            // in the SAME write. Field finding #5 (SKS-G824 / PR #1760): a
+            // design amendment arriving while a PR is rereview-ready
+            // previously left rereview-ready in place after request-update,
+            // producing a PR `worker claim` correctly refuses (rereview-ready
+            // is the reviewer's to pick up) — a canonical-state deadlock with
+            // no installed command able to proceed. A repair request always
+            // supersedes pending rereview-readiness, so rereview-ready (and
+            // its legacy string form) is cleared alongside the pre-existing
+            // intent-pr-reviewing removal.
             TransitionRequestUpdate => new TransitionPlan(
                 AddLabels:
                 [
@@ -191,6 +201,8 @@ internal static class AutomationPrTransitionCommand
                 RemoveLabels:
                 [
                     WorkerPrReviewPreflightConstants.Labels.IntentPrReviewing,
+                    WorkerNextActionConstants.Labels.IntentPrRereviewReady,
+                    "rereview-ready",
                 ]),
             // G292: release the reviewer lease without claiming an
             // implementation-side repair is needed. Removes
@@ -218,10 +230,16 @@ internal static class AutomationPrTransitionCommand
         // G503: approved joins this set so clearing rereview-ready /
         // request-update / update-in-progress stays idempotent when those
         // labels are absent.
+        // G535: request-update joins this set too — the new
+        // intent-pr-rereview-ready / "rereview-ready" supersession removal
+        // must only be reported/applied when the label is actually present,
+        // so a rerun (or a PR that was never rereview-ready) stays
+        // idempotent and the reported plan matches what gh actually mutates.
         if (string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal)
             && (string.Equals(transition, TransitionReviewStart, StringComparison.Ordinal)
                 || string.Equals(transition, TransitionReviewRelease, StringComparison.Ordinal)
-                || string.Equals(transition, TransitionApproved, StringComparison.Ordinal)))
+                || string.Equals(transition, TransitionApproved, StringComparison.Ordinal)
+                || string.Equals(transition, TransitionRequestUpdate, StringComparison.Ordinal)))
         {
             var currentLabelSet = new HashSet<string>(currentLabels, StringComparer.Ordinal);
             return plannedRemoveLabels

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
@@ -49,6 +49,37 @@ internal interface IGitHubLabelMutator
 }
 
 /// <summary>
+/// G535 review repair: testability seam for atomically replacing an
+/// issue/PR's ENTIRE label set in a single GitHub API request, instead of
+/// the sequential add/remove calls <see cref="IGitHubLabelMutator.ApplyLabelTransitions"/>
+/// issues via <c>gh &lt;kind&gt; edit --add-label --remove-label</c> (which
+/// is a `gh` CLI convenience wrapper, not proven to be one atomic HTTP
+/// request). Kept as a separate, narrower interface — implemented only by
+/// <see cref="GhCliGitHubLabelMutator"/> and the one command (<c>automation
+/// pr-transition</c>'s <c>request-update</c> path) that needs the stronger
+/// atomicity guarantee — so the many existing <see cref="IGitHubLabelMutator"/>
+/// fakes across the test suite do not need to implement a capability they
+/// never exercise.
+/// </summary>
+internal interface IGitHubLabelSetReplacer
+{
+    /// <summary>
+    /// Replace the entire current label set on the issue/PR with
+    /// <paramref name="desiredLabels"/> via one GitHub API request. The
+    /// caller is responsible for computing the full desired set (current
+    /// labels minus superseded ones, plus new ones) so unrelated labels
+    /// are preserved. Must throw without any partial effect on failure —
+    /// see <see cref="GhCliGitHubLabelMutator.ReplaceLabelSet"/> for the
+    /// production adapter's documented atomicity/concurrency model.
+    /// </summary>
+    void ReplaceLabelSet(
+        string repo,
+        string kind,
+        int number,
+        IReadOnlyCollection<string> desiredLabels);
+}
+
+/// <summary>
 /// G211: Default mutator that shells out to <c>gh</c>. The only file
 /// in the worker claim/complete surface permitted to call
 /// <c>Process.Start</c> — analyzer and command layers stay pure. The
@@ -59,8 +90,21 @@ internal interface IGitHubLabelMutator
 /// <see cref="ApplyLabelTransitions"/> entry point; direct shell-out is
 /// not exposed.
 /// </summary>
-internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator
+internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator, IGitHubLabelSetReplacer
 {
+    /// <summary>
+    /// G535 review repair: injectable seam for <see cref="ReplaceLabelSet"/>'s
+    /// two `gh` invocations (the atomic PUT and the post-write verification
+    /// re-read), so adapter-level tests can simulate a mutation failure, a
+    /// re-read failure, or a re-read mismatch (concurrent change) without
+    /// spawning a real `gh` process. Signature: (arguments, standard-input-
+    /// or-null, description) -&gt; stdout. <see langword="null"/> (the
+    /// default) uses the real <c>Process.Start</c>-based runner; only test
+    /// code overrides it, and only for this method — <see cref="ReadLabels"/>
+    /// and <see cref="ApplyLabelTransitions"/> keep their own unmodified
+    /// <c>RunGh</c> path.
+    /// </summary>
+    internal static Func<IReadOnlyList<string>, string?, string, string>? GhInvokerOverride { get; set; }
     /// <summary>
     /// G211: stable kind tokens accepted by <see cref="ReadLabels"/> and
     /// <see cref="ApplyLabelTransitions"/>. Exposed internally so the
@@ -165,11 +209,132 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator
         return args;
     }
 
+    /// <summary>
+    /// G535 review repair: build the <c>gh api --method PUT
+    /// repos/&lt;repo&gt;/issues/&lt;number&gt;/labels --input -</c> argument
+    /// list for atomically replacing a label set. GitHub's REST API models
+    /// PR labels through the issues endpoint for both issues and PRs, so
+    /// <paramref name="kind"/> is validated but not part of the path.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildReplaceLabelsArguments(string repo, string kind, int number)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        if (number <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(number),
+                "issue/PR number must be positive.");
+        }
+        if (!string.Equals(kind, Kinds.Issue, StringComparison.Ordinal)
+            && !string.Equals(kind, Kinds.Pr, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"unrecognized kind '{kind}'. Supported: '{Kinds.Issue}', '{Kinds.Pr}'.",
+                nameof(kind));
+        }
+
+        return new List<string>
+        {
+            "api",
+            "--method", "PUT",
+            $"repos/{repo}/issues/{number}/labels",
+            "--input", "-",
+        };
+    }
+
+    /// <summary>
+    /// G535 review repair: build the JSON request body for the labels-PUT
+    /// call above — <c>{"labels":[...]}</c>, deterministically ordered so
+    /// the payload (and any test assertion against it) is stable.
+    /// </summary>
+    internal static string BuildReplaceLabelsRequestBody(IReadOnlyCollection<string> desiredLabels)
+    {
+        ArgumentNullException.ThrowIfNull(desiredLabels);
+        var normalized = NormalizeLabelSet(desiredLabels);
+        return JsonSerializer.Serialize(new ReplaceLabelsRequestBody { Labels = normalized });
+    }
+
+    /// <summary>
+    /// G535 review repair: deterministic, deduplicated, whitespace-free
+    /// label set — shared by the request-body builder and the post-write
+    /// verification comparison so both sides normalize identically.
+    /// </summary>
+    private static IReadOnlyList<string> NormalizeLabelSet(IEnumerable<string> labels) =>
+        labels
+            .Where(label => !string.IsNullOrWhiteSpace(label))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(label => label, StringComparer.Ordinal)
+            .ToArray();
+
+    private sealed record ReplaceLabelsRequestBody
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("labels")]
+        public required IReadOnlyList<string> Labels { get; init; }
+    }
+
     public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number)
     {
         var args = BuildViewArguments(repo, kind, number);
         var stdout = RunGh(args, $"read labels on {kind} #{number} in {repo}");
         return DeserializeLabels(stdout, $"`gh {kind} view #{number}` for {repo}");
+    }
+
+    /// <summary>
+    /// G535 review repair: replaces the PR/issue's entire label set with
+    /// <paramref name="desiredLabels"/> via ONE GitHub REST call (<c>PUT
+    /// /repos/{repo}/issues/{number}/labels</c>), instead of the sequential
+    /// add/remove calls <see cref="ApplyLabelTransitions"/> issues through
+    /// <c>gh &lt;kind&gt; edit</c>. A single HTTP call means a failure can
+    /// never leave a half-applied state (e.g. remove succeeded but add
+    /// failed, or vice versa) — the request either fully lands or the call
+    /// throws and nothing on GitHub has changed.
+    ///
+    /// Bounded concurrency model: GitHub's "Set labels" endpoint has no
+    /// conditional/If-Match support for optimistic concurrency, so a label
+    /// change racing between the caller's label read (before it computed
+    /// <paramref name="desiredLabels"/>) and this write cannot be prevented
+    /// outright. Instead, after the PUT this method re-reads the labels and
+    /// fails loudly — throws — if the result does not match
+    /// <paramref name="desiredLabels"/> exactly, rather than silently
+    /// claiming success on a lost update.
+    /// </summary>
+    public void ReplaceLabelSet(
+        string repo,
+        string kind,
+        int number,
+        IReadOnlyCollection<string> desiredLabels)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        ArgumentNullException.ThrowIfNull(desiredLabels);
+
+        // Policy guard: intent-pr-created is issue-only, mirroring
+        // ApplyLabelTransitions' equivalent check.
+        if (string.Equals(kind, Kinds.Pr, StringComparison.Ordinal)
+            && desiredLabels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"label policy violation: '{WorkerNextActionConstants.Labels.IntentPrCreated}' is issue-only and must not be applied to a PR.");
+        }
+
+        var normalizedDesired = NormalizeLabelSet(desiredLabels);
+        var putArguments = BuildReplaceLabelsArguments(repo, kind, number);
+        var requestBody = BuildReplaceLabelsRequestBody(normalizedDesired);
+
+        InvokeGh(putArguments, requestBody, $"replace label set on {kind} #{number} in {repo}");
+
+        var verifyArguments = BuildViewArguments(repo, kind, number);
+        var verifyStdout = InvokeGh(verifyArguments, null, $"verify replaced label set on {kind} #{number} in {repo}");
+        var actualLabels = NormalizeLabelSet(
+            DeserializeLabels(verifyStdout, $"`gh {kind} view #{number}` for {repo}").Select(label => label.Name));
+
+        if (!actualLabels.SequenceEqual(normalizedDesired, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"label replacement on {kind} #{number} in {repo} could not be verified: expected "
+                + $"[{string.Join(", ", normalizedDesired)}] but read back [{string.Join(", ", actualLabels)}] "
+                + "after the write (possible concurrent label change); refusing to claim success.");
+        }
     }
 
     public void ApplyLabelTransitions(
@@ -233,6 +398,79 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator
         var args = BuildEditArguments(repo, kind, number, addLabels, removeLabels);
         RunGh(args,
             $"apply reconcile label transitions on {kind} #{number} in {repo}");
+    }
+
+    /// <summary>
+    /// G535 review repair: dispatches through <see cref="GhInvokerOverride"/>
+    /// when a test has set one, otherwise runs the real `gh` process
+    /// (piping <paramref name="standardInput"/> to stdin when non-null).
+    /// Used exclusively by <see cref="ReplaceLabelSet"/> — <see cref="ReadLabels"/>
+    /// and <see cref="ApplyLabelTransitions"/> keep calling <see cref="RunGh"/>
+    /// directly, unaffected by this seam.
+    /// </summary>
+    private static string InvokeGh(IReadOnlyList<string> arguments, string? standardInput, string description)
+    {
+        if (GhInvokerOverride is { } overrideInvoker)
+        {
+            return overrideInvoker(arguments, standardInput, description);
+        }
+
+        return standardInput is null
+            ? RunGh(arguments, description)
+            : RunGhWithInput(arguments, standardInput, description);
+    }
+
+    private static string RunGhWithInput(IReadOnlyList<string> arguments, string standardInput, string description)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            RedirectStandardInput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        string stdout;
+        string stderr;
+        int exitCode;
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException(
+                    $"failed to start `gh` process to {description}");
+            process.StandardInput.Write(standardInput);
+            process.StandardInput.Close();
+            stdout = process.StandardOutput.ReadToEnd();
+            stderr = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            exitCode = process.ExitCode;
+        }
+        catch (Exception exception) when (
+            exception is System.ComponentModel.Win32Exception
+            or InvalidOperationException
+            or IOException)
+        {
+            throw new InvalidOperationException(
+                $"could not invoke `gh` to {description}: {exception.Message}",
+                exception);
+        }
+
+        if (exitCode != 0)
+        {
+            var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
+            throw new InvalidOperationException(
+                $"`gh` failed to {description} with exit {exitCode}: {errorBody.Trim()}");
+        }
+
+        return stdout;
     }
 
     private static string RunGh(IReadOnlyList<string> arguments, string description)

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
@@ -66,17 +66,126 @@ internal interface IGitHubLabelSetReplacer
     /// <summary>
     /// Replace the entire current label set on the issue/PR with
     /// <paramref name="desiredLabels"/> via one GitHub API request. The
-    /// caller is responsible for computing the full desired set (current
-    /// labels minus superseded ones, plus new ones) so unrelated labels
-    /// are preserved. Must throw without any partial effect on failure —
-    /// see <see cref="GhCliGitHubLabelMutator.ReplaceLabelSet"/> for the
+    /// caller passes <paramref name="currentLabels"/> (already fetched)
+    /// alongside the full desired set (current labels minus superseded
+    /// ones, plus new ones) so unrelated labels are preserved AND so the
+    /// implementation can detect an already-converged request and perform
+    /// a genuine no-op — zero GitHub calls — without an extra read.
+    ///
+    /// Returns <see cref="LabelSetReplacementCertainty"/> on a KNOWN good
+    /// outcome (converged no-op, or applied-and-verified). On any failure
+    /// whose outcome on GitHub is not certain, throws
+    /// <see cref="LabelSetReplacementException"/> carrying a
+    /// <see cref="LabelSetReplacementFailureCertainty"/> — implementations
+    /// must never claim "nothing changed" once a mutation request may
+    /// have reached GitHub. See
+    /// <see cref="GhCliGitHubLabelMutator.ReplaceLabelSet"/> for the
     /// production adapter's documented atomicity/concurrency model.
     /// </summary>
-    void ReplaceLabelSet(
+    LabelSetReplacementCertainty ReplaceLabelSet(
         string repo,
         string kind,
         int number,
+        IReadOnlyCollection<string> currentLabels,
         IReadOnlyCollection<string> desiredLabels);
+}
+
+/// <summary>
+/// G535 review repair: the KNOWN-good outcomes of
+/// <see cref="IGitHubLabelSetReplacer.ReplaceLabelSet"/>. Ambiguous/failed
+/// outcomes are never represented here — they throw
+/// <see cref="LabelSetReplacementException"/> instead, so a caller can
+/// never mistake "I don't know what happened" for a success value.
+/// </summary>
+internal enum LabelSetReplacementCertainty
+{
+    /// <summary>The desired set already equaled the current set (order-insensitive) — no GitHub call was made.</summary>
+    NoOpAlreadyConverged,
+
+    /// <summary>The PUT was transmitted and the post-write verification read confirmed the desired set landed exactly.</summary>
+    AppliedAndVerified,
+}
+
+/// <summary>
+/// G535 review repair: classifies a <see cref="LabelSetReplacementException"/>
+/// by what is actually knowable about whether the mutation reached GitHub —
+/// never conflating "we don't know" with "it definitely didn't happen".
+/// </summary>
+internal enum LabelSetReplacementFailureCertainty
+{
+    /// <summary>
+    /// The failure occurred before any request was transmitted (e.g. the
+    /// `gh` process itself never started). GitHub was never contacted —
+    /// safe to report that nothing changed.
+    /// </summary>
+    KnownUnapplied,
+
+    /// <summary>
+    /// The `gh` process for the PUT call started, but something failed
+    /// before its outcome could be confirmed (non-zero exit, a write/read
+    /// error mid-transmission, a timeout). The request may already have
+    /// been transmitted and applied by GitHub — the caller must re-read
+    /// current labels rather than assume either outcome.
+    /// </summary>
+    MayHaveApplied,
+
+    /// <summary>
+    /// The PUT call itself reported success, but the post-write
+    /// verification read failed, so the resulting label state could not be
+    /// confirmed. The mutation most likely applied.
+    /// </summary>
+    AppliedButVerificationReadFailed,
+
+    /// <summary>
+    /// The PUT call reported success and the verification read succeeded,
+    /// but the labels read back did not match the desired set. This
+    /// generally means a concurrent change raced the write — but note the
+    /// bounded limitation documented on
+    /// <see cref="GhCliGitHubLabelMutator.ReplaceLabelSet"/>: a concurrent
+    /// label added BEFORE this method's PUT (and therefore invisible to
+    /// its <c>desiredLabels</c> computation) may have been silently
+    /// overwritten by the PUT and is UNDETECTABLE by this check, since the
+    /// verification read would then equal <c>desiredLabels</c> exactly.
+    /// </summary>
+    AppliedButMismatchedOrConcurrentlyChanged,
+}
+
+/// <summary>
+/// G535 review repair: thrown by <see cref="IGitHubLabelSetReplacer.ReplaceLabelSet"/>
+/// for any outcome that is not a KNOWN success. <see cref="Certainty"/>
+/// tells the caller exactly how much (or how little) is knowable about
+/// whether the mutation reached GitHub.
+/// </summary>
+internal sealed class LabelSetReplacementException : InvalidOperationException
+{
+    public LabelSetReplacementException(
+        string message,
+        LabelSetReplacementFailureCertainty certainty,
+        Exception? innerException = null)
+        : base(message, innerException)
+    {
+        Certainty = certainty;
+    }
+
+    public LabelSetReplacementFailureCertainty Certainty { get; }
+}
+
+/// <summary>
+/// G535 review repair: thrown specifically when the `gh` process for a
+/// label-set-replacing PUT call never actually started (e.g. the
+/// executable could not be launched) — the one case where a subsequent
+/// failure can be confidently classified as
+/// <see cref="LabelSetReplacementFailureCertainty.KnownUnapplied"/> rather
+/// than <see cref="LabelSetReplacementFailureCertainty.MayHaveApplied"/>.
+/// Once a process has started, ANY failure is ambiguous — see
+/// <see cref="GhCliGitHubLabelMutator.RunGhWithInput"/>.
+/// </summary>
+internal sealed class GhProcessNotStartedException : IOException
+{
+    public GhProcessNotStartedException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
 }
 
 /// <summary>
@@ -284,32 +393,77 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator, IGitHubLabe
     /// <paramref name="desiredLabels"/> via ONE GitHub REST call (<c>PUT
     /// /repos/{repo}/issues/{number}/labels</c>), instead of the sequential
     /// add/remove calls <see cref="ApplyLabelTransitions"/> issues through
-    /// <c>gh &lt;kind&gt; edit</c>. A single HTTP call means a failure can
-    /// never leave a half-applied state (e.g. remove succeeded but add
-    /// failed, or vice versa) — the request either fully lands or the call
-    /// throws and nothing on GitHub has changed.
+    /// <c>gh &lt;kind&gt; edit</c>. A single HTTP call means there is no
+    /// window where one label lands and another doesn't from THIS call's
+    /// own actions — but it does NOT mean every failure is knowably
+    /// harmless; see the phase-aware failure semantics below.
     ///
-    /// Bounded concurrency model: GitHub's "Set labels" endpoint has no
-    /// conditional/If-Match support for optimistic concurrency, so a label
-    /// change racing between the caller's label read (before it computed
-    /// <paramref name="desiredLabels"/>) and this write cannot be prevented
-    /// outright. Instead, after the PUT this method re-reads the labels and
-    /// fails loudly — throws — if the result does not match
-    /// <paramref name="desiredLabels"/> exactly, rather than silently
-    /// claiming success on a lost update.
+    /// <para><b>Already-converged no-op:</b> if <paramref name="currentLabels"/>
+    /// already equals <paramref name="desiredLabels"/> (order-insensitive),
+    /// this returns <see cref="LabelSetReplacementCertainty.NoOpAlreadyConverged"/>
+    /// immediately — zero GitHub calls, genuinely idempotent, not merely
+    /// non-erroring.</para>
+    ///
+    /// <para><b>Phase-aware failure semantics — this is the part that must
+    /// never overclaim safety:</b></para>
+    /// <list type="bullet">
+    /// <item>If the `gh` process for the PUT never starts (e.g. the
+    /// executable can't be launched), NOTHING was transmitted — throws
+    /// with <see cref="LabelSetReplacementFailureCertainty.KnownUnapplied"/>.</item>
+    /// <item>Once that process HAS started, ANY failure (non-zero exit, a
+    /// write/read error, a timeout) is ambiguous: `gh` may have already
+    /// transmitted the request and GitHub may have already applied it
+    /// before the failure surfaced. Throws with
+    /// <see cref="LabelSetReplacementFailureCertainty.MayHaveApplied"/> —
+    /// never claims the mutation did not happen.</item>
+    /// <item>If the PUT itself reports success but the post-write
+    /// verification read fails, the mutation MOST LIKELY applied but its
+    /// resulting state is unconfirmed — throws with
+    /// <see cref="LabelSetReplacementFailureCertainty.AppliedButVerificationReadFailed"/>.</item>
+    /// <item>If the PUT reports success and the verification read
+    /// succeeds but the labels don't match, throws with
+    /// <see cref="LabelSetReplacementFailureCertainty.AppliedButMismatchedOrConcurrentlyChanged"/>
+    /// — this is NOT a rollback signal, the PUT itself still very likely
+    /// applied.</item>
+    /// </list>
+    ///
+    /// <para><b>Bounded concurrency model — stated honestly:</b> GitHub's
+    /// "Set labels" endpoint has no conditional/If-Match support for
+    /// optimistic concurrency, so a label change racing between the
+    /// caller's initial label read (used to compute <paramref
+    /// name="desiredLabels"/>) and this method's PUT cannot be prevented.
+    /// The post-write verification read only detects a mismatch that is
+    /// STILL PRESENT at the moment of that read. A label added by another
+    /// process AFTER the caller's initial read but BEFORE this PUT — and
+    /// therefore never reflected in <paramref name="desiredLabels"/> — can
+    /// be silently overwritten by the PUT; if nothing ELSE changes labels
+    /// between the PUT and the verification read, that read will equal
+    /// <paramref name="desiredLabels"/> exactly and this method will
+    /// report <see cref="LabelSetReplacementCertainty.AppliedAndVerified"/>
+    /// even though a concurrent addition was just lost. This race is
+    /// fundamentally undetectable by a read-after-write check alone —
+    /// verification proves "the state now matches what we intended," not
+    /// "no concurrent change occurred at any point."</para>
     /// </summary>
-    public void ReplaceLabelSet(
+    public LabelSetReplacementCertainty ReplaceLabelSet(
         string repo,
         string kind,
         int number,
+        IReadOnlyCollection<string> currentLabels,
         IReadOnlyCollection<string> desiredLabels)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
         ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+        ArgumentNullException.ThrowIfNull(currentLabels);
         ArgumentNullException.ThrowIfNull(desiredLabels);
 
         // Policy guard: intent-pr-created is issue-only, mirroring
-        // ApplyLabelTransitions' equivalent check.
+        // ApplyLabelTransitions' equivalent check. This is a pure
+        // validation refusal before any GitHub interaction — genuinely
+        // known-unapplied, so it stays a plain InvalidOperationException
+        // rather than a LabelSetReplacementException; the command layer
+        // treats any non-LabelSetReplacementException failure as
+        // known-unapplied by construction.
         if (string.Equals(kind, Kinds.Pr, StringComparison.Ordinal)
             && desiredLabels.Contains(WorkerNextActionConstants.Labels.IntentPrCreated, StringComparer.Ordinal))
         {
@@ -317,24 +471,73 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator, IGitHubLabe
                 $"label policy violation: '{WorkerNextActionConstants.Labels.IntentPrCreated}' is issue-only and must not be applied to a PR.");
         }
 
+        var normalizedCurrent = NormalizeLabelSet(currentLabels);
         var normalizedDesired = NormalizeLabelSet(desiredLabels);
+
+        if (normalizedCurrent.SequenceEqual(normalizedDesired, StringComparer.Ordinal))
+        {
+            return LabelSetReplacementCertainty.NoOpAlreadyConverged;
+        }
+
         var putArguments = BuildReplaceLabelsArguments(repo, kind, number);
         var requestBody = BuildReplaceLabelsRequestBody(normalizedDesired);
 
-        InvokeGh(putArguments, requestBody, $"replace label set on {kind} #{number} in {repo}");
+        try
+        {
+            InvokeGh(putArguments, requestBody, $"replace label set on {kind} #{number} in {repo}");
+        }
+        catch (GhProcessNotStartedException exception)
+        {
+            throw new LabelSetReplacementException(
+                $"the label-set replacement request for {kind} #{number} in {repo} was never transmitted: "
+                + $"{exception.Message}",
+                LabelSetReplacementFailureCertainty.KnownUnapplied,
+                exception);
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            throw new LabelSetReplacementException(
+                $"the label-set replacement request for {kind} #{number} in {repo} may already have reached "
+                + $"GitHub before this failure occurred: {exception.Message}. The mutation's outcome is UNKNOWN — "
+                + $"re-read current labels (`gh {kind} view {number} --repo {repo} --json labels`) before "
+                + "retrying or assuming any state.",
+                LabelSetReplacementFailureCertainty.MayHaveApplied,
+                exception);
+        }
 
-        var verifyArguments = BuildViewArguments(repo, kind, number);
-        var verifyStdout = InvokeGh(verifyArguments, null, $"verify replaced label set on {kind} #{number} in {repo}");
-        var actualLabels = NormalizeLabelSet(
-            DeserializeLabels(verifyStdout, $"`gh {kind} view #{number}` for {repo}").Select(label => label.Name));
+        IReadOnlyList<GitHubAutomationLabel> actual;
+        try
+        {
+            var verifyArguments = BuildViewArguments(repo, kind, number);
+            var verifyStdout = InvokeGh(verifyArguments, null, $"verify replaced label set on {kind} #{number} in {repo}");
+            actual = DeserializeLabels(verifyStdout, $"`gh {kind} view #{number}` for {repo}");
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or IOException)
+        {
+            throw new LabelSetReplacementException(
+                $"the label-set replacement request for {kind} #{number} in {repo} was transmitted, but the "
+                + $"post-write verification read failed: {exception.Message}. The mutation LIKELY applied but its "
+                + "exact resulting state is unconfirmed — re-read current labels before assuming any state.",
+                LabelSetReplacementFailureCertainty.AppliedButVerificationReadFailed,
+                exception);
+        }
 
+        var actualLabels = NormalizeLabelSet(actual.Select(label => label.Name));
         if (!actualLabels.SequenceEqual(normalizedDesired, StringComparer.Ordinal))
         {
-            throw new InvalidOperationException(
-                $"label replacement on {kind} #{number} in {repo} could not be verified: expected "
-                + $"[{string.Join(", ", normalizedDesired)}] but read back [{string.Join(", ", actualLabels)}] "
-                + "after the write (possible concurrent label change); refusing to claim success.");
+            throw new LabelSetReplacementException(
+                $"the label-set replacement request for {kind} #{number} in {repo} was transmitted, but the "
+                + $"post-write read-back does not match the intended set: expected [{string.Join(", ", normalizedDesired)}] "
+                + $"but read [{string.Join(", ", actualLabels)}]. The write itself very likely applied — this most "
+                + "often means a concurrent label change followed it — re-read current labels before assuming any state.",
+                LabelSetReplacementFailureCertainty.AppliedButMismatchedOrConcurrentlyChanged);
         }
+
+        return LabelSetReplacementCertainty.AppliedAndVerified;
     }
 
     public void ApplyLabelTransitions(
@@ -420,6 +623,16 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator, IGitHubLabe
             : RunGhWithInput(arguments, standardInput, description);
     }
 
+    /// <summary>
+    /// G535 review repair: used exclusively by <see cref="ReplaceLabelSet"/>'s
+    /// PUT call, where the distinction between "never started" (safe to
+    /// call known-unapplied) and "started but failed" (ambiguous — may
+    /// have transmitted/applied) is load-bearing. <see cref="Process.Start(ProcessStartInfo)"/>
+    /// failing or returning null throws <see cref="GhProcessNotStartedException"/>;
+    /// any failure after that point (writing stdin, reading stdout, a
+    /// non-zero exit) throws a plain <see cref="InvalidOperationException"/>
+    /// so the caller cannot mistake it for the known-unapplied case.
+    /// </summary>
     private static string RunGhWithInput(IReadOnlyList<string> arguments, string standardInput, string description)
     {
         var startInfo = new ProcessStartInfo
@@ -438,28 +651,52 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator, IGitHubLabe
             startInfo.ArgumentList.Add(argument);
         }
 
+        Process process;
+        try
+        {
+            process = Process.Start(startInfo)
+                ?? throw new GhProcessNotStartedException(
+                    $"failed to start `gh` process to {description}");
+        }
+        catch (GhProcessNotStartedException)
+        {
+            throw;
+        }
+        catch (Exception exception) when (
+            exception is System.ComponentModel.Win32Exception
+            or IOException)
+        {
+            // Process.Start itself threw before any process exists — still
+            // definitively "never started."
+            throw new GhProcessNotStartedException(
+                $"could not start `gh` to {description}: {exception.Message}",
+                exception);
+        }
+
         string stdout;
         string stderr;
         int exitCode;
         try
         {
-            using var process = Process.Start(startInfo)
-                ?? throw new InvalidOperationException(
-                    $"failed to start `gh` process to {description}");
-            process.StandardInput.Write(standardInput);
-            process.StandardInput.Close();
-            stdout = process.StandardOutput.ReadToEnd();
-            stderr = process.StandardError.ReadToEnd();
-            process.WaitForExit();
-            exitCode = process.ExitCode;
+            using (process)
+            {
+                process.StandardInput.Write(standardInput);
+                process.StandardInput.Close();
+                stdout = process.StandardOutput.ReadToEnd();
+                stderr = process.StandardError.ReadToEnd();
+                process.WaitForExit();
+                exitCode = process.ExitCode;
+            }
         }
         catch (Exception exception) when (
-            exception is System.ComponentModel.Win32Exception
-            or InvalidOperationException
+            exception is InvalidOperationException
             or IOException)
         {
+            // The process DID start — from here on, any failure is
+            // ambiguous: `gh` may already have transmitted (and GitHub
+            // already applied) the request before this exception surfaced.
             throw new InvalidOperationException(
-                $"could not invoke `gh` to {description}: {exception.Message}",
+                $"`gh` process for '{description}' started but failed before completion: {exception.Message}",
                 exception);
         }
 
@@ -467,7 +704,8 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator, IGitHubLabe
         {
             var errorBody = string.IsNullOrWhiteSpace(stderr) ? stdout : stderr;
             throw new InvalidOperationException(
-                $"`gh` failed to {description} with exit {exitCode}: {errorBody.Trim()}");
+                $"`gh` exited {exitCode} to {description}: {errorBody.Trim()} (the process started, so the "
+                + "underlying request may already have reached GitHub)");
         }
 
         return stdout;

--- a/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
@@ -528,11 +528,14 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         // Truthful output: nothing was actually superseded, so nothing is
         // reported as removed (G535 review repair blocker #1).
         Assert.Empty(result.RemoveLabels);
+        Assert.True(result.Applied);
+        Assert.False(result.MayHaveApplied);
 
+        // G535 review repair (round 3): the desired set already equals the
+        // current set, so this is a genuine no-op — ZERO ReplaceLabelSet
+        // GitHub calls, not merely an empty removal list.
         Assert.Empty(mutator.AppliedTransitions);
-        var replacedSet = Assert.Single(mutator.ReplacedLabelSets);
-        Assert.Contains("intent-target", replacedSet);
-        Assert.Contains("intent-pr-request-update", replacedSet);
+        Assert.Empty(mutator.ReplacedLabelSets);
     }
 
     [Fact]
@@ -563,9 +566,123 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
             writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("failed to apply PR transition", writer.ToString(), StringComparison.Ordinal);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.False(result.Applied);
+        Assert.False(result.MayHaveApplied);
+        Assert.Contains("failed to apply PR transition", result.Error, StringComparison.Ordinal);
         // No half-transition: the original label set is exactly what remains.
         Assert.Equal(new[] { "intent-target", "intent-pr-rereview-ready" }, mutator.Labels);
+    }
+
+    [Theory]
+    [InlineData(nameof(LabelSetReplacementFailureCertainty.MayHaveApplied))]
+    [InlineData(nameof(LabelSetReplacementFailureCertainty.AppliedButVerificationReadFailed))]
+    [InlineData(nameof(LabelSetReplacementFailureCertainty.AppliedButMismatchedOrConcurrentlyChanged))]
+    public void Execute_RequestUpdate_AmbiguousFailure_ReportsMayHaveAppliedWithRecoveryInfo(string certaintyName)
+    {
+        // G535 review repair (round 3): once a mutation MAY have reached
+        // GitHub, the command must report `applied: false` AND
+        // `may_have_applied: true` — never a bare "failed, nothing
+        // changed" claim — plus the intended final label set and an exact
+        // recovery command so an operator can resolve the ambiguity.
+        var certainty = Enum.Parse<LabelSetReplacementFailureCertainty>(certaintyName);
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new ThrowingMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready" },
+            ReplaceLabelSetFailureCertainty = certainty,
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "1760",
+                "--transition", "request-update",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.False(result.Applied);
+        Assert.True(result.MayHaveApplied);
+        Assert.NotNull(result.IntendedLabels);
+        Assert.Contains("intent-pr-request-update", result.IntendedLabels!);
+        Assert.Equal(
+            "gh pr view 1760 --repo J-Tech-Japan/intent-system --json labels",
+            result.RecoveryCommand);
+        Assert.Contains("may already have", result.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RequestUpdate_AmbiguousFailure_TextFormatIncludesRecoveryInfo()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new ThrowingMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready" },
+            ReplaceLabelSetFailureCertainty = LabelSetReplacementFailureCertainty.MayHaveApplied,
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "1760",
+                "--transition", "request-update",
+                "--write",
+            },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("applied: false", output, StringComparison.Ordinal);
+        Assert.Contains("may_have_applied: true", output, StringComparison.Ordinal);
+        Assert.Contains("intended_labels:", output, StringComparison.Ordinal);
+        Assert.Contains("recovery_command: gh pr view 1760", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RequestUpdate_KnownUnappliedFailure_DoesNotReportMayHaveApplied()
+    {
+        // Contrast with the ambiguous cases above: a pre-send failure is
+        // genuinely known-unapplied and must NOT carry the may-have-applied
+        // ambiguity markers.
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new ThrowingMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready" },
+            ReplaceLabelSetFailureCertainty = LabelSetReplacementFailureCertainty.KnownUnapplied,
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "1760",
+                "--transition", "request-update",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.False(result.Applied);
+        Assert.False(result.MayHaveApplied);
+        Assert.Null(result.IntendedLabels);
+        Assert.Null(result.RecoveryCommand);
     }
 
     [Fact]
@@ -910,15 +1027,18 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         }
 
         /// <summary>
-        /// G535: mirrors the production adapter's contract — replaces
+        /// G535: mirrors the production adapter's contract — an
+        /// already-converged desired set is a genuine no-op (no call
+        /// recorded, <see cref="Labels"/> untouched); otherwise replaces
         /// <see cref="Labels"/> wholesale with the desired set (as if the
         /// PUT-then-verified-re-read succeeded), and records the call so
         /// tests can assert exactly one atomic mutation payload.
         /// </summary>
-        public void ReplaceLabelSet(
+        public LabelSetReplacementCertainty ReplaceLabelSet(
             string repo,
             string kind,
             int number,
+            IReadOnlyCollection<string> currentLabels,
             IReadOnlyCollection<string> desiredLabels)
         {
             if (string.Equals(kind, "pr", StringComparison.Ordinal)
@@ -927,13 +1047,24 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
                 throw new InvalidOperationException("'intent-pr-created' is issue-only.");
             }
 
-            var normalized = desiredLabels
+            var normalizedCurrent = currentLabels
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(label => label, StringComparer.Ordinal)
+                .ToArray();
+            var normalizedDesired = desiredLabels
                 .Where(label => !string.IsNullOrWhiteSpace(label))
                 .Distinct(StringComparer.Ordinal)
                 .OrderBy(label => label, StringComparer.Ordinal)
                 .ToArray();
-            ReplacedLabelSets.Add(normalized);
-            Labels = normalized;
+
+            if (normalizedCurrent.SequenceEqual(normalizedDesired, StringComparer.Ordinal))
+            {
+                return LabelSetReplacementCertainty.NoOpAlreadyConverged;
+            }
+
+            ReplacedLabelSets.Add(normalizedDesired);
+            Labels = normalizedDesired;
+            return LabelSetReplacementCertainty.AppliedAndVerified;
         }
 
         public void ApplyReconcileTransitions(
@@ -955,11 +1086,18 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
     /// <summary>
     /// G535: fake mutator whose mutation paths always throw, simulating a
     /// `gh` API failure, to prove the command reports failure without
-    /// claiming <c>applied: true</c> — no half-transition.
+    /// claiming <c>applied: true</c> — no half-transition. When
+    /// <see cref="ReplaceLabelSetFailureCertainty"/> is set, <see cref="ReplaceLabelSet"/>
+    /// throws a <see cref="LabelSetReplacementException"/> with that
+    /// certainty instead of a plain <see cref="IOException"/>, so
+    /// command-layer tests can exercise the phase-aware
+    /// may-have-applied reporting without going through the real adapter.
     /// </summary>
     private sealed class ThrowingMutator : IGitHubLabelMutator, IGitHubLabelSetReplacer
     {
         public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+
+        public LabelSetReplacementFailureCertainty? ReplaceLabelSetFailureCertainty { get; init; }
 
         public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
             Labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
@@ -972,12 +1110,20 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
             IReadOnlyCollection<string> removeLabels) =>
             throw new IOException("simulated gh API failure");
 
-        public void ReplaceLabelSet(
+        public LabelSetReplacementCertainty ReplaceLabelSet(
             string repo,
             string kind,
             int number,
-            IReadOnlyCollection<string> desiredLabels) =>
+            IReadOnlyCollection<string> currentLabels,
+            IReadOnlyCollection<string> desiredLabels)
+        {
+            if (ReplaceLabelSetFailureCertainty is { } certainty)
+            {
+                throw new LabelSetReplacementException("simulated ambiguous gh API failure", certainty);
+            }
+
             throw new IOException("simulated gh API failure");
+        }
 
         public void ApplyReconcileTransitions(
             string repo,

--- a/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
@@ -399,6 +399,208 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         Assert.DoesNotContain("intent-pr-created", transition.RemoveLabels);
     }
 
+    // ─── G535 tests: request-update supersedes stale rereview-ready ─────────
+
+    [Fact]
+    public void Execute_RequestUpdate_DryRunNamesRereviewReadyAsSuperseded()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready", "rereview-ready" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "1760",
+                "--transition", "request-update",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.False(result.Applied);
+        Assert.Contains("intent-pr-request-update", result.AddLabels);
+        // Both the current and legacy rereview-ready forms are named as superseded.
+        Assert.Contains("intent-pr-rereview-ready", result.RemoveLabels);
+        Assert.Contains("rereview-ready", result.RemoveLabels);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_RequestUpdate_SksG824_ClearsStaleRereviewReadyAndClaimSucceeds()
+    {
+        // G535 field finding #5 (SKS-G824 / PR #1760): a design amendment
+        // arrives while the PR is rereview-ready. request-update must clear
+        // rereview-ready in the SAME write, so worker claim can proceed
+        // afterwards instead of hitting the canonical-state deadlock
+        // (request-update present, but rereview-ready still refuses claim).
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "1760",
+                "--transition", "request-update",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.Contains("intent-pr-request-update", result.AddLabels);
+        Assert.Contains("intent-pr-rereview-ready", result.RemoveLabels);
+
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Contains("intent-pr-request-update", transition.AddLabels);
+        Assert.Contains("intent-pr-rereview-ready", transition.RemoveLabels);
+
+        // Simulate the resulting label set and prove `worker claim` now succeeds.
+        var postTransitionLabels = mutator.Labels
+            .Except(transition.RemoveLabels, StringComparer.Ordinal)
+            .Concat(transition.AddLabels)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        var claimDecision = WorkerClaimAnalyzer.Analyze(GhCliGitHubLabelMutator.Kinds.Pr, postTransitionLabels);
+        Assert.True(claimDecision.Proceed);
+        Assert.Contains("intent-pr-update-in-progress", claimDecision.AddLabels);
+    }
+
+    [Fact]
+    public void Execute_RequestUpdate_ClaimStillRefusesUntransitionedRereviewReady()
+    {
+        // G535: unchanged behavior pin — a rereview-ready PR that has NOT
+        // been through request-update must still be refused by claim (it
+        // is the reviewer's to pick up, not the worker's).
+        var untransitionedLabels = new[] { "intent-target", "intent-pr-rereview-ready" };
+
+        var claimDecision = WorkerClaimAnalyzer.Analyze(GhCliGitHubLabelMutator.Kinds.Pr, untransitionedLabels);
+
+        Assert.False(claimDecision.Proceed);
+        Assert.Contains(claimDecision.Errors, e => e.Contains("already-rereview-ready", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_RequestUpdate_WriteIsIdempotent_WhenRereviewReadyAlreadyAbsent()
+    {
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            // Already transitioned once: rereview-ready is gone, request-update present.
+            Labels = new[] { "intent-target", "intent-pr-request-update" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "1760",
+                "--transition", "request-update",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var transition = Assert.Single(mutator.AppliedTransitions);
+        Assert.Contains("intent-pr-request-update", transition.AddLabels);
+        Assert.DoesNotContain("intent-pr-rereview-ready", transition.RemoveLabels);
+        Assert.DoesNotContain("rereview-ready", transition.RemoveLabels);
+        Assert.DoesNotContain("intent-pr-reviewing", transition.RemoveLabels);
+    }
+
+    [Fact]
+    public void Execute_RequestUpdate_ApiFailureAppliesNoPartialTransition()
+    {
+        // G535: the add+remove edit is a single gh call (already-atomic by
+        // construction) — a failure must leave the PR's labels completely
+        // untouched, never a half-applied state (request-update added but
+        // rereview-ready not yet cleared, or vice versa).
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new ThrowingMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "1760",
+                "--transition", "request-update",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("failed to apply PR transition", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ReviewStartAndApproved_LabelSetsUnchanged_G535Regression()
+    {
+        // G535 must not touch any other transition's label set. Pins
+        // review-start and approved stay byte-identical to their
+        // pre-G535 plans.
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var reviewStartMutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready", "rereview-ready" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => reviewStartMutator;
+
+        using var reviewStartWriter = new StringWriter();
+        AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "542", "--transition", "review-start", "--write", "--format", "json" },
+            reviewStartWriter);
+        var reviewStartTransition = Assert.Single(reviewStartMutator.AppliedTransitions);
+        Assert.Equal(
+            new[] { "intent-target", "intent-pr-reviewing" },
+            reviewStartTransition.AddLabels);
+        Assert.Equal(
+            new[] { "intent-pr-rereview-ready", "rereview-ready" },
+            reviewStartTransition.RemoveLabels);
+
+        var approvedMutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-reviewing" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => approvedMutator;
+
+        using var approvedWriter = new StringWriter();
+        AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--pr", "542", "--transition", "approved", "--write", "--format", "json" },
+            approvedWriter);
+        var approvedTransition = Assert.Single(approvedMutator.AppliedTransitions);
+        Assert.Equal(new[] { "intent-pr-approved" }, approvedTransition.AddLabels);
+        Assert.Equal(new[] { "intent-pr-reviewing" }, approvedTransition.RemoveLabels);
+    }
+
     // ─── G292 tests ────────────────────────────────────────────────────────────
 
     [Fact]
@@ -641,6 +843,35 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         int Number,
         IReadOnlyList<string> AddLabels,
         IReadOnlyList<string> RemoveLabels);
+
+    /// <summary>
+    /// G535: fake mutator whose <see cref="ApplyLabelTransitions"/> always
+    /// throws, simulating a `gh` API failure, to prove the command reports
+    /// failure without claiming <c>applied: true</c> — no half-transition.
+    /// </summary>
+    private sealed class ThrowingMutator : IGitHubLabelMutator
+    {
+        public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            Labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+
+        public void ApplyLabelTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            throw new IOException("simulated gh API failure");
+
+        public void ApplyReconcileTransitions(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> addLabels,
+            IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException("reconcile path not exercised by these tests");
+    }
 
     private sealed class AutomationPrTransitionWorkspace : IDisposable
     {

--- a/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPrTransitionCommandTests.cs
@@ -390,13 +390,15 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
         Assert.True(result.Applied);
 
-        var transition = Assert.Single(mutator.AppliedTransitions);
-        Assert.Equal("pr", transition.Kind);
-        Assert.Equal(542, transition.Number);
-        Assert.Contains("intent-pr-request-update", transition.AddLabels);
-        Assert.Contains("intent-pr-reviewing", transition.RemoveLabels);
-        Assert.DoesNotContain("intent-pr-created", transition.AddLabels);
-        Assert.DoesNotContain("intent-pr-created", transition.RemoveLabels);
+        // G535 review repair: request-update must apply via ONE atomic
+        // ReplaceLabelSet call carrying the full desired set, never via
+        // ApplyLabelTransitions' sequential add/remove.
+        Assert.Empty(mutator.AppliedTransitions);
+        var replacedSet = Assert.Single(mutator.ReplacedLabelSets);
+        Assert.Contains("intent-target", replacedSet);
+        Assert.Contains("intent-pr-request-update", replacedSet);
+        Assert.DoesNotContain("intent-pr-reviewing", replacedSet);
+        Assert.DoesNotContain("intent-pr-created", replacedSet);
     }
 
     // ─── G535 tests: request-update supersedes stale rereview-ready ─────────
@@ -467,17 +469,18 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         Assert.Contains("intent-pr-request-update", result.AddLabels);
         Assert.Contains("intent-pr-rereview-ready", result.RemoveLabels);
 
-        var transition = Assert.Single(mutator.AppliedTransitions);
-        Assert.Contains("intent-pr-request-update", transition.AddLabels);
-        Assert.Contains("intent-pr-rereview-ready", transition.RemoveLabels);
+        // G535 review repair: applied via ONE atomic ReplaceLabelSet call,
+        // never sequential add/remove.
+        Assert.Empty(mutator.AppliedTransitions);
+        var replacedSet = Assert.Single(mutator.ReplacedLabelSets);
+        Assert.Contains("intent-target", replacedSet);
+        Assert.Contains("intent-pr-request-update", replacedSet);
+        Assert.DoesNotContain("intent-pr-rereview-ready", replacedSet);
 
-        // Simulate the resulting label set and prove `worker claim` now succeeds.
-        var postTransitionLabels = mutator.Labels
-            .Except(transition.RemoveLabels, StringComparer.Ordinal)
-            .Concat(transition.AddLabels)
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-        var claimDecision = WorkerClaimAnalyzer.Analyze(GhCliGitHubLabelMutator.Kinds.Pr, postTransitionLabels);
+        // The fake mutator's own Labels reflect the replacement (mirroring
+        // the production adapter's re-read-and-verify contract) — prove
+        // `worker claim` now succeeds directly against it.
+        var claimDecision = WorkerClaimAnalyzer.Analyze(GhCliGitHubLabelMutator.Kinds.Pr, mutator.Labels);
         Assert.True(claimDecision.Proceed);
         Assert.Contains("intent-pr-update-in-progress", claimDecision.AddLabels);
     }
@@ -521,20 +524,24 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
             writer);
 
         Assert.Equal(0, exitCode);
-        var transition = Assert.Single(mutator.AppliedTransitions);
-        Assert.Contains("intent-pr-request-update", transition.AddLabels);
-        Assert.DoesNotContain("intent-pr-rereview-ready", transition.RemoveLabels);
-        Assert.DoesNotContain("rereview-ready", transition.RemoveLabels);
-        Assert.DoesNotContain("intent-pr-reviewing", transition.RemoveLabels);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        // Truthful output: nothing was actually superseded, so nothing is
+        // reported as removed (G535 review repair blocker #1).
+        Assert.Empty(result.RemoveLabels);
+
+        Assert.Empty(mutator.AppliedTransitions);
+        var replacedSet = Assert.Single(mutator.ReplacedLabelSets);
+        Assert.Contains("intent-target", replacedSet);
+        Assert.Contains("intent-pr-request-update", replacedSet);
     }
 
     [Fact]
     public void Execute_RequestUpdate_ApiFailureAppliesNoPartialTransition()
     {
-        // G535: the add+remove edit is a single gh call (already-atomic by
-        // construction) — a failure must leave the PR's labels completely
-        // untouched, never a half-applied state (request-update added but
-        // rereview-ready not yet cleared, or vice versa).
+        // G535 review repair blocker #2: the mutation is ONE atomic
+        // ReplaceLabelSet call — a failure must leave the PR's labels
+        // completely untouched, never a half-applied state (request-update
+        // added but rereview-ready not yet cleared, or vice versa).
         using var workspace = new AutomationPrTransitionWorkspace();
         var mutator = new ThrowingMutator
         {
@@ -557,6 +564,77 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
 
         Assert.Equal(1, exitCode);
         Assert.Contains("failed to apply PR transition", writer.ToString(), StringComparison.Ordinal);
+        // No half-transition: the original label set is exactly what remains.
+        Assert.Equal(new[] { "intent-target", "intent-pr-rereview-ready" }, mutator.Labels);
+    }
+
+    [Fact]
+    public void Execute_RequestUpdate_WritePreservesUnrelatedLabels()
+    {
+        // G535 review repair: labels this transition never touches (e.g. a
+        // domain/priority label) must survive the atomic replace untouched.
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-reviewing", "priority-high", "domain-billing" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "request-update",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var replacedSet = Assert.Single(mutator.ReplacedLabelSets);
+        Assert.Contains("intent-target", replacedSet);
+        Assert.Contains("priority-high", replacedSet);
+        Assert.Contains("domain-billing", replacedSet);
+        Assert.Contains("intent-pr-request-update", replacedSet);
+        Assert.DoesNotContain("intent-pr-reviewing", replacedSet);
+    }
+
+    [Fact]
+    public void Execute_RequestUpdate_DryRunDoesNotCallEitherMutationPath()
+    {
+        // G535 review repair: dry/write parity check — dry-run must never
+        // call ApplyLabelTransitions NOR ReplaceLabelSet.
+        using var workspace = new AutomationPrTransitionWorkspace();
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target", "intent-pr-rereview-ready", "rereview-ready" },
+        };
+        AutomationPrTransitionCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPrTransitionCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--pr", "542",
+                "--transition", "request-update",
+                "--dry-run",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationPrTransitionResult>(writer.ToString())!;
+        Assert.False(result.Applied);
+        // Both present forms are named as superseded, truthfully, in dry-run too.
+        Assert.Contains("intent-pr-rereview-ready", result.RemoveLabels);
+        Assert.Contains("rereview-ready", result.RemoveLabels);
+        Assert.Empty(mutator.AppliedTransitions);
+        Assert.Empty(mutator.ReplacedLabelSets);
     }
 
     [Fact]
@@ -788,11 +866,14 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
             "AutomationPrTransitionCommand must never invoke NestedProviderLauncher.");
     }
 
-    private sealed class FakeMutator : IGitHubLabelMutator
+    private sealed class FakeMutator : IGitHubLabelMutator, IGitHubLabelSetReplacer
     {
-        public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
+        public IReadOnlyList<string> Labels { get; set; } = Array.Empty<string>();
 
         public List<AppliedTransition> AppliedTransitions { get; } = new();
+
+        /// <summary>G535: each ReplaceLabelSet call's full desired set, in call order.</summary>
+        public List<IReadOnlyList<string>> ReplacedLabelSets { get; } = new();
 
         public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
             Labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
@@ -828,6 +909,33 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
                 removeLabels.ToArray()));
         }
 
+        /// <summary>
+        /// G535: mirrors the production adapter's contract — replaces
+        /// <see cref="Labels"/> wholesale with the desired set (as if the
+        /// PUT-then-verified-re-read succeeded), and records the call so
+        /// tests can assert exactly one atomic mutation payload.
+        /// </summary>
+        public void ReplaceLabelSet(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> desiredLabels)
+        {
+            if (string.Equals(kind, "pr", StringComparison.Ordinal)
+                && desiredLabels.Contains("intent-pr-created", StringComparer.Ordinal))
+            {
+                throw new InvalidOperationException("'intent-pr-created' is issue-only.");
+            }
+
+            var normalized = desiredLabels
+                .Where(label => !string.IsNullOrWhiteSpace(label))
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(label => label, StringComparer.Ordinal)
+                .ToArray();
+            ReplacedLabelSets.Add(normalized);
+            Labels = normalized;
+        }
+
         public void ApplyReconcileTransitions(
             string repo,
             string kind,
@@ -845,11 +953,11 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
         IReadOnlyList<string> RemoveLabels);
 
     /// <summary>
-    /// G535: fake mutator whose <see cref="ApplyLabelTransitions"/> always
-    /// throws, simulating a `gh` API failure, to prove the command reports
-    /// failure without claiming <c>applied: true</c> — no half-transition.
+    /// G535: fake mutator whose mutation paths always throw, simulating a
+    /// `gh` API failure, to prove the command reports failure without
+    /// claiming <c>applied: true</c> — no half-transition.
     /// </summary>
-    private sealed class ThrowingMutator : IGitHubLabelMutator
+    private sealed class ThrowingMutator : IGitHubLabelMutator, IGitHubLabelSetReplacer
     {
         public IReadOnlyList<string> Labels { get; init; } = Array.Empty<string>();
 
@@ -862,6 +970,13 @@ public sealed class AutomationPrTransitionCommandTests : IDisposable
             int number,
             IReadOnlyCollection<string> addLabels,
             IReadOnlyCollection<string> removeLabels) =>
+            throw new IOException("simulated gh API failure");
+
+        public void ReplaceLabelSet(
+            string repo,
+            string kind,
+            int number,
+            IReadOnlyCollection<string> desiredLabels) =>
             throw new IOException("simulated gh API failure");
 
         public void ApplyReconcileTransitions(

--- a/tests/IntentSystem.Cli.Tests/GhCliGitHubLabelMutatorReplaceLabelSetTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GhCliGitHubLabelMutatorReplaceLabelSetTests.cs
@@ -1,0 +1,179 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G535 review repair: adapter-level tests for
+/// <see cref="GhCliGitHubLabelMutator.ReplaceLabelSet"/> — the atomic,
+/// single-GitHub-request label-set replacement used by <c>automation
+/// pr-transition</c>'s <c>request-update</c> path. These exercise the real
+/// adapter class (not a fake <see cref="IGitHubLabelMutator"/>), injecting
+/// <see cref="GhCliGitHubLabelMutator.GhInvokerOverride"/> to simulate the
+/// underlying `gh` process without spawning one, so the atomicity and
+/// bounded-concurrency (re-read-and-verify) contract is actually proven
+/// rather than merely asserted at the command layer.
+/// </summary>
+public sealed class GhCliGitHubLabelMutatorReplaceLabelSetTests : IDisposable
+{
+    public void Dispose()
+    {
+        GhCliGitHubLabelMutator.GhInvokerOverride = null;
+    }
+
+    [Fact]
+    public void ReplaceLabelSet_IssuesExactlyOnePutCall_ThenOneVerifyReadNoOtherCalls()
+    {
+        var invocations = new List<(IReadOnlyList<string> Arguments, string? StandardInput)>();
+        var mutator = new GhCliGitHubLabelMutator();
+        GhCliGitHubLabelMutator.GhInvokerOverride = (arguments, standardInput, _) =>
+        {
+            invocations.Add((arguments, standardInput));
+            if (invocations.Count == 1)
+            {
+                return string.Empty; // PUT response body is unused.
+            }
+
+            return """{"labels":[{"name":"intent-target"},{"name":"intent-pr-request-update"}]}""";
+        };
+
+        mutator.ReplaceLabelSet(
+            "org/repo",
+            GhCliGitHubLabelMutator.Kinds.Pr,
+            1760,
+            new[] { "intent-pr-request-update", "intent-target" });
+
+        Assert.Equal(2, invocations.Count);
+
+        var put = invocations[0];
+        Assert.Equal("api", put.Arguments[0]);
+        Assert.Contains("--method", put.Arguments);
+        Assert.Contains("PUT", put.Arguments);
+        Assert.Contains("repos/org/repo/issues/1760/labels", put.Arguments);
+        Assert.NotNull(put.StandardInput);
+        Assert.Contains("intent-target", put.StandardInput);
+        Assert.Contains("intent-pr-request-update", put.StandardInput);
+        // No sequential add/remove `gh pr edit` call anywhere in the sequence.
+        Assert.DoesNotContain(invocations, call => call.Arguments.Contains("edit"));
+
+        var verify = invocations[1];
+        Assert.Equal("pr", verify.Arguments[0]);
+        Assert.Equal("view", verify.Arguments[1]);
+        Assert.Null(verify.StandardInput);
+    }
+
+    [Fact]
+    public void ReplaceLabelSet_MutationFailure_ThrowsAndNeverAttemptsVerifyRead()
+    {
+        // "Mutation HTTP failure" — the PUT call itself throws. No
+        // half-transition: since it's the first and only call attempted,
+        // nothing on GitHub could have changed, and the adapter must not
+        // even attempt the verification re-read.
+        var invocations = 0;
+        var mutator = new GhCliGitHubLabelMutator();
+        GhCliGitHubLabelMutator.GhInvokerOverride = (_, _, description) =>
+        {
+            invocations++;
+            throw new InvalidOperationException($"simulated `gh` failure: {description}");
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => mutator.ReplaceLabelSet(
+                "org/repo", GhCliGitHubLabelMutator.Kinds.Pr, 1760, new[] { "intent-target" }));
+
+        Assert.Contains("simulated `gh` failure", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(1, invocations);
+    }
+
+    [Fact]
+    public void ReplaceLabelSet_VerifyReadFailure_Throws()
+    {
+        // "Current-label fetch failure" on the post-write verification
+        // re-read — the PUT succeeded but we can no longer confirm it, so
+        // the adapter must fail loudly rather than silently claim success.
+        var invocations = 0;
+        var mutator = new GhCliGitHubLabelMutator();
+        GhCliGitHubLabelMutator.GhInvokerOverride = (_, _, description) =>
+        {
+            invocations++;
+            if (invocations == 1)
+            {
+                return string.Empty; // PUT succeeds.
+            }
+
+            throw new InvalidOperationException($"simulated re-read failure: {description}");
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => mutator.ReplaceLabelSet(
+                "org/repo", GhCliGitHubLabelMutator.Kinds.Pr, 1760, new[] { "intent-target" }));
+
+        Assert.Contains("simulated re-read failure", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(2, invocations);
+    }
+
+    [Fact]
+    public void ReplaceLabelSet_VerifyReadMismatch_ThrowsConcurrentChangeError()
+    {
+        // "Response mismatch/concurrent-change failure" — the PUT call
+        // reports success but the re-read shows a DIFFERENT set than what
+        // was requested (e.g. another process changed labels in between).
+        // The adapter must fail loudly, never claim atomic success on a
+        // lost update.
+        var mutator = new GhCliGitHubLabelMutator();
+        GhCliGitHubLabelMutator.GhInvokerOverride = (_, _, _) =>
+        {
+            return """{"labels":[{"name":"intent-target"},{"name":"some-other-label"}]}""";
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => mutator.ReplaceLabelSet(
+                "org/repo",
+                GhCliGitHubLabelMutator.Kinds.Pr,
+                1760,
+                new[] { "intent-target", "intent-pr-request-update" }));
+
+        Assert.Contains("could not be verified", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("concurrent", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ReplaceLabelSet_DesiredSetContainingIntentPrCreatedOnPr_RefusesBeforeAnyGhCall()
+    {
+        var invocations = 0;
+        var mutator = new GhCliGitHubLabelMutator();
+        GhCliGitHubLabelMutator.GhInvokerOverride = (_, _, _) =>
+        {
+            invocations++;
+            return string.Empty;
+        };
+
+        Assert.Throws<InvalidOperationException>(
+            () => mutator.ReplaceLabelSet(
+                "org/repo",
+                GhCliGitHubLabelMutator.Kinds.Pr,
+                1760,
+                new[] { "intent-target", "intent-pr-created" }));
+
+        Assert.Equal(0, invocations);
+    }
+
+    [Fact]
+    public void BuildReplaceLabelsArguments_ReturnsSinglePutCallShape()
+    {
+        var arguments = GhCliGitHubLabelMutator.BuildReplaceLabelsArguments(
+            "org/repo", GhCliGitHubLabelMutator.Kinds.Pr, 1760);
+
+        Assert.Equal(
+            new[] { "api", "--method", "PUT", "repos/org/repo/issues/1760/labels", "--input", "-" },
+            arguments);
+    }
+
+    [Fact]
+    public void BuildReplaceLabelsRequestBody_SerializesDeduplicatedSortedLabels()
+    {
+        var body = GhCliGitHubLabelMutator.BuildReplaceLabelsRequestBody(
+            new[] { "intent-pr-request-update", "intent-target", "intent-target", "", "  " });
+
+        Assert.Equal("""{"labels":["intent-pr-request-update","intent-target"]}""", body);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GhCliGitHubLabelMutatorReplaceLabelSetTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GhCliGitHubLabelMutatorReplaceLabelSetTests.cs
@@ -9,15 +9,37 @@ namespace IntentSystem.Cli.Tests;
 /// pr-transition</c>'s <c>request-update</c> path. These exercise the real
 /// adapter class (not a fake <see cref="IGitHubLabelMutator"/>), injecting
 /// <see cref="GhCliGitHubLabelMutator.GhInvokerOverride"/> to simulate the
-/// underlying `gh` process without spawning one, so the atomicity and
-/// bounded-concurrency (re-read-and-verify) contract is actually proven
-/// rather than merely asserted at the command layer.
+/// underlying `gh` process without spawning one, so the atomicity,
+/// idempotent-no-op, and phase-aware failure-certainty contract is
+/// actually proven rather than merely asserted at the command layer.
 /// </summary>
 public sealed class GhCliGitHubLabelMutatorReplaceLabelSetTests : IDisposable
 {
     public void Dispose()
     {
         GhCliGitHubLabelMutator.GhInvokerOverride = null;
+    }
+
+    [Fact]
+    public void ReplaceLabelSet_AlreadyConverged_ReturnsNoOpAndMakesZeroGhCalls()
+    {
+        var invocations = 0;
+        var mutator = new GhCliGitHubLabelMutator();
+        GhCliGitHubLabelMutator.GhInvokerOverride = (_, _, _) =>
+        {
+            invocations++;
+            return string.Empty;
+        };
+
+        var certainty = mutator.ReplaceLabelSet(
+            "org/repo",
+            GhCliGitHubLabelMutator.Kinds.Pr,
+            1760,
+            currentLabels: new[] { "intent-target", "intent-pr-request-update" },
+            desiredLabels: new[] { "intent-pr-request-update", "intent-target" }); // same set, different order
+
+        Assert.Equal(LabelSetReplacementCertainty.NoOpAlreadyConverged, certainty);
+        Assert.Equal(0, invocations);
     }
 
     [Fact]
@@ -36,12 +58,14 @@ public sealed class GhCliGitHubLabelMutatorReplaceLabelSetTests : IDisposable
             return """{"labels":[{"name":"intent-target"},{"name":"intent-pr-request-update"}]}""";
         };
 
-        mutator.ReplaceLabelSet(
+        var certainty = mutator.ReplaceLabelSet(
             "org/repo",
             GhCliGitHubLabelMutator.Kinds.Pr,
             1760,
-            new[] { "intent-pr-request-update", "intent-target" });
+            currentLabels: new[] { "intent-target", "intent-pr-rereview-ready" },
+            desiredLabels: new[] { "intent-pr-request-update", "intent-target" });
 
+        Assert.Equal(LabelSetReplacementCertainty.AppliedAndVerified, certainty);
         Assert.Equal(2, invocations.Count);
 
         var put = invocations[0];
@@ -62,34 +86,61 @@ public sealed class GhCliGitHubLabelMutatorReplaceLabelSetTests : IDisposable
     }
 
     [Fact]
-    public void ReplaceLabelSet_MutationFailure_ThrowsAndNeverAttemptsVerifyRead()
+    public void ReplaceLabelSet_GhProcessNeverStarts_ThrowsKnownUnapplied()
     {
-        // "Mutation HTTP failure" — the PUT call itself throws. No
-        // half-transition: since it's the first and only call attempted,
-        // nothing on GitHub could have changed, and the adapter must not
-        // even attempt the verification re-read.
+        // "Pre-send failure" — the gh process itself never started, so
+        // nothing was transmitted to GitHub. Safe to report known-unapplied.
+        var mutator = new GhCliGitHubLabelMutator();
+        GhCliGitHubLabelMutator.GhInvokerOverride = (_, _, description) =>
+            throw new GhProcessNotStartedException($"simulated launch failure: {description}");
+
+        var exception = Assert.Throws<LabelSetReplacementException>(
+            () => mutator.ReplaceLabelSet(
+                "org/repo",
+                GhCliGitHubLabelMutator.Kinds.Pr,
+                1760,
+                currentLabels: new[] { "intent-target" },
+                desiredLabels: new[] { "intent-target", "intent-pr-request-update" }));
+
+        Assert.Equal(LabelSetReplacementFailureCertainty.KnownUnapplied, exception.Certainty);
+        Assert.Contains("never transmitted", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReplaceLabelSet_MutationTransmissionAmbiguous_ThrowsMayHaveApplied()
+    {
+        // "Post-send nonzero/timeout" — the gh process for the PUT started
+        // but failed afterward (e.g. non-zero exit, mid-transmission
+        // error). We cannot know whether GitHub already applied it.
         var invocations = 0;
         var mutator = new GhCliGitHubLabelMutator();
         GhCliGitHubLabelMutator.GhInvokerOverride = (_, _, description) =>
         {
             invocations++;
-            throw new InvalidOperationException($"simulated `gh` failure: {description}");
+            throw new InvalidOperationException($"simulated post-send failure: {description}");
         };
 
-        var exception = Assert.Throws<InvalidOperationException>(
+        var exception = Assert.Throws<LabelSetReplacementException>(
             () => mutator.ReplaceLabelSet(
-                "org/repo", GhCliGitHubLabelMutator.Kinds.Pr, 1760, new[] { "intent-target" }));
+                "org/repo",
+                GhCliGitHubLabelMutator.Kinds.Pr,
+                1760,
+                currentLabels: new[] { "intent-target" },
+                desiredLabels: new[] { "intent-target", "intent-pr-request-update" }));
 
-        Assert.Contains("simulated `gh` failure", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(LabelSetReplacementFailureCertainty.MayHaveApplied, exception.Certainty);
+        Assert.Contains("may already have reached", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("UNKNOWN", exception.Message, StringComparison.Ordinal);
+        // Never even attempts the verify re-read once the PUT's own outcome is ambiguous.
         Assert.Equal(1, invocations);
     }
 
     [Fact]
-    public void ReplaceLabelSet_VerifyReadFailure_Throws()
+    public void ReplaceLabelSet_VerifyReadFailure_ThrowsAppliedButVerificationReadFailed()
     {
-        // "Current-label fetch failure" on the post-write verification
-        // re-read — the PUT succeeded but we can no longer confirm it, so
-        // the adapter must fail loudly rather than silently claim success.
+        // "Verify failure" — the PUT succeeded, but the post-write
+        // verification read itself failed (e.g. current-label fetch
+        // failure). The mutation LIKELY applied; must not report rollback.
         var invocations = 0;
         var mutator = new GhCliGitHubLabelMutator();
         GhCliGitHubLabelMutator.GhInvokerOverride = (_, _, description) =>
@@ -103,37 +154,42 @@ public sealed class GhCliGitHubLabelMutatorReplaceLabelSetTests : IDisposable
             throw new InvalidOperationException($"simulated re-read failure: {description}");
         };
 
-        var exception = Assert.Throws<InvalidOperationException>(
-            () => mutator.ReplaceLabelSet(
-                "org/repo", GhCliGitHubLabelMutator.Kinds.Pr, 1760, new[] { "intent-target" }));
-
-        Assert.Contains("simulated re-read failure", exception.Message, StringComparison.Ordinal);
-        Assert.Equal(2, invocations);
-    }
-
-    [Fact]
-    public void ReplaceLabelSet_VerifyReadMismatch_ThrowsConcurrentChangeError()
-    {
-        // "Response mismatch/concurrent-change failure" — the PUT call
-        // reports success but the re-read shows a DIFFERENT set than what
-        // was requested (e.g. another process changed labels in between).
-        // The adapter must fail loudly, never claim atomic success on a
-        // lost update.
-        var mutator = new GhCliGitHubLabelMutator();
-        GhCliGitHubLabelMutator.GhInvokerOverride = (_, _, _) =>
-        {
-            return """{"labels":[{"name":"intent-target"},{"name":"some-other-label"}]}""";
-        };
-
-        var exception = Assert.Throws<InvalidOperationException>(
+        var exception = Assert.Throws<LabelSetReplacementException>(
             () => mutator.ReplaceLabelSet(
                 "org/repo",
                 GhCliGitHubLabelMutator.Kinds.Pr,
                 1760,
-                new[] { "intent-target", "intent-pr-request-update" }));
+                currentLabels: new[] { "intent-target" },
+                desiredLabels: new[] { "intent-target", "intent-pr-request-update" }));
 
-        Assert.Contains("could not be verified", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("concurrent", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(LabelSetReplacementFailureCertainty.AppliedButVerificationReadFailed, exception.Certainty);
+        Assert.Contains("LIKELY applied", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(2, invocations);
+    }
+
+    [Fact]
+    public void ReplaceLabelSet_VerifyReadMismatch_ThrowsAppliedButMismatchedOrConcurrentlyChanged()
+    {
+        // "Mismatch" — the PUT call reports success and the re-read
+        // succeeds, but shows a DIFFERENT set than requested. Must not be
+        // reported as a rollback/no-mutation — the write itself very
+        // likely applied.
+        var mutator = new GhCliGitHubLabelMutator();
+        GhCliGitHubLabelMutator.GhInvokerOverride = (_, _, _) =>
+            """{"labels":[{"name":"intent-target"},{"name":"some-other-label"}]}""";
+
+        var exception = Assert.Throws<LabelSetReplacementException>(
+            () => mutator.ReplaceLabelSet(
+                "org/repo",
+                GhCliGitHubLabelMutator.Kinds.Pr,
+                1760,
+                currentLabels: new[] { "intent-target" },
+                desiredLabels: new[] { "intent-target", "intent-pr-request-update" }));
+
+        Assert.Equal(
+            LabelSetReplacementFailureCertainty.AppliedButMismatchedOrConcurrentlyChanged,
+            exception.Certainty);
+        Assert.Contains("very likely applied", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -147,13 +203,17 @@ public sealed class GhCliGitHubLabelMutatorReplaceLabelSetTests : IDisposable
             return string.Empty;
         };
 
-        Assert.Throws<InvalidOperationException>(
+        var exception = Assert.Throws<InvalidOperationException>(
             () => mutator.ReplaceLabelSet(
                 "org/repo",
                 GhCliGitHubLabelMutator.Kinds.Pr,
                 1760,
-                new[] { "intent-target", "intent-pr-created" }));
+                currentLabels: new[] { "intent-target" },
+                desiredLabels: new[] { "intent-target", "intent-pr-created" }));
 
+        // A pure validation refusal, not a phase-aware ambiguity — never
+        // reached GitHub at all.
+        Assert.IsNotType<LabelSetReplacementException>(exception);
         Assert.Equal(0, invocations);
     }
 


### PR DESCRIPTION
## Summary

- `automation pr-transition --transition request-update` now clears a stale `intent-pr-rereview-ready` (and its legacy `rereview-ready` string form) in the **same** label write that adds `intent-pr-request-update` and removes `intent-pr-reviewing`.
- Fixes field finding #5 (SKS-G824 / PR #1760): a design amendment arriving while a PR was rereview-ready previously left the PR in a deadlock — `request-update` marked it for repair but `worker claim` (correctly) refuses any PR still carrying `rereview-ready`, and no installed command could break the cycle except a non-obvious `review-start` → `request-update` detour.
- `--write` mode only removes labels actually present (matching the existing convention for `review-start`/`approved`/`review-release`), so reruns stay idempotent; `--dry-run` still reports the full planned removal set. The add+remove edit remains a single `gh` call, so a failure leaves labels completely untouched (no half-transition).
- `worker claim` itself is unchanged — it still refuses a rereview-ready PR that has not been through `request-update`.
- No other transition's label set changed.

## Test plan

- [x] New fixture reproducing the exact SKS-G824/PR#1760 sequence: rereview-ready → `request-update` → `worker claim` succeeds (verified via `WorkerClaimAnalyzer` on the post-transition label set)
- [x] Fixture pinning `worker claim` still refuses an untransitioned rereview-ready PR
- [x] Idempotent rerun (rereview-ready already absent) fixture
- [x] API-failure fixture proving no half-applied transition
- [x] Regression fixture pinning `review-start`/`approved` label sets are byte-identical to before this change
- [x] All existing `AutomationPrTransitionCommandTests` (17) still green
- [x] Full solution test suite: 3579 CLI tests + all other projects passed, 1 pre-existing skip, 0 failures
- [x] `git diff --check` clean
- [x] Manual end-to-end verification against the built CLI binary with a stubbed `gh` reproducing the real label-mutation shell-out: claim refuses before the transition, `request-update --write` clears rereview-ready and names it in the output, claim succeeds afterward
- [x] ja/en developer-reference docs updated with a new G535 section

Closes #1172