### PR TITLE
G536: Publish-flow idempotent rerun independently verifies and restores durable state

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -841,6 +841,46 @@ rewritten check:
   calling `gh issue create`**; **multiple** matches → fails closed,
   non-mutating, exit 1 — ambiguity is never resolved automatically.
 
+**Round-5 review repair — GitHub enumeration is real cursor pagination, not
+a raised limit; body normalization is stricter; queue-state cardinality is
+checked.** A further review round found that a fixed `--limit` (however
+high) is still a cap that can, in principle, silently drop a real
+duplicate once the filtered result exceeds it — and that a blanket
+`Trim()` on the candidate/expected body could accept Markdown with
+different leading indentation (e.g. a code block) as if it were identical.
+
+- The GitHub existence check now uses `gh api graphql` with a real
+  `search(... first: 100, after: $cursor)` cursor-pagination loop —
+  `state=all` is preserved (open and closed issues both participate), and
+  the loop continues while `pageInfo.hasNextPage` is true, accumulating
+  every page rather than stopping at a fixed count. A page reporting
+  `hasNextPage: true` with no `endCursor`, or a result set that doesn't
+  terminate within an internal safety ceiling (50 pages / 5,000
+  candidates), fails loud (`InvalidOperationException`) instead of
+  silently truncating.
+- Body normalization now does **only** line-ending conversion (`\r\n`/`\r`
+  → `\n`) and treats "ends with exactly one trailing newline" as
+  equivalent to "no trailing newline" (GitHub's own storage convention) —
+  it no longer calls `Trim()`. Leading indentation, inner spacing, and any
+  trailing whitespace *before* the newline are preserved and compared
+  exactly, so a body that differs by so much as a single leading or
+  interior space is correctly treated as a **different** issue, not a
+  match.
+- `queue-state.json`'s `ReadQueueSignal` now collects **every** item
+  matching the execution unit rather than returning on the first match —
+  a second item for the same unit fails closed
+  (`queue_state_duplicate_execution_unit`, naming every matching index and
+  its identity) regardless of whether the duplicate entries agree or
+  conflict; identity must never depend on JSON array order.
+- New tests exercise the **real** `GhCliExistingIssueChecker` production
+  class end-to-end (not just the `IGitHubExistingIssueChecker` interface
+  stub used at the command level) via a `PageFetcherOverride` test seam
+  that replaces only the literal `gh` process spawn with canned GraphQL
+  JSON — covering multi-page open+closed accumulation, the two
+  fail-loud-on-truncation paths, and the body-normalization matrix
+  (byte-identical / CRLF vs LF / single-trailing-newline / leading /
+  inner / trailing whitespace drift).
+
 ---
 
 ### Facet-aware context supply (G530)

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -920,6 +920,31 @@ classification.
   title, null body, and URL mismatches — wrong repo, wrong number, wrong
   scheme, or null).
 
+**Round-7 review repair — the last two provider fail-closed gaps: a
+non-null-but-empty cursor, and JSON `null` in place of a "non-nullable"
+shape.** A further review round found that `hasNextPage=true` with an
+**empty or whitespace-only** `endCursor` slipped past the null-only check
+from round 6 — it would be sent back as `cursor=` on the next request and
+recorded into the seen-cursors set as if it were a real value. Separately,
+System.Text.Json silently assigns `null` to a declared-non-nullable
+reference-type property when the JSON value is `null` (C# doesn't enforce
+non-null at runtime) — so `pageInfo: null`, `nodes: null`, or a `null`
+entry inside `nodes` would previously degrade into an incidental
+`NullReferenceException` rather than an intentional provider diagnostic.
+
+- `endCursor` is now checked with `string.IsNullOrWhiteSpace` — null,
+  empty, and whitespace-only are all treated as "missing cursor" and fail
+  loud before the loop would fetch again.
+- `pageInfo`, `nodes`, and each individual node are explicitly checked for
+  `null` immediately after parsing — a `null` in any of these positions
+  fails loud with a specific diagnostic naming which piece was missing,
+  never an unhandled NRE.
+- New tests pin the full malformed-shape matrix through
+  `FetchAllCandidates` itself: empty/whitespace-only `endCursor`, a
+  `null`/wrong-type top-level envelope (`null`, `[]`, a bare number, a
+  bare string), empty process output, `pageInfo: null`, `nodes: null`, and
+  a `null` entry inside `nodes`.
+
 ---
 
 ### Facet-aware context supply (G530)

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -784,6 +784,63 @@ so an operator (or a test) can directly compare a `publish-recovery`
 unsafe stop against what `issue publish-flow`'s own rerun independently
 detects and restores for the identical durable state.
 
+**Round-4 review repair — the canonical identity is a full tuple, not just
+a number.** A subsequent review round found that treating "same issue
+number" as sufficient still let contradictory or self-inconsistent data
+through: two artifacts naming the same issue *number* but a different
+*repo*, or a single artifact whose own repo/number/URL fields disagreed
+with each other, were silently accepted. The analyzer now requires every
+present signal to be:
+
+- **Internally self-consistent** — `queue-state.json`'s `linked_issue`
+  (which carries `repo`, `number`, and `url` as three separate fields) and
+  each `runs.jsonl` event (which may carry both a `linked_issue`
+  `repo#number` descriptor and a `reason` issue URL) must agree with
+  themselves before they're even accepted as a signal at all.
+- **A canonical GitHub issue URL** — `https://github.com/<owner>/<repo>/issues/<number>`
+  exactly; any `/issues/`-containing string that doesn't match this shape
+  is no longer accepted as if it were canonical.
+- **Checked against the confirmed target repo directly**, not merely
+  pairwise between artifacts — a signal whose repo doesn't match the
+  `--repo` this command run is scoped to is a contradiction even when it's
+  the ONLY present signal.
+
+A malformed/unreadable `queue-state.json` now also fails closed exactly
+like `publish.yaml`/`runs.jsonl` already did (`queue_state_malformed`),
+rather than being silently treated as absent — a surviving `publish.yaml`
+or `runs.jsonl` signal must never authorize restoration around a
+`queue-state.json` this analyzer couldn't actually read. `publish.yaml`'s
+own `execution_unit` field is validated against the unit the packet path
+is scoped to (`publish_yaml_malformed` on mismatch — data copied from
+another unit's packet is corruption, not a signal for this unit).
+
+**The GitHub existence check is now a classification (zero / exactly-one /
+multiple), not a bare boolean, and requires exact title AND body
+linkage.** The prior round's `gh issue list --search ... --limit 20` with
+prefix-boundary title matching could both miss a real duplicate beyond the
+first 20 results and match a merely similarly-titled unrelated issue. The
+rewritten check:
+
+- Retrieves candidates with `--limit 1000` (vs. the prior round's 20) so a
+  legitimate duplicate is never silently dropped by client-side
+  truncation for any realistic repo's issue history — GitHub's own
+  `in:title` search is still used as a fast pre-filter, not the identity
+  decision itself.
+- Requires the candidate's title to equal the resolved expected title
+  **exactly** (no prefix/boundary heuristic — a similarly-titled unrelated
+  issue can never match).
+- Additionally requires the candidate's body to match the local packet's
+  `github-body.md` content byte-for-byte (normalized for line endings) —
+  the same content that was (or would be) posted via `gh issue create
+  --body-file`, giving a genuine content-linkage check rather than a title
+  guess alone.
+- Classifies the result: **zero** matches → safe to create; **exactly
+  one** → that confirmed GitHub identity is fed directly into the same
+  `PublishDurableArtifactAnalyzer`-backed restoration path used for a
+  local-signal rerun, restoring all three local artifacts **without ever
+  calling `gh issue create`**; **multiple** matches → fails closed,
+  non-mutating, exit 1 — ambiguity is never resolved automatically.
+
 ---
 
 ### Facet-aware context supply (G530)

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -881,6 +881,45 @@ different leading indentation (e.g. a code block) as if it were identical.
   (byte-identical / CRLF vs LF / single-trailing-newline / leading /
   inner / trailing whitespace drift).
 
+**Round-6 review repair — the GraphQL provider now fails closed on
+authoritative-response defects, not just structural pagination gaps.** A
+further review round found that the checker still trusted an
+authoritative-looking response even when it wasn't: a GraphQL response can
+carry non-empty `errors` alongside otherwise-plausible `data`; a
+misbehaving server could return the same `endCursor` twice, looping the
+fetch forever short of the safety cap; the search `type: ISSUE` field
+actually matches both issues AND pull requests unless the query itself
+excludes PRs; and an individual candidate could be incomplete (null body,
+null/empty title, non-positive number, or a URL that doesn't exactly match
+the requested repo) without being rejected before it reached
+classification.
+
+- Every GraphQL response is checked for a non-empty `errors` array
+  **before** its `data` is ever read — the spec permits both to be present
+  simultaneously, and partial `data` alongside an error is never treated as
+  authoritative.
+- The search query now includes `is:issue` (`repo:<repo> <unit> in:title
+  is:issue`) so a similarly-titled pull request is excluded server-side
+  rather than risking an empty/default-deserialized node; `state:` remains
+  deliberately absent so both open and closed issues stay in scope. The
+  exact literal query string is pinned by a test.
+- Each page's `endCursor` is tracked in a seen-cursors set; a repeated
+  cursor value fails loud immediately (`InvalidOperationException`) rather
+  than looping until the 50-page safety cap.
+- Every fetched candidate is validated **before** it is accumulated (not
+  after, and never discovered only once classification or a restoration
+  write is already underway): a positive issue number, a non-null/
+  non-empty title, a non-null body (a null body is an invalid provider
+  response — never silently substituted with empty text), and a URL
+  matching the canonical `https://github.com/<requested repo>/issues/<number>`
+  shape **exactly** for the repo this check was scoped to.
+- New production-provider tests cover GraphQL errors alongside partial
+  data, repeated-cursor detection, the literal `is:issue`/no-`state:`
+  query pin, page-fetcher failure propagation, malformed JSON, and every
+  candidate-validation failure mode (non-positive number, null/empty
+  title, null body, and URL mismatches — wrong repo, wrong number, wrong
+  scheme, or null).
+
 ---
 
 ### Facet-aware context supply (G530)

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -688,72 +688,101 @@ that has not been through `request-update`.
 
 ### `issue publish-flow` idempotent rerun independently verifies and restores all three durable artifacts (G536)
 
-Field incident (2026-07-19, publishing G530 as issue #1164): host `main`
-advanced concurrently after the GitHub issue was created, forcing a stash +
-fast-forward sync mid-publish. `publish.yaml` survived with its
-`issue-created` record intact, but `queue-state.json`'s `linked_issue` and
-the `runs.jsonl` `issue-created` event both reverted to their pre-publish
-(absent) state. The idempotent rerun that followed reported
-`durable_state_synced: true` anyway — a false positive, since neither of
-the two artifacts that had actually reverted was ever checked.
+Field incidents (2026-07-19, publishing G530 as issue #1164 and G531 as
+issue #1166): host `main` advanced concurrently after each GitHub issue was
+created, forcing a stash + fast-forward sync mid-publish. For #1164,
+`publish.yaml` survived with its `issue-created` record intact, but
+`queue-state.json`'s `linked_issue` and the `runs.jsonl` `issue-created`
+event both reverted to their pre-publish (absent) state. For #1166, the
+loss was worse: `queue-state.json`'s `linked_issue` AND `publish.yaml`'s
+`issue-created` record were both lost — `runs.jsonl`'s `issue-created`
+event was the *only* surviving signal. The pre-G536 idempotent rerun only
+ever consulted `publish.yaml` or `queue-state.json` and never read
+`runs.jsonl` as an identity source at all, so the #1166 shape fell through
+to the normal create path — risking a **second GitHub issue** for the same
+execution unit, the single most severe defect this repair fixes.
 
-**The pre-G536 idempotent rerun only ever consulted ONE of the three
-artifacts.** It short-circuited on whichever of `publish.yaml`'s
-`issue-created` marker or `queue-state.json`'s `linked_issue` it found
-first, reported `durable_state_synced: true` unconditionally the instant
-either fired, and never even read `runs.jsonl`. There was no cross-check
-between the three artifacts and no restoration of whichever ones were
-actually missing.
+**A single shared analyzer, `PublishDurableArtifactAnalyzer`, now backs
+both `issue publish-flow`'s idempotent rerun and `automation
+publish-recovery`.** It independently parses all three durable artifacts —
+`queue-state.json`'s `linked_issue`, `publish.yaml`'s `issue-created`
+record, and every canonical `issue-created` event in `runs.jsonl` — and
+resolves a single canonical issue identity, or fails closed. Both commands
+report the identical, stable gap identifiers
+(`queue_linked_issue_missing`, `publish_yaml_missing`,
+`runs_event_missing`) for the same durable-state shape, so the two
+surfaces can never disagree about what's missing.
 
-**The idempotent-rerun checklist now verifies all three durable artifacts
-independently, every time, and restores whichever are missing:**
+**`runs.jsonl` is classified, not just checked for presence.** An
+execution unit's `issue-created` events are read as a set and classified:
 
-1. **queue-state.json's `linked_issue`** — must name the same repo/issue
-   number/URL as the canonical issue identity.
-2. **`publish.yaml`'s `issue-created` record** — must carry
-   `publish_status: issue-created` with a matching issue number/URL.
-3. **`runs.jsonl`'s `issue-created` event** — an event for this execution
-   unit must exist (scanned via the full run log, not assumed).
+- **Zero** matching events → the `runs_event_missing` gap.
+- **Exactly one**, or **duplicate-identical** (multiple events all naming
+  the same issue number — e.g. a retried append) → present, no gap.
+- **Conflicting** (events naming *different* issue numbers for the same
+  execution unit) → fails closed as `runs_event_conflicting`, a data
+  contradiction, never silently resolved either way.
 
-The canonical issue identity is established from whichever signal(s) are
-present (`publish.yaml` takes precedence when both agree). Any artifact
-found missing is restored using the exact same write helpers the
-first-run success path uses (`TryPatchQueueStateLinkedIssue`,
-`WritePublishArtifact`, `AppendIssueCreatedRunEvent`) — restoration is
-itself idempotent: a unit already fully in sync makes no further writes,
-and `runs.jsonl` is scanned for an existing `issue-created` event before
-ever appending one, so a repeated rerun can never produce a duplicate
-event. `durable_state_synced: true` is reported **only** once all three
-verify (whether they were already correct or just restored); `gh` is
+**Malformed data fails closed, distinct from "missing."** An unparseable
+`publish.yaml` (`publish_yaml_malformed`) or an `issue-created` run event
+that carries neither a recognizable `linked_issue` (`repo#number`) nor a
+`reason` issue URL (`runs_malformed`) is never silently treated as absent
+— treating malformed data as "missing" would invite an unsafe overwrite of
+a file that might carry a real, just-corrupted record. The whole analysis
+short-circuits to a fail-closed result before any gap/restoration logic
+runs.
+
+**Genuine cross-artifact contradictions fail loud instead of picking a
+side.** If the artifacts disagree on the issue number for the same
+execution unit, that is a data contradiction, not a missing artifact — the
+command refuses (exit 1, `cross_artifact_contradiction`), names every
+conflicting value, and never silently trusts one side over the other.
+
+**Restoration only touches genuinely-missing artifacts, and is verified by
+re-reading, not by trusting write helpers' return values.** The rerun
+iterates the analyzer's gap list and restores only those artifacts using
+the same write helpers the first-run success path uses
+(`TryPatchQueueStateLinkedIssue`, `WritePublishArtifact`,
+`AppendIssueCreatedRunEvent`). After attempting restoration, it
+re-invokes `PublishDurableArtifactAnalyzer.Analyze` a **second time**
+against the freshly-written files and reports `durable_state_synced:
+true` only when that independent re-read confirms zero remaining gaps —
+a write helper reporting success is never enough on its own. `gh` is
 never re-invoked during any idempotent rerun.
-
-**Genuine contradictions fail loud instead of picking a side.** If
-`publish.yaml` and `queue-state.json` both carry a `linked_issue`/
-`issue-created` record but name *different* issue numbers, that is a data
-contradiction, not a missing artifact — the command refuses (exit 1),
-names both conflicting values, and never silently trusts one side over
-the other.
 
 **Restoration failure also fails loud, naming exactly what's missing and
 how to recover.** If an artifact cannot be restored (e.g. `queue-state.json`
 no longer has any item for this execution unit to patch), the command
 exits non-zero, reports `durable_state_synced: false`, and its `error`
-names precisely which artifact(s) remain missing/inconsistent plus the
-exact recovery commands (`issue publish-flow ... --write` to retry, or
-`automation publish-recovery ... --write` to reconcile queue-state
-linkage). Artifact verification is independent, not all-or-nothing: an
-artifact that *could* be restored still gets restored even when another
-one couldn't.
+names precisely which artifact(s) remain missing/inconsistent (from the
+post-restoration re-analysis) plus the exact recovery commands (`issue
+publish-flow ... --write` to retry, or `automation publish-recovery
+... --write` to reconcile queue-state linkage). Artifact verification is
+independent, not all-or-nothing: an artifact that *could* be restored
+still gets restored even when another one couldn't.
 
-**`automation publish-recovery` reports the identical gap.** Given the
-exact field-incident shape (queue-state's `linked_issue`/`linked_pr` both
-null, `publish.yaml` already records the created issue, no PR open yet),
-`publish-recovery`'s dry-run surfaces the same execution unit as an
-unsafe stop (`no-closing-pr-for-published-issue`) rather than silently
-reporting nothing to do — consistent with what `issue publish-flow`'s own
-rerun independently detects (and, unlike `publish-recovery`, can safely
-self-restore without needing PR evidence, since it already knows the
-issue it just verified is the one it's re-verifying).
+**Dry-run plans only — it never writes, and reports `would_restore`.**
+`issue publish-flow <unit> --repo <owner/repo>` (no `--write`) runs the
+same read-only analysis and, when an existing issue identity is found,
+reports `would_restore` — the exact gap list a subsequent `--write` rerun
+would restore — without ever invoking a write helper or `gh`.
+
+**Before ever creating on a "zero local signal" unit, a GitHub-side
+existence check runs first.** When the analyzer finds no identity across
+all three local artifacts, falling straight through to `gh issue create`
+would risk a genuine duplicate if every local artifact was reset/lost but
+the GitHub issue itself was never re-created. A `gh issue list --search`
+corroboration check runs before create; if it finds a title match, the
+command refuses (exit 1) and points the operator at `automation
+publish-recovery --write` or a manual backfill, rather than creating a
+duplicate or attempting to reconstruct identity from a fuzzy match.
+
+**`automation publish-recovery` reports the identical gap.** Every unsafe
+stop now carries a `durable_artifact_gaps` field — the output of the same
+shared analyzer, called on the same paths for the same execution unit —
+so an operator (or a test) can directly compare a `publish-recovery`
+unsafe stop against what `issue publish-flow`'s own rerun independently
+detects and restores for the identical durable state.
 
 ---
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -686,6 +686,77 @@ that has not been through `request-update`.
 
 ---
 
+### `issue publish-flow` idempotent rerun independently verifies and restores all three durable artifacts (G536)
+
+Field incident (2026-07-19, publishing G530 as issue #1164): host `main`
+advanced concurrently after the GitHub issue was created, forcing a stash +
+fast-forward sync mid-publish. `publish.yaml` survived with its
+`issue-created` record intact, but `queue-state.json`'s `linked_issue` and
+the `runs.jsonl` `issue-created` event both reverted to their pre-publish
+(absent) state. The idempotent rerun that followed reported
+`durable_state_synced: true` anyway — a false positive, since neither of
+the two artifacts that had actually reverted was ever checked.
+
+**The pre-G536 idempotent rerun only ever consulted ONE of the three
+artifacts.** It short-circuited on whichever of `publish.yaml`'s
+`issue-created` marker or `queue-state.json`'s `linked_issue` it found
+first, reported `durable_state_synced: true` unconditionally the instant
+either fired, and never even read `runs.jsonl`. There was no cross-check
+between the three artifacts and no restoration of whichever ones were
+actually missing.
+
+**The idempotent-rerun checklist now verifies all three durable artifacts
+independently, every time, and restores whichever are missing:**
+
+1. **queue-state.json's `linked_issue`** — must name the same repo/issue
+   number/URL as the canonical issue identity.
+2. **`publish.yaml`'s `issue-created` record** — must carry
+   `publish_status: issue-created` with a matching issue number/URL.
+3. **`runs.jsonl`'s `issue-created` event** — an event for this execution
+   unit must exist (scanned via the full run log, not assumed).
+
+The canonical issue identity is established from whichever signal(s) are
+present (`publish.yaml` takes precedence when both agree). Any artifact
+found missing is restored using the exact same write helpers the
+first-run success path uses (`TryPatchQueueStateLinkedIssue`,
+`WritePublishArtifact`, `AppendIssueCreatedRunEvent`) — restoration is
+itself idempotent: a unit already fully in sync makes no further writes,
+and `runs.jsonl` is scanned for an existing `issue-created` event before
+ever appending one, so a repeated rerun can never produce a duplicate
+event. `durable_state_synced: true` is reported **only** once all three
+verify (whether they were already correct or just restored); `gh` is
+never re-invoked during any idempotent rerun.
+
+**Genuine contradictions fail loud instead of picking a side.** If
+`publish.yaml` and `queue-state.json` both carry a `linked_issue`/
+`issue-created` record but name *different* issue numbers, that is a data
+contradiction, not a missing artifact — the command refuses (exit 1),
+names both conflicting values, and never silently trusts one side over
+the other.
+
+**Restoration failure also fails loud, naming exactly what's missing and
+how to recover.** If an artifact cannot be restored (e.g. `queue-state.json`
+no longer has any item for this execution unit to patch), the command
+exits non-zero, reports `durable_state_synced: false`, and its `error`
+names precisely which artifact(s) remain missing/inconsistent plus the
+exact recovery commands (`issue publish-flow ... --write` to retry, or
+`automation publish-recovery ... --write` to reconcile queue-state
+linkage). Artifact verification is independent, not all-or-nothing: an
+artifact that *could* be restored still gets restored even when another
+one couldn't.
+
+**`automation publish-recovery` reports the identical gap.** Given the
+exact field-incident shape (queue-state's `linked_issue`/`linked_pr` both
+null, `publish.yaml` already records the created issue, no PR open yet),
+`publish-recovery`'s dry-run surfaces the same execution unit as an
+unsafe stop (`no-closing-pr-for-published-issue`) rather than silently
+reporting nothing to do — consistent with what `issue publish-flow`'s own
+rerun independently detects (and, unlike `publish-recovery`, can safely
+self-restore without needing PR evidence, since it already knows the
+issue it just verified is the one it's re-verifying).
+
+---
+
 ### Facet-aware context supply (G530)
 
 Building on G529's four semantic facets (`vocabulary`, `invariant`,

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -723,83 +723,114 @@ refuse されます。
 
 ### `issue publish-flow` の idempotent rerun が 3 つの durable artifact すべてを独立に検証・復元する (G536)
 
-Field incident(2026-07-19、G530 を issue #1164 として publish 中):
-GitHub issue の作成後に host `main` が並行して進み、publish の途中で
-stash + fast-forward sync を強いられました。`publish.yaml` は
-`issue-created` の記録を保持したまま生き残りましたが、
-`queue-state.json` の `linked_issue` と `runs.jsonl` の
+Field incident(2026-07-19、G530 を issue #1164、G531 を issue #1166 として
+publish 中): それぞれの GitHub issue 作成後に host `main` が並行して
+進み、publish の途中で stash + fast-forward sync を強いられました。
+#1164 では `publish.yaml` が `issue-created` の記録を保持したまま
+生き残りましたが、`queue-state.json` の `linked_issue` と `runs.jsonl` の
 `issue-created` event は、どちらも publish 前(存在しない状態)に
-戻ってしまいました。その後の idempotent rerun は、実際には revert
-された 2 つの artifact のどちらも一度も check していないにもかかわらず、
-`durable_state_synced: true` と報告してしまいました — false positive
-です。
+戻ってしまいました。#1166 ではさらに深刻で、`queue-state.json` の
+`linked_issue` と `publish.yaml` の `issue-created` record が両方とも
+失われ、`runs.jsonl` の `issue-created` event だけが唯一生き残った
+signal でした。G536 以前の idempotent rerun は `publish.yaml` か
+`queue-state.json` しか参照しておらず、`runs.jsonl` を identity source
+として一度も read していなかったため、#1166 の形状は通常の create path
+に fall through してしまい、同一 execution unit に対して**2 つ目の
+GitHub issue** を作成しかねない状態でした — これが今回の repair で
+修正した最も深刻な defect です。
 
-**G536 以前の idempotent rerun は、3 つの artifact のうち常に
-たった 1 つしか参照していませんでした。** `publish.yaml` の
-`issue-created` marker と `queue-state.json` の `linked_issue` の
-どちらか先に見つかった方で short-circuit し、どちらか一方が hit した
-瞬間に無条件で `durable_state_synced: true` を報告し、`runs.jsonl` は
-一度も read しませんでした。3 つの artifact 間の cross-check は無く、
-実際に欠けている artifact の復元もありませんでした。
+**単一の共有 analyzer `PublishDurableArtifactAnalyzer` が、`issue
+publish-flow` の idempotent rerun と `automation publish-recovery` の
+両方を今や支えています。** この analyzer は 3 つの durable artifact —
+`queue-state.json` の `linked_issue`、`publish.yaml` の `issue-created`
+record、`runs.jsonl` 内のすべての canonical `issue-created` event — を
+独立に parse し、単一の canonical issue identity を解決するか、fail
+closed します。両方のコマンドは、同じ durable-state の形状に対して
+まったく同じ、安定した gap identifier
+(`queue_linked_issue_missing`、`publish_yaml_missing`、
+`runs_event_missing`)を報告するため、2 つの surface が何が欠けている
+かについて食い違うことは決してありません。
 
-**idempotent-rerun のチェックリストは、今や 3 つの durable artifact
-すべてを毎回独立に検証し、欠けているものを復元します:**
+**`runs.jsonl` は存在有無だけでなく分類されます。** ある execution
+unit の `issue-created` event は集合として read され、以下のように
+分類されます:
 
-1. **queue-state.json の `linked_issue`** — canonical な issue identity
-   と同じ repo/issue number/URL を指している必要があります。
-2. **`publish.yaml` の `issue-created` record** — 一致する issue
-   number/URL を伴う `publish_status: issue-created` を持っている
-   必要があります。
-3. **`runs.jsonl` の `issue-created` event** — この execution unit の
-   event が存在している必要があります(前提とするのではなく、完全な
-   run log を scan して確認します)。
+- **ゼロ件** の一致する event → `runs_event_missing` gap。
+- **ちょうど 1 件**、あるいは **duplicate-identical**(複数 event が
+  すべて同じ issue number を指している — 例えばリトライによる追記)
+  → present、gap なし。
+- **conflicting**(同一 execution unit に対して event が**異なる**
+  issue number を指している)→ `runs_event_conflicting` として fail
+  closed する data contradiction であり、どちらか一方に黙って解決
+  されることは決してありません。
 
-canonical な issue identity は、存在するどちらかの signal から
-確立されます(両方が存在し一致する場合は `publish.yaml` を優先)。
-欠けていると判明した artifact は、first-run の success path が使う
+**malformed なデータは "missing" とは区別して fail closed します。**
+parse 不能な `publish.yaml`(`publish_yaml_malformed`)や、
+`linked_issue`(`repo#number`)も `reason` issue URL も認識可能な形で
+持たない `issue-created` run event(`runs_malformed`)は、決して
+silently に absent 扱いされません — malformed なデータを "missing"
+扱いすることは、実際には壊れているだけで本物の record を持つファイルへの
+安全でない上書きを招くためです。分析全体は、gap/復元 logic が走る前に
+fail-closed な結果へと short-circuit します。
+
+**真の cross-artifact contradiction はどちらか一方を選ぶのではなく、
+fail loud します。** artifact 同士が同一 execution unit の issue
+number について食い違っている場合、それは欠けている artifact ではなく
+data contradiction です — コマンドは refuse し
+(exit 1、`cross_artifact_contradiction`)、矛盾するすべての値を named
+し、どちらか一方を黙って信用することは決してありません。
+
+**復元は本当に欠けている artifact だけに触れ、write helper の戻り値を
+信用するのではなく re-read によって検証されます。** rerun は
+analyzer の gap list を iterate し、first-run の success path が使う
 のと全く同じ write helper(`TryPatchQueueStateLinkedIssue`、
-`WritePublishArtifact`、`AppendIssueCreatedRunEvent`)を使って復元
-されます — 復元自体も idempotent です: 既に完全に sync している
-unit はそれ以上何も書き込みませんし、`runs.jsonl` は
-`issue-created` event を追記する前に既存の event の有無を scan する
-ため、繰り返し rerun しても重複した event が生成されることは決して
-ありません。`durable_state_synced: true` が報告されるのは、3 つ
-すべてが検証済み(元々正しかった場合も、今回復元された場合も含む)に
-なった場合**のみ**です。idempotent rerun の間、`gh` が再び呼び出さ
-れることはありません。
-
-**真の contradiction はどちらか一方を選ぶのではなく、fail loud
-します。** `publish.yaml` と `queue-state.json` の両方が
-`linked_issue`/`issue-created` record を持っているにもかかわらず、
-互いに**異なる** issue number を記録している場合、それは欠けている
-artifact ではなく data contradiction です — コマンドは refuse し
-(exit 1)、矛盾する両方の値を named し、どちらか一方を黙って信用する
-ことは決してありません。
+`WritePublishArtifact`、`AppendIssueCreatedRunEvent`)を使って、
+欠けている artifact だけを復元します。復元を試みた後、
+`PublishDurableArtifactAnalyzer.Analyze` を**もう一度**、書き込み直後の
+ファイルに対して独立に呼び出し、その re-read が残っている gap が
+ゼロであることを確認した場合**のみ** `durable_state_synced: true` を
+報告します — write helper が success を返しただけでは十分では
+ありません。idempotent rerun の間、`gh` が再び呼び出されることは
+ありません。
 
 **復元が失敗した場合も、正確に何が欠けているか・どう recovery するか
 を named した上で fail loud します。** artifact を復元できない場合
 (例えば `queue-state.json` にこの execution unit を patch すべき
 item がもはや存在しない場合)、コマンドは non-zero で exit し、
-`durable_state_synced: false` を報告し、その `error` は、欠けている /
-矛盾している artifact を正確に named した上で、正確な recovery
-command(再試行する `issue publish-flow ... --write`、または
-queue-state の linkage を reconcile する
-`automation publish-recovery ... --write`)を示します。artifact の
-検証は独立しており、all-or-nothing ではありません — 復元*できる*
+`durable_state_synced: false` を報告し、その `error` は(復元後の
+re-analysis に基づいて)欠けている / 矛盾している artifact を正確に
+named した上で、正確な recovery command(再試行する `issue
+publish-flow ... --write`、または queue-state の linkage を reconcile
+する `automation publish-recovery ... --write`)を示します。artifact
+の検証は独立しており、all-or-nothing ではありません — 復元*できる*
 artifact は、他の artifact が復元できなかった場合でも復元されます。
 
-**`automation publish-recovery` は同一の gap を報告します。** field
-incident とまったく同じ形状(queue-state の `linked_issue`/`linked_pr`
-がどちらも null で、`publish.yaml` は既に created issue を記録して
-おり、PR はまだ open していない)を与えると、`publish-recovery` の
-dry-run は「何もすることがない」と黙って報告するのではなく、同じ
-execution unit を unsafe stop
-(`no-closing-pr-for-published-issue`)として surface します — これは
-`issue publish-flow` 自身の rerun が独立に検出するものと consistent
-です(ただし `publish-recovery` と異なり、`issue publish-flow` は
-PR evidence を必要とせず安全に self-restore できます。今まさに
-re-verify している issue が、自分がさっき検証した issue そのもので
-あることを既に知っているためです)。
+**dry-run は計画するだけで、決して書き込まず、`would_restore` を
+報告します。** `issue publish-flow <unit> --repo <owner/repo>`
+(`--write` なし)は同じ read-only な分析を実行し、既存の issue
+identity が見つかった場合は、write helper や `gh` を一切呼び出す
+ことなく、後続の `--write` rerun が復元するであろう正確な gap list
+である `would_restore` を報告します。
+
+**"local signal がゼロ" の unit に対して create する前に、まず
+GitHub 側の existence check が走ります。** analyzer が 3 つの
+local artifact すべてに対して identity を見つけられなかった場合、
+そのまま `gh issue create` に fall through すると、すべての
+local artifact が reset/lost されていても GitHub issue 自体は
+再作成されていないケースで、本物の duplicate を生む risk があります。
+create の前に `gh issue list --search` による corroboration check が
+走り、title の一致が見つかった場合はコマンドは refuse し(exit 1)、
+duplicate を作成したり曖昧な一致から identity を再構築しようと
+試みたりするのではなく、operator に `automation
+publish-recovery --write` か手動での backfill を案内します。
+
+**`automation publish-recovery` は同一の gap を報告します。** すべての
+unsafe stop は今や `durable_artifact_gaps` field を持ちます —
+同じ execution unit・同じ path に対して呼び出された、同一の共有
+analyzer の出力です。これにより operator(あるいは test)は、
+`publish-recovery` の unsafe stop と、`issue publish-flow` 自身の
+rerun が同一の durable state に対して独立に検出・復元するものとを、
+直接比較できます。
 
 ---
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -721,6 +721,88 @@ refuse されます。
 
 ---
 
+### `issue publish-flow` の idempotent rerun が 3 つの durable artifact すべてを独立に検証・復元する (G536)
+
+Field incident(2026-07-19、G530 を issue #1164 として publish 中):
+GitHub issue の作成後に host `main` が並行して進み、publish の途中で
+stash + fast-forward sync を強いられました。`publish.yaml` は
+`issue-created` の記録を保持したまま生き残りましたが、
+`queue-state.json` の `linked_issue` と `runs.jsonl` の
+`issue-created` event は、どちらも publish 前(存在しない状態)に
+戻ってしまいました。その後の idempotent rerun は、実際には revert
+された 2 つの artifact のどちらも一度も check していないにもかかわらず、
+`durable_state_synced: true` と報告してしまいました — false positive
+です。
+
+**G536 以前の idempotent rerun は、3 つの artifact のうち常に
+たった 1 つしか参照していませんでした。** `publish.yaml` の
+`issue-created` marker と `queue-state.json` の `linked_issue` の
+どちらか先に見つかった方で short-circuit し、どちらか一方が hit した
+瞬間に無条件で `durable_state_synced: true` を報告し、`runs.jsonl` は
+一度も read しませんでした。3 つの artifact 間の cross-check は無く、
+実際に欠けている artifact の復元もありませんでした。
+
+**idempotent-rerun のチェックリストは、今や 3 つの durable artifact
+すべてを毎回独立に検証し、欠けているものを復元します:**
+
+1. **queue-state.json の `linked_issue`** — canonical な issue identity
+   と同じ repo/issue number/URL を指している必要があります。
+2. **`publish.yaml` の `issue-created` record** — 一致する issue
+   number/URL を伴う `publish_status: issue-created` を持っている
+   必要があります。
+3. **`runs.jsonl` の `issue-created` event** — この execution unit の
+   event が存在している必要があります(前提とするのではなく、完全な
+   run log を scan して確認します)。
+
+canonical な issue identity は、存在するどちらかの signal から
+確立されます(両方が存在し一致する場合は `publish.yaml` を優先)。
+欠けていると判明した artifact は、first-run の success path が使う
+のと全く同じ write helper(`TryPatchQueueStateLinkedIssue`、
+`WritePublishArtifact`、`AppendIssueCreatedRunEvent`)を使って復元
+されます — 復元自体も idempotent です: 既に完全に sync している
+unit はそれ以上何も書き込みませんし、`runs.jsonl` は
+`issue-created` event を追記する前に既存の event の有無を scan する
+ため、繰り返し rerun しても重複した event が生成されることは決して
+ありません。`durable_state_synced: true` が報告されるのは、3 つ
+すべてが検証済み(元々正しかった場合も、今回復元された場合も含む)に
+なった場合**のみ**です。idempotent rerun の間、`gh` が再び呼び出さ
+れることはありません。
+
+**真の contradiction はどちらか一方を選ぶのではなく、fail loud
+します。** `publish.yaml` と `queue-state.json` の両方が
+`linked_issue`/`issue-created` record を持っているにもかかわらず、
+互いに**異なる** issue number を記録している場合、それは欠けている
+artifact ではなく data contradiction です — コマンドは refuse し
+(exit 1)、矛盾する両方の値を named し、どちらか一方を黙って信用する
+ことは決してありません。
+
+**復元が失敗した場合も、正確に何が欠けているか・どう recovery するか
+を named した上で fail loud します。** artifact を復元できない場合
+(例えば `queue-state.json` にこの execution unit を patch すべき
+item がもはや存在しない場合)、コマンドは non-zero で exit し、
+`durable_state_synced: false` を報告し、その `error` は、欠けている /
+矛盾している artifact を正確に named した上で、正確な recovery
+command(再試行する `issue publish-flow ... --write`、または
+queue-state の linkage を reconcile する
+`automation publish-recovery ... --write`)を示します。artifact の
+検証は独立しており、all-or-nothing ではありません — 復元*できる*
+artifact は、他の artifact が復元できなかった場合でも復元されます。
+
+**`automation publish-recovery` は同一の gap を報告します。** field
+incident とまったく同じ形状(queue-state の `linked_issue`/`linked_pr`
+がどちらも null で、`publish.yaml` は既に created issue を記録して
+おり、PR はまだ open していない)を与えると、`publish-recovery` の
+dry-run は「何もすることがない」と黙って報告するのではなく、同じ
+execution unit を unsafe stop
+(`no-closing-pr-for-published-issue`)として surface します — これは
+`issue publish-flow` 自身の rerun が独立に検出するものと consistent
+です(ただし `publish-recovery` と異なり、`issue publish-flow` は
+PR evidence を必要とせず安全に self-restore できます。今まさに
+re-verify している issue が、自分がさっき検証した issue そのもので
+あることを既に知っているためです)。
+
+---
+
 ### facet を意識した context 供給 (G530)
 
 G529 の 4 つの semantic facet（`vocabulary`、`invariant`、`decider`、

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -977,6 +977,34 @@ repo と正確に一致しない URL という形で)不完全なまま classifi
   null/empty title、null body、URL mismatch — 間違った repo、間違った
   number、間違った scheme、あるいは null)をカバーします。
 
+**Round-7 review repair — provider fail-closed の残り 2 つの gap:
+non-null だが empty な cursor、そして "non-nullable" な形状の代わりの
+JSON `null`。** さらなる review round で、`hasNextPage=true` かつ
+**empty あるいは whitespace-only** な `endCursor` が、round 6 の
+null のみの check をすり抜けてしまうことが判明しました — それは次の
+request で `cursor=` として送り返され、あたかも本物の値であるかのように
+seen-cursors set に記録されてしまいます。別の問題として、
+System.Text.Json は、JSON の値が `null` の場合、宣言上
+non-nullable な reference-type property に silently に `null` を
+代入します(C# は runtime で non-null を強制しません)— そのため
+`pageInfo: null`、`nodes: null`、あるいは `nodes` 内の `null` な
+entry は、以前は意図的な provider diagnostic ではなく、偶発的な
+`NullReferenceException` へと degrade してしまっていました。
+
+- `endCursor` は今や `string.IsNullOrWhiteSpace` で check されます —
+  null、empty、whitespace-only はすべて「missing cursor」として扱われ、
+  loop が再度 fetch する前に fail loud します。
+- `pageInfo`、`nodes`、そして個々の node は、parse 直後に明示的に
+  `null` check されます — これらのどの位置での `null` も、どの部分が
+  欠けていたかを named した具体的な diagnostic で fail loud し、
+  未処理の NRE になることは決してありません。
+- 新しい test は、`FetchAllCandidates` 自身を通した完全な
+  malformed-shape matrix を pin します: empty/whitespace-only な
+  `endCursor`、`null`/wrong-type な top-level envelope(`null`、
+  `[]`、単なる数値、単なる文字列)、empty な process output、
+  `pageInfo: null`、`nodes: null`、そして `nodes` 内の `null` な
+  entry。
+
 ---
 
 ### facet を意識した context 供給 (G530)

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -832,6 +832,68 @@ analyzer の出力です。これにより operator(あるいは test)は、
 rerun が同一の durable state に対して独立に検出・復元するものとを、
 直接比較できます。
 
+**Round-4 review repair — canonical identity は number だけでなく完全な
+tuple です。** 後続の review round で、"issue number が同じ" だけを
+十分とみなすと、矛盾したデータや自己矛盾したデータをまだ通してしまう
+ことが判明しました: 2 つの artifact が同じ issue *number* を記録して
+いても *repo* が異なる場合や、単一の artifact 自身の repo/number/URL
+field が互いに食い違っている場合が、silently に受け入れられて
+いました。analyzer は今や、存在する各 signal に以下を要求します:
+
+- **内部的に自己矛盾がないこと** — `queue-state.json` の
+  `linked_issue`(`repo`、`number`、`url` を別々の field として持つ)や
+  各 `runs.jsonl` event(`linked_issue` の `repo#number` descriptor と
+  `reason` issue URL の両方を持ちうる)は、そもそも signal として
+  受け入れられる前に、自分自身と一致していなければなりません。
+- **canonical な GitHub issue URL であること** —
+  `https://github.com/<owner>/<repo>/issues/<number>` に正確に一致する
+  必要があります。この形に一致しない `/issues/` を含む文字列は、もはや
+  canonical として受け入れられません。
+- **確認済みの target repo と直接照合されること** — artifact 同士の
+  pairwise な比較だけでなく、この command run がスコープする `--repo`
+  と一致しない signal は、それが唯一の存在する signal であっても
+  contradiction になります。
+
+malformed / read 不能な `queue-state.json` も、`publish.yaml`/
+`runs.jsonl` と全く同じように fail closed するようになりました
+(`queue_state_malformed`)— 生き残った `publish.yaml` や `runs.jsonl` の
+signal が、この analyzer が実際には read できなかった
+`queue-state.json` の周りでの復元を authorize することは決してあり
+ません。`publish.yaml` 自身の `execution_unit` field も、packet path が
+スコープする unit と照合されます(不一致なら
+`publish_yaml_malformed` — 別 unit の packet からコピーされたデータは
+corruption であり、この unit の signal ではありません)。
+
+**GitHub existence check は今や bool ではなく分類
+(zero / exactly-one / multiple)であり、exact title と body の両方の
+linkage を要求します。** 前の round の
+`gh issue list --search ... --limit 20` と prefix-boundary な title
+matching は、20 件を超えた実際の duplicate を見逃す可能性と、単に
+似た title を持つだけの無関係な issue に一致する可能性の両方が
+ありました。書き直された check は:
+
+- `--limit 1000`(前 round の 20 に対して)で candidate を取得し、
+  現実的などのような repo の issue 履歴に対しても、client-side の
+  truncation によって本物の duplicate が silently に drop されない
+  ようにします — GitHub 自身の `in:title` search は、identity の
+  決定そのものではなく、高速な pre-filter として引き続き使用します。
+- candidate の title が resolved された expected title と**完全に**
+  一致することを要求します(prefix/boundary heuristic はもう
+  ありません — 似た title を持つだけの無関係な issue は決して一致
+  しません)。
+- さらに、candidate の body が local packet の `github-body.md` の
+  内容と(改行を normalize した上で)byte-for-byte 一致することを
+  要求します — これは `gh issue create --body-file` で post された
+  (あるいは post されるはずの)まさにその内容であり、title だけの
+  推測ではなく本物の content-linkage check になります。
+- 結果を分類します: **zero** 件の一致 → create しても安全、
+  **ちょうど 1 件** → その確認済みの GitHub identity が、local
+  signal による rerun と同じ `PublishDurableArtifactAnalyzer` ベースの
+  復元 path に直接 feed され、`gh issue create` を一切呼び出す
+  ことなく 3 つすべての local artifact を復元します。**multiple**
+  件の一致 → fail closed、non-mutating、exit 1 — 曖昧さが自動的に
+  解決されることは決してありません。
+
 ---
 
 ### facet を意識した context 供給 (G530)

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -936,6 +936,47 @@ leading indentation が異なる Markdown(例えばcode block)を同一として
   matrix(byte-identical / CRLF vs LF / single-trailing-newline /
   leading / inner / trailing whitespace drift)をカバーします。
 
+**Round-6 review repair — GraphQL provider は構造的な pagination の
+gap だけでなく、authoritative-response の欠陥に対しても fail closed
+します。** さらなる review round で、checker がまだ authoritative に
+「見える」response を、実際にはそうでない場合にも信用してしまうことが
+判明しました: GraphQL response は、一見妥当な `data` と共に空でない
+`errors` を持ちうること、誤動作する server が同じ `endCursor` を
+2 回返し、safety cap まで永遠に loop してしまいうること、search の
+`type: ISSUE` field は実際には query 自身が PR を除外しない限り issue
+と pull request の両方に一致すること、そして個々の candidate が
+(null body、null/empty title、non-positive number、あるいは requested
+repo と正確に一致しない URL という形で)不完全なまま classification に
+到達する前に reject されないことがありました。
+
+- すべての GraphQL response は、その `data` が read される**前に**
+  空でない `errors` array の有無を check します — spec は両方が同時に
+  存在することを許容しており、error を伴う部分的な `data` が
+  authoritative として扱われることは決してありません。
+- search query は今や `is:issue` を含みます(`repo:<repo> <unit>
+  in:title is:issue`)。これにより、似た title を持つ pull request は
+  空/default に deserialize された node として risk を負うのではなく、
+  server-side で除外されます。`state:` は意図的に含まれないままで、
+  open と closed の両方の issue がスコープに残ります。正確な literal
+  query 文字列は test で pin されています。
+- 各 page の `endCursor` は seen-cursors set に追跡され、繰り返された
+  cursor 値は 50-page の safety cap まで loop するのではなく、直ちに
+  fail loud します(`InvalidOperationException`)。
+- fetch されたすべての candidate は、蓄積される**前に**(そして
+  classification や復元の write が既に進行してから発見するのでは
+  なく)検証されます: positive な issue number、non-null/non-empty な
+  title、non-null な body(null body は無効な provider response であり、
+  空 text として silently に代替されることは決してありません)、そして
+  この check がスコープする repo に対して canonical な
+  `https://github.com/<requested repo>/issues/<number>` 形式に**厳密に**
+  一致する URL。
+- 新しい production-provider test は、部分的な data を伴う GraphQL
+  errors、repeated-cursor 検出、literal な `is:issue`/`state:` 無しの
+  query pin、page-fetcher failure の伝播、malformed JSON、そして
+  すべての candidate-validation failure mode(non-positive number、
+  null/empty title、null body、URL mismatch — 間違った repo、間違った
+  number、間違った scheme、あるいは null)をカバーします。
+
 ---
 
 ### facet を意識した context 供給 (G530)

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -894,6 +894,48 @@ matching は、20 件を超えた実際の duplicate を見逃す可能性と、
   件の一致 → fail closed、non-mutating、exit 1 — 曖昧さが自動的に
   解決されることは決してありません。
 
+**Round-5 review repair — GitHub enumeration は raised limit ではなく
+本物の cursor pagination であり、body normalization はより厳格に、
+queue-state の cardinality も検証されます。** さらなる review round
+で、固定の `--limit`(どれだけ高くても)は、filter 後の結果がそれを
+超えた場合に本物の duplicate を silently に drop しうる cap のままで
+あること、そして candidate/expected body への一律の `Trim()` が、
+leading indentation が異なる Markdown(例えばcode block)を同一として
+受け入れてしまいうることが判明しました。
+
+- GitHub existence check は今や `gh api graphql` を使い、本物の
+  `search(... first: 100, after: $cursor)` cursor-pagination loop を
+  実行します — `state=all` は維持され(open と closed の両方の issue
+  が参加します)、loop は `pageInfo.hasNextPage` が true である限り
+  継続し、固定件数で止まるのではなくすべての page を蓄積します。
+  `hasNextPage: true` かつ `endCursor` が無い page や、内部の safety
+  ceiling(50 page / 5,000 candidate)以内に終了しない結果セットは、
+  silently に truncate するのではなく fail loud します
+  (`InvalidOperationException`)。
+- body normalization は今や改行変換(`\r\n`/`\r` → `\n`)と、「末尾に
+  ちょうど 1 つの改行がある」ことを「末尾に改行が無い」ことと同等と
+  みなす処理(GitHub 自身の storage convention)**だけ**を行い、
+  `Trim()` はもう呼び出しません。leading indentation、inner の
+  spacing、改行の**前**にある trailing whitespace はすべて保持され、
+  厳密に比較されます — そのため、たった 1 つの leading あるいは
+  interior space が異なるだけの body は、正しく**別の** issue として
+  扱われ、一致とはみなされません。
+- `queue-state.json` の `ReadQueueSignal` は、最初に一致した item を
+  返すのではなく、execution unit に一致する**すべて**の item を
+  収集するようになりました — 同一 unit に対する 2 つ目の item は、
+  それらが一致していようと矛盾していようと関係なく fail closed し
+  (`queue_state_duplicate_execution_unit`、一致するすべての index と
+  identity を named します)、identity が JSON array の順序に依存する
+  ことは決してありません。
+- 新しい test は、command level で使われる `IGitHubExistingIssueChecker`
+  interface stub だけでなく、**本物の** `GhCliExistingIssueChecker`
+  production class を、`PageFetcherOverride` という test seam経由で
+  end-to-end に検証します — 実際の `gh` process の spawn だけを
+  canned GraphQL JSON に置き換えます。multi-page の open+closed
+  蓄積、2 つの fail-loud-on-truncation path、body-normalization の
+  matrix(byte-identical / CRLF vs LF / single-trailing-newline /
+  leading / inner / trailing whitespace drift)をカバーします。
+
 ---
 
 ### facet を意識した context 供給 (G530)

--- a/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
@@ -184,6 +184,14 @@ internal static class AutomationPublishRecoveryCommand
             }
         }
 
+        // G536 review repair: attach the SAME shared-analyzer gap
+        // identifiers `issue publish-flow`'s idempotent rerun reports for
+        // this execution unit, so the two surfaces can never disagree
+        // about what durable state is missing.
+        var unsafeStopsWithGaps = analysis.UnsafeStops
+            .Select(stop => AttachDurableArtifactGaps(context, repo!, stop))
+            .ToArray();
+
         var result = new AutomationPublishRecoveryResult
         {
             Repo = repo!,
@@ -192,7 +200,7 @@ internal static class AutomationPublishRecoveryCommand
             Domain = domain,
             QueueStatePath = queueStatePath,
             SafeRepairs = analysis.SafeRepairs,
-            UnsafeStops = analysis.UnsafeStops,
+            UnsafeStops = unsafeStopsWithGaps,
             AppliedCount = applied.Count,
             Warnings = failures,
             Summary = BuildSummary(analysis, applied.Count, write),
@@ -269,6 +277,38 @@ internal static class AutomationPublishRecoveryCommand
         var reinvocation = $"intent-cli automation publish-recovery --repo {repo} --domain <name>"
             + (selectedPr is int pr ? $" --pr {pr}" : string.Empty);
         return PacketDomainResolution.Resolve(explicitDomain, packetDeclaredDomain, candidateDomains, reinvocation);
+    }
+
+    /// <summary>
+    /// G536 review repair: independently re-analyzes this stop's execution
+    /// unit via the SAME <see cref="PublishDurableArtifactAnalyzer"/>
+    /// <c>issue publish-flow</c> consults, so an unsafe stop here always
+    /// names the identical gaps a rerun would restore for the same durable
+    /// state. Skips synthetic PR-scoped placeholder units (e.g.
+    /// <c>&lt;selected-pr-5&gt;</c>) that have no real execution unit to
+    /// analyze.
+    /// </summary>
+    private static PublishRecoveryUnsafeStop AttachDurableArtifactGaps(
+        CliContext context, string repo, PublishRecoveryUnsafeStop stop)
+    {
+        if (stop.ExecutionUnit.StartsWith('<'))
+        {
+            return stop;
+        }
+
+        var queueStatePath = context.GetQueueStatePath();
+        var runLogPath = context.GetRunLogPath();
+        var publishYamlPath = Path.Combine(
+            context.RepoRoot,
+            IssuePublishArtifactPathResolver.Resolve(stop.ExecutionUnit).Replace('/', Path.DirectorySeparatorChar));
+
+        var analysis = PublishDurableArtifactAnalyzer.Analyze(
+            stop.ExecutionUnit, repo, queueStatePath, publishYamlPath, runLogPath);
+
+        var gaps = analysis.IsInvalid
+            ? new[] { $"{analysis.InvalidReason}: {analysis.InvalidDetail}" }
+            : analysis.Gaps;
+        return stop with { DurableArtifactGaps = gaps };
     }
 
     private static IReadOnlyList<PublishRecoveryCandidate> BuildCandidates(CliContext context, QueueState queueState)
@@ -455,6 +495,10 @@ internal static class AutomationPublishRecoveryCommand
             foreach (var stop in result.UnsafeStops)
             {
                 writer.WriteLine($"- `{stop.Kind}` on `{stop.ExecutionUnit}`: {stop.Reason}");
+                if (stop.DurableArtifactGaps is { Count: > 0 } gaps)
+                {
+                    writer.WriteLine($"  - durable_artifact_gaps: {string.Join(", ", gaps)}");
+                }
             }
         }
     }

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -1453,9 +1453,16 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
     internal IReadOnlyList<GhIssueListEntry> FetchAllCandidates(string repo, string executionUnit)
     {
         var fetchPage = PageFetcherOverride ?? RunGh;
-        var searchQuery = $"repo:{repo} {executionUnit} in:title";
+        // G536 round-6 review repair: `is:issue` — GraphQL search
+        // `type: ISSUE` covers BOTH issues and pull requests; without this
+        // qualifier a matching PR would come back as a node with no Issue
+        // fields (deserializing to an empty/default entry) instead of
+        // being excluded. `state:` is deliberately never added — omitting
+        // it is what keeps both open and closed issues in scope.
+        var searchQuery = $"repo:{repo} {executionUnit} in:title is:issue";
         var results = new List<GhIssueListEntry>();
         string? cursor = null;
+        var seenCursors = new HashSet<string>(StringComparer.Ordinal);
 
         for (var page = 0; ; page++)
         {
@@ -1486,23 +1493,94 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
                 throw new InvalidOperationException($"gh api graphql returned unparseable JSON: {exception.Message}");
             }
 
+            // G536 round-6 review repair: a GraphQL response can carry a
+            // non-empty `errors` array alongside partial `data` (the spec
+            // permits both simultaneously) — that partial data must never
+            // be treated as authoritative. Checked BEFORE touching `data`
+            // at all.
+            if (response?.Errors is { Count: > 0 } errors)
+            {
+                var messages = string.Join("; ", errors.Select(error => error.Message ?? "(no message)"));
+                throw new InvalidOperationException(
+                    $"gh api graphql returned error(s) for the issue-existence check on '{executionUnit}' ({repo}): {messages}");
+            }
+
             var search = response?.Data?.Search
                 ?? throw new InvalidOperationException("gh api graphql returned no search data for the issue-existence check.");
 
-            results.AddRange(search.Nodes);
+            // G536 round-6 review repair: validate every candidate BEFORE
+            // accumulating it — a malformed/incomplete authoritative
+            // response must fail loud here, not be silently carried
+            // forward to discover only after classification (or worse,
+            // after a restoration write) that the fetched identity was
+            // never trustworthy.
+            foreach (var node in search.Nodes)
+            {
+                results.Add(ValidateCandidate(node, repo));
+            }
 
             if (!search.PageInfo.HasNextPage)
             {
                 break;
             }
 
-            cursor = search.PageInfo.EndCursor
+            var nextCursor = search.PageInfo.EndCursor
                 ?? throw new InvalidOperationException(
                     "gh api graphql reported hasNextPage=true with no endCursor; refusing to silently stop "
                     + "pagination short of the real result set.");
+
+            if (!seenCursors.Add(nextCursor))
+            {
+                throw new InvalidOperationException(
+                    $"gh api graphql returned repeated cursor '{nextCursor}'; the pagination loop would re-fetch "
+                    + "the same page indefinitely. Refusing to loop until the safety cap — investigate the "
+                    + "GraphQL search API response.");
+            }
+
+            cursor = nextCursor;
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// G536 round-6 review repair: a candidate must be a complete,
+    /// self-consistent authoritative record before it is ever accumulated
+    /// — a positive issue number, a non-null/non-empty title, a non-null
+    /// body (required to prove content linkage later; a null body is an
+    /// invalid provider response, never silently treated as empty text),
+    /// and a URL matching the canonical
+    /// <c>https://github.com/&lt;requested repo&gt;/issues/&lt;number&gt;</c>
+    /// shape EXACTLY for the repo this check was scoped to.
+    /// </summary>
+    internal static GhIssueListEntry ValidateCandidate(GhIssueListEntry entry, string repo)
+    {
+        if (entry.Number <= 0)
+        {
+            throw new InvalidOperationException(
+                $"gh api graphql returned a candidate with a non-positive issue number ({entry.Number}) for repo '{repo}'.");
+        }
+
+        if (string.IsNullOrEmpty(entry.Title))
+        {
+            throw new InvalidOperationException(
+                $"gh api graphql returned candidate #{entry.Number} on '{repo}' with a null/empty title.");
+        }
+
+        if (entry.Body is null)
+        {
+            throw new InvalidOperationException(
+                $"gh api graphql returned candidate #{entry.Number} on '{repo}' with a null body; cannot verify content linkage.");
+        }
+
+        var expectedUrl = $"https://github.com/{repo}/issues/{entry.Number}";
+        if (!string.Equals(entry.Url, expectedUrl, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"gh api graphql returned candidate #{entry.Number} with url '{entry.Url ?? "(null)"}'; expected exactly '{expectedUrl}'.");
+        }
+
+        return entry;
     }
 
     private static string RunGh(IReadOnlyList<string> arguments)
@@ -1586,7 +1664,11 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
         [property: JsonPropertyName("url")] string Url,
         [property: JsonPropertyName("body")] string? Body);
 
-    private sealed record GraphQlResponse([property: JsonPropertyName("data")] GraphQlData? Data);
+    private sealed record GraphQlResponse(
+        [property: JsonPropertyName("data")] GraphQlData? Data,
+        [property: JsonPropertyName("errors")] List<GraphQlError>? Errors);
+
+    private sealed record GraphQlError([property: JsonPropertyName("message")] string? Message);
 
     private sealed record GraphQlData([property: JsonPropertyName("search")] GraphQlSearch? Search);
 

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -270,8 +270,7 @@ internal static class IssuePublishFlowCommand
         // create, corroborate against GitHub itself. If a matching issue
         // already exists there (e.g. every local artifact was reset/lost
         // but the GitHub issue itself was never re-created), creating here
-        // would produce a genuine duplicate. This check never reconstructs
-        // an identity from the GitHub-side match — it only ever REFUSES.
+        // would produce a genuine duplicate.
         IGitHubExistingIssueChecker existingIssueChecker;
         try
         {
@@ -298,15 +297,15 @@ internal static class IssuePublishFlowCommand
             return 1;
         }
 
-        bool existingIssueFoundOnGitHub;
+        GitHubExistingIssueLookupResult lookup;
         try
         {
-            existingIssueFoundOnGitHub = existingIssueChecker.ExistingIssueFound(repo!, executionUnit!);
+            lookup = existingIssueChecker.FindExistingIssue(repo!, executionUnit!, title!, File.ReadAllText(githubBodyPath));
         }
         catch (Exception exception) when (exception is InvalidOperationException or IOException)
         {
-            // Fail closed: an unresolvable corroboration check must never
-            // be treated as "no existing issue."
+            // Fail closed: an unresolvable corroboration check (a search
+            // failure) must never be treated as "no existing issue."
             var checkerFailedResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
                 packetExists: true,
                 githubBodyPresent: true,
@@ -328,9 +327,9 @@ internal static class IssuePublishFlowCommand
             return 1;
         }
 
-        if (existingIssueFoundOnGitHub)
+        if (lookup.Classification == GitHubExistingIssueClassification.Multiple)
         {
-            var duplicateGuardResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
+            var ambiguousResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
                 packetExists: true,
                 githubBodyPresent: true,
                 missingSections: Array.Empty<string>(),
@@ -343,14 +342,45 @@ internal static class IssuePublishFlowCommand
                 queueStatePatched: false,
                 publishYamlPatched: false,
                 runsAppended: false,
-                error: $"an issue whose title matches '{executionUnit}' already exists on {repo}, but no local "
-                    + "durable artifact (queue-state, publish.yaml, runs.jsonl) recorded it. Refusing to create a "
-                    + $"duplicate. Reconcile manually — confirm the exact issue number, then backfill via "
-                    + $"`intent-cli automation publish-recovery --repo {repo} --write` or a manual queue-state/"
-                    + "publish.yaml/runs.jsonl repair — before re-running.",
+                error: $"multiple issues on {repo} match both the exact expected title and body for '{executionUnit}'; "
+                    + "cannot deterministically pick which one is canonical. Refusing to create or restore around an "
+                    + "ambiguous match — reconcile the duplicate GitHub issues manually, then re-run.",
                 titleSource: titleSource);
-            EmitResult(writer, duplicateGuardResult, format);
+            EmitResult(writer, ambiguousResult, format);
             return 1;
+        }
+
+        if (lookup.Classification == GitHubExistingIssueClassification.Unique)
+        {
+            // G536 round-4 review repair: a unique, exact title+body match
+            // already exists on GitHub even though every local artifact was
+            // lost — feed that identity into the SAME shared analyzer/
+            // restoration path used for a local-signal rerun, so all three
+            // local artifacts are restored WITHOUT ever calling `gh issue
+            // create` (which would produce a genuine duplicate).
+            var githubSourcedAnalysis = PublishDurableArtifactAnalysis.ExistingIssue(
+                lookup.IssueNumber,
+                lookup.IssueUrl!,
+                new[]
+                {
+                    PublishDurableArtifactAnalyzer.GapQueueLinkedIssueMissing,
+                    PublishDurableArtifactAnalyzer.GapPublishYamlMissing,
+                    PublishDurableArtifactAnalyzer.GapRunsEventMissing,
+                });
+            return ExecuteIdempotentRerun(
+                writer,
+                format,
+                executionUnit!,
+                domain,
+                repo!,
+                packetDirectory,
+                githubBodyPath,
+                publishYamlPath,
+                queueStatePathForIdempotency,
+                runLogPathForIdempotency,
+                title,
+                titleSource,
+                githubSourcedAnalysis);
         }
 
         // G363 (PR #830 review repair): atomic-seed gate. The
@@ -1347,20 +1377,41 @@ internal interface IIssueCreator
 internal sealed record IssueCreateOutcome(string IssueUrl);
 
 /// <summary>
-/// G536 review repair: corroborates against GitHub itself, before the
-/// first-create path, that no issue for this execution unit already exists.
-/// This check only ever REFUSES (fails closed) — it never reconstructs a
-/// canonical identity from a fuzzy GitHub-side match; that stays the job of
-/// the local durable artifacts and <see cref="PublishDurableArtifactAnalyzer"/>.
+/// G536 round-4 review repair: corroborates against GitHub itself, before
+/// the first-create path, whether an issue for this execution unit already
+/// exists — classified zero / exactly-one / multiple, never a bare bool.
+/// Matching requires BOTH the exact expected issue title (not a prefix —
+/// "G53" must never match "G536 ...") AND the candidate's body matching
+/// the exact local packet body that would have been (or was) posted to
+/// GitHub, so a merely similarly-titled unrelated issue can never match.
+/// This check never GUESSES or reconstructs identity from a fuzzy match —
+/// zero classifies as "safe to create," exactly-one feeds the confirmed
+/// GitHub identity into the same <see cref="PublishDurableArtifactAnalyzer"/>-
+/// backed restoration path (never a `gh issue create`), and multiple fails
+/// closed, non-mutating.
 /// </summary>
 internal interface IGitHubExistingIssueChecker
 {
-    bool ExistingIssueFound(string repo, string executionUnit);
+    GitHubExistingIssueLookupResult FindExistingIssue(string repo, string executionUnit, string expectedTitle, string expectedBody);
+}
+
+internal enum GitHubExistingIssueClassification
+{
+    None,
+    Unique,
+    Multiple,
+}
+
+internal sealed record GitHubExistingIssueLookupResult
+{
+    public required GitHubExistingIssueClassification Classification { get; init; }
+    public int? IssueNumber { get; init; }
+    public string? IssueUrl { get; init; }
 }
 
 internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
 {
-    public bool ExistingIssueFound(string repo, string executionUnit)
+    public GitHubExistingIssueLookupResult FindExistingIssue(string repo, string executionUnit, string expectedTitle, string expectedBody)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -1377,12 +1428,18 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
         startInfo.ArgumentList.Add(repo);
         startInfo.ArgumentList.Add("--state");
         startInfo.ArgumentList.Add("all");
+        // Narrows candidates via GitHub's own title search — a coarse,
+        // fast pre-filter, not the identity check itself (exact title+body
+        // matching below is what actually decides). 1000 (vs the prior
+        // round's 20) so a legitimate duplicate candidate is never
+        // silently dropped by client-side truncation for any realistic
+        // repo's issue history.
         startInfo.ArgumentList.Add("--search");
         startInfo.ArgumentList.Add($"{executionUnit} in:title");
         startInfo.ArgumentList.Add("--json");
-        startInfo.ArgumentList.Add("number,title");
+        startInfo.ArgumentList.Add("number,title,url,body");
         startInfo.ArgumentList.Add("--limit");
-        startInfo.ArgumentList.Add("20");
+        startInfo.ArgumentList.Add("1000");
 
         using var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to start gh process.");
@@ -1406,33 +1463,32 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
             throw new InvalidOperationException($"gh issue list returned unparseable JSON: {exception.Message}");
         }
 
-        if (entries is null)
-        {
-            return false;
-        }
+        var normalizedExpectedBody = NormalizeBody(expectedBody);
+        var candidates = (entries ?? new List<GhIssueListEntry>())
+            .Where(entry => string.Equals(entry.Title, expectedTitle, StringComparison.Ordinal))
+            .Where(entry => string.Equals(NormalizeBody(entry.Body ?? string.Empty), normalizedExpectedBody, StringComparison.Ordinal))
+            .ToArray();
 
-        // Same prefix convention as FormatIssueTitle: a matching issue's
-        // title starts with the execution-unit token followed by a
-        // non-alphanumeric boundary (space, colon, etc.), never a
-        // same-prefix-different-unit false positive like "G53" matching
-        // "G536 ...".
-        return entries.Any(entry => TitleStartsWithExecutionUnit(entry.Title, executionUnit));
+        return candidates.Length switch
+        {
+            0 => new GitHubExistingIssueLookupResult { Classification = GitHubExistingIssueClassification.None },
+            1 => new GitHubExistingIssueLookupResult
+            {
+                Classification = GitHubExistingIssueClassification.Unique,
+                IssueNumber = candidates[0].Number,
+                IssueUrl = candidates[0].Url,
+            },
+            _ => new GitHubExistingIssueLookupResult { Classification = GitHubExistingIssueClassification.Multiple },
+        };
     }
 
-    private static bool TitleStartsWithExecutionUnit(string? title, string executionUnit)
-    {
-        if (string.IsNullOrWhiteSpace(title) || !title.StartsWith(executionUnit, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        return title.Length == executionUnit.Length
-            || !char.IsLetterOrDigit(title[executionUnit.Length]);
-    }
+    private static string NormalizeBody(string body) => body.Replace("\r\n", "\n").Trim();
 
     private sealed record GhIssueListEntry(
         [property: JsonPropertyName("number")] int Number,
-        [property: JsonPropertyName("title")] string Title);
+        [property: JsonPropertyName("title")] string Title,
+        [property: JsonPropertyName("url")] string Url,
+        [property: JsonPropertyName("body")] string? Body);
 }
 
 internal sealed class GhCliIssueCreator : IIssueCreator

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -1409,9 +1409,103 @@ internal sealed record GitHubExistingIssueLookupResult
     public string? IssueUrl { get; init; }
 }
 
+/// <summary>
+/// G536 round-5 review repair: enumerates ALL matching issues (open and
+/// closed — <c>state=all</c>, matching the previous rounds' contract) via
+/// GraphQL cursor pagination rather than a fixed <c>--limit</c>, so a real
+/// duplicate can never be silently dropped by a result-count cap. Any page
+/// that reports <c>hasNextPage: true</c> without an <c>endCursor</c>, or a
+/// result set that does not terminate within <see cref="MaxPages"/> pages,
+/// fails loud rather than silently truncating.
+/// </summary>
 internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
 {
+    // Safety ceiling, not a silent cap: if genuinely exceeded, FetchAllCandidates
+    // throws (fails loud) rather than returning a truncated, incomplete result.
+    private const int MaxPages = 50;
+
+    private const string GraphQlQuery = """
+        query($searchQuery: String!, $cursor: String) {
+          search(query: $searchQuery, type: ISSUE, first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              ... on Issue { number title url body }
+            }
+          }
+        }
+        """;
+
+    /// <summary>
+    /// Test seam: replaces the real <c>gh api graphql</c> shell-out for a
+    /// single page. Production default shells to <c>gh</c>; tests inject a
+    /// fake returning canned GraphQL JSON so the real pagination loop,
+    /// truncation guard, and candidate classification/normalization below
+    /// are exercised end-to-end without spawning a process.
+    /// </summary>
+    internal Func<IReadOnlyList<string>, string>? PageFetcherOverride { get; init; }
+
     public GitHubExistingIssueLookupResult FindExistingIssue(string repo, string executionUnit, string expectedTitle, string expectedBody)
+    {
+        var allCandidates = FetchAllCandidates(repo, executionUnit);
+        return ClassifyCandidates(allCandidates, expectedTitle, expectedBody);
+    }
+
+    internal IReadOnlyList<GhIssueListEntry> FetchAllCandidates(string repo, string executionUnit)
+    {
+        var fetchPage = PageFetcherOverride ?? RunGh;
+        var searchQuery = $"repo:{repo} {executionUnit} in:title";
+        var results = new List<GhIssueListEntry>();
+        string? cursor = null;
+
+        for (var page = 0; ; page++)
+        {
+            if (page >= MaxPages)
+            {
+                throw new InvalidOperationException(
+                    $"gh api graphql issue search for '{executionUnit}' on {repo} did not complete within "
+                    + $"{MaxPages} pages ({MaxPages * 100} candidates); refusing to silently truncate the "
+                    + "candidate set. Narrow the search or investigate an unexpectedly large result set.");
+            }
+
+            var arguments = new List<string> { "api", "graphql", "-f", $"query={GraphQlQuery}", "-f", $"searchQuery={searchQuery}" };
+            if (cursor is not null)
+            {
+                arguments.Add("-f");
+                arguments.Add($"cursor={cursor}");
+            }
+
+            var stdout = fetchPage(arguments);
+
+            GraphQlResponse? response;
+            try
+            {
+                response = JsonSerializer.Deserialize<GraphQlResponse>(stdout);
+            }
+            catch (JsonException exception)
+            {
+                throw new InvalidOperationException($"gh api graphql returned unparseable JSON: {exception.Message}");
+            }
+
+            var search = response?.Data?.Search
+                ?? throw new InvalidOperationException("gh api graphql returned no search data for the issue-existence check.");
+
+            results.AddRange(search.Nodes);
+
+            if (!search.PageInfo.HasNextPage)
+            {
+                break;
+            }
+
+            cursor = search.PageInfo.EndCursor
+                ?? throw new InvalidOperationException(
+                    "gh api graphql reported hasNextPage=true with no endCursor; refusing to silently stop "
+                    + "pagination short of the real result set.");
+        }
+
+        return results;
+    }
+
+    private static string RunGh(IReadOnlyList<string> arguments)
     {
         var startInfo = new ProcessStartInfo
         {
@@ -1422,24 +1516,10 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
             StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
             StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom
         };
-        startInfo.ArgumentList.Add("issue");
-        startInfo.ArgumentList.Add("list");
-        startInfo.ArgumentList.Add("--repo");
-        startInfo.ArgumentList.Add(repo);
-        startInfo.ArgumentList.Add("--state");
-        startInfo.ArgumentList.Add("all");
-        // Narrows candidates via GitHub's own title search — a coarse,
-        // fast pre-filter, not the identity check itself (exact title+body
-        // matching below is what actually decides). 1000 (vs the prior
-        // round's 20) so a legitimate duplicate candidate is never
-        // silently dropped by client-side truncation for any realistic
-        // repo's issue history.
-        startInfo.ArgumentList.Add("--search");
-        startInfo.ArgumentList.Add($"{executionUnit} in:title");
-        startInfo.ArgumentList.Add("--json");
-        startInfo.ArgumentList.Add("number,title,url,body");
-        startInfo.ArgumentList.Add("--limit");
-        startInfo.ArgumentList.Add("1000");
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
 
         using var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to start gh process.");
@@ -1450,21 +1530,17 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
 
         if (process.ExitCode != 0)
         {
-            throw new InvalidOperationException($"gh issue list exit {process.ExitCode}: {stderr.Trim()}");
+            throw new InvalidOperationException($"gh api graphql exit {process.ExitCode}: {stderr.Trim()}");
         }
 
-        List<GhIssueListEntry>? entries;
-        try
-        {
-            entries = JsonSerializer.Deserialize<List<GhIssueListEntry>>(stdout);
-        }
-        catch (JsonException exception)
-        {
-            throw new InvalidOperationException($"gh issue list returned unparseable JSON: {exception.Message}");
-        }
+        return stdout;
+    }
 
+    internal static GitHubExistingIssueLookupResult ClassifyCandidates(
+        IReadOnlyList<GhIssueListEntry> allCandidates, string expectedTitle, string expectedBody)
+    {
         var normalizedExpectedBody = NormalizeBody(expectedBody);
-        var candidates = (entries ?? new List<GhIssueListEntry>())
+        var candidates = allCandidates
             .Where(entry => string.Equals(entry.Title, expectedTitle, StringComparison.Ordinal))
             .Where(entry => string.Equals(NormalizeBody(entry.Body ?? string.Empty), normalizedExpectedBody, StringComparison.Ordinal))
             .ToArray();
@@ -1482,13 +1558,45 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
         };
     }
 
-    private static string NormalizeBody(string body) => body.Replace("\r\n", "\n").Trim();
+    /// <summary>
+    /// G536 round-5 review repair: the only permitted normalization is
+    /// line-ending conversion (CRLF/CR → LF) and equating "ends with
+    /// exactly one trailing newline" with "no trailing newline" (GitHub's
+    /// own storage/rendering convention). Unlike a blanket <c>Trim()</c>,
+    /// this NEVER touches leading whitespace/indentation or any other
+    /// interior/trailing whitespace — an indented Markdown code block (or
+    /// any other authored whitespace) is semantically significant, so a
+    /// body that differs only in a single trailing newline is treated as
+    /// identical, but any other whitespace drift is treated as a genuine
+    /// difference (not the same issue).
+    /// </summary>
+    internal static string NormalizeBody(string body)
+    {
+        var normalized = body.Replace("\r\n", "\n").Replace("\r", "\n");
+        if (normalized.EndsWith('\n'))
+        {
+            normalized = normalized[..^1];
+        }
+        return normalized;
+    }
 
-    private sealed record GhIssueListEntry(
+    internal sealed record GhIssueListEntry(
         [property: JsonPropertyName("number")] int Number,
         [property: JsonPropertyName("title")] string Title,
         [property: JsonPropertyName("url")] string Url,
         [property: JsonPropertyName("body")] string? Body);
+
+    private sealed record GraphQlResponse([property: JsonPropertyName("data")] GraphQlData? Data);
+
+    private sealed record GraphQlData([property: JsonPropertyName("search")] GraphQlSearch? Search);
+
+    private sealed record GraphQlSearch(
+        [property: JsonPropertyName("pageInfo")] GraphQlPageInfo PageInfo,
+        [property: JsonPropertyName("nodes")] List<GhIssueListEntry> Nodes);
+
+    private sealed record GraphQlPageInfo(
+        [property: JsonPropertyName("hasNextPage")] bool HasNextPage,
+        [property: JsonPropertyName("endCursor")] string? EndCursor);
 }
 
 internal sealed class GhCliIssueCreator : IIssueCreator

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -1508,7 +1508,23 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
             var search = response?.Data?.Search
                 ?? throw new InvalidOperationException("gh api graphql returned no search data for the issue-existence check.");
 
-            // G536 round-6 review repair: validate every candidate BEFORE
+            // G536 round-7 review repair: a JSON `null` for a "non-nullable"
+            // shape (pageInfo / nodes / an individual node) deserializes
+            // silently rather than throwing — never dereference it without
+            // an explicit check first, or an incomplete authoritative
+            // response degrades into an incidental NullReferenceException
+            // instead of an intentional provider diagnostic.
+            if (search.PageInfo is null)
+            {
+                throw new InvalidOperationException("gh api graphql returned a search result with no pageInfo.");
+            }
+
+            if (search.Nodes is null)
+            {
+                throw new InvalidOperationException("gh api graphql returned a search result with no nodes array.");
+            }
+
+            // G536 round-6/7 review repair: validate every candidate BEFORE
             // accumulating it — a malformed/incomplete authoritative
             // response must fail loud here, not be silently carried
             // forward to discover only after classification (or worse,
@@ -1516,6 +1532,13 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
             // never trustworthy.
             foreach (var node in search.Nodes)
             {
+                if (node is null)
+                {
+                    throw new InvalidOperationException(
+                        "gh api graphql returned a null node in the search results; refusing to process an "
+                        + "incomplete authoritative response.");
+                }
+
                 results.Add(ValidateCandidate(node, repo));
             }
 
@@ -1524,10 +1547,18 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
                 break;
             }
 
-            var nextCursor = search.PageInfo.EndCursor
-                ?? throw new InvalidOperationException(
-                    "gh api graphql reported hasNextPage=true with no endCursor; refusing to silently stop "
-                    + "pagination short of the real result set.");
+            // G536 round-7 review repair: null, empty, AND whitespace-only
+            // are all a missing cursor — a bare `?? throw` only caught the
+            // null case, letting an empty-string endCursor be sent back as
+            // `cursor=` on the next request and recorded into seenCursors
+            // as if it were a real value.
+            var nextCursor = search.PageInfo.EndCursor;
+            if (string.IsNullOrWhiteSpace(nextCursor))
+            {
+                throw new InvalidOperationException(
+                    "gh api graphql reported hasNextPage=true with a missing endCursor (null, empty, or "
+                    + "whitespace-only); refusing to silently stop pagination short of the real result set.");
+            }
 
             if (!seenCursors.Add(nextCursor))
             {
@@ -1673,8 +1704,8 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
     private sealed record GraphQlData([property: JsonPropertyName("search")] GraphQlSearch? Search);
 
     private sealed record GraphQlSearch(
-        [property: JsonPropertyName("pageInfo")] GraphQlPageInfo PageInfo,
-        [property: JsonPropertyName("nodes")] List<GhIssueListEntry> Nodes);
+        [property: JsonPropertyName("pageInfo")] GraphQlPageInfo? PageInfo,
+        [property: JsonPropertyName("nodes")] List<GhIssueListEntry?>? Nodes);
 
     private sealed record GraphQlPageInfo(
         [property: JsonPropertyName("hasNextPage")] bool HasNextPage,

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -186,53 +186,43 @@ internal static class IssuePublishFlowCommand
         }
 
         var queueStatePathForIdempotency = context.GetQueueStatePath();
+        var runLogPathForIdempotency = context.GetRunLogPath();
 
-        // G278 idempotency: if publish.yaml already records issue-created with a
-        // URL, do NOT call gh again and do NOT re-mutate durable state.
-        if (TryReadExistingIssueCreatedArtifact(publishYamlPath, out var existing))
-        {
-            var idempotentResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
-                packetExists: true,
-                githubBodyPresent: true,
-                missingSections: Array.Empty<string>(),
-                title: title,
-                created: false,
-                idempotent: true,
-                durableStateSynced: true,
-                issueUrl: existing.CreatedIssueUrl,
-                issueNumber: existing.CreatedIssueNumber,
-                queueStatePatched: false,
-                publishYamlPatched: false,
-                runsAppended: false,
-                error: null,
-                titleSource: titleSource);
-            EmitResult(writer, idempotentResult, format);
-            return 0;
-        }
+        // G536: detect whether the GitHub issue already exists via EITHER
+        // signal (publish.yaml issue-created marker OR queue-state
+        // linked_issue), WITHOUT yet trusting either one alone as proof
+        // that all THREE durable artifacts (queue-state linked_issue,
+        // publish.yaml, runs.jsonl issue-created event) are actually in
+        // sync. Field incident (2026-07-19, G530/#1164): a concurrent
+        // host-main advance forced a stash+ff-sync mid-publish, and the
+        // pre-G536 short-circuit (whichever signal fired first won
+        // immediately, unconditionally reporting durable_state_synced:true)
+        // reported synced while queue-state's linked_issue and the runs.jsonl
+        // issue-created event were both actually missing.
+        var hasPublishYamlSignal = TryReadExistingIssueCreatedArtifact(publishYamlPath, out var publishYamlArtifact);
+        var hasQueueStateSignal = TryReadExistingQueueStateLinkedIssue(
+            queueStatePathForIdempotency, executionUnit!, out var queueLinkedIssueSignal);
 
-        // G278 idempotency (PR #660 follow-up): if publish.yaml is missing or stale
-        // but queue-state.json already records linked_issue for this execution
-        // unit, treat as idempotent so a rerun cannot create a duplicate GitHub
-        // issue. Both artifact-level checks must short-circuit before any gh call.
-        if (TryReadExistingQueueStateLinkedIssue(queueStatePathForIdempotency, executionUnit!, out var queueLinkedIssue))
+        if (hasPublishYamlSignal || hasQueueStateSignal)
         {
-            var queueIdempotentResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
-                packetExists: true,
-                githubBodyPresent: true,
-                missingSections: Array.Empty<string>(),
-                title: title,
-                created: false,
-                idempotent: true,
-                durableStateSynced: true,
-                issueUrl: queueLinkedIssue.Url,
-                issueNumber: queueLinkedIssue.Number,
-                queueStatePatched: false,
-                publishYamlPatched: false,
-                runsAppended: false,
-                error: null,
-                titleSource: titleSource);
-            EmitResult(writer, queueIdempotentResult, format);
-            return 0;
+            return ExecuteIdempotentRerun(
+                context,
+                writer,
+                format,
+                executionUnit!,
+                domain,
+                repo!,
+                packetDirectory,
+                githubBodyPath,
+                publishYamlPath,
+                queueStatePathForIdempotency,
+                runLogPathForIdempotency,
+                title,
+                titleSource,
+                hasPublishYamlSignal,
+                publishYamlArtifact,
+                hasQueueStateSignal,
+                queueLinkedIssueSignal);
         }
 
         // G363 (PR #830 review repair): atomic-seed gate. The
@@ -435,6 +425,290 @@ internal static class IssuePublishFlowCommand
             titleSource: titleSource);
         EmitResult(writer, successResult, format);
         return 0;
+    }
+
+    /// <summary>
+    /// G536: the idempotent-rerun path. At least one signal (publish.yaml
+    /// or queue-state linked_issue) already proves the GitHub issue for
+    /// this execution unit exists — establish the canonical issue identity
+    /// from whichever signal(s) are present (refusing to proceed on a
+    /// genuine contradiction between them), then independently verify and,
+    /// where missing, RESTORE each of the three durable artifacts
+    /// (queue-state linked_issue, publish.yaml, runs.jsonl issue-created
+    /// event) against that identity. Reports <c>durable_state_synced:
+    /// true</c> only when all three verify after restoration; otherwise
+    /// fails loud (exit 1) naming exactly which artifacts remain
+    /// missing/inconsistent and the recovery command, never a false
+    /// "synced" positive.
+    /// </summary>
+    private static int ExecuteIdempotentRerun(
+        CliContext context,
+        TextWriter writer,
+        string format,
+        string executionUnit,
+        string domain,
+        string repo,
+        string packetDirectory,
+        string githubBodyPath,
+        string publishYamlPath,
+        string queueStatePath,
+        string runLogPath,
+        string? title,
+        string? titleSource,
+        bool hasPublishYamlSignal,
+        IssuePublishArtifact publishYamlArtifact,
+        bool hasQueueStateSignal,
+        LinkedIssue queueLinkedIssueSignal)
+    {
+        // Establish the canonical issue identity. Prefer publish.yaml when
+        // both signals are present (matches the pre-G536 precedence), but
+        // refuse to proceed if the two signals materially disagree on the
+        // issue number — that is a genuine data contradiction, not a
+        // "missing artifact," and must never be silently resolved either
+        // direction.
+        if (hasPublishYamlSignal && hasQueueStateSignal
+            && publishYamlArtifact.CreatedIssueNumber.HasValue
+            && queueLinkedIssueSignal.Number.HasValue
+            && publishYamlArtifact.CreatedIssueNumber.Value != queueLinkedIssueSignal.Number.Value)
+        {
+            var contradictionResult = NewResult(executionUnit, domain, repo, packetDirectory, githubBodyPath, publishYamlPath, write: true,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                idempotent: true,
+                durableStateSynced: false,
+                issueUrl: publishYamlArtifact.CreatedIssueUrl,
+                issueNumber: publishYamlArtifact.CreatedIssueNumber,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
+                error: $"durable-state contradiction for '{executionUnit}': publish.yaml at {publishYamlPath} records "
+                    + $"issue #{publishYamlArtifact.CreatedIssueNumber} but queue-state.json records issue "
+                    + $"#{queueLinkedIssueSignal.Number} for the same execution unit. Refusing to pick one "
+                    + "automatically — inspect both artifacts, correct whichever is stale, then re-run "
+                    + $"`intent-cli issue publish-flow {executionUnit} --repo {repo} --write`.",
+                titleSource: titleSource);
+            EmitResult(writer, contradictionResult, format);
+            return 1;
+        }
+
+        int? canonicalIssueNumber;
+        string canonicalIssueUrl;
+        if (hasPublishYamlSignal)
+        {
+            canonicalIssueNumber = publishYamlArtifact.CreatedIssueNumber;
+            canonicalIssueUrl = publishYamlArtifact.CreatedIssueUrl!;
+        }
+        else
+        {
+            canonicalIssueNumber = queueLinkedIssueSignal.Number;
+            canonicalIssueUrl = queueLinkedIssueSignal.Url!;
+        }
+
+        var restoredAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var restoredArtifacts = new HashSet<string>(StringComparer.Ordinal);
+        var problems = new List<string>();
+
+        // 1) queue-state.json linked_issue
+        bool queueStateOk;
+        if (hasQueueStateSignal && QueueLinkedIssueMatchesCanonical(queueLinkedIssueSignal, repo, canonicalIssueNumber, canonicalIssueUrl))
+        {
+            queueStateOk = true;
+        }
+        else if (hasQueueStateSignal)
+        {
+            queueStateOk = false;
+            problems.Add(
+                $"queue-state.json linked_issue points to {queueLinkedIssueSignal.Repo}#{queueLinkedIssueSignal.Number} "
+                + $"({queueLinkedIssueSignal.Url}), which does not match the canonical {repo}#{canonicalIssueNumber} "
+                + $"({canonicalIssueUrl})");
+        }
+        else
+        {
+            try
+            {
+                queueStateOk = TryPatchQueueStateLinkedIssue(
+                    queueStatePath, executionUnit, repo, canonicalIssueNumber, canonicalIssueUrl, restoredAt);
+                if (queueStateOk)
+                {
+                    restoredArtifacts.Add("queue_state");
+                }
+                else
+                {
+                    problems.Add(
+                        File.Exists(queueStatePath)
+                            ? $"queue-state.json has no item with execution_unit '{executionUnit}' to restore linked_issue onto"
+                            : $"queue-state.json not found at {queueStatePath}");
+                }
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                queueStateOk = false;
+                problems.Add($"queue-state.json linked_issue restoration failed: {exception.Message}");
+            }
+        }
+
+        // 2) publish.yaml
+        bool publishYamlOk;
+        if (hasPublishYamlSignal && PublishArtifactMatchesCanonical(publishYamlArtifact, canonicalIssueNumber, canonicalIssueUrl))
+        {
+            publishYamlOk = true;
+        }
+        else if (hasPublishYamlSignal)
+        {
+            // Only reachable when the contradiction check above didn't
+            // already refuse — i.e. one side lacked a number to compare.
+            // Treat as inconsistent rather than silently overwriting.
+            publishYamlOk = false;
+            problems.Add(
+                $"publish.yaml at {publishYamlPath} does not match the canonical {repo}#{canonicalIssueNumber} "
+                + $"({canonicalIssueUrl})");
+        }
+        else
+        {
+            try
+            {
+                publishYamlOk = WritePublishArtifact(
+                    publishYamlPath, packetDirectory, githubBodyPath, executionUnit, canonicalIssueNumber, canonicalIssueUrl);
+                if (publishYamlOk)
+                {
+                    restoredArtifacts.Add("publish_yaml");
+                }
+                else
+                {
+                    problems.Add($"publish.yaml at {publishYamlPath} was not written");
+                }
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                publishYamlOk = false;
+                problems.Add($"publish.yaml restoration failed: {exception.Message}");
+            }
+        }
+
+        // 3) runs.jsonl issue-created event
+        bool runsOk = RunsLogHasIssueCreatedEvent(runLogPath, executionUnit);
+        if (!runsOk)
+        {
+            try
+            {
+                runsOk = AppendIssueCreatedRunEvent(
+                    runLogPath, executionUnit, repo, canonicalIssueNumber, canonicalIssueUrl, restoredAt);
+                if (runsOk)
+                {
+                    restoredArtifacts.Add("runs");
+                }
+                else
+                {
+                    problems.Add($"runs.jsonl at {runLogPath} did not receive the issue-created event");
+                }
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                runsOk = false;
+                problems.Add($"runs.jsonl issue-created event restoration failed: {exception.Message}");
+            }
+        }
+
+        var fullySynced = queueStateOk && publishYamlOk && runsOk;
+
+        var result = NewResult(executionUnit, domain, repo, packetDirectory, githubBodyPath, publishYamlPath, write: true,
+            packetExists: true,
+            githubBodyPresent: true,
+            missingSections: Array.Empty<string>(),
+            title: title,
+            created: false,
+            idempotent: true,
+            durableStateSynced: fullySynced,
+            issueUrl: canonicalIssueUrl,
+            issueNumber: canonicalIssueNumber,
+            queueStatePatched: restoredArtifacts.Contains("queue_state"),
+            publishYamlPatched: restoredArtifacts.Contains("publish_yaml"),
+            runsAppended: restoredArtifacts.Contains("runs"),
+            error: fullySynced
+                ? null
+                : $"GitHub issue {canonicalIssueUrl} already exists but parent durable state could not be fully "
+                    + $"restored: {string.Join("; ", problems)}. Recovery: re-run "
+                    + $"`intent-cli issue publish-flow {executionUnit} --repo {repo} --write` after ensuring these "
+                    + "paths are writable, or run `intent-cli automation publish-recovery "
+                    + $"--repo {repo} --write` to reconcile queue-state linkage.",
+            titleSource: titleSource);
+        EmitResult(writer, result, format);
+        return fullySynced ? 0 : 1;
+    }
+
+    private static bool QueueLinkedIssueMatchesCanonical(
+        LinkedIssue linkedIssue, string repo, int? issueNumber, string issueUrl)
+    {
+        if (!string.Equals(linkedIssue.Repo, repo, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (issueNumber.HasValue && linkedIssue.Number.HasValue && linkedIssue.Number.Value != issueNumber.Value)
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(linkedIssue.Url)
+            && !string.IsNullOrWhiteSpace(issueUrl)
+            && !string.Equals(linkedIssue.Url, issueUrl, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool PublishArtifactMatchesCanonical(
+        IssuePublishArtifact artifact, int? issueNumber, string issueUrl)
+    {
+        if (!string.Equals(artifact.PublishStatus, PublishStatusIssueCreated, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(artifact.CreatedIssueUrl))
+        {
+            return false;
+        }
+
+        if (issueNumber.HasValue && artifact.CreatedIssueNumber.HasValue
+            && artifact.CreatedIssueNumber.Value != issueNumber.Value)
+        {
+            return false;
+        }
+
+        return string.Equals(artifact.CreatedIssueUrl, issueUrl, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G536: scans runs.jsonl for an existing <c>issue-created</c> event for
+    /// this execution unit, so the idempotent-rerun restoration never
+    /// appends a duplicate event when one already exists.
+    /// </summary>
+    private static bool RunsLogHasIssueCreatedEvent(string runLogPath, string executionUnit)
+    {
+        if (!File.Exists(runLogPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            var events = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            return events.Any(runEvent =>
+                string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                && string.Equals(runEvent.Event, IssueCreatedEventName, StringComparison.Ordinal));
+        }
+        catch (Exception exception) when (exception is InvalidOperationException
+            or IOException
+            or System.Text.Json.JsonException)
+        {
+            return false;
+        }
     }
 
     private static bool TryReadExistingIssueCreatedArtifact(string publishYamlPath, out IssuePublishArtifact existing)

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -53,6 +53,15 @@ internal static class IssuePublishFlowCommand
     /// <summary>Test seam — replaces the default <c>gh issue create</c> shell out.</summary>
     public static Func<IIssueCreator>? CreatorFactory { get; set; }
 
+    /// <summary>
+    /// G536 review repair: test seam — replaces the default
+    /// <c>gh issue list --search</c> shell out used to corroborate that no
+    /// GitHub issue already exists before falling through to
+    /// <c>gh issue create</c> when all three local durable artifacts are
+    /// missing.
+    /// </summary>
+    public static Func<IGitHubExistingIssueChecker>? ExistingIssueCheckerFactory { get; set; }
+
     /// <summary>G278: test seam for the durable-state event timestamp.</summary>
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
 
@@ -164,9 +173,32 @@ internal static class IssuePublishFlowCommand
             return 1;
         }
 
-        if (!write)
+        var queueStatePathForIdempotency = context.GetQueueStatePath();
+        var runLogPathForIdempotency = context.GetRunLogPath();
+
+        // G536 review repair: ONE shared, fail-closed analyzer independently
+        // parses all three durable artifacts (queue-state linked_issue,
+        // publish.yaml issue-created record, runs.jsonl issue-created
+        // event(s) — classified zero/exactly-one/duplicate-identical/
+        // conflicting) and resolves a single canonical issue identity, or
+        // fails closed on malformed data or a cross-artifact contradiction.
+        // `AutomationPublishRecoveryCommand` consults the SAME analyzer so
+        // the two surfaces can never disagree about what is missing.
+        //
+        // Field incidents (2026-07-19, G530/#1164 and #1166): a concurrent
+        // host-main advance forced a stash+ff-sync mid-publish. The
+        // pre-G536 short-circuit trusted whichever ONE signal it found
+        // first (publish.yaml or queue-state) and unconditionally reported
+        // durable_state_synced:true without ever checking runs.jsonl —
+        // and a unit whose ONLY surviving signal was runs.jsonl fell
+        // through to the create path entirely, risking a SECOND GitHub
+        // issue for the same execution unit.
+        var analysis = PublishDurableArtifactAnalyzer.Analyze(
+            executionUnit!, repo!, queueStatePathForIdempotency, publishYamlPath, runLogPathForIdempotency);
+
+        if (analysis.IsInvalid)
         {
-            var dryRunResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
+            var invalidResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
                 packetExists: true,
                 githubBodyPresent: true,
                 missingSections: Array.Empty<string>(),
@@ -179,34 +211,45 @@ internal static class IssuePublishFlowCommand
                 queueStatePatched: false,
                 publishYamlPatched: false,
                 runsAppended: false,
-                error: null,
+                error: $"durable-state analysis for '{executionUnit}' failed closed ({analysis.InvalidReason}): "
+                    + $"{analysis.InvalidDetail} Refusing to create, restore, or otherwise guess at this unit's "
+                    + $"state — inspect {analysis.InvalidArtifactPath} manually, then re-run "
+                    + $"`intent-cli issue publish-flow {executionUnit} --repo {repo} --write` once resolved.",
                 titleSource: titleSource);
+            EmitResult(writer, invalidResult, format);
+            return 1;
+        }
+
+        if (!write)
+        {
+            // Dry-run: PLAN only, never write. When the analyzer finds an
+            // existing issue, report the idempotent-rerun plan (canonical
+            // identity plus any artifacts that would be restored) purely
+            // from the read-only analysis — no restoration helper is ever
+            // invoked here.
+            var dryRunResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                idempotent: analysis.HasExistingIssue,
+                durableStateSynced: analysis.IsFullySynced,
+                issueUrl: analysis.CanonicalIssueUrl,
+                issueNumber: analysis.CanonicalIssueNumber,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
+                error: null,
+                titleSource: titleSource,
+                wouldRestore: analysis.HasExistingIssue ? analysis.Gaps : null);
             EmitResult(writer, dryRunResult, format);
             return 0;
         }
 
-        var queueStatePathForIdempotency = context.GetQueueStatePath();
-        var runLogPathForIdempotency = context.GetRunLogPath();
-
-        // G536: detect whether the GitHub issue already exists via EITHER
-        // signal (publish.yaml issue-created marker OR queue-state
-        // linked_issue), WITHOUT yet trusting either one alone as proof
-        // that all THREE durable artifacts (queue-state linked_issue,
-        // publish.yaml, runs.jsonl issue-created event) are actually in
-        // sync. Field incident (2026-07-19, G530/#1164): a concurrent
-        // host-main advance forced a stash+ff-sync mid-publish, and the
-        // pre-G536 short-circuit (whichever signal fired first won
-        // immediately, unconditionally reporting durable_state_synced:true)
-        // reported synced while queue-state's linked_issue and the runs.jsonl
-        // issue-created event were both actually missing.
-        var hasPublishYamlSignal = TryReadExistingIssueCreatedArtifact(publishYamlPath, out var publishYamlArtifact);
-        var hasQueueStateSignal = TryReadExistingQueueStateLinkedIssue(
-            queueStatePathForIdempotency, executionUnit!, out var queueLinkedIssueSignal);
-
-        if (hasPublishYamlSignal || hasQueueStateSignal)
+        if (analysis.HasExistingIssue)
         {
             return ExecuteIdempotentRerun(
-                context,
                 writer,
                 format,
                 executionUnit!,
@@ -219,10 +262,95 @@ internal static class IssuePublishFlowCommand
                 runLogPathForIdempotency,
                 title,
                 titleSource,
-                hasPublishYamlSignal,
-                publishYamlArtifact,
-                hasQueueStateSignal,
-                queueLinkedIssueSignal);
+                analysis);
+        }
+
+        // G536 review repair: the analyzer found NO existing-issue identity
+        // across all three LOCAL artifacts — before falling through to
+        // create, corroborate against GitHub itself. If a matching issue
+        // already exists there (e.g. every local artifact was reset/lost
+        // but the GitHub issue itself was never re-created), creating here
+        // would produce a genuine duplicate. This check never reconstructs
+        // an identity from the GitHub-side match — it only ever REFUSES.
+        IGitHubExistingIssueChecker existingIssueChecker;
+        try
+        {
+            existingIssueChecker = ExistingIssueCheckerFactory?.Invoke() ?? new GhCliExistingIssueChecker();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            var checkerErrorResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                idempotent: false,
+                durableStateSynced: false,
+                issueUrl: null,
+                issueNumber: null,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
+                error: $"failed to initialize GitHub existing-issue check: {exception.Message}",
+                titleSource: titleSource);
+            EmitResult(writer, checkerErrorResult, format);
+            return 1;
+        }
+
+        bool existingIssueFoundOnGitHub;
+        try
+        {
+            existingIssueFoundOnGitHub = existingIssueChecker.ExistingIssueFound(repo!, executionUnit!);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            // Fail closed: an unresolvable corroboration check must never
+            // be treated as "no existing issue."
+            var checkerFailedResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                idempotent: false,
+                durableStateSynced: false,
+                issueUrl: null,
+                issueNumber: null,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
+                error: $"could not verify with GitHub whether an issue for '{executionUnit}' already exists "
+                    + $"({exception.Message}); refusing to create without that corroboration. Retry once GitHub "
+                    + "is reachable.",
+                titleSource: titleSource);
+            EmitResult(writer, checkerFailedResult, format);
+            return 1;
+        }
+
+        if (existingIssueFoundOnGitHub)
+        {
+            var duplicateGuardResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
+                packetExists: true,
+                githubBodyPresent: true,
+                missingSections: Array.Empty<string>(),
+                title: title,
+                created: false,
+                idempotent: false,
+                durableStateSynced: false,
+                issueUrl: null,
+                issueNumber: null,
+                queueStatePatched: false,
+                publishYamlPatched: false,
+                runsAppended: false,
+                error: $"an issue whose title matches '{executionUnit}' already exists on {repo}, but no local "
+                    + "durable artifact (queue-state, publish.yaml, runs.jsonl) recorded it. Refusing to create a "
+                    + $"duplicate. Reconcile manually — confirm the exact issue number, then backfill via "
+                    + $"`intent-cli automation publish-recovery --repo {repo} --write` or a manual queue-state/"
+                    + "publish.yaml/runs.jsonl repair — before re-running.",
+                titleSource: titleSource);
+            EmitResult(writer, duplicateGuardResult, format);
+            return 1;
         }
 
         // G363 (PR #830 review repair): atomic-seed gate. The
@@ -428,21 +556,20 @@ internal static class IssuePublishFlowCommand
     }
 
     /// <summary>
-    /// G536: the idempotent-rerun path. At least one signal (publish.yaml
-    /// or queue-state linked_issue) already proves the GitHub issue for
-    /// this execution unit exists — establish the canonical issue identity
-    /// from whichever signal(s) are present (refusing to proceed on a
-    /// genuine contradiction between them), then independently verify and,
-    /// where missing, RESTORE each of the three durable artifacts
-    /// (queue-state linked_issue, publish.yaml, runs.jsonl issue-created
-    /// event) against that identity. Reports <c>durable_state_synced:
-    /// true</c> only when all three verify after restoration; otherwise
-    /// fails loud (exit 1) naming exactly which artifacts remain
-    /// missing/inconsistent and the recovery command, never a false
-    /// "synced" positive.
+    /// G536 review repair: the idempotent-rerun path. The shared
+    /// <see cref="PublishDurableArtifactAnalyzer"/> already proved a
+    /// canonical issue identity exists and named exactly which of the three
+    /// durable artifacts (queue-state linked_issue, publish.yaml,
+    /// runs.jsonl issue-created event) are genuinely missing — this method
+    /// restores ONLY those, never touching an artifact the analyzer found
+    /// present (whether correct or, on a prior contradiction, already
+    /// rejected upstream). After attempting restoration it NEVER trusts the
+    /// write helpers' boolean return values alone: it re-invokes the same
+    /// analyzer against the freshly re-read files and reports
+    /// <c>durable_state_synced: true</c> only when that second, independent
+    /// read confirms zero remaining gaps.
     /// </summary>
     private static int ExecuteIdempotentRerun(
-        CliContext context,
         TextWriter writer,
         string format,
         string executionUnit,
@@ -455,164 +582,112 @@ internal static class IssuePublishFlowCommand
         string runLogPath,
         string? title,
         string? titleSource,
-        bool hasPublishYamlSignal,
-        IssuePublishArtifact publishYamlArtifact,
-        bool hasQueueStateSignal,
-        LinkedIssue queueLinkedIssueSignal)
+        PublishDurableArtifactAnalysis analysis)
     {
-        // Establish the canonical issue identity. Prefer publish.yaml when
-        // both signals are present (matches the pre-G536 precedence), but
-        // refuse to proceed if the two signals materially disagree on the
-        // issue number — that is a genuine data contradiction, not a
-        // "missing artifact," and must never be silently resolved either
-        // direction.
-        if (hasPublishYamlSignal && hasQueueStateSignal
-            && publishYamlArtifact.CreatedIssueNumber.HasValue
-            && queueLinkedIssueSignal.Number.HasValue
-            && publishYamlArtifact.CreatedIssueNumber.Value != queueLinkedIssueSignal.Number.Value)
-        {
-            var contradictionResult = NewResult(executionUnit, domain, repo, packetDirectory, githubBodyPath, publishYamlPath, write: true,
-                packetExists: true,
-                githubBodyPresent: true,
-                missingSections: Array.Empty<string>(),
-                title: title,
-                created: false,
-                idempotent: true,
-                durableStateSynced: false,
-                issueUrl: publishYamlArtifact.CreatedIssueUrl,
-                issueNumber: publishYamlArtifact.CreatedIssueNumber,
-                queueStatePatched: false,
-                publishYamlPatched: false,
-                runsAppended: false,
-                error: $"durable-state contradiction for '{executionUnit}': publish.yaml at {publishYamlPath} records "
-                    + $"issue #{publishYamlArtifact.CreatedIssueNumber} but queue-state.json records issue "
-                    + $"#{queueLinkedIssueSignal.Number} for the same execution unit. Refusing to pick one "
-                    + "automatically — inspect both artifacts, correct whichever is stale, then re-run "
-                    + $"`intent-cli issue publish-flow {executionUnit} --repo {repo} --write`.",
-                titleSource: titleSource);
-            EmitResult(writer, contradictionResult, format);
-            return 1;
-        }
-
-        int? canonicalIssueNumber;
-        string canonicalIssueUrl;
-        if (hasPublishYamlSignal)
-        {
-            canonicalIssueNumber = publishYamlArtifact.CreatedIssueNumber;
-            canonicalIssueUrl = publishYamlArtifact.CreatedIssueUrl!;
-        }
-        else
-        {
-            canonicalIssueNumber = queueLinkedIssueSignal.Number;
-            canonicalIssueUrl = queueLinkedIssueSignal.Url!;
-        }
-
+        var canonicalIssueNumber = analysis.CanonicalIssueNumber;
+        var canonicalIssueUrl = analysis.CanonicalIssueUrl!;
         var restoredAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
         var restoredArtifacts = new HashSet<string>(StringComparer.Ordinal);
-        var problems = new List<string>();
+        var writeProblems = new List<string>();
 
-        // 1) queue-state.json linked_issue
-        bool queueStateOk;
-        if (hasQueueStateSignal && QueueLinkedIssueMatchesCanonical(queueLinkedIssueSignal, repo, canonicalIssueNumber, canonicalIssueUrl))
+        foreach (var gap in analysis.Gaps)
         {
-            queueStateOk = true;
-        }
-        else if (hasQueueStateSignal)
-        {
-            queueStateOk = false;
-            problems.Add(
-                $"queue-state.json linked_issue points to {queueLinkedIssueSignal.Repo}#{queueLinkedIssueSignal.Number} "
-                + $"({queueLinkedIssueSignal.Url}), which does not match the canonical {repo}#{canonicalIssueNumber} "
-                + $"({canonicalIssueUrl})");
-        }
-        else
-        {
-            try
+            switch (gap)
             {
-                queueStateOk = TryPatchQueueStateLinkedIssue(
-                    queueStatePath, executionUnit, repo, canonicalIssueNumber, canonicalIssueUrl, restoredAt);
-                if (queueStateOk)
-                {
-                    restoredArtifacts.Add("queue_state");
-                }
-                else
-                {
-                    problems.Add(
-                        File.Exists(queueStatePath)
-                            ? $"queue-state.json has no item with execution_unit '{executionUnit}' to restore linked_issue onto"
-                            : $"queue-state.json not found at {queueStatePath}");
-                }
-            }
-            catch (Exception exception) when (exception is IOException or InvalidOperationException)
-            {
-                queueStateOk = false;
-                problems.Add($"queue-state.json linked_issue restoration failed: {exception.Message}");
-            }
-        }
+                case PublishDurableArtifactAnalyzer.GapQueueLinkedIssueMissing:
+                    try
+                    {
+                        if (TryPatchQueueStateLinkedIssue(
+                                queueStatePath, executionUnit, repo, canonicalIssueNumber, canonicalIssueUrl, restoredAt))
+                        {
+                            restoredArtifacts.Add("queue_state");
+                        }
+                        else
+                        {
+                            writeProblems.Add(
+                                File.Exists(queueStatePath)
+                                    ? $"queue-state.json has no item with execution_unit '{executionUnit}' to restore linked_issue onto"
+                                    : $"queue-state.json not found at {queueStatePath}");
+                        }
+                    }
+                    catch (Exception exception) when (exception is IOException or InvalidOperationException)
+                    {
+                        writeProblems.Add($"queue-state.json linked_issue restoration failed: {exception.Message}");
+                    }
+                    break;
 
-        // 2) publish.yaml
-        bool publishYamlOk;
-        if (hasPublishYamlSignal && PublishArtifactMatchesCanonical(publishYamlArtifact, canonicalIssueNumber, canonicalIssueUrl))
-        {
-            publishYamlOk = true;
-        }
-        else if (hasPublishYamlSignal)
-        {
-            // Only reachable when the contradiction check above didn't
-            // already refuse — i.e. one side lacked a number to compare.
-            // Treat as inconsistent rather than silently overwriting.
-            publishYamlOk = false;
-            problems.Add(
-                $"publish.yaml at {publishYamlPath} does not match the canonical {repo}#{canonicalIssueNumber} "
-                + $"({canonicalIssueUrl})");
-        }
-        else
-        {
-            try
-            {
-                publishYamlOk = WritePublishArtifact(
-                    publishYamlPath, packetDirectory, githubBodyPath, executionUnit, canonicalIssueNumber, canonicalIssueUrl);
-                if (publishYamlOk)
-                {
-                    restoredArtifacts.Add("publish_yaml");
-                }
-                else
-                {
-                    problems.Add($"publish.yaml at {publishYamlPath} was not written");
-                }
-            }
-            catch (Exception exception) when (exception is IOException or InvalidOperationException)
-            {
-                publishYamlOk = false;
-                problems.Add($"publish.yaml restoration failed: {exception.Message}");
+                case PublishDurableArtifactAnalyzer.GapPublishYamlMissing:
+                    try
+                    {
+                        if (WritePublishArtifact(
+                                publishYamlPath, packetDirectory, githubBodyPath, executionUnit, canonicalIssueNumber, canonicalIssueUrl))
+                        {
+                            restoredArtifacts.Add("publish_yaml");
+                        }
+                        else
+                        {
+                            writeProblems.Add($"publish.yaml at {publishYamlPath} was not written");
+                        }
+                    }
+                    catch (Exception exception) when (exception is IOException or InvalidOperationException)
+                    {
+                        writeProblems.Add($"publish.yaml restoration failed: {exception.Message}");
+                    }
+                    break;
+
+                case PublishDurableArtifactAnalyzer.GapRunsEventMissing:
+                    try
+                    {
+                        if (AppendIssueCreatedRunEvent(
+                                runLogPath, executionUnit, repo, canonicalIssueNumber, canonicalIssueUrl, restoredAt))
+                        {
+                            restoredArtifacts.Add("runs");
+                        }
+                        else
+                        {
+                            writeProblems.Add($"runs.jsonl at {runLogPath} did not receive the issue-created event");
+                        }
+                    }
+                    catch (Exception exception) when (exception is IOException or InvalidOperationException)
+                    {
+                        writeProblems.Add($"runs.jsonl issue-created event restoration failed: {exception.Message}");
+                    }
+                    break;
             }
         }
 
-        // 3) runs.jsonl issue-created event
-        bool runsOk = RunsLogHasIssueCreatedEvent(runLogPath, executionUnit);
-        if (!runsOk)
-        {
-            try
-            {
-                runsOk = AppendIssueCreatedRunEvent(
-                    runLogPath, executionUnit, repo, canonicalIssueNumber, canonicalIssueUrl, restoredAt);
-                if (runsOk)
-                {
-                    restoredArtifacts.Add("runs");
-                }
-                else
-                {
-                    problems.Add($"runs.jsonl at {runLogPath} did not receive the issue-created event");
-                }
-            }
-            catch (Exception exception) when (exception is IOException or InvalidOperationException)
-            {
-                runsOk = false;
-                problems.Add($"runs.jsonl issue-created event restoration failed: {exception.Message}");
-            }
-        }
+        // Never trust the write helpers' boolean returns alone: re-read and
+        // re-analyze all three artifacts from disk before ever reporting
+        // durable_state_synced:true. A concurrent change between the write
+        // above and this re-read (or a write that silently no-opped) is
+        // caught here rather than masked.
+        var reAnalysis = PublishDurableArtifactAnalyzer.Analyze(
+            executionUnit, repo, queueStatePath, publishYamlPath, runLogPath);
+        var fullySynced = reAnalysis.HasExistingIssue && !reAnalysis.IsInvalid && reAnalysis.Gaps.Count == 0;
 
-        var fullySynced = queueStateOk && publishYamlOk && runsOk;
+        string? error = null;
+        if (!fullySynced)
+        {
+            var remaining = new List<string>();
+            if (reAnalysis.IsInvalid)
+            {
+                remaining.Add($"post-restoration re-analysis failed closed ({reAnalysis.InvalidReason}): {reAnalysis.InvalidDetail}");
+            }
+            else if (reAnalysis.Gaps.Count > 0)
+            {
+                remaining.Add($"still missing: {string.Join(", ", reAnalysis.Gaps)}");
+            }
+            if (writeProblems.Count > 0)
+            {
+                remaining.Add(string.Join("; ", writeProblems));
+            }
+
+            error = $"GitHub issue {canonicalIssueUrl} already exists but parent durable state could not be fully "
+                + $"restored: {string.Join("; ", remaining)}. Recovery: re-run "
+                + $"`intent-cli issue publish-flow {executionUnit} --repo {repo} --write` after ensuring these "
+                + "paths are writable, or run `intent-cli automation publish-recovery "
+                + $"--repo {repo} --write` to reconcile queue-state linkage.";
+        }
 
         var result = NewResult(executionUnit, domain, repo, packetDirectory, githubBodyPath, publishYamlPath, write: true,
             packetExists: true,
@@ -622,164 +697,15 @@ internal static class IssuePublishFlowCommand
             created: false,
             idempotent: true,
             durableStateSynced: fullySynced,
-            issueUrl: canonicalIssueUrl,
-            issueNumber: canonicalIssueNumber,
+            issueUrl: reAnalysis.CanonicalIssueUrl ?? canonicalIssueUrl,
+            issueNumber: reAnalysis.CanonicalIssueNumber ?? canonicalIssueNumber,
             queueStatePatched: restoredArtifacts.Contains("queue_state"),
             publishYamlPatched: restoredArtifacts.Contains("publish_yaml"),
             runsAppended: restoredArtifacts.Contains("runs"),
-            error: fullySynced
-                ? null
-                : $"GitHub issue {canonicalIssueUrl} already exists but parent durable state could not be fully "
-                    + $"restored: {string.Join("; ", problems)}. Recovery: re-run "
-                    + $"`intent-cli issue publish-flow {executionUnit} --repo {repo} --write` after ensuring these "
-                    + "paths are writable, or run `intent-cli automation publish-recovery "
-                    + $"--repo {repo} --write` to reconcile queue-state linkage.",
+            error: error,
             titleSource: titleSource);
         EmitResult(writer, result, format);
         return fullySynced ? 0 : 1;
-    }
-
-    private static bool QueueLinkedIssueMatchesCanonical(
-        LinkedIssue linkedIssue, string repo, int? issueNumber, string issueUrl)
-    {
-        if (!string.Equals(linkedIssue.Repo, repo, StringComparison.OrdinalIgnoreCase))
-        {
-            return false;
-        }
-
-        if (issueNumber.HasValue && linkedIssue.Number.HasValue && linkedIssue.Number.Value != issueNumber.Value)
-        {
-            return false;
-        }
-
-        if (!string.IsNullOrWhiteSpace(linkedIssue.Url)
-            && !string.IsNullOrWhiteSpace(issueUrl)
-            && !string.Equals(linkedIssue.Url, issueUrl, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    private static bool PublishArtifactMatchesCanonical(
-        IssuePublishArtifact artifact, int? issueNumber, string issueUrl)
-    {
-        if (!string.Equals(artifact.PublishStatus, PublishStatusIssueCreated, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        if (string.IsNullOrWhiteSpace(artifact.CreatedIssueUrl))
-        {
-            return false;
-        }
-
-        if (issueNumber.HasValue && artifact.CreatedIssueNumber.HasValue
-            && artifact.CreatedIssueNumber.Value != issueNumber.Value)
-        {
-            return false;
-        }
-
-        return string.Equals(artifact.CreatedIssueUrl, issueUrl, StringComparison.Ordinal);
-    }
-
-    /// <summary>
-    /// G536: scans runs.jsonl for an existing <c>issue-created</c> event for
-    /// this execution unit, so the idempotent-rerun restoration never
-    /// appends a duplicate event when one already exists.
-    /// </summary>
-    private static bool RunsLogHasIssueCreatedEvent(string runLogPath, string executionUnit)
-    {
-        if (!File.Exists(runLogPath))
-        {
-            return false;
-        }
-
-        try
-        {
-            var events = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
-            return events.Any(runEvent =>
-                string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
-                && string.Equals(runEvent.Event, IssueCreatedEventName, StringComparison.Ordinal));
-        }
-        catch (Exception exception) when (exception is InvalidOperationException
-            or IOException
-            or System.Text.Json.JsonException)
-        {
-            return false;
-        }
-    }
-
-    private static bool TryReadExistingIssueCreatedArtifact(string publishYamlPath, out IssuePublishArtifact existing)
-    {
-        existing = default!;
-        if (!File.Exists(publishYamlPath))
-        {
-            return false;
-        }
-
-        try
-        {
-            var artifact = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(publishYamlPath));
-            if (string.Equals(artifact.PublishStatus, PublishStatusIssueCreated, StringComparison.Ordinal)
-                && !string.IsNullOrWhiteSpace(artifact.CreatedIssueUrl))
-            {
-                existing = artifact;
-                return true;
-            }
-        }
-        catch (Exception exception) when (exception is InvalidOperationException or IOException)
-        {
-            // fall through; treat as no existing publish artifact
-        }
-
-        return false;
-    }
-
-    private static bool TryReadExistingQueueStateLinkedIssue(
-        string queueStatePath,
-        string executionUnit,
-        out LinkedIssue linkedIssue)
-    {
-        linkedIssue = default!;
-        if (!File.Exists(queueStatePath))
-        {
-            return false;
-        }
-
-        try
-        {
-            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
-            foreach (var item in queueState.Items)
-            {
-                if (!string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                if (item.LinkedIssue is { } existing && !string.IsNullOrWhiteSpace(existing.Url))
-                {
-                    linkedIssue = existing;
-                    return true;
-                }
-
-                break;
-            }
-        }
-        catch (Exception exception) when (exception is InvalidOperationException
-            or IOException
-            or System.Text.Json.JsonException)
-        {
-            // fall through; treat as no idempotency hit.
-            // PR #830 review repair: JsonException added so a
-            // malformed queue-state.json cannot crash this idempotency
-            // probe — it just bypasses the early-exit fast path and
-            // lets the atomic-seed gate (below) handle the malformed
-            // file as "not present" with a structured operator stop.
-        }
-
-        return false;
     }
 
     /// <summary>
@@ -992,7 +918,8 @@ internal static class IssuePublishFlowCommand
         bool publishYamlPatched,
         bool runsAppended,
         string? error,
-        string? titleSource = null)
+        string? titleSource = null,
+        IReadOnlyList<string>? wouldRestore = null)
     {
         var nextSteps = new List<string>();
         if (created)
@@ -1040,6 +967,7 @@ internal static class IssuePublishFlowCommand
             Warnings = string.Equals(titleSource, TitleSourceFallbackUntitled, StringComparison.Ordinal)
                 ? new[] { "title-fallback" }
                 : Array.Empty<string>(),
+            WouldRestore = wouldRestore,
             Error = error
         };
     }
@@ -1104,6 +1032,10 @@ internal static class IssuePublishFlowCommand
         writer.WriteLine($"- created: {(result.Created ? "yes" : "no")}");
         writer.WriteLine($"- idempotent: {(result.Idempotent ? "yes" : "no")}");
         writer.WriteLine($"- durable_state_synced: {(result.DurableStateSynced ? "yes" : "no")}");
+        if (result.WouldRestore is { Count: > 0 } wouldRestore)
+        {
+            writer.WriteLine($"- would_restore: {string.Join(", ", wouldRestore)}");
+        }
         if (result.IssueNumber is { } issueNumber)
         {
             writer.WriteLine($"- issue number: {issueNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
@@ -1414,6 +1346,95 @@ internal interface IIssueCreator
 
 internal sealed record IssueCreateOutcome(string IssueUrl);
 
+/// <summary>
+/// G536 review repair: corroborates against GitHub itself, before the
+/// first-create path, that no issue for this execution unit already exists.
+/// This check only ever REFUSES (fails closed) — it never reconstructs a
+/// canonical identity from a fuzzy GitHub-side match; that stays the job of
+/// the local durable artifacts and <see cref="PublishDurableArtifactAnalyzer"/>.
+/// </summary>
+internal interface IGitHubExistingIssueChecker
+{
+    bool ExistingIssueFound(string repo, string executionUnit);
+}
+
+internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
+{
+    public bool ExistingIssueFound(string repo, string executionUnit)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "gh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom
+        };
+        startInfo.ArgumentList.Add("issue");
+        startInfo.ArgumentList.Add("list");
+        startInfo.ArgumentList.Add("--repo");
+        startInfo.ArgumentList.Add(repo);
+        startInfo.ArgumentList.Add("--state");
+        startInfo.ArgumentList.Add("all");
+        startInfo.ArgumentList.Add("--search");
+        startInfo.ArgumentList.Add($"{executionUnit} in:title");
+        startInfo.ArgumentList.Add("--json");
+        startInfo.ArgumentList.Add("number,title");
+        startInfo.ArgumentList.Add("--limit");
+        startInfo.ArgumentList.Add("20");
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("Failed to start gh process.");
+
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"gh issue list exit {process.ExitCode}: {stderr.Trim()}");
+        }
+
+        List<GhIssueListEntry>? entries;
+        try
+        {
+            entries = JsonSerializer.Deserialize<List<GhIssueListEntry>>(stdout);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException($"gh issue list returned unparseable JSON: {exception.Message}");
+        }
+
+        if (entries is null)
+        {
+            return false;
+        }
+
+        // Same prefix convention as FormatIssueTitle: a matching issue's
+        // title starts with the execution-unit token followed by a
+        // non-alphanumeric boundary (space, colon, etc.), never a
+        // same-prefix-different-unit false positive like "G53" matching
+        // "G536 ...".
+        return entries.Any(entry => TitleStartsWithExecutionUnit(entry.Title, executionUnit));
+    }
+
+    private static bool TitleStartsWithExecutionUnit(string? title, string executionUnit)
+    {
+        if (string.IsNullOrWhiteSpace(title) || !title.StartsWith(executionUnit, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return title.Length == executionUnit.Length
+            || !char.IsLetterOrDigit(title[executionUnit.Length]);
+    }
+
+    private sealed record GhIssueListEntry(
+        [property: JsonPropertyName("number")] int Number,
+        [property: JsonPropertyName("title")] string Title);
+}
+
 internal sealed class GhCliIssueCreator : IIssueCreator
 {
     public IssueCreateOutcome CreateIssue(string repo, string title, string bodyFilePath)
@@ -1541,6 +1562,15 @@ internal sealed record IssuePublishFlowResult
 
     [JsonPropertyName("runs_appended")]
     public required bool RunsAppended { get; init; }
+
+    /// <summary>
+    /// G536: dry-run-only plan of durable artifacts that a subsequent
+    /// <c>--write</c> rerun would restore, taken verbatim from
+    /// <see cref="PublishDurableArtifactAnalysis.Gaps"/>. Null unless an
+    /// existing issue identity was found in dry-run mode.
+    /// </summary>
+    [JsonPropertyName("would_restore")]
+    public IReadOnlyList<string>? WouldRestore { get; init; }
 
     [JsonPropertyName("intent_target_applied")]
     public required bool IntentTargetApplied { get; init; }

--- a/src/IntentSystem.Cli/Commands/PublishDurableArtifactAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PublishDurableArtifactAnalyzer.cs
@@ -1,0 +1,403 @@
+using System.Text.Json;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G536 review repair: the single, shared, fail-closed analyzer for the
+/// three local durable artifacts that record a published GitHub issue for
+/// an execution unit — <c>queue-state.json</c>'s <c>linked_issue</c>,
+/// <c>publish.yaml</c>'s <c>issue-created</c> record, and
+/// <c>runs.jsonl</c>'s <c>issue-created</c> event(s). Used by BOTH
+/// <see cref="IssuePublishFlowCommand"/> (idempotent rerun / dry-run
+/// planning) and <see cref="AutomationPublishRecoveryCommand"/> (gap
+/// reporting), so the two surfaces can never disagree about which
+/// artifacts are missing or in conflict for the same execution unit.
+///
+/// Read-only: never mutates any file. Callers restore missing artifacts
+/// (using their own write helpers) and then re-invoke <see cref="Analyze"/>
+/// to prove the restoration actually landed before claiming synced state
+/// — this analyzer itself has no concept of "success," only "current
+/// state."
+/// </summary>
+internal static class PublishDurableArtifactAnalyzer
+{
+    // Stable gap identifiers — shared verbatim between publish-flow and
+    // publish-recovery output so an operator (or another tool) never has
+    // to reconcile two different vocabularies for the same underlying gap.
+    public const string GapQueueLinkedIssueMissing = "queue_linked_issue_missing";
+    public const string GapPublishYamlMissing = "publish_yaml_missing";
+    public const string GapRunsEventMissing = "runs_event_missing";
+
+    // Fail-closed conditions — never treated as "missing" (which would
+    // invite silent restoration/overwrite); always block identity
+    // resolution entirely.
+    public const string InvalidPublishYamlMalformed = "publish_yaml_malformed";
+    public const string InvalidRunsMalformed = "runs_malformed";
+    public const string InvalidRunsEventConflicting = "runs_event_conflicting";
+    public const string InvalidCrossArtifactContradiction = "cross_artifact_contradiction";
+
+    public static PublishDurableArtifactAnalysis Analyze(
+        string executionUnit,
+        string repo,
+        string queueStatePath,
+        string publishYamlPath,
+        string runLogPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var queueSignal = ReadQueueSignal(queueStatePath, executionUnit, repo);
+        var publishSignal = ReadPublishSignal(publishYamlPath);
+        var runsSignal = ReadRunsSignal(runLogPath, executionUnit);
+
+        // Any artifact that is individually invalid (unreadable/malformed,
+        // or runs carrying conflicting issue-created events) fails the
+        // WHOLE analysis closed immediately — never collapsed into
+        // "missing," which would invite silently overwriting data we
+        // could not actually read.
+        if (publishSignal.Kind == ArtifactSignalKind.Invalid)
+        {
+            return PublishDurableArtifactAnalysis.Invalid(
+                InvalidPublishYamlMalformed, publishSignal.Detail!, publishYamlPath);
+        }
+
+        if (runsSignal.Kind == ArtifactSignalKind.Invalid)
+        {
+            return PublishDurableArtifactAnalysis.Invalid(
+                runsSignal.InvalidReason!, runsSignal.Detail!, runLogPath);
+        }
+
+        var present = new List<(string Source, int? Number, string? Url)>();
+        if (queueSignal.Kind == ArtifactSignalKind.Present)
+        {
+            present.Add(("queue-state.json", queueSignal.IssueNumber, queueSignal.IssueUrl));
+        }
+        if (publishSignal.Kind == ArtifactSignalKind.Present)
+        {
+            present.Add(("publish.yaml", publishSignal.IssueNumber, publishSignal.IssueUrl));
+        }
+        if (runsSignal.Kind == ArtifactSignalKind.Present)
+        {
+            present.Add(("runs.jsonl", runsSignal.IssueNumber, runsSignal.IssueUrl));
+        }
+
+        if (present.Count == 0)
+        {
+            return PublishDurableArtifactAnalysis.NoExistingIssue();
+        }
+
+        var distinctNumbers = present
+            .Select(p => p.Number)
+            .Where(n => n.HasValue)
+            .Select(n => n!.Value)
+            .Distinct()
+            .ToArray();
+
+        if (distinctNumbers.Length > 1)
+        {
+            var detail = string.Join("; ", present
+                .Where(p => p.Number.HasValue)
+                .Select(p => $"{p.Source} records issue #{p.Number}"));
+            return PublishDurableArtifactAnalysis.Invalid(
+                InvalidCrossArtifactContradiction,
+                $"durable artifacts disagree on the issue number for '{executionUnit}': {detail}.",
+                queueStatePath);
+        }
+
+        var canonicalNumber = distinctNumbers.Length == 1 ? distinctNumbers[0] : (int?)null;
+        var canonicalUrl = present.Select(p => p.Url).FirstOrDefault(u => !string.IsNullOrWhiteSpace(u))
+            ?? (canonicalNumber.HasValue ? $"https://github.com/{repo}/issues/{canonicalNumber.Value}" : null);
+
+        var gaps = new List<string>();
+        if (queueSignal.Kind != ArtifactSignalKind.Present)
+        {
+            gaps.Add(GapQueueLinkedIssueMissing);
+        }
+        if (publishSignal.Kind != ArtifactSignalKind.Present)
+        {
+            gaps.Add(GapPublishYamlMissing);
+        }
+        if (runsSignal.Kind != ArtifactSignalKind.Present)
+        {
+            gaps.Add(GapRunsEventMissing);
+        }
+
+        return PublishDurableArtifactAnalysis.ExistingIssue(canonicalNumber, canonicalUrl!, gaps);
+    }
+
+    private enum ArtifactSignalKind
+    {
+        /// <summary>No usable identity from this artifact (file absent, or present but not yet recording a created issue) — not an error.</summary>
+        Absent,
+        /// <summary>This artifact records a specific issue identity.</summary>
+        Present,
+        /// <summary>This artifact exists but could not be read/parsed, or (runs.jsonl only) records CONFLICTING issue-created events — fails the whole analysis closed.</summary>
+        Invalid,
+    }
+
+    private readonly record struct ArtifactSignal(
+        ArtifactSignalKind Kind,
+        int? IssueNumber,
+        string? IssueUrl,
+        string? Detail,
+        string? InvalidReason = null)
+    {
+        public static ArtifactSignal Absent() => new(ArtifactSignalKind.Absent, null, null, null);
+        public static ArtifactSignal Present(int? number, string? url) => new(ArtifactSignalKind.Present, number, url, null);
+        public static ArtifactSignal Invalid(string reason, string detail) => new(ArtifactSignalKind.Invalid, null, null, detail, reason);
+    }
+
+    private static ArtifactSignal ReadQueueSignal(string queueStatePath, string executionUnit, string repo)
+    {
+        if (!File.Exists(queueStatePath))
+        {
+            return ArtifactSignal.Absent();
+        }
+
+        try
+        {
+            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            foreach (var item in queueState.Items)
+            {
+                if (!string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (item.LinkedIssue is { } linked && !string.IsNullOrWhiteSpace(linked.Url))
+                {
+                    return ArtifactSignal.Present(linked.Number, linked.Url);
+                }
+
+                return ArtifactSignal.Absent();
+            }
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
+        {
+            // A malformed queue-state.json is a pre-existing, separately
+            // handled fail-closed condition (the G363 atomic-seed gate and
+            // publish-flow's own queue-state read both already refuse to
+            // proceed on an unparseable file) — treat as absent here so
+            // this analyzer doesn't duplicate that diagnostic; the caller
+            // will hit the existing queue-state-level refusal first.
+        }
+
+        return ArtifactSignal.Absent();
+    }
+
+    private static ArtifactSignal ReadPublishSignal(string publishYamlPath)
+    {
+        if (!File.Exists(publishYamlPath))
+        {
+            return ArtifactSignal.Absent();
+        }
+
+        IssuePublishArtifact artifact;
+        try
+        {
+            artifact = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(publishYamlPath));
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            return ArtifactSignal.Invalid(InvalidPublishYamlMalformed, $"publish.yaml could not be parsed: {exception.Message}");
+        }
+
+        if (!string.Equals(artifact.PublishStatus, IssuePublishFlowCommand.PublishStatusIssueCreated, StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(artifact.CreatedIssueUrl))
+        {
+            // Not yet published (still draft / different lifecycle stage) —
+            // no identity signal from this source, not an error.
+            return ArtifactSignal.Absent();
+        }
+
+        return ArtifactSignal.Present(artifact.CreatedIssueNumber, artifact.CreatedIssueUrl);
+    }
+
+    private static ArtifactSignal ReadRunsSignal(string runLogPath, string executionUnit)
+    {
+        if (!File.Exists(runLogPath))
+        {
+            return ArtifactSignal.Absent();
+        }
+
+        IReadOnlyList<RunEvent> events;
+        try
+        {
+            events = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
+        {
+            return ArtifactSignal.Invalid(InvalidRunsMalformed, $"runs.jsonl could not be parsed: {exception.Message}");
+        }
+
+        var matching = events
+            .Where(runEvent =>
+                string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                && string.Equals(runEvent.Event, IssuePublishFlowCommand.IssueCreatedEventName, StringComparison.Ordinal))
+            .ToArray();
+
+        if (matching.Length == 0)
+        {
+            return ArtifactSignal.Absent();
+        }
+
+        var parsedIdentities = new List<(int? Number, string? Url)>();
+        foreach (var runEvent in matching)
+        {
+            if (!TryParseRunsIssueIdentity(runEvent, out var number, out var url))
+            {
+                return ArtifactSignal.Invalid(
+                    InvalidRunsMalformed,
+                    $"an issue-created run event for '{executionUnit}' could not be parsed into a recognizable "
+                    + "issue identity (neither linked_issue nor reason matched a supported repo#number or issue-URL shape).");
+            }
+
+            parsedIdentities.Add((number, url));
+        }
+
+        var distinctNumbers = parsedIdentities
+            .Select(p => p.Number)
+            .Where(n => n.HasValue)
+            .Select(n => n!.Value)
+            .Distinct()
+            .ToArray();
+
+        if (distinctNumbers.Length > 1)
+        {
+            return ArtifactSignal.Invalid(
+                InvalidRunsEventConflicting,
+                $"runs.jsonl carries {matching.Length} issue-created events for '{executionUnit}' naming "
+                + $"conflicting issue numbers: {string.Join(", ", distinctNumbers.Select(n => $"#{n}"))}.");
+        }
+
+        // Duplicate-IDENTICAL events (same number repeated) are fine — not
+        // a gap, not an error; they simply all agree.
+        var canonical = parsedIdentities[0];
+        return ArtifactSignal.Present(canonical.Number, canonical.Url);
+    }
+
+    /// <summary>
+    /// G536 review repair: parses an issue-created run event's identity
+    /// from whichever documented shape is present. The canonical shape
+    /// (<see cref="IssuePublishFlowCommand.AppendIssueCreatedRunEvent"/>)
+    /// writes <c>linked_issue: "&lt;repo&gt;#&lt;number&gt;"</c> and
+    /// <c>reason: "&lt;issue-url&gt;"</c>. Historical events recorded before
+    /// that convention may carry only a raw issue URL in either field.
+    /// Returns false when neither field matches a recognized shape at all
+    /// — this is what makes an unrecognizable event MALFORMED rather than
+    /// silently treated as absent.
+    /// </summary>
+    private static bool TryParseRunsIssueIdentity(RunEvent runEvent, out int? number, out string? url)
+    {
+        number = null;
+        url = null;
+
+        if (!string.IsNullOrWhiteSpace(runEvent.LinkedIssue))
+        {
+            var hashIndex = runEvent.LinkedIssue.LastIndexOf('#');
+            if (hashIndex >= 0
+                && hashIndex + 1 < runEvent.LinkedIssue.Length
+                && int.TryParse(
+                    runEvent.LinkedIssue[(hashIndex + 1)..],
+                    System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var parsedFromDescriptor))
+            {
+                number = parsedFromDescriptor;
+                url = !string.IsNullOrWhiteSpace(runEvent.Reason) ? runEvent.Reason : null;
+                return true;
+            }
+
+            if (TryParseIssueNumberFromUrl(runEvent.LinkedIssue, out var parsedFromLinkedUrl))
+            {
+                number = parsedFromLinkedUrl;
+                url = runEvent.LinkedIssue;
+                return true;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(runEvent.Reason) && TryParseIssueNumberFromUrl(runEvent.Reason, out var parsedFromReason))
+        {
+            number = parsedFromReason;
+            url = runEvent.Reason;
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseIssueNumberFromUrl(string candidate, out int number)
+    {
+        number = 0;
+        if (!candidate.Contains("/issues/", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var index = candidate.LastIndexOf('/');
+        if (index < 0 || index + 1 >= candidate.Length)
+        {
+            return false;
+        }
+
+        return int.TryParse(
+            candidate[(index + 1)..],
+            System.Globalization.NumberStyles.Integer,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out number);
+    }
+}
+
+/// <summary>
+/// G536 review repair: the outcome of <see cref="PublishDurableArtifactAnalyzer.Analyze"/>.
+/// Exactly one of three shapes: no existing issue (safe to create), an
+/// existing issue with zero or more missing-artifact gaps to restore, or
+/// an invalid/contradictory state that must fail closed and never create.
+/// </summary>
+internal sealed record PublishDurableArtifactAnalysis
+{
+    public required bool HasExistingIssue { get; init; }
+
+    public int? CanonicalIssueNumber { get; init; }
+
+    public string? CanonicalIssueUrl { get; init; }
+
+    /// <summary>Stable gap identifiers for artifacts missing relative to the canonical issue. Empty when fully synced.</summary>
+    public required IReadOnlyList<string> Gaps { get; init; }
+
+    /// <summary>Set only when the analysis fails closed (malformed data or a cross-artifact contradiction) — never create, never silently restore.</summary>
+    public string? InvalidReason { get; init; }
+
+    public string? InvalidDetail { get; init; }
+
+    public string? InvalidArtifactPath { get; init; }
+
+    public bool IsInvalid => InvalidReason is not null;
+
+    public bool IsFullySynced => HasExistingIssue && !IsInvalid && Gaps.Count == 0;
+
+    public static PublishDurableArtifactAnalysis NoExistingIssue() => new()
+    {
+        HasExistingIssue = false,
+        Gaps = Array.Empty<string>(),
+    };
+
+    public static PublishDurableArtifactAnalysis ExistingIssue(int? issueNumber, string issueUrl, IReadOnlyList<string> gaps) => new()
+    {
+        HasExistingIssue = true,
+        CanonicalIssueNumber = issueNumber,
+        CanonicalIssueUrl = issueUrl,
+        Gaps = gaps,
+    };
+
+    public static PublishDurableArtifactAnalysis Invalid(string reason, string detail, string artifactPath) => new()
+    {
+        HasExistingIssue = true,
+        Gaps = Array.Empty<string>(),
+        InvalidReason = reason,
+        InvalidDetail = detail,
+        InvalidArtifactPath = artifactPath,
+    };
+}

--- a/src/IntentSystem.Cli/Commands/PublishDurableArtifactAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PublishDurableArtifactAnalyzer.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -14,6 +16,15 @@ namespace IntentSystem.Cli.Commands;
 /// planning) and <see cref="AutomationPublishRecoveryCommand"/> (gap
 /// reporting), so the two surfaces can never disagree about which
 /// artifacts are missing or in conflict for the same execution unit.
+///
+/// Round-4 review repair: the canonical identity is a full tuple — exact
+/// repo, positive issue number, canonical GitHub issue URL — not merely a
+/// number. Every present signal's repo is validated against the confirmed
+/// target repo (not just against each other), every present signal must be
+/// internally self-consistent (its own number/url/repo fields must agree
+/// with each other), and a malformed/unreadable queue-state.json now fails
+/// closed exactly like publish.yaml/runs.jsonl already did, rather than
+/// being silently treated as absent.
 ///
 /// Read-only: never mutates any file. Callers restore missing artifacts
 /// (using their own write helpers) and then re-invoke <see cref="Analyze"/>
@@ -33,10 +44,23 @@ internal static class PublishDurableArtifactAnalyzer
     // Fail-closed conditions — never treated as "missing" (which would
     // invite silent restoration/overwrite); always block identity
     // resolution entirely.
+    public const string InvalidQueueStateMalformed = "queue_state_malformed";
     public const string InvalidPublishYamlMalformed = "publish_yaml_malformed";
     public const string InvalidRunsMalformed = "runs_malformed";
     public const string InvalidRunsEventConflicting = "runs_event_conflicting";
     public const string InvalidCrossArtifactContradiction = "cross_artifact_contradiction";
+
+    private static readonly Regex GithubIssueUrlRegex = new(
+        @"^https://github\.com/(?<repo>[^\s/]+/[^\s/]+)/issues/(?<number>\d+)/?$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex RepoNumberDescriptorRegex = new(
+        @"^(?<repo>[^\s/]+/[^\s/]+)#(?<number>\d+)$",
+        RegexOptions.Compiled);
+
+    private static readonly Regex BareNumberDescriptorRegex = new(
+        @"^#(?<number>\d+)$",
+        RegexOptions.Compiled);
 
     public static PublishDurableArtifactAnalysis Analyze(
         string executionUnit,
@@ -48,39 +72,39 @@ internal static class PublishDurableArtifactAnalyzer
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
         ArgumentException.ThrowIfNullOrWhiteSpace(repo);
 
-        var queueSignal = ReadQueueSignal(queueStatePath, executionUnit, repo);
-        var publishSignal = ReadPublishSignal(publishYamlPath);
-        var runsSignal = ReadRunsSignal(runLogPath, executionUnit);
+        var queueSignal = ReadQueueSignal(queueStatePath, executionUnit);
+        if (queueSignal.Kind == ArtifactSignalKind.Invalid)
+        {
+            return PublishDurableArtifactAnalysis.Invalid(
+                queueSignal.InvalidReason!, queueSignal.Detail!, queueStatePath);
+        }
 
-        // Any artifact that is individually invalid (unreadable/malformed,
-        // or runs carrying conflicting issue-created events) fails the
-        // WHOLE analysis closed immediately — never collapsed into
-        // "missing," which would invite silently overwriting data we
-        // could not actually read.
+        var publishSignal = ReadPublishSignal(publishYamlPath, executionUnit);
         if (publishSignal.Kind == ArtifactSignalKind.Invalid)
         {
             return PublishDurableArtifactAnalysis.Invalid(
-                InvalidPublishYamlMalformed, publishSignal.Detail!, publishYamlPath);
+                publishSignal.InvalidReason!, publishSignal.Detail!, publishYamlPath);
         }
 
+        var runsSignal = ReadRunsSignal(runLogPath, executionUnit);
         if (runsSignal.Kind == ArtifactSignalKind.Invalid)
         {
             return PublishDurableArtifactAnalysis.Invalid(
                 runsSignal.InvalidReason!, runsSignal.Detail!, runLogPath);
         }
 
-        var present = new List<(string Source, int? Number, string? Url)>();
+        var present = new List<IdentityEntry>();
         if (queueSignal.Kind == ArtifactSignalKind.Present)
         {
-            present.Add(("queue-state.json", queueSignal.IssueNumber, queueSignal.IssueUrl));
+            present.Add(new IdentityEntry("queue-state.json", queueSignal.Repo, queueSignal.IssueNumber, queueSignal.IssueUrl));
         }
         if (publishSignal.Kind == ArtifactSignalKind.Present)
         {
-            present.Add(("publish.yaml", publishSignal.IssueNumber, publishSignal.IssueUrl));
+            present.Add(new IdentityEntry("publish.yaml", publishSignal.Repo, publishSignal.IssueNumber, publishSignal.IssueUrl));
         }
         if (runsSignal.Kind == ArtifactSignalKind.Present)
         {
-            present.Add(("runs.jsonl", runsSignal.IssueNumber, runsSignal.IssueUrl));
+            present.Add(new IdentityEntry("runs.jsonl", runsSignal.Repo, runsSignal.IssueNumber, runsSignal.IssueUrl));
         }
 
         if (present.Count == 0)
@@ -88,26 +112,23 @@ internal static class PublishDurableArtifactAnalyzer
             return PublishDurableArtifactAnalysis.NoExistingIssue();
         }
 
-        var distinctNumbers = present
-            .Select(p => p.Number)
-            .Where(n => n.HasValue)
-            .Select(n => n!.Value)
-            .Distinct()
-            .ToArray();
+        // The confirmed target repo participates in reconciliation as its
+        // own entry — any present signal whose repo disagrees with the
+        // repo this command run is scoped to is a genuine contradiction,
+        // not merely a mismatch between two artifacts.
+        var reconciliationEntries = new List<IdentityEntry> { new("--repo (confirmed target)", repo, null, null) };
+        reconciliationEntries.AddRange(present);
 
-        if (distinctNumbers.Length > 1)
+        if (!TryReconcileIdentities(reconciliationEntries, out var reconciled, out var conflictDetail))
         {
-            var detail = string.Join("; ", present
-                .Where(p => p.Number.HasValue)
-                .Select(p => $"{p.Source} records issue #{p.Number}"));
             return PublishDurableArtifactAnalysis.Invalid(
                 InvalidCrossArtifactContradiction,
-                $"durable artifacts disagree on the issue number for '{executionUnit}': {detail}.",
+                $"durable artifacts disagree on the canonical issue identity for '{executionUnit}': {conflictDetail}.",
                 queueStatePath);
         }
 
-        var canonicalNumber = distinctNumbers.Length == 1 ? distinctNumbers[0] : (int?)null;
-        var canonicalUrl = present.Select(p => p.Url).FirstOrDefault(u => !string.IsNullOrWhiteSpace(u))
+        var canonicalNumber = reconciled.Number;
+        var canonicalUrl = reconciled.Url
             ?? (canonicalNumber.HasValue ? $"https://github.com/{repo}/issues/{canonicalNumber.Value}" : null);
 
         var gaps = new List<string>();
@@ -127,67 +148,141 @@ internal static class PublishDurableArtifactAnalyzer
         return PublishDurableArtifactAnalysis.ExistingIssue(canonicalNumber, canonicalUrl!, gaps);
     }
 
+    private readonly record struct IdentityEntry(string Source, string? Repo, int? Number, string? Url);
+
+    /// <summary>
+    /// Field-by-field n-way reconciliation shared by both the top-level
+    /// cross-artifact check and the within-runs.jsonl multi-event check.
+    /// Any field (repo case-insensitive, number, url exact) with more than
+    /// one DISTINCT non-null value among the entries is a contradiction.
+    /// Entries that leave a field null (an unknown/unparseable value, e.g.
+    /// a legacy runs event with no repo prefix) never contradict — only
+    /// values that are actually present can disagree.
+    /// </summary>
+    private static bool TryReconcileIdentities(
+        IReadOnlyList<IdentityEntry> entries,
+        out IdentityEntry reconciled,
+        out string conflictDetail)
+    {
+        var distinctRepos = entries
+            .Select(e => e.Repo)
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(r => r!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var distinctNumbers = entries
+            .Select(e => e.Number)
+            .Where(n => n.HasValue)
+            .Select(n => n!.Value)
+            .Distinct()
+            .ToArray();
+        var distinctUrls = entries
+            .Select(e => e.Url)
+            .Where(u => !string.IsNullOrWhiteSpace(u))
+            .Select(u => u!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        if (distinctRepos.Length > 1 || distinctNumbers.Length > 1 || distinctUrls.Length > 1)
+        {
+            var parts = entries
+                .Where(e => e.Repo is not null || e.Number.HasValue || e.Url is not null)
+                .Select(e => $"{e.Source} records repo={e.Repo ?? "?"}, number={(e.Number.HasValue ? e.Number.Value.ToString(CultureInfo.InvariantCulture) : "?")}, url={e.Url ?? "?"}");
+            conflictDetail = string.Join("; ", parts);
+            reconciled = default;
+            return false;
+        }
+
+        conflictDetail = string.Empty;
+        reconciled = new IdentityEntry(
+            "reconciled",
+            distinctRepos.Length == 1 ? distinctRepos[0] : null,
+            distinctNumbers.Length == 1 ? distinctNumbers[0] : null,
+            distinctUrls.Length == 1 ? distinctUrls[0] : null);
+        return true;
+    }
+
     private enum ArtifactSignalKind
     {
         /// <summary>No usable identity from this artifact (file absent, or present but not yet recording a created issue) — not an error.</summary>
         Absent,
-        /// <summary>This artifact records a specific issue identity.</summary>
+        /// <summary>This artifact records a specific, internally self-consistent issue identity.</summary>
         Present,
-        /// <summary>This artifact exists but could not be read/parsed, or (runs.jsonl only) records CONFLICTING issue-created events — fails the whole analysis closed.</summary>
+        /// <summary>This artifact exists but could not be read/parsed, is internally self-contradictory, or (runs.jsonl only) records CONFLICTING issue-created events — fails the whole analysis closed.</summary>
         Invalid,
     }
 
     private readonly record struct ArtifactSignal(
         ArtifactSignalKind Kind,
+        string? Repo,
         int? IssueNumber,
         string? IssueUrl,
         string? Detail,
         string? InvalidReason = null)
     {
-        public static ArtifactSignal Absent() => new(ArtifactSignalKind.Absent, null, null, null);
-        public static ArtifactSignal Present(int? number, string? url) => new(ArtifactSignalKind.Present, number, url, null);
-        public static ArtifactSignal Invalid(string reason, string detail) => new(ArtifactSignalKind.Invalid, null, null, detail, reason);
+        public static ArtifactSignal Absent() => new(ArtifactSignalKind.Absent, null, null, null, null);
+        public static ArtifactSignal Present(string? repo, int? number, string? url) => new(ArtifactSignalKind.Present, repo, number, url, null);
+        public static ArtifactSignal Invalid(string reason, string detail) => new(ArtifactSignalKind.Invalid, null, null, null, detail, reason);
     }
 
-    private static ArtifactSignal ReadQueueSignal(string queueStatePath, string executionUnit, string repo)
+    private static ArtifactSignal ReadQueueSignal(string queueStatePath, string executionUnit)
     {
         if (!File.Exists(queueStatePath))
         {
             return ArtifactSignal.Absent();
         }
 
+        QueueState queueState;
         try
         {
-            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
-            foreach (var item in queueState.Items)
-            {
-                if (!string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                if (item.LinkedIssue is { } linked && !string.IsNullOrWhiteSpace(linked.Url))
-                {
-                    return ArtifactSignal.Present(linked.Number, linked.Url);
-                }
-
-                return ArtifactSignal.Absent();
-            }
+            queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
         }
         catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
         {
-            // A malformed queue-state.json is a pre-existing, separately
-            // handled fail-closed condition (the G363 atomic-seed gate and
-            // publish-flow's own queue-state read both already refuse to
-            // proceed on an unparseable file) — treat as absent here so
-            // this analyzer doesn't duplicate that diagnostic; the caller
-            // will hit the existing queue-state-level refusal first.
+            // Round-4 review repair: a malformed queue-state.json must fail
+            // closed here too — publish.yaml or runs.jsonl surviving alone
+            // must never authorize restoration/repair around a
+            // queue-state.json this analyzer could not actually read.
+            return ArtifactSignal.Invalid(InvalidQueueStateMalformed, $"queue-state.json could not be parsed: {exception.Message}");
+        }
+
+        foreach (var item in queueState.Items)
+        {
+            if (!string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (item.LinkedIssue is not { } linked || string.IsNullOrWhiteSpace(linked.Url))
+            {
+                return ArtifactSignal.Absent();
+            }
+
+            if (linked.Number is not int number || number <= 0)
+            {
+                return ArtifactSignal.Invalid(InvalidQueueStateMalformed,
+                    $"queue-state.json linked_issue for '{executionUnit}' has no positive issue number.");
+            }
+
+            if (!TryParseGithubIssueUrl(linked.Url, out var urlRepo, out var urlNumber) || urlNumber != number)
+            {
+                return ArtifactSignal.Invalid(InvalidQueueStateMalformed,
+                    $"queue-state.json linked_issue for '{executionUnit}' is internally inconsistent: number={number}, url='{linked.Url}'.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(linked.Repo) && !string.Equals(linked.Repo, urlRepo, StringComparison.OrdinalIgnoreCase))
+            {
+                return ArtifactSignal.Invalid(InvalidQueueStateMalformed,
+                    $"queue-state.json linked_issue for '{executionUnit}' is internally inconsistent: repo='{linked.Repo}' does not match url='{linked.Url}'.");
+            }
+
+            return ArtifactSignal.Present(!string.IsNullOrWhiteSpace(linked.Repo) ? linked.Repo : urlRepo, number, linked.Url);
         }
 
         return ArtifactSignal.Absent();
     }
 
-    private static ArtifactSignal ReadPublishSignal(string publishYamlPath)
+    private static ArtifactSignal ReadPublishSignal(string publishYamlPath, string executionUnit)
     {
         if (!File.Exists(publishYamlPath))
         {
@@ -212,7 +307,30 @@ internal static class PublishDurableArtifactAnalyzer
             return ArtifactSignal.Absent();
         }
 
-        return ArtifactSignal.Present(artifact.CreatedIssueNumber, artifact.CreatedIssueUrl);
+        // Round-4 review repair: a publish.yaml whose own execution_unit
+        // field doesn't match the unit this path is scoped to is corrupted
+        // data (e.g. copied from another unit's packet), not a genuine
+        // signal for THIS unit — must fail closed, never be silently
+        // accepted because the issue number happened to look plausible.
+        if (!string.Equals(artifact.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+        {
+            return ArtifactSignal.Invalid(InvalidPublishYamlMalformed,
+                $"publish.yaml at the '{executionUnit}' packet path records execution_unit '{artifact.ExecutionUnit}', not '{executionUnit}'.");
+        }
+
+        if (artifact.CreatedIssueNumber is not int number || number <= 0)
+        {
+            return ArtifactSignal.Invalid(InvalidPublishYamlMalformed,
+                $"publish.yaml for '{executionUnit}' has no positive created_issue_number.");
+        }
+
+        if (!TryParseGithubIssueUrl(artifact.CreatedIssueUrl, out var urlRepo, out var urlNumber) || urlNumber != number)
+        {
+            return ArtifactSignal.Invalid(InvalidPublishYamlMalformed,
+                $"publish.yaml for '{executionUnit}' created_issue_url ('{artifact.CreatedIssueUrl}') is not a canonical GitHub issue URL matching created_issue_number {number}.");
+        }
+
+        return ArtifactSignal.Present(urlRepo, number, artifact.CreatedIssueUrl);
     }
 
     private static ArtifactSignal ReadRunsSignal(string runLogPath, string executionUnit)
@@ -243,110 +361,148 @@ internal static class PublishDurableArtifactAnalyzer
             return ArtifactSignal.Absent();
         }
 
-        var parsedIdentities = new List<(int? Number, string? Url)>();
-        foreach (var runEvent in matching)
+        var identities = new List<IdentityEntry>();
+        for (var index = 0; index < matching.Length; index++)
         {
-            if (!TryParseRunsIssueIdentity(runEvent, out var number, out var url))
+            if (!TryParseRunsIssueIdentity(matching[index], out var repo, out var number, out var url))
             {
                 return ArtifactSignal.Invalid(
                     InvalidRunsMalformed,
-                    $"an issue-created run event for '{executionUnit}' could not be parsed into a recognizable "
-                    + "issue identity (neither linked_issue nor reason matched a supported repo#number or issue-URL shape).");
+                    $"an issue-created run event for '{executionUnit}' could not be parsed into a recognizable, "
+                    + "self-consistent issue identity (neither linked_issue nor reason matched a supported "
+                    + "repo#number or issue-URL shape, or the two fields contradicted each other).");
             }
 
-            parsedIdentities.Add((number, url));
+            identities.Add(new IdentityEntry($"runs.jsonl[{index}]", repo, number, url));
         }
 
-        var distinctNumbers = parsedIdentities
-            .Select(p => p.Number)
-            .Where(n => n.HasValue)
-            .Select(n => n!.Value)
-            .Distinct()
-            .ToArray();
-
-        if (distinctNumbers.Length > 1)
+        // Duplicate-IDENTICAL events (every field agrees) are fine — not a
+        // gap, not an error. Events that disagree on ANY field (repo,
+        // number, or url) are a genuine conflict, not a coincidence.
+        if (!TryReconcileIdentities(identities, out var reconciled, out var conflictDetail))
         {
             return ArtifactSignal.Invalid(
                 InvalidRunsEventConflicting,
-                $"runs.jsonl carries {matching.Length} issue-created events for '{executionUnit}' naming "
-                + $"conflicting issue numbers: {string.Join(", ", distinctNumbers.Select(n => $"#{n}"))}.");
+                $"runs.jsonl carries {matching.Length} issue-created event(s) for '{executionUnit}' naming conflicting identities: {conflictDetail}.");
         }
 
-        // Duplicate-IDENTICAL events (same number repeated) are fine — not
-        // a gap, not an error; they simply all agree.
-        var canonical = parsedIdentities[0];
-        return ArtifactSignal.Present(canonical.Number, canonical.Url);
+        return ArtifactSignal.Present(reconciled.Repo, reconciled.Number, reconciled.Url);
     }
 
     /// <summary>
     /// G536 review repair: parses an issue-created run event's identity
-    /// from whichever documented shape is present. The canonical shape
-    /// (<see cref="IssuePublishFlowCommand.AppendIssueCreatedRunEvent"/>)
+    /// from whichever documented shape is present, into a full
+    /// (repo, number, url) tuple. The canonical shape (see
+    /// <see cref="IssuePublishFlowCommand.AppendIssueCreatedRunEvent"/>)
     /// writes <c>linked_issue: "&lt;repo&gt;#&lt;number&gt;"</c> and
-    /// <c>reason: "&lt;issue-url&gt;"</c>. Historical events recorded before
-    /// that convention may carry only a raw issue URL in either field.
-    /// Returns false when neither field matches a recognized shape at all
-    /// — this is what makes an unrecognizable event MALFORMED rather than
-    /// silently treated as absent.
+    /// <c>reason: "&lt;issue-url&gt;"</c>. Historical events recorded
+    /// before that convention may carry only a raw issue URL, or a bare
+    /// <c>#&lt;number&gt;</c> with no repo prefix, in either field.
+    ///
+    /// Round-4 review repair: a canonical GitHub issue URL is required —
+    /// any <c>/issues/</c>-containing string that does NOT match
+    /// <c>https://github.com/&lt;owner&gt;/&lt;repo&gt;/issues/&lt;number&gt;</c>
+    /// exactly is no longer accepted as if it were canonical. When both
+    /// <c>linked_issue</c> and <c>reason</c> yield a repo and/or number,
+    /// they must agree with each other — a single event whose own fields
+    /// contradict each other is itself malformed, not merely "missing a
+    /// repo." Returns false whenever no number can be resolved at all, or
+    /// the event's own fields are self-contradictory.
     /// </summary>
-    private static bool TryParseRunsIssueIdentity(RunEvent runEvent, out int? number, out string? url)
+    private static bool TryParseRunsIssueIdentity(RunEvent runEvent, out string? repo, out int? number, out string? url)
     {
+        repo = null;
         number = null;
         url = null;
 
+        string? descriptorRepo = null;
+        int? descriptorNumber = null;
+        string? urlRepo = null;
+        int? urlNumber = null;
+        string? urlValue = null;
+
         if (!string.IsNullOrWhiteSpace(runEvent.LinkedIssue))
         {
-            var hashIndex = runEvent.LinkedIssue.LastIndexOf('#');
-            if (hashIndex >= 0
-                && hashIndex + 1 < runEvent.LinkedIssue.Length
-                && int.TryParse(
-                    runEvent.LinkedIssue[(hashIndex + 1)..],
-                    System.Globalization.NumberStyles.Integer,
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    out var parsedFromDescriptor))
+            var candidate = runEvent.LinkedIssue.Trim();
+            if (TryParseGithubIssueUrl(candidate, out var parsedRepo, out var parsedNumber))
             {
-                number = parsedFromDescriptor;
-                url = !string.IsNullOrWhiteSpace(runEvent.Reason) ? runEvent.Reason : null;
-                return true;
+                urlRepo = parsedRepo;
+                urlNumber = parsedNumber;
+                urlValue = candidate;
             }
-
-            if (TryParseIssueNumberFromUrl(runEvent.LinkedIssue, out var parsedFromLinkedUrl))
+            else
             {
-                number = parsedFromLinkedUrl;
-                url = runEvent.LinkedIssue;
-                return true;
+                var descriptorMatch = RepoNumberDescriptorRegex.Match(candidate);
+                if (descriptorMatch.Success)
+                {
+                    descriptorRepo = descriptorMatch.Groups["repo"].Value;
+                    descriptorNumber = int.Parse(descriptorMatch.Groups["number"].Value, CultureInfo.InvariantCulture);
+                }
+                else
+                {
+                    var bareMatch = BareNumberDescriptorRegex.Match(candidate);
+                    if (bareMatch.Success)
+                    {
+                        descriptorNumber = int.Parse(bareMatch.Groups["number"].Value, CultureInfo.InvariantCulture);
+                    }
+                }
             }
         }
 
-        if (!string.IsNullOrWhiteSpace(runEvent.Reason) && TryParseIssueNumberFromUrl(runEvent.Reason, out var parsedFromReason))
+        if (!string.IsNullOrWhiteSpace(runEvent.Reason)
+            && TryParseGithubIssueUrl(runEvent.Reason.Trim(), out var reasonRepo, out var reasonNumber))
         {
-            number = parsedFromReason;
-            url = runEvent.Reason;
-            return true;
+            if (urlNumber is int existingUrlNumber && existingUrlNumber != reasonNumber)
+            {
+                return false;
+            }
+            if (urlRepo is not null && !string.Equals(urlRepo, reasonRepo, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            urlRepo ??= reasonRepo;
+            urlNumber ??= reasonNumber;
+            urlValue ??= runEvent.Reason.Trim();
         }
 
-        return false;
+        if (descriptorNumber is int dNum && urlNumber is int uNum && dNum != uNum)
+        {
+            return false;
+        }
+        if (descriptorRepo is not null && urlRepo is not null
+            && !string.Equals(descriptorRepo, urlRepo, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var resolvedNumber = urlNumber ?? descriptorNumber;
+        if (resolvedNumber is not int finalNumber || finalNumber <= 0)
+        {
+            return false;
+        }
+
+        repo = urlRepo ?? descriptorRepo;
+        number = finalNumber;
+        url = urlValue;
+        return true;
     }
 
-    private static bool TryParseIssueNumberFromUrl(string candidate, out int number)
+    private static bool TryParseGithubIssueUrl(string candidate, out string repo, out int number)
     {
+        repo = string.Empty;
         number = 0;
-        if (!candidate.Contains("/issues/", StringComparison.Ordinal))
+        var match = GithubIssueUrlRegex.Match(candidate.Trim());
+        if (!match.Success)
         {
             return false;
         }
 
-        var index = candidate.LastIndexOf('/');
-        if (index < 0 || index + 1 >= candidate.Length)
-        {
-            return false;
-        }
-
+        repo = match.Groups["repo"].Value;
         return int.TryParse(
-            candidate[(index + 1)..],
-            System.Globalization.NumberStyles.Integer,
-            System.Globalization.CultureInfo.InvariantCulture,
-            out number);
+            match.Groups["number"].Value,
+            NumberStyles.Integer,
+            CultureInfo.InvariantCulture,
+            out number) && number > 0;
     }
 }
 

--- a/src/IntentSystem.Cli/Commands/PublishDurableArtifactAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PublishDurableArtifactAnalyzer.cs
@@ -45,6 +45,7 @@ internal static class PublishDurableArtifactAnalyzer
     // invite silent restoration/overwrite); always block identity
     // resolution entirely.
     public const string InvalidQueueStateMalformed = "queue_state_malformed";
+    public const string InvalidQueueStateDuplicateExecutionUnit = "queue_state_duplicate_execution_unit";
     public const string InvalidPublishYamlMalformed = "publish_yaml_malformed";
     public const string InvalidRunsMalformed = "runs_malformed";
     public const string InvalidRunsEventConflicting = "runs_event_conflicting";
@@ -246,40 +247,61 @@ internal static class PublishDurableArtifactAnalyzer
             return ArtifactSignal.Invalid(InvalidQueueStateMalformed, $"queue-state.json could not be parsed: {exception.Message}");
         }
 
-        foreach (var item in queueState.Items)
+        // Round-5 review repair: collect EVERY item matching this execution
+        // unit rather than returning on the first match — identity must
+        // never depend on JSON array order, and a second item (whether it
+        // agrees or conflicts with the first) is itself a data-integrity
+        // problem that must fail closed, not be silently shadowed.
+        var matchingIndices = new List<int>();
+        for (var index = 0; index < queueState.Items.Count; index++)
         {
-            if (!string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            if (string.Equals(queueState.Items[index].ExecutionUnit, executionUnit, StringComparison.Ordinal))
             {
-                continue;
+                matchingIndices.Add(index);
             }
-
-            if (item.LinkedIssue is not { } linked || string.IsNullOrWhiteSpace(linked.Url))
-            {
-                return ArtifactSignal.Absent();
-            }
-
-            if (linked.Number is not int number || number <= 0)
-            {
-                return ArtifactSignal.Invalid(InvalidQueueStateMalformed,
-                    $"queue-state.json linked_issue for '{executionUnit}' has no positive issue number.");
-            }
-
-            if (!TryParseGithubIssueUrl(linked.Url, out var urlRepo, out var urlNumber) || urlNumber != number)
-            {
-                return ArtifactSignal.Invalid(InvalidQueueStateMalformed,
-                    $"queue-state.json linked_issue for '{executionUnit}' is internally inconsistent: number={number}, url='{linked.Url}'.");
-            }
-
-            if (!string.IsNullOrWhiteSpace(linked.Repo) && !string.Equals(linked.Repo, urlRepo, StringComparison.OrdinalIgnoreCase))
-            {
-                return ArtifactSignal.Invalid(InvalidQueueStateMalformed,
-                    $"queue-state.json linked_issue for '{executionUnit}' is internally inconsistent: repo='{linked.Repo}' does not match url='{linked.Url}'.");
-            }
-
-            return ArtifactSignal.Present(!string.IsNullOrWhiteSpace(linked.Repo) ? linked.Repo : urlRepo, number, linked.Url);
         }
 
-        return ArtifactSignal.Absent();
+        if (matchingIndices.Count == 0)
+        {
+            return ArtifactSignal.Absent();
+        }
+
+        if (matchingIndices.Count > 1)
+        {
+            var detail = string.Join("; ", matchingIndices.Select(index =>
+            {
+                var linkedIssue = queueState.Items[index].LinkedIssue;
+                return $"items[{index}] linked_issue={(linkedIssue is null ? "null" : $"{linkedIssue.Repo}#{linkedIssue.Number} ({linkedIssue.Url})")}";
+            }));
+            return ArtifactSignal.Invalid(InvalidQueueStateDuplicateExecutionUnit,
+                $"queue-state.json has {matchingIndices.Count} items for execution_unit '{executionUnit}': {detail}.");
+        }
+
+        var item = queueState.Items[matchingIndices[0]];
+        if (item.LinkedIssue is not { } linked || string.IsNullOrWhiteSpace(linked.Url))
+        {
+            return ArtifactSignal.Absent();
+        }
+
+        if (linked.Number is not int number || number <= 0)
+        {
+            return ArtifactSignal.Invalid(InvalidQueueStateMalformed,
+                $"queue-state.json linked_issue for '{executionUnit}' has no positive issue number.");
+        }
+
+        if (!TryParseGithubIssueUrl(linked.Url, out var urlRepo, out var urlNumber) || urlNumber != number)
+        {
+            return ArtifactSignal.Invalid(InvalidQueueStateMalformed,
+                $"queue-state.json linked_issue for '{executionUnit}' is internally inconsistent: number={number}, url='{linked.Url}'.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(linked.Repo) && !string.Equals(linked.Repo, urlRepo, StringComparison.OrdinalIgnoreCase))
+        {
+            return ArtifactSignal.Invalid(InvalidQueueStateMalformed,
+                $"queue-state.json linked_issue for '{executionUnit}' is internally inconsistent: repo='{linked.Repo}' does not match url='{linked.Url}'.");
+        }
+
+        return ArtifactSignal.Present(!string.IsNullOrWhiteSpace(linked.Repo) ? linked.Repo : urlRepo, number, linked.Url);
     }
 
     private static ArtifactSignal ReadPublishSignal(string publishYamlPath, string executionUnit)

--- a/src/IntentSystem.Cli/Commands/PublishRecoveryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PublishRecoveryAnalyzer.cs
@@ -467,4 +467,16 @@ internal sealed record PublishRecoveryUnsafeStop
     public required string ExecutionUnit { get; init; }
     public required string Reason { get; init; }
     public required string PublishArtifactPath { get; init; }
+
+    /// <summary>
+    /// G536 review repair: the SAME stable gap identifiers
+    /// <see cref="PublishDurableArtifactAnalyzer"/> reports for this
+    /// execution unit (e.g. <c>queue_linked_issue_missing</c>), attached by
+    /// the command layer so an operator — or a test — can directly compare
+    /// this stop against what <c>issue publish-flow</c>'s idempotent rerun
+    /// independently detects and restores for the identical durable state.
+    /// Null for synthetic PR-scoped placeholder stops that have no real
+    /// execution unit to analyze.
+    /// </summary>
+    public IReadOnlyList<string>? DurableArtifactGaps { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
@@ -107,6 +107,47 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_G536FieldIncidentFixture_ReportsSamePartialStateGapAsPublishFlow()
+    {
+        // G536 (publish-flow's idempotent-rerun hardening) acceptance
+        // criterion: "publish-recovery on the same fixture reports the
+        // identical gap set." Reproduces the exact durable-state shape
+        // from the field incident BEFORE any PR exists — queue-state's
+        // linked_issue/linked_pr are both null, but publish.yaml already
+        // records the created issue. publish-recovery must not silently
+        // treat this as "nothing to do" — with no open PR to serve as
+        // closing evidence, it must surface this specific execution unit
+        // as an unsafe stop naming the same gap publish-flow's own rerun
+        // independently detects and (self-)restores.
+        using var workspace = new RecoveryWorkspace();
+        workspace.WriteQueueState(BuildQueueState("G530", linkedIssue: null, linkedPr: null));
+        workspace.WritePublishArtifact("G530", createdIssueNumber: 1164);
+
+        AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(Array.Empty<GitHubAutomationPrCandidate>());
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationPublishRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("safe_repairs").GetArrayLength());
+        var unsafeStops = doc.RootElement.GetProperty("unsafe_stops");
+        Assert.Equal(1, unsafeStops.GetArrayLength());
+        var stop = unsafeStops[0];
+        Assert.Equal("G530", stop.GetProperty("execution_unit").GetString());
+        Assert.Equal("no-closing-pr-for-published-issue", stop.GetProperty("kind").GetString());
+
+        // Mutation invariant: dry-run never writes.
+        var queueAfter = QueueStateSerializer.Deserialize(
+            File.ReadAllText(workspace.Context.GetQueueStatePath()));
+        Assert.Null(queueAfter.Items[0].LinkedIssue);
+        Assert.Null(queueAfter.Items[0].LinkedPr);
+    }
+
+    [Fact]
     public void Execute_AlreadyLinkedItem_NotIncluded()
     {
         using var workspace = new RecoveryWorkspace();

--- a/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationPublishRecoveryCommandTests.cs
@@ -109,42 +109,110 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
     [Fact]
     public void Execute_G536FieldIncidentFixture_ReportsSamePartialStateGapAsPublishFlow()
     {
-        // G536 (publish-flow's idempotent-rerun hardening) acceptance
-        // criterion: "publish-recovery on the same fixture reports the
-        // identical gap set." Reproduces the exact durable-state shape
-        // from the field incident BEFORE any PR exists — queue-state's
-        // linked_issue/linked_pr are both null, but publish.yaml already
-        // records the created issue. publish-recovery must not silently
-        // treat this as "nothing to do" — with no open PR to serve as
-        // closing evidence, it must surface this specific execution unit
-        // as an unsafe stop naming the same gap publish-flow's own rerun
-        // independently detects and (self-)restores.
+        // G536 review repair acceptance criterion: "publish-recovery on the
+        // same fixture reports the identical gap set" — not merely its own
+        // unrelated "no-closing-pr" vocabulary. Reproduces the exact
+        // durable-state shape from the field incident (2026-07-19, G530 as
+        // issue #1164) BEFORE any PR exists: queue-state's linked_issue/
+        // linked_pr are both null, but publish.yaml already records the
+        // created issue and runs.jsonl has no issue-created event. Both
+        // `automation publish-recovery` and `issue publish-flow`'s
+        // idempotent rerun now consult the SAME
+        // PublishDurableArtifactAnalyzer — this test proves that parity
+        // directly by running BOTH commands against the identical on-disk
+        // fixture and asserting their gap lists are byte-for-byte equal,
+        // instead of asserting one command's kind string in isolation.
         using var workspace = new RecoveryWorkspace();
+        var title = "G530 Facet-aware context supply";
         workspace.WriteQueueState(BuildQueueState("G530", linkedIssue: null, linkedPr: null));
         workspace.WritePublishArtifact("G530", createdIssueNumber: 1164);
+        workspace.WriteGithubBody("G530", BuildCompleteContractBody(title));
 
         AutomationPublishRecoveryCommand.CandidateListerFactory = () => new FakePrLister(Array.Empty<GitHubAutomationPrCandidate>());
 
-        using var writer = new StringWriter();
-        var exitCode = AutomationPublishRecoveryCommand.Execute(
+        using var recoveryWriter = new StringWriter();
+        var recoveryExit = AutomationPublishRecoveryCommand.Execute(
             workspace.Context,
             ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--format", "json"],
-            writer);
+            recoveryWriter);
 
-        Assert.Equal(0, exitCode);
-        using var doc = JsonDocument.Parse(writer.ToString());
-        Assert.Equal(0, doc.RootElement.GetProperty("safe_repairs").GetArrayLength());
-        var unsafeStops = doc.RootElement.GetProperty("unsafe_stops");
+        Assert.Equal(0, recoveryExit);
+        using var recoveryDoc = JsonDocument.Parse(recoveryWriter.ToString());
+        Assert.Equal(0, recoveryDoc.RootElement.GetProperty("safe_repairs").GetArrayLength());
+        var unsafeStops = recoveryDoc.RootElement.GetProperty("unsafe_stops");
         Assert.Equal(1, unsafeStops.GetArrayLength());
         var stop = unsafeStops[0];
         Assert.Equal("G530", stop.GetProperty("execution_unit").GetString());
-        Assert.Equal("no-closing-pr-for-published-issue", stop.GetProperty("kind").GetString());
+        var recoveryGaps = stop.GetProperty("durable_artifact_gaps").EnumerateArray()
+            .Select(e => e.GetString())
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToArray();
 
-        // Mutation invariant: dry-run never writes.
+        using var publishFlowWriter = new StringWriter();
+        var publishFlowExit = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G530", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            publishFlowWriter);
+
+        Assert.Equal(0, publishFlowExit);
+        using var publishFlowDoc = JsonDocument.Parse(publishFlowWriter.ToString());
+        Assert.True(publishFlowDoc.RootElement.GetProperty("idempotent").GetBoolean());
+        Assert.False(publishFlowDoc.RootElement.GetProperty("durable_state_synced").GetBoolean());
+        var wouldRestore = publishFlowDoc.RootElement.GetProperty("would_restore").EnumerateArray()
+            .Select(e => e.GetString())
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.NotEmpty(wouldRestore);
+        Assert.Equal(wouldRestore, recoveryGaps);
+
+        // Mutation invariant: dry-run never writes, on either surface.
         var queueAfter = QueueStateSerializer.Deserialize(
             File.ReadAllText(workspace.Context.GetQueueStatePath()));
         Assert.Null(queueAfter.Items[0].LinkedIssue);
         Assert.Null(queueAfter.Items[0].LinkedPr);
+    }
+
+    private static string BuildCompleteContractBody(string title)
+    {
+        return $"""
+            # {title}
+
+            ## Goal
+            x
+
+            ## Why This Slice Exists Now
+            x
+
+            ## Current Observed State
+            x
+
+            ## Accepted Baseline You May Assume
+            x
+
+            ## Target Repo / Path / Part
+            x
+
+            ## In Scope
+            - x
+
+            ## Out Of Scope
+            - x
+
+            ## Acceptance Criteria
+            - x
+
+            ## Verification
+            x
+
+            ## Related Links
+            - x
+
+            ## Base Branch Policy
+            Policy: `direct-main`
+            Expected PR base branch: `main`
+            Open all child PRs against `main` directly.
+            """;
     }
 
     [Fact]
@@ -905,7 +973,13 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
             var artifact = new IssuePublishArtifact
             {
                 ExecutionUnit = executionUnit,
-                PublishStatus = "published",
+                // G536 review repair: use the same canonical status
+                // `IssuePublishFlowCommand.PublishStatusIssueCreated`
+                // ("issue-created") that `PublishDurableArtifactAnalyzer`
+                // recognizes, so this fixture's publish.yaml is a genuine
+                // "present" signal for the shared analyzer, not silently
+                // treated as absent.
+                PublishStatus = IssuePublishFlowCommand.PublishStatusIssueCreated,
                 PacketPath = $".intent-cli/issues/{executionUnit}/packet.yaml",
                 IssueBodyPath = $".intent-cli/issues/{executionUnit}/github-body.md",
                 CreatedIssueNumber = createdIssueNumber,
@@ -925,6 +999,18 @@ public sealed class AutomationPublishRecoveryCommandTests : IDisposable
             var dir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
             Directory.CreateDirectory(dir);
             File.WriteAllText(Path.Combine(dir, "packet.yaml"), $"domain: {domain}\n");
+        }
+
+        /// <summary>
+        /// G536 review repair: seeds a complete Child Issue Contract body so
+        /// <c>issue publish-flow</c> can also run against this exact
+        /// workspace/fixture, for cross-command gap-parity assertions.
+        /// </summary>
+        public void WriteGithubBody(string executionUnit, string content)
+        {
+            var dir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "github-body.md"), content);
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/GhCliExistingIssueCheckerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GhCliExistingIssueCheckerTests.cs
@@ -168,6 +168,158 @@ public sealed class GhCliExistingIssueCheckerTests
         Assert.Equal(GitHubExistingIssueClassification.Multiple, result.Classification);
     }
 
+    // ─── G536 round-6 tests ─────────────────────────────────────────────────
+
+    [Fact]
+    public void FetchAllCandidates_PinsLiteralProductionSearchQuery_IsIssueIncludedNoStateFilter()
+    {
+        IReadOnlyList<string>? capturedArguments = null;
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = arguments =>
+            {
+                capturedArguments = arguments;
+                return GraphQlPage(hasNextPage: false, endCursor: null, nodes: Array.Empty<(int, string, string, string)>());
+            },
+        };
+
+        checker.FetchAllCandidates("acme/widgets", "G536");
+
+        Assert.NotNull(capturedArguments);
+        Assert.Contains("searchQuery=repo:acme/widgets G536 in:title is:issue", capturedArguments!);
+        Assert.DoesNotContain(capturedArguments!, arg => arg.Contains("state:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void FetchAllCandidates_GraphQlErrorsPresentAlongsidePartialData_FailsLoudRatherThanAcceptingPartialData()
+    {
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = _ => GraphQlPageWithErrors(
+                hasNextPage: false,
+                endCursor: null,
+                nodes: new[] { (1, "G536 partial candidate", "https://github.com/acme/widgets/issues/1", "body") },
+                errorMessages: new[] { "Something went wrong while executing your query" }),
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("Something went wrong", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FetchAllCandidates_RepeatedCursor_FailsLoudInsteadOfLoopingUntilSafetyCap()
+    {
+        var pageCalls = 0;
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = arguments =>
+            {
+                pageCalls++;
+                var cursor = ExtractCursor(arguments);
+                // Page 1 (no cursor) -> "cursor-a". Page 2 (cursor-a) also
+                // reports "cursor-a" as its OWN endCursor — a server bug
+                // that would otherwise loop forever.
+                return GraphQlPage(hasNextPage: true, endCursor: "cursor-a", nodes: Array.Empty<(int, string, string, string)>());
+            },
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("repeated cursor", exception.Message, StringComparison.OrdinalIgnoreCase);
+        // Fails on the second occurrence, long before the 50-page safety cap.
+        Assert.Equal(2, pageCalls);
+    }
+
+    [Fact]
+    public void FetchAllCandidates_PageFetcherThrows_PropagatesFailureWithoutSwallowing()
+    {
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = _ => throw new InvalidOperationException("gh api graphql exit 1: authentication required"),
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("authentication required", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FetchAllCandidates_MalformedJson_FailsLoud()
+    {
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = _ => "not json at all",
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("unparseable JSON", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FetchAllCandidates_NodeWithNullBody_FailsLoudRatherThanAccumulating()
+    {
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = _ => "{\"data\":{\"search\":{\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null},"
+                + "\"nodes\":[{\"number\":1,\"title\":\"G536 issue\",\"url\":\"https://github.com/acme/widgets/issues/1\",\"body\":null}]}}}",
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("null body", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateCandidate_HappyPath_ReturnsSameEntry()
+    {
+        var entry = new GhCliExistingIssueChecker.GhIssueListEntry(7, "G536 Title", "https://github.com/acme/widgets/issues/7", "body");
+
+        var validated = GhCliExistingIssueChecker.ValidateCandidate(entry, "acme/widgets");
+
+        Assert.Equal(entry, validated);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ValidateCandidate_NonPositiveNumber_ThrowsFailLoud(int number)
+    {
+        var entry = new GhCliExistingIssueChecker.GhIssueListEntry(number, "G536 Title", $"https://github.com/acme/widgets/issues/{number}", "body");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => GhCliExistingIssueChecker.ValidateCandidate(entry, "acme/widgets"));
+        Assert.Contains("non-positive issue number", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void ValidateCandidate_NullOrEmptyTitle_ThrowsFailLoud(string? title)
+    {
+        var entry = new GhCliExistingIssueChecker.GhIssueListEntry(1, title!, "https://github.com/acme/widgets/issues/1", "body");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => GhCliExistingIssueChecker.ValidateCandidate(entry, "acme/widgets"));
+        Assert.Contains("null/empty title", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateCandidate_NullBody_ThrowsFailLoud()
+    {
+        var entry = new GhCliExistingIssueChecker.GhIssueListEntry(1, "G536 Title", "https://github.com/acme/widgets/issues/1", null);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => GhCliExistingIssueChecker.ValidateCandidate(entry, "acme/widgets"));
+        Assert.Contains("null body", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("https://github.com/other-org/other-repo/issues/1")] // different repo entirely
+    [InlineData("https://github.com/acme/widgets/issues/2")] // number mismatch
+    [InlineData("http://github.com/acme/widgets/issues/1")] // wrong scheme
+    [InlineData(null)]
+    public void ValidateCandidate_UrlNotExactCanonicalForRequestedRepo_ThrowsFailLoud(string? url)
+    {
+        var entry = new GhCliExistingIssueChecker.GhIssueListEntry(1, "G536 Title", url!, "body");
+
+        var exception = Assert.Throws<InvalidOperationException>(() => GhCliExistingIssueChecker.ValidateCandidate(entry, "acme/widgets"));
+        Assert.Contains("expected exactly", exception.Message, StringComparison.Ordinal);
+    }
+
     private static string? ExtractCursor(IReadOnlyList<string> arguments)
     {
         for (var index = 0; index < arguments.Count; index++)
@@ -180,7 +332,14 @@ public sealed class GhCliExistingIssueCheckerTests
         return null;
     }
 
-    private static string GraphQlPage(bool hasNextPage, string? endCursor, IReadOnlyList<(int Number, string Title, string Url, string Body)> nodes)
+    private static string GraphQlPage(bool hasNextPage, string? endCursor, IReadOnlyList<(int Number, string Title, string Url, string Body)> nodes) =>
+        GraphQlPageWithErrors(hasNextPage, endCursor, nodes, errorMessages: null);
+
+    private static string GraphQlPageWithErrors(
+        bool hasNextPage,
+        string? endCursor,
+        IReadOnlyList<(int Number, string Title, string Url, string Body)> nodes,
+        IReadOnlyList<string>? errorMessages)
     {
         var nodesJson = string.Join(",", nodes.Select(n => System.Text.Json.JsonSerializer.Serialize(new
         {
@@ -191,7 +350,16 @@ public sealed class GhCliExistingIssueCheckerTests
         })));
         var endCursorJson = endCursor is null ? "null" : System.Text.Json.JsonSerializer.Serialize(endCursor);
         var hasNextPageJson = hasNextPage ? "true" : "false";
-        return "{\"data\":{\"search\":{\"pageInfo\":{\"hasNextPage\":" + hasNextPageJson
-            + ",\"endCursor\":" + endCursorJson + "},\"nodes\":[" + nodesJson + "]}}}";
+        var dataJson = "{\"search\":{\"pageInfo\":{\"hasNextPage\":" + hasNextPageJson
+            + ",\"endCursor\":" + endCursorJson + "},\"nodes\":[" + nodesJson + "]}}";
+
+        if (errorMessages is null || errorMessages.Count == 0)
+        {
+            return "{\"data\":" + dataJson + "}";
+        }
+
+        var errorsJson = string.Join(",", errorMessages.Select(message =>
+            "{\"message\":" + System.Text.Json.JsonSerializer.Serialize(message) + "}"));
+        return "{\"data\":" + dataJson + ",\"errors\":[" + errorsJson + "]}";
     }
 }

--- a/tests/IntentSystem.Cli.Tests/GhCliExistingIssueCheckerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GhCliExistingIssueCheckerTests.cs
@@ -75,6 +75,88 @@ public sealed class GhCliExistingIssueCheckerTests
         Assert.Contains("hasNextPage=true", exception.Message, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FetchAllCandidates_HasNextPageTrueWithEmptyOrWhitespaceEndCursor_ThrowsRatherThanFetchingAgain(string emptyCursor)
+    {
+        // G536 round-7 review repair: an empty/whitespace-only endCursor
+        // is just as much a "missing cursor" as null — a bare `?? throw`
+        // only rejected null, letting an empty string be sent back as
+        // `cursor=` on the next request and recorded as if it were real.
+        var pageCalls = 0;
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = _ =>
+            {
+                pageCalls++;
+                return GraphQlPage(hasNextPage: true, endCursor: emptyCursor, nodes: Array.Empty<(int, string, string, string)>());
+            },
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("hasNextPage=true", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(1, pageCalls); // never re-fetched with the bad cursor
+    }
+
+    [Theory]
+    [InlineData("null")]
+    [InlineData("[]")]
+    [InlineData("123")]
+    [InlineData("\"just a string\"")]
+    public void FetchAllCandidates_NullOrWrongTypeEnvelope_FailsLoudNotNullReferenceException(string malformedJson)
+    {
+        var checker = new GhCliExistingIssueChecker { PageFetcherOverride = _ => malformedJson };
+
+        // Must be an intentional diagnostic, never an incidental NRE.
+        Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+    }
+
+    [Fact]
+    public void FetchAllCandidates_EmptyOutput_FailsLoudAsUnparseableJson()
+    {
+        var checker = new GhCliExistingIssueChecker { PageFetcherOverride = _ => string.Empty };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("unparseable JSON", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FetchAllCandidates_NullPageInfo_FailsLoudNotNullReferenceException()
+    {
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = _ => "{\"data\":{\"search\":{\"pageInfo\":null,\"nodes\":[]}}}",
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("no pageInfo", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FetchAllCandidates_NullNodesArray_FailsLoudNotNullReferenceException()
+    {
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = _ => "{\"data\":{\"search\":{\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null},\"nodes\":null}}}",
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("no nodes array", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FetchAllCandidates_NullNodeWithinNodesArray_FailsLoudNotNullReferenceException()
+    {
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = _ => "{\"data\":{\"search\":{\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null},\"nodes\":[null]}}}",
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("null node", exception.Message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void FetchAllCandidates_NeverTerminates_FailsLoudInsteadOfSilentlyTruncating()
     {

--- a/tests/IntentSystem.Cli.Tests/GhCliExistingIssueCheckerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GhCliExistingIssueCheckerTests.cs
@@ -1,0 +1,197 @@
+using IntentSystem.Cli.Commands;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G536 round-5 review repair: exercises the REAL <see cref="GhCliExistingIssueChecker"/>
+/// production logic end-to-end (pagination loop, truncation guard, exact
+/// title/body classification, and body normalization) via its
+/// <see cref="GhCliExistingIssueChecker.PageFetcherOverride"/> test seam —
+/// only the literal OS process spawn is replaced with canned GraphQL JSON.
+/// This is deliberately NOT the same thing as stubbing
+/// <see cref="IGitHubExistingIssueChecker"/> at the interface level (as
+/// <c>IssuePublishFlowCommandTests</c> does for command-level tests): here
+/// the actual pagination algorithm, cursor handling, and normalization code
+/// that ships in the checker is what runs.
+/// </summary>
+public sealed class GhCliExistingIssueCheckerTests
+{
+    [Fact]
+    public void FetchAllCandidates_MultiPagePagination_AccumulatesEveryPageOpenAndClosed()
+    {
+        var pageCalls = new List<IReadOnlyList<string>>();
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = arguments =>
+            {
+                pageCalls.Add(arguments);
+                var cursor = ExtractCursor(arguments);
+                return cursor switch
+                {
+                    null => GraphQlPage(
+                        hasNextPage: true,
+                        endCursor: "cursor-a",
+                        nodes: new[]
+                        {
+                            (1, "G536 first open issue", "https://github.com/acme/widgets/issues/1", "body one"),
+                            (2, "G536 second open issue", "https://github.com/acme/widgets/issues/2", "body two"),
+                        }),
+                    "cursor-a" => GraphQlPage(
+                        hasNextPage: true,
+                        endCursor: "cursor-b",
+                        nodes: new[]
+                        {
+                            (3, "G536 a closed issue", "https://github.com/acme/widgets/issues/3", "body three"),
+                        }),
+                    "cursor-b" => GraphQlPage(
+                        hasNextPage: false,
+                        endCursor: null,
+                        nodes: new[]
+                        {
+                            (4, "G536 last page issue", "https://github.com/acme/widgets/issues/4", "body four"),
+                        }),
+                    _ => throw new InvalidOperationException($"unexpected cursor '{cursor}' in test"),
+                };
+            },
+        };
+
+        var all = checker.FetchAllCandidates("acme/widgets", "G536");
+
+        Assert.Equal(3, pageCalls.Count);
+        Assert.Equal(new[] { 1, 2, 3, 4 }, all.Select(e => e.Number).ToArray());
+        // state=all contract preserved — GraphQL search query never adds a state qualifier.
+        Assert.DoesNotContain(pageCalls[0], arg => arg.Contains("state:"));
+    }
+
+    [Fact]
+    public void FetchAllCandidates_HasNextPageTrueWithNoEndCursor_ThrowsRatherThanStoppingSilently()
+    {
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = _ => GraphQlPage(hasNextPage: true, endCursor: null, nodes: Array.Empty<(int, string, string, string)>()),
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("hasNextPage=true", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FetchAllCandidates_NeverTerminates_FailsLoudInsteadOfSilentlyTruncating()
+    {
+        var callCount = 0;
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = _ =>
+            {
+                callCount++;
+                return GraphQlPage(hasNextPage: true, endCursor: $"cursor-{callCount}", nodes: Array.Empty<(int, string, string, string)>());
+            },
+        };
+
+        var exception = Assert.Throws<InvalidOperationException>(() => checker.FetchAllCandidates("acme/widgets", "G536"));
+        Assert.Contains("refusing to silently truncate", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FindExistingIssue_EndToEnd_UniqueExactMatchAcrossTwoPages_ClassifiesUnique()
+    {
+        var checker = new GhCliExistingIssueChecker
+        {
+            PageFetcherOverride = arguments => ExtractCursor(arguments) switch
+            {
+                null => GraphQlPage(
+                    hasNextPage: true,
+                    endCursor: "cursor-a",
+                    nodes: new[] { (10, "G536 unrelated issue", "https://github.com/acme/widgets/issues/10", "unrelated body") }),
+                "cursor-a" => GraphQlPage(
+                    hasNextPage: false,
+                    endCursor: null,
+                    nodes: new[] { (11, "G536 Canonical Title", "https://github.com/acme/widgets/issues/11", "the exact body") }),
+                _ => throw new InvalidOperationException("unexpected cursor"),
+            },
+        };
+
+        var result = checker.FindExistingIssue("acme/widgets", "G536", "G536 Canonical Title", "the exact body");
+
+        Assert.Equal(GitHubExistingIssueClassification.Unique, result.Classification);
+        Assert.Equal(11, result.IssueNumber);
+        Assert.Equal("https://github.com/acme/widgets/issues/11", result.IssueUrl);
+    }
+
+    [Theory]
+    [InlineData("the exact body", "the exact body", true)] // byte-for-byte identical
+    [InlineData("the exact body\n", "the exact body", true)] // GitHub's single trailing newline convention
+    [InlineData("the exact body\r\n", "the exact body\n", true)] // CRLF vs LF
+    [InlineData(" the exact body", "the exact body", false)] // leading space drift must NOT match
+    [InlineData("the  exact body", "the exact body", false)] // inner space drift must NOT match
+    [InlineData("the exact body ", "the exact body", false)] // trailing (non-newline) space drift must NOT match
+    [InlineData("the exact body\n\n", "the exact body", false)] // more than one trailing newline is a real difference
+    public void ClassifyCandidates_BodyNormalization_OnlyLineEndingAndSingleTrailingNewlineAreEquivalent(
+        string candidateBody, string expectedBody, bool shouldMatch)
+    {
+        var candidates = new[]
+        {
+            new GhCliExistingIssueChecker.GhIssueListEntry(1, "G536 Canonical Title", "https://github.com/acme/widgets/issues/1", candidateBody),
+        };
+
+        var result = GhCliExistingIssueChecker.ClassifyCandidates(candidates, "G536 Canonical Title", expectedBody);
+
+        Assert.Equal(
+            shouldMatch ? GitHubExistingIssueClassification.Unique : GitHubExistingIssueClassification.None,
+            result.Classification);
+    }
+
+    [Fact]
+    public void ClassifyCandidates_SimilarTitlePrefix_NeverMatchesExactTitle()
+    {
+        var candidates = new[]
+        {
+            new GhCliExistingIssueChecker.GhIssueListEntry(1, "G53 unrelated but similarly prefixed issue", "https://github.com/acme/widgets/issues/1", "body"),
+        };
+
+        var result = GhCliExistingIssueChecker.ClassifyCandidates(candidates, "G536 Canonical Title", "body");
+
+        Assert.Equal(GitHubExistingIssueClassification.None, result.Classification);
+    }
+
+    [Fact]
+    public void ClassifyCandidates_TwoExactTitleAndBodyMatches_ClassifiesMultiple()
+    {
+        var candidates = new[]
+        {
+            new GhCliExistingIssueChecker.GhIssueListEntry(1, "G536 Canonical Title", "https://github.com/acme/widgets/issues/1", "the exact body"),
+            new GhCliExistingIssueChecker.GhIssueListEntry(2, "G536 Canonical Title", "https://github.com/acme/widgets/issues/2", "the exact body"),
+        };
+
+        var result = GhCliExistingIssueChecker.ClassifyCandidates(candidates, "G536 Canonical Title", "the exact body");
+
+        Assert.Equal(GitHubExistingIssueClassification.Multiple, result.Classification);
+    }
+
+    private static string? ExtractCursor(IReadOnlyList<string> arguments)
+    {
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            if (arguments[index].StartsWith("cursor=", StringComparison.Ordinal))
+            {
+                return arguments[index]["cursor=".Length..];
+            }
+        }
+        return null;
+    }
+
+    private static string GraphQlPage(bool hasNextPage, string? endCursor, IReadOnlyList<(int Number, string Title, string Url, string Body)> nodes)
+    {
+        var nodesJson = string.Join(",", nodes.Select(n => System.Text.Json.JsonSerializer.Serialize(new
+        {
+            number = n.Number,
+            title = n.Title,
+            url = n.Url,
+            body = n.Body,
+        })));
+        var endCursorJson = endCursor is null ? "null" : System.Text.Json.JsonSerializer.Serialize(endCursor);
+        var hasNextPageJson = hasNextPage ? "true" : "false";
+        return "{\"data\":{\"search\":{\"pageInfo\":{\"hasNextPage\":" + hasNextPageJson
+            + ",\"endCursor\":" + endCursorJson + "},\"nodes\":[" + nodesJson + "]}}}";
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
@@ -963,6 +963,94 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenQueueStateHasDuplicateExecutionUnitItems_FailsClosedRegardlessOfAgreement()
+    {
+        // G536 round-5 review repair: a second queue-state item for the
+        // SAME execution unit must fail closed regardless of whether the
+        // two items agree or conflict — identity must never depend on
+        // which one happens to come first in the JSON array.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+
+        var linkedIssue = new LinkedIssue
+        {
+            Repo = "J-Tech-Japan/intent-system",
+            Number = 659,
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/659",
+        };
+        var duplicateState = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = new DateTimeOffset(2026, 7, 19, 3, 0, 0, TimeSpan.Zero),
+            Items = new[]
+            {
+                new QueueItem
+                {
+                    ExecutionUnit = "G278",
+                    Title = title,
+                    State = QueueItemState.Queued,
+                    Dependencies = Array.Empty<string>(),
+                    BlockedBy = Array.Empty<string>(),
+                    ClarificationReturnPath = string.Empty,
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G278/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G278/review-context.md",
+                        Yaml = ".intent-cli/issues/G278/packet.yaml",
+                    },
+                    LinkedIssue = linkedIssue,
+                    WorkerRole = "Claude",
+                    ReviewRole = "Codex",
+                    Priority = "normal",
+                },
+                new QueueItem
+                {
+                    // Even an IDENTICAL second entry (not just a conflicting
+                    // one) must fail closed — cardinality itself is the
+                    // problem, independent of agreement.
+                    ExecutionUnit = "G278",
+                    Title = title,
+                    State = QueueItemState.Queued,
+                    Dependencies = Array.Empty<string>(),
+                    BlockedBy = Array.Empty<string>(),
+                    ClarificationReturnPath = string.Empty,
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = ".intent-cli/issues/G278/implementation.md",
+                        ReviewContext = ".intent-cli/issues/G278/review-context.md",
+                        Yaml = ".intent-cli/issues/G278/packet.yaml",
+                    },
+                    LinkedIssue = linkedIssue,
+                    WorkerRole = "Claude",
+                    ReviewRole = "Codex",
+                    Priority = "normal",
+                },
+            },
+        };
+        Directory.CreateDirectory(Path.GetDirectoryName(workspace.QueueStatePath)!);
+        File.WriteAllText(workspace.QueueStatePath, QueueStateSerializer.Serialize(duplicateState));
+
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("queue_state_duplicate_execution_unit", error, StringComparison.Ordinal);
+        Assert.Contains("items[0]", error, StringComparison.Ordinal);
+        Assert.Contains("items[1]", error, StringComparison.Ordinal);
+
+        // No mutation on refusal.
+        Assert.Equal(2, QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath)).Items.Count);
+    }
+
+    [Fact]
     public void Execute_GivenQueueLinkedIssueFromDifferentRepo_FailsClosedAsCrossRepoContradiction()
     {
         // G536 round-4 review repair: queue-state's linked_issue naming a

--- a/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
@@ -474,8 +474,13 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_GivenLinkedIssueInQueueStateButPublishYamlMissing_IsIdempotentAndDoesNotCallGitHub()
+    public void Execute_GivenLinkedIssueInQueueStateButPublishYamlMissing_RestoresPublishYamlAndRunsEventThenSynced()
     {
+        // G536: queue-state's linked_issue is the only surviving signal —
+        // publish.yaml and runs.jsonl are both missing (as in the field
+        // incident's post-stash/ff-sync state). The rerun must RESTORE both
+        // missing artifacts (never merely report them absent) before
+        // claiming durable_state_synced:true, and must never call gh again.
         using var workspace = new IssuePublishFlowWorkspace();
         workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
         workspace.SeedQueueStateWithLinkedIssue(
@@ -506,13 +511,269 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
         Assert.True(root.GetProperty("durable_state_synced").GetBoolean());
         Assert.Equal(659, root.GetProperty("issue_number").GetInt32());
         Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/659", root.GetProperty("issue_url").GetString());
+        // queue-state already had linked_issue — nothing to patch there.
+        Assert.False(root.GetProperty("queue_state_patched").GetBoolean());
+        // publish.yaml and the runs event were MISSING and are restored this run.
+        Assert.True(root.GetProperty("publish_yaml_patched").GetBoolean());
+        Assert.True(root.GetProperty("runs_appended").GetBoolean());
+
+        // No duplicate gh issue create was made, but both previously-missing
+        // artifacts now exist and reflect the canonical (queue-state) issue.
+        var publishArtifact = IssuePublishArtifactYaml.Deserialize(
+            File.ReadAllText(workspace.PublishYamlPath("G278")));
+        Assert.Equal("issue-created", publishArtifact.PublishStatus);
+        Assert.Equal(659, publishArtifact.CreatedIssueNumber);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/659", publishArtifact.CreatedIssueUrl);
+
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        var restoredEvent = Assert.Single(events);
+        Assert.Equal("issue-created", restoredEvent.Event);
+        Assert.Equal("G278", restoredEvent.ExecutionUnit);
+    }
+
+    [Fact]
+    public void Execute_GivenAllThreeArtifactsAlreadyRestored_SecondRerunIsPureNoOp()
+    {
+        // G536: after a restoring rerun (previous test), a THIRD run must
+        // find all three artifacts already correct and make no further
+        // writes at all — proving restoration itself is idempotent.
+        using var workspace = new IssuePublishFlowWorkspace();
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
+        workspace.SeedQueueStateWithLinkedIssue(
+            "G278",
+            "G278 Fix issue publish-flow durable state synchronization",
+            repo: "J-Tech-Japan/intent-system",
+            issueNumber: 659,
+            issueUrl: "https://github.com/J-Tech-Japan/intent-system/issues/659");
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/9999");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+
+        using (var restoringRun = new StringWriter())
+        {
+            Assert.Equal(0, IssuePublishFlowCommand.Execute(
+                workspace.Context,
+                ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+                restoringRun));
+        }
+
+        var runsAfterRestore = File.ReadAllText(workspace.RunsLogPath);
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(0, stub.CallCount);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("durable_state_synced").GetBoolean());
         Assert.False(root.GetProperty("queue_state_patched").GetBoolean());
         Assert.False(root.GetProperty("publish_yaml_patched").GetBoolean());
         Assert.False(root.GetProperty("runs_appended").GetBoolean());
 
-        // queue-state must remain unchanged; no duplicate gh issue create was made
-        Assert.False(File.Exists(workspace.PublishYamlPath("G278")));
+        // No duplicate issue-created event was appended.
+        Assert.Equal(runsAfterRestore, File.ReadAllText(workspace.RunsLogPath));
+        Assert.Single(RunLogSerializer.DeserializeAll(runsAfterRestore));
+    }
+
+    [Fact]
+    public void Execute_FieldIncidentRegression_G530Issue1164_RestoresLinkageAndRunsEventAfterDurableStateReset()
+    {
+        // G536 field incident (2026-07-19, publishing G530 as issue #1164):
+        // host main advanced concurrently after issue creation, forcing a
+        // stash + ff-sync mid-publish. The synced state that resulted had
+        // publish.yaml intact but queue-state's linked_issue AND the
+        // runs.jsonl issue-created event both reverted to their
+        // pre-publish (absent) state. The pre-G536 idempotent rerun
+        // reported durable_state_synced:true anyway (a false positive) —
+        // this fixture reproduces the exact sequence and proves the rerun
+        // now restores BOTH missing artifacts from publish.yaml (the
+        // surviving signal) before ever reporting synced.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G530 Facet-aware context supply";
+        workspace.WriteGithubBody("G530", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G530", title);
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/1164");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+        var createdAt = new DateTimeOffset(2026, 7, 19, 3, 0, 0, TimeSpan.Zero);
+        IssuePublishFlowCommand.UtcNowFactory = () => createdAt;
+
+        // Step 1: normal publish — creates the issue, all three artifacts sync.
+        using (var createRun = new StringWriter())
+        {
+            Assert.Equal(0, IssuePublishFlowCommand.Execute(
+                workspace.Context,
+                ["G530", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+                createRun));
+        }
+
+        Assert.Equal(1, stub.CallCount);
+        Assert.True(File.Exists(workspace.PublishYamlPath("G530")));
+
+        // Step 2: simulate the host-main stash+ff-sync — queue-state and
+        // runs.jsonl revert to their pre-publish snapshot (as if the
+        // concurrent main advance's older versions won the ff-sync), but
+        // publish.yaml (written earlier, not part of the reverted files in
+        // the field sequence) survives untouched.
+        workspace.SeedQueueState("G530", title);
+        File.Delete(workspace.RunsLogPath);
         Assert.False(File.Exists(workspace.RunsLogPath));
+
+        // Step 3: rerun. Must restore queue-state's linked_issue and the
+        // runs.jsonl issue-created event from publish.yaml's surviving
+        // record, make NO new gh call, and only THEN report synced.
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G530", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, stub.CallCount); // still just the one gh call from step 1
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("idempotent").GetBoolean());
+        Assert.True(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.Equal(1164, root.GetProperty("issue_number").GetInt32());
+        Assert.True(root.GetProperty("queue_state_patched").GetBoolean());
+        Assert.False(root.GetProperty("publish_yaml_patched").GetBoolean()); // already present, untouched
+        Assert.True(root.GetProperty("runs_appended").GetBoolean());
+
+        var restoredQueueState = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        var restoredItem = Assert.Single(restoredQueueState.Items);
+        Assert.NotNull(restoredItem.LinkedIssue);
+        Assert.Equal("J-Tech-Japan/intent-system", restoredItem.LinkedIssue!.Repo);
+        Assert.Equal(1164, restoredItem.LinkedIssue.Number);
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/issues/1164", restoredItem.LinkedIssue.Url);
+
+        var restoredEvents = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        var restoredEvent = Assert.Single(restoredEvents);
+        Assert.Equal("issue-created", restoredEvent.Event);
+        Assert.Equal("G530", restoredEvent.ExecutionUnit);
+    }
+
+    [Fact]
+    public void Execute_GivenRestorationImpossible_FailsLoudNamingMissingArtifactAndRecoveryCommand()
+    {
+        // G536 acceptance criterion: "with restoration impossible ... exits
+        // non-zero naming exactly the missing artifacts and the recovery
+        // command." Simulate: publish.yaml survives (the signal) but
+        // queue-state.json exists with NO item for this execution unit at
+        // all (so TryPatchQueueStateLinkedIssue cannot find anywhere to
+        // restore the linked_issue onto).
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G278", title);
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/659");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+
+        using (var createRun = new StringWriter())
+        {
+            Assert.Equal(0, IssuePublishFlowCommand.Execute(
+                workspace.Context,
+                ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+                createRun));
+        }
+
+        // Simulate a queue-state.json that no longer carries ANY item for
+        // this execution unit (e.g. a bad hand-edit, or a sync that lost
+        // the whole entry) — restoration has nowhere to write onto.
+        File.WriteAllText(
+            workspace.QueueStatePath,
+            QueueStateSerializer.Serialize(new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = new DateTimeOffset(2026, 7, 19, 3, 0, 0, TimeSpan.Zero),
+                Items = Array.Empty<QueueItem>(),
+            }));
+        File.Delete(workspace.RunsLogPath);
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("durable_state_synced").GetBoolean());
+        var error = root.GetProperty("error").GetString();
+        Assert.Contains("queue-state.json has no item with execution_unit", error, StringComparison.Ordinal);
+        Assert.Contains("issue publish-flow G278 --repo", error, StringComparison.Ordinal);
+        Assert.Contains("automation publish-recovery", error, StringComparison.Ordinal);
+
+        // The runs.jsonl event WAS restorable (publish.yaml gave canonical
+        // identity) and independent artifact verification is not
+        // all-or-nothing — that one still gets fixed even though
+        // queue-state could not be.
+        Assert.True(root.GetProperty("runs_appended").GetBoolean());
+    }
+
+    [Fact]
+    public void Execute_GivenContradictoryDurableState_FailsLoudWithoutPickingASide()
+    {
+        // G536: publish.yaml and queue-state.json disagree on the issue
+        // number for the same execution unit — a genuine data
+        // contradiction, not a "missing artifact." Must refuse rather than
+        // silently trusting either side, and must not mutate anything.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueStateWithLinkedIssue(
+            "G278", title,
+            repo: "J-Tech-Japan/intent-system",
+            issueNumber: 700,
+            issueUrl: "https://github.com/J-Tech-Japan/intent-system/issues/700");
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/9999");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+
+        // Hand-seed a publish.yaml recording a DIFFERENT issue number than
+        // queue-state's linked_issue — simulating a corrupted/foreign sync.
+        var publishYamlPath = workspace.PublishYamlPath("G278");
+        Directory.CreateDirectory(Path.GetDirectoryName(publishYamlPath)!);
+        File.WriteAllText(
+            publishYamlPath,
+            IssuePublishArtifactYaml.Serialize(new IssuePublishArtifact
+            {
+                ExecutionUnit = "G278",
+                PublishStatus = "issue-created",
+                PacketPath = ".intent-cli/issues/G278",
+                IssueBodyPath = ".intent-cli/issues/G278/github-body.md",
+                CreatedIssueNumber = 659,
+                CreatedIssueUrl = "https://github.com/J-Tech-Japan/intent-system/issues/659",
+                PublishedLabelName = null,
+            }));
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(0, stub.CallCount);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("durable_state_synced").GetBoolean());
+        var error = root.GetProperty("error").GetString();
+        Assert.Contains("contradiction", error, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("659", error, StringComparison.Ordinal);
+        Assert.Contains("700", error, StringComparison.Ordinal);
+
+        // Neither artifact was mutated by the refusal.
+        var queueStateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal(700, queueStateAfter.Items.Single().LinkedIssue!.Number);
+        var publishArtifactAfter = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(publishYamlPath));
+        Assert.Equal(659, publishArtifactAfter.CreatedIssueNumber);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
@@ -17,7 +17,7 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
         // the pre-existing create-path tests (which predate this check)
         // are unaffected; tests covering the new duplicate-refusal path
         // override this per-test.
-        IssuePublishFlowCommand.ExistingIssueCheckerFactory = () => new StubExistingIssueChecker(found: false);
+        IssuePublishFlowCommand.ExistingIssueCheckerFactory = () => new StubExistingIssueChecker(GitHubExistingIssueClassification.None);
     }
 
     public void Dispose()
@@ -441,15 +441,19 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
         // `queue-state.json` exists but is MALFORMED (truncated
         // write, hand-edit typo, partial commit, etc.),
         // `QueueStateSerializer.Deserialize` throws `JsonException`.
-        // Before this fix the atomic-seed gate only caught
+        // Before that fix the atomic-seed gate only caught
         // `InvalidOperationException` and `IOException`, so the
         // exception bubbled up and crashed `issue publish-flow
-        // --write` instead of returning a structured stop. The fix
-        // adds `JsonException` to the catch list so malformed input
-        // falls through to "not present" → atomic-seed gate trips →
-        // operator sees the same structured stop and recovery
-        // command as the missing-file case. The CreatorFactory stub
-        // MUST NOT be invoked.
+        // --write` instead of returning a structured stop.
+        //
+        // G536 round-4 review repair: the SHARED
+        // `PublishDurableArtifactAnalyzer` now reads queue-state.json
+        // FIRST and fails closed on malformed input itself
+        // (`queue_state_malformed`) rather than silently treating it
+        // as absent — a surviving publish.yaml/runs.jsonl signal must
+        // never authorize restoration/repair around a queue-state.json
+        // this analyzer could not actually read. The CreatorFactory
+        // stub MUST NOT be invoked either way.
         using var workspace = new IssuePublishFlowWorkspace();
         workspace.WriteGithubBody("G278", BuildCompleteContractBody("G278 Fix issue publish-flow durable state synchronization"));
         // Write deliberately malformed queue-state.json (truncated
@@ -472,9 +476,8 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
         var root = document.RootElement;
         Assert.False(root.GetProperty("created").GetBoolean());
         var error = root.GetProperty("error").GetString()!;
-        Assert.Contains("execution_unit `G278`", error, StringComparison.Ordinal);
-        Assert.Contains("atomic-seed gate", error, StringComparison.Ordinal);
-        Assert.Contains("queue-seed-from-packet", error, StringComparison.Ordinal);
+        Assert.Contains("queue_state_malformed", error, StringComparison.Ordinal);
+        Assert.Contains("failed closed", error, StringComparison.Ordinal);
         // Defensive: no GitHub mutation occurred.
         Assert.Equal(0, stub.CallCount);
     }
@@ -960,21 +963,21 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_GivenNoLocalSignalButGitHubIssueAlreadyExists_RefusesToCreateDuplicate()
+    public void Execute_GivenQueueLinkedIssueFromDifferentRepo_FailsClosedAsCrossRepoContradiction()
     {
-        // G536: when the analyzer finds NO identity across all three local
-        // artifacts (e.g. every one was reset/lost but the GitHub issue
-        // itself was never re-created), falling straight through to `gh
-        // issue create` would produce a genuine duplicate. The new
-        // GitHub-existence corroboration check must refuse instead.
+        // G536 round-4 review repair: queue-state's linked_issue naming a
+        // DIFFERENT repo than the confirmed `--repo` target — even with a
+        // matching issue number — is a genuine identity contradiction, not
+        // a same-number coincidence to silently accept.
         using var workspace = new IssuePublishFlowWorkspace();
         var title = "G278 Fix issue publish-flow durable state synchronization";
         workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
-        workspace.SeedQueueState("G278", title);
-        Assert.False(File.Exists(workspace.PublishYamlPath("G278")));
-        Assert.False(File.Exists(workspace.RunsLogPath));
+        workspace.SeedQueueStateWithLinkedIssue(
+            "G278", title,
+            repo: "some-other-org/unrelated-repo",
+            issueNumber: 659,
+            issueUrl: "https://github.com/some-other-org/unrelated-repo/issues/659");
 
-        IssuePublishFlowCommand.ExistingIssueCheckerFactory = () => new StubExistingIssueChecker(found: true);
         IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
 
         using var writer = new StringWriter();
@@ -986,8 +989,173 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
         Assert.Equal(1, exitCode);
         using var document = JsonDocument.Parse(writer.ToString());
         var error = document.RootElement.GetProperty("error").GetString();
-        Assert.Contains("already exists", error, StringComparison.Ordinal);
-        Assert.Contains("Refusing to create a duplicate", error, StringComparison.Ordinal);
+        Assert.Contains("cross_artifact_contradiction", error, StringComparison.Ordinal);
+
+        var queueStateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("some-other-org/unrelated-repo", queueStateAfter.Items.Single().LinkedIssue!.Repo);
+    }
+
+    [Fact]
+    public void Execute_GivenPublishYamlForDifferentExecutionUnit_FailsClosedNotTreatedAsMissing()
+    {
+        // G536 round-4 review repair: a publish.yaml whose own
+        // execution_unit field does not match the unit this path is
+        // scoped to is corrupted data (e.g. copied from another unit's
+        // packet) — must fail closed rather than being silently accepted
+        // because the issue number happened to look plausible.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G278", title);
+
+        var publishYamlPath = workspace.PublishYamlPath("G278");
+        Directory.CreateDirectory(Path.GetDirectoryName(publishYamlPath)!);
+        File.WriteAllText(
+            publishYamlPath,
+            IssuePublishArtifactYaml.Serialize(new IssuePublishArtifact
+            {
+                ExecutionUnit = "G999",
+                PublishStatus = "issue-created",
+                PacketPath = ".intent-cli/issues/G999",
+                IssueBodyPath = ".intent-cli/issues/G999/github-body.md",
+                CreatedIssueNumber = 659,
+                CreatedIssueUrl = "https://github.com/J-Tech-Japan/intent-system/issues/659",
+                PublishedLabelName = null,
+            }));
+
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("publish_yaml_malformed", error, StringComparison.Ordinal);
+        Assert.Contains("G999", error, StringComparison.Ordinal);
+
+        var queueStateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Null(queueStateAfter.Items.Single().LinkedIssue);
+    }
+
+    [Fact]
+    public void Execute_GivenRunsEventFromDifferentRepo_FailsClosedInsteadOfCollapsingToOneIdentity()
+    {
+        // G536 round-4 review repair: a runs.jsonl issue-created event
+        // whose linked_issue names a DIFFERENT repo than another present
+        // signal must be a genuine conflict, never silently collapsed into
+        // one "identical" identity just because the issue NUMBER matches.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueStateWithLinkedIssue(
+            "G278", title,
+            repo: "J-Tech-Japan/intent-system",
+            issueNumber: 659,
+            issueUrl: "https://github.com/J-Tech-Japan/intent-system/issues/659");
+
+        Directory.CreateDirectory(Path.GetDirectoryName(workspace.RunsLogPath)!);
+        var crossRepoEvent = new RunEvent
+        {
+            Ts = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero),
+            ExecutionUnit = "G278",
+            Event = "issue-created",
+            By = "issue-publish-flow",
+            LinkedIssue = "some-other-org/unrelated-repo#659",
+        };
+        File.WriteAllText(workspace.RunsLogPath, RunLogSerializer.SerializeLine(crossRepoEvent) + "\n");
+
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("cross_artifact_contradiction", error, StringComparison.Ordinal);
+
+        var queueStateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal(659, queueStateAfter.Items.Single().LinkedIssue!.Number);
+    }
+
+    [Fact]
+    public void Execute_GivenNoLocalSignalButUniqueGitHubIssueAlreadyExists_RestoresWithoutCreatingDuplicate()
+    {
+        // G536 round-4 review repair: when the analyzer finds NO identity
+        // across all three local artifacts (e.g. every one was reset/lost
+        // but the GitHub issue itself was never re-created), falling
+        // straight through to `gh issue create` would produce a genuine
+        // duplicate. An exact title+body match on GitHub must instead feed
+        // that confirmed identity into the same restoration path — never a
+        // `gh issue create` call — restoring all three local artifacts.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        var body = BuildCompleteContractBody(title);
+        workspace.WriteGithubBody("G278", body);
+        workspace.SeedQueueState("G278", title);
+        Assert.False(File.Exists(workspace.PublishYamlPath("G278")));
+        Assert.False(File.Exists(workspace.RunsLogPath));
+
+        IssuePublishFlowCommand.ExistingIssueCheckerFactory = () => new StubExistingIssueChecker(
+            GitHubExistingIssueClassification.Unique,
+            issueNumber: 8080,
+            issueUrl: "https://github.com/J-Tech-Japan/intent-system/issues/8080");
+        // Never invoked if the fix holds — this path must restore, not create.
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("created").GetBoolean());
+        Assert.True(root.GetProperty("idempotent").GetBoolean());
+        Assert.True(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.Equal(8080, root.GetProperty("issue_number").GetInt32());
+
+        var queueStateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal(8080, queueStateAfter.Items.Single().LinkedIssue!.Number);
+        var restoredArtifact = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(workspace.PublishYamlPath("G278")));
+        Assert.Equal(8080, restoredArtifact.CreatedIssueNumber);
+        Assert.Single(RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath)));
+    }
+
+    [Fact]
+    public void Execute_GivenNoLocalSignalAndMultipleMatchingGitHubIssues_FailsClosedNonMutating()
+    {
+        // G536 round-4 review repair: an ambiguous GitHub-side match (more
+        // than one issue with the exact expected title and body) must never
+        // be resolved automatically — refuse, never create, never guess.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G278", title);
+
+        IssuePublishFlowCommand.ExistingIssueCheckerFactory = () => new StubExistingIssueChecker(
+            GitHubExistingIssueClassification.Multiple);
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("multiple issues", error, StringComparison.Ordinal);
 
         var queueStateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
         Assert.Null(queueStateAfter.Items.Single().LinkedIssue);
@@ -997,15 +1165,15 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     [Fact]
     public void Execute_GivenNoLocalSignalAndNoGitHubIssue_CreatesNormally()
     {
-        // Counterpart to the refusal test above: when the GitHub
-        // corroboration check genuinely finds nothing, the normal create
-        // path proceeds exactly as before G536.
+        // Counterpart to the tests above: when the GitHub corroboration
+        // check genuinely finds nothing, the normal create path proceeds
+        // exactly as before G536.
         using var workspace = new IssuePublishFlowWorkspace();
         var title = "G278 Fix issue publish-flow durable state synchronization";
         workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
         workspace.SeedQueueState("G278", title);
 
-        var checker = new StubExistingIssueChecker(found: false);
+        var checker = new StubExistingIssueChecker(GitHubExistingIssueClassification.None);
         IssuePublishFlowCommand.ExistingIssueCheckerFactory = () => checker;
         var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/659");
         IssuePublishFlowCommand.CreatorFactory = () => stub;
@@ -1565,31 +1733,40 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
 
     /// <summary>
     /// G536 review repair: replaces the real <c>gh issue list --search</c>
-    /// shell-out for tests. Defaults to "not found" so pre-existing tests
-    /// that exercise the normal create path are unaffected; tests covering
-    /// the duplicate-refusal path construct one with <c>found: true</c>.
+    /// shell-out for tests. Defaults to
+    /// <see cref="GitHubExistingIssueClassification.None"/> so pre-existing
+    /// tests that exercise the normal create path are unaffected; tests
+    /// covering the GitHub-restore or ambiguous-refusal paths construct one
+    /// with <see cref="GitHubExistingIssueClassification.Unique"/> or
+    /// <see cref="GitHubExistingIssueClassification.Multiple"/>.
     /// </summary>
     private sealed class StubExistingIssueChecker : IGitHubExistingIssueChecker
     {
-        private readonly bool found;
+        private readonly GitHubExistingIssueLookupResult result;
 
-        public StubExistingIssueChecker(bool found)
+        public StubExistingIssueChecker(
+            GitHubExistingIssueClassification classification, int? issueNumber = null, string? issueUrl = null)
         {
-            this.found = found;
+            result = new GitHubExistingIssueLookupResult
+            {
+                Classification = classification,
+                IssueNumber = issueNumber,
+                IssueUrl = issueUrl,
+            };
         }
 
         public int CallCount { get; private set; }
 
-        public bool ExistingIssueFound(string repo, string executionUnit)
+        public GitHubExistingIssueLookupResult FindExistingIssue(string repo, string executionUnit, string expectedTitle, string expectedBody)
         {
             CallCount++;
-            return found;
+            return result;
         }
     }
 
     private sealed class ThrowingExistingIssueChecker : IGitHubExistingIssueChecker
     {
-        public bool ExistingIssueFound(string repo, string executionUnit)
+        public GitHubExistingIssueLookupResult FindExistingIssue(string repo, string executionUnit, string expectedTitle, string expectedBody)
         {
             throw new InvalidOperationException("simulated gh failure");
         }

--- a/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishFlowCommandTests.cs
@@ -13,12 +13,18 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     {
         IssuePublishFlowCommand.CreatorFactory = null;
         IssuePublishFlowCommand.UtcNowFactory = null;
+        // G536 review repair: default to "no existing issue on GitHub" so
+        // the pre-existing create-path tests (which predate this check)
+        // are unaffected; tests covering the new duplicate-refusal path
+        // override this per-test.
+        IssuePublishFlowCommand.ExistingIssueCheckerFactory = () => new StubExistingIssueChecker(found: false);
     }
 
     public void Dispose()
     {
         IssuePublishFlowCommand.CreatorFactory = null;
         IssuePublishFlowCommand.UtcNowFactory = null;
+        IssuePublishFlowCommand.ExistingIssueCheckerFactory = null;
     }
 
     // ─── G290 tests ────────────────────────────────────────────────────────────
@@ -658,6 +664,368 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_FieldIncidentRegression_G531Issue1166_RunsOnlySignal_RestoresWithoutDuplicateIssueCreate()
+    {
+        // G536 field incident (2026-07-19, publishing G531 as issue #1166,
+        // same concurrent host-main stash+ff-sync sequence as G530/#1164):
+        // this time BOTH queue-state's linked_issue AND publish.yaml's
+        // issue-created record were lost — runs.jsonl's issue-created event
+        // was the ONLY surviving signal. The pre-G536 idempotent-rerun
+        // trigger only ever checked publish.yaml / queue-state and
+        // completely ignored runs.jsonl as an identity source, so this
+        // exact shape fell through to the normal create path and could
+        // have produced a SECOND GitHub issue for the same execution unit
+        // — the single most severe defect this review repair fixes.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G531 Add read-only intent facet-check scaffold";
+        workspace.WriteGithubBody("G531", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G531", title);
+        Assert.False(File.Exists(workspace.PublishYamlPath("G531")));
+
+        Directory.CreateDirectory(Path.GetDirectoryName(workspace.RunsLogPath)!);
+        var survivingEvent = new RunEvent
+        {
+            Ts = new DateTimeOffset(2026, 7, 19, 2, 0, 0, TimeSpan.Zero),
+            ExecutionUnit = "G531",
+            Event = "issue-created",
+            By = "issue-publish-flow",
+            LinkedIssue = "J-Tech-Japan/intent-system#1166",
+            Reason = "https://github.com/J-Tech-Japan/intent-system/issues/1166",
+        };
+        File.WriteAllText(workspace.RunsLogPath, RunLogSerializer.SerializeLine(survivingEvent) + "\n");
+
+        // Never actually invoked if the fix holds — throws immediately if
+        // the rerun still falls through to a second `gh issue create`.
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G531", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("idempotent").GetBoolean());
+        Assert.True(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.Equal(1166, root.GetProperty("issue_number").GetInt32());
+        Assert.True(root.GetProperty("queue_state_patched").GetBoolean());
+        Assert.True(root.GetProperty("publish_yaml_patched").GetBoolean());
+        Assert.False(root.GetProperty("runs_appended").GetBoolean()); // event already present, untouched
+
+        var restoredQueueState = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        var restoredItem = Assert.Single(restoredQueueState.Items);
+        Assert.NotNull(restoredItem.LinkedIssue);
+        Assert.Equal(1166, restoredItem.LinkedIssue!.Number);
+        Assert.Equal("J-Tech-Japan/intent-system", restoredItem.LinkedIssue.Repo);
+
+        var restoredArtifact = IssuePublishArtifactYaml.Deserialize(
+            File.ReadAllText(workspace.PublishYamlPath("G531")));
+        Assert.Equal("issue-created", restoredArtifact.PublishStatus);
+        Assert.Equal(1166, restoredArtifact.CreatedIssueNumber);
+
+        // No duplicate issue-created event was appended — still exactly one.
+        Assert.Single(RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath)));
+    }
+
+    [Fact]
+    public void Execute_DryRun_RunsOnlySignal_ReportsWouldRestoreWithoutMutatingAnyFile()
+    {
+        // G536: dry-run must PLAN only — report the would_restore gap list
+        // for the same runs-only-signal shape above, without writing
+        // queue-state.json, creating publish.yaml, or touching runs.jsonl.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G531 Add read-only intent facet-check scaffold";
+        workspace.WriteGithubBody("G531", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G531", title);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(workspace.RunsLogPath)!);
+        var survivingEvent = new RunEvent
+        {
+            Ts = new DateTimeOffset(2026, 7, 19, 2, 0, 0, TimeSpan.Zero),
+            ExecutionUnit = "G531",
+            Event = "issue-created",
+            By = "issue-publish-flow",
+            LinkedIssue = "J-Tech-Japan/intent-system#1166",
+            Reason = "https://github.com/J-Tech-Japan/intent-system/issues/1166",
+        };
+        File.WriteAllText(workspace.RunsLogPath, RunLogSerializer.SerializeLine(survivingEvent) + "\n");
+
+        var queueStateBefore = File.ReadAllText(workspace.QueueStatePath);
+        var runsLogBefore = File.ReadAllText(workspace.RunsLogPath);
+
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G531", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("idempotent").GetBoolean());
+        Assert.False(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.Equal(1166, root.GetProperty("issue_number").GetInt32());
+        var wouldRestore = root.GetProperty("would_restore").EnumerateArray()
+            .Select(e => e.GetString())
+            .OrderBy(s => s, StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(
+            new[] { "publish_yaml_missing", "queue_linked_issue_missing" },
+            wouldRestore);
+
+        // Byte-for-byte: dry-run never writes.
+        Assert.Equal(queueStateBefore, File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal(runsLogBefore, File.ReadAllText(workspace.RunsLogPath));
+        Assert.False(File.Exists(workspace.PublishYamlPath("G531")));
+    }
+
+    [Fact]
+    public void Execute_GivenConflictingRunsEvents_FailsClosedDistinctFromMissing()
+    {
+        // G536: two issue-created events for the same execution unit naming
+        // DIFFERENT issue numbers is a genuine data contradiction — must
+        // fail closed as "conflicting", never be silently collapsed into
+        // "missing" (which would invite an unsafe overwrite) or "present"
+        // (which would silently pick one side).
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G278", title);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(workspace.RunsLogPath)!);
+        var eventA = new RunEvent
+        {
+            Ts = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero),
+            ExecutionUnit = "G278",
+            Event = "issue-created",
+            By = "issue-publish-flow",
+            LinkedIssue = "J-Tech-Japan/intent-system#659",
+        };
+        var eventB = eventA with { LinkedIssue = "J-Tech-Japan/intent-system#700", Ts = eventA.Ts.AddMinutes(5) };
+        File.WriteAllText(
+            workspace.RunsLogPath,
+            RunLogSerializer.SerializeLine(eventA) + "\n" + RunLogSerializer.SerializeLine(eventB) + "\n");
+
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("runs_event_conflicting", error, StringComparison.Ordinal);
+        Assert.Contains("659", error, StringComparison.Ordinal);
+        Assert.Contains("700", error, StringComparison.Ordinal);
+
+        // No mutation on refusal.
+        var queueStateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Null(queueStateAfter.Items.Single().LinkedIssue);
+        Assert.False(File.Exists(workspace.PublishYamlPath("G278")));
+        Assert.Equal(2, RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath)).Count);
+    }
+
+    [Fact]
+    public void Execute_GivenDuplicateIdenticalRunsEvents_TreatedAsPresentNotConflicting()
+    {
+        // G536: two issue-created events for the same execution unit naming
+        // the SAME issue number is a harmless duplicate (e.g. a retried
+        // append) — must be treated as present/fine, not conflicting.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G278", title);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(workspace.RunsLogPath)!);
+        var eventA = new RunEvent
+        {
+            Ts = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero),
+            ExecutionUnit = "G278",
+            Event = "issue-created",
+            By = "issue-publish-flow",
+            LinkedIssue = "J-Tech-Japan/intent-system#659",
+            Reason = "https://github.com/J-Tech-Japan/intent-system/issues/659",
+        };
+        var eventADuplicate = eventA with { Ts = eventA.Ts.AddMinutes(5) };
+        File.WriteAllText(
+            workspace.RunsLogPath,
+            RunLogSerializer.SerializeLine(eventA) + "\n" + RunLogSerializer.SerializeLine(eventADuplicate) + "\n");
+
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/9999");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(0, stub.CallCount);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("durable_state_synced").GetBoolean());
+        Assert.Equal(659, root.GetProperty("issue_number").GetInt32());
+        Assert.True(root.GetProperty("queue_state_patched").GetBoolean());
+        Assert.True(root.GetProperty("publish_yaml_patched").GetBoolean());
+        Assert.False(root.GetProperty("runs_appended").GetBoolean()); // already present, no third event added
+
+        Assert.Equal(2, RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath)).Count);
+    }
+
+    [Fact]
+    public void Execute_GivenMalformedPublishYaml_FailsClosedNotTreatedAsMissing()
+    {
+        // G536: an unparseable publish.yaml must fail closed distinctly
+        // ("malformed") rather than being silently treated as "missing" —
+        // which would invite an unsafe overwrite of a file that might carry
+        // a real, just-corrupted issue record.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G278", title);
+
+        var publishYamlPath = workspace.PublishYamlPath("G278");
+        Directory.CreateDirectory(Path.GetDirectoryName(publishYamlPath)!);
+        File.WriteAllText(publishYamlPath, "{{{ not valid yaml at all :::\n\tthis is garbage");
+
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("publish_yaml_malformed", error, StringComparison.Ordinal);
+
+        // No mutation on refusal — the malformed file is left for manual inspection.
+        var queueStateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Null(queueStateAfter.Items.Single().LinkedIssue);
+        Assert.Equal("{{{ not valid yaml at all :::\n\tthis is garbage", File.ReadAllText(publishYamlPath));
+    }
+
+    [Fact]
+    public void Execute_GivenUnparseableIssueCreatedRunsEvent_FailsClosedNotTreatedAsMissing()
+    {
+        // G536: an issue-created run event that carries neither a
+        // recognizable `linked_issue` (repo#number) nor a `reason` issue
+        // URL is malformed data, not an absent signal — must fail closed
+        // rather than being silently skipped as if the event never
+        // existed (which is exactly the gap that risked a duplicate
+        // `gh issue create` in the field incidents).
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G278", title);
+
+        Directory.CreateDirectory(Path.GetDirectoryName(workspace.RunsLogPath)!);
+        var unparseableEvent = new RunEvent
+        {
+            Ts = new DateTimeOffset(2026, 5, 6, 12, 0, 0, TimeSpan.Zero),
+            ExecutionUnit = "G278",
+            Event = "issue-created",
+            By = "issue-publish-flow",
+            LinkedIssue = null,
+            Reason = "created without a recorded issue reference",
+        };
+        File.WriteAllText(workspace.RunsLogPath, RunLogSerializer.SerializeLine(unparseableEvent) + "\n");
+
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("runs_malformed", error, StringComparison.Ordinal);
+
+        var queueStateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Null(queueStateAfter.Items.Single().LinkedIssue);
+        Assert.False(File.Exists(workspace.PublishYamlPath("G278")));
+    }
+
+    [Fact]
+    public void Execute_GivenNoLocalSignalButGitHubIssueAlreadyExists_RefusesToCreateDuplicate()
+    {
+        // G536: when the analyzer finds NO identity across all three local
+        // artifacts (e.g. every one was reset/lost but the GitHub issue
+        // itself was never re-created), falling straight through to `gh
+        // issue create` would produce a genuine duplicate. The new
+        // GitHub-existence corroboration check must refuse instead.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G278", title);
+        Assert.False(File.Exists(workspace.PublishYamlPath("G278")));
+        Assert.False(File.Exists(workspace.RunsLogPath));
+
+        IssuePublishFlowCommand.ExistingIssueCheckerFactory = () => new StubExistingIssueChecker(found: true);
+        IssuePublishFlowCommand.CreatorFactory = () => new ThrowingIssueCreator();
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("already exists", error, StringComparison.Ordinal);
+        Assert.Contains("Refusing to create a duplicate", error, StringComparison.Ordinal);
+
+        var queueStateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Null(queueStateAfter.Items.Single().LinkedIssue);
+        Assert.False(File.Exists(workspace.PublishYamlPath("G278")));
+    }
+
+    [Fact]
+    public void Execute_GivenNoLocalSignalAndNoGitHubIssue_CreatesNormally()
+    {
+        // Counterpart to the refusal test above: when the GitHub
+        // corroboration check genuinely finds nothing, the normal create
+        // path proceeds exactly as before G536.
+        using var workspace = new IssuePublishFlowWorkspace();
+        var title = "G278 Fix issue publish-flow durable state synchronization";
+        workspace.WriteGithubBody("G278", BuildCompleteContractBody(title));
+        workspace.SeedQueueState("G278", title);
+
+        var checker = new StubExistingIssueChecker(found: false);
+        IssuePublishFlowCommand.ExistingIssueCheckerFactory = () => checker;
+        var stub = new StubIssueCreator("https://github.com/J-Tech-Japan/intent-system/issues/659");
+        IssuePublishFlowCommand.CreatorFactory = () => stub;
+
+        using var writer = new StringWriter();
+        var exitCode = IssuePublishFlowCommand.Execute(
+            workspace.Context,
+            ["G278", "--repo", "J-Tech-Japan/intent-system", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(1, checker.CallCount);
+        Assert.Equal(1, stub.CallCount);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("created").GetBoolean());
+        Assert.True(root.GetProperty("durable_state_synced").GetBoolean());
+    }
+
+    [Fact]
     public void Execute_GivenRestorationImpossible_FailsLoudNamingMissingArtifactAndRecoveryCommand()
     {
         // G536 acceptance criterion: "with restoration impossible ... exits
@@ -1190,6 +1558,38 @@ public sealed class IssuePublishFlowCommandTests : IDisposable
     private sealed class ThrowingIssueCreator : IIssueCreator
     {
         public IssueCreateOutcome CreateIssue(string repo, string title, string bodyFilePath)
+        {
+            throw new InvalidOperationException("simulated gh failure");
+        }
+    }
+
+    /// <summary>
+    /// G536 review repair: replaces the real <c>gh issue list --search</c>
+    /// shell-out for tests. Defaults to "not found" so pre-existing tests
+    /// that exercise the normal create path are unaffected; tests covering
+    /// the duplicate-refusal path construct one with <c>found: true</c>.
+    /// </summary>
+    private sealed class StubExistingIssueChecker : IGitHubExistingIssueChecker
+    {
+        private readonly bool found;
+
+        public StubExistingIssueChecker(bool found)
+        {
+            this.found = found;
+        }
+
+        public int CallCount { get; private set; }
+
+        public bool ExistingIssueFound(string repo, string executionUnit)
+        {
+            CallCount++;
+            return found;
+        }
+    }
+
+    private sealed class ThrowingExistingIssueChecker : IGitHubExistingIssueChecker
+    {
+        public bool ExistingIssueFound(string repo, string executionUnit)
         {
             throw new InvalidOperationException("simulated gh failure");
         }


### PR DESCRIPTION
## Summary

- `issue publish-flow`'s idempotent-rerun path no longer trusts a single short-circuit signal (whichever of `publish.yaml`/`queue-state.json` fires first) as proof that all durable state is in sync. It now independently verifies all three durable artifacts — queue-state's `linked_issue`, `publish.yaml`'s `issue-created` record, and `runs.jsonl`'s `issue-created` event — and restores whichever are missing, using the same write helpers the first-run success path already uses.
- Fixes field incident from 2026-07-19 (publishing G530 as issue #1164): a concurrent host-main advance forced a stash+ff-sync mid-publish, leaving `publish.yaml` intact but queue-state's `linked_issue` and the runs event both reverted. The prior idempotent rerun reported `durable_state_synced: true` anyway — a false positive that required manual hand-restoration from the preserved stash.
- `durable_state_synced: true` is now reported only once all three artifacts verify (whether already correct or freshly restored this run); `gh` is never re-invoked on any idempotent rerun.
- A genuine contradiction between `publish.yaml` and `queue-state.json` (different issue numbers) fails loud rather than silently trusting either side.
- When restoration is impossible, the command exits non-zero naming exactly the missing/inconsistent artifacts and the recovery command (`issue publish-flow ... --write` retry, or `automation publish-recovery ... --write`).
- `automation publish-recovery` reports the identical gap on the same fixture shape (as an unsafe stop, since it requires PR evidence publish-flow doesn't need for its own prior record) — proving consistency rather than silence.
- ja/en developer-reference docs updated with the new artifact-verification checklist.

## Test plan

- [x] Field-incident regression fixture: create → reset queue-state/runs.jsonl to pre-publish snapshot (stash+ff-sync simulation) → rerun restores both from publish.yaml, then reports synced — verified against the real production binary with a stubbed `gh`
- [x] Restoration-impossible fixture: exits non-zero, names the exact missing artifact and recovery command
- [x] Contradiction fixture: publish.yaml and queue-state disagree on issue number → refuses, mutates nothing
- [x] Idempotent-restoration-is-itself-idempotent fixture: a third rerun after restoration makes zero further writes
- [x] `automation publish-recovery` consistency fixture: same durable-state shape reports the same execution unit as a gap (unsafe stop), not silence
- [x] All pre-existing publish-flow/publish-recovery fixtures updated/still green
- [x] Full solution test suite: 3600 CLI tests + all other projects passed, 1 pre-existing skip, 0 failures
- [x] `git diff --check` clean
- [x] Manual replay of the exact field sequence against the built CLI binary

Closes #1174