### PR TITLE
G537: Canonical publish-order override — honor queue priority in next-slice selection

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1015,9 +1015,27 @@ is reversed — the runs event is appended **first**, `queue-state.json`
   fails, the audit trail already proves the attempted change and its
   reason even though the state file doesn't yet reflect it — never a
   silent, unaudited mutation. Re-running the exact same command detects
-  the already-recorded event (matched on execution unit + event name +
-  the deterministic reason text) and retries **only** the `queue-state.json`
+  the already-recorded event and retries **only** the `queue-state.json`
   write, so convergence never produces a duplicate event.
+
+**Round-2 review repair — the dedup match is bound to the queue-state
+generation, not merely the reusable transition text.** Matching only on
+execution unit + event name + the deterministic reason text has a real
+collision: replaying the exact same transition later (e.g. `normal→high`
+reason `R`, then `high→normal` reason `S`, then `normal→high` reason `R`
+again — a genuine third mutation) produces a reason string
+byte-identical to the first event's, so the naive dedup would wrongly
+treat that stale historical event as the pending audit for the third
+mutation and skip appending its own — violating "one reasoned event per
+mutation." The match now additionally requires the candidate event's
+`Ts` to be **at or after** the `UpdatedAt` value read from
+`queue-state.json` at the top of the current invocation. Every successful
+write this command makes advances `UpdatedAt` to the same timestamp used
+for its own event — so an event from any prior generation is necessarily
+older than the current `UpdatedAt` and can never be mistaken for a
+pending retry, while an event genuinely written moments ago by an
+immediately-preceding failed attempt (against this same still-unmutated
+generation) always satisfies the bound.
 
 ---
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -947,6 +947,56 @@ entry inside `nodes` would previously degrade into an incidental
 
 ---
 
+### Canonical publish-order override — queue priority (G537)
+
+Field incident (2026-07-19): after the G529 closeout, the orchestrator
+ruled — with justification — to publish field-impact fixes G532/G534
+ahead of a G530/G531 continuation. `queue-state.json`'s `priority` field
+(values like `high` observed in the field) already existed, but no
+selection surface consulted it — the orchestrator faced the forbidden
+choice of hand-editing ordering state or abandoning the ruling, correctly
+abandoned it, and reported the gap.
+
+**`intent-cli queue reprioritize <execution-unit> --priority
+<high|normal|low> --reason <text> [--write]`** is the bounded canonical
+transition that closes this gap:
+
+- Only ever mutates a **queued, not-yet-published** item's `priority` —
+  refuses (no mutation, naming why) when the item's state isn't `queued`,
+  or when it already has a linked GitHub issue.
+- `--reason <text>` is required — a priority change without a recorded
+  reason is never permitted.
+- **Dry-run by default.** Without `--write`, the command reports the
+  exact mutation that would happen (old priority, requested priority,
+  whether anything would actually change) without touching
+  `queue-state.json`. `--write` is required to mutate and append the
+  `priority-changed` runs event (old/new priority plus the operator's
+  reason).
+- Requesting the item's current priority is a no-op (idempotent) — no
+  write, no runs event, `changed: false`.
+
+**`intent next-slice` orders eligible candidates priority-class-first
+(high > normal > low), with authoring order (queue-state array order) as
+the in-class tiebreak.** Every existing eligibility gate — packet
+directory presence, execution-unit namespace regex, domain/repo filter,
+G534's lifecycle-aware exclusion, and the legacy-retirement-marker check
+— still runs exactly as before, per candidate, inside the same loop;
+priority never lets a candidate skip a gate it would otherwise fail. It
+only reorders which already-eligible candidate is tried, and in which
+order, before that per-candidate gate loop runs. Because the reorder uses
+a **stable** sort, a host where every item carries the enqueue default
+(`"normal"`) — i.e. no priorities meaningfully set — produces
+byte-identical output to pre-G537 behavior.
+
+`QueueItem.Priority` remains a plain, unvalidated `string` at the schema
+level (unchanged) — `queue reprioritize` is the only writer that
+normalizes and validates it (`high`/`normal`/`low`, case-insensitive);
+`next-slice`'s ranking function treats any unrecognized/missing value as
+`normal` rather than erroring, so hand-authored or historical
+`queue-state.json` files never fail closed on this field.
+
+---
+
 ### Facet-aware context supply (G530)
 
 Building on G529's four semantic facets (`vocabulary`, `invariant`,

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1027,35 +1027,49 @@ reason string byte-identical to the first event's, so a naive dedup on
 execution unit + event name + reason text alone would wrongly treat that
 stale historical event as the pending audit for the third mutation.
 
-**Round-3 review repair — wall-clock ordering is not a safe generation
-marker; the dedup match is now a content fingerprint, not a timestamp
-comparison.** The round-2 `Ts >= UpdatedAt` bound breaks in three ways: at
-timestamp equality (`UtcNowFactory` fixed to one value across several
-operations — or genuine same-tick production writes) it cannot
-distinguish "my own immediately-preceding failed attempt" from an older,
-unrelated transition; a clock rollback can move a later write's
-`UpdatedAt` *behind* an earlier one; and the write path never guaranteed
-`changedAt` strictly advances past the current `UpdatedAt` in the first
-place. The generation marker is now a **SHA-256 digest of the exact
-pre-mutation `queue-state.json` bytes**, read at the top of the current
-invocation, appended to the recorded reason (e.g. `... (generation
-3f9a2b7c1d4e5f60)`). This needs no clock at all:
+**Round-3 review repair (superseded by round 4 below) — the dedup match
+was next bound to a SHA-256 content fingerprint of the pre-mutation
+`queue-state.json` bytes,** to eliminate all wall-clock dependence from
+round 2's `Ts >= UpdatedAt` bound (which broke at timestamp equality, on
+clock rollback, and because the write path never guaranteed `changedAt`
+strictly advances past `UpdatedAt` in the first place).
 
-- A genuine retry (failed attempt, then re-run) starts from the
-  IDENTICAL un-mutated file — the failed attempt never wrote it — so the
-  retry computes the exact same fingerprint and finds its own
-  already-recorded event, regardless of what any clock did in between.
-- Any other, older transition necessarily read `queue-state.json`
-  *before* at least one subsequent successful write changed its content
-  (this command's own transitions always change the item's `priority`
-  field, and typically `updated_at` too) — so its fingerprint differs
-  and can never collide with the current generation's fingerprint. Same-
-  tick collisions and clock rollback/future-skew are structurally
-  impossible to trigger, since no timestamp is compared at all.
-- A historical event with no fingerprint tag at all (data predating this
-  fix, or hand-edited) can never exact-match a freshly-computed tagged
-  reason, so it is correctly treated as unrelated history rather than a
-  pending retry.
+**Round-4 review repair — a content fingerprint identifies BYTES, and
+this state machine can revisit identical bytes; the dedup token is now a
+durable, injective `priority_revision` counter, not a fingerprint of
+anything.** The round-3 fingerprint is collision-resistant for different
+content, but genuinely revisitable: `normal→high(R)` then `high→normal(S)`
+under one fixed clock reproduces the *exact original file bytes* (same
+priority, same `updated_at`, same everything) — a real revisit, not a
+hypothetical one. A subsequent `normal→high(R)` request then computes the
+identical fingerprint and tagged reason as the first event, so the
+fingerprint-based dedup wrongly treats that stale first event as pending
+for the third, genuinely distinct mutation.
+
+`QueueItem` now carries `priority_revision` — a plain `int`, deliberately
+NOT `required`, so a legacy `queue-state.json` predating this field
+simply deserializes it as `0` (the correct migration semantics: revision
+counting starts from the first `queue reprioritize` ever applied to a
+given item). Every successful `--write` bumps it by exactly 1. The
+recorded reason now carries the `fromRevision->toRevision` pair (e.g.
+`... (revision 0->1)`), and the dedup match is an exact match on that
+tagged reason (plus execution unit + event name), same as before — only
+the tag's *source* changed:
+
+- `toRevision` can mathematically never be produced by two distinct
+  successful mutations of the same item: each mutation strictly consumes
+  the "next" integer in the durably-persisted sequence, and once
+  consumed it is never the "next" one again — **regardless of whether
+  every other field of `queue-state.json` later cycles back to
+  byte-identical content**, since the counter itself is part of that same
+  durable content and only ever moves forward.
+- A genuine retry (failed queue-state write, then re-run) reads the SAME
+  `fromRevision` from the still-unmutated file both times — the failed
+  attempt never wrote the bump — so it computes the identical
+  `fromRevision->toRevision` pair and finds its own already-recorded
+  event.
+- A historical event with no revision tag at all (data predating this
+  fix, or hand-edited) can never exact-match a freshly-tagged reason.
 
 ---
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -979,12 +979,19 @@ transition that closes this gap:
 (high > normal > low), with authoring order (queue-state array order) as
 the in-class tiebreak.** Every existing eligibility gate — packet
 directory presence, execution-unit namespace regex, domain/repo filter,
-G534's lifecycle-aware exclusion, and the legacy-retirement-marker check
-— still runs exactly as before, per candidate, inside the same loop;
-priority never lets a candidate skip a gate it would otherwise fail. It
-only reorders which already-eligible candidate is tried, and in which
-order, before that per-candidate gate loop runs. Because the reorder uses
-a **stable** sort, a host where every item carries the enqueue default
+**dependency completeness / non-empty `blocked_by`** (review repair: the
+same rule `QueueSelection.SelectNext` already enforces — every
+`dependencies` entry must be `completed`, and `blocked_by` must be
+empty), G534's lifecycle-aware exclusion, and the legacy-retirement-marker
+check — still runs exactly as before, per candidate, inside the same
+loop; priority never lets a candidate skip a gate it would otherwise
+fail. A "high" priority queued unit with an incomplete dependency or a
+non-empty `blocked_by` is never selected ahead of an eligible
+lower-priority unit — the loop simply tries the next candidate in
+priority/authoring order, same as any other gate failure. Priority only
+reorders which already-eligible candidate is tried, and in which order,
+before that per-candidate gate loop runs. Because the reorder uses a
+**stable** sort, a host where every item carries the enqueue default
 (`"normal"`) — i.e. no priorities meaningfully set — produces
 byte-identical output to pre-G537 behavior.
 
@@ -994,6 +1001,23 @@ normalizes and validates it (`high`/`normal`/`low`, case-insensitive);
 `next-slice`'s ranking function treats any unrecognized/missing value as
 `normal` rather than erroring, so hand-authored or historical
 `queue-state.json` files never fail closed on this field.
+
+**Review repair — `queue reprioritize --write` uses a fail-closed,
+repairable write order.** Writing `queue-state.json` before appending the
+required `priority-changed` runs event could leave a durable priority
+mutation with no audit record if the append step then failed. The order
+is reversed — the runs event is appended **first**, `queue-state.json`
+**second**:
+
+- If the event append fails, `queue-state.json` is never touched at all
+  — no durable change happened, and a plain retry starts fresh.
+- If the event append succeeds but the `queue-state.json` write then
+  fails, the audit trail already proves the attempted change and its
+  reason even though the state file doesn't yet reflect it — never a
+  silent, unaudited mutation. Re-running the exact same command detects
+  the already-recorded event (matched on execution unit + event name +
+  the deterministic reason text) and retries **only** the `queue-state.json`
+  write, so convergence never produces a duplicate event.
 
 ---
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1107,6 +1107,29 @@ against a concurrent writer.**
   copy from the top of `Execute`), so an unrelated concurrent change to
   any *other* field or item is preserved rather than clobbered.
 
+**Round-6 review repair — the round-5 "re-read + compare" was still a
+TOCTOU check, not authoritative mutual exclusion.** Two concurrent
+invocations could both read the same `priority_revision`, both classify
+zero event claims, both append their own event, both re-read and see the
+still-unchanged revision, and both then commit — with identical requests
+that duplicates the audit trail; with different requests it silently
+produces last-writer-wins state with a conflicting orphaned event.
+
+`--write` now acquires a **non-blocking, OS-level exclusive lock**
+(`FileShare.None` on a stable sibling file next to `queue-state.json`,
+e.g. `queue-state.reprioritize.lock`) **before** the authoritative
+queue-state/runs.jsonl read, and holds it across revision validation,
+event-claim classification/append, the fresh re-read, and the final
+commit — released only once the invocation is completely done. A second,
+concurrent invocation that cannot acquire the same lock fails closed
+**immediately** (no wait, no retry) rather than racing to the compare
+point at all. Dry-run never mutates and never takes the lock. The
+round-5 fresh-re-read-and-rebuild is retained *underneath* the lock — it
+still protects against a non-cooperating writer (any tool that mutates
+`queue-state.json` without going through this lock), while the lock
+itself is what makes two *cooperating* `queue reprioritize` invocations
+mutually exclusive.
+
 ---
 
 ### Facet-aware context supply (G530)

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1018,24 +1018,44 @@ is reversed — the runs event is appended **first**, `queue-state.json`
   the already-recorded event and retries **only** the `queue-state.json`
   write, so convergence never produces a duplicate event.
 
-**Round-2 review repair — the dedup match is bound to the queue-state
-generation, not merely the reusable transition text.** Matching only on
-execution unit + event name + the deterministic reason text has a real
-collision: replaying the exact same transition later (e.g. `normal→high`
-reason `R`, then `high→normal` reason `S`, then `normal→high` reason `R`
-again — a genuine third mutation) produces a reason string
-byte-identical to the first event's, so the naive dedup would wrongly
-treat that stale historical event as the pending audit for the third
-mutation and skip appending its own — violating "one reasoned event per
-mutation." The match now additionally requires the candidate event's
-`Ts` to be **at or after** the `UpdatedAt` value read from
-`queue-state.json` at the top of the current invocation. Every successful
-write this command makes advances `UpdatedAt` to the same timestamp used
-for its own event — so an event from any prior generation is necessarily
-older than the current `UpdatedAt` and can never be mistaken for a
-pending retry, while an event genuinely written moments ago by an
-immediately-preceding failed attempt (against this same still-unmutated
-generation) always satisfies the bound.
+**Round-2 review repair (superseded by round 3 below) — the dedup match
+was first bound to `queue-state.json`'s `UpdatedAt` timestamp,** to fix a
+real collision: replaying the exact same transition later (e.g.
+`normal→high` reason `R`, then `high→normal` reason `S`, then
+`normal→high` reason `R` again — a genuine third mutation) produces a
+reason string byte-identical to the first event's, so a naive dedup on
+execution unit + event name + reason text alone would wrongly treat that
+stale historical event as the pending audit for the third mutation.
+
+**Round-3 review repair — wall-clock ordering is not a safe generation
+marker; the dedup match is now a content fingerprint, not a timestamp
+comparison.** The round-2 `Ts >= UpdatedAt` bound breaks in three ways: at
+timestamp equality (`UtcNowFactory` fixed to one value across several
+operations — or genuine same-tick production writes) it cannot
+distinguish "my own immediately-preceding failed attempt" from an older,
+unrelated transition; a clock rollback can move a later write's
+`UpdatedAt` *behind* an earlier one; and the write path never guaranteed
+`changedAt` strictly advances past the current `UpdatedAt` in the first
+place. The generation marker is now a **SHA-256 digest of the exact
+pre-mutation `queue-state.json` bytes**, read at the top of the current
+invocation, appended to the recorded reason (e.g. `... (generation
+3f9a2b7c1d4e5f60)`). This needs no clock at all:
+
+- A genuine retry (failed attempt, then re-run) starts from the
+  IDENTICAL un-mutated file — the failed attempt never wrote it — so the
+  retry computes the exact same fingerprint and finds its own
+  already-recorded event, regardless of what any clock did in between.
+- Any other, older transition necessarily read `queue-state.json`
+  *before* at least one subsequent successful write changed its content
+  (this command's own transitions always change the item's `priority`
+  field, and typically `updated_at` too) — so its fingerprint differs
+  and can never collide with the current generation's fingerprint. Same-
+  tick collisions and clock rollback/future-skew are structurally
+  impossible to trigger, since no timestamp is compared at all.
+- A historical event with no fingerprint tag at all (data predating this
+  fix, or hand-edited) can never exact-match a freshly-computed tagged
+  reason, so it is correctly treated as unrelated history rather than a
+  pending retry.
 
 ---
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1071,6 +1071,42 @@ the tag's *source* changed:
 - A historical event with no revision tag at all (data predating this
   fix, or hand-edited) can never exact-match a freshly-tagged reason.
 
+**Round-5 review repair — the revision counter itself needed input
+validation; recovery needed explicit cardinality/ownership classification
+instead of a bare existence check; and the final write needed protection
+against a concurrent writer.**
+
+- `PriorityRevision` was an unconstrained `int` — a negative value
+  deserialized successfully, and `fromRevision + 1` was unchecked
+  arithmetic that would silently wrap to `int.MinValue` at
+  `int.MaxValue`, directly violating the monotonic/injective invariant.
+  Both dry-run and `--write` now validate `PriorityRevision >= 0` and
+  compute `toRevision` with `checked` arithmetic **before** previewing or
+  mutating anything — a negative or exhausted revision fails closed with
+  no event and no queue-state write, requiring manual repair.
+- Recovery used `events.Any(...)` — a bare existence check. Since the
+  revision pair *is* the operation identity, two IDENTICAL events already
+  claiming the same pair were silently accepted as "one pending attempt"
+  (masking a real duplication bug), and a genuinely CONFLICTING event —
+  same pair, different reason or direction — was silently ignored, with a
+  second, different event appended right past it. Recovery is now an
+  explicit classification: **zero** matches → safe to append; **exactly
+  one EXACT match** (same reason too) → the pending audit for an
+  in-progress retry; **two or more identical matches**, or **any
+  mismatched-reason match** on the same pair → fails closed (exit 1,
+  queue-state untouched, naming the conflicting/duplicate event) rather
+  than silently resolved either direction.
+- The read (top of `Execute`) → event-append → queue-write sequence is
+  now protected against a stale concurrent writer. Immediately before the
+  final `queue-state.json` write, the file is re-read fresh; if the
+  target item's `priority_revision` no longer equals the `fromRevision`
+  this attempt started from, the write refuses (the audit event is
+  already durably recorded, so this is never silent) rather than
+  blindly overwriting whatever a concurrent writer produced. The final
+  mutation is also applied onto that **fresh** re-read (not the stale
+  copy from the top of `Execute`), so an unrelated concurrent change to
+  any *other* field or item is preserved rather than clobbered.
+
 ---
 
 ### Facet-aware context supply (G530)

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1130,6 +1130,27 @@ still protects against a non-cooperating writer (any tool that mutates
 itself is what makes two *cooperating* `queue reprioritize` invocations
 mutually exclusive.
 
+**Round-7 review repair — the lock could still leak on a throwing
+test callback, one boundary short of the round-6 guarantee.** The
+test-only `OnLockAcquiredForTest` hook fired *before* entering the
+`try`/`finally` that disposes the acquired lock stream. Any exception
+from that callback (or, by the same shape, any future post-acquisition
+code accidentally placed ahead of the `try`) would leave the OS-level
+lock handle undisposed — a subsequent independent invocation would stay
+locked out until GC/finalization eventually closed the handle, an
+unbounded and non-deterministic window.
+
+Every post-acquisition operation, including the callback, now runs
+*inside* the `try`/`finally` that disposes the lock stream — acquisition
+and the guarded region are adjacent with nothing but the callback
+invocation between them. A callback (or any post-acquisition step) that
+throws still releases the lock immediately as the exception unwinds,
+before any other invocation could observe it as unavailable for longer
+than necessary. A new deterministic test seeds a throwing callback,
+confirms the first call propagates the exception with the queue/runs
+state left byte-unchanged, and then confirms a second, independent call
+acquires the same lock immediately and completes normally.
+
 ---
 
 ### Facet-aware context supply (G530)

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1183,6 +1183,32 @@ concurrent writer に対する保護が必要でした。**
   他の field や item への無関係な concurrent change は、上書きされる
   のではなく保持されます。
 
+**Round-6 review repair — round 5 の「re-read + compare」は依然として
+TOCTOU check であり、authoritative な mutual exclusion ではありません
+でした。** 2 つの concurrent な invocation が、両方とも同じ
+`priority_revision` を read し、両方とも event claim ゼロを classify
+し、両方とも自分自身の event を追記し、両方とも re-read してまだ
+変わっていない revision を見て、両方ともそのまま commit してしまう
+可能性がありました——同一の request であれば audit trail が
+duplicate し、異なる request であれば silently に last-writer-wins な
+state と conflicting な orphaned event が残ってしまいます。
+
+`--write` は今や、authoritative な queue-state/runs.jsonl の read
+**より前**に **non-blocking な OS-level exclusive lock**
+(`queue-state.json` の隣に置く stable な sibling file、例えば
+`queue-state.reprioritize.lock` に対する `FileShare.None`)を取得し、
+revision validation、event-claim の classification/追記、fresh な
+re-read、そして最終的な commit にわたってそれを保持し続けます——解放
+されるのは、この invocation が完全に完了した時だけです。同じ lock を
+取得できなかった 2 つ目の concurrent な invocation は、compare point
+に到達することすらなく、**即座に** fail closed します(wait も retry
+もありません)。dry-run は決して mutate せず、決して lock を取得
+しません。round 5 の fresh-re-read-and-rebuild は、その lock の
+**内側**に維持されます——これは、この lock を経由しない non-cooperating
+な writer(`queue-state.json` を直接 mutate する任意の tool)に対する
+保護であり続けます。一方、lock 自体が、2 つの **cooperating** な
+`queue reprioritize` invocation を互いに排他的にするものです。
+
 ---
 
 ### facet を意識した context 供給 (G530)

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1094,39 +1094,53 @@ event と byte-identical になるため、execution unit + event name +
 reason text だけに頼る素朴な dedup は、その stale な historical event
 を 3 番目の mutation の pending audit だと誤認してしまいます。
 
-**Round-3 review repair — wall-clock ordering は安全な generation
-marker ではありません。dedup の match は今や timestamp 比較ではなく
-content fingerprint です。** round 2 の `Ts >= UpdatedAt` という束縛は
-3 つの方法で破綻します: timestamp が等しい場合(`UtcNowFactory` が
-複数の operation にわたって同じ値を返す場合——あるいは本物の
-production での同一 tick write の場合)、「自分自身の直前の失敗した
-attempt」と、無関係な古い transition とを区別できません。clock
-rollback は、より後の write の `UpdatedAt` を、より前の write よりも
-**前**に動かしてしまう可能性があります。そして write path は、そもそも
-`changedAt` が現在の `UpdatedAt` を厳密に上回ることを保証していません
-でした。generation marker は今や、**現在の invocation の先頭で read
-した、mutation 前の `queue-state.json` の正確な bytes の SHA-256
-digest** であり、記録される reason に追記されます(例:
-`... (generation 3f9a2b7c1d4e5f60)`)。これは一切 clock を必要と
-しません:
+**Round-3 review repair(round 4 で置き換え済み)— dedup の match は
+次に、mutation 前の `queue-state.json` bytes の SHA-256 content
+fingerprint に束縛されました。** これは round 2 の `Ts >= UpdatedAt`
+という束縛(timestamp が等しい場合や clock rollback で破綻し、そもそも
+`changedAt` が `UpdatedAt` を厳密に上回ることも保証していなかった)から
+wall-clock への依存を完全に排除するためでした。
 
-- 本物の retry(失敗した attempt の後の re-run)は、全く同じ
-  未 mutate な file から始まります——失敗した attempt はそれを
-  書き込んでいません——そのため retry は全く同じ fingerprint を
-  計算し、間で clock が何をしていたかに関わらず、自分自身の既に
-  記録された event を見つけます。
-- 他の、より古い transition は、必然的に、その後 少なくとも 1 回の
-  成功した write がその内容を変更する**前**に `queue-state.json` を
-  read しています(このコマンド自身の transition は常に item の
-  `priority` field を、多くの場合 `updated_at` も変更します)——その
-  ため fingerprint が異なり、現在の generation の fingerprint と
-  衝突することは決してありません。同一 tick の collision や clock
-  rollback/future-skew は、そもそも timestamp を一切比較しないため、
-  構造的に発生し得ません。
-- fingerprint tag を全く持たない historical event(この fix より前の
-  データ、あるいは手作業で編集されたもの)は、新たに計算された tagged
-  reason と exact-match することは決してないため、pending retry では
-  なく無関係な履歴として正しく扱われます。
+**Round-4 review repair — content fingerprint は bytes を識別するもの
+であり、この state machine は同一の bytes を再訪しうる。dedup token は
+今や、何かの fingerprint ではなく、durable かつ injective な
+`priority_revision` counter です。** round 3 の fingerprint は異なる
+content に対しては collision-resistant ですが、genuinely revisit
+可能です: 1 つの固定 clock のもとで `normal→high(R)`、続いて
+`high→normal(S)` を行うと、**元の file の bytes そのもの**が再現されて
+しまいます(同じ priority、同じ `updated_at`、その他すべて同じ)——
+これは仮定ではなく本物の revisit です。その後の `normal→high(R)`
+request は、最初の event と同一の fingerprint と tagged reason を計算
+してしまうため、fingerprint ベースの dedup は、その stale な最初の
+event を、正当に異なる 3 番目の mutation の pending event だと誤認
+します。
+
+`QueueItem` は今や `priority_revision` を持ちます——単なる `int` で、
+意図的に `required` にはしていません。そのため、この field より前の
+legacy な `queue-state.json` は、単に `0` として deserialize されます
+(正しい migration semantics です: revision の計測は、その item に
+初めて `queue reprioritize` が適用された時点から始まります)。成功した
+`--write` は必ずそれを 1 だけ進めます。記録される reason は今や
+`fromRevision->toRevision` のペアを持ちます(例: `... (revision
+0->1)`)。dedup の match は、その tagged reason(に加えて execution
+unit + event name)への exact match のままです——変わったのは tag の
+**source** だけです:
+
+- `toRevision` は、同一 item に対する 2 つの異なる成功した mutation
+  によって生成されることが数学的に決してありません: 各 mutation は、
+  durable に永続化された sequence の「次」の整数を厳密に消費し、一度
+  消費されると二度と「次」にはなりません——**`queue-state.json` の
+  他のすべての field が後で byte-identical な content に戻っても
+  関係ありません**。counter 自身がその同じ durable な content の一部
+  であり、常に前にしか進まないためです。
+- 本物の retry(失敗した queue-state write の後の re-run)は、両方の
+  試行で、依然として未 mutate な file から同じ `fromRevision` を
+  read します——失敗した attempt はその bump を書き込んでいません
+  ——そのため同一の `fromRevision->toRevision` ペアを計算し、自分
+  自身の既に記録された event を見つけます。
+- revision tag を全く持たない historical event(この fix より前の
+  データ、あるいは手作業で編集されたもの)は、新たに tag された
+  reason と exact-match することは決してありません。
 
 ---
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1209,6 +1209,28 @@ re-read、そして最終的な commit にわたってそれを保持し続け�
 保護であり続けます。一方、lock 自体が、2 つの **cooperating** な
 `queue reprioritize` invocation を互いに排他的にするものです。
 
+**Round-7 review repair — round 6 の保証には、throw する test callback
+によって lock が leak しうる境界がまだ一箇所残っていました。**
+test 専用の `OnLockAcquiredForTest` hook は、取得した lock stream を
+dispose する `try`/`finally` に入る**前**に発火していました。この
+callback から例外が飛ぶと(あるいは、同じ形で、`try` より前に誤って
+配置された将来の post-acquisition コードから飛んでも)、OS-level の
+lock handle が dispose されないまま残ってしまい——後続の独立した
+invocation は、GC/finalization がいずれ handle を閉じるまで、
+unbounded かつ non-deterministic な期間 lock され続けてしまいます。
+
+callback を含む、lock 取得後のすべての操作は、今や lock stream を
+dispose する `try`/`finally` の**内側**で実行されます——取得と
+guarded region は隣接しており、その間にあるのは callback の呼び出し
+だけです。callback (あるいは他の post-acquisition のステップ) が
+throw しても、他の invocation がそれを「利用不可」として観測できる
+期間を必要以上に長くする前に、例外が unwind する過程で lock は
+直ちに解放されます。新しい deterministic な test は、throw する
+callback を仕込んで、1 回目の call が例外を伝播しつつ queue/runs の
+state が byte 単位で変化していないことを確認し、その上で 2 回目の
+独立した call が同じ lock を直ちに取得して正常に完了することを
+確認します。
+
 ---
 
 ### facet を意識した context 供給 (G530)

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1039,16 +1039,24 @@ bounded canonical transition です:
 (high > normal > low)で order し、class 内では authoring order
 (queue-state array order)を tiebreak として使います。** 既存の
 すべての eligibility gate——packet directory の存在、execution-unit
-namespace regex、domain/repo filter、G534 の lifecycle-aware exclusion、
-legacy-retirement-marker check——は、以前と全く同じように同じ loop
-内で candidate ごとに実行され続けます。priority が、candidate が
-本来 fail するはずの gate を skip させることは決してありません。
-priority が変えるのは、すでに eligible な candidate のうちどれを、
-どの順序で試すかだけであり、それは per-candidate の gate loop が
-走る**前**に行われます。この reorder は **stable** な sort を使う
-ため、すべての item が enqueue のデフォルト値(`"normal"`)を持つ
-host——つまり実質的に priority が設定されていない host——では、
-G537 以前の挙動と byte-identical な出力になります。
+namespace regex、domain/repo filter、**dependency completeness /
+non-empty `blocked_by`**(review repair: `QueueSelection.SelectNext` が
+既に強制しているのと同じ rule——`dependencies` のすべての entry が
+`completed` であること、`blocked_by` が空であること)、G534 の
+lifecycle-aware exclusion、legacy-retirement-marker check——は、以前と
+全く同じように同じ loop 内で candidate ごとに実行され続けます。
+priority が、candidate が本来 fail するはずの gate を skip させる
+ことは決してありません。incomplete な dependency や non-empty な
+`blocked_by` を持つ "high" priority の queued unit は、eligible な
+lower-priority unit よりも先に選ばれることは決してありません——loop
+は単に、他の gate failure と全く同じように、priority/authoring order
+で次の candidate を試すだけです。priority が変えるのは、すでに
+eligible な candidate のうちどれを、どの順序で試すかだけであり、
+それは per-candidate の gate loop が走る**前**に行われます。この
+reorder は **stable** な sort を使うため、すべての item が enqueue
+のデフォルト値(`"normal"`)を持つ host——つまり実質的に priority が
+設定されていない host——では、G537 以前の挙動と byte-identical な
+出力になります。
 
 `QueueItem.Priority` は schema level では引き続き単なる、validate
 されない `string` です(変更なし)——`queue reprioritize` だけが
@@ -1057,6 +1065,25 @@ case-insensitive)。`next-slice` の ranking function は、認識できない
 値や欠けている値をすべて `normal` として扱い、error にはしません。
 そのため、手作業で書かれた、あるいは historical な `queue-state.json`
 ファイルがこの field によって fail closed することはありません。
+
+**Review repair — `queue reprioritize --write` は fail-closed かつ
+repairable な write 順序を使います。** `queue-state.json` を必須の
+`priority-changed` runs event の追記より先に書き込むと、追記 step が
+その後失敗した場合に、audit record の無い durable な priority mutation
+が残ってしまう可能性がありました。順序は逆にされています——runs
+event を**先に**追記し、`queue-state.json` は**後で**書き込みます:
+
+- event の追記が失敗した場合、`queue-state.json` は一切触れられません
+  ——durable な変更は何も起きておらず、単純な retry がまっさらな状態
+  から始まります。
+- event の追記が成功した後で `queue-state.json` の書き込みが失敗した
+  場合、state file がまだそれを反映していなくても、audit trail は
+  既に試みられた変更とその reason を証明します——silent で unaudited
+  な mutation には決してなりません。全く同じコマンドを再実行すると、
+  既に記録されている event(execution unit + event name + 決定論的な
+  reason text で一致)を検出し、`queue-state.json` の書き込み**のみ**を
+  retry するため、convergence が duplicate な event を生成することは
+  決してありません。
 
 ---
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1084,25 +1084,49 @@ event を**先に**追記し、`queue-state.json` は**後で**書き込みま�
   **のみ**を retry するため、convergence が duplicate な event を
   生成することは決してありません。
 
-**Round-2 review repair — dedup の match は、再利用可能な transition
-text だけでなく queue-state の generation に束縛されます。** execution
-unit + event name + 決定論的な reason text だけで match すると、本物の
-collision が起こります: 全く同じ transition を後で replay した場合
-(例えば `normal→high` reason `R`、続いて `high→normal` reason `S`、
-そして再び `normal→high` reason `R`——これは正当な 3 番目の mutation
-です)、生成される reason 文字列が最初の event と byte-identical に
-なるため、素朴な dedup はその stale な historical event を 3 番目の
-mutation の pending audit だと誤認し、自分自身の event の追記を
-skip してしまいます——「1 mutation につき 1 つの reasoned event」
-という原則に違反します。match は今や追加で、candidate event の `Ts`
-が、今回の invocation の先頭で `queue-state.json` から read した
-`UpdatedAt` の値**以降**であることを要求します。このコマンドが行う
-すべての成功した write は、`UpdatedAt` を自分自身の event と同じ
-timestamp に進めます——そのため、それより前の generation の event は
-必然的に現在の `UpdatedAt` より古く、pending retry と誤認される
-ことは決してありません。一方、直前の失敗した attempt によって、この
-同じ未 mutate な generation に対して実際にたった今書き込まれた event
-は、常にこの束縛を満たします。
+**Round-2 review repair(round 3 で置き換え済み)— dedup の match は
+まず `queue-state.json` の `UpdatedAt` timestamp に束縛されました。**
+これは本物の collision を修正するためでした: 全く同じ transition を
+後で replay した場合(例えば `normal→high` reason `R`、続いて
+`high→normal` reason `S`、そして再び `normal→high` reason `R`——これは
+正当な 3 番目の mutation です)、生成される reason 文字列が最初の
+event と byte-identical になるため、execution unit + event name +
+reason text だけに頼る素朴な dedup は、その stale な historical event
+を 3 番目の mutation の pending audit だと誤認してしまいます。
+
+**Round-3 review repair — wall-clock ordering は安全な generation
+marker ではありません。dedup の match は今や timestamp 比較ではなく
+content fingerprint です。** round 2 の `Ts >= UpdatedAt` という束縛は
+3 つの方法で破綻します: timestamp が等しい場合(`UtcNowFactory` が
+複数の operation にわたって同じ値を返す場合——あるいは本物の
+production での同一 tick write の場合)、「自分自身の直前の失敗した
+attempt」と、無関係な古い transition とを区別できません。clock
+rollback は、より後の write の `UpdatedAt` を、より前の write よりも
+**前**に動かしてしまう可能性があります。そして write path は、そもそも
+`changedAt` が現在の `UpdatedAt` を厳密に上回ることを保証していません
+でした。generation marker は今や、**現在の invocation の先頭で read
+した、mutation 前の `queue-state.json` の正確な bytes の SHA-256
+digest** であり、記録される reason に追記されます(例:
+`... (generation 3f9a2b7c1d4e5f60)`)。これは一切 clock を必要と
+しません:
+
+- 本物の retry(失敗した attempt の後の re-run)は、全く同じ
+  未 mutate な file から始まります——失敗した attempt はそれを
+  書き込んでいません——そのため retry は全く同じ fingerprint を
+  計算し、間で clock が何をしていたかに関わらず、自分自身の既に
+  記録された event を見つけます。
+- 他の、より古い transition は、必然的に、その後 少なくとも 1 回の
+  成功した write がその内容を変更する**前**に `queue-state.json` を
+  read しています(このコマンド自身の transition は常に item の
+  `priority` field を、多くの場合 `updated_at` も変更します)——その
+  ため fingerprint が異なり、現在の generation の fingerprint と
+  衝突することは決してありません。同一 tick の collision や clock
+  rollback/future-skew は、そもそも timestamp を一切比較しないため、
+  構造的に発生し得ません。
+- fingerprint tag を全く持たない historical event(この fix より前の
+  データ、あるいは手作業で編集されたもの)は、新たに計算された tagged
+  reason と exact-match することは決してないため、pending retry では
+  なく無関係な履歴として正しく扱われます。
 
 ---
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1142,6 +1142,47 @@ unit + event name)への exact match のままです——変わったのは tag
   データ、あるいは手作業で編集されたもの)は、新たに tag された
   reason と exact-match することは決してありません。
 
+**Round-5 review repair — revision counter 自身に input validation が
+必要であり、recovery には bare existence check ではなく明示的な
+cardinality/ownership の classification が必要であり、最終 write には
+concurrent writer に対する保護が必要でした。**
+
+- `PriorityRevision` は制約のない `int` でした——negative な値も
+  問題なく deserialize され、`fromRevision + 1` は unchecked な
+  arithmetic であり、`int.MaxValue` で silently に `int.MinValue` へと
+  wrap し、monotonic/injective という invariant に直接違反していました。
+  dry-run と `--write` の両方が、今や何かを preview・mutate する**前**
+  に `PriorityRevision >= 0` を validate し、`checked` arithmetic で
+  `toRevision` を計算します——negative あるいは exhausted な revision
+  は、event も queue-state の write も無く fail closed し、手動の
+  修復を要求します。
+- Recovery は `events.Any(...)` という bare な existence check を
+  使っていました。revision pair が operation identity である以上、
+  同じ pair を claim する 2 つの IDENTICAL な event は silently に
+  「1 つの pending attempt」として受け入れられてしまい(本物の
+  duplication bug を隠蔽してしまいます)、genuinely CONFLICTING な
+  event——同じ pair だが異なる reason や direction——は silently に
+  無視され、その脇をすり抜けて 2 つ目の異なる event が追記されて
+  いました。recovery は今や明示的な classification です: **zero**
+  match → append しても安全、**ちょうど 1 つの exact match**(reason
+  も一致)→ in-progress な retry の pending audit、**2 つ以上の
+  identical match**、あるいは**同じ pair 上の任意の reason 不一致な
+  match** → fail closed(exit 1、queue-state は無傷のまま、
+  conflicting/duplicate な event を named)——どちらか一方に silently
+  に解決されることは決してありません。
+- `Execute` の先頭での read → event の追記 → queue write という
+  sequence は、今や stale な concurrent writer に対して保護されて
+  います。最終的な `queue-state.json` の write の直前に、file が
+  fresh に re-read されます。target item の `priority_revision` が、
+  この attempt が開始した時点の `fromRevision` と一致しなくなっていた
+  場合、write は refuse します(audit event は既に durably に記録
+  されているため、これは決して silent にはなりません)——concurrent
+  writer が生成したものを blind に上書きするのではなく。最終的な
+  mutation も、その **fresh** な re-read の上に適用されます
+  (`Execute` の先頭で読んだ stale な copy の上ではなく)。そのため、
+  他の field や item への無関係な concurrent change は、上書きされる
+  のではなく保持されます。
+
 ---
 
 ### facet を意識した context 供給 (G530)

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1007,6 +1007,59 @@ entry は、以前は意図的な provider diagnostic ではなく、偶発的�
 
 ---
 
+### Canonical な publish-order override — queue priority (G537)
+
+Field incident(2026-07-19): G529 の closeout 後、orchestrator は
+——正当な理由をもって——field-impact fix である G532/G534 を
+G530/G531 の continuation よりも先に publish するよう ruling を
+下しました。`queue-state.json` の `priority` field(field で観測された
+`high` のような値)は既に存在していましたが、どの selection surface も
+それを参照していませんでした——orchestrator は「host state を
+hand-edit するか、ruling を諦めるか」という禁じられた選択を迫られ、
+正しく ruling を諦めて gap を報告しました。
+
+**`intent-cli queue reprioritize <execution-unit> --priority
+<high|normal|low> --reason <text> [--write]`** は、この gap を埋める
+bounded canonical transition です:
+
+- **queued かつ未 publish** の item の `priority` のみを mutate します
+  ——item の state が `queued` でない場合、あるいは既に linked GitHub
+  issue がある場合は refuse します(mutation なし、理由を named)。
+- `--reason <text>` は必須です——理由が記録されない priority 変更は
+  決して許可されません。
+- **デフォルトは dry-run です。** `--write` なしでは、コマンドは
+  実際に起こる mutation(old priority、requested priority、実際に
+  何か変わるかどうか)を報告するだけで、`queue-state.json` には
+  一切触れません。mutate して `priority-changed` runs event(old/new
+  priority と operator の reason)を追記するには `--write` が必要です。
+- item の現在の priority を再度 request した場合は no-op(idempotent)
+  です——write も runs event も無く、`changed: false` です。
+
+**`intent next-slice` は、eligible な candidate を priority-class-first
+(high > normal > low)で order し、class 内では authoring order
+(queue-state array order)を tiebreak として使います。** 既存の
+すべての eligibility gate——packet directory の存在、execution-unit
+namespace regex、domain/repo filter、G534 の lifecycle-aware exclusion、
+legacy-retirement-marker check——は、以前と全く同じように同じ loop
+内で candidate ごとに実行され続けます。priority が、candidate が
+本来 fail するはずの gate を skip させることは決してありません。
+priority が変えるのは、すでに eligible な candidate のうちどれを、
+どの順序で試すかだけであり、それは per-candidate の gate loop が
+走る**前**に行われます。この reorder は **stable** な sort を使う
+ため、すべての item が enqueue のデフォルト値(`"normal"`)を持つ
+host——つまり実質的に priority が設定されていない host——では、
+G537 以前の挙動と byte-identical な出力になります。
+
+`QueueItem.Priority` は schema level では引き続き単なる、validate
+されない `string` です(変更なし)——`queue reprioritize` だけが
+それを normalize・validate します(`high`/`normal`/`low`、
+case-insensitive)。`next-slice` の ranking function は、認識できない
+値や欠けている値をすべて `normal` として扱い、error にはしません。
+そのため、手作業で書かれた、あるいは historical な `queue-state.json`
+ファイルがこの field によって fail closed することはありません。
+
+---
+
 ### facet を意識した context 供給 (G530)
 
 G529 の 4 つの semantic facet（`vocabulary`、`invariant`、`decider`、

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1080,10 +1080,29 @@ event を**先に**追記し、`queue-state.json` は**後で**書き込みま�
   場合、state file がまだそれを反映していなくても、audit trail は
   既に試みられた変更とその reason を証明します——silent で unaudited
   な mutation には決してなりません。全く同じコマンドを再実行すると、
-  既に記録されている event(execution unit + event name + 決定論的な
-  reason text で一致)を検出し、`queue-state.json` の書き込み**のみ**を
-  retry するため、convergence が duplicate な event を生成することは
-  決してありません。
+  既に記録されている event を検出し、`queue-state.json` の書き込み
+  **のみ**を retry するため、convergence が duplicate な event を
+  生成することは決してありません。
+
+**Round-2 review repair — dedup の match は、再利用可能な transition
+text だけでなく queue-state の generation に束縛されます。** execution
+unit + event name + 決定論的な reason text だけで match すると、本物の
+collision が起こります: 全く同じ transition を後で replay した場合
+(例えば `normal→high` reason `R`、続いて `high→normal` reason `S`、
+そして再び `normal→high` reason `R`——これは正当な 3 番目の mutation
+です)、生成される reason 文字列が最初の event と byte-identical に
+なるため、素朴な dedup はその stale な historical event を 3 番目の
+mutation の pending audit だと誤認し、自分自身の event の追記を
+skip してしまいます——「1 mutation につき 1 つの reasoned event」
+という原則に違反します。match は今や追加で、candidate event の `Ts`
+が、今回の invocation の先頭で `queue-state.json` から read した
+`UpdatedAt` の値**以降**であることを要求します。このコマンドが行う
+すべての成功した write は、`UpdatedAt` を自分自身の event と同じ
+timestamp に進めます——そのため、それより前の generation の event は
+必然的に現在の `UpdatedAt` より古く、pending retry と誤認される
+ことは決してありません。一方、直前の失敗した attempt によって、この
+同じ未 mutate な generation に対して実際にたった今書き込まれた event
+は、常にこの束縛を満たします。
 
 ---
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -126,7 +126,8 @@ internal static class CommandRouter
                 ["next"] = QueueNextCommand.Execute,
                 ["enqueue"] = QueueEnqueueCommand.Execute,
                 ["dispatch"] = QueueDispatchCommand.Execute,
-                ["transition"] = QueueTransitionCommand.Execute
+                ["transition"] = QueueTransitionCommand.Execute,
+                ["reprioritize"] = QueueReprioritizeCommand.Execute
             },
             ["issue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -249,10 +249,12 @@ internal static class IntentNextSliceCommand
         var retired = new HashSet<string>(StringComparer.Ordinal);
         // G537: priority only ORDERS the queued bucket below — every gate
         // (domain/repo, execution-unit namespace, WIP, clarification,
-        // lifecycle) is still evaluated per-candidate in the loop at the
-        // `queued` foreach exactly as before; priority never lets a
-        // candidate skip a gate it would otherwise fail.
+        // lifecycle, and — per review repair — dependency/blocked-by) is
+        // still evaluated per-candidate in the loop at the `queued`
+        // foreach exactly as before; priority never lets a candidate skip
+        // a gate it would otherwise fail.
         var priorityByUnit = new Dictionary<string, string>(StringComparer.Ordinal);
+        var queuedItemByUnit = new Dictionary<string, QueueItem>(StringComparer.Ordinal);
         if (queueState is not null)
         {
             foreach (var item in queueState.Items)
@@ -279,6 +281,7 @@ internal static class IntentNextSliceCommand
                     case QueueItemState.Queued:
                         queued.Add(item.ExecutionUnit);
                         priorityByUnit[item.ExecutionUnit] = item.Priority;
+                        queuedItemByUnit[item.ExecutionUnit] = item;
                         break;
 
                     case QueueItemState.Completed:
@@ -387,6 +390,20 @@ internal static class IntentNextSliceCommand
                 }
 
                 if (!MatchesDomainAndRepoFilter(domain, targetRepo, queueState, executionUnit, directory))
+                {
+                    continue;
+                }
+
+                // G537 review repair: dependency/blocked-by is an
+                // authoritative eligibility gate exactly like the domain/
+                // repo filter and lifecycle exclusion above/below it — it
+                // must dominate priority. A high-priority queued item with
+                // an incomplete dependency or a non-empty `blocked_by` is
+                // never selected; the loop simply tries the next
+                // candidate in priority/authoring order, same as any
+                // other gate failure.
+                if (queuedItemByUnit.TryGetValue(executionUnit, out var queuedItem)
+                    && !IsDependencyAndBlockedByEligible(queuedItem, completed))
                 {
                     continue;
                 }
@@ -756,6 +773,33 @@ internal static class IntentNextSliceCommand
         QueueReprioritizeCommand.PriorityLow => 2,
         _ => 1,
     };
+
+    /// <summary>
+    /// G537 review repair: the authoritative dependency/blocked-by
+    /// eligibility gate for the `queued` candidate loop — mirrors
+    /// <see cref="IntentSystem.Supervisor.QueueSelection.SelectNext"/>'s
+    /// semantics (empty <c>blocked_by</c>, every <c>dependencies</c> entry
+    /// already in the completed set) so the SAME rule that gates the
+    /// legacy queue selector also gates next-slice, and dominates
+    /// priority exactly like every other gate here.
+    /// </summary>
+    private static bool IsDependencyAndBlockedByEligible(QueueItem item, HashSet<string> completed)
+    {
+        if (item.BlockedBy.Count > 0)
+        {
+            return false;
+        }
+
+        foreach (var dependency in item.Dependencies)
+        {
+            if (!completed.Contains(dependency))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 
     private static bool MatchesExecutionUnitRegex(Regex? regex, string executionUnit)
     {

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -247,6 +247,12 @@ internal static class IntentNextSliceCommand
         // re-surface it as a next-slice candidate. Track retired units
         // explicitly and exclude them the same way completed ones are.
         var retired = new HashSet<string>(StringComparer.Ordinal);
+        // G537: priority only ORDERS the queued bucket below — every gate
+        // (domain/repo, execution-unit namespace, WIP, clarification,
+        // lifecycle) is still evaluated per-candidate in the loop at the
+        // `queued` foreach exactly as before; priority never lets a
+        // candidate skip a gate it would otherwise fail.
+        var priorityByUnit = new Dictionary<string, string>(StringComparer.Ordinal);
         if (queueState is not null)
         {
             foreach (var item in queueState.Items)
@@ -272,6 +278,7 @@ internal static class IntentNextSliceCommand
 
                     case QueueItemState.Queued:
                         queued.Add(item.ExecutionUnit);
+                        priorityByUnit[item.ExecutionUnit] = item.Priority;
                         break;
 
                     case QueueItemState.Completed:
@@ -283,6 +290,17 @@ internal static class IntentNextSliceCommand
                         break;
                 }
             }
+
+            // G537: reorder the queued bucket priority-class-first (high >
+            // normal > low), with authoring order (original queue-state.json
+            // array order — the order `queued` was just built in) preserved
+            // as the in-class tiebreak. `OrderBy` (LINQ) is a STABLE sort,
+            // so when every item ranks the same (no priorities set, or all
+            // "normal" — the enqueue default), this is a byte-identical
+            // no-op versus the pre-G537 authoring-order behavior.
+            queued = queued
+                .OrderBy(unit => PriorityRank(priorityByUnit.GetValueOrDefault(unit)))
+                .ToList();
         }
 
         var clarificationPath = Path.Combine(context.RepoRoot, "intents", domain, "clarifications", "open.md");
@@ -725,6 +743,20 @@ internal static class IntentNextSliceCommand
     /// every unit passes so pre-G359 hosts and misconfigured bindings
     /// never silently block all candidates.
     /// </summary>
+    /// <summary>
+    /// G537: ranks a queue item's <c>priority</c> field for candidate
+    /// ordering — lower rank sorts earlier. Unrecognized, missing, or
+    /// empty values (including the pre-G537 default <c>"normal"</c>) all
+    /// rank the same as an explicit <c>"normal"</c>, so a host with no
+    /// priorities set (or all-normal) never changes ordering.
+    /// </summary>
+    private static int PriorityRank(string? priority) => priority?.Trim().ToLowerInvariant() switch
+    {
+        QueueReprioritizeCommand.PriorityHigh => 0,
+        QueueReprioritizeCommand.PriorityLow => 2,
+        _ => 1,
+    };
+
     private static bool MatchesExecutionUnitRegex(Regex? regex, string executionUnit)
     {
         if (regex is null)

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -82,11 +82,10 @@ internal static class QueueReprioritizeCommand
             return 1;
         }
 
-        var queueStateRawText = File.ReadAllText(queueStatePath);
         QueueState queueState;
         try
         {
-            queueState = QueueStateSerializer.Deserialize(queueStateRawText);
+            queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
         }
         catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
         {
@@ -149,7 +148,23 @@ internal static class QueueReprioritizeCommand
         }
 
         var changedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
-        var updatedItem = item with { Priority = requestedPriority! };
+        // Round-4 review repair: `PriorityRevision` is the durable,
+        // injective operation identity — read fresh from the
+        // not-yet-mutated item, exactly once per invocation. It is never
+        // decremented and never reused: every successful write below
+        // bumps it by exactly 1, so `toRevision` can mathematically never
+        // be produced by two distinct successful mutations of this item,
+        // REGARDLESS of whether every other field of `queue-state.json`
+        // (priority, updated_at, ...) later cycles back to byte-identical
+        // content. A content fingerprint of the whole file cannot make
+        // this guarantee — the state machine can genuinely revisit
+        // identical bytes (e.g. normal->high->normal under a fixed clock
+        // reproduces the exact original file) — but a monotonic counter
+        // durably persisted IN that same file can never repeat a value it
+        // has already consumed.
+        var fromRevision = item.PriorityRevision;
+        var toRevision = fromRevision + 1;
+        var updatedItem = item with { Priority = requestedPriority!, PriorityRevision = toRevision };
         var newItems = queueState.Items.ToArray();
         newItems[index0] = updatedItem;
         var updatedState = queueState with { Items = newItems, UpdatedAt = changedAt };
@@ -162,41 +177,18 @@ internal static class QueueReprioritizeCommand
         //
         // - If the event append fails, queue-state is never touched: no
         //   durable change happened at all, and a plain retry starts
-        //   fresh.
+        //   fresh — it will recompute the SAME `fromRevision`/`toRevision`
+        //   pair, since `item.PriorityRevision` on disk is unchanged.
         // - If the event append succeeds but the queue-state write then
         //   fails, the audit trail already proves the attempted change
         //   and its reason even though the state file doesn't yet
         //   reflect it. Re-running this EXACT command detects the
-        //   already-recorded event and skips re-appending — it only
-        //   retries the queue-state write, so convergence never produces
-        //   a duplicate event.
-        //
-        // Round-3 review repair: wall-clock ordering (`Ts >= UpdatedAt`)
-        // is not a safe generation marker — at timestamp equality
-        // (`UtcNowFactory` fixed to one value across several operations,
-        // or genuine same-tick production writes) it cannot tell "my own
-        // immediately-preceding failed attempt" apart from an older,
-        // fully-completed transition, and a clock rollback/future-skewed
-        // `UpdatedAt` can invalidate the bound entirely in either
-        // direction. The generation marker is now a content fingerprint —
-        // a SHA-256 digest of the EXACT pre-mutation `queue-state.json`
-        // bytes read at the top of THIS invocation, appended to the
-        // recorded reason. This needs no clock at all:
-        //
-        // - A genuine retry (failed attempt, then re-run) starts from the
-        //   IDENTICAL un-mutated file — the failed attempt never wrote it
-        //   — so the retry computes the SAME fingerprint and finds its
-        //   own already-recorded event.
-        // - Any other, older transition necessarily read queue-state.json
-        //   BEFORE at least one subsequent successful write changed its
-        //   content (this command's own transitions always change the
-        //   item's `priority` field, and typically `updated_at` too) — so
-        //   its fingerprint differs and can never collide with the
-        //   current generation's fingerprint, regardless of what any
-        //   clock did in between.
-        var generationId = ComputeGenerationId(queueStateRawText);
+        //   already-recorded event (same `toRevision`, since queue-state
+        //   still shows the old `PriorityRevision`) and skips
+        //   re-appending — it only retries the queue-state write, so
+        //   convergence never produces a duplicate event.
         var expectedReason = $"priority changed from '{item.Priority}' to '{requestedPriority}': {reason}";
-        var taggedReason = $"{expectedReason} (generation {generationId})";
+        var taggedReason = $"{expectedReason} (revision {fromRevision}->{toRevision})";
         var alreadyAudited = RunsLogHasMatchingPriorityChangedEvent(runLogPath, executionUnit!, taggedReason);
 
         if (!alreadyAudited)
@@ -260,34 +252,23 @@ internal static class QueueReprioritizeCommand
             return false;
         }
 
-        // Round-3 review repair: the match is now purely content-based —
-        // an EXACT match on `taggedReason` (which embeds the current
-        // pre-mutation queue-state content fingerprint) is both necessary
-        // and sufficient. No timestamp/ordering comparison is involved at
-        // all, so clock behavior (same-tick collisions, rollback,
-        // future-skew) cannot affect this decision either way. An older
-        // event lacking a fingerprint tag entirely (pre-round-3 data) or
-        // carrying a DIFFERENT fingerprint never matches and is correctly
-        // treated as unrelated history, not a pending retry.
+        // Round-4 review repair: the match is now purely on `taggedReason`,
+        // which embeds the durable, injective `fromRevision->toRevision`
+        // pair — necessary and sufficient, both for correctness and
+        // because it can never spuriously match. Unlike a content
+        // fingerprint of the whole file (round 3), `toRevision` can never
+        // be produced twice by two distinct successful mutations of this
+        // item, even if the state machine revisits byte-identical
+        // `queue-state.json` content overall (e.g. normal->high->normal
+        // under a fixed clock) — the revision counter itself is part of
+        // that durable content and only ever moves forward. An older
+        // event lacking a revision tag entirely (pre-round-4 data) or
+        // carrying a DIFFERENT revision pair never matches and is
+        // correctly treated as unrelated history, not a pending retry.
         return events.Any(runEvent =>
             string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
             && string.Equals(runEvent.Event, PriorityChangedEventName, StringComparison.Ordinal)
             && string.Equals(runEvent.Reason, taggedReason, StringComparison.Ordinal));
-    }
-
-    /// <summary>
-    /// G537 round-3 review repair: a strictly content-addressed,
-    /// clock-independent generation identity for the pre-mutation
-    /// <c>queue-state.json</c> bytes — a SHA-256 digest (hex, truncated to
-    /// 16 characters; 64 bits of entropy is ample for this narrow,
-    /// same-file-scoped disambiguation purpose). Always computable and
-    /// never malformed/missing, since it is a pure function of the exact
-    /// text already successfully read and parsed earlier in <see cref="Execute"/>.
-    /// </summary>
-    internal static string ComputeGenerationId(string queueStateRawText)
-    {
-        var hash = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(queueStateRawText));
-        return Convert.ToHexString(hash)[..16];
     }
 
     private static void AppendPriorityChangedEvent(string runLogPath, RunEvent runEvent)

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -42,6 +42,21 @@ internal static class QueueReprioritizeCommand
     /// <summary>G537 test seam: overrides the recorded event timestamp.</summary>
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
 
+    /// <summary>
+    /// G537 review repair test seam: replaces the real
+    /// <c>runs.jsonl</c> append. Throwing simulates an append failure so
+    /// tests can prove the fail-closed/repairable write strategy without
+    /// depending on real filesystem-permission tricks.
+    /// </summary>
+    internal static Action<string, RunEvent>? AppendPriorityChangedEventOverride { get; set; }
+
+    /// <summary>
+    /// G537 review repair test seam: replaces the real
+    /// <c>queue-state.json</c> write. Throwing simulates a write failure
+    /// AFTER the runs event has already been durably recorded.
+    /// </summary>
+    internal static Action<string, QueueState>? WriteQueueStateOverride { get; set; }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -137,26 +152,117 @@ internal static class QueueReprioritizeCommand
         var newItems = queueState.Items.ToArray();
         newItems[index0] = updatedItem;
         var updatedState = queueState with { Items = newItems, UpdatedAt = changedAt };
-
-        var runEvent = new RunEvent
-        {
-            Ts = changedAt,
-            ExecutionUnit = executionUnit!,
-            Event = PriorityChangedEventName,
-            By = ReprioritizeActor,
-            Reason = $"priority changed from '{item.Priority}' to '{requestedPriority}': {reason}",
-        };
-
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
-
         var runLogPath = context.GetRunLogPath();
+
+        // G537 review repair: fail-closed, repairable write strategy. The
+        // audit event is written FIRST, queue-state SECOND — the reverse
+        // of the naive ordering — so a failure at either step never
+        // produces a silent, unaudited priority mutation:
+        //
+        // - If the event append fails, queue-state is never touched: no
+        //   durable change happened at all, and a plain retry starts
+        //   fresh.
+        // - If the event append succeeds but the queue-state write then
+        //   fails, the audit trail already proves the attempted change
+        //   and its reason even though the state file doesn't yet
+        //   reflect it. Re-running this EXACT command detects the
+        //   already-recorded event (matched on execution unit + event
+        //   name + the deterministic reason text) and skips re-appending
+        //   — it only retries the queue-state write, so convergence never
+        //   produces a duplicate event.
+        var expectedReason = $"priority changed from '{item.Priority}' to '{requestedPriority}': {reason}";
+        var alreadyAudited = RunsLogHasMatchingPriorityChangedEvent(runLogPath, executionUnit!, expectedReason);
+
+        if (!alreadyAudited)
+        {
+            var runEvent = new RunEvent
+            {
+                Ts = changedAt,
+                ExecutionUnit = executionUnit!,
+                Event = PriorityChangedEventName,
+                By = ReprioritizeActor,
+                Reason = expectedReason,
+            };
+
+            try
+            {
+                AppendPriorityChangedEvent(runLogPath, runEvent);
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
+                    error: $"failed to append the required priority-changed runs event ({exception.Message}); queue-state.json was NOT touched — no durable change was made. Retry once the failure is resolved."));
+                return 1;
+            }
+        }
+
+        try
+        {
+            WriteQueueState(queueStatePath, updatedState);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
+                error: $"the priority-changed runs event was recorded, but queue-state.json could not be updated ({exception.Message}); "
+                    + $"queue-state on disk still shows the OLD priority '{item.Priority}'. Re-run this exact command to retry — it will "
+                    + "detect the already-recorded event and only retry the queue-state write, without appending a duplicate event."));
+            return 1;
+        }
+
+        EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: true, error: null));
+        return 0;
+    }
+
+    private static bool RunsLogHasMatchingPriorityChangedEvent(string runLogPath, string executionUnit, string expectedReason)
+    {
+        if (!File.Exists(runLogPath))
+        {
+            return false;
+        }
+
+        IReadOnlyList<RunEvent> events;
+        try
+        {
+            events = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
+        {
+            // Fail OPEN here: an unreadable/malformed runs.jsonl must never
+            // suppress recording a genuinely-needed audit event. Worst
+            // case on this path is a redundant append once the file is
+            // repaired, which is far preferable to a silently missing one.
+            return false;
+        }
+
+        return events.Any(runEvent =>
+            string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+            && string.Equals(runEvent.Event, PriorityChangedEventName, StringComparison.Ordinal)
+            && string.Equals(runEvent.Reason, expectedReason, StringComparison.Ordinal));
+    }
+
+    private static void AppendPriorityChangedEvent(string runLogPath, RunEvent runEvent)
+    {
+        if (AppendPriorityChangedEventOverride is not null)
+        {
+            AppendPriorityChangedEventOverride(runLogPath, runEvent);
+            return;
+        }
+
         var runLogDirectory = Path.GetDirectoryName(runLogPath)
             ?? throw new InvalidOperationException("Run log path did not contain a directory.");
         Directory.CreateDirectory(runLogDirectory);
         File.AppendAllText(runLogPath, RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
+    }
 
-        EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: true, error: null));
-        return 0;
+    private static void WriteQueueState(string queueStatePath, QueueState state)
+    {
+        if (WriteQueueStateOverride is not null)
+        {
+            WriteQueueStateOverride(queueStatePath, state);
+            return;
+        }
+
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(state));
     }
 
     private static bool TryParseArguments(

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -57,6 +57,17 @@ internal static class QueueReprioritizeCommand
     /// </summary>
     internal static Action<string, QueueState>? WriteQueueStateOverride { get; set; }
 
+    /// <summary>
+    /// G537 round-6 review repair test seam: invoked synchronously,
+    /// exactly once, immediately after this invocation successfully
+    /// acquires the interprocess lock — while it is still held. Tests use
+    /// this to deterministically run a SECOND concurrent
+    /// <c>Execute</c> call (which must fail to acquire the same lock and
+    /// fail closed) without depending on genuine OS-thread-scheduling
+    /// nondeterminism.
+    /// </summary>
+    internal static Action? OnLockAcquiredForTest { get; set; }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
@@ -76,6 +87,54 @@ internal static class QueueReprioritizeCommand
         }
 
         var queueStatePath = context.GetQueueStatePath();
+
+        // G537 round-6 review repair: a fresh re-read + compare immediately
+        // before the final write (round 5) is still a TOCTOU check, not
+        // authoritative mutual exclusion — two concurrent invocations can
+        // both pass that compare before either commits. Write mode now
+        // acquires an OS-level interprocess exclusive lock (an
+        // OpenOrCreate + FileShare.None handle on a stable sibling path)
+        // BEFORE the authoritative queue-state/runs.jsonl read, and holds
+        // it across revision validation, event-claim classification and
+        // append, the fresh re-read, and the final commit — releasing it
+        // only once this invocation is completely done, success or
+        // failure. A concurrent second invocation that cannot acquire the
+        // lock fails closed immediately (no retry/wait) rather than
+        // racing; dry-run never mutates and never takes the lock.
+        FileStream? lockStream = null;
+        if (write)
+        {
+            var lockPath = GetLockPath(queueStatePath);
+            if (!TryAcquireLock(lockPath, out lockStream))
+            {
+                EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: null, requestedPriority!, reason!, changed: false,
+                    error: $"another 'queue reprioritize' invocation currently holds the exclusive lock at {lockPath}; refusing to proceed concurrently (avoids a lost-update race). Retry once it completes."));
+                return 1;
+            }
+
+            OnLockAcquiredForTest?.Invoke();
+        }
+
+        try
+        {
+            return ExecuteUnderLock(context, queueStatePath, executionUnit!, requestedPriority!, reason!, write, format, writer);
+        }
+        finally
+        {
+            lockStream?.Dispose();
+        }
+    }
+
+    private static int ExecuteUnderLock(
+        CliContext context,
+        string queueStatePath,
+        string executionUnit,
+        string requestedPriority,
+        string reason,
+        bool write,
+        string format,
+        TextWriter writer)
+    {
         if (!File.Exists(queueStatePath))
         {
             writer.WriteLine($"No queue state found at {queueStatePath}");
@@ -422,6 +481,47 @@ internal static class QueueReprioritizeCommand
         }
 
         File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(state));
+    }
+
+    /// <summary>
+    /// G537 round-6 review repair: a stable sibling path to
+    /// <c>queue-state.json</c> — one lock file per repo/host, so
+    /// concurrent <c>queue reprioritize</c> invocations against the SAME
+    /// queue-state.json (and only that one) mutually exclude, regardless
+    /// of which execution unit each targets (a global-per-repo lock is
+    /// the simplest correct scope; this command's critical section is
+    /// already brief).
+    /// </summary>
+    private static string GetLockPath(string queueStatePath) =>
+        Path.Combine(Path.GetDirectoryName(queueStatePath) ?? ".", "queue-state.reprioritize.lock");
+
+    /// <summary>
+    /// G537 round-6 review repair: a non-blocking, OS-enforced exclusive
+    /// lock — <see cref="FileShare.None"/> means any other process (or,
+    /// for tests, any other open handle to the same path) attempting the
+    /// same open fails immediately with <see cref="IOException"/> rather
+    /// than blocking. This command never waits/retries for the lock: the
+    /// loser of a contention race fails closed immediately, and the
+    /// operator/orchestrator decides whether and when to retry.
+    /// </summary>
+    private static bool TryAcquireLock(string lockPath, out FileStream? lockStream)
+    {
+        try
+        {
+            var lockDirectory = Path.GetDirectoryName(lockPath);
+            if (!string.IsNullOrEmpty(lockDirectory))
+            {
+                Directory.CreateDirectory(lockDirectory);
+            }
+
+            lockStream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            return true;
+        }
+        catch (IOException)
+        {
+            lockStream = null;
+            return false;
+        }
     }
 
     private static bool TryParseArguments(

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -82,10 +82,11 @@ internal static class QueueReprioritizeCommand
             return 1;
         }
 
+        var queueStateRawText = File.ReadAllText(queueStatePath);
         QueueState queueState;
         try
         {
-            queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            queueState = QueueStateSerializer.Deserialize(queueStateRawText);
         }
         catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
         {
@@ -170,25 +171,33 @@ internal static class QueueReprioritizeCommand
         //   retries the queue-state write, so convergence never produces
         //   a duplicate event.
         //
-        // Round-2 review repair: execution unit + event name + the
-        // deterministic reason text ALONE is not enough to tell "the
-        // pending event from my own immediately-preceding failed attempt"
-        // apart from "a genuinely historical, fully-completed transition
-        // that happens to share the same old/new priority and reason"
-        // (e.g. normal->high reason R, then high->normal reason S, then
-        // normal->high reason R again — a real, distinct third mutation
-        // whose reason text collides byte-for-byte with the first). The
-        // match is now ALSO bound to `queueState.UpdatedAt` — the CURRENT,
-        // not-yet-mutated queue-state generation read at the top of this
-        // invocation: only an event timestamped AT OR AFTER that
-        // generation could possibly be the audit record from an attempt
-        // that started against this SAME unmutated state and then failed
-        // before the queue-state write landed. Any older event was
-        // necessarily superseded by at least one successful queue-state
-        // write since (this command always advances `UpdatedAt` on every
-        // successful write) and can never be mistaken for a pending retry.
+        // Round-3 review repair: wall-clock ordering (`Ts >= UpdatedAt`)
+        // is not a safe generation marker — at timestamp equality
+        // (`UtcNowFactory` fixed to one value across several operations,
+        // or genuine same-tick production writes) it cannot tell "my own
+        // immediately-preceding failed attempt" apart from an older,
+        // fully-completed transition, and a clock rollback/future-skewed
+        // `UpdatedAt` can invalidate the bound entirely in either
+        // direction. The generation marker is now a content fingerprint —
+        // a SHA-256 digest of the EXACT pre-mutation `queue-state.json`
+        // bytes read at the top of THIS invocation, appended to the
+        // recorded reason. This needs no clock at all:
+        //
+        // - A genuine retry (failed attempt, then re-run) starts from the
+        //   IDENTICAL un-mutated file — the failed attempt never wrote it
+        //   — so the retry computes the SAME fingerprint and finds its
+        //   own already-recorded event.
+        // - Any other, older transition necessarily read queue-state.json
+        //   BEFORE at least one subsequent successful write changed its
+        //   content (this command's own transitions always change the
+        //   item's `priority` field, and typically `updated_at` too) — so
+        //   its fingerprint differs and can never collide with the
+        //   current generation's fingerprint, regardless of what any
+        //   clock did in between.
+        var generationId = ComputeGenerationId(queueStateRawText);
         var expectedReason = $"priority changed from '{item.Priority}' to '{requestedPriority}': {reason}";
-        var alreadyAudited = RunsLogHasMatchingPriorityChangedEvent(runLogPath, executionUnit!, expectedReason, queueState.UpdatedAt);
+        var taggedReason = $"{expectedReason} (generation {generationId})";
+        var alreadyAudited = RunsLogHasMatchingPriorityChangedEvent(runLogPath, executionUnit!, taggedReason);
 
         if (!alreadyAudited)
         {
@@ -198,7 +207,7 @@ internal static class QueueReprioritizeCommand
                 ExecutionUnit = executionUnit!,
                 Event = PriorityChangedEventName,
                 By = ReprioritizeActor,
-                Reason = expectedReason,
+                Reason = taggedReason,
             };
 
             try
@@ -230,8 +239,7 @@ internal static class QueueReprioritizeCommand
         return 0;
     }
 
-    private static bool RunsLogHasMatchingPriorityChangedEvent(
-        string runLogPath, string executionUnit, string expectedReason, DateTimeOffset currentQueueStateGeneration)
+    private static bool RunsLogHasMatchingPriorityChangedEvent(string runLogPath, string executionUnit, string taggedReason)
     {
         if (!File.Exists(runLogPath))
         {
@@ -252,20 +260,34 @@ internal static class QueueReprioritizeCommand
             return false;
         }
 
-        // Round-2 review repair: `Ts >= currentQueueStateGeneration` is the
-        // binding that tells a genuine pending-retry event (recorded
-        // against THIS still-unmutated queue-state generation) apart from
-        // a stale, fully-historical event that happens to share the same
-        // execution unit/event name/reason text. Every successful write
-        // this command makes advances `queue-state.json`'s `UpdatedAt` to
-        // the SAME timestamp used for its own event's `Ts` — so an event
-        // from any PRIOR generation is necessarily older than the current
-        // `UpdatedAt` and can never satisfy this bound.
+        // Round-3 review repair: the match is now purely content-based —
+        // an EXACT match on `taggedReason` (which embeds the current
+        // pre-mutation queue-state content fingerprint) is both necessary
+        // and sufficient. No timestamp/ordering comparison is involved at
+        // all, so clock behavior (same-tick collisions, rollback,
+        // future-skew) cannot affect this decision either way. An older
+        // event lacking a fingerprint tag entirely (pre-round-3 data) or
+        // carrying a DIFFERENT fingerprint never matches and is correctly
+        // treated as unrelated history, not a pending retry.
         return events.Any(runEvent =>
             string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
             && string.Equals(runEvent.Event, PriorityChangedEventName, StringComparison.Ordinal)
-            && string.Equals(runEvent.Reason, expectedReason, StringComparison.Ordinal)
-            && runEvent.Ts >= currentQueueStateGeneration);
+            && string.Equals(runEvent.Reason, taggedReason, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// G537 round-3 review repair: a strictly content-addressed,
+    /// clock-independent generation identity for the pre-mutation
+    /// <c>queue-state.json</c> bytes — a SHA-256 digest (hex, truncated to
+    /// 16 characters; 64 bits of entropy is ample for this narrow,
+    /// same-file-scoped disambiguation purpose). Always computable and
+    /// never malformed/missing, since it is a pure function of the exact
+    /// text already successfully read and parsed earlier in <see cref="Execute"/>.
+    /// </summary>
+    internal static string ComputeGenerationId(string queueStateRawText)
+    {
+        var hash = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(queueStateRawText));
+        return Convert.ToHexString(hash)[..16];
     }
 
     private static void AppendPriorityChangedEvent(string runLogPath, RunEvent runEvent)

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -140,6 +140,33 @@ internal static class QueueReprioritizeCommand
             return 0;
         }
 
+        // Round-5 review repair: `PriorityRevision` is the durable,
+        // injective operation identity that every downstream step
+        // depends on — validate it BEFORE previewing or mutating
+        // anything, in both dry-run and write mode. A negative value, or
+        // one that would overflow on increment, is corrupted/exhausted
+        // durable state, not a value this command can safely reason
+        // about.
+        if (item.PriorityRevision < 0)
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
+                error: $"'{executionUnit}' has a negative priority_revision ({item.PriorityRevision}) in queue-state.json; refusing to reprioritize corrupted durable state. Repair queue-state.json manually before retrying."));
+            return 1;
+        }
+
+        int toRevision;
+        try
+        {
+            toRevision = checked(item.PriorityRevision + 1);
+        }
+        catch (OverflowException)
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
+                error: $"'{executionUnit}' has priority_revision at int.MaxValue ({item.PriorityRevision}); the revision counter is exhausted and refuses to wrap. Manual intervention (e.g. a durable migration to a wider counter) is required before this unit can be reprioritized again."));
+            return 1;
+        }
+        var fromRevision = item.PriorityRevision;
+
         if (!write)
         {
             EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: true,
@@ -148,50 +175,42 @@ internal static class QueueReprioritizeCommand
         }
 
         var changedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
-        // Round-4 review repair: `PriorityRevision` is the durable,
-        // injective operation identity — read fresh from the
-        // not-yet-mutated item, exactly once per invocation. It is never
-        // decremented and never reused: every successful write below
-        // bumps it by exactly 1, so `toRevision` can mathematically never
-        // be produced by two distinct successful mutations of this item,
-        // REGARDLESS of whether every other field of `queue-state.json`
-        // (priority, updated_at, ...) later cycles back to byte-identical
-        // content. A content fingerprint of the whole file cannot make
-        // this guarantee — the state machine can genuinely revisit
-        // identical bytes (e.g. normal->high->normal under a fixed clock
-        // reproduces the exact original file) — but a monotonic counter
-        // durably persisted IN that same file can never repeat a value it
-        // has already consumed.
-        var fromRevision = item.PriorityRevision;
-        var toRevision = fromRevision + 1;
-        var updatedItem = item with { Priority = requestedPriority!, PriorityRevision = toRevision };
-        var newItems = queueState.Items.ToArray();
-        newItems[index0] = updatedItem;
-        var updatedState = queueState with { Items = newItems, UpdatedAt = changedAt };
         var runLogPath = context.GetRunLogPath();
 
         // G537 review repair: fail-closed, repairable write strategy. The
         // audit event is written FIRST, queue-state SECOND — the reverse
         // of the naive ordering — so a failure at either step never
-        // produces a silent, unaudited priority mutation:
-        //
-        // - If the event append fails, queue-state is never touched: no
-        //   durable change happened at all, and a plain retry starts
-        //   fresh — it will recompute the SAME `fromRevision`/`toRevision`
-        //   pair, since `item.PriorityRevision` on disk is unchanged.
-        // - If the event append succeeds but the queue-state write then
-        //   fails, the audit trail already proves the attempted change
-        //   and its reason even though the state file doesn't yet
-        //   reflect it. Re-running this EXACT command detects the
-        //   already-recorded event (same `toRevision`, since queue-state
-        //   still shows the old `PriorityRevision`) and skips
-        //   re-appending — it only retries the queue-state write, so
-        //   convergence never produces a duplicate event.
+        // produces a silent, unaudited priority mutation. Round-4:
+        // `fromRevision`/`toRevision` is the durable, injective operation
+        // identity embedded in the recorded reason — it can never be
+        // produced twice by two distinct successful mutations of this
+        // item, even if every other field of `queue-state.json` later
+        // cycles back to byte-identical content, since the counter is
+        // itself part of that durable content and only ever moves
+        // forward.
         var expectedReason = $"priority changed from '{item.Priority}' to '{requestedPriority}': {reason}";
         var taggedReason = $"{expectedReason} (revision {fromRevision}->{toRevision})";
-        var alreadyAudited = RunsLogHasMatchingPriorityChangedEvent(runLogPath, executionUnit!, taggedReason);
 
-        if (!alreadyAudited)
+        // Round-5 review repair: the revision pair (fromRevision,
+        // toRevision) IS the operation identity, so recovery must
+        // classify its cardinality/ownership explicitly rather than using
+        // `.Any(...)` — a bare existence check silently accepts
+        // duplicate-identical events as "one pending attempt" and
+        // silently ignores a genuinely conflicting claim on the SAME
+        // pair (appending yet another event instead of stopping).
+        var classification = ClassifyPriorityChangedRecovery(
+            runLogPath, executionUnit!, fromRevision, toRevision, taggedReason, out var recoveryDetail);
+
+        if (classification is PriorityChangedRecoveryClassification.Conflicting or PriorityChangedRecoveryClassification.DuplicateIdentical)
+        {
+            var kind = classification == PriorityChangedRecoveryClassification.Conflicting ? "conflicting" : "duplicate-identical";
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
+                error: $"runs.jsonl has a {kind} claim on revision {fromRevision}->{toRevision} for '{executionUnit}': {recoveryDetail} "
+                    + "queue-state.json was NOT touched. Reconcile runs.jsonl manually before retrying."));
+            return 1;
+        }
+
+        if (classification == PriorityChangedRecoveryClassification.None)
         {
             var runEvent = new RunEvent
             {
@@ -214,14 +233,57 @@ internal static class QueueReprioritizeCommand
             }
         }
 
+        // Round-5 review repair: protect the read -> event -> queue-write
+        // boundary from a stale concurrent queue writer. The event above
+        // is already durably recorded proving this attempt happened, but
+        // the actual mutation must be applied against a FRESH read of
+        // queue-state.json — never the stale copy read at the top of this
+        // invocation — and must refuse (not silently overwrite) if the
+        // target item's `priority_revision` no longer matches
+        // `fromRevision`, since that proves something else changed this
+        // item since this attempt started. Rebuilding the final state
+        // from the fresh read (rather than the stale one) also means an
+        // unrelated concurrent change to any OTHER item is preserved
+        // rather than clobbered.
+        QueueState currentOnDisk;
         try
         {
-            WriteQueueState(queueStatePath, updatedState);
+            currentOnDisk = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
+                error: $"the priority-changed runs event was recorded (revision {fromRevision}->{toRevision}), but queue-state.json could not be re-read to verify no concurrent change occurred before the final write ({exception.Message}); refusing to write blind. Re-run this exact command to retry."));
+            return 1;
+        }
+
+        var currentItem = currentOnDisk.Items.FirstOrDefault(candidate =>
+            string.Equals(candidate.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+
+        if (currentItem is null || currentItem.PriorityRevision != fromRevision)
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
+                error: $"queue-state.json changed concurrently since this attempt started (expected priority_revision {fromRevision} for '{executionUnit}', "
+                    + $"found {(currentItem is null ? "the item missing entirely" : currentItem.PriorityRevision.ToString(System.Globalization.CultureInfo.InvariantCulture))}); "
+                    + $"refusing to overwrite a concurrent change. The priority-changed runs event was already recorded (revision {fromRevision}->{toRevision}); "
+                    + "re-run this command to retry against the current state."));
+            return 1;
+        }
+
+        var freshItems = currentOnDisk.Items.ToArray();
+        var freshIndex = Array.FindIndex(freshItems, candidate =>
+            string.Equals(candidate.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+        freshItems[freshIndex] = currentItem with { Priority = requestedPriority!, PriorityRevision = toRevision };
+        var finalState = currentOnDisk with { Items = freshItems, UpdatedAt = changedAt };
+
+        try
+        {
+            WriteQueueState(queueStatePath, finalState);
         }
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
         {
             EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
-                error: $"the priority-changed runs event was recorded, but queue-state.json could not be updated ({exception.Message}); "
+                error: $"the priority-changed runs event was recorded (revision {fromRevision}->{toRevision}), but queue-state.json could not be updated ({exception.Message}); "
                     + $"queue-state on disk still shows the OLD priority '{item.Priority}'. Re-run this exact command to retry — it will "
                     + "detect the already-recorded event and only retry the queue-state write, without appending a duplicate event."));
             return 1;
@@ -231,11 +293,41 @@ internal static class QueueReprioritizeCommand
         return 0;
     }
 
-    private static bool RunsLogHasMatchingPriorityChangedEvent(string runLogPath, string executionUnit, string taggedReason)
+    private enum PriorityChangedRecoveryClassification
     {
+        /// <summary>No existing event claims this exact revision pair — safe to append a new one.</summary>
+        None,
+
+        /// <summary>Exactly one existing event claims this exact revision pair, with the EXACT same reason — the pending audit for an in-progress retry.</summary>
+        PendingRetry,
+
+        /// <summary>Two or more IDENTICAL events already claim this exact revision pair — an integrity problem, never silently treated as "fine."</summary>
+        DuplicateIdentical,
+
+        /// <summary>An event (or events) claim this exact revision pair with a DIFFERENT reason — a genuine data contradiction.</summary>
+        Conflicting,
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex RevisionPairPattern = new(
+        @"\(revision (?<from>-?\d+)->(?<to>-?\d+)\)$", System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>
+    /// G537 round-5 review repair: the revision pair (<paramref name="fromRevision"/>,
+    /// <paramref name="toRevision"/>) IS the operation identity, so recovery
+    /// classifies cardinality/ownership explicitly instead of a bare
+    /// existence check: zero matches means safe to append; exactly one
+    /// EXACT match (same reason too) means a pending retry; two or more
+    /// IDENTICAL matches, or any mismatched-reason match, means the durable
+    /// log has an integrity problem that must fail closed rather than be
+    /// silently resolved either direction.
+    /// </summary>
+    private static PriorityChangedRecoveryClassification ClassifyPriorityChangedRecovery(
+        string runLogPath, string executionUnit, int fromRevision, int toRevision, string expectedReason, out string? detail)
+    {
+        detail = null;
         if (!File.Exists(runLogPath))
         {
-            return false;
+            return PriorityChangedRecoveryClassification.None;
         }
 
         IReadOnlyList<RunEvent> events;
@@ -249,26 +341,62 @@ internal static class QueueReprioritizeCommand
             // suppress recording a genuinely-needed audit event. Worst
             // case on this path is a redundant append once the file is
             // repaired, which is far preferable to a silently missing one.
+            return PriorityChangedRecoveryClassification.None;
+        }
+
+        var matching = events
+            .Where(runEvent =>
+                string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                && string.Equals(runEvent.Event, PriorityChangedEventName, StringComparison.Ordinal)
+                && TryParseRevisionPair(runEvent.Reason, out var parsedFrom, out var parsedTo)
+                && parsedFrom == fromRevision
+                && parsedTo == toRevision)
+            .ToArray();
+
+        if (matching.Length == 0)
+        {
+            return PriorityChangedRecoveryClassification.None;
+        }
+
+        var distinctReasons = matching.Select(runEvent => runEvent.Reason).Distinct(StringComparer.Ordinal).ToArray();
+        if (distinctReasons.Length > 1)
+        {
+            detail = $"{matching.Length} event(s) disagree on the claim for this revision pair: {string.Join(" | ", distinctReasons)}.";
+            return PriorityChangedRecoveryClassification.Conflicting;
+        }
+
+        if (matching.Length > 1)
+        {
+            detail = $"{matching.Length} identical events already claim this revision pair ('{distinctReasons[0]}'); this duplication must be reconciled manually.";
+            return PriorityChangedRecoveryClassification.DuplicateIdentical;
+        }
+
+        if (!string.Equals(matching[0].Reason, expectedReason, StringComparison.Ordinal))
+        {
+            detail = $"an existing event claims this revision pair with reason '{matching[0].Reason}', which does not match the expected reason for this request ('{expectedReason}').";
+            return PriorityChangedRecoveryClassification.Conflicting;
+        }
+
+        return PriorityChangedRecoveryClassification.PendingRetry;
+    }
+
+    private static bool TryParseRevisionPair(string? reasonText, out int fromRevision, out int toRevision)
+    {
+        fromRevision = 0;
+        toRevision = 0;
+        if (string.IsNullOrEmpty(reasonText))
+        {
             return false;
         }
 
-        // Round-4 review repair: the match is now purely on `taggedReason`,
-        // which embeds the durable, injective `fromRevision->toRevision`
-        // pair — necessary and sufficient, both for correctness and
-        // because it can never spuriously match. Unlike a content
-        // fingerprint of the whole file (round 3), `toRevision` can never
-        // be produced twice by two distinct successful mutations of this
-        // item, even if the state machine revisits byte-identical
-        // `queue-state.json` content overall (e.g. normal->high->normal
-        // under a fixed clock) — the revision counter itself is part of
-        // that durable content and only ever moves forward. An older
-        // event lacking a revision tag entirely (pre-round-4 data) or
-        // carrying a DIFFERENT revision pair never matches and is
-        // correctly treated as unrelated history, not a pending retry.
-        return events.Any(runEvent =>
-            string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
-            && string.Equals(runEvent.Event, PriorityChangedEventName, StringComparison.Ordinal)
-            && string.Equals(runEvent.Reason, taggedReason, StringComparison.Ordinal));
+        var match = RevisionPairPattern.Match(reasonText);
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        return int.TryParse(match.Groups["from"].Value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out fromRevision)
+            && int.TryParse(match.Groups["to"].Value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out toRevision);
     }
 
     private static void AppendPriorityChangedEvent(string runLogPath, RunEvent runEvent)

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -166,12 +166,29 @@ internal static class QueueReprioritizeCommand
         //   fails, the audit trail already proves the attempted change
         //   and its reason even though the state file doesn't yet
         //   reflect it. Re-running this EXACT command detects the
-        //   already-recorded event (matched on execution unit + event
-        //   name + the deterministic reason text) and skips re-appending
-        //   — it only retries the queue-state write, so convergence never
-        //   produces a duplicate event.
+        //   already-recorded event and skips re-appending — it only
+        //   retries the queue-state write, so convergence never produces
+        //   a duplicate event.
+        //
+        // Round-2 review repair: execution unit + event name + the
+        // deterministic reason text ALONE is not enough to tell "the
+        // pending event from my own immediately-preceding failed attempt"
+        // apart from "a genuinely historical, fully-completed transition
+        // that happens to share the same old/new priority and reason"
+        // (e.g. normal->high reason R, then high->normal reason S, then
+        // normal->high reason R again — a real, distinct third mutation
+        // whose reason text collides byte-for-byte with the first). The
+        // match is now ALSO bound to `queueState.UpdatedAt` — the CURRENT,
+        // not-yet-mutated queue-state generation read at the top of this
+        // invocation: only an event timestamped AT OR AFTER that
+        // generation could possibly be the audit record from an attempt
+        // that started against this SAME unmutated state and then failed
+        // before the queue-state write landed. Any older event was
+        // necessarily superseded by at least one successful queue-state
+        // write since (this command always advances `UpdatedAt` on every
+        // successful write) and can never be mistaken for a pending retry.
         var expectedReason = $"priority changed from '{item.Priority}' to '{requestedPriority}': {reason}";
-        var alreadyAudited = RunsLogHasMatchingPriorityChangedEvent(runLogPath, executionUnit!, expectedReason);
+        var alreadyAudited = RunsLogHasMatchingPriorityChangedEvent(runLogPath, executionUnit!, expectedReason, queueState.UpdatedAt);
 
         if (!alreadyAudited)
         {
@@ -213,7 +230,8 @@ internal static class QueueReprioritizeCommand
         return 0;
     }
 
-    private static bool RunsLogHasMatchingPriorityChangedEvent(string runLogPath, string executionUnit, string expectedReason)
+    private static bool RunsLogHasMatchingPriorityChangedEvent(
+        string runLogPath, string executionUnit, string expectedReason, DateTimeOffset currentQueueStateGeneration)
     {
         if (!File.Exists(runLogPath))
         {
@@ -234,10 +252,20 @@ internal static class QueueReprioritizeCommand
             return false;
         }
 
+        // Round-2 review repair: `Ts >= currentQueueStateGeneration` is the
+        // binding that tells a genuine pending-retry event (recorded
+        // against THIS still-unmutated queue-state generation) apart from
+        // a stale, fully-historical event that happens to share the same
+        // execution unit/event name/reason text. Every successful write
+        // this command makes advances `queue-state.json`'s `UpdatedAt` to
+        // the SAME timestamp used for its own event's `Ts` — so an event
+        // from any PRIOR generation is necessarily older than the current
+        // `UpdatedAt` and can never satisfy this bound.
         return events.Any(runEvent =>
             string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal)
             && string.Equals(runEvent.Event, PriorityChangedEventName, StringComparison.Ordinal)
-            && string.Equals(runEvent.Reason, expectedReason, StringComparison.Ordinal));
+            && string.Equals(runEvent.Reason, expectedReason, StringComparison.Ordinal)
+            && runEvent.Ts >= currentQueueStateGeneration);
     }
 
     private static void AppendPriorityChangedEvent(string runLogPath, RunEvent runEvent)

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -111,12 +111,20 @@ internal static class QueueReprioritizeCommand
                     error: $"another 'queue reprioritize' invocation currently holds the exclusive lock at {lockPath}; refusing to proceed concurrently (avoids a lost-update race). Retry once it completes."));
                 return 1;
             }
-
-            OnLockAcquiredForTest?.Invoke();
         }
 
+        // G537 round-7 review repair: every post-acquisition operation —
+        // including the test-only callback — must run inside the
+        // try/finally that disposes lockStream. Invoking the callback
+        // before entering try/finally left a window where a throwing
+        // callback would leak the OS-level lock handle undisposed.
         try
         {
+            if (write)
+            {
+                OnLockAcquiredForTest?.Invoke();
+            }
+
             return ExecuteUnderLock(context, queueStatePath, executionUnit!, requestedPriority!, reason!, write, format, writer);
         }
         finally

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -1,0 +1,344 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G537: <c>intent-cli queue reprioritize &lt;execution-unit&gt; --priority
+/// &lt;high|normal|low&gt; --reason &lt;text&gt; [--write] [--format
+/// markdown|json]</c> — the bounded canonical transition that lets an
+/// operator/orchestrator express a publish-order ruling (e.g. "publish
+/// G532 ahead of G530") without hand-editing <c>queue-state.json</c>.
+///
+/// Only ever mutates a QUEUED, NOT-YET-PUBLISHED item's <c>priority</c>
+/// field. Refuses (no mutation) on any other state or once a GitHub issue
+/// is already linked — a priority change past that point cannot influence
+/// candidate selection and would be misleading to allow. Dry-run by
+/// default; <c>--write</c> is required to actually mutate
+/// <c>queue-state.json</c> and append the <c>priority-changed</c> runs
+/// event that records the old/new priority and the operator's reason.
+///
+/// This command has no opinion on ordering — <see cref="IntentNextSliceCommand"/>
+/// is the sole consumer of <see cref="QueueItem.Priority"/> for candidate
+/// ordering (priority-class-first, authoring-order tiebreak, gates keep
+/// absolute precedence).
+/// </summary>
+internal static class QueueReprioritizeCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+    private const string ModeDryRun = "dry-run";
+    private const string ModeWrite = "write";
+
+    public const string PriorityHigh = "high";
+    public const string PriorityNormal = "normal";
+    public const string PriorityLow = "low";
+
+    public const string PriorityChangedEventName = "priority-changed";
+    private const string ReprioritizeActor = "intent-cli";
+
+    /// <summary>G537 test seam: overrides the recorded event timestamp.</summary>
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (!TryParseArguments(args, out var executionUnit, out var requestedPriority, out var reason, out var write, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var queueStatePath = context.GetQueueStatePath();
+        if (!File.Exists(queueStatePath))
+        {
+            writer.WriteLine($"No queue state found at {queueStatePath}");
+            return 1;
+        }
+
+        QueueState queueState;
+        try
+        {
+            queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
+        {
+            writer.WriteLine($"queue-state.json could not be parsed: {exception.Message}");
+            return 1;
+        }
+
+        var matchingIndices = new List<int>();
+        for (var index = 0; index < queueState.Items.Count; index++)
+        {
+            if (string.Equals(queueState.Items[index].ExecutionUnit, executionUnit, StringComparison.Ordinal))
+            {
+                matchingIndices.Add(index);
+            }
+        }
+
+        if (matchingIndices.Count == 0)
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: null, requestedPriority!, reason!, changed: false,
+                error: $"queue-state.json has no item with execution_unit '{executionUnit}'."));
+            return 1;
+        }
+
+        if (matchingIndices.Count > 1)
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: null, requestedPriority!, reason!, changed: false,
+                error: $"queue-state.json has {matchingIndices.Count} items for execution_unit '{executionUnit}'; refusing to reprioritize an ambiguous entry."));
+            return 1;
+        }
+
+        var index0 = matchingIndices[0];
+        var item = queueState.Items[index0];
+
+        if (item.State != QueueItemState.Queued)
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
+                error: $"'{executionUnit}' is in state '{FormatState(item.State)}', not queued; refusing to reprioritize a published/in-flight/completed/retired unit."));
+            return 1;
+        }
+
+        if (item.LinkedIssue is not null)
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
+                error: $"'{executionUnit}' already has a linked GitHub issue (#{item.LinkedIssue.Number}); refusing to reprioritize a published unit."));
+            return 1;
+        }
+
+        if (string.Equals(item.Priority, requestedPriority, StringComparison.Ordinal))
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: false,
+                error: null));
+            return 0;
+        }
+
+        if (!write)
+        {
+            EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: true,
+                error: null));
+            return 0;
+        }
+
+        var changedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var updatedItem = item with { Priority = requestedPriority! };
+        var newItems = queueState.Items.ToArray();
+        newItems[index0] = updatedItem;
+        var updatedState = queueState with { Items = newItems, UpdatedAt = changedAt };
+
+        var runEvent = new RunEvent
+        {
+            Ts = changedAt,
+            ExecutionUnit = executionUnit!,
+            Event = PriorityChangedEventName,
+            By = ReprioritizeActor,
+            Reason = $"priority changed from '{item.Priority}' to '{requestedPriority}': {reason}",
+        };
+
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+
+        var runLogPath = context.GetRunLogPath();
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(runLogPath, RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
+
+        EmitResult(writer, format, NewResult(executionUnit!, write, oldPriority: item.Priority, requestedPriority!, reason!, changed: true, error: null));
+        return 0;
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? executionUnit,
+        out string? priority,
+        out string? reason,
+        out bool write,
+        out string format,
+        out string error)
+    {
+        executionUnit = null;
+        priority = null;
+        reason = null;
+        write = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]) || args[0].StartsWith("--", StringComparison.Ordinal))
+        {
+            error = "Queue reprioritize command requires an execution unit as the first argument.";
+            return false;
+        }
+
+        executionUnit = args[0];
+
+        for (var index = 1; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--priority":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--priority requires a value (high, normal, or low).";
+                        return false;
+                    }
+                    if (!TryNormalizePriority(args[++index], out priority))
+                    {
+                        error = $"Unsupported --priority value '{args[index]}'. Supported values: high, normal, low.";
+                        return false;
+                    }
+                    break;
+                case "--reason":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--reason requires a value.";
+                        return false;
+                    }
+                    reason = args[++index].Trim();
+                    break;
+                case "--write":
+                    write = true;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requestedFormat = args[++index].Trim();
+                    if (!string.Equals(requestedFormat, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        if (priority is null)
+        {
+            error = "Queue reprioritize command requires '--priority <high|normal|low>'.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(reason))
+        {
+            error = "Queue reprioritize command requires '--reason <text>' — a priority change without a recorded reason is not permitted.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryNormalizePriority(string raw, out string? normalized)
+    {
+        switch (raw.Trim().ToLowerInvariant())
+        {
+            case PriorityHigh:
+                normalized = PriorityHigh;
+                return true;
+            case PriorityNormal:
+                normalized = PriorityNormal;
+                return true;
+            case PriorityLow:
+                normalized = PriorityLow;
+                return true;
+            default:
+                normalized = null;
+                return false;
+        }
+    }
+
+    private static string FormatState(QueueItemState state)
+    {
+        return state switch
+        {
+            QueueItemState.ClarifyBlocked => "clarify-blocked",
+            _ => state.ToString().ToLowerInvariant(),
+        };
+    }
+
+    private static QueueReprioritizeResult NewResult(
+        string executionUnit,
+        bool write,
+        string? oldPriority,
+        string requestedPriority,
+        string reason,
+        bool changed,
+        string? error) => new()
+    {
+        ExecutionUnit = executionUnit,
+        Mode = write ? ModeWrite : ModeDryRun,
+        OldPriority = oldPriority,
+        RequestedPriority = requestedPriority,
+        Reason = reason,
+        Changed = changed,
+        Error = error,
+    };
+
+    private static void EmitResult(TextWriter writer, string format, QueueReprioritizeResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        writer.WriteLine($"# Queue reprioritize — {result.ExecutionUnit}");
+        writer.WriteLine();
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- old priority: {result.OldPriority ?? "-"}");
+        writer.WriteLine($"- requested priority: {result.RequestedPriority}");
+        writer.WriteLine($"- reason: {result.Reason}");
+        writer.WriteLine($"- changed: {(result.Changed ? "yes" : "no")}");
+        if (!string.IsNullOrWhiteSpace(result.Error))
+        {
+            writer.WriteLine($"- error: {result.Error}");
+        }
+        else if (result.Changed && string.Equals(result.Mode, ModeDryRun, StringComparison.Ordinal))
+        {
+            writer.WriteLine($"- would set priority to '{result.RequestedPriority}' and append a `{PriorityChangedEventName}` runs event; re-run with --write to apply.");
+        }
+    }
+}
+
+internal sealed record QueueReprioritizeResult
+{
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("old_priority")]
+    public string? OldPriority { get; init; }
+
+    [JsonPropertyName("requested_priority")]
+    public required string RequestedPriority { get; init; }
+
+    [JsonPropertyName("reason")]
+    public required string Reason { get; init; }
+
+    [JsonPropertyName("changed")]
+    public required bool Changed { get; init; }
+
+    [JsonPropertyName("error")]
+    public string? Error { get; init; }
+}

--- a/src/IntentSystem.Supervisor/Models/QueueItem.cs
+++ b/src/IntentSystem.Supervisor/Models/QueueItem.cs
@@ -36,4 +36,20 @@ public sealed record QueueItem
     /// optionally suffixed with an operator note. Null for every other state.
     /// </summary>
     public string? RetirementReason { get; init; }
+
+    /// <summary>
+    /// G537 round-4 review repair: a durable, monotonically-incrementing
+    /// counter bumped by exactly 1 on every successful <c>queue
+    /// reprioritize --write</c>. Deliberately NOT <c>required</c> — legacy
+    /// <c>queue-state.json</c> files predating this field simply
+    /// deserialize it as <c>0</c> (the JSON default for an absent `int`
+    /// property), which is the correct migration semantics: revision
+    /// counting starts from the first reprioritize this command ever
+    /// applies to a given item. Unlike a content fingerprint of the whole
+    /// file, this value can never recur for two distinct mutations of the
+    /// same item, even if every other field of <c>queue-state.json</c>
+    /// later cycles back to byte-identical content — it only ever moves
+    /// forward.
+    /// </summary>
+    public int PriorityRevision { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -376,6 +376,178 @@ public sealed class IntentNextSliceCommandTests
     }
 
     [Fact]
+    public void Execute_HighPriorityUnitWithIncompleteDependency_IsNeverSelectedOverEligibleLowerPriorityUnit()
+    {
+        // G537 review repair: dependency completeness is an authoritative
+        // eligibility gate — a "high" priority queued unit whose
+        // dependency has NOT reached `completed` must never be selected
+        // ahead of an eligible normal-priority unit with no unmet
+        // dependencies. Priority only orders candidates that already pass
+        // every gate, dependencies included.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(".intent-cli/issues/G600/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G601/github-body.md", BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-19T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G600",
+                  "title": "high priority but depends on unfinished work",
+                  "state": "queued",
+                  "dependencies": ["G599"],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                },
+                {
+                  "execution_unit": "G601",
+                  "title": "normal priority, no dependencies, fully eligible",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G601", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_HighPriorityUnitWithNonEmptyBlockedBy_IsNeverSelectedOverEligibleLowerPriorityUnit()
+    {
+        // G537 review repair: a non-empty `blocked_by` is likewise an
+        // authoritative eligibility gate that dominates priority.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(".intent-cli/issues/G610/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G611/github-body.md", BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-19T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G610",
+                  "title": "high priority but explicitly blocked",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": ["waiting on infra approval"],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                },
+                {
+                  "execution_unit": "G611",
+                  "title": "normal priority, not blocked",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G611", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_HighPriorityUnitWithCompletedDependency_IsSelected()
+    {
+        // Counterpart: once the dependency reaches `completed`, the
+        // high-priority unit becomes eligible and priority correctly wins.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(".intent-cli/issues/G620/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G621/github-body.md", BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-19T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G619",
+                  "title": "the dependency, already completed",
+                  "state": "completed",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "G620",
+                  "title": "high priority, dependency now complete",
+                  "state": "queued",
+                  "dependencies": ["G619"],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                },
+                {
+                  "execution_unit": "G621",
+                  "title": "normal priority, authored second",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G620", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
     public void Execute_NoPrioritiesSet_SelectionStaysByteIdenticalToAuthoringOrder()
     {
         // G537 required regression: with every item at the enqueue default

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -260,6 +260,187 @@ public sealed class IntentNextSliceCommandTests
         Assert.Equal("G245", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
     }
 
+    // ─── G537: priority-aware candidate ordering ────────────────────────────
+
+    [Fact]
+    public void Execute_FieldScenario_LaterAuthoredHighPriorityUnit_IsSelectedOverEarlierAuthoredNormalUnit()
+    {
+        // G537 field incident: G530 (authored first, normal priority) and
+        // G532 (authored second, but the orchestrator ruled it should
+        // publish FIRST). Setting G532's queue priority to "high" must now
+        // make the selector return G532 instead of the authoring-order
+        // winner G530.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(".intent-cli/issues/G530/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G532/github-body.md", BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-19T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G530",
+                  "title": "authored first",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "G532",
+                  "title": "field-impact fix, ruled to publish first",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G532", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_HighPriorityUnitExcludedByLifecycleGate_NormalPriorityUnitStillSelected()
+    {
+        // G537: gate precedence over priority. A "high" priority unit that
+        // fails a hard eligibility gate (here: G534's lifecycle exclusion —
+        // absorbed via lifecycle.yaml) must NEVER be selected ahead of an
+        // eligible lower-priority unit; priority only orders candidates
+        // that already passed every gate.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(".intent-cli/issues/G244/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(
+            ".intent-cli/issues/G244/lifecycle.yaml",
+            "lifecycle: absorbed\nabsorbed_by: G245\nretired_reason: \"fully absorbed into G245\"\n");
+        workspace.WriteFile(".intent-cli/issues/G245/github-body.md", BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-19T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G244",
+                  "title": "absorbed slice, but marked high priority",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                },
+                {
+                  "execution_unit": "G245",
+                  "title": "eligible normal-priority slice",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G245", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_NoPrioritiesSet_SelectionStaysByteIdenticalToAuthoringOrder()
+    {
+        // G537 required regression: with every item at the enqueue default
+        // ("normal"), ordering must be unchanged from pre-G537 behavior —
+        // plain authoring (queue-state array) order.
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(".intent-cli/issues/G100/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G101/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G102/github-body.md", BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-19T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G100",
+                  "title": "first authored",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "G101",
+                  "title": "second authored",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                },
+                {
+                  "execution_unit": "G102",
+                  "title": "third authored",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
+        Assert.Equal("G100", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
     [Fact]
     public void Execute_LifecycleRetiredPacket_NoQueueEntryAtAll_ExcludedAndNextRealCandidateSelected()
     {

--- a/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
@@ -391,14 +391,17 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.Equal(2, events.Count);
     }
 
+    // ─── G537 round-5 review repair: revision-pair recovery classification,
+    // checked/validated PriorityRevision, and concurrent-writer protection ──
+
     [Fact]
-    public void Execute_StaleHistoricalEventWithDifferentReasonText_NeverSuppressesTheNewEvent()
+    public void Execute_ConflictingClaimSameRevisionPairDifferentReason_FailsClosedQueueUntouched()
     {
-        // "Wrong reason": a stale event sharing the SAME (correct,
-        // matching) revision pair but a DIFFERENT reason string must
-        // still never dedupe — isolates that the reason text is
-        // independently required, not merely a side effect of a
-        // mismatched revision.
+        // Round-5 review: an existing event claiming the SAME revision
+        // pair but a DIFFERENT reason is a genuine data contradiction —
+        // the revision pair IS the operation identity, so this must fail
+        // closed (never silently append a second, different claim on the
+        // same pair).
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
         SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': OLD_REASON (revision 0->1)");
@@ -409,19 +412,25 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
             ["G537", "--priority", "high", "--reason", "NEW_REASON", "--write", "--format", "json"],
             writer);
 
-        Assert.Equal(0, exitCode);
+        Assert.Equal(1, exitCode);
         using var document = JsonDocument.Parse(writer.ToString());
-        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
-        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
-        Assert.Equal(2, events.Count);
-        Assert.Contains(events, e => e.Reason!.Contains("NEW_REASON", StringComparison.Ordinal));
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("conflicting", error, StringComparison.Ordinal);
+        Assert.False(document.RootElement.GetProperty("changed").GetBoolean());
+
+        // Queue untouched, no second event appended.
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("normal", stateAfter.Items.Single().Priority);
+        Assert.Equal(0, stateAfter.Items.Single().PriorityRevision);
+        Assert.Single(RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath)));
     }
 
     [Fact]
-    public void Execute_StaleHistoricalEventWithOppositeDirection_NeverSuppressesTheNewEvent()
+    public void Execute_ConflictingClaimSameRevisionPairOppositeDirection_FailsClosedQueueUntouched()
     {
-        // "Wrong direction": same matching revision pair, but the event
-        // records the OPPOSITE transition — must never dedupe.
+        // Round-5 review: same revision pair, but the existing event
+        // records the OPPOSITE transition direction — also a conflict,
+        // not a "wrong reason, append anyway" case.
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
         SeedHistoricalEvent(workspace, "G537", "priority changed from 'high' to 'normal': R (revision 0->1)");
@@ -432,12 +441,226 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
             ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
             writer);
 
-        Assert.Equal(0, exitCode);
+        Assert.Equal(1, exitCode);
         using var document = JsonDocument.Parse(writer.ToString());
-        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
-        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
-        Assert.Equal(2, events.Count);
-        Assert.Contains(events, e => e.Reason!.StartsWith("priority changed from 'normal' to 'high': R", StringComparison.Ordinal));
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("conflicting", error, StringComparison.Ordinal);
+
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("normal", stateAfter.Items.Single().Priority);
+        Assert.Single(RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath)));
+    }
+
+    [Theory]
+    [InlineData(0, 1)] // conflicting event listed FIRST, matching-shape event would be second (never appended)
+    [InlineData(1, 0)] // reversed order: conflicting event listed SECOND
+    public void Execute_ConflictingClaim_OrderIndependent_AlwaysFailsClosed(int conflictingIndex, int unusedIndex)
+    {
+        // "Reversed/order-independent": classification must not depend on
+        // which position in runs.jsonl the conflicting event occupies.
+        // This fixture seeds exactly one (conflicting) historical event —
+        // the SAME conflict must be detected regardless of the requested
+        // insertion order semantics exercised via conflictingIndex.
+        _ = unusedIndex;
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        if (conflictingIndex == 0)
+        {
+            SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': DIFFERENT (revision 0->1)");
+        }
+        else
+        {
+            // Seed an unrelated (non-matching-unit) event first, THEN the
+            // conflicting one, to prove order of appearance in the file
+            // never matters to the classification.
+            SeedHistoricalEvent(workspace, "G000", "priority changed from 'normal' to 'high': unrelated (revision 0->1)");
+            SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': DIFFERENT (revision 0->1)");
+        }
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Contains("conflicting", document.RootElement.GetProperty("error").GetString(), StringComparison.Ordinal);
+        Assert.Equal("normal", QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath)).Items.Single().Priority);
+    }
+
+    [Fact]
+    public void Execute_DuplicateIdenticalEventsForSameRevisionPair_FailsClosedQueueUntouched()
+    {
+        // Round-5 review: TWO existing events, both claiming the SAME
+        // revision pair with the IDENTICAL reason, is itself an integrity
+        // problem (how did that happen?) — must fail closed, not be
+        // silently treated as "one pending retry."
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': R (revision 0->1)");
+        SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': R (revision 0->1)");
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("duplicate-identical", error, StringComparison.Ordinal);
+
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("normal", stateAfter.Items.Single().Priority);
+        Assert.Equal(2, RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath)).Count); // no third event appended
+    }
+
+    [Fact]
+    public void Execute_NegativePriorityRevision_FailsClosedInDryRunAndWrite()
+    {
+        // Round-5 review: a negative priority_revision is corrupted
+        // durable state — must refuse before any preview/mutation, in
+        // BOTH dry-run and write mode.
+        using var workspace = new ReprioritizeWorkspace();
+        var baseState = QueueStateSerializer.Deserialize(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(QueueStateSerializer.Serialize(
+            baseState with { Items = new[] { baseState.Items.Single() with { PriorityRevision = -1 } } }));
+
+        using var dryRunWriter = new StringWriter();
+        var dryRunExitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "high", "--reason", "R", "--format", "json"], dryRunWriter);
+        Assert.Equal(1, dryRunExitCode);
+        using var dryRunDoc = JsonDocument.Parse(dryRunWriter.ToString());
+        Assert.Contains("negative priority_revision", dryRunDoc.RootElement.GetProperty("error").GetString(), StringComparison.Ordinal);
+
+        using var writeWriter = new StringWriter();
+        var writeExitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"], writeWriter);
+        Assert.Equal(1, writeExitCode);
+        using var writeDoc = JsonDocument.Parse(writeWriter.ToString());
+        Assert.Contains("negative priority_revision", writeDoc.RootElement.GetProperty("error").GetString(), StringComparison.Ordinal);
+
+        Assert.False(File.Exists(workspace.RunsLogPath));
+        Assert.Equal(-1, QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath)).Items.Single().PriorityRevision);
+    }
+
+    [Fact]
+    public void Execute_ExhaustedMaxRevision_FailsClosedInDryRunAndWrite_CheckedArithmeticNeverWraps()
+    {
+        // Round-5 review: `int.MaxValue + 1` unchecked wraps to
+        // int.MinValue, directly violating the monotonic/injective
+        // invariant. Must fail closed instead, in BOTH dry-run and write.
+        using var workspace = new ReprioritizeWorkspace();
+        var baseState = QueueStateSerializer.Deserialize(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(QueueStateSerializer.Serialize(
+            baseState with { Items = new[] { baseState.Items.Single() with { PriorityRevision = int.MaxValue } } }));
+
+        using var dryRunWriter = new StringWriter();
+        var dryRunExitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "high", "--reason", "R", "--format", "json"], dryRunWriter);
+        Assert.Equal(1, dryRunExitCode);
+        using var dryRunDoc = JsonDocument.Parse(dryRunWriter.ToString());
+        Assert.Contains("exhausted", dryRunDoc.RootElement.GetProperty("error").GetString(), StringComparison.Ordinal);
+
+        using var writeWriter = new StringWriter();
+        var writeExitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"], writeWriter);
+        Assert.Equal(1, writeExitCode);
+        using var writeDoc = JsonDocument.Parse(writeWriter.ToString());
+        Assert.Contains("exhausted", writeDoc.RootElement.GetProperty("error").GetString(), StringComparison.Ordinal);
+
+        Assert.False(File.Exists(workspace.RunsLogPath));
+        Assert.Equal(int.MaxValue, QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath)).Items.Single().PriorityRevision);
+    }
+
+    [Fact]
+    public void Execute_MalformedPriorityRevisionType_FailsClosedAtQueueStateParse()
+    {
+        // "Malformed": priority_revision as a JSON string (wrong type)
+        // fails at the existing queue-state.json parse step — pinned
+        // explicitly per review request.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-08T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G537",
+                  "title": "malformed priority_revision type",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "Claude",
+                  "review_role": "Codex",
+                  "priority": "normal",
+                  "priority_revision": "not-a-number"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "high", "--reason", "R", "--write"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("could not be parsed", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(workspace.RunsLogPath));
+    }
+
+    [Fact]
+    public void Execute_ConcurrentQueueStateChangeBetweenEventAppendAndFinalWrite_FailsClosedWithoutOverwriting()
+    {
+        // Round-5 review: protect the read -> event -> queue-write
+        // boundary. Simulate a concurrent writer mutating queue-state.json
+        // (bumping priority_revision unrelated to this attempt) DURING
+        // the runs-event append step, via the AppendPriorityChangedEventOverride
+        // seam. The subsequent final write must detect the mismatch and
+        // refuse, rather than blindly overwriting the concurrent change.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+
+        QueueReprioritizeCommand.AppendPriorityChangedEventOverride = (path, runEvent) =>
+        {
+            File.AppendAllText(path, RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
+
+            // Simulate a concurrent, unrelated writer bumping this same
+            // item's priority_revision after our read but before our
+            // write.
+            var concurrentState = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+            var concurrentItem = concurrentState.Items.Single();
+            var mutated = concurrentState with
+            {
+                Items = new[] { concurrentItem with { Priority = "low", PriorityRevision = concurrentItem.PriorityRevision + 100 } },
+            };
+            File.WriteAllText(workspace.QueueStatePath, QueueStateSerializer.Serialize(mutated));
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("changed concurrently", error, StringComparison.Ordinal);
+
+        // The concurrent writer's own change survives untouched — our
+        // stale mutation must never have overwritten it.
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("low", stateAfter.Items.Single().Priority);
+        Assert.Equal(100, stateAfter.Items.Single().PriorityRevision);
+
+        // The audit event for OUR attempt was still durably recorded.
+        Assert.Single(RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath)));
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
@@ -761,6 +761,64 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
     }
 
+    // ─── G537 round-7 review repair: exception-safe lock release ──────────
+
+    [Fact]
+    public void Execute_CallbackThrowsAfterLockAcquired_LockStillReleasedDeterministically()
+    {
+        // Round-7 review: OnLockAcquiredForTest previously fired BEFORE
+        // entering the try/finally that disposes lockStream. A throwing
+        // callback would therefore leak the acquired OS-level lock handle
+        // undisposed, leaving a subsequent independent Execute locked out
+        // until GC/finalization. This proves the fix: the callback now
+        // runs inside the try/finally, so even when it throws, the lock
+        // is released deterministically and a second call can proceed
+        // immediately — with the queue/runs state left byte-unchanged by
+        // the failed first call.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+
+        QueueReprioritizeCommand.OnLockAcquiredForTest = () =>
+        {
+            QueueReprioritizeCommand.OnLockAcquiredForTest = null;
+            throw new InvalidOperationException("simulated callback failure");
+        };
+
+        using var firstWriter = new StringWriter();
+        var thrown = Assert.Throws<InvalidOperationException>(() =>
+            QueueReprioritizeCommand.Execute(
+                workspace.Context,
+                ["G537", "--priority", "high", "--reason", "R (first, throws)", "--write", "--format", "json"],
+                firstWriter));
+        Assert.Equal("simulated callback failure", thrown.Message);
+
+        // The failed first call must never have reached the write path.
+        var stateAfterFirst = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("normal", stateAfterFirst.Items.Single().Priority);
+        Assert.Equal(0, stateAfterFirst.Items.Single().PriorityRevision);
+        Assert.False(File.Exists(workspace.RunsLogPath));
+
+        // A second, fully independent invocation must acquire the same
+        // lock immediately (proving it was released, not leaked) and
+        // succeed normally.
+        using var secondWriter = new StringWriter();
+        var secondExitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R (second, after throw)", "--write", "--format", "json"],
+            secondWriter);
+
+        Assert.Equal(0, secondExitCode);
+        using var secondDoc = JsonDocument.Parse(secondWriter.ToString());
+        Assert.True(secondDoc.RootElement.GetProperty("changed").GetBoolean());
+
+        var stateAfterSecond = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("high", stateAfterSecond.Items.Single().Priority);
+        Assert.Equal(1, stateAfterSecond.Items.Single().PriorityRevision);
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        var runEvent = Assert.Single(events);
+        Assert.Contains("second, after throw", runEvent.Reason, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Execute_StaleHistoricalEventForDifferentExecutionUnit_NeverSuppressesTheNewEvent()
     {

--- a/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
@@ -12,11 +12,15 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     public QueueReprioritizeCommandTests()
     {
         QueueReprioritizeCommand.UtcNowFactory = null;
+        QueueReprioritizeCommand.AppendPriorityChangedEventOverride = null;
+        QueueReprioritizeCommand.WriteQueueStateOverride = null;
     }
 
     public void Dispose()
     {
         QueueReprioritizeCommand.UtcNowFactory = null;
+        QueueReprioritizeCommand.AppendPriorityChangedEventOverride = null;
+        QueueReprioritizeCommand.WriteQueueStateOverride = null;
     }
 
     [Fact]
@@ -189,6 +193,112 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         using var document = JsonDocument.Parse(writer.ToString());
         Assert.False(document.RootElement.GetProperty("changed").GetBoolean());
         Assert.False(File.Exists(workspace.RunsLogPath));
+    }
+
+    // ─── G537 review repair: fail-closed, repairable write strategy ────────
+
+    [Fact]
+    public void Execute_RunsEventAppendFails_QueueStateNeverTouched_FailsLoud()
+    {
+        // The audit event is written FIRST; if that fails, queue-state.json
+        // must never be mutated at all — no silent, unaudited change.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        var queueStateBefore = File.ReadAllText(workspace.QueueStatePath);
+        QueueReprioritizeCommand.AppendPriorityChangedEventOverride = (_, _) =>
+            throw new IOException("simulated disk failure appending runs.jsonl");
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "publish ahead", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("queue-state.json was NOT touched", error, StringComparison.Ordinal);
+        Assert.Contains("no durable change was made", error, StringComparison.Ordinal);
+
+        // Byte-for-byte: nothing was mutated.
+        Assert.Equal(queueStateBefore, File.ReadAllText(workspace.QueueStatePath));
+        Assert.False(File.Exists(workspace.RunsLogPath));
+    }
+
+    [Fact]
+    public void Execute_QueueStateWriteFailsAfterEventAppended_FailsLoudNamingTheHalfTransition()
+    {
+        // The event append succeeds (durable audit trail exists — this is
+        // NOT a silent unaudited mutation), but the queue-state write then
+        // fails. Must fail loud and explain exactly what state the
+        // operator is in.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        QueueReprioritizeCommand.WriteQueueStateOverride = (_, _) =>
+            throw new IOException("simulated disk failure writing queue-state.json");
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "publish ahead", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("priority-changed runs event was recorded", error, StringComparison.Ordinal);
+        Assert.Contains("still shows the OLD priority", error, StringComparison.Ordinal);
+
+        // The audit event WAS durably recorded, proving this is not silent.
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        var runEvent = Assert.Single(events);
+        Assert.Equal("priority-changed", runEvent.Event);
+
+        // queue-state genuinely was not updated (the write failed).
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("normal", stateAfter.Items.Single().Priority);
+    }
+
+    [Fact]
+    public void Execute_RetryAfterQueueStateWriteFailure_ConvergesWithoutDuplicateEvent()
+    {
+        // Idempotent retry: the SAME command, re-run after the queue-state
+        // write failure above, must detect the already-recorded event
+        // (skip re-appending — no duplicate), retry ONLY the queue-state
+        // write, and converge to a fully consistent, singly-audited state.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        QueueReprioritizeCommand.WriteQueueStateOverride = (_, _) =>
+            throw new IOException("simulated disk failure writing queue-state.json");
+
+        using (var firstAttempt = new StringWriter())
+        {
+            var firstExitCode = QueueReprioritizeCommand.Execute(
+                workspace.Context,
+                ["G537", "--priority", "high", "--reason", "publish ahead", "--write", "--format", "json"],
+                firstAttempt);
+            Assert.Equal(1, firstExitCode);
+        }
+
+        // Fault resolved — retry with the real write path restored.
+        QueueReprioritizeCommand.WriteQueueStateOverride = null;
+
+        using var retryWriter = new StringWriter();
+        var retryExitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "publish ahead", "--write", "--format", "json"],
+            retryWriter);
+
+        Assert.Equal(0, retryExitCode);
+        using var document = JsonDocument.Parse(retryWriter.ToString());
+        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
+
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("high", stateAfter.Items.Single().Priority);
+
+        // Exactly ONE event — the retry did not append a duplicate.
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        Assert.Single(events);
     }
 
     private static string BuildQueueState((string ExecutionUnit, QueueItemState State, string Priority, LinkedIssue? LinkedIssue) item)

--- a/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
@@ -14,6 +14,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         QueueReprioritizeCommand.UtcNowFactory = null;
         QueueReprioritizeCommand.AppendPriorityChangedEventOverride = null;
         QueueReprioritizeCommand.WriteQueueStateOverride = null;
+        QueueReprioritizeCommand.OnLockAcquiredForTest = null;
     }
 
     public void Dispose()
@@ -21,6 +22,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         QueueReprioritizeCommand.UtcNowFactory = null;
         QueueReprioritizeCommand.AppendPriorityChangedEventOverride = null;
         QueueReprioritizeCommand.WriteQueueStateOverride = null;
+        QueueReprioritizeCommand.OnLockAcquiredForTest = null;
     }
 
     [Fact]
@@ -661,6 +663,102 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
 
         // The audit event for OUR attempt was still durably recorded.
         Assert.Single(RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath)));
+    }
+
+    // ─── G537 round-6 review repair: authoritative interprocess lock ───────
+
+    [Fact]
+    public void Execute_ConcurrentInvocationWhileLockHeld_LoserFailsClosed_WinnerAppliesExactlyOneMutation()
+    {
+        // Round-6 review: the round-5 "re-read + compare" was still a
+        // TOCTOU check, not authoritative mutual exclusion — two
+        // concurrent invocations could both pass the compare before
+        // either commits. This deterministically proves the fix: while
+        // the OUTER invocation holds the lock (via OnLockAcquiredForTest,
+        // fired synchronously right after lock acquisition), a SECOND,
+        // fully independent Execute call for the SAME repo/execution unit
+        // is attempted. It must fail to acquire the same OS-level lock
+        // and fail closed immediately — never racing, never silently
+        // partially applying. After the outer call completes, exactly
+        // ONE mutation and ONE event must exist.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+
+        int? innerExitCode = null;
+        string? innerOutput = null;
+        QueueReprioritizeCommand.OnLockAcquiredForTest = () =>
+        {
+            // Prevent recursion: the inner call must NOT itself try to
+            // spawn a third concurrent attempt.
+            QueueReprioritizeCommand.OnLockAcquiredForTest = null;
+
+            using var innerWriter = new StringWriter();
+            innerExitCode = QueueReprioritizeCommand.Execute(
+                workspace.Context,
+                ["G537", "--priority", "high", "--reason", "R (inner, concurrent)", "--write", "--format", "json"],
+                innerWriter);
+            innerOutput = innerWriter.ToString();
+        };
+
+        using var outerWriter = new StringWriter();
+        var outerExitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R (outer, winner)", "--write", "--format", "json"],
+            outerWriter);
+
+        // The outer (lock-holding) invocation wins and succeeds.
+        Assert.Equal(0, outerExitCode);
+        using var outerDoc = JsonDocument.Parse(outerWriter.ToString());
+        Assert.True(outerDoc.RootElement.GetProperty("changed").GetBoolean());
+
+        // The inner (concurrent) invocation could not acquire the same
+        // lock and failed closed immediately — it never raced, never
+        // partially wrote anything.
+        Assert.NotNull(innerExitCode);
+        Assert.Equal(1, innerExitCode);
+        Assert.NotNull(innerOutput);
+        using var innerDoc = JsonDocument.Parse(innerOutput!);
+        var innerError = innerDoc.RootElement.GetProperty("error").GetString();
+        Assert.Contains("holds the exclusive lock", innerError, StringComparison.Ordinal);
+        Assert.False(innerDoc.RootElement.GetProperty("changed").GetBoolean());
+
+        // Exactly ONE mutation, ONE event — the outer winner's, never a
+        // duplicate or a conflicting write from the inner loser.
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("high", stateAfter.Items.Single().Priority);
+        Assert.Equal(1, stateAfter.Items.Single().PriorityRevision);
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        var runEvent = Assert.Single(events);
+        Assert.Contains("outer, winner", runEvent.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DryRunNeverAcquiresLock_ConcurrentWriteStillProceedsUnaffected()
+    {
+        // Dry-run never mutates, so it must never contend for the lock —
+        // a concurrent --write invocation must be able to proceed
+        // normally even while a dry-run preview is (conceptually)
+        // in-flight. Since dry-run doesn't hold the lock at all, this is
+        // really just confirming dry-run doesn't regress: it must still
+        // succeed even with the lock file already present/created by a
+        // prior write.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+
+        // A prior --write created (and released) the lock file; it stays
+        // on disk afterward (never deleted — only ever held/released).
+        Assert.Equal(0, QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "high", "--reason", "R", "--write"], new StringWriter()));
+
+        using var dryRunWriter = new StringWriter();
+        var dryRunExitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "normal", "--reason", "S", "--format", "json"],
+            dryRunWriter);
+
+        Assert.Equal(0, dryRunExitCode);
+        using var document = JsonDocument.Parse(dryRunWriter.ToString());
+        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
@@ -1,0 +1,266 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class QueueReprioritizeCommandTests : IDisposable
+{
+    public QueueReprioritizeCommandTests()
+    {
+        QueueReprioritizeCommand.UtcNowFactory = null;
+    }
+
+    public void Dispose()
+    {
+        QueueReprioritizeCommand.UtcNowFactory = null;
+    }
+
+    [Fact]
+    public void Execute_DryRunDefault_ReportsWouldChangeWithoutMutating()
+    {
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        var queueStateBefore = File.ReadAllText(workspace.QueueStatePath);
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "publish ahead of G530", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("dry-run", root.GetProperty("mode").GetString());
+        Assert.Equal("normal", root.GetProperty("old_priority").GetString());
+        Assert.Equal("high", root.GetProperty("requested_priority").GetString());
+        Assert.True(root.GetProperty("changed").GetBoolean());
+
+        // No mutation on dry-run.
+        Assert.Equal(queueStateBefore, File.ReadAllText(workspace.QueueStatePath));
+        Assert.False(File.Exists(workspace.RunsLogPath));
+    }
+
+    [Fact]
+    public void Execute_Write_MutatesPriorityAndAppendsReasonedRunEvent()
+    {
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        var changedAt = new DateTimeOffset(2026, 7, 19, 3, 0, 0, TimeSpan.Zero);
+        QueueReprioritizeCommand.UtcNowFactory = () => changedAt;
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "publish ahead of G530", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("write", root.GetProperty("mode").GetString());
+        Assert.True(root.GetProperty("changed").GetBoolean());
+
+        var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("high", updatedState.Items.Single().Priority);
+        Assert.Equal(changedAt, updatedState.UpdatedAt);
+
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        var runEvent = Assert.Single(events);
+        Assert.Equal("priority-changed", runEvent.Event);
+        Assert.Equal("G537", runEvent.ExecutionUnit);
+        Assert.Equal("intent-cli", runEvent.By);
+        Assert.Contains("normal", runEvent.Reason, StringComparison.Ordinal);
+        Assert.Contains("high", runEvent.Reason, StringComparison.Ordinal);
+        Assert.Contains("publish ahead of G530", runEvent.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RefusesOnNonQueuedState()
+    {
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Active, "normal", linkedIssue: null)));
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "x", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("not queued", error, StringComparison.Ordinal);
+        Assert.False(File.Exists(workspace.RunsLogPath));
+
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("normal", stateAfter.Items.Single().Priority);
+    }
+
+    [Fact]
+    public void Execute_RefusesOnAlreadyPublishedUnit()
+    {
+        using var workspace = new ReprioritizeWorkspace();
+        var linkedIssue = new LinkedIssue { Repo = "J-Tech-Japan/intent-system", Number = 1176, Url = "https://github.com/J-Tech-Japan/intent-system/issues/1176" };
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue)));
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "x", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("already has a linked GitHub issue", error, StringComparison.Ordinal);
+
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("normal", stateAfter.Items.Single().Priority);
+    }
+
+    [Fact]
+    public void Execute_RefusesOnUnknownExecutionUnit()
+    {
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G999", "--priority", "high", "--reason", "x", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var error = document.RootElement.GetProperty("error").GetString();
+        Assert.Contains("no item with execution_unit", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RefusesWithoutReason()
+    {
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--reason", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RefusesUnsupportedPriorityValue()
+    {
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "urgent", "--reason", "x", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unsupported --priority value", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_SamePriorityRequested_IsIdempotentNoOp()
+    {
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "high", linkedIssue: null)));
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "no-op", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.False(document.RootElement.GetProperty("changed").GetBoolean());
+        Assert.False(File.Exists(workspace.RunsLogPath));
+    }
+
+    private static string BuildQueueState((string ExecutionUnit, QueueItemState State, string Priority, LinkedIssue? LinkedIssue) item)
+    {
+        var state = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = new DateTimeOffset(2026, 5, 8, 0, 0, 0, TimeSpan.Zero),
+            Items = new[]
+            {
+                new QueueItem
+                {
+                    ExecutionUnit = item.ExecutionUnit,
+                    Title = $"{item.ExecutionUnit} title",
+                    State = item.State,
+                    Dependencies = Array.Empty<string>(),
+                    BlockedBy = Array.Empty<string>(),
+                    ClarificationReturnPath = string.Empty,
+                    PacketPaths = new PacketPaths
+                    {
+                        Yaml = $".intent-cli/issues/{item.ExecutionUnit}/packet.yaml",
+                        Implementation = $".intent-cli/issues/{item.ExecutionUnit}/implementation.md",
+                        ReviewContext = $".intent-cli/issues/{item.ExecutionUnit}/review-context.md"
+                    },
+                    LinkedIssue = item.LinkedIssue,
+                    WorkerRole = "Claude",
+                    ReviewRole = "Codex",
+                    Priority = item.Priority
+                }
+            }
+        };
+        return QueueStateSerializer.Serialize(state);
+    }
+
+    private sealed class ReprioritizeWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory
+            .CreateTempSubdirectory("queue-reprioritize-tests-")
+            .FullName;
+
+        public ReprioritizeWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees"
+                    }
+                }
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string QueueStatePath => Context.GetQueueStatePath();
+
+        public string RunsLogPath => Context.GetRunLogPath();
+
+        public void WriteQueueState(string json) => File.WriteAllText(QueueStatePath, json);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
@@ -301,18 +301,19 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.Single(events);
     }
 
-    // ─── G537 round-2 review repair: dedup bound to queue-state generation ──
+    // ─── G537 round-3 review repair: dedup bound to a content fingerprint,
+    // never wall-clock ordering ─────────────────────────────────────────────
 
     [Fact]
     public void Execute_RoundTripStaleCollision_ThirdMutationGetsItsOwnEvent()
     {
-        // The exact reproduction from review: normal->high reason R
+        // The reproduction from round 2's review: normal->high reason R
         // completes; high->normal reason S completes; normal->high reason
-        // R is requested AGAIN. The third request's expected reason text
-        // is BYTE-IDENTICAL to the first event's — but the first event is
-        // now stale (superseded by the second transition's queue-state
-        // write), so the third mutation must get its OWN new event, not
-        // be silently skipped as if it were a pending retry of the first.
+        // R is requested AGAIN. The third request's UNTAGGED reason text
+        // is byte-identical to the first event's — but the first event's
+        // content fingerprint is now stale (the second transition's write
+        // changed queue-state.json), so the third mutation must get its
+        // OWN new event.
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
 
@@ -342,24 +343,89 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
         Assert.Equal(3, events.Count);
         Assert.All(events, e => Assert.Equal("priority-changed", e.Event));
-        Assert.Equal(new DateTimeOffset(2026, 7, 19, 1, 0, 0, TimeSpan.Zero), events[0].Ts);
-        Assert.Equal(new DateTimeOffset(2026, 7, 19, 2, 0, 0, TimeSpan.Zero), events[1].Ts);
-        Assert.Equal(new DateTimeOffset(2026, 7, 19, 3, 0, 0, TimeSpan.Zero), events[2].Ts);
+        // Every event's own fingerprint tag is distinct (each was computed
+        // against a genuinely different pre-mutation queue-state.json).
+        Assert.Equal(3, events.Select(e => e.Reason).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void Execute_RoundTripStaleCollision_SameFixedClockAcrossAllThreeOperations_StillGetsThreeEvents()
+    {
+        // The EXACT round-3 review reproduction: UtcNowFactory returns ONE
+        // identical timestamp for all three successful operations, so
+        // `Ts` can never discriminate between them at all. The content
+        // fingerprint must still correctly produce three distinct events,
+        // since it never looks at time.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        var fixedNow = new DateTimeOffset(2026, 7, 19, 4, 0, 0, TimeSpan.Zero);
+        QueueReprioritizeCommand.UtcNowFactory = () => fixedNow;
+
+        Assert.Equal(0, QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "high", "--reason", "R", "--write"], new StringWriter()));
+        Assert.Equal(0, QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "normal", "--reason", "S", "--write"], new StringWriter()));
+
+        using var thirdWriter = new StringWriter();
+        var thirdExitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
+            thirdWriter);
+
+        Assert.Equal(0, thirdExitCode);
+        using var document = JsonDocument.Parse(thirdWriter.ToString());
+        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
+
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        Assert.Equal(3, events.Count);
+        Assert.All(events, e => Assert.Equal(fixedNow, e.Ts)); // confirms Ts truly never discriminated here
+        Assert.Equal(3, events.Select(e => e.Reason).Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void Execute_ClockRollback_StillGetsItsOwnEventAndNeverDedupesAgainstAnEarlierTimestampedEvent()
+    {
+        // Round-3 review: a clock rollback between operations (op2's
+        // UtcNowFactory value is EARLIER than op1's) must not break
+        // anything, since the fingerprint never consults time at all.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+
+        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 10, 0, 0, TimeSpan.Zero);
+        Assert.Equal(0, QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "high", "--reason", "R", "--write"], new StringWriter()));
+
+        // Rolled BACK relative to the first operation.
+        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 9, 0, 0, TimeSpan.Zero);
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "normal", "--reason", "S", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
+
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("normal", stateAfter.Items.Single().Priority);
+
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        Assert.Equal(2, events.Count);
     }
 
     [Fact]
     public void Execute_StaleHistoricalEventWithDifferentReasonText_NeverSuppressesTheNewEvent()
     {
-        // "Wrong reason": a stale historical event whose reason text
-        // differs must never dedupe — this was already implicitly
-        // guaranteed (reason text is part of the match), pinned explicitly
-        // per review request.
+        // "Wrong reason": a stale event sharing the SAME (correct, matching)
+        // generation fingerprint but a DIFFERENT reason string must still
+        // never dedupe — isolates that the reason text is independently
+        // required, not merely a side effect of a mismatched fingerprint.
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
-        var eventTimestamp = new DateTimeOffset(2026, 7, 19, 0, 0, 0, TimeSpan.Zero);
-        SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': OLD_REASON", eventTimestamp);
+        var matchingGenerationId = QueueReprioritizeCommand.ComputeGenerationId(File.ReadAllText(workspace.QueueStatePath));
+        SeedHistoricalEvent(workspace, "G537", $"priority changed from 'normal' to 'high': OLD_REASON (generation {matchingGenerationId})");
 
-        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 5, 0, 0, TimeSpan.Zero);
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
             workspace.Context,
@@ -371,21 +437,19 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
         var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
         Assert.Equal(2, events.Count);
-        Assert.Contains(events, e => e.Reason == "priority changed from 'normal' to 'high': NEW_REASON");
+        Assert.Contains(events, e => e.Reason!.Contains("NEW_REASON", StringComparison.Ordinal));
     }
 
     [Fact]
     public void Execute_StaleHistoricalEventWithOppositeDirection_NeverSuppressesTheNewEvent()
     {
-        // "Wrong direction": a stale event recording the OPPOSITE
-        // transition (high->normal) must never dedupe a normal->high
-        // request, even if it shares the same reason word.
+        // "Wrong direction": same matching fingerprint, but the event
+        // records the OPPOSITE transition — must never dedupe.
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
-        var eventTimestamp = new DateTimeOffset(2026, 7, 19, 0, 0, 0, TimeSpan.Zero);
-        SeedHistoricalEvent(workspace, "G537", "priority changed from 'high' to 'normal': R", eventTimestamp);
+        var matchingGenerationId = QueueReprioritizeCommand.ComputeGenerationId(File.ReadAllText(workspace.QueueStatePath));
+        SeedHistoricalEvent(workspace, "G537", $"priority changed from 'high' to 'normal': R (generation {matchingGenerationId})");
 
-        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 5, 0, 0, TimeSpan.Zero);
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
             workspace.Context,
@@ -397,20 +461,19 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
         var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
         Assert.Equal(2, events.Count);
-        Assert.Contains(events, e => e.Reason == "priority changed from 'normal' to 'high': R");
+        Assert.Contains(events, e => e.Reason!.StartsWith("priority changed from 'normal' to 'high': R", StringComparison.Ordinal));
     }
 
     [Fact]
     public void Execute_StaleHistoricalEventForDifferentExecutionUnit_NeverSuppressesTheNewEvent()
     {
-        // "Wrong unit": a stale event for a DIFFERENT execution unit must
-        // never dedupe this unit's request, even with identical reason text.
+        // "Wrong unit": same matching fingerprint AND reason text, but for
+        // a DIFFERENT execution unit — must never dedupe this unit's request.
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
-        var eventTimestamp = new DateTimeOffset(2026, 7, 19, 0, 0, 0, TimeSpan.Zero);
-        SeedHistoricalEvent(workspace, "G999", "priority changed from 'normal' to 'high': R", eventTimestamp);
+        var matchingGenerationId = QueueReprioritizeCommand.ComputeGenerationId(File.ReadAllText(workspace.QueueStatePath));
+        SeedHistoricalEvent(workspace, "G999", $"priority changed from 'normal' to 'high': R (generation {matchingGenerationId})");
 
-        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 5, 0, 0, TimeSpan.Zero);
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
             workspace.Context,
@@ -422,23 +485,48 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
         var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
         Assert.Equal(2, events.Count);
-        Assert.Contains(events, e => e.ExecutionUnit == "G537" && e.Reason == "priority changed from 'normal' to 'high': R");
+        Assert.Contains(events, e => e.ExecutionUnit == "G537");
     }
 
     [Fact]
-    public void Execute_GenuinePendingEventAtOrAfterCurrentGeneration_IsDedupedAsRetry()
+    public void Execute_HistoricalEventMissingGenerationTagEntirely_NeverSuppressesTheNewEvent()
+    {
+        // "Malformed/missing generation": a historical event predating
+        // this fix (or hand-edited) with no fingerprint tag at all, but
+        // otherwise-matching unit/reason — a tagged expected reason can
+        // never exact-match an untagged one, so this must never dedupe.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': R");
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        Assert.Equal(2, events.Count);
+        Assert.Contains(events, e => e.Reason!.Contains("(generation ", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GenuinePendingEventWithMatchingFingerprint_IsDedupedAsRetry()
     {
         // Direct fixture for the genuine-retry path (complementary to the
         // WriteQueueStateOverride fault-injection test above): an event
-        // already recorded at/after the CURRENT queue-state generation,
-        // exactly matching unit/event/reason, must be recognized as the
-        // pending audit for an in-progress attempt and never duplicated.
+        // already recorded with the CORRECT fingerprint for the CURRENT,
+        // still-unmutated queue-state.json, exactly matching unit/event/
+        // reason, must be recognized as the pending audit for an
+        // in-progress attempt and never duplicated.
         using var workspace = new ReprioritizeWorkspace();
-        var currentGeneration = new DateTimeOffset(2026, 7, 19, 2, 0, 0, TimeSpan.Zero);
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null), currentGeneration));
-        SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': R", currentGeneration);
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        var matchingGenerationId = QueueReprioritizeCommand.ComputeGenerationId(File.ReadAllText(workspace.QueueStatePath));
+        SeedHistoricalEvent(workspace, "G537", $"priority changed from 'normal' to 'high': R (generation {matchingGenerationId})");
 
-        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 5, 0, 0, TimeSpan.Zero);
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
             workspace.Context,
@@ -457,6 +545,9 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.Single(events);
     }
 
+    private static void SeedHistoricalEvent(ReprioritizeWorkspace workspace, string executionUnit, string reason) =>
+        SeedHistoricalEvent(workspace, executionUnit, reason, new DateTimeOffset(2026, 7, 19, 0, 0, 0, TimeSpan.Zero));
+
     private static void SeedHistoricalEvent(ReprioritizeWorkspace workspace, string executionUnit, string reason, DateTimeOffset ts)
     {
         Directory.CreateDirectory(Path.GetDirectoryName(workspace.RunsLogPath)!);
@@ -471,14 +562,12 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         File.AppendAllText(workspace.RunsLogPath, RunLogSerializer.SerializeLine(historicalEvent) + Environment.NewLine);
     }
 
-    private static string BuildQueueState(
-        (string ExecutionUnit, QueueItemState State, string Priority, LinkedIssue? LinkedIssue) item,
-        DateTimeOffset? updatedAt = null)
+    private static string BuildQueueState((string ExecutionUnit, QueueItemState State, string Priority, LinkedIssue? LinkedIssue) item)
     {
         var state = new QueueState
         {
             SchemaVersion = "1",
-            UpdatedAt = updatedAt ?? new DateTimeOffset(2026, 5, 8, 0, 0, 0, TimeSpan.Zero),
+            UpdatedAt = new DateTimeOffset(2026, 5, 8, 0, 0, 0, TimeSpan.Zero),
             Items = new[]
             {
                 new QueueItem

--- a/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
@@ -301,64 +301,28 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.Single(events);
     }
 
-    // ─── G537 round-3 review repair: dedup bound to a content fingerprint,
-    // never wall-clock ordering ─────────────────────────────────────────────
+    // ─── G537 round-4 review repair: dedup bound to a durable injective
+    // priority_revision counter, never content fingerprinting or wall-clock
+    // ordering ───────────────────────────────────────────────────────────────
 
     [Fact]
-    public void Execute_RoundTripStaleCollision_ThirdMutationGetsItsOwnEvent()
+    public void Execute_RevisitedByteIdenticalPrestate_RepeatedTransitionStillGetsItsOwnEvent()
     {
-        // The reproduction from round 2's review: normal->high reason R
-        // completes; high->normal reason S completes; normal->high reason
-        // R is requested AGAIN. The third request's UNTAGGED reason text
-        // is byte-identical to the first event's — but the first event's
-        // content fingerprint is now stale (the second transition's write
-        // changed queue-state.json), so the third mutation must get its
-        // OWN new event.
+        // The round-4 review's exact counter-example to round 3's content
+        // fingerprint: seed queue-state.json with UpdatedAt EQUAL to the
+        // fixed clock used for every operation below. After normal->high
+        // (R) then high->normal (S) — both under that SAME fixed clock —
+        // the file's priority/state/updated_at genuinely revisit the
+        // ORIGINAL prestate bytes (asserted explicitly below, ignoring
+        // only the priority_revision counter itself). A content
+        // fingerprint of the whole file would be fooled into treating the
+        // stale first event as pending for the third (repeated) request;
+        // the durable `priority_revision` counter cannot be, because it
+        // never repeats a value once consumed.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
-
-        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 1, 0, 0, TimeSpan.Zero);
-        Assert.Equal(0, QueueReprioritizeCommand.Execute(
-            workspace.Context, ["G537", "--priority", "high", "--reason", "R", "--write"], new StringWriter()));
-
-        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 2, 0, 0, TimeSpan.Zero);
-        Assert.Equal(0, QueueReprioritizeCommand.Execute(
-            workspace.Context, ["G537", "--priority", "normal", "--reason", "S", "--write"], new StringWriter()));
-
-        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 3, 0, 0, TimeSpan.Zero);
-        using var thirdWriter = new StringWriter();
-        var thirdExitCode = QueueReprioritizeCommand.Execute(
-            workspace.Context,
-            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
-            thirdWriter);
-
-        Assert.Equal(0, thirdExitCode);
-        using var document = JsonDocument.Parse(thirdWriter.ToString());
-        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
-
-        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
-        Assert.Equal("high", stateAfter.Items.Single().Priority);
-
-        // THREE distinct mutations -> THREE events, one per mutation.
-        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
-        Assert.Equal(3, events.Count);
-        Assert.All(events, e => Assert.Equal("priority-changed", e.Event));
-        // Every event's own fingerprint tag is distinct (each was computed
-        // against a genuinely different pre-mutation queue-state.json).
-        Assert.Equal(3, events.Select(e => e.Reason).Distinct(StringComparer.Ordinal).Count());
-    }
-
-    [Fact]
-    public void Execute_RoundTripStaleCollision_SameFixedClockAcrossAllThreeOperations_StillGetsThreeEvents()
-    {
-        // The EXACT round-3 review reproduction: UtcNowFactory returns ONE
-        // identical timestamp for all three successful operations, so
-        // `Ts` can never discriminate between them at all. The content
-        // fingerprint must still correctly produce three distinct events,
-        // since it never looks at time.
-        using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
         var fixedNow = new DateTimeOffset(2026, 7, 19, 4, 0, 0, TimeSpan.Zero);
+        var originalRaw = BuildQueueStateWithUpdatedAt(("G537", QueueItemState.Queued, "normal", linkedIssue: null), fixedNow);
+        workspace.WriteQueueState(originalRaw);
         QueueReprioritizeCommand.UtcNowFactory = () => fixedNow;
 
         Assert.Equal(0, QueueReprioritizeCommand.Execute(
@@ -366,6 +330,12 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.Equal(0, QueueReprioritizeCommand.Execute(
             workspace.Context, ["G537", "--priority", "normal", "--reason", "S", "--write"], new StringWriter()));
 
+        // Prove the revisit is real: every field except priority_revision
+        // is now byte-for-byte identical to the original prestate.
+        var afterTwoOpsRaw = File.ReadAllText(workspace.QueueStatePath);
+        Assert.Equal(StripPriorityRevision(originalRaw), StripPriorityRevision(afterTwoOpsRaw));
+        Assert.NotEqual(originalRaw, afterTwoOpsRaw); // only priority_revision differs (0 -> 2)
+
         using var thirdWriter = new StringWriter();
         var thirdExitCode = QueueReprioritizeCommand.Execute(
             workspace.Context,
@@ -378,16 +348,22 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
 
         var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
         Assert.Equal(3, events.Count);
-        Assert.All(events, e => Assert.Equal(fixedNow, e.Ts)); // confirms Ts truly never discriminated here
-        Assert.Equal(3, events.Select(e => e.Reason).Distinct(StringComparer.Ordinal).Count());
+        Assert.All(events, e => Assert.Equal(fixedNow, e.Ts)); // clock never discriminated
+        Assert.Contains(events, e => e.Reason!.EndsWith("(revision 0->1)", StringComparison.Ordinal));
+        Assert.Contains(events, e => e.Reason!.EndsWith("(revision 1->2)", StringComparison.Ordinal));
+        Assert.Contains(events, e => e.Reason!.EndsWith("(revision 2->3)", StringComparison.Ordinal));
+
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("high", stateAfter.Items.Single().Priority);
+        Assert.Equal(3, stateAfter.Items.Single().PriorityRevision);
     }
 
     [Fact]
     public void Execute_ClockRollback_StillGetsItsOwnEventAndNeverDedupesAgainstAnEarlierTimestampedEvent()
     {
-        // Round-3 review: a clock rollback between operations (op2's
-        // UtcNowFactory value is EARLIER than op1's) must not break
-        // anything, since the fingerprint never consults time at all.
+        // A clock rollback between operations (op2's UtcNowFactory value
+        // is EARLIER than op1's) must not break anything, since the
+        // revision counter never consults time at all.
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
 
@@ -409,6 +385,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
 
         var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
         Assert.Equal("normal", stateAfter.Items.Single().Priority);
+        Assert.Equal(2, stateAfter.Items.Single().PriorityRevision);
 
         var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
         Assert.Equal(2, events.Count);
@@ -417,14 +394,14 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     [Fact]
     public void Execute_StaleHistoricalEventWithDifferentReasonText_NeverSuppressesTheNewEvent()
     {
-        // "Wrong reason": a stale event sharing the SAME (correct, matching)
-        // generation fingerprint but a DIFFERENT reason string must still
-        // never dedupe — isolates that the reason text is independently
-        // required, not merely a side effect of a mismatched fingerprint.
+        // "Wrong reason": a stale event sharing the SAME (correct,
+        // matching) revision pair but a DIFFERENT reason string must
+        // still never dedupe — isolates that the reason text is
+        // independently required, not merely a side effect of a
+        // mismatched revision.
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
-        var matchingGenerationId = QueueReprioritizeCommand.ComputeGenerationId(File.ReadAllText(workspace.QueueStatePath));
-        SeedHistoricalEvent(workspace, "G537", $"priority changed from 'normal' to 'high': OLD_REASON (generation {matchingGenerationId})");
+        SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': OLD_REASON (revision 0->1)");
 
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
@@ -443,12 +420,11 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     [Fact]
     public void Execute_StaleHistoricalEventWithOppositeDirection_NeverSuppressesTheNewEvent()
     {
-        // "Wrong direction": same matching fingerprint, but the event
+        // "Wrong direction": same matching revision pair, but the event
         // records the OPPOSITE transition — must never dedupe.
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
-        var matchingGenerationId = QueueReprioritizeCommand.ComputeGenerationId(File.ReadAllText(workspace.QueueStatePath));
-        SeedHistoricalEvent(workspace, "G537", $"priority changed from 'high' to 'normal': R (generation {matchingGenerationId})");
+        SeedHistoricalEvent(workspace, "G537", "priority changed from 'high' to 'normal': R (revision 0->1)");
 
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
@@ -467,12 +443,12 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     [Fact]
     public void Execute_StaleHistoricalEventForDifferentExecutionUnit_NeverSuppressesTheNewEvent()
     {
-        // "Wrong unit": same matching fingerprint AND reason text, but for
-        // a DIFFERENT execution unit — must never dedupe this unit's request.
+        // "Wrong unit": same matching revision pair AND reason text, but
+        // for a DIFFERENT execution unit — must never dedupe this unit's
+        // request.
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
-        var matchingGenerationId = QueueReprioritizeCommand.ComputeGenerationId(File.ReadAllText(workspace.QueueStatePath));
-        SeedHistoricalEvent(workspace, "G999", $"priority changed from 'normal' to 'high': R (generation {matchingGenerationId})");
+        SeedHistoricalEvent(workspace, "G999", "priority changed from 'normal' to 'high': R (revision 0->1)");
 
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
@@ -489,10 +465,10 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_HistoricalEventMissingGenerationTagEntirely_NeverSuppressesTheNewEvent()
+    public void Execute_HistoricalEventMissingRevisionTagEntirely_NeverSuppressesTheNewEvent()
     {
         // "Malformed/missing generation": a historical event predating
-        // this fix (or hand-edited) with no fingerprint tag at all, but
+        // this fix (or hand-edited) with no revision tag at all, but
         // otherwise-matching unit/reason — a tagged expected reason can
         // never exact-match an untagged one, so this must never dedupe.
         using var workspace = new ReprioritizeWorkspace();
@@ -510,22 +486,21 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
         var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
         Assert.Equal(2, events.Count);
-        Assert.Contains(events, e => e.Reason!.Contains("(generation ", StringComparison.Ordinal));
+        Assert.Contains(events, e => e.Reason!.Contains("(revision ", StringComparison.Ordinal));
     }
 
     [Fact]
-    public void Execute_GenuinePendingEventWithMatchingFingerprint_IsDedupedAsRetry()
+    public void Execute_GenuinePendingEventWithMatchingRevisionPair_IsDedupedAsRetry()
     {
         // Direct fixture for the genuine-retry path (complementary to the
         // WriteQueueStateOverride fault-injection test above): an event
-        // already recorded with the CORRECT fingerprint for the CURRENT,
-        // still-unmutated queue-state.json, exactly matching unit/event/
-        // reason, must be recognized as the pending audit for an
-        // in-progress attempt and never duplicated.
+        // already recorded with the CORRECT from/to revision pair for the
+        // CURRENT, still-unmutated queue-state.json, exactly matching
+        // unit/event/reason, must be recognized as the pending audit for
+        // an in-progress attempt and never duplicated.
         using var workspace = new ReprioritizeWorkspace();
         workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
-        var matchingGenerationId = QueueReprioritizeCommand.ComputeGenerationId(File.ReadAllText(workspace.QueueStatePath));
-        SeedHistoricalEvent(workspace, "G537", $"priority changed from 'normal' to 'high': R (generation {matchingGenerationId})");
+        SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': R (revision 0->1)");
 
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
@@ -539,10 +514,65 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
 
         var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
         Assert.Equal("high", stateAfter.Items.Single().Priority);
+        Assert.Equal(1, stateAfter.Items.Single().PriorityRevision);
 
         // Still exactly ONE event — recognized as the pending retry, not duplicated.
         var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
         Assert.Single(events);
+    }
+
+    [Fact]
+    public void Execute_LegacyItemMissingPriorityRevisionField_MigratesAsZero()
+    {
+        // Legacy migration semantics: a hand-authored/pre-G537
+        // queue-state.json with no `priority_revision` field at all
+        // deserializes it as 0 — the first reprioritize on such an item
+        // records revision 0->1, same as a brand-new item.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-05-08T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G537",
+                  "title": "legacy item, no priority_revision field",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "Claude",
+                  "review_role": "Codex",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal(1, stateAfter.Items.Single().PriorityRevision);
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        Assert.Contains(events, e => e.Reason!.EndsWith("(revision 0->1)", StringComparison.Ordinal));
+    }
+
+    private static string StripPriorityRevision(string queueStateJson) =>
+        System.Text.RegularExpressions.Regex.Replace(queueStateJson, @",?\s*""priority_revision""\s*:\s*\d+", string.Empty);
+
+    private static string BuildQueueStateWithUpdatedAt(
+        (string ExecutionUnit, QueueItemState State, string Priority, LinkedIssue? LinkedIssue) item, DateTimeOffset updatedAt)
+    {
+        var raw = BuildQueueState(item);
+        var state = QueueStateSerializer.Deserialize(raw) with { UpdatedAt = updatedAt };
+        return QueueStateSerializer.Serialize(state);
     }
 
     private static void SeedHistoricalEvent(ReprioritizeWorkspace workspace, string executionUnit, string reason) =>

--- a/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
@@ -301,12 +301,184 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         Assert.Single(events);
     }
 
-    private static string BuildQueueState((string ExecutionUnit, QueueItemState State, string Priority, LinkedIssue? LinkedIssue) item)
+    // ─── G537 round-2 review repair: dedup bound to queue-state generation ──
+
+    [Fact]
+    public void Execute_RoundTripStaleCollision_ThirdMutationGetsItsOwnEvent()
+    {
+        // The exact reproduction from review: normal->high reason R
+        // completes; high->normal reason S completes; normal->high reason
+        // R is requested AGAIN. The third request's expected reason text
+        // is BYTE-IDENTICAL to the first event's — but the first event is
+        // now stale (superseded by the second transition's queue-state
+        // write), so the third mutation must get its OWN new event, not
+        // be silently skipped as if it were a pending retry of the first.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+
+        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 1, 0, 0, TimeSpan.Zero);
+        Assert.Equal(0, QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "high", "--reason", "R", "--write"], new StringWriter()));
+
+        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 2, 0, 0, TimeSpan.Zero);
+        Assert.Equal(0, QueueReprioritizeCommand.Execute(
+            workspace.Context, ["G537", "--priority", "normal", "--reason", "S", "--write"], new StringWriter()));
+
+        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 3, 0, 0, TimeSpan.Zero);
+        using var thirdWriter = new StringWriter();
+        var thirdExitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
+            thirdWriter);
+
+        Assert.Equal(0, thirdExitCode);
+        using var document = JsonDocument.Parse(thirdWriter.ToString());
+        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
+
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("high", stateAfter.Items.Single().Priority);
+
+        // THREE distinct mutations -> THREE events, one per mutation.
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        Assert.Equal(3, events.Count);
+        Assert.All(events, e => Assert.Equal("priority-changed", e.Event));
+        Assert.Equal(new DateTimeOffset(2026, 7, 19, 1, 0, 0, TimeSpan.Zero), events[0].Ts);
+        Assert.Equal(new DateTimeOffset(2026, 7, 19, 2, 0, 0, TimeSpan.Zero), events[1].Ts);
+        Assert.Equal(new DateTimeOffset(2026, 7, 19, 3, 0, 0, TimeSpan.Zero), events[2].Ts);
+    }
+
+    [Fact]
+    public void Execute_StaleHistoricalEventWithDifferentReasonText_NeverSuppressesTheNewEvent()
+    {
+        // "Wrong reason": a stale historical event whose reason text
+        // differs must never dedupe — this was already implicitly
+        // guaranteed (reason text is part of the match), pinned explicitly
+        // per review request.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        var eventTimestamp = new DateTimeOffset(2026, 7, 19, 0, 0, 0, TimeSpan.Zero);
+        SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': OLD_REASON", eventTimestamp);
+
+        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 5, 0, 0, TimeSpan.Zero);
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "NEW_REASON", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        Assert.Equal(2, events.Count);
+        Assert.Contains(events, e => e.Reason == "priority changed from 'normal' to 'high': NEW_REASON");
+    }
+
+    [Fact]
+    public void Execute_StaleHistoricalEventWithOppositeDirection_NeverSuppressesTheNewEvent()
+    {
+        // "Wrong direction": a stale event recording the OPPOSITE
+        // transition (high->normal) must never dedupe a normal->high
+        // request, even if it shares the same reason word.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        var eventTimestamp = new DateTimeOffset(2026, 7, 19, 0, 0, 0, TimeSpan.Zero);
+        SeedHistoricalEvent(workspace, "G537", "priority changed from 'high' to 'normal': R", eventTimestamp);
+
+        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 5, 0, 0, TimeSpan.Zero);
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        Assert.Equal(2, events.Count);
+        Assert.Contains(events, e => e.Reason == "priority changed from 'normal' to 'high': R");
+    }
+
+    [Fact]
+    public void Execute_StaleHistoricalEventForDifferentExecutionUnit_NeverSuppressesTheNewEvent()
+    {
+        // "Wrong unit": a stale event for a DIFFERENT execution unit must
+        // never dedupe this unit's request, even with identical reason text.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        var eventTimestamp = new DateTimeOffset(2026, 7, 19, 0, 0, 0, TimeSpan.Zero);
+        SeedHistoricalEvent(workspace, "G999", "priority changed from 'normal' to 'high': R", eventTimestamp);
+
+        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 5, 0, 0, TimeSpan.Zero);
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        Assert.Equal(2, events.Count);
+        Assert.Contains(events, e => e.ExecutionUnit == "G537" && e.Reason == "priority changed from 'normal' to 'high': R");
+    }
+
+    [Fact]
+    public void Execute_GenuinePendingEventAtOrAfterCurrentGeneration_IsDedupedAsRetry()
+    {
+        // Direct fixture for the genuine-retry path (complementary to the
+        // WriteQueueStateOverride fault-injection test above): an event
+        // already recorded at/after the CURRENT queue-state generation,
+        // exactly matching unit/event/reason, must be recognized as the
+        // pending audit for an in-progress attempt and never duplicated.
+        using var workspace = new ReprioritizeWorkspace();
+        var currentGeneration = new DateTimeOffset(2026, 7, 19, 2, 0, 0, TimeSpan.Zero);
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null), currentGeneration));
+        SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': R", currentGeneration);
+
+        QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 5, 0, 0, TimeSpan.Zero);
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G537", "--priority", "high", "--reason", "R", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("changed").GetBoolean());
+
+        var stateAfter = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("high", stateAfter.Items.Single().Priority);
+
+        // Still exactly ONE event — recognized as the pending retry, not duplicated.
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        Assert.Single(events);
+    }
+
+    private static void SeedHistoricalEvent(ReprioritizeWorkspace workspace, string executionUnit, string reason, DateTimeOffset ts)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(workspace.RunsLogPath)!);
+        var historicalEvent = new RunEvent
+        {
+            Ts = ts,
+            ExecutionUnit = executionUnit,
+            Event = "priority-changed",
+            By = "intent-cli",
+            Reason = reason,
+        };
+        File.AppendAllText(workspace.RunsLogPath, RunLogSerializer.SerializeLine(historicalEvent) + Environment.NewLine);
+    }
+
+    private static string BuildQueueState(
+        (string ExecutionUnit, QueueItemState State, string Priority, LinkedIssue? LinkedIssue) item,
+        DateTimeOffset? updatedAt = null)
     {
         var state = new QueueState
         {
             SchemaVersion = "1",
-            UpdatedAt = new DateTimeOffset(2026, 5, 8, 0, 0, 0, TimeSpan.Zero),
+            UpdatedAt = updatedAt ?? new DateTimeOffset(2026, 5, 8, 0, 0, 0, TimeSpan.Zero),
             Items = new[]
             {
                 new QueueItem


### PR DESCRIPTION
Closes #1176

## Summary
- Adds `queue reprioritize <execution-unit> --priority <high|normal|low> --reason <text> [--write]`: a bounded canonical transition that sets `priority` on a queued, not-yet-published execution unit, with a required reason and a `priority-changed` runs event. Dry-run by default; refuses (naming why) on any non-queued state or once a GitHub issue is linked; idempotent no-op when the requested priority matches the current one.
- `intent next-slice` now orders eligible candidates priority-class-first (high > normal > low), with authoring order (queue-state array order) as the in-class tiebreak. This is a stable sort applied to the existing `queued` bucket *before* the per-candidate gate loop runs — every existing gate (packet directory presence, execution-unit regex, domain/repo filter, G534 lifecycle exclusion, legacy retirement marker) still runs exactly as before, per candidate. Priority only changes try-order among candidates that already pass every gate; it never lets a candidate skip one.
- A host with no priorities meaningfully set (everything at the enqueue default `"normal"`) produces byte-identical output to pre-G537 behavior — proven by the full existing 72-test `IntentNextSliceCommandTests` suite passing unchanged, plus a new explicit regression test.

## Field incident this closes
2026-07-19: after the G529 closeout, the orchestrator ruled — with justification — to publish field-impact fixes G532/G534 ahead of a G530/G531 continuation. No installed surface could express that ruling (`priority` existed in the schema but nothing consulted it), so the orchestrator faced the forbidden choice of hand-editing queue-state or abandoning the ruling, correctly abandoned it, and reported the gap.

## Scope note for reviewers
`next-slice`'s existing candidate loop has no dependency (`Dependencies`/`BlockedBy`) gate today — that logic lives only in the separate, simpler legacy `QueueSelection.SelectNext` (`queue next`) surface, which this PR does not touch (out of scope per the field incident, which was specifically about next-slice/publish ordering). The "gate precedence" fixture therefore demonstrates precedence over next-slice's actual gates (G534's lifecycle exclusion) rather than a literal dependency gate, since next-slice doesn't have one to test against.

## Test plan
- [x] New fixtures: field-incident reorder scenario, gate-precedence (lifecycle exclusion beats priority), explicit no-priority-set regression
- [x] Full `QueueReprioritizeCommand` test matrix: dry-run reporting, `--write` mutation + runs event, refusal on non-queued state, refusal on already-published unit, refusal on unknown unit, refusal without `--reason`, refusal on unsupported priority value, idempotent no-op
- [x] Manual end-to-end replay of the field scenario against the built CLI binary (dry-run → write → next-slice re-selection)
- [x] Full solution test suite green (3663 passed, 1 pre-existing skip)
- [x] `git diff --check` clean
- [x] ja/en developer-reference docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)