### PR TITLE
G538: Prepare v0.5.0 minor release metadata for G529-G537

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1464,104 +1464,110 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.3.15",
-  "nextVersion": "0.4.0"
+  "stableVersion": "0.4.0",
+  "nextVersion": "0.5.0"
 }
 ```
 
 | Stage | Version form | How it is derived |
 | --- | --- | --- |
-| Local pack / install | `0.4.0-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.4.0-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.4.0-rc.N` | Publishing the GitHub Release for tag `v0.4.0-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
-| Stable release | `0.4.0` | Publishing the GitHub Release for tag `v0.4.0` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.4.1-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.4.1` |
+| Local pack / install | `0.5.0-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.5.0-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.5.0-rc.N` | Publishing the GitHub Release for tag `v0.5.0-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
+| Stable release | `0.5.0` | Publishing the GitHub Release for tag `v0.5.0` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.5.1-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.5.1` |
 
-**After releasing `v0.4.0`**, bump both fields in `eng/version.json`:
+**After releasing `v0.5.0`**, bump both fields in `eng/version.json`:
 
 ```json
 {
-  "stableVersion": "0.4.0",
-  "nextVersion": "0.4.1"
+  "stableVersion": "0.5.0",
+  "nextVersion": "0.5.1"
 }
 ```
 
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.4.1-preview.<run>.<attempt>` / `0.4.1-<sha>-<G-unit>` rather than continuing to
-emit `0.4.0` (which would collide with the stable release version).
+`0.5.1-preview.<run>.<attempt>` / `0.5.1-<sha>-<G-unit>` rather than continuing to
+emit `0.5.0` (which would collide with the stable release version).
 
-### Next release readiness (v0.4.0)
+### Next release readiness (v0.5.0)
 
-**`v0.3.15` shipped** (GitHub Release + NuGet) and the version policy was bumped
-to the `0.4.0` development line — a **minor** bump, not a patch: three new
-automation commands plus a visible fail-loud behavior change justify more than
-a patch release. The repository is now on the in-development **`0.4.0`**
-`nextVersion`; G528 is **prepare-only** — it bumps the version metadata and
-docs and adds no publish steps. The version-bump merge does **not** create a
-GitHub Release or tag. After it merges and the
-[release-readiness gate](release-notes-v0.4.0.md#release-readiness-gate-g528)
+**`v0.4.0` shipped** (GitHub Release + NuGet) and the version policy was bumped
+to the `0.5.0` development line — a **minor** bump, not a patch: the batch
+ships two new commands (`intent facet-check`, `queue reprioritize`), a new
+intent-tree schema surface (`facets`), new stalled-work kinds, and a new
+transition target (`retired`) — more than a patch release justifies. The
+repository is now on the in-development **`0.5.0`** `nextVersion`; G538 is
+**prepare-only** — it bumps the version metadata and docs and adds no publish
+steps. The version-bump merge does **not** create a GitHub Release or tag.
+After it merges and the
+[release-readiness gate](release-notes-v0.5.0.md#release-readiness-gate-g538)
 holds, a **maintainer/operator (or external release automation) creates and
-publishes the GitHub Release** for `v0.4.0`; publishing that Release fires
+publishes the GitHub Release** for `v0.5.0`; publishing that Release fires
 `.github/workflows/release.yml` (`on: release: published`), which builds and
 publishes the NuGet package and the per-platform binary artifacts. Full
 changelog and operator checklist:
-[release-notes-v0.4.0.md](release-notes-v0.4.0.md).
+[release-notes-v0.5.0.md](release-notes-v0.5.0.md).
 
-**To ship in `v0.4.0` (changes since `v0.3.15`) — orchestrator stall-prevention
-batch, fail-loud domain resolution, and a parser fix:**
+**To ship in `v0.5.0` (changes since `v0.4.0`) — semantic facets, stalled-work
+correctness, queue robustness, label supersession, publish reliability, and
+priority override:**
 
-- **Three new automation commands** — `automation stalled-work` (G523),
-  `automation heartbeat` (G526), and `automation issue-retire` (G525): a
-  read-only pending-transition inventory, a read-only wrapper of it that
-  emits a ready-to-send reconcile message for an external low-frequency
-  scheduler, and a canonical atomic transition to retire a published issue
-  that can never be started as authored.
-- **Fail-loud domain resolution** (G522) — execution-unit-resolving surfaces
-  (`automation queue-seed-from-packet`, `review closeout-plan`,
-  `automation publish-recovery`) now resolve domain as: explicit `--domain`
-  wins (erroring on contradiction with the packet's own `domain:` field) >
-  the packet-declared domain > fail loud naming candidate domains and the
-  exact re-invocation — never a silent fallback to the host's config-default
-  domain. **Migration:** any script or automation that relied on the previous
-  silent fallback must now either pass `--domain` explicitly or ensure the
-  resolved packet.yaml declares its `domain:` field.
-- **Orchestrator wake contract** (G524) — publish and delegate in the SAME
-  wake (no more "deferred to the next wake"); the message cap is reframed as
-  "at most one delegation per receiver per wake"; a new end-of-wake
-  `automation stalled-work` check with a never-defer rule; the receiver
-  completion-or-blocked report is now a REQUIRED FINAL STEP of every
-  delegation; and dispatch roster verification (`team.sh`) before every send.
-- **Managed review worktrees + design-alignment checks** (G520) — review
-  worktrees are enforced under the managed root
-  (`.intent-cli/worktrees/review-<unit>`), never `/tmp`; a review `completed`
-  reply missing design-alignment evidence (packet, review-context, intent
-  tree, ADR/decision notes) is now incomplete.
-- **Codex monitor (beta) guidance** (G521) — a setup preflight and three new
-  troubleshooting entries (silent launcher, static TUI, doubled responses)
-  for the agmsg Codex bridge.
-- **Packet-yaml parser fix** (G527) — `PreparedPacketYamlScalarParser`'s
-  quote-balance check is now delimiter-aware, fixing the exact field
-  incident where a double-quoted value merely containing an apostrophe was
-  wrongly rejected.
+- **Semantic facets** (G529–G531) — a closed set of four `facets:` values
+  (`vocabulary`, `invariant`, `decider`, `acceptance-property`) an intent-tree
+  node may declare in its frontmatter; `intent-cli context collect` and
+  `packet draft` now supply a facet-classified `## Facet context` section as
+  the preferred, localized semantic context ahead of the unclassified
+  queue-state/clarification context; and read-only `intent facet-check`
+  points a change proposal at the facet nodes it should respect, surfacing
+  naming collisions and coverage gaps without ever gating.
+- **stalled-work correctness** (G532–G533) — leading-ID/nested-domain
+  execution-unit identification is corroborated against real packet/queue
+  linkage rather than trusted from a title alone; `--domain` is a required,
+  authoritative scoping input; and three new informational kinds
+  (`repair-pending`, `rereview-pending`, `claimed-but-silent`) stop
+  mid-repair and mid-rereview PRs from being misreported with a wrong
+  `review-start` recommendation.
+- **Queue robustness** (G534) — packet readers accept both YAML list-item
+  indentation conventions; `retired` is now a guarded, terminal `queue
+  transition` target (verified against the linked PR's real GitHub state
+  before applying); and `intent next-slice` combines queue-state and
+  packet-lifecycle retirement evidence explicitly, fail-closed on
+  contradiction.
+- **Label supersession** (G535) — `automation pr-transition --transition
+  request-update` now clears a stale `intent-pr-rereview-ready` in the same
+  write, closing a deadlock where `worker claim` refused a PR that
+  `request-update` had marked for repair.
+- **Publish reliability** (G536) — `issue publish-flow`'s idempotent rerun
+  now independently verifies and restores all three durable artifacts (the
+  GitHub issue, the queue-state entry, the `runs.jsonl` event) instead of
+  trusting one signal for all three, and fails loud rather than silently
+  leaving state inconsistent.
+- **Priority override** (G537) — the new `queue reprioritize` command sets a
+  queued, unpublished execution unit's priority under a durable, revision-
+  counted, lock-protected audit protocol; `intent next-slice` selects
+  eligible candidates priority-class-first (high > normal > low, stable
+  tiebreak by authoring order), with dependency/WIP/clarification/lifecycle
+  gates always dominating priority.
 - Orchestrator mode remains **preview/experimental**: opt-in, still being
   hardened, with the timer-loop mode fully supported and unchanged. See
   [Agent-message orchestration](12-agent-message-orchestration.md).
 
-**Release-readiness verification (run before merging the `v0.4.0` version
+**Release-readiness verification (run before merging the `v0.5.0` version
 bump):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.3.15 (published), nextVersion 0.4.0 (to release)
+cat eng/version.json   # stableVersion 0.4.0 (published), nextVersion 0.5.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.4.0-<sha>-G52x   (NOT a stale literal)
+#   expected shape: intent-cli 0.5.0-<sha>-G53x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.4.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.5.0.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -1569,11 +1575,12 @@ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
 ```
 
 After the version-bump merge lands on `main`, a maintainer/operator (or external
-release automation) creates and publishes the GitHub Release for `v0.4.0`;
+release automation) creates and publishes the GitHub Release for `v0.5.0`;
 publishing it triggers `release.yml` (`on: release: published`) to build and
 publish the NuGet package and the per-platform binary artifacts. Once it has
 published, apply the post-release `eng/version.json` bump above
-(`stableVersion → 0.4.0`, `nextVersion → 0.4.1`).
+(`stableVersion → 0.5.0`, `nextVersion → 0.5.1`) — deferred to the NEXT
+release-prep packet, not this one.
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.5.0.md
+++ b/docs/en/release-notes-v0.5.0.md
@@ -1,0 +1,263 @@
+# Release Notes — intent-cli v0.5.0
+
+> **Release model:** a maintainer/operator (or external release automation)
+> **creates and publishes the GitHub Release** for `v0.5.0` — the version-bump
+> merge does **not** create a Release or tag on its own. Publishing the GitHub
+> Release fires `.github/workflows/release.yml` (`on: release: published`), which
+> then builds and publishes the NuGet package and platform binary artifacts.
+> This packet is **prepare-only**: it bumps version metadata and docs and adds
+> **no** publish steps. See the
+> [pre-merge release-readiness gate](#release-readiness-gate-g538) and
+> [publishing v0.5.0](#publishing-v050).
+
+## What's in v0.5.0
+
+v0.5.0 is a **minor release** covering nine slices (G529–G537) completed
+after `v0.4.0`. It is a minor bump rather than a patch because it ships
+**two new commands** (`intent facet-check`, `queue reprioritize`), a **new
+intent-tree schema surface** (`facets`), **new stalled-work kinds**, and a
+**new transition target** (`retired`) — all more than routine maintenance.
+The package id remains `JTechJapan.IntentSystem.Cli`; there are no package
+id, license, or workflow-semantics changes.
+
+> **Orchestrator mode is still preview/experimental.** It is opt-in, still
+> being hardened, and not the default workflow. intent-cli and GitHub remain
+> the authoritative source of truth; agmsg is only a message/progress/
+> completion signal layer.
+
+### Semantic facets (G529–G531)
+
+Originating from operator issue #1159, this three-slice initiative gives
+intent-tree nodes a closed, four-value vocabulary for the kind of semantic
+weight they carry, then makes that classification consumable by both
+tooling and reviewers.
+
+- **`facets:` frontmatter** (G529) — a node may declare zero or more of
+  `vocabulary` (event/command vocabulary: what counts as a fact),
+  `invariant` (invariants and consistency boundaries), `decider` (decider
+  judgments: what a command decides), or `acceptance-property` (what must
+  not break). Facets are optional and additive — a tree with none of them
+  annotated is unaffected.
+- **Facet-aware context supply** (G530) — `intent-cli context collect` gains
+  a `## Facet context` section, rendered AHEAD of the unclassified
+  queue-state/clarification/automation-bindings context (the semantic core,
+  not an afterthought), grouped in the canonical order `vocabulary →
+  invariant → decider → acceptance-property`. `--facets` restricts which
+  groups appear; `--scope` narrows to nodes overlapping given paths, checked
+  symmetrically in both directions. `intent-cli packet draft` generates the
+  same section inside scaffolded `review-context.md`, scoped to the
+  packet's own `intent_references`, kept current on every rerun via a
+  fail-closed marker-pair protocol that never touches hand-written prose
+  around the generated block.
+- **`intent facet-check`** (G531) — a read-only lexical scaffold that points
+  a change proposal AT the facet nodes G530 makes reachable: it checks a
+  proposal's candidate command/event terms against existing
+  `vocabulary`/`invariant` nodes so reviewers see naming collisions and
+  coverage gaps early. Explicitly **not** a semantic verifier and **never**
+  a gate — matching is lexical, false negatives are expected, and the
+  command always exits `0` regardless of findings.
+
+### stalled-work correctness (G532–G533)
+
+Field data against a downstream adopter (2026-07-15, 2026-07-18) showed
+`automation stalled-work` misclassifying candidates when its execution-unit
+identification logic itself was wrong.
+
+- **Execution-unit and domain identification** (G532) — the candidate
+  execution unit is now the LEADING ID token of the issue/PR title with a
+  mandatory right boundary, trusted only when a real
+  `.intent-cli/issues/<token>/packet.yaml` corroborates it; otherwise the
+  candidate is matched against every packet's own declared
+  `source_execution_unit`. Domain confirmation applies the same `--domain` >
+  packet-declared > fail-loud order as every other execution-unit-resolving
+  surface, but only for a candidate whose execution unit is itself
+  corroborated by real packet/queue linkage — an uncorroborated candidate is
+  excluded (`domain-underivable`) rather than silently guessed.
+- **Informational stalled-work kinds** (G533) — three new kinds
+  (`repair-pending`, `rereview-pending`, `claimed-but-silent`), each
+  `is_informational: true` with descriptive (never transition-command)
+  `recommended_action`. Fixes the exact field incident where a PR mid-repair
+  was misreported as `pr-created-not-reviewing` with a wrong `review-start`
+  recommendation. `claimed-but-silent` fails closed into `excluded[]` on any
+  unusable activity-timestamp data rather than guessing from `createdAt`.
+
+### Queue robustness (G534)
+
+Three related field findings against real, hand-authored packets and queue
+state, fixed together:
+
+- **`queue enqueue` accepts both YAML list-item conventions** — the
+  4-space-plus-`"- "` renderer convention and the more common 2-space
+  convention are both recognized by content, not column count.
+- **`queue transition --to retired` backfills a queue-state entry** — a
+  new guarded, idempotent, terminal transition with its own entry point
+  (`QueueManager.Retire`), consistent with `automation issue-retire`'s
+  refusal semantics: legal from any state except `Completed`; verifies the
+  linked PR's real GitHub state (refusing when it is confirmed merged or
+  closed) before mutating; idempotent when already `Retired`; and terminal —
+  a retired item can never transition to any other state again.
+- **The publish selector (`intent next-slice`) combines queue-state and
+  packet-lifecycle evidence explicitly** — either signal alone recording
+  retirement excludes the unit; a contradiction between the two now
+  surfaces as an actionable `lifecycle-metadata-diagnostic` warning instead
+  of resolving silently in either direction.
+
+### Label supersession (G535)
+
+Field finding #5 (SKS-G824 / PR #1760): `automation pr-transition
+--transition request-update` added its repair labels but left a
+pre-existing `intent-pr-rereview-ready` in place — `worker claim` correctly
+refuses a rereview-ready PR, producing a deadlock between two canonical
+rules with no installed command able to proceed. `request-update` now
+clears `intent-pr-rereview-ready` (and its legacy string form) in the
+**same** write that adds `intent-pr-request-update` — a repair request
+always supersedes pending rereview-readiness.
+
+### Publish reliability (G536)
+
+`issue publish-flow`'s idempotent rerun now independently verifies and
+restores all three durable artifacts — the GitHub issue, the queue-state
+entry, and the `runs.jsonl` event — instead of trusting one signal (e.g. the
+GitHub issue existing) to imply the other two are also intact. A partial
+prior failure that left, say, the queue-state entry missing while the issue
+was created is now detected and repaired on rerun rather than silently
+treated as fully done; genuinely unrecoverable inconsistencies fail loud
+rather than being papered over.
+
+### Priority override (G537)
+
+The new `queue reprioritize <execution-unit> --priority <high|normal|low>
+--reason <text> [--write]` command sets priority on a queued, unpublished
+execution unit under a durable, concurrency-safe audit protocol:
+
+- `intent next-slice` now selects eligible publish candidates
+  **priority-class-first** (high > normal > low), with a stable tiebreak by
+  authoring order within a class — dependency/WIP/clarification/lifecycle
+  gates always dominate priority; a high-priority but gate-blocked candidate
+  is never selected over an eligible lower-priority one.
+- Each successful `--write` is identified by a durable, monotonically
+  incrementing `priority_revision` counter (not wall-clock time, not a
+  content fingerprint — both were tried and broken by clock non-monotonicity
+  and genuine state revisits respectively) recorded on the queue item, so a
+  retry can always distinguish "my own prior attempt, safe to skip
+  re-appending" from "a genuinely new mutation" from "a conflicting claim,"
+  and fails closed on the latter two.
+- `--write` acquires a non-blocking, OS-level exclusive lock (`FileShare.None`
+  on a sibling `queue-state.reprioritize.lock` file) before the authoritative
+  read and holds it across the entire write critical section — a concurrent
+  invocation that cannot acquire the lock fails closed immediately rather
+  than racing. Dry-run never mutates and never takes the lock.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.5.0
+```
+
+Or download the self-contained binary from the
+[v0.5.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.5.0).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.4.0
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.5.0
+```
+
+Everything in this release is additive: the two new commands
+(`intent facet-check`, `queue reprioritize`) are opt-in surfaces, `facets:`
+frontmatter is an optional annotation, and the new stalled-work kinds only
+add finer-grained classification to an existing read-only surface. No
+existing command's default behavior changes.
+
+**Consumers running the sekiban-as-a-service-orch field-workaround set**
+(SKS-G8xx: title-convention workaround, duplicated top-level `domain:`
+fields, queue-state hand-edit recovery) can retire all three once this
+release is installed — G532's execution-unit identification no longer needs
+the title-convention workaround, G534's `queue transition --to retired`
+replaces the hand-edit recovery path, and the duplicated top-level `domain:`
+field compatibility alias (already supported since earlier releases) covers
+the remaining case cleanly going forward.
+
+## Release-readiness gate (G538)
+
+These items must hold **before the GitHub Release for `v0.5.0` is published**.
+This gate fails closed — if any item is unmet, do not publish the Release yet.
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G529, G530, G531, G532, G533, G534, G535, G536, G537 (and this G538
+      release-notes prep). Confirm on the host/review side via the host
+      queue-state / GitHub PR state — the child implementation loop must not
+      read parent queue-state, so this is a host-owned precondition.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before
+      publishing).
+- [ ] `eng/version.json` `nextVersion` is `0.5.0` (the intended release
+      version). `release.yml` builds the package version from the published
+      Release/tag; `src/IntentSystem.Cli/IntentSystem.Cli.csproj` derives its
+      local default from the same policy.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] Release notes / README keep **orchestrator mode described as
+      preview/experimental** and opt-in, with timer-loop mode unchanged.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+- [ ] **Post-merge build + pack evidence** on the merge commit is recorded in
+      the PR (mirroring the G528 readiness gate).
+
+## Publishing v0.5.0
+
+This packet does **not** publish the release and adds **no** publish steps. The
+version-bump merge does **not** create a GitHub Release or tag on its own.
+
+1. After this version bump is merged and the readiness gate above holds, a
+   **maintainer/operator (or external release automation) creates and publishes
+   the GitHub Release** for `v0.5.0` (tagging the release commit). This is a
+   post-merge host/operator/external action.
+2. Publishing that GitHub Release fires `.github/workflows/release.yml`
+   (`on: release: published`), which builds and publishes the NuGet package and
+   the per-platform binary archives (with `.sha256` checksums) and attaches them
+   to the triggering Release.
+
+Post-release verification (after the GitHub Release is published and
+`release.yml` has run):
+
+- [ ] NuGet.org package page links all resolve correctly.
+- [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+      accessible.
+- [ ] `.sha256` checksums match the downloaded artifacts.
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.5.0`)
+      then `intent-cli --version` reports `0.5.0`.
+- [ ] Binary artifact smoke check: download the platform archive, verify its
+      `.sha256`, extract, and run `./intent-cli --version` → `0.5.0`.
+- [ ] **New commands smoke**: `intent-cli intent facet-check --domain <d>
+      --terms Example --format json` and `intent-cli queue reprioritize
+      --help` both run against a real repo without crashing.
+- [ ] **Facet context smoke** (G530): `intent-cli context collect --domain <d>
+      --format json` renders a `## Facet context` section (or its
+      `facet_context_note` graceful-degradation note on a tree with no
+      annotated nodes).
+- [ ] **stalled-work classification smoke** (G532/G533): `intent-cli
+      automation stalled-work --domain <d> --repo <r> --format json` reports
+      the new `repair-pending` / `rereview-pending` / `claimed-but-silent`
+      kinds where applicable, each carrying `is_informational: true`.
+- [ ] **Queue retirement smoke** (G534): `intent-cli queue transition
+      <execution-unit> retired --help` and `intent-cli queue enqueue --help`
+      both run without crashing against a real repo.
+- [ ] **Priority override smoke** (G537): `intent-cli queue reprioritize
+      --help` and `intent-cli intent next-slice --help` both run without
+      crashing; priority-class-first ordering documented in
+      [09-developer-reference.md](09-developer-reference.md#canonical-publish-order-override--queue-priority-g537).
+- [ ] Notify the operator to publish the `v0.5.0` GitHub Release, then notify
+      sekiban-as-a-service-orch to drop the three documented workarounds
+      after installing `v0.5.0`.
+- [ ] Local preview/dry-run version metadata uses the next development line
+      after `0.5.0` (bump `eng/version.json` per the post-release step in
+      [Version flow](09-developer-reference.md#version-flow)):
+      `stableVersion → 0.5.0`, `nextVersion → 0.5.1`. This bump is deferred to
+      the **next** release-prep packet, not this one.

--- a/docs/en/release-notes-v0.5.0.md
+++ b/docs/en/release-notes-v0.5.0.md
@@ -164,11 +164,37 @@ Verify the `.sha256` sidecar before use.
 dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.5.0
 ```
 
-Everything in this release is additive: the two new commands
-(`intent facet-check`, `queue reprioritize`) are opt-in surfaces, `facets:`
-frontmatter is an optional annotation, and the new stalled-work kinds only
-add finer-grained classification to an existing read-only surface. No
-existing command's default behavior changes.
+This release is **compatibility-conscious and non-breaking in intent**, but
+not every change is purely additive — a few slices correct the behavior of
+already-shipped commands, and consumers relying on the corrected behavior
+should read these carefully:
+
+- **Additive, no action needed**: the two new commands
+  (`intent facet-check`, `queue reprioritize`) are opt-in surfaces, `facets:`
+  frontmatter is an optional annotation, and G533's new stalled-work kinds
+  only add finer-grained classification to an existing read-only surface.
+- **Corrective — existing command behavior changes**:
+  - **G535** — `automation pr-transition --transition request-update` now
+    also clears a stale `intent-pr-rereview-ready` label in the same write.
+    A caller that previously expected `request-update` to leave that label
+    untouched (e.g. re-applying it manually afterward) will see it gone.
+  - **G536** — `issue publish-flow`'s idempotent rerun now independently
+    verifies and restores all three durable artifacts instead of trusting
+    one signal for all three; a rerun that previously silently no-opped on
+    a partially-failed prior run may now perform additional writes (or fail
+    loud) where it previously did neither.
+  - **G532/G534** — `automation stalled-work`'s execution-unit/domain
+    identification is stricter (an uncorroborated candidate is now
+    excluded rather than possibly misattributed), and `intent next-slice`'s
+    retirement-evidence combination is stricter (a lifecycle/queue-state
+    contradiction that previously resolved silently in one direction now
+    excludes the candidate and raises a diagnostic instead). A candidate
+    that previously matched loosely may now be excluded or flagged where it
+    previously was not.
+
+No package id, license, or CLI argument/flag shape changes; every corrective
+change above is a bug fix to bring behavior in line with the documented
+intent of its own command, not a new command surface or a removed one.
 
 **Consumers running the sekiban-as-a-service-orch field-workaround set**
 (SKS-G8xx: title-convention workaround, duplicated top-level `domain:`

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1586,103 +1586,108 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.3.15",
-  "nextVersion": "0.4.0"
+  "stableVersion": "0.4.0",
+  "nextVersion": "0.5.0"
 }
 ```
 
 | ステージ | バージョン形式 | 導出方法 |
 | --- | --- | --- |
-| ローカル pack / install | `0.4.0-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.4.0-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.4.0-rc.N` | タグ `v0.4.0-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
-| 安定版リリース | `0.4.0` | タグ `v0.4.0` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.4.1-preview.<run>.<attempt>` | `nextVersion` を `0.4.1` にバンプ後 |
+| ローカル pack / install | `0.5.0-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.5.0-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.5.0-rc.N` | タグ `v0.5.0-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
+| 安定版リリース | `0.5.0` | タグ `v0.5.0` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.5.1-preview.<run>.<attempt>` | `nextVersion` を `0.5.1` にバンプ後 |
 
-**`v0.4.0` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+**`v0.5.0` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
 
 ```json
 {
-  "stableVersion": "0.4.0",
-  "nextVersion": "0.4.1"
+  "stableVersion": "0.5.0",
+  "nextVersion": "0.5.1"
 }
 ```
 
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.4.1-preview.<run>.<attempt>` / `0.4.1-<sha>-<G-unit>` を生成し、`0.4.0`（安定版
+`0.5.1-preview.<run>.<attempt>` / `0.5.1-<sha>-<G-unit>` を生成し、`0.5.0`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備（v0.4.0）
+### 次リリース準備(v0.5.0)
 
-**`v0.3.15` は publish 済み**（GitHub Release + NuGet）で、バージョンポリシーは
-`0.4.0` 開発ラインにバンプされました — これは patch ではなく **minor** バンプです:
-3 つの新しい automation コマンドに加えて、目に見える fail-loud な挙動変更があるため、
-patch リリース以上の扱いが妥当です。リポジトリは現在 in-development の **`0.4.0`**
-`nextVersion` 上にあり、G528 は **prepare-only** です — version メタデータと docs をバンプするだけで
-publish ステップを追加しません。version-bump マージ自体は GitHub Release やタグを作成しません。
-マージされ
-[リリース準備ゲート](release-notes-v0.4.0.md#リリース準備ゲート-g528)が成り立った後、
-**メンテナ/オペレーター（または外部のリリース automation）が `v0.4.0` の GitHub Release を作成・
-publish** します。その Release の publish が `.github/workflows/release.yml`（`on: release: published`）を
+**`v0.4.0` は publish 済み**(GitHub Release + NuGet)で、バージョンポリシーは
+`0.5.0` 開発ラインにバンプされました — これは patch ではなく **minor** バンプです:
+このバッチは 2 つの新しいコマンド(`intent facet-check`、`queue reprioritize`)、新しい
+intent-tree schema サーフェス(`facets`)、新しい stalled-work kind、新しい transition
+target(`retired`)を出荷するため、patch リリース以上の扱いが妥当です。リポジトリは現在
+in-development の **`0.5.0`** `nextVersion` 上にあり、G538 は **prepare-only** です —
+version メタデータと docs をバンプするだけで publish ステップを追加しません。
+version-bump マージ自体は GitHub Release やタグを作成しません。マージされ
+[リリース準備ゲート](release-notes-v0.5.0.md#リリース準備ゲート-g538)が成り立った後、
+**メンテナ/オペレーター(または外部のリリース automation)が `v0.5.0` の GitHub Release を作成・
+publish** します。その Release の publish が `.github/workflows/release.yml`(`on: release: published`)を
 発火させ、NuGet package とプラットフォームごとのバイナリ成果物を build・publish します。
 完全な changelog と operator チェックリスト:
-[release-notes-v0.4.0.md](release-notes-v0.4.0.md)。
+[release-notes-v0.5.0.md](release-notes-v0.5.0.md)。
 
-**`v0.4.0` で出荷予定（`v0.3.15` 以降の変更）— orchestrator スタール防止バッチ、
-fail-loud な domain 解決、parser 修正:**
+**`v0.5.0` で出荷予定（`v0.4.0` 以降の変更）— semantic facets、stalled-work の正確性、
+queue の頑健性、label supersession、publish の信頼性、priority override:**
 
-- **3 つの新しい automation コマンド** — `automation stalled-work`（G523）、
-  `automation heartbeat`（G526）、`automation issue-retire`（G525）: 保留中の
-  transition を一覧する read-only な棚卸しコマンド、それを外部の低頻度スケジューラ向けに
-  ラップして送信可能な reconcile メッセージを返す read-only コマンド、そして authored 通りには
-  決して開始できない published issue を retire する canonical かつ atomic な transition。
-- **fail-loud な domain 解決**（G522）— execution-unit を解決するサーフェス
-  （`automation queue-seed-from-packet`、`review closeout-plan`、
-  `automation publish-recovery`）は、明示的な `--domain` が優先され（packet 自身の
-  `domain:` フィールドと矛盾する場合はエラー）、次に packet-declared な domain、
-  どちらも無い場合は candidate domains と正確な re-invocation を示して fail loud する
-  ようになりました — host の config-default domain への黙ったフォールバックは
-  もうありません。**移行方法:** これまで黙ったフォールバックに依存していたスクリプトや
-  automation は、`--domain` を明示的に渡すか、解決対象の packet.yaml が `domain:`
-  フィールドを宣言していることを確認する必要があります。
-- **orchestrator wake contract**（G524）— publish と delegate を同じ wake 内で行う
-  (「次の wake に持ち越す」はもうありません); メッセージ上限は「wake ごと・receiver ごとに
-  最大 1 通の delegation」と再定義; 新しい end-of-wake の `automation stalled-work`
-  チェック（never-defer ルール付き）; receiver の completion/blocked レポートは
-  すべての delegation の REQUIRED FINAL STEP になりました; そして送信のたびに
-  dispatch roster を検証（`team.sh`）。
-- **managed review worktree + design-alignment チェック**（G520）— review worktree は
-  managed root（`.intent-cli/worktrees/review-<unit>`）配下で強制され、`/tmp` は
-  使われません; design-alignment のエビデンス（packet、review-context、intent tree、
-  ADR/decision note）が無い review completed 返信は incomplete 扱いになります。
-- **Codex monitor（beta）ガイダンス**（G521）— agmsg Codex bridge 向けの setup preflight
-  と 3 つの新しい troubleshooting エントリ（silent launcher、static TUI、doubled
-  responses）。
-- **packet-yaml parser 修正**（G527）— `PreparedPacketYamlScalarParser` の
-  quote-balance チェックが delimiter-aware になり、アポストロフィだけを含む
-  double-quoted 値が誤って拒否されていたフィールドインシデントを修正しました。
+- **semantic facets**(G529–G531)— intent-tree ノードが frontmatter で宣言できる
+  4 つの closed set の `facets:` 値(`vocabulary`、`invariant`、`decider`、
+  `acceptance-property`)。`intent-cli context collect` と `packet draft` は、
+  分類されていない queue-state/clarification context より前に、facet で分類された
+  `## Facet context` セクションを優先的な局所化された semantic context として供給する
+  ようになりました。read-only な `intent facet-check` は、change proposal を facet
+  ノードに照らして、命名衝突やカバレッジのギャップを、決して gate することなく
+  表面化します。
+- **stalled-work の正確性**(G532–G533)— leading-ID/nested-domain の execution-unit
+  識別は、タイトルだけを信頼するのではなく実際の packet/queue linkage で裏付けられる
+  ようになりました。`--domain` は必須の authoritative なスコープ入力です。3 つの
+  新しい informational kind(`repair-pending`、`rereview-pending`、
+  `claimed-but-silent`)により、修理中/再レビュー待ちの PR が誤った `review-start`
+  推奨で誤報告されることがなくなりました。
+- **queue の頑健性**(G534)— packet reader は両方の YAML list-item インデント慣習を
+  受け入れるようになりました。`retired` は今や guarded かつ terminal な `queue
+  transition` target です(適用前に紐づく PR の実際の GitHub 状態を検証)。
+  `intent next-slice` は queue-state と packet-lifecycle の retirement エビデンスを
+  明示的に組み合わせ、矛盾があれば fail closed します。
+- **label supersession**(G535)— `automation pr-transition --transition
+  request-update` は、同じ write の中で古い `intent-pr-rereview-ready` を
+  クリアするようになりました。これにより、`request-update` が修理対象としてマークした
+  PR を `worker claim` が拒否してしまうデッドロックが解消されました。
+- **publish の信頼性**(G536)— `issue publish-flow` の idempotent な再実行は、
+  3 つの durable artifact(GitHub issue、queue-state エントリ、`runs.jsonl`
+  イベント)すべてを、1 つのシグナルを信頼するのではなく独立に検証・復元する
+  ようになり、state が矛盾したまま黙って残るのではなく fail loud するようになりました。
+- **priority override**(G537)— 新しい `queue reprioritize` コマンドは、queued かつ
+  未 publish の execution unit の priority を、durable かつ revision-counted、
+  lock-protected な audit protocol の下で設定します。`intent next-slice` は
+  priority class を優先(high > normal > low、authoring order による安定した
+  tiebreak)して候補を選択し、dependency/WIP/clarification/lifecycle の gate は
+  常に priority に優先します。
 - orchestrator モードは引き続き **preview/experimental** です: オプトインで、まだ hardening 中であり、
   timer-loop モードは完全サポート・不変です。
   [エージェントメッセージオーケストレーション](12-agent-message-orchestration.md) を参照。
 
-**リリース準備の検証（`v0.4.0` version bump のマージ前に実行）:**
+**リリース準備の検証（`v0.5.0` version bump のマージ前に実行）:**
 
 ```bash
-cat eng/version.json   # stableVersion 0.3.15（公開済み）, nextVersion 0.4.0（リリース対象）
+cat eng/version.json   # stableVersion 0.4.0（公開済み）, nextVersion 0.5.0（リリース対象）
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.4.0-<sha>-G52x （stale なリテラルではない）
+#   期待形: intent-cli 0.5.0-<sha>-G53x （stale なリテラルではない）
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.4.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.5.0.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
 version-bump マージが `main` に入った後、メンテナ/オペレーター（または外部のリリース automation）が
-`v0.4.0` の GitHub Release を作成・publish します。その publish が `release.yml`
+`v0.5.0` の GitHub Release を作成・publish します。その publish が `release.yml`
 （`on: release: published`）を発火させ、NuGet package とプラットフォームごとのバイナリ成果物を
 build・publish します。publish 後、上記のリリース後 `eng/version.json` バンプ
-（`stableVersion → 0.4.0`, `nextVersion → 0.4.1`）を適用します。
+（`stableVersion → 0.5.0`, `nextVersion → 0.5.1`）を適用します — これは今回のパケットではなく
+NEXT のリリース準備パケットに委ねられます。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.5.0.md
+++ b/docs/ja/release-notes-v0.5.0.md
@@ -1,0 +1,249 @@
+# リリースノート — intent-cli v0.5.0
+
+> **リリースモデル:** メンテナ/オペレーター(または外部のリリース automation)が `v0.5.0` の
+> **GitHub Release を作成・publish** します — version-bump マージ自体は Release やタグを作成しません。
+> GitHub Release の publish が `.github/workflows/release.yml`(`on: release: published`)を発火させ、
+> NuGet package とプラットフォームバイナリ成果物を build・publish します。本パケットは
+> **prepare-only** で、version メタデータと docs をバンプするだけで publish ステップを **追加しません**。
+> [マージ前 リリース準備ゲート](#リリース準備ゲート-g538) と
+> [v0.5.0 の publish](#v050-の-publish) を参照。
+
+## v0.5.0 の内容
+
+v0.5.0 は **minor リリース** で、`v0.4.0` 以降に完了した 9 件のスライス(G529–G537)を
+カバーします。patch ではなく minor バンプなのは、**2 つの新しいコマンド**
+(`intent facet-check`、`queue reprioritize`)、**新しい intent-tree schema サーフェス**
+(`facets`)、**新しい stalled-work kind**、**新しい transition target**(`retired`)を
+出荷するためで、どれも通常のメンテナンス以上のものです。package id は
+`JTechJapan.IntentSystem.Cli` のままで、package id・ライセンス・workflow セマンティクスの
+変更はありません。
+
+> **orchestrator モードは引き続き preview/experimental です。** オプトインで、まだ hardening 中で
+> あり、デフォルトの workflow ではありません。intent-cli と GitHub が権威 source of truth であり
+> 続け、agmsg はメッセージ / 進捗 / 完了のシグナル層のみです。
+
+### semantic facets(G529–G531)
+
+オペレーター issue #1159 に端を発するこの 3 スライスのイニシアチブは、intent-tree の
+ノードに、それが担う semantic な重みの種類を表す closed かつ 4 値の語彙を与え、その分類を
+tooling とレビュアーの双方が消費できるようにします。
+
+- **`facets:` frontmatter**(G529)— ノードは `vocabulary`(event/command 語彙:
+  何が fact としてカウントされるか)、`invariant`(不変条件と一貫性の境界)、
+  `decider`(decider の判断: コマンドが何を決定するか)、`acceptance-property`
+  (壊してはいけないもの)のうち 0 個以上を宣言できます。facets はオプションかつ
+  加算的です — どれも annotate されていない tree には影響しません。
+- **facet を意識した context 供給**(G530)— `intent-cli context collect` は、
+  分類されていない queue-state/clarification/automation-bindings context より前に
+  レンダリングされる `## Facet context` セクションを持つようになりました(これは
+  semantic な核であり、おまけではありません)。canonical な順序 `vocabulary →
+  invariant → decider → acceptance-property` でグループ化されます。`--facets` は
+  表示するグループを制限し、`--scope` は指定されたパスに overlap するノードへと
+  絞り込みます(双方向対称にチェック)。`intent-cli packet draft` は、scaffold された
+  `review-context.md` の中に同じセクションを、packet 自身の `intent_references` に
+  スコープして生成します。再実行のたびに、生成ブロックの周囲にある手書きの文章には
+  一切触れない fail-closed な marker-pair プロトコルによって最新に保たれます。
+- **`intent facet-check`**(G531)— change proposal を、G530 が到達可能にした facet
+  ノードに照らす read-only な lexical scaffold です: proposal の候補となる
+  command/event term を既存の `vocabulary`/`invariant` ノードと突き合わせ、
+  レビュアーが命名衝突やカバレッジのギャップを早期に把握できるようにします。
+  明示的に semantic verifier では **ありません**し、決して gate にも **なりません**
+  — matching は lexical であり、false negative は想定内で、コマンドは findings に
+  関わらず常に exit `0` します。
+
+### stalled-work の正確性(G532–G533)
+
+downstream adopter に対するフィールドデータ(2026-07-15、2026-07-18)は、
+`automation stalled-work` の execution-unit 識別ロジック自体が誤っている場合に
+候補を誤分類することを示していました。
+
+- **execution-unit と domain の識別**(G532)— candidate execution unit は今や、
+  issue/PR タイトルの LEADING ID token であり、必須の right boundary を持ちます。
+  実在の `.intent-cli/issues/<token>/packet.yaml` が裏付ける場合にのみ信頼され、
+  それ以外の場合は candidate は各 packet 自身が宣言する `source_execution_unit`
+  と照合されます。domain の確認は、他のあらゆる execution-unit を解決するサーフェスと
+  同じ `--domain` > packet-declared > fail-loud の順序を適用しますが、これは
+  execution unit 自体が実際の packet/queue linkage によって裏付けられている
+  candidate に対してのみです — 裏付けの無い candidate は、黙って推測されるのではなく
+  除外されます(`domain-underivable`)。
+- **informational な stalled-work kind**(G533)— 3 つの新しい kind
+  (`repair-pending`、`rereview-pending`、`claimed-but-silent`)がそれぞれ
+  `is_informational: true` を持ち、`recommended_action` は記述的なプローズです
+  (transition コマンドでは決してありません)。修理中の PR が誤った
+  `review-start` 推奨とともに `pr-created-not-reviewing` として誤報告された
+  正確なフィールドインシデントを修正します。`claimed-but-silent` は、使用不能な
+  活動タイムスタンプデータに対して `createdAt` から推測するのではなく、
+  `excluded[]` へ fail closed します。
+
+### queue の頑健性(G534)
+
+実際の hand-authored な packet と queue state に対する 3 つの関連したフィールド発見を
+まとめて修正しました:
+
+- **`queue enqueue` は両方の YAML list-item 慣習を受け入れます** — 4 スペース +
+  `"- "` という renderer の慣習と、より一般的な 2 スペースの慣習の両方が、
+  カラム数ではなく内容によって認識されます。
+- **`queue transition --to retired` が queue-state エントリを backfill します** —
+  新しい guarded かつ idempotent、terminal な transition で、`automation
+  issue-retire` の拒否セマンティクスと整合する独自の entry point
+  (`QueueManager.Retire`)を持ちます: `Completed` 以外のあらゆる state から合法;
+  mutate する前に紐づく PR の実際の GitHub 状態を検証(merge または close が
+  確認された場合は拒否); 既に `Retired` であれば idempotent; そして terminal —
+  一度 retire された item は二度と他の state に transition できません。
+- **publish selector(`intent next-slice`)は queue-state と packet-lifecycle の
+  エビデンスを明示的に組み合わせます** — どちらか一方のシグナルが retirement を
+  記録していればその unit は除外されます。両者の矛盾は、どちらか一方向に黙って
+  解決されるのではなく、実行可能な `lifecycle-metadata-diagnostic` 警告として
+  表面化するようになりました。
+
+### label supersession(G535)
+
+フィールド発見 #5(SKS-G824 / PR #1760): `automation pr-transition
+--transition request-update` は修理ラベルを追加しましたが、既存の
+`intent-pr-rereview-ready` をそのままにしていました — `worker claim` は
+rereview-ready な PR を正しく拒否するため、2 つの canonical なルールの間で
+デッドロックが発生し、インストール済みのどのコマンドも先に進めませんでした。
+`request-update` は今や、`intent-pr-request-update` を追加するのと **同じ** write
+の中で `intent-pr-rereview-ready`(とそのレガシー文字列形式)をクリアします —
+repair request は常に pending な rereview-readiness に優先します。
+
+### publish の信頼性(G536)
+
+`issue publish-flow` の idempotent な再実行は、GitHub issue・queue-state
+エントリ・`runs.jsonl` イベントという 3 つの durable artifact すべてを、1 つの
+シグナル(例えば GitHub issue が存在すること)を信頼して他の 2 つも無傷だと
+みなすのではなく、独立に検証・復元するようになりました。issue は作成されたが
+queue-state エントリが欠落しているような部分的な過去の失敗は、re-run 時に
+silently に完了扱いされるのではなく検出・修復されます。本当に回復不能な矛盾は
+覆い隠されるのではなく fail loud します。
+
+### priority override(G537)
+
+新しい `queue reprioritize <execution-unit> --priority <high|normal|low>
+--reason <text> [--write]` コマンドは、queued かつ未 publish の execution unit の
+priority を、durable かつ concurrency-safe な audit protocol の下で設定します:
+
+- `intent next-slice` は今や、eligible な publish candidate を
+  **priority class を優先**(high > normal > low)して選択し、class 内では
+  authoring order による安定した tiebreak を行います — dependency/WIP/
+  clarification/lifecycle の gate は常に priority に優先します。高 priority
+  だが gate でブロックされている candidate が、eligible なより低い priority の
+  candidate より優先して選ばれることはありません。
+- 各成功した `--write` は、queue item 上に記録される durable かつ単調増加する
+  `priority_revision` カウンタによって識別されます(wall-clock time でも
+  content fingerprint でもありません — どちらも試みられましたが、それぞれ
+  clock の非単調性と genuine な state の再訪によって破綻しました)。これにより
+  retry は常に「自分自身の以前の試み(再追記をスキップして安全)」と
+  「本当に新しい mutation」と「矛盾する claim」を区別でき、後者 2 つに対しては
+  fail closed します。
+- `--write` は、authoritative な read の前に non-blocking な OS-level exclusive
+  lock(sibling file `queue-state.reprioritize.lock` に対する `FileShare.None`)
+  を取得し、write の critical section 全体にわたってそれを保持します —
+  同じ lock を取得できなかった concurrent な invocation は、race するのではなく
+  即座に fail closed します。dry-run は決して mutate せず、決して lock を
+  取得しません。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.5.0
+```
+
+または [v0.5.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.5.0)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを検証します。
+
+## v0.4.0 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.5.0
+```
+
+この リリースはすべて加算的な変更です: 2 つの新しいコマンド(`intent facet-check`、
+`queue reprioritize`)はオプトインのサーフェスであり、`facets:` frontmatter は
+オプションの annotation であり、新しい stalled-work kind は既存の read-only な
+サーフェスへより細かい分類を追加するだけです。既存コマンドのデフォルト挙動は
+変更されません。
+
+**sekiban-as-a-service-orch のフィールドワークアラウンド一式**(SKS-G8xx:
+title-convention workaround、重複したトップレベルの `domain:` フィールド、
+queue-state hand-edit recovery)を運用しているコンシューマーは、本リリースを
+インストール後、3 つすべてを廃止できます — G532 の execution-unit 識別は
+もはや title-convention workaround を必要とせず、G534 の `queue transition
+--to retired` は hand-edit recovery パスを置き換え、重複したトップレベルの
+`domain:` フィールドの互換エイリアス(以前のリリースから既にサポート済み)が
+残るケースを今後もきれいにカバーします。
+
+## リリース準備ゲート(G538)
+
+次の項目は **`v0.5.0` の GitHub Release が publish される前** に成り立っている必要があります。
+このゲートは fail closed です — 1 つでも未充足なら、まだ Release を publish しないでください。
+
+- [ ] リリース対象の各パケットが **完了し PR が `main` にマージ済み**: G529、G530、
+      G531、G532、G533、G534、G535、G536、G537(および release-notes 準備の G538)。
+      host queue-state / GitHub PR 状態で host/review 側から確認する(child 実装
+      ループは parent queue-state を読まないため、これは host 所有の前提条件)。
+- [ ] 本リリース対象の open な intent-system PR や WIP パケットが誤ってスキップされて
+      いない(publish 前に host queue / open PR リストを確認)。
+- [ ] `eng/version.json` の `nextVersion` が `0.5.0`(意図したリリースバージョン)。
+      `release.yml` は publish された Release/タグから package バージョンをビルドし、
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` も同じポリシーからローカル
+      デフォルトを導出する。
+- [ ] package メタデータが正しい: `PackageId = JTechJapan.IntentSystem.Cli`、
+      `RepositoryUrl` / `PackageProjectUrl` が `https://github.com/J-Tech-Japan/intent-system` を指す、
+      `PackageLicenseExpression = Apache-2.0`、README/docs リンクが解決し、公式サービスサイト
+      `https://www.intent-driven-development.com/` が README からリンクされている。
+- [ ] リリースノート / README が **orchestrator モードは preview/experimental** かつオプトインで
+      あること、timer-loop モードが不変であることを保っている。
+- [ ] リリースコミットで **Main CI が green**(`Build and test (source contract)`)であり、
+      **preview-pack** workflow も green。
+- [ ] マージコミットでの **post-merge build + pack のエビデンス** が PR に記録されている
+      (G528 の readiness gate を踏襲)。
+
+## v0.5.0 の publish
+
+本パケットはリリースを publish せず、publish ステップを **追加しません**。version-bump マージ自体は
+GitHub Release やタグを作成しません。
+
+1. この version bump がマージされ上記の準備ゲートが成り立った後、**メンテナ/オペレーター(または
+   外部のリリース automation)が `v0.5.0` の GitHub Release を作成・publish** します
+   (リリースコミットにタグ付け)。これはマージ後の host/operator/外部リリースアクションです。
+2. その GitHub Release の publish が `.github/workflows/release.yml`(`on: release: published`)を
+   発火させ、NuGet package とプラットフォームごとのバイナリアーカイブ(`.sha256` チェックサム付き)を
+   build・publish し、トリガーとなった Release に添付します。
+
+リリース後の検証(GitHub Release が publish され `release.yml` が実行された後):
+
+- [ ] NuGet.org の package ページのリンクがすべて正しく解決する。
+- [ ] GitHub release アセットリンク(`.tar.gz`, `.zip`, `.exe`, `.nupkg`)にアクセスできる。
+- [ ] `.sha256` チェックサムがダウンロード成果物と一致する。
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`(または
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.5.0`)後、
+      `intent-cli --version` が `0.5.0` を報告する。
+- [ ] バイナリ成果物スモーク: プラットフォームアーカイブをダウンロードし `.sha256` を検証、
+      展開して `./intent-cli --version` → `0.5.0`。
+- [ ] **新コマンドスモーク**: `intent-cli intent facet-check --domain <d>
+      --terms Example --format json` と `intent-cli queue reprioritize --help` が
+      実リポジトリに対してクラッシュせず実行できる。
+- [ ] **Facet context スモーク**(G530): `intent-cli context collect --domain <d>
+      --format json` が `## Facet context` セクション(または annotate されたノードが
+      無い tree に対する `facet_context_note` の graceful-degradation ノート)を
+      レンダリングする。
+- [ ] **stalled-work classification スモーク**(G532/G533): `intent-cli
+      automation stalled-work --domain <d> --repo <r> --format json` が該当する
+      場合に新しい `repair-pending` / `rereview-pending` / `claimed-but-silent`
+      kind を、それぞれ `is_informational: true` 付きで報告する。
+- [ ] **queue retirement スモーク**(G534): `intent-cli queue transition
+      <execution-unit> retired --help` と `intent-cli queue enqueue --help` が
+      実リポジトリに対してクラッシュせず実行できる。
+- [ ] **priority override スモーク**(G537): `intent-cli queue reprioritize
+      --help` と `intent-cli intent next-slice --help` がクラッシュせず実行できる。
+      priority-class-first の順序は
+      [09-developer-reference.md](09-developer-reference.md#canonical-な-publish-order-override--queue-priority-g537)
+      に記載。
+- [ ] `v0.5.0` の GitHub Release を publish するようオペレーターに通知し、`v0.5.0`
+      インストール後に sekiban-as-a-service-orch へ 3 つの documented workaround を
+      廃止するよう通知する。
+- [ ] ローカル preview/dry-run のバージョンメタデータが `0.5.0` の次の開発ラインを使う
+      ([バージョンフロー](09-developer-reference.md#バージョンフロー) のリリース後ステップに従い
+      `eng/version.json` をバンプ): `stableVersion → 0.5.0`, `nextVersion → 0.5.1`。
+      このバンプは今回のパケットではなく **次の** リリース準備パケットに委ねられます。

--- a/docs/ja/release-notes-v0.5.0.md
+++ b/docs/ja/release-notes-v0.5.0.md
@@ -158,11 +158,37 @@ dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.5.0
 dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.5.0
 ```
 
-この リリースはすべて加算的な変更です: 2 つの新しいコマンド(`intent facet-check`、
-`queue reprioritize`)はオプトインのサーフェスであり、`facets:` frontmatter は
-オプションの annotation であり、新しい stalled-work kind は既存の read-only な
-サーフェスへより細かい分類を追加するだけです。既存コマンドのデフォルト挙動は
-変更されません。
+本リリースは **compatibility-conscious かつ non-breaking な意図** で作られていますが、
+すべての変更が純粋に加算的というわけではありません — いくつかのスライスは既に
+出荷済みのコマンドの挙動を修正しており、その修正済みの挙動に依存しているコンシューマーは
+注意して読んでください:
+
+- **加算的で対応不要**: 2 つの新しいコマンド(`intent facet-check`、
+  `queue reprioritize`)はオプトインのサーフェスであり、`facets:` frontmatter は
+  オプションの annotation であり、G533 の新しい stalled-work kind は既存の
+  read-only なサーフェスへより細かい分類を追加するだけです。
+- **修正的 — 既存コマンドの挙動が変わります**:
+  - **G535** — `automation pr-transition --transition request-update` は今や、
+    同じ write の中で古い `intent-pr-rereview-ready` ラベルもクリアします。
+    以前は `request-update` がそのラベルに触れないことを期待していた呼び出し元
+    (例えば事後に手動で再適用していた場合)は、そのラベルが消えていることに
+    気づくはずです。
+  - **G536** — `issue publish-flow` の idempotent な再実行は、1 つのシグナルを
+    信頼して 3 つすべてを推測するのではなく、3 つの durable artifact すべてを
+    独立に検証・復元するようになりました。以前は部分的に失敗した先行実行に対して
+    黙って no-op していた再実行が、今後は追加の書き込みを行う(あるいは
+    fail loud する)ことがあります。
+  - **G532/G534** — `automation stalled-work` の execution-unit/domain 識別は
+    より厳格になりました(裏付けの無い candidate は、誤って帰属させられる
+    可能性があった従来と異なり、今後は除外されます)。`intent next-slice` の
+    retirement エビデンスの組み合わせもより厳格になりました(以前は一方向に
+    黙って解決されていた lifecycle/queue-state の矛盾が、今後は candidate を
+    除外し診断を発生させます)。以前は緩く一致していた candidate が、今後は
+    除外またはフラグ付けされる可能性があります。
+
+package id・ライセンス・CLI の引数/フラグの形状に変更はありません。上記の
+修正的な変更はいずれも、新しいコマンドサーフェスや廃止されたサーフェスではなく、
+各コマンド自身の documented intent に挙動を合わせるためのバグ修正です。
 
 **sekiban-as-a-service-orch のフィールドワークアラウンド一式**(SKS-G8xx:
 title-convention workaround、重複したトップレベルの `domain:` フィールド、

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.3.15",
-  "nextVersion": "0.4.0"
+  "stableVersion": "0.4.0",
+  "nextVersion": "0.5.0"
 }

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,12 +124,14 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.4.0 as the next development line
-        // (post-v0.3.15 release bump, see G528 — v0.3.15 was published to
+        // be parseable and must point to 0.5.0 as the next development line
+        // (post-v0.4.0 release bump, see G538 — v0.4.0 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.4.0 — a minor bump, since three new automation
-        // commands plus a visible fail-loud behavior change justify more
-        // than a patch — while recording 0.3.15 as the published stable).
+        // forward to 0.5.0 — a minor bump, since the batch ships two new
+        // commands (`intent facet-check`, `queue reprioritize`), a new
+        // intent-tree schema surface (`facets`), new stalled-work kinds, and
+        // a new transition target (`retired`) — while recording 0.4.0 as
+        // the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -139,8 +141,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.4.0", policy.NextVersion);
-        Assert.Equal("0.3.15", policy.StableVersion);
+        Assert.Equal("0.5.0", policy.NextVersion);
+        Assert.Equal("0.4.0", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary
- Bump `eng/version.json` to `stableVersion 0.4.0` / `nextVersion 0.5.0` — also catches up the post-v0.4.0 stable bump that was missed at G528 closeout.
- Update `VersionPolicyTests`' repo smoke test to the new values.
- Author `docs/ja/release-notes-v0.5.0.md` and `docs/en/release-notes-v0.5.0.md`, covering the nine merged slices G529–G537 grouped by six themes (semantic facets, stalled-work correctness, queue robustness, label supersession, publish reliability, priority override), the minor-bump rationale, the prepare-only release model with operator publishing steps, and consumer upgrade effects (including retirement of the three sekiban-as-a-service-orch workarounds).
- Cross-link `docs/en/09-developer-reference.md` / `docs/ja/09-developer-reference.md`'s "Version flow" / "Next release readiness" sections to the new v0.5.0 state.

Prepare-only, per the accepted baseline: no tag, no GitHub Release creation, no `release.yml` changes or triggering. The operator publishes the Release for `v0.5.0` post-merge.

Closes #1178

## Test plan
- [x] `dotnet build IntentSystem.sln -c Debug` — 0 errors.
- [x] `dotnet test IntentSystem.sln -c Debug --filter "FullyQualifiedName~VersionPolicyTests"` — 9/9 passed.
- [x] `dotnet test IntentSystem.sln -c Debug` (full suite) — 3687 passed, 1 pre-existing skip.
- [x] `git diff --check` — clean.
- [x] Diff inspection: no tag/Release/publish-workflow steps added anywhere.
- [ ] Post-merge: build + pack evidence on the merge commit, recorded in this PR before closeout (mirrors the G528 readiness gate).