### PR TITLE
G541: Reposition orchestration as the primary model in README, NuGet, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ repository and paste one of these prompts:
 > I want to work on `<owner>/<repo>` with intent-cli.
 > Ask intent-cli what phase I'm in and what I should decide next.
 
-**Start an implementation loop:**
+**Start four-thread agmsg orchestration (primary path):**
+
+> I want to start agmsg orchestrator mode for `<owner>/<repo>` with intent-cli.
+> Ask intent-cli for the orchestrator setup checklist.
+
+**Start an implementation loop (timer-loop alternative):**
 
 > Set up a child implementation loop for `<owner>/<repo>`.
 > Ask intent-cli for the next step.
@@ -88,11 +93,6 @@ repository and paste one of these prompts:
 > Inspect `<target>` with intent-cli.
 > Observe the real behavior, separate evidence from inference, and propose packet candidates.
 
-**Start agmsg orchestrator mode (preview):**
-
-> I want to start agmsg orchestrator mode for `<owner>/<repo>` with intent-cli.
-> Ask intent-cli for the orchestrator setup checklist.
-
 The agent runs `intent-cli` commands internally and brings back questions or
 results. You focus on intent, priorities, and approval decisions. In **grill**
 mode (`intent-cli grill`) the thread stays persistent — it builds an
@@ -110,23 +110,27 @@ each answer until a stop condition is reached.
   — agent-facing and power-user command surfaces.
 - **Developer reference:** [`docs/en/09-developer-reference.md`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/09-developer-reference.md)
   — packaged invocation smoke test, preview channel, version flow.
-- **Agent-message orchestration (preview):** [`docs/en/12-agent-message-orchestration.md`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/12-agent-message-orchestration.md)
-  — the optional agmsg orchestrator mode (日本語: [`docs/ja/12`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/ja/12-agent-message-orchestration.md)).
+- **Agent-message orchestration (primary):** [`docs/en/12-agent-message-orchestration.md`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/12-agent-message-orchestration.md)
+  — the primary four-thread agmsg orchestrator model (日本語: [`docs/ja/12`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/ja/12-agent-message-orchestration.md)).
 
-> **Orchestrator mode is preview/experimental.** By default, implementation and
-> review run as independent **timer loops** (fully supported, unchanged). The
-> optional **agmsg orchestrator mode** adds a fourth orchestrator thread that
-> paces the implementation and review threads over a local message bus instead
-> of timers: the normal steady state is message-driven — implementation/review
-> replies wake the orchestrator, so routine fast polling is not required — with
-> an optional low-frequency design-side watchdog as the safety net; an explicit
-> orchestrator timer remains supported only as a fallback/legacy polling
-> option. The implementation and review threads are always loopless receivers,
-> and you should not also run their recurring timers for the same route. It
-> covers single/multi-domain routing, next-slice publication, CI wait,
-> dependency planning, a safe stale-thread health check, and safe-repair vs
-> escalation. agmsg is a signal layer only — intent-cli and GitHub stay
-> authoritative. This mode is opt-in and still being hardened.
+> **Four-thread agmsg orchestration is the primary way to run intent-cli.** A
+> **design** thread authors intent and packets; an **orchestrator** thread
+> moves ready packets through the workflow and paces the loopless
+> **implementation** and **review** threads over a local message bus (agmsg)
+> instead of independent timers. The steady state is message-driven —
+> implementation/review replies wake the orchestrator, so routine fast polling
+> is not required — with a 30-minute-class design-thread watchdog loop as the
+> recommended default safety net; an explicit orchestrator timer remains
+> supported only as a fallback/legacy polling option. It covers
+> single/multi-domain routing, next-slice publication, CI wait, dependency
+> planning, a safe stale-thread health check, and safe-repair vs escalation.
+> agmsg is a signal layer only — intent-cli and GitHub stay authoritative.
+> This is the practiced, maintained model (still being hardened in places).
+>
+> **Timer loops remain a fully supported, simpler alternative:** implementation
+> and review run as independent timer loops with no orchestrator thread
+> required. Exactly one mode applies per domain/repo — never mix the two for
+> the same domain/repo.
 
 ---
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1602,9 +1602,15 @@ priority override:**
   eligible candidates priority-class-first (high > normal > low, stable
   tiebreak by authoring order), with dependency/WIP/clarification/lifecycle
   gates always dominating priority.
-- Orchestrator mode remains **preview/experimental**: opt-in, still being
-  hardened, with the timer-loop mode fully supported and unchanged. See
-  [Agent-message orchestration](12-agent-message-orchestration.md).
+- **Historical note (v0.5.0-era, pre-G540/G541):** at the time `v0.5.0` shipped,
+  orchestrator mode was described here as preview/experimental and opt-in.
+  **That framing is superseded.** As of G540/G541, four-thread agmsg
+  orchestration (design/orchestrator/implementation/review) is the **PRIMARY**
+  documented collaboration model — the practiced, maintained workflow — with
+  timer-loop mode retained as the fully supported, simpler alternative. See
+  the current guidance in
+  [Agent-message orchestration](12-agent-message-orchestration.md) and
+  [ADR 0001](../adr/0001-four-thread-orchestration-primary-model.md).
 
 **Release-readiness verification (run before merging the `v0.5.0` version
 bump):**

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -2,9 +2,10 @@
 
 ← [Review standing policy](11-review-standing-policy.md) | [docs index](README.md)
 
-This page describes the **optional** agmsg-backed orchestrator thread and, in
-particular, how it stays safe when a single host repository holds **several
-intent domains**. The authoritative, paste-ready prompts come from installed
+This page describes the **primary** agmsg-backed four-thread orchestrator
+model (design / orchestrator / implementation / review) and, in particular,
+how it stays safe when a single host repository holds **several intent
+domains**. The authoritative, paste-ready prompts come from installed
 intent-cli guidance — do not copy prompts from this page by hand. Generate the
 current prompts with:
 
@@ -114,8 +115,8 @@ before acting on it. intent-cli never launches Claude/Codex or any AI provider.
 
 | Mode | Driver | Notes |
 |---|---|---|
-| **timer-loop mode** | recurring timers | Existing, fully supported. Implementation/review threads self-schedule and read `worker next-action` / host review-next-slice. No orchestrator required. |
-| **orchestrator-message mode** | a fourth orchestrator thread | Opt-in. The orchestrator paces the implementation/review threads over agmsg; at steady state this is message-driven, with a 30-minute-class design-thread watchdog loop as the RECOMMENDED default safety net (an orchestrator-side long-interval automation is the selectable alternative). An explicit 5-minute orchestrator timer remains supported as a fallback/legacy option. |
+| **orchestrator-message mode** | a fourth orchestrator thread | **PRIMARY.** The practiced, maintained model: the orchestrator paces the implementation/review threads over agmsg; at steady state this is message-driven, with a 30-minute-class design-thread watchdog loop as the RECOMMENDED default safety net (an orchestrator-side long-interval automation is the selectable alternative). An explicit 5-minute orchestrator timer remains supported as a fallback/legacy option. |
+| **timer-loop mode** | recurring timers | **ALTERNATIVE.** Fully supported, simpler setup for a domain/repo that does not run an orchestrator thread. Implementation/review threads self-schedule and read `worker next-action` / host review-next-slice. No orchestrator required. |
 
 Do **not** run both modes for the same domain/repo. In orchestrator-message
 mode, do not also launch the implementation/review recurring timer loops — two

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -20,12 +20,12 @@ The agent runs `intent-cli` internally and brings back questions or results. You
 3. [Intent Storming & organize intents](03-intents.md)
 4. [Create packets & publish issues](04-packets-issues.md)
 4a. [GitHub workflow labels and what they mean](04a-workflow-labels.md) — label meanings and how to read them
-5. [Implementation loop setup](05-implementation-loop.md)
-6. [Review / next-slice loop setup](06-review-next-slice-loop.md)
+12. [Agent-message orchestration](12-agent-message-orchestration.md) — **primary**: the four-thread (design/orchestrator/implementation/review) agmsg orchestrator model; single-domain vs multi-domain routing
+5. [Implementation loop setup](05-implementation-loop.md) — timer-loop **alternative** setup
+6. [Review / next-slice loop setup](06-review-next-slice-loop.md) — timer-loop **alternative** setup
 7. [Recover when a loop looks wrong](07-recovery.md)
 8. [Command reference](08-command-reference.md) — agent-facing and power-user command surfaces
 9. [Developer reference](09-developer-reference.md) — packaged invocation, preview channel, version flow
-12. [Agent-message orchestration](12-agent-message-orchestration.md) — optional agmsg orchestrator thread; single-domain vs multi-domain routing
 
 ## What is Intent Storming?
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1719,9 +1719,16 @@ queue の頑健性、label supersession、publish の信頼性、priority overri
   priority class を優先(high > normal > low、authoring order による安定した
   tiebreak)して候補を選択し、dependency/WIP/clarification/lifecycle の gate は
   常に priority に優先します。
-- orchestrator モードは引き続き **preview/experimental** です: オプトインで、まだ hardening 中であり、
-  timer-loop モードは完全サポート・不変です。
-  [エージェントメッセージオーケストレーション](12-agent-message-orchestration.md) を参照。
+- **historical な注記(v0.5.0 時点、G540/G541 以前):** `v0.5.0` の出荷時点では、
+  ここで orchestrator モードを preview/experimental かつオプトインと記述して
+  いました。**この位置づけは現在では置き換えられています。** G540/G541 以降、
+  4 スレッドの agmsg orchestration(design/orchestrator/implementation/
+  review)が **PRIMARY** な、実践され保守されているワークフローとして
+  documented collaboration model であり、timer-loop モードは完全サポートされる
+  よりシンプルな alternative として維持されます。現在のガイダンスは
+  [エージェントメッセージオーケストレーション](12-agent-message-orchestration.md)
+  と [ADR 0001](../adr/0001-four-thread-orchestration-primary-model.md) を
+  参照してください。
 
 **リリース準備の検証（`v0.5.0` version bump のマージ前に実行）:**
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -2,9 +2,10 @@
 
 ← [レビュー standing-policy](11-review-standing-policy.md) | [docs インデックス](README.md)
 
-このページは **オプションの** agmsg ベースの orchestrator スレッドと、特に
-1 つの host リポジトリが **複数の intent ドメイン** を保持する場合に、それを
-どう安全に保つかを説明します。権威ある貼り付け可能なプロンプトはインストール済み
+このページは **主要な(primary)** agmsg ベースの 4 スレッドの orchestrator
+モデル(design / orchestrator / implementation / review)と、特に 1 つの
+host リポジトリが **複数の intent ドメイン** を保持する場合に、それをどう
+安全に保つかを説明します。権威ある貼り付け可能なプロンプトはインストール済み
 の intent-cli ガイダンスから生成され、このページのプロンプトを手で写してはいけません。
 現在のプロンプトは次で生成します:
 
@@ -106,8 +107,8 @@ orchestrator はそれに従って行動する前に、すべての主張を int
 
 | モード | ドライバー | 備考 |
 |---|---|---|
-| **timer-loop モード** | 定期タイマー | 既存・完全サポート。実装/レビュースレッドが自己スケジュールし、`worker next-action` / host review-next-slice を読む。orchestrator は不要。 |
-| **orchestrator-message モード** | 4 つ目の orchestrator スレッド | オプトイン。orchestrator が agmsg 経由で実装/レビュースレッドをペース配分する。定常状態はメッセージ駆動で、30 分クラスの design-thread watchdog loop を RECOMMENDED なデフォルトのセーフティネットとする（orchestrator-side の長間隔 automation は選択可能な alternative）。明示的な 5 分の orchestrator タイマーは fallback/legacy オプションとして引き続きサポートされる。 |
+| **orchestrator-message モード** | 4 つ目の orchestrator スレッド | **PRIMARY。** 実践され、メンテナンスされているモデル。orchestrator が agmsg 経由で実装/レビュースレッドをペース配分する。定常状態はメッセージ駆動で、30 分クラスの design-thread watchdog loop を RECOMMENDED なデフォルトのセーフティネットとする(orchestrator-side の長間隔 automation は選択可能な alternative)。明示的な 5 分の orchestrator タイマーは fallback/legacy オプションとして引き続きサポートされる。 |
+| **timer-loop モード** | 定期タイマー | **ALTERNATIVE。** orchestrator スレッドを実行しない domain/repo 向けの、完全サポートされたよりシンプルなセットアップ。実装/レビュースレッドが自己スケジュールし、`worker next-action` / host review-next-slice を読む。orchestrator は不要。 |
 
 同じ domain/repo に対して両モードを同時に実行しては **いけません**。
 orchestrator-message モードでは、実装/レビューの定期タイマーループも起動しないでください。

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -20,12 +20,12 @@ agent が内部で `intent-cli` を実行し、質問や結果を返します。
 3. [Intent Storming と intent の整理](03-intents.md)
 4. [packet 作成と issue 公開](04-packets-issues.md)
 4a. [GitHub ワークフローラベルで見る現在地](04a-workflow-labels.md) — ラベルの意味と読み方
-5. [実装ループの設定](05-implementation-loop.md)
-6. [レビュー / next-slice ループの設定](06-review-next-slice-loop.md)
+12. [agent メッセージオーケストレーション](12-agent-message-orchestration.md) — **primary**: 4 スレッド(design/orchestrator/implementation/review)の agmsg orchestrator モデル、single-domain と multi-domain のルーティング
+5. [実装ループの設定](05-implementation-loop.md) — timer-loop の **alternative** セットアップ
+6. [レビュー / next-slice ループの設定](06-review-next-slice-loop.md) — timer-loop の **alternative** セットアップ
 7. [ループがおかしいときの復旧](07-recovery.md)
 8. [コマンドリファレンス](08-command-reference.md) — agent 向け・パワーユーザー向けコマンド一覧
 9. [開発者リファレンス](09-developer-reference.md) — パッケージ化された実行、preview チャンネル、バージョンフロー
-12. [agent メッセージオーケストレーション](12-agent-message-orchestration.md) — オプションの agmsg orchestrator スレッド、single-domain と multi-domain のルーティング
 
 ## Intent Storming とは
 

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -42,8 +42,8 @@
     <Version Condition="'$(Version)' == '' AND '$(IntentSystemNextVersionFromPolicy)' != ''">$(IntentSystemNextVersionFromPolicy)</Version>
     <Version Condition="'$(Version)' == ''">0.0.0-dev</Version>
     <Authors>J-Tech-Japan</Authors>
-    <Description>Intent System CLI — deterministic support tooling for intent-driven development on GitHub. Install: dotnet tool install -g JTechJapan.IntentSystem.Cli. Command: intent-cli.</Description>
-    <PackageTags>intent-cli;dotnet-tool;intent-system</PackageTags>
+    <Description>Intent System CLI — deterministic support tooling for intent-driven development on GitHub. Primary model: four-thread agmsg orchestration (design/orchestrator/implementation/review); timer-loop mode remains a fully supported simpler alternative. Install: dotnet tool install -g JTechJapan.IntentSystem.Cli. Command: intent-cli.</Description>
+    <PackageTags>intent-cli;dotnet-tool;intent-system;agmsg;orchestration;ai-agent</PackageTags>
     <RepositoryUrl>https://github.com/J-Tech-Japan/intent-system</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <!--

--- a/tests/IntentSystem.Cli.Tests/ReleasePackageMetadataTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleasePackageMetadataTests.cs
@@ -27,6 +27,38 @@ public sealed class ReleasePackageMetadataTests
     }
 
     [Fact]
+    public void Csproj_DescriptionAndTags_NameOrchestrationModel_PackageIdAndLicenseUnchanged_G541()
+    {
+        var csproj = File.ReadAllText(CsprojPath());
+
+        // G541: the NuGet Description must name the primary four-thread
+        // orchestration model so a NuGet visitor learns the primary workflow,
+        // and PackageTags must gain orchestration-relevant tags — while
+        // package id, tool command, and license stay exactly as they were
+        // (diff-verified: same assertions as Csproj_PinsPublicPackageMetadata).
+        var descriptionMatch = System.Text.RegularExpressions.Regex.Match(csproj, "<Description>(.*?)</Description>", System.Text.RegularExpressions.RegexOptions.Singleline);
+        Assert.True(descriptionMatch.Success, "csproj must declare a <Description>");
+        var description = descriptionMatch.Groups[1].Value;
+        Assert.Contains("orchestration", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("four-thread", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("timer-loop", description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("alternative", description, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("preview", description, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("experimental", description, StringComparison.OrdinalIgnoreCase);
+
+        var tagsMatch = System.Text.RegularExpressions.Regex.Match(csproj, "<PackageTags>(.*?)</PackageTags>");
+        Assert.True(tagsMatch.Success, "csproj must declare <PackageTags>");
+        var tags = tagsMatch.Groups[1].Value.Split(';', StringSplitOptions.RemoveEmptyEntries);
+        Assert.Contains(tags, t => t.Equals("agmsg", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(tags, t => t.Equals("orchestration", StringComparison.OrdinalIgnoreCase));
+
+        // Package id, command, and license unchanged.
+        Assert.Contains("<PackageId>JTechJapan.IntentSystem.Cli</PackageId>", csproj, StringComparison.Ordinal);
+        Assert.Contains("<ToolCommandName>intent-cli</ToolCommandName>", csproj, StringComparison.Ordinal);
+        Assert.Contains("<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>", csproj, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void VersionPolicy_RecordsReleaseToBeCut_AheadOfPublishedStable()
     {
         var policy = VersionPolicy.TryReadFromRepo(FindRepoRoot());


### PR DESCRIPTION
## Summary
- **README.md**: quickstart gains a "Start four-thread agmsg orchestration (primary path)" prompt at the top of the list; the implementation-loop prompt is now labeled "(timer-loop alternative)"; the "(preview)" quickstart heading and the "Orchestrator mode is preview/experimental" caveat are replaced with a role list (design/orchestrator/implementation/review), the message-driven steady state, and the recommended design-thread watchdog safety net, followed by an explicit "timer loops remain a fully supported, simpler alternative" paragraph.
- **`IntentSystem.Cli.csproj`**: `Description` names the primary four-thread orchestration model and the timer-loop alternative; `PackageTags` gain `agmsg`/`orchestration`/`ai-agent`. Package id (`JTechJapan.IntentSystem.Cli`), tool command, and license unchanged — diff-verified by a new focused test and confirmed with a local `dotnet pack` + nuspec inspection.
- **`docs/en/README.md`, `docs/ja/README.md`**: the agent-message-orchestration index entry moves ahead of the timer-loop setup entries, marked primary/alternative respectively.
- **`docs/en/12-agent-message-orchestration.md`, `docs/ja/12-agent-message-orchestration.md`**: drop the remaining "optional"/"Opt-in" framing in the page intro and the "Two driver modes" table (orchestrator-message mode now listed first, marked PRIMARY; timer-loop mode marked ALTERNATIVE).

Mixed-mode invariant unchanged. No command, workflow-semantics, package id, or license changes. `docs/en/orchestrator-message-mode.md` and `docs/{en,ja}/09-developer-reference.md` were checked — the former already carried no preview/optional framing; the latter's stale "preview/experimental" mention lives inside the frozen "Next release readiness (v0.5.0)" historical section describing what shipped in the already-released v0.5.0 line (before G539–G541 existed), so it's left untouched as out of this slice's scope (README/NuGet/docs-index/orchestration-documents only).

Closes #1184

## Test plan
- [x] `dotnet build IntentSystem.sln -c Debug` — 0 errors, 0 warnings.
- [x] `dotnet test IntentSystem.sln -c Debug --filter "FullyQualifiedName~ReleasePackageMetadataTests"` — 5/5 passed.
- [x] `dotnet test IntentSystem.sln -c Debug` (full suite) — 3691 passed, 1 pre-existing skip.
- [x] `git diff --check` — clean.
- [x] `dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release` succeeded; inspected the produced `.nuspec` and confirmed `<id>JTechJapan.IntentSystem.Cli</id>` unchanged, `<description>`/`<tags>` updated as intended.
- [x] Rendered README.md and both docs indexes; confirmed primary/alternative ordering and framing.