### PR TITLE
G543: Reconcile legacy queue priority values with the documented enum and define their selection order

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1002,6 +1002,53 @@ normalizes and validates it (`high`/`normal`/`low`, case-insensitive);
 `normal` rather than erroring, so hand-authored or historical
 `queue-state.json` files never fail closed on this field.
 
+**Legacy/out-of-enum priority values and their ordering rule (G543).**
+Field observation, 2026-07-20: the host `queue-state.json` (1467 items)
+has `high` 1405, `medium` 59, `normal` 3 — `medium` is not in the
+documented `high|normal|low` enum. The documented enum itself is **not**
+expanded to include `medium` or any other legacy value; instead, this
+defines exactly how out-of-enum data behaves, so the selector's behavior
+on real data is never undefined:
+
+- **What priority is for**: it only orders already-**eligible** candidates
+  (see above — every gate still dominates). With a host at 1405/1467
+  items on `high`, priority-first selection degenerates to authoring
+  order among the `high` bucket — not a defect, just the shape this
+  mechanism produces when almost everything shares one priority class.
+- **Ordering rule for every value, including legacy ones**: `high` ranks
+  first, `low` ranks last, and **every other value — missing, empty, or
+  any out-of-enum/legacy string such as `medium` — ranks exactly like an
+  explicit `normal`**, between `high` and `low`. This is total and
+  deterministic: there is no priority value for which the selector's
+  ordering position is undefined. `QueuePriorityClassification.Rank` (in
+  `IntentSystem.Cli.Commands`) is the single shared implementation both
+  `next-slice` ordering and the drift report (below) use, so the two
+  surfaces can never disagree. A regression fixture with a literal
+  `"medium"` item proves this position.
+- **Migration recipe (no new command needed)**: `queue reprioritize
+  <execution-unit> --priority <high|normal|low> --reason <text> --write`
+  already works as the canonical migration path off a legacy value —
+  only the *requested* value is validated against the documented enum;
+  the *existing* value is read, reported (`old_priority`), and compared
+  with **no** validation at all, so an item currently at `medium` (or any
+  other legacy value) can move to any documented value without
+  hand-editing `queue-state.json`. The same fail-closed, audited
+  `priority-changed` runs event described below applies unchanged.
+- **Drift visibility**: **`intent-cli queue priority-drift [--format
+  json|markdown]`** is a new, read-only report — never mutates
+  `queue-state.json` or `runs.jsonl` — listing the item count for every
+  distinct priority value present, always including `high`/`normal`/`low`
+  (even at zero) for a stable report shape, and flagging any value
+  outside that documented enum (`has_drift: true`,
+  `out_of_enum_values: [...]`). Out-of-enum values are ordered by count
+  descending (biggest drift first), tie-broken alphabetically. This is
+  how the 59-item `medium` case becomes visible without a hand-written
+  script.
+- **No silent rewriting**: no command mutates `priority` as a side effect
+  of an unrelated operation — e.g. `queue transition` re-serializes the
+  whole `QueueState` to change `state`/`blocked_by`, but a pre-existing
+  `medium` value on that same item survives byte-for-byte untouched.
+
 **Review repair — `queue reprioritize --write` uses a fail-closed,
 repairable write order.** Writing `queue-state.json` before appending the
 required `priority-changed` runs event could leave a durable priority

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1066,6 +1066,55 @@ case-insensitive)。`next-slice` の ranking function は、認識できない
 そのため、手作業で書かれた、あるいは historical な `queue-state.json`
 ファイルがこの field によって fail closed することはありません。
 
+**Legacy / out-of-enum な priority 値とその ordering rule(G543)。**
+Field observation、2026-07-20: host の `queue-state.json`(1467 items)
+は `high` 1405、`medium` 59、`normal` 3 という分布であり、`medium` は
+documented された `high|normal|low` enum に含まれません。documented
+enum 自体は `medium` などの legacy 値を含むように拡張**しません**——
+その代わり、既存の out-of-enum なデータがどう振る舞うかを正確に定義し、
+実データに対する selector の挙動が undefined にならないようにします:
+
+- **priority が何のためのものか**: すでに **eligible** な candidate
+  だけを order します(上記のとおり、すべての gate が引き続き優先され
+  ます)。host のように 1467 items 中 1405 items が `high` である場合、
+  priority-first selection は `high` bucket 内では実質的に authoring
+  order に退化します——これは欠陥ではなく、ほぼすべての item が同じ
+  priority class を共有しているときにこの機構が生む自然な形です。
+- **すべての値(legacy 値を含む)に対する ordering rule**: `high` が
+  最初、`low` が最後にランクされ、**それ以外の値——欠けている値、空の
+  値、`medium` のような out-of-enum/legacy な文字列すべて——は明示的な
+  `normal` と全く同じにランクされ**、`high` と `low` の間に位置します。
+  これは total かつ deterministic です——selector の ordering position が
+  undefined になる priority 値は存在しません。
+  `QueuePriorityClassification.Rank`(`IntentSystem.Cli.Commands` 内)が
+  唯一の shared 実装であり、`next-slice` の ordering と(後述の)drift
+  report の両方がこれを使うため、この 2 つの surface が食い違うことは
+  ありません。リテラルの `"medium"` item を含む regression fixture が
+  この位置を証明しています。
+- **Migration recipe(新規 command は不要)**: `queue reprioritize
+  <execution-unit> --priority <high|normal|low> --reason <text> --write`
+  は、legacy 値からの canonical な migration path としてすでに機能して
+  います——validate されるのは *requested* 値だけで、documented enum に
+  対して検証されます。*既存の* 値は validation 無しに読み取られ、
+  report され(`old_priority`)、比較されます。そのため `medium`(他の
+  legacy 値も同様)にある item は、`queue-state.json` を hand-edit する
+  ことなく documented な値へ移行できます。下記で説明する fail-closed・
+  audited な `priority-changed` runs event はそのまま適用されます。
+- **Drift visibility**: **`intent-cli queue priority-drift [--format
+  json|markdown]`** は新しい read-only な report です——
+  `queue-state.json` や `runs.jsonl` を一切 mutate しません——存在する
+  distinct な priority 値ごとの item count を一覧表示し、常に
+  `high`/`normal`/`low` を(count が 0 でも)含めて report の形を安定
+  させ、documented enum の外にある値を flag します(`has_drift: true`、
+  `out_of_enum_values: [...]`)。out-of-enum な値は count の降順で
+  order され、tie は alphabetically に解決されます。これにより、
+  59 item の `medium` case を手書き script 無しに可視化できます。
+- **Silent な書き換えの禁止**: 無関係な操作の side effect として
+  `priority` を mutate する command はありません——例えば `queue
+  transition` は `state`/`blocked_by` を変更するために `QueueState`
+  全体を re-serialize しますが、同じ item に既存の `medium` 値があれば
+  byte-for-byte で変更されず残ります。
+
 **Review repair — `queue reprioritize --write` は fail-closed かつ
 repairable な write 順序を使います。** `queue-state.json` を必須の
 `priority-changed` runs event の追記より先に書き込むと、追記 step が

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -128,7 +128,8 @@ internal static class CommandRouter
                 ["enqueue"] = QueueEnqueueCommand.Execute,
                 ["dispatch"] = QueueDispatchCommand.Execute,
                 ["transition"] = QueueTransitionCommand.Execute,
-                ["reprioritize"] = QueueReprioritizeCommand.Execute
+                ["reprioritize"] = QueueReprioritizeCommand.Execute,
+                ["priority-drift"] = QueuePriorityDriftCommand.Execute
             },
             ["issue"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -300,9 +300,13 @@ internal static class IntentNextSliceCommand
             // as the in-class tiebreak. `OrderBy` (LINQ) is a STABLE sort,
             // so when every item ranks the same (no priorities set, or all
             // "normal" — the enqueue default), this is a byte-identical
-            // no-op versus the pre-G537 authoring-order behavior.
+            // no-op versus the pre-G537 authoring-order behavior. G543:
+            // ranking itself (including every out-of-enum/legacy value,
+            // e.g. field-observed "medium") is the single shared
+            // <see cref="QueuePriorityClassification.Rank"/> — see there
+            // for the documented, deterministic rule.
             queued = queued
-                .OrderBy(unit => PriorityRank(priorityByUnit.GetValueOrDefault(unit)))
+                .OrderBy(unit => QueuePriorityClassification.Rank(priorityByUnit.GetValueOrDefault(unit)))
                 .ToList();
         }
 
@@ -753,28 +757,6 @@ internal static class IntentNextSliceCommand
     }
 
     /// <summary>
-    /// G359: Returns true when the given <paramref name="executionUnit"/>
-    /// matches the domain's bindings.md <c>execution_unit_regex</c>. When
-    /// <paramref name="regex"/> is null (bindings file missing, field
-    /// missing, or invalid pattern) the filter is treated as "open" —
-    /// every unit passes so pre-G359 hosts and misconfigured bindings
-    /// never silently block all candidates.
-    /// </summary>
-    /// <summary>
-    /// G537: ranks a queue item's <c>priority</c> field for candidate
-    /// ordering — lower rank sorts earlier. Unrecognized, missing, or
-    /// empty values (including the pre-G537 default <c>"normal"</c>) all
-    /// rank the same as an explicit <c>"normal"</c>, so a host with no
-    /// priorities set (or all-normal) never changes ordering.
-    /// </summary>
-    private static int PriorityRank(string? priority) => priority?.Trim().ToLowerInvariant() switch
-    {
-        QueueReprioritizeCommand.PriorityHigh => 0,
-        QueueReprioritizeCommand.PriorityLow => 2,
-        _ => 1,
-    };
-
-    /// <summary>
     /// G537 review repair: the authoritative dependency/blocked-by
     /// eligibility gate for the `queued` candidate loop — mirrors
     /// <see cref="IntentSystem.Supervisor.QueueSelection.SelectNext"/>'s
@@ -801,6 +783,14 @@ internal static class IntentNextSliceCommand
         return true;
     }
 
+    /// <summary>
+    /// G359: Returns true when the given <paramref name="executionUnit"/>
+    /// matches the domain's bindings.md <c>execution_unit_regex</c>. When
+    /// <paramref name="regex"/> is null (bindings file missing, field
+    /// missing, or invalid pattern) the filter is treated as "open" —
+    /// every unit passes so pre-G359 hosts and misconfigured bindings
+    /// never silently block all candidates.
+    /// </summary>
     private static bool MatchesExecutionUnitRegex(Regex? regex, string executionUnit)
     {
         if (regex is null)

--- a/src/IntentSystem.Cli/Commands/QueuePriorityClassification.cs
+++ b/src/IntentSystem.Cli/Commands/QueuePriorityClassification.cs
@@ -1,0 +1,46 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G543: the single source of truth for the documented queue-item
+/// <c>priority</c> enum (<c>high|normal|low</c>, introduced by G537) and for
+/// how EVERY value the candidate selector can encounter — including
+/// legacy/out-of-enum values such as the field-observed <c>"medium"</c> (host
+/// queue-state, 2026-07-20: high 1405, medium 59, normal 3) — ranks for
+/// ordering. Both <see cref="IntentNextSliceCommand"/> (candidate ordering)
+/// and <see cref="QueuePriorityDriftCommand"/> (the read-only drift report)
+/// use this so the two surfaces can never disagree about which values are
+/// "documented" or how an unrecognized value orders. The documented enum
+/// itself is NOT expanded by this type — <c>medium</c> is still not a valid
+/// <c>--priority</c> argument to <c>queue reprioritize</c>; this only defines
+/// how existing out-of-enum data behaves.
+/// </summary>
+internal static class QueuePriorityClassification
+{
+    public const string High = "high";
+    public const string Normal = "normal";
+    public const string Low = "low";
+
+    /// <summary>The three documented enum members, in canonical high-to-low order.</summary>
+    public static readonly IReadOnlyList<string> DocumentedValues = new[] { High, Normal, Low };
+
+    /// <summary>Normalizes a raw priority value for comparison: trims and lowercases. Never null — blank/null input normalizes to an empty string.</summary>
+    public static string Normalize(string? priority) => priority?.Trim().ToLowerInvariant() ?? string.Empty;
+
+    /// <summary>True when the normalized value is exactly one of the three documented enum members.</summary>
+    public static bool IsDocumented(string? priority) => DocumentedValues.Contains(Normalize(priority), StringComparer.Ordinal);
+
+    /// <summary>
+    /// Ranks a priority value for candidate ordering — lower rank sorts
+    /// earlier. <c>"high"</c> ranks 0, <c>"low"</c> ranks 2. EVERY other
+    /// value — missing, empty, or any out-of-enum/legacy string such as
+    /// <c>"medium"</c> — ranks 1, the same as an explicit <c>"normal"</c>.
+    /// This is deterministic and total: there is no priority value for
+    /// which this function's ordering position is undefined.
+    /// </summary>
+    public static int Rank(string? priority) => Normalize(priority) switch
+    {
+        High => 0,
+        Low => 2,
+        _ => 1,
+    };
+}

--- a/src/IntentSystem.Cli/Commands/QueuePriorityDriftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueuePriorityDriftCommand.cs
@@ -1,0 +1,214 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G543: <c>intent-cli queue priority-drift [--format json|markdown]</c> —
+/// a read-only report of how many <c>queue-state.json</c> items hold each
+/// distinct <c>priority</c> value, flagging any value outside the documented
+/// <see cref="QueuePriorityClassification.DocumentedValues"/> enum (e.g. the
+/// field-observed <c>"medium"</c>). Never mutates <c>queue-state.json</c> or
+/// <c>runs.jsonl</c> — this exists purely so an operator can see the 59-item
+/// (or any) drift shape without hand-writing a script.
+/// </summary>
+internal static class QueuePriorityDriftCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string UsageLine = "Usage: intent-cli queue priority-drift [--format json|markdown]";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var queueStatePath = context.GetQueueStatePath();
+
+        // G543: group by the SAME normalization QueuePriorityClassification
+        // uses for ordering/documented-membership, so this report and
+        // candidate ordering can never disagree about which raw values are
+        // "the same" priority. A missing queue-state.json is simply zero
+        // items — the report shape (documented values always listed) stays
+        // identical either way.
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        var totalItems = 0;
+        if (File.Exists(queueStatePath))
+        {
+            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            totalItems = queueState.Items.Count;
+            foreach (var item in queueState.Items)
+            {
+                var normalized = QueuePriorityClassification.Normalize(item.Priority);
+                counts[normalized] = counts.GetValueOrDefault(normalized) + 1;
+            }
+        }
+
+        // Documented values are always listed, even at zero, so the report
+        // shape is stable regardless of which values happen to be present.
+        // Out-of-enum values are appended after, ordered by count
+        // descending (the biggest drift first) then by value ascending for
+        // a deterministic tiebreak.
+        var groups = new List<QueuePriorityDriftGroup>();
+        foreach (var documented in QueuePriorityClassification.DocumentedValues)
+        {
+            groups.Add(new QueuePriorityDriftGroup
+            {
+                Priority = documented,
+                Count = counts.GetValueOrDefault(documented),
+                Documented = true,
+            });
+        }
+
+        var outOfEnum = counts
+            .Where(pair => !QueuePriorityClassification.IsDocumented(pair.Key))
+            .OrderByDescending(pair => pair.Value)
+            .ThenBy(pair => pair.Key, StringComparer.Ordinal)
+            .Select(pair => new QueuePriorityDriftGroup
+            {
+                Priority = string.IsNullOrEmpty(pair.Key) ? "(missing)" : pair.Key,
+                Count = pair.Value,
+                Documented = false,
+            });
+        groups.AddRange(outOfEnum);
+
+        EmitResult(writer, format, BuildResult(queueStatePath, totalItems, groups));
+        return 0;
+    }
+
+    private static QueuePriorityDriftResult BuildResult(string queueStatePath, int totalItems, IReadOnlyList<QueuePriorityDriftGroup> groups)
+    {
+        var outOfEnumGroups = groups.Where(group => !group.Documented && group.Count > 0).ToArray();
+        return new QueuePriorityDriftResult
+        {
+            QueueStatePath = queueStatePath,
+            TotalItems = totalItems,
+            ByPriority = groups,
+            HasDrift = outOfEnumGroups.Length > 0,
+            OutOfEnumValues = outOfEnumGroups.Select(group => group.Priority).ToArray(),
+        };
+    }
+
+    private static void EmitResult(TextWriter writer, string format, QueuePriorityDriftResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        writer.WriteLine("# Queue priority drift");
+        writer.WriteLine();
+        writer.WriteLine($"- queue state path: {result.QueueStatePath}");
+        writer.WriteLine($"- total items: {result.TotalItems}");
+        writer.WriteLine($"- drift: {(result.HasDrift ? "yes" : "no")}");
+        writer.WriteLine();
+        writer.WriteLine("| priority | count | documented |");
+        writer.WriteLine("| --- | --- | --- |");
+        foreach (var group in result.ByPriority)
+        {
+            writer.WriteLine($"| {group.Priority} | {group.Count} | {(group.Documented ? "yes" : "no")} |");
+        }
+
+        if (result.HasDrift)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"Out-of-enum values present: {string.Join(", ", result.OutOfEnumValues)}. These still order deterministically (same as an explicit \"normal\") — see `queue reprioritize` to migrate an item to a documented value.");
+        }
+    }
+
+    private static bool TryParseArguments(string[] args, out string format, out string error)
+    {
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    var requested = args[++index].Trim();
+                    if (!string.Equals(requested, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(requested, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{requested}').";
+                        return false;
+                    }
+                    format = requested;
+                    break;
+
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("queue priority-drift");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("Read-only: reports item counts per queue-item priority value, flagging any value");
+        writer.WriteLine("outside the documented high|normal|low enum (e.g. a legacy \"medium\" value). Never");
+        writer.WriteLine("mutates queue-state.json or runs.jsonl.");
+    }
+}
+
+internal sealed record QueuePriorityDriftResult
+{
+    [JsonPropertyName("queue_state_path")]
+    public required string QueueStatePath { get; init; }
+
+    [JsonPropertyName("total_items")]
+    public required int TotalItems { get; init; }
+
+    [JsonPropertyName("by_priority")]
+    public required IReadOnlyList<QueuePriorityDriftGroup> ByPriority { get; init; }
+
+    [JsonPropertyName("has_drift")]
+    public required bool HasDrift { get; init; }
+
+    [JsonPropertyName("out_of_enum_values")]
+    public required IReadOnlyList<string> OutOfEnumValues { get; init; }
+}
+
+internal sealed record QueuePriorityDriftGroup
+{
+    [JsonPropertyName("priority")]
+    public required string Priority { get; init; }
+
+    [JsonPropertyName("count")]
+    public required int Count { get; init; }
+
+    [JsonPropertyName("documented")]
+    public required bool Documented { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -32,9 +32,9 @@ internal static class QueueReprioritizeCommand
     private const string ModeDryRun = "dry-run";
     private const string ModeWrite = "write";
 
-    public const string PriorityHigh = "high";
-    public const string PriorityNormal = "normal";
-    public const string PriorityLow = "low";
+    public const string PriorityHigh = QueuePriorityClassification.High;
+    public const string PriorityNormal = QueuePriorityClassification.Normal;
+    public const string PriorityLow = QueuePriorityClassification.Low;
 
     public const string PriorityChangedEventName = "priority-changed";
     private const string ReprioritizeActor = "intent-cli";

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -317,6 +317,170 @@ public sealed class IntentNextSliceCommandTests
         Assert.Equal("G532", root.GetProperty("candidate").GetProperty("execution_unit").GetString());
     }
 
+    // ─── G543: legacy/out-of-enum priority values (e.g. "medium") ──────────
+
+    [Fact]
+    public void Execute_FieldScenario_MediumPriorityUnit_OutrankedByHighPriorityUnit_G543()
+    {
+        // G543 field observation, 2026-07-20: the host queue-state has 59
+        // items at priority "medium" — a value outside the documented
+        // high|normal|low enum. QueuePriorityClassification.Rank ranks any
+        // out-of-enum value the same as "normal" (between high and low).
+        // This proves "high" still outranks "medium" (authored later, but
+        // priority-first ordering still wins).
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(".intent-cli/issues/G610/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G611/github-body.md", BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-20T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G610",
+                  "title": "authored first, legacy medium priority",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "medium"
+                },
+                {
+                  "execution_unit": "G611",
+                  "title": "authored second, documented high priority",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "high"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("G611", document.RootElement.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_FieldScenario_MediumPriorityUnit_OutranksLowPriorityUnit_G543()
+    {
+        // The other half of the position proof: "medium" must still
+        // outrank "low", exactly like "normal" would, even though it is
+        // authored first (so authoring order alone would have picked it
+        // anyway — the assertion below is really pinned by the companion
+        // test above, which proves "medium" loses to "high").
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(".intent-cli/issues/G612/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G613/github-body.md", BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-20T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G612",
+                  "title": "authored first, documented low priority",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "low"
+                },
+                {
+                  "execution_unit": "G613",
+                  "title": "authored second, legacy medium priority",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "medium"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("G613", document.RootElement.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_MediumAndNormalPriorityUnits_ShareExactlyTheSameRank_AuthoringOrderTiebreaks_G543()
+    {
+        // "medium" doesn't just fall SOMEWHERE between high and low — it
+        // ranks IDENTICALLY to "normal", proven by the authoring-order
+        // tiebreak going to whichever of the two was authored first,
+        // regardless of which one is "medium" and which is "normal".
+        using var workspace = new IntentNextSliceWorkspace();
+        workspace.WriteFile(".intent-cli/issues/G614/github-body.md", BuildCompleteContractBody());
+        workspace.WriteFile(".intent-cli/issues/G615/github-body.md", BuildCompleteContractBody());
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-20T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G614",
+                  "title": "authored first, legacy medium priority",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "medium"
+                },
+                {
+                  "execution_unit": "G615",
+                  "title": "authored second, documented normal priority",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        // "medium", authored FIRST, wins the tiebreak over "normal" —
+        // proving the two ranked identically (a real ordering difference
+        // between them would have picked "normal" regardless of order).
+        Assert.Equal("G614", document.RootElement.GetProperty("candidate").GetProperty("execution_unit").GetString());
+    }
+
     [Fact]
     public void Execute_HighPriorityUnitExcludedByLifecycleGate_NormalPriorityUnitStillSelected()
     {

--- a/tests/IntentSystem.Cli.Tests/QueuePriorityDriftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueuePriorityDriftCommandTests.cs
@@ -1,0 +1,254 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G543: coverage for the read-only <c>intent-cli queue priority-drift</c>
+/// report — item counts per <c>priority</c> value, flagging any value
+/// outside the documented <c>high|normal|low</c> enum (e.g. the field-
+/// observed <c>"medium"</c>), without ever mutating queue-state.json.
+/// </summary>
+public sealed class QueuePriorityDriftCommandTests : IDisposable
+{
+    public void Dispose()
+    {
+    }
+
+    [Fact]
+    public void Execute_MissingQueueState_ReturnsCleanEmptyReport()
+    {
+        using var workspace = new PriorityDriftWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = QueuePriorityDriftCommand.Execute(workspace.Context, ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal(0, root.GetProperty("total_items").GetInt32());
+        Assert.False(root.GetProperty("has_drift").GetBoolean());
+        Assert.Empty(root.GetProperty("out_of_enum_values").EnumerateArray());
+
+        // The three documented values are always listed, even at zero.
+        var byPriority = root.GetProperty("by_priority").EnumerateArray().ToArray();
+        Assert.Equal(3, byPriority.Length);
+        Assert.Equal("high", byPriority[0].GetProperty("priority").GetString());
+        Assert.Equal(0, byPriority[0].GetProperty("count").GetInt32());
+        Assert.True(byPriority[0].GetProperty("documented").GetBoolean());
+        Assert.Equal("normal", byPriority[1].GetProperty("priority").GetString());
+        Assert.Equal("low", byPriority[2].GetProperty("priority").GetString());
+    }
+
+    [Fact]
+    public void Execute_FieldObservedDistributionShape_ReportsCountsAndFlagsMediumAsDrift()
+    {
+        // G543 field observation, 2026-07-20 (host queue-state, 1467
+        // items): high 1405, medium 59, normal 3. This fixture reproduces
+        // the SHAPE (one legacy value dwarfing "normal", zero "low") with
+        // smaller counts for test speed.
+        using var workspace = new PriorityDriftWorkspace();
+        workspace.WriteQueueState(BuildQueueState(
+            ("G1", "high"), ("G2", "high"), ("G3", "high"), ("G4", "high"), ("G5", "high"),
+            ("G6", "medium"), ("G7", "medium"),
+            ("G8", "normal")));
+
+        using var writer = new StringWriter();
+        var exitCode = QueuePriorityDriftCommand.Execute(workspace.Context, ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal(8, root.GetProperty("total_items").GetInt32());
+        Assert.True(root.GetProperty("has_drift").GetBoolean());
+        Assert.Equal(new[] { "medium" }, root.GetProperty("out_of_enum_values").EnumerateArray().Select(e => e.GetString()));
+
+        var byPriority = root.GetProperty("by_priority").EnumerateArray().ToArray();
+        Assert.Equal(4, byPriority.Length); // high, normal, low (always) + medium (drift)
+        Assert.Equal("high", byPriority[0].GetProperty("priority").GetString());
+        Assert.Equal(5, byPriority[0].GetProperty("count").GetInt32());
+        Assert.Equal("normal", byPriority[1].GetProperty("priority").GetString());
+        Assert.Equal(1, byPriority[1].GetProperty("count").GetInt32());
+        Assert.Equal("low", byPriority[2].GetProperty("priority").GetString());
+        Assert.Equal(0, byPriority[2].GetProperty("count").GetInt32());
+        Assert.Equal("medium", byPriority[3].GetProperty("priority").GetString());
+        Assert.Equal(2, byPriority[3].GetProperty("count").GetInt32());
+        Assert.False(byPriority[3].GetProperty("documented").GetBoolean());
+    }
+
+    [Fact]
+    public void Execute_OnlyDocumentedValuesPresent_HasDriftFalse()
+    {
+        using var workspace = new PriorityDriftWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G1", "high"), ("G2", "normal"), ("G3", "low")));
+
+        using var writer = new StringWriter();
+        var exitCode = QueuePriorityDriftCommand.Execute(workspace.Context, ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.False(root.GetProperty("has_drift").GetBoolean());
+        Assert.Empty(root.GetProperty("out_of_enum_values").EnumerateArray());
+        Assert.Equal(3, root.GetProperty("by_priority").EnumerateArray().Count());
+    }
+
+    [Fact]
+    public void Execute_MultipleOutOfEnumValues_OrderedByCountDescendingThenAlphabeticallyOnTies()
+    {
+        using var workspace = new PriorityDriftWorkspace();
+        workspace.WriteQueueState(BuildQueueState(
+            ("G1", "urgent"), ("G2", "urgent"),
+            ("G3", "zebra"),
+            ("G4", "alpha")));
+
+        using var writer = new StringWriter();
+        var exitCode = QueuePriorityDriftCommand.Execute(workspace.Context, ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var byPriority = document.RootElement.GetProperty("by_priority").EnumerateArray().ToArray();
+        var outOfEnum = byPriority.Skip(3).ToArray(); // after high/normal/low
+        Assert.Equal(3, outOfEnum.Length);
+        // "urgent" (count 2) sorts first by count descending. "alpha" and
+        // "zebra" tie at count 1 -- the deterministic tiebreak is
+        // alphabetical (Ordinal), so "alpha" comes before "zebra".
+        Assert.Equal("urgent", outOfEnum[0].GetProperty("priority").GetString());
+        Assert.Equal("alpha", outOfEnum[1].GetProperty("priority").GetString());
+        Assert.Equal("zebra", outOfEnum[2].GetProperty("priority").GetString());
+    }
+
+    [Fact]
+    public void Execute_MarkdownFormat_ListsCountsAndFlagsDrift()
+    {
+        using var workspace = new PriorityDriftWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G1", "high"), ("G2", "medium")));
+
+        using var writer = new StringWriter();
+        var exitCode = QueuePriorityDriftCommand.Execute(workspace.Context, ["--format", "markdown"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("drift: yes", output, StringComparison.Ordinal);
+        Assert.Contains("| medium | 1 | no |", output, StringComparison.Ordinal);
+        Assert.Contains("Out-of-enum values present: medium.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_NeverMutatesQueueStateFile()
+    {
+        using var workspace = new PriorityDriftWorkspace();
+        var originalJson = BuildQueueState(("G1", "medium"));
+        workspace.WriteQueueState(originalJson);
+        var beforeBytes = File.ReadAllBytes(workspace.QueueStatePath);
+
+        using var writer = new StringWriter();
+        var exitCode = QueuePriorityDriftCommand.Execute(workspace.Context, ["--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        var afterBytes = File.ReadAllBytes(workspace.QueueStatePath);
+        Assert.Equal(beforeBytes, afterBytes);
+    }
+
+    [Fact]
+    public void Execute_HelpFlag_PrintsUsage()
+    {
+        using var workspace = new PriorityDriftWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = QueuePriorityDriftCommand.Execute(workspace.Context, ["--help"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("queue priority-drift", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_UnknownArgument_ReturnsUsageError()
+    {
+        using var workspace = new PriorityDriftWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = QueuePriorityDriftCommand.Execute(workspace.Context, ["--surprise"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Unknown argument '--surprise'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_InvalidFormatValue_ReturnsUsageError()
+    {
+        using var workspace = new PriorityDriftWorkspace();
+        using var writer = new StringWriter();
+        var exitCode = QueuePriorityDriftCommand.Execute(workspace.Context, ["--format", "xml"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--format must be 'markdown' or 'json'", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static string BuildQueueState(params (string ExecutionUnit, string Priority)[] items)
+    {
+        var state = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = new DateTimeOffset(2026, 7, 20, 0, 0, 0, TimeSpan.Zero),
+            Items = items.Select(item => new QueueItem
+            {
+                ExecutionUnit = item.ExecutionUnit,
+                Title = $"{item.ExecutionUnit} title",
+                State = QueueItemState.Queued,
+                Dependencies = Array.Empty<string>(),
+                BlockedBy = Array.Empty<string>(),
+                ClarificationReturnPath = string.Empty,
+                PacketPaths = new PacketPaths
+                {
+                    Yaml = $".intent-cli/issues/{item.ExecutionUnit}/packet.yaml",
+                    Implementation = $".intent-cli/issues/{item.ExecutionUnit}/implementation.md",
+                    ReviewContext = $".intent-cli/issues/{item.ExecutionUnit}/review-context.md",
+                },
+                WorkerRole = "Claude",
+                ReviewRole = "Codex",
+                Priority = item.Priority,
+            }).ToArray(),
+        };
+        return QueueStateSerializer.Serialize(state);
+    }
+
+    private sealed class PriorityDriftWorkspace : IDisposable
+    {
+        private readonly string rootPath = Directory.CreateTempSubdirectory("queue-priority-drift-tests-").FullName;
+
+        public PriorityDriftWorkspace()
+        {
+            Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = rootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+        }
+
+        public CliContext Context { get; }
+
+        public string QueueStatePath => Context.GetQueueStatePath();
+
+        public void WriteQueueState(string json) => File.WriteAllText(QueueStatePath, json);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
@@ -180,6 +180,47 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_Write_MigratesLegacyMediumPriorityToDocumentedHigh_G543()
+    {
+        // G543: the canonical migration recipe for a legacy/out-of-enum
+        // priority value (e.g. the field-observed "medium", 59 items on
+        // the host) is this exact, already-working command -- only the
+        // REQUESTED value is validated against the documented enum; the
+        // OLD value is read/reported/compared with no validation at all,
+        // so an item currently at "medium" can move to any documented
+        // value without hand-editing queue-state.json. No new command was
+        // needed for this; this test locks the existing behavior in as
+        // the documented recipe.
+        using var workspace = new ReprioritizeWorkspace();
+        workspace.WriteQueueState(BuildQueueState(("G543", QueueItemState.Queued, "medium", linkedIssue: null)));
+        var changedAt = new DateTimeOffset(2026, 7, 20, 8, 0, 0, TimeSpan.Zero);
+        QueueReprioritizeCommand.UtcNowFactory = () => changedAt;
+
+        using var writer = new StringWriter();
+        var exitCode = QueueReprioritizeCommand.Execute(
+            workspace.Context,
+            ["G543", "--priority", "high", "--reason", "migrate legacy medium value off the enum", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.Equal("write", root.GetProperty("mode").GetString());
+        Assert.Equal("medium", root.GetProperty("old_priority").GetString());
+        Assert.Equal("high", root.GetProperty("requested_priority").GetString());
+        Assert.True(root.GetProperty("changed").GetBoolean());
+
+        var updatedState = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("high", updatedState.Items.Single().Priority);
+
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsLogPath));
+        var runEvent = Assert.Single(events);
+        Assert.Equal("priority-changed", runEvent.Event);
+        Assert.Contains("medium", runEvent.Reason, StringComparison.Ordinal);
+        Assert.Contains("high", runEvent.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_SamePriorityRequested_IsIdempotentNoOp()
     {
         using var workspace = new ReprioritizeWorkspace();

--- a/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueTransitionCommandTests.cs
@@ -41,6 +41,38 @@ public sealed class QueueTransitionCommandTests
     }
 
     [Fact]
+    public void Execute_GivenLegacyMediumPriorityItem_TransitionNeverRewritesPriority_G543()
+    {
+        // G543 acceptance criterion: no command rewrites priority values as
+        // an unrelated side effect. `queue transition` mutates State (and,
+        // for blocking transitions, BlockedBy) — it must never touch a
+        // pre-existing out-of-enum Priority value like the field-observed
+        // "medium", even though it re-serializes the whole QueueState.
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var queueState = CreateQueueState();
+        var withMediumPriority = queueState with
+        {
+            Items = queueState.Items
+                .Select(item => item.ExecutionUnit == "A2" ? item with { Priority = "medium" } : item)
+                .ToArray(),
+        };
+        tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(withMediumPriority));
+        using var writer = new StringWriter();
+
+        var exitCode = QueueTransitionCommand.Execute(CreateContext(repoRoot), ["A2", "completed"], writer);
+
+        Assert.Equal(0, exitCode);
+        var updatedState = QueueStateSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(repoRoot, ".intent-cli", "queue-state.json")));
+        var updatedA2 = updatedState.Items.Single(item => item.ExecutionUnit == "A2");
+        Assert.Equal(QueueItemState.Completed, updatedA2.State);
+        Assert.Equal("medium", updatedA2.Priority);
+    }
+
+    [Fact]
     public void Execute_GivenBlockedTransitionWithReason_UpdatesBlockedByAndAppendsReasonedRunLog()
     {
         using var tempDirectory = new TemporaryDirectory();


### PR DESCRIPTION
Closes #1188

## Summary

- New `QueuePriorityClassification` is the single shared source of truth for the documented `high|normal|low` enum and for how EVERY priority value the candidate selector can encounter ranks for ordering — including legacy/out-of-enum values such as the field-observed `medium` (host queue-state, 2026-07-20: high 1405, medium 59, normal 3). `IntentNextSliceCommand`'s candidate ordering now delegates to it (previously private, duplicated logic); the ranking rule itself is unchanged (unknown values rank like `normal`, between `high` and `low`), just now shared, documented, and pinned by fixtures with a literal `"medium"` item.
- New read-only `intent-cli queue priority-drift [--format json|markdown]` reports item counts per priority value, always listing `high`/`normal`/`low` (even at zero) for a stable shape, and flags any out-of-enum value (`has_drift`, `out_of_enum_values`). Never mutates `queue-state.json` or `runs.jsonl`.
- The canonical migration path off a legacy value already existed and needed no new command: `queue reprioritize <unit> --priority <high|normal|low> --reason <text> --write` only validates the *requested* value — the existing value is read/reported/compared with no validation at all. A new regression test locks this in as the documented recipe.
- New regression test proves `queue transition` (which re-serializes the whole `QueueState` to change `state`/`blocked_by`) never rewrites a pre-existing out-of-enum priority value as a side effect.
- `docs/en` and `docs/ja` `09-developer-reference.md` document the enum, the ordering rule for legacy values, what priority is for, the migration recipe, and the new drift report.
- The documented enum itself is **not** expanded, and G537 gate precedence is unchanged (out of scope, per the issue).

## Test plan

- [x] Focused suites green: `IntentNextSliceCommandTests`, `QueueReprioritizeCommandTests`, `QueueTransitionCommandTests`, `QueuePriorityDriftCommandTests` (147 tests)
- [x] Full solution suite green: `dotnet test IntentSystem.sln -c Debug` — 3729 passed, 1 skipped, 0 failed
- [x] `git diff --check` clean
- [x] Manual run of `queue priority-drift` against a fixture reproducing the exact 1405 high / 59 medium / 3 normal field distribution — confirmed correct counts, `has_drift: true`, `out_of_enum_values: ["medium"]`, and byte-identical `queue-state.json` before/after (both JSON and markdown formats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4yoyeXmTeJWD16RLvktQd