### PR TITLE
G545: Exempt queue-blocked units from claimed-but-silent, and add a canonical issue-level blocked representation

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -347,13 +347,52 @@ is reported for visibility only:
   completion, failure, or any transition from silence alone. Once a PR
   exists for the issue (`intent-pr-created`), the PR-lifecycle kinds take
   over instead; detecting a repair-state PR that is itself stale beyond a
-  threshold is an explicit out-of-scope follow-up.
+  threshold is an explicit out-of-scope follow-up. **G545: exempts a unit
+  whose queue-state item is `state=blocked`** — consulted once per
+  `stalled-work` call, tolerant of a missing/malformed `queue-state.json`
+  (falls through to this kind's pre-G545 GitHub-labels-only behavior
+  unchanged, so a domain that never uses `queue-state.json` never loses
+  this detection). A queue-blocked unit is never reported here; see
+  `blocked-label-drift` below.
+- `blocked-label-drift` (G545) — a transitional GitHub/queue-state mismatch,
+  never a stall: the queue-state item for this unit is `state=blocked` (an
+  explicit `blocked_by` reason recorded via `queue transition <unit>
+  blocked --reason <text>`), but its GitHub issue does not yet carry
+  `intent-issue-blocked` — the label side hasn't been reconciled yet.
+  `recommended_action` names the exact canonical reconcile command
+  (`intent-cli automation issue-block --repo <r> --issue <n> --reason
+  "<blocked_by text>" --write --format json`). Once that command applies
+  the label, the same unit disappears from `stalled-work` entirely (neither
+  `claimed-but-silent` nor `blocked-label-drift` fires — GitHub and
+  queue-state agree). Field finding, 2026-07-21 (sekiban-as-a-service): 5
+  items (SKS-G818, SKS-G837, SKS-G835, SKS-G839, SKS-G840) were `state=blocked`
+  in queue-state with an explicit `blocked_by` dependency, yet each was
+  reported as `claimed-but-silent` every wake because `claimed-but-silent`
+  read only GitHub labels and no issue-level "blocked" representation
+  existed at all.
+
+**`intent-cli automation issue-block --repo <owner/repo> --issue <n>
+--reason <text> [--write] [--dry-run] [--format text|json]`** (and its
+`--clear` counterpart, `--reason` omitted) is the canonical, bounded
+transition that applies/removes `intent-issue-blocked` — the ONLY supported
+way to make GitHub agree with a queue-state `blocked` transition; raw `gh
+... edit --add-label`/`--remove-label` is never permitted. Dry-run by
+default. Idempotent both directions (`applied: false` with an explanatory
+`summary` if the label already reflects the requested state). `--reason` is
+required when applying (never permitted with `--clear`) — a blocked
+transition without a recorded reason is refused, mirroring `queue
+reprioritize`'s reason requirement. `intent-issue-blocked` coexists with
+`intent-issue-in-progress` rather than replacing it: the worker still owns
+the issue, it just cannot currently proceed. This command never touches
+`queue-state.json` or `runs.jsonl` — it exists purely to reconcile GitHub
+onto a `blocked` transition that already happened via `queue transition
+<unit> blocked --reason <text>` (unchanged by this slice).
 
 Each item reports `kind`, `execution_unit`, `issue` and/or `pr` (number +
 url), `age_minutes`, `is_informational`, and `recommended_action`.
 `--stale-minutes` filters out items younger than the given threshold
 (default `0` — report everything with its age; callers pick their own
-threshold) — this applies uniformly across all seven kinds; `claimed-but-silent`
+threshold) — this applies uniformly across all eight kinds; `claimed-but-silent`
 and `backlog-ready-idle` each additionally gate on their OWN
 `--claimed-silent-minutes` / `--backlog-idle-minutes` threshold before an
 item is even considered (so raising `--stale-minutes` alone can never make

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -355,13 +355,12 @@ is reported for visibility only:
   this detection). A queue-blocked unit is never reported here; see
   `blocked-label-drift` below.
 - `blocked-label-drift` (G545) — a transitional GitHub/queue-state mismatch,
-  never a stall: the queue-state item for this unit is `state=blocked` (an
-  explicit `blocked_by` reason recorded via `queue transition <unit>
-  blocked --reason <text>`), but its GitHub issue does not yet carry
+  never a stall: the queue-state item for this unit is `state=blocked` with
+  an explicit `blocked_by` reason, but its GitHub issue does not yet carry
   `intent-issue-blocked` — the label side hasn't been reconciled yet.
   `recommended_action` names the exact canonical reconcile command
-  (`intent-cli automation issue-block --repo <r> --issue <n> --reason
-  "<blocked_by text>" --write --format json`). Once that command applies
+  (`intent-cli automation issue-block <unit> --repo <r> --issue <n> --reason
+  "<blocked_by text>" --write --format json`). Once that command converges
   the label, the same unit disappears from `stalled-work` entirely (neither
   `claimed-but-silent` nor `blocked-label-drift` fires — GitHub and
   queue-state agree). Field finding, 2026-07-21 (sekiban-as-a-service): 5
@@ -371,22 +370,55 @@ is reported for visibility only:
   read only GitHub labels and no issue-level "blocked" representation
   existed at all.
 
-**`intent-cli automation issue-block --repo <owner/repo> --issue <n>
---reason <text> [--write] [--dry-run] [--format text|json]`** (and its
-`--clear` counterpart, `--reason` omitted) is the canonical, bounded
-transition that applies/removes `intent-issue-blocked` — the ONLY supported
-way to make GitHub agree with a queue-state `blocked` transition; raw `gh
-... edit --add-label`/`--remove-label` is never permitted. Dry-run by
-default. Idempotent both directions (`applied: false` with an explanatory
-`summary` if the label already reflects the requested state). `--reason` is
-required when applying (never permitted with `--clear`) — a blocked
-transition without a recorded reason is refused, mirroring `queue
-reprioritize`'s reason requirement. `intent-issue-blocked` coexists with
-`intent-issue-in-progress` rather than replacing it: the worker still owns
-the issue, it just cannot currently proceed. This command never touches
-`queue-state.json` or `runs.jsonl` — it exists purely to reconcile GitHub
-onto a `blocked` transition that already happened via `queue transition
-<unit> blocked --reason <text>` (unchanged by this slice).
+**`intent-cli automation issue-block <execution-unit> --repo <owner/repo>
+--issue <n> --reason <text> [--write] [--dry-run] [--format text|json]`**
+(and its `--clear` counterpart, `--reason` omitted) is the ONE canonical,
+bounded transition that converges BOTH authoritative representations of
+"blocked" for a single execution unit:
+
+- **queue-state** — `state=blocked` and `blocked_by: ["<reason>"]`, applied
+  through the existing, unmodified `QueueManager` blocking transition (the
+  same mechanism `queue transition <unit> blocked` uses), plus a durable
+  `runs.jsonl` audit event (`event: blocked` / `queued`, `by: intent-cli
+  automation issue-block`, carrying the reason).
+- **GitHub** — the `intent-issue-blocked` label, applied through the same
+  `IGitHubLabelMutator` seam `worker claim`/`worker complete` use. Raw `gh
+  ... edit --add-label`/`--remove-label` is never permitted.
+
+`--clear` converges both sides back: it restores `state=queued` **and
+empties `blocked_by`**, then removes the label. Emptying `blocked_by` is not
+cosmetic — `intent next-slice`'s eligibility gate rejects any item with a
+non-empty `blocked_by` regardless of its state, so leaving the stale reason
+behind would keep a "cleared" unit permanently unselectable, merely
+relocating the drift from GitHub into queue-state.
+
+The execution unit is a **required positional argument**, never inferred
+from the issue title. When the queue item declares a `linked_issue`, its
+number is cross-checked against `--issue` and a mismatch is refused rather
+than trusted — the command will not label a possibly-wrong issue. A unit
+that is already blocked with a *different* reason is likewise refused, not
+silently overwritten; clear it first.
+
+**Write ordering is fail-loud and repairable.** The `runs.jsonl` audit event
+is appended FIRST and `queue-state.json` written SECOND (matching `queue
+reprioritize`'s convention), so no queue mutation is ever silently
+unaudited. The two sides are then converged **independently**: each side
+checks its own current state and mutates only if it is not already at the
+target. Re-running the exact same command after any partial failure
+therefore retries only what has not converged — a completed step is never
+repeated. Queue-side audit idempotency is decided by the run log itself: a
+matching event is reused (never duplicated) only when it is the most recent
+event for that unit *and* queue-state has not yet caught up to it, which
+distinguishes a genuine partial-failure retry from a later re-block that
+happens to reuse the same reason text after a full block/unblock cycle.
+
+Dry-run by default: it reports what would change on both sides and touches
+neither `queue-state.json`, `runs.jsonl`, nor GitHub, and never reports
+`converged: true`. `--reason` is required when applying and never permitted
+with `--clear` — a blocked transition without a recorded reason is refused,
+mirroring `queue reprioritize`'s reason requirement. `intent-issue-blocked`
+coexists with `intent-issue-in-progress` rather than replacing it: the
+worker still owns the issue, it just cannot currently proceed.
 
 Each item reports `kind`, `execution_unit`, `issue` and/or `pr` (number +
 url), `age_minutes`, `is_informational`, and `recommended_action`.

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -393,11 +393,24 @@ behind would keep a "cleared" unit permanently unselectable, merely
 relocating the drift from GitHub into queue-state.
 
 The execution unit is a **required positional argument**, never inferred
-from the issue title. When the queue item declares a `linked_issue`, its
-number is cross-checked against `--issue` and a mismatch is refused rather
-than trusted — the command will not label a possibly-wrong issue. A unit
-that is already blocked with a *different* reason is likewise refused, not
-silently overwritten; clear it first.
+from the issue title. The queue item must additionally carry a **complete
+`linked_issue`** — both a repo and a number — and both must agree with
+`--repo`/`--issue`: the repo is compared canonically (URL/ssh/`.git`/
+trailing-slash shapes normalized to `owner/repo`) and case-insensitively,
+the number exactly. Missing linkage, a different repo, and a different
+number are each refused; a missing linkage is absent evidence, not consent,
+and number-only agreement proves nothing because issue #818 exists in
+almost every repository. A unit already blocked with a *different* reason is
+likewise refused, not silently overwritten; clear it first.
+
+A present but unreadable/unparseable `runs.jsonl` is also a hard stop: the
+command refuses before appending, writing queue-state, or even *reading*
+GitHub labels, and names `intent-cli automation runs-audit` as the repair
+path. Transitioning against a trail it cannot parse would corrupt that trail
+further and would decide retry-vs-fresh-append from no evidence at all. A
+**missing** run log remains the valid first-event case. Every refusal above
+happens before any interaction with the run log, queue-state, or GitHub, so
+all three sides are left byte-identical.
 
 **Write ordering is fail-loud and repairable.** The `runs.jsonl` audit event
 is appended FIRST and `queue-state.json` written SECOND (matching `queue

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -359,14 +359,14 @@ age は可視性のためだけに報告されます:
   報告されません——下記の `blocked-label-drift` を参照してください。
 - `blocked-label-drift` (G545) — GitHub と queue-state の一時的な
   mismatch であり、stall では**ありません**: この unit の queue-state
-  item は `state=blocked`(`queue transition <unit> blocked --reason
-  <text>` で記録された明示的な `blocked_by` reason を持つ)ですが、
+  item は明示的な `blocked_by` reason を伴う `state=blocked` ですが、
   対応する GitHub issue はまだ `intent-issue-blocked` を持っていません
   ——label 側がまだ reconcile されていない状態です。`recommended_action`
   は正確な canonical reconcile コマンド(`intent-cli automation
-  issue-block --repo <r> --issue <n> --reason "<blocked_by のテキスト>"
-  --write --format json`)を名指しします。このコマンドが label を適用
-  すると、同じ unit は `stalled-work` から完全に姿を消します
+  issue-block <unit> --repo <r> --issue <n> --reason
+  "<blocked_by のテキスト>" --write --format json`)を名指しします。
+  このコマンドが label を収束させると、同じ unit は `stalled-work` から
+  完全に姿を消します
   (`claimed-but-silent` も `blocked-label-drift` も発火しません——
   GitHub と queue-state が一致するためです)。field finding、
   2026-07-21(sekiban-as-a-service): 5 item(SKS-G818、SKS-G837、
@@ -376,23 +376,55 @@ age は可視性のためだけに報告されます:
   「blocked」表現が全く存在しなかったため、毎 wake `claimed-but-silent`
   として報告されていました。
 
-**`intent-cli automation issue-block --repo <owner/repo> --issue <n>
---reason <text> [--write] [--dry-run] [--format text|json]`**
-(および、その `--clear` 版——`--reason` を省略)は、`intent-issue-blocked`
-を適用/削除する canonical で bounded な transition です——queue-state の
-`blocked` transition と GitHub を一致させる唯一サポートされた方法であり、
-raw な `gh ... edit --add-label`/`--remove-label` は決して許可されません。
-デフォルトは dry-run。双方向で idempotent です(label が既に要求された
-状態を反映していれば `applied: false` と、その旨を説明する `summary`)。
-`--reason` は apply 時には必須です(`--clear` とは決して併用できません)
-——reason が記録されない blocked transition は拒否されます。これは
-`queue reprioritize` の reason 要件を踏襲しています。`intent-issue-blocked`
-は `intent-issue-in-progress` を置き換えるのではなく共存します——worker は
-引き続き issue を所有しており、単に現時点で作業を進められないだけです。
-このコマンドは `queue-state.json` や `runs.jsonl` に一切触れません——
-既に `queue transition <unit> blocked --reason <text>`(この slice では
-変更しません)経由で起きた `blocked` transition に GitHub 側を
-reconcile するためだけに存在します。
+**`intent-cli automation issue-block <execution-unit> --repo <owner/repo>
+--issue <n> --reason <text> [--write] [--dry-run] [--format text|json]`**
+(および、その `--clear` 版——`--reason` を省略)は、単一 execution unit に
+ついて「blocked」の**両方の authoritative な表現を収束させる唯一の
+canonical で bounded な transition** です:
+
+- **queue-state** — `state=blocked` と `blocked_by: ["<reason>"]`。既存の
+  変更されていない `QueueManager` の blocking transition(`queue transition
+  <unit> blocked` と同じ機構)経由で適用し、あわせて durable な
+  `runs.jsonl` audit event(`event: blocked` / `queued`、`by: intent-cli
+  automation issue-block`、reason 付き)を追記します。
+- **GitHub** — `intent-issue-blocked` label。`worker claim`/`worker complete`
+  と同じ `IGitHubLabelMutator` seam 経由で適用します。raw な
+  `gh ... edit --add-label`/`--remove-label` は決して許可されません。
+
+`--clear` は両側を元に戻します: `state=queued` へ戻すことに加えて
+**`blocked_by` を空にし**、その後 label を削除します。`blocked_by` を空に
+するのは体裁上の話ではありません——`intent next-slice` の eligibility gate は
+state に関係なく `blocked_by` が非空の item を不適格にするため、stale な
+reason を残すと「clear された」はずの unit が永久に選択不能のままとなり、
+drift を GitHub から queue-state へ移動させただけになります。
+
+execution unit は**必須の positional 引数**であり、issue title から推測する
+ことはありません。queue item が `linked_issue` を宣言している場合、その番号が
+`--issue` と突き合わせられ、不一致は信用せずに拒否されます——誤った issue に
+label を付ける可能性を排除するためです。既に**異なる** reason で blocked に
+なっている unit も同様に、黙って上書きせず拒否します(先に clear してください)。
+
+**書き込み順序は fail-loud かつ repairable です。** `runs.jsonl` の audit
+event を先に追記し、`queue-state.json` の書き込みを後に行います
+(`queue reprioritize` の規約と同じ)。これにより queue の変更が audit なしで
+黙って成立することは決してありません。その上で両側は**独立に**収束されます:
+各 side は自分自身の現在状態を確認し、既に目標状態であれば変更しません。
+したがって partial failure 後に全く同じコマンドを再実行すると、まだ収束して
+いない側だけが再試行され、完了済みの step が繰り返されることはありません。
+queue 側の audit idempotency は run log 自身で判定します: 一致する event が
+再利用される(二重追記されない)のは、それがその unit の最新 event であり
+**かつ** queue-state がまだ追いついていない場合だけであり、これにより
+「partial failure の再試行」と「block/unblock を一巡した後に同じ reason
+テキストで再度 block した」ケースが区別されます。
+
+デフォルトは dry-run: 両側で何が変わるかを報告するだけで、
+`queue-state.json`、`runs.jsonl`、GitHub のいずれにも触れず、
+`converged: true` を返すこともありません。`--reason` は apply 時には必須です
+(`--clear` とは決して併用できません)——reason が記録されない blocked
+transition は拒否されます。これは `queue reprioritize` の reason 要件を
+踏襲しています。`intent-issue-blocked` は `intent-issue-in-progress` を
+置き換えるのではなく共存します——worker は引き続き issue を所有しており、
+単に現時点で作業を進められないだけです。
 
 各 item は `kind`、`execution_unit`、`issue` および/または `pr`
 （番号 + url）、`age_minutes`、`is_informational`、`recommended_action`

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -399,10 +399,24 @@ reason を残すと「clear された」はずの unit が永久に選択不能�
 drift を GitHub から queue-state へ移動させただけになります。
 
 execution unit は**必須の positional 引数**であり、issue title から推測する
-ことはありません。queue item が `linked_issue` を宣言している場合、その番号が
-`--issue` と突き合わせられ、不一致は信用せずに拒否されます——誤った issue に
-label を付ける可能性を排除するためです。既に**異なる** reason で blocked に
-なっている unit も同様に、黙って上書きせず拒否します(先に clear してください)。
+ことはありません。さらに queue item は**完全な `linked_issue`**(repo と
+number の両方)を持っている必要があり、その両方が `--repo`/`--issue` と
+一致しなければなりません: repo は canonical 化(URL / ssh / `.git` / 末尾
+スラッシュの各形を `owner/repo` へ正規化)した上で case-insensitive に、
+number は厳密に比較されます。linkage 欠落・repo 不一致・number 不一致は
+いずれも拒否されます——linkage の欠落は「異議なし」ではなく証拠の欠如であり、
+また issue #818 はほぼ全ての repository に存在するため number の一致だけでは
+同一 issue の証明になりません。既に**異なる** reason で blocked になっている
+unit も同様に、黙って上書きせず拒否します(先に clear してください)。
+
+`runs.jsonl` が存在するのに読めない/parse できない場合も hard stop です:
+audit 追記・queue-state 書き込みはもちろん、GitHub label の**読み取り前**に
+拒否し、修復手段として `intent-cli automation runs-audit` を名指しします。
+parse できない trail に対して transition すると、その trail をさらに壊した上、
+「retry か新規追記か」を証拠ゼロで判断することになるためです。run log が
+**存在しない**場合は従来どおり正当な first-event ケースです。上記の拒否は
+いずれも run log / queue-state / GitHub への一切の interaction より前に
+起きるため、3つの side すべてが byte 単位で無変更のまま残ります。
 
 **書き込み順序は fail-loud かつ repairable です。** `runs.jsonl` の audit
 event を先に追記し、`queue-state.json` の書き込みを後に行います

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -350,13 +350,55 @@ age は可視性のためだけに報告されます:
   仮定しません。issue に PR が作成されると（`intent-pr-created`）、
   代わりに PR-lifecycle の kind が引き継ぎます。repair 状態の PR 自体が
   閾値を超えて stale であることを検出するのは、明示的に out-of-scope の
-  follow-up です。
+  follow-up です。**G545: queue-state item が `state=blocked` である
+  unit を exempt します** — `stalled-work` 呼び出しごとに一度だけ
+  consult され、`queue-state.json` が欠落・パース不能でも許容します
+  (この kind の G545 以前の GitHub-labels-only な挙動へそのままフォール
+  スルーするため、`queue-state.json` を一切使わない domain でもこの
+  検出を失うことはありません)。queue-blocked な unit はここでは決して
+  報告されません——下記の `blocked-label-drift` を参照してください。
+- `blocked-label-drift` (G545) — GitHub と queue-state の一時的な
+  mismatch であり、stall では**ありません**: この unit の queue-state
+  item は `state=blocked`(`queue transition <unit> blocked --reason
+  <text>` で記録された明示的な `blocked_by` reason を持つ)ですが、
+  対応する GitHub issue はまだ `intent-issue-blocked` を持っていません
+  ——label 側がまだ reconcile されていない状態です。`recommended_action`
+  は正確な canonical reconcile コマンド(`intent-cli automation
+  issue-block --repo <r> --issue <n> --reason "<blocked_by のテキスト>"
+  --write --format json`)を名指しします。このコマンドが label を適用
+  すると、同じ unit は `stalled-work` から完全に姿を消します
+  (`claimed-but-silent` も `blocked-label-drift` も発火しません——
+  GitHub と queue-state が一致するためです)。field finding、
+  2026-07-21(sekiban-as-a-service): 5 item(SKS-G818、SKS-G837、
+  SKS-G835、SKS-G839、SKS-G840)が明示的な `blocked_by` dependency を
+  伴って queue-state 上で `state=blocked` であったにもかかわらず、
+  `claimed-but-silent` は GitHub label しか読まず、issue-level の
+  「blocked」表現が全く存在しなかったため、毎 wake `claimed-but-silent`
+  として報告されていました。
+
+**`intent-cli automation issue-block --repo <owner/repo> --issue <n>
+--reason <text> [--write] [--dry-run] [--format text|json]`**
+(および、その `--clear` 版——`--reason` を省略)は、`intent-issue-blocked`
+を適用/削除する canonical で bounded な transition です——queue-state の
+`blocked` transition と GitHub を一致させる唯一サポートされた方法であり、
+raw な `gh ... edit --add-label`/`--remove-label` は決して許可されません。
+デフォルトは dry-run。双方向で idempotent です(label が既に要求された
+状態を反映していれば `applied: false` と、その旨を説明する `summary`)。
+`--reason` は apply 時には必須です(`--clear` とは決して併用できません)
+——reason が記録されない blocked transition は拒否されます。これは
+`queue reprioritize` の reason 要件を踏襲しています。`intent-issue-blocked`
+は `intent-issue-in-progress` を置き換えるのではなく共存します——worker は
+引き続き issue を所有しており、単に現時点で作業を進められないだけです。
+このコマンドは `queue-state.json` や `runs.jsonl` に一切触れません——
+既に `queue transition <unit> blocked --reason <text>`(この slice では
+変更しません)経由で起きた `blocked` transition に GitHub 側を
+reconcile するためだけに存在します。
 
 各 item は `kind`、`execution_unit`、`issue` および/または `pr`
 （番号 + url）、`age_minutes`、`is_informational`、`recommended_action`
 を報告します。`--stale-minutes` は、指定した閾値より新しい item を
 除外します（デフォルトは `0` — すべてを age 付きで報告し、閾値は
-呼び出し側が選ぶ）— これは 7 つすべての kind に一律に適用されます。
+呼び出し側が選ぶ）— これは 8 つすべての kind に一律に適用されます。
 `claimed-but-silent` と `backlog-ready-idle` は、そもそも item が
 検討される前に、それぞれ自身の `--claimed-silent-minutes` /
 `--backlog-idle-minutes` 閾値でも追加でゲートされます（そのため

--- a/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
@@ -1,40 +1,90 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G545: the canonical issue-level mirror of queue-state's <c>state=blocked</c>
-/// — <c>intent-cli automation issue-block --repo &lt;owner/repo&gt; --issue &lt;n&gt;
-/// --reason &lt;text&gt; [--write] [--dry-run] [--format text|json]</c> applies
-/// <see cref="WorkerNextActionConstants.Labels.IntentIssueBlocked"/>, recording
-/// the queue's own <c>blocked_by</c> reason text; the counterpart <c>--clear</c>
-/// removes it once the unit is unblocked. Coexists with
-/// <see cref="WorkerNextActionConstants.Labels.IntentIssueInProgress"/> rather
-/// than replacing it — the worker still owns the issue, it just cannot
-/// currently proceed. Dry-run by default; WITHOUT raw <c>gh ... edit
-/// --add-label</c>/<c>--remove-label</c>, mutating labels only through the
-/// installed <see cref="IGitHubLabelMutator"/>, exactly like the existing
-/// <see cref="AutomationIssueReleaseCommand"/>. Never edits queue-state or
-/// runs.jsonl, and never launches an AI provider — this command only makes
-/// GitHub agree with a `blocked` transition that already happened via
-/// <c>queue transition &lt;unit&gt; blocked --reason &lt;text&gt;</c>.
+/// G545: <c>intent-cli automation issue-block &lt;execution-unit&gt; --repo
+/// &lt;owner/repo&gt; --issue &lt;n&gt; --reason &lt;text&gt; [--write] [--dry-run]
+/// [--format text|json]</c> — the ONE canonical, bounded transition that
+/// converges BOTH authoritative representations of "blocked" for a single
+/// execution unit: queue-state (<c>state=blocked</c> + <c>blocked_by</c>
+/// reason, via the existing, unmodified <see cref="QueueManager.TransitionBlocking"/>)
+/// and the GitHub issue-level <see cref="WorkerNextActionConstants.Labels.IntentIssueBlocked"/>
+/// label (via the installed <see cref="IGitHubLabelMutator"/>). The
+/// counterpart <c>--clear</c> (no <c>--reason</c>) converges both back to
+/// unblocked. Never a raw <c>gh ... edit --add-label</c>/<c>--remove-label</c>;
+/// never a direct queue-state hand-edit.
+///
+/// Review repair (G545 round 2): a prior label-only version of this command
+/// left queue-state untouched, immediately recreating the exact drift this
+/// slice exists to close. The execution unit is now a REQUIRED positional
+/// argument (never guessed from the issue title) so "which queue item does
+/// this affect" is resolved exactly, not heuristically — and, when the
+/// queue item declares a <see cref="QueueItem.LinkedIssue"/>, its number is
+/// cross-checked against <c>--issue</c>, refusing to label a possibly-wrong
+/// issue rather than trusting the caller blindly.
+///
+/// Fail-closed, repairable write order — mirrors <see
+/// cref="QueueReprioritizeCommand"/>'s established convention: the queue-side
+/// <c>runs.jsonl</c> audit event is appended FIRST, <c>queue-state.json</c>
+/// SECOND, so a failure at either step never produces a silent, unaudited
+/// queue mutation. The two authoritative sides (queue-state, GitHub label)
+/// are then converged INDEPENDENTLY of each other — if the queue side is
+/// already in the target state, its own mutation is skipped, but the label
+/// side is still checked/applied, and vice versa — so re-running this exact
+/// command after ANY partial failure retries only whatever has not yet
+/// converged, without duplicating a completed step. Idempotency for the
+/// queue-side audit event itself is decided by <see cref="FindPendingRetryEvent"/>:
+/// a matching event is treated as an already-recorded pending write (reused,
+/// never duplicated) only when it is the MOST RECENT run-log event for this
+/// execution unit AND queue-state does not yet reflect it — distinguishing a
+/// genuine partial-failure retry from an unrelated later re-request that
+/// happens to reuse the same reason text after a full block/unblock cycle.
+///
+/// Clearing also empties <see cref="QueueItem.BlockedBy"/>, not just the
+/// state. <see cref="QueueManager.TransitionNonBlocking"/> deliberately
+/// leaves <c>blocked_by</c> alone (it is a general-purpose transition that
+/// must not assume the caller owns that list), but the blocking half of THIS
+/// command sets it wholesale to the single recorded reason, so its exact
+/// inverse is to empty it. Leaving the stale reason behind would keep the
+/// unit permanently ineligible for selection — <see
+/// cref="IntentNextSliceCommand"/>'s dependency/blocked-by gate rejects any
+/// item with a non-empty <c>blocked_by</c> regardless of its state — i.e. a
+/// "cleared" unit that is still, in effect, blocked.
 /// </summary>
 internal static class AutomationIssueBlockCommand
 {
     private const string FormatText = "text";
     private const string FormatJson = "json";
     private const string BlockedLabel = WorkerNextActionConstants.Labels.IntentIssueBlocked;
+    private const string TransitionActor = "intent-cli automation issue-block";
+
+    /// <summary>The queue-side target for <c>--clear</c> — restores the item to the pool <see cref="IntentNextSliceCommand"/>/<c>next-slice</c> selects from.</summary>
+    private const QueueItemState UnblockTargetState = QueueItemState.Queued;
 
     public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
 
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    /// <summary>Test seam: throws to simulate a runs.jsonl append failure AFTER it would have succeeded, or replaces the real append.</summary>
+    internal static Action<string, RunEvent>? AppendRunEventOverride { get; set; }
+
+    /// <summary>Test seam: throws to simulate a queue-state.json write failure AFTER the runs event was already durably appended.</summary>
+    internal static Action<string, QueueState>? WriteQueueStateOverride { get; set; }
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.Never,
     };
+
+    private const string UsageLine =
+        "Usage: intent-cli automation issue-block <execution-unit> --repo <owner/repo> --issue <n> --reason <text> [--write] [--dry-run] [--format text|json]\n"
+        + "       intent-cli automation issue-block <execution-unit> --repo <owner/repo> --issue <n> --clear [--write] [--dry-run] [--format text|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -48,9 +98,62 @@ internal static class AutomationIssueBlockCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var repo, out var issue, out var reason, out var clear, out var mode, out var format, out var error))
+        if (!TryParseArguments(args, out var executionUnit, out var repo, out var issue, out var reason, out var clear, out var write, out var format, out var error))
         {
             writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var queueStatePath = context.GetQueueStatePath();
+        if (!File.Exists(queueStatePath))
+        {
+            writer.WriteLine($"No queue state found at {queueStatePath}");
+            return 1;
+        }
+
+        QueueState queueState;
+        try
+        {
+            queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
+        {
+            writer.WriteLine($"queue-state.json could not be parsed: {exception.Message}");
+            return 1;
+        }
+
+        var queueItem = queueState.Items.FirstOrDefault(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+        if (queueItem is null)
+        {
+            writer.WriteLine($"queue-state.json has no item with execution_unit '{executionUnit}'.");
+            return 1;
+        }
+
+        if (queueItem.LinkedIssue is { Number: { } linkedNumber } && linkedNumber != issue)
+        {
+            writer.WriteLine(
+                $"'{executionUnit}'s queue-state linked_issue is #{linkedNumber}, not the requested #{issue}; "
+                + "refusing to label a possibly-wrong issue. Re-invoke with the linked issue number, or fix the "
+                + "queue-state linkage first.");
+            return 1;
+        }
+
+        var now = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var runLogPath = context.GetRunLogPath();
+        var beforeState = queueItem.State;
+        var beforeBlockedBy = queueItem.BlockedBy;
+
+        QueueQueueSideResult queueResult;
+        try
+        {
+            queueResult = clear
+                ? ConvergeQueueSide(queueStatePath, runLogPath, queueState, queueItem, executionUnit!, UnblockTargetState, reason: null, write, now)
+                : ConvergeQueueSide(queueStatePath, runLogPath, queueState, queueItem, executionUnit!, QueueItemState.Blocked, reason, write, now);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
+        {
+            writer.WriteLine($"failed to converge queue-state for '{executionUnit}': {exception.Message}");
             return 1;
         }
 
@@ -76,61 +179,90 @@ internal static class AutomationIssueBlockCommand
         }
         catch (Exception exception) when (exception is InvalidOperationException or IOException)
         {
-            writer.WriteLine($"failed to read current labels for issue #{issue} in {repo}: {exception.Message}");
+            writer.WriteLine(
+                $"queue-state converged for '{executionUnit}' (or already was), but failed to read current labels "
+                + $"for issue #{issue} in {repo}: {exception.Message}. Re-run this exact command to retry the label step only.");
             return 1;
         }
 
         var hasBlockedLabel = currentLabels.Contains(BlockedLabel, StringComparer.Ordinal);
-        var applied = false;
-        var transitionAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
-        var isWrite = string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal);
+        var labelApplied = false;
 
-        if (clear)
+        if (write)
         {
-            if (isWrite && hasBlockedLabel)
+            if (!clear && !hasBlockedLabel)
+            {
+                try
+                {
+                    mutator.ApplyLabelTransitions(repo!, GhCliGitHubLabelMutator.Kinds.Issue, issue!.Value, [BlockedLabel], Array.Empty<string>());
+                    labelApplied = true;
+                }
+                catch (Exception exception) when (exception is InvalidOperationException or IOException)
+                {
+                    writer.WriteLine(
+                        $"queue-state converged for '{executionUnit}' (or already was), but failed to apply the "
+                        + $"{BlockedLabel} label on issue #{issue} in {repo}: {exception.Message}. Re-run this exact "
+                        + "command to retry the label step only.");
+                    return 1;
+                }
+            }
+            else if (clear && hasBlockedLabel)
             {
                 try
                 {
                     mutator.ApplyLabelTransitions(repo!, GhCliGitHubLabelMutator.Kinds.Issue, issue!.Value, Array.Empty<string>(), [BlockedLabel]);
-                    applied = true;
+                    labelApplied = true;
                 }
                 catch (Exception exception) when (exception is InvalidOperationException or IOException)
                 {
-                    writer.WriteLine($"failed to clear the blocked transition on issue #{issue} in {repo}: {exception.Message}");
+                    writer.WriteLine(
+                        $"queue-state converged for '{executionUnit}' (or already was), but failed to clear the "
+                        + $"{BlockedLabel} label on issue #{issue} in {repo}: {exception.Message}. Re-run this exact "
+                        + "command to retry the label step only.");
                     return 1;
                 }
             }
         }
-        else if (isWrite && !hasBlockedLabel)
-        {
-            try
-            {
-                mutator.ApplyLabelTransitions(repo!, GhCliGitHubLabelMutator.Kinds.Issue, issue!.Value, [BlockedLabel], Array.Empty<string>());
-                applied = true;
-            }
-            catch (Exception exception) when (exception is InvalidOperationException or IOException)
-            {
-                writer.WriteLine($"failed to apply the blocked transition on issue #{issue} in {repo}: {exception.Message}");
-                return 1;
-            }
-        }
+
+        // Converged only ever means "both sides now agree" — dry-run never
+        // claims it, since nothing was actually written.
+        var queueConverged = clear
+            ? queueResult.AfterState != QueueItemState.Blocked && queueResult.AfterBlockedBy.Count == 0
+            : queueResult.AfterState == QueueItemState.Blocked;
+        var labelConverged = clear
+            ? !hasBlockedLabel || labelApplied
+            : hasBlockedLabel || labelApplied;
+        var converged = write && queueConverged && labelConverged;
 
         var result = new AutomationIssueBlockResult
         {
             Repo = repo!,
+            ExecutionUnit = executionUnit!,
             Issue = issue!.Value,
             IssueUrl = BuildIssueUrl(repo!, issue.Value),
-            Mode = mode,
+            Mode = write ? WorkerClaimCompleteConstants.Modes.Write : WorkerClaimCompleteConstants.Modes.DryRun,
             Clear = clear,
-            Applied = applied,
-            BlockedLabel = BlockedLabel,
-            HadBlockedLabel = hasBlockedLabel,
             Reason = reason,
-            AddLabels = clear ? Array.Empty<string>() : [BlockedLabel],
-            RemoveLabels = clear ? [BlockedLabel] : Array.Empty<string>(),
-            CurrentLabels = currentLabels,
-            TransitionedAt = transitionAt,
-            Summary = BuildSummary(issue.Value, clear, hasBlockedLabel, reason),
+            Queue = new AutomationIssueBlockQueueResult
+            {
+                BeforeState = FormatState(beforeState),
+                BeforeBlockedBy = beforeBlockedBy,
+                TargetState = FormatState(clear ? UnblockTargetState : QueueItemState.Blocked),
+                AlreadyConverged = queueResult.AlreadyConverged,
+                Applied = queueResult.Applied,
+                AfterState = FormatState(queueResult.AfterState),
+                AfterBlockedBy = queueResult.AfterBlockedBy,
+            },
+            Label = new AutomationIssueBlockLabelResult
+            {
+                BlockedLabel = BlockedLabel,
+                HadBlockedLabel = hasBlockedLabel,
+                Applied = labelApplied,
+                CurrentLabels = currentLabels,
+            },
+            Converged = converged,
+            TransitionedAt = now,
+            Summary = BuildSummary(executionUnit!, issue.Value, clear, write, queueResult, hasBlockedLabel, labelApplied),
         };
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
@@ -145,48 +277,251 @@ internal static class AutomationIssueBlockCommand
         return 0;
     }
 
-    private static string BuildSummary(int issue, bool clear, bool hasBlockedLabel, string? reason)
+    private readonly record struct QueueQueueSideResult(
+        bool AlreadyConverged, bool Applied, QueueItemState AfterState, IReadOnlyList<string> AfterBlockedBy);
+
+    /// <summary>
+    /// Converges the queue-side state toward <paramref name="targetState"/>
+    /// (Blocked with <paramref name="reason"/>, or the unblock target with no
+    /// reason). Idempotent: a no-op when already converged. Dry-run reports
+    /// what WOULD happen without writing anything.
+    /// </summary>
+    private static QueueQueueSideResult ConvergeQueueSide(
+        string queueStatePath,
+        string runLogPath,
+        QueueState queueState,
+        QueueItem queueItem,
+        string executionUnit,
+        QueueItemState targetState,
+        string? reason,
+        bool write,
+        DateTimeOffset now)
     {
-        if (clear)
+        // Convergence is judged on BOTH queue fields this command owns:
+        // blocked means state=blocked AND blocked_by == [reason]; unblocked
+        // means state!=blocked AND blocked_by empty. A unit left with a
+        // stale blocked_by is NOT converged — the selector still treats it
+        // as blocked.
+        var alreadyConverged = targetState == QueueItemState.Blocked
+            ? queueItem.State == QueueItemState.Blocked && queueItem.BlockedBy.Count == 1 && string.Equals(queueItem.BlockedBy[0], reason, StringComparison.Ordinal)
+            : queueItem.State != QueueItemState.Blocked && queueItem.BlockedBy.Count == 0;
+
+        if (alreadyConverged)
         {
-            return hasBlockedLabel
-                ? $"Would clear the blocked transition on issue #{issue} by removing {BlockedLabel}."
-                : $"Issue #{issue} does not carry {BlockedLabel}; nothing to clear.";
+            return new QueueQueueSideResult(true, false, queueItem.State, queueItem.BlockedBy);
         }
 
-        return hasBlockedLabel
-            ? $"Issue #{issue} already carries {BlockedLabel}; nothing to apply."
-            : $"Would apply the blocked transition on issue #{issue} by adding {BlockedLabel}"
-                + (string.IsNullOrWhiteSpace(reason) ? "." : $" (reason: {reason}).");
+        if (targetState == QueueItemState.Blocked && queueItem.State == QueueItemState.Blocked)
+        {
+            // Already blocked, but with a DIFFERENT reason than requested —
+            // a genuine conflict, never silently overwritten.
+            throw new InvalidOperationException(
+                $"'{executionUnit}' is already blocked with reason '{string.Join("; ", queueItem.BlockedBy)}', "
+                + $"which does not match the requested reason '{reason}'. Reconcile manually (e.g. clear first) "
+                + "before requesting a different reason.");
+        }
+
+        if (!write)
+        {
+            var previewState = targetState == QueueItemState.Blocked
+                ? QueueManager.TransitionBlocking(queueState, executionUnit, targetState, reason!, TransitionActor, now).UpdatedState
+                : ClearQueueSideBlocking(
+                    QueueManager.TransitionNonBlocking(queueState, executionUnit, targetState, TransitionActor, now).UpdatedState,
+                    executionUnit,
+                    targetState);
+            var previewItem = previewState.Items.First(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+            return new QueueQueueSideResult(false, true, previewItem.State, previewItem.BlockedBy);
+        }
+
+        var eventName = targetState == QueueItemState.Blocked ? "blocked" : MapUnblockEventName(targetState);
+        var pendingEvent = FindPendingRetryEvent(runLogPath, executionUnit, eventName, reason);
+
+        RunEvent runEvent;
+        QueueState updatedState;
+        if (pendingEvent is not null)
+        {
+            // A matching event is already durably recorded from a prior
+            // attempt whose queue-state write must have failed — reuse it
+            // rather than appending a duplicate.
+            runEvent = pendingEvent;
+            updatedState = targetState == QueueItemState.Blocked
+                ? ApplyBlockedState(queueState, executionUnit, reason!)
+                : ClearQueueSideBlocking(queueState, executionUnit, targetState);
+        }
+        else
+        {
+            var transitionResult = targetState == QueueItemState.Blocked
+                ? QueueManager.TransitionBlocking(queueState, executionUnit, targetState, reason!, TransitionActor, now)
+                : QueueManager.TransitionNonBlocking(queueState, executionUnit, targetState, TransitionActor, now);
+            runEvent = transitionResult.Event;
+            updatedState = targetState == QueueItemState.Blocked
+                ? transitionResult.UpdatedState
+                : ClearQueueSideBlocking(transitionResult.UpdatedState, executionUnit, targetState);
+
+            AppendRunEvent(runLogPath, runEvent);
+        }
+
+        WriteQueueState(queueStatePath, updatedState);
+
+        var finalItem = updatedState.Items.First(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+        return new QueueQueueSideResult(false, true, finalItem.State, finalItem.BlockedBy);
+    }
+
+    private static QueueState ApplyBlockedState(QueueState state, string executionUnit, string reason) =>
+        state with
+        {
+            Items = state.Items.Select(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                ? item with { State = QueueItemState.Blocked, BlockedBy = [reason] }
+                : item).ToArray(),
+        };
+
+    /// <summary>
+    /// The exact inverse of the blocking half of this command: restores
+    /// <paramref name="targetState"/> AND empties <c>blocked_by</c>, which
+    /// <see cref="QueueManager.TransitionNonBlocking"/> deliberately leaves
+    /// untouched. Without this, a "cleared" unit keeps the stale reason and
+    /// stays ineligible for selection — the drift this slice exists to close,
+    /// merely relocated from GitHub to queue-state.
+    /// </summary>
+    private static QueueState ClearQueueSideBlocking(QueueState state, string executionUnit, QueueItemState targetState) =>
+        state with
+        {
+            Items = state.Items.Select(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal)
+                ? item with { State = targetState, BlockedBy = Array.Empty<string>() }
+                : item).ToArray(),
+        };
+
+    private static string MapUnblockEventName(QueueItemState targetState) => targetState switch
+    {
+        QueueItemState.Queued => "queued",
+        QueueItemState.Active => "activated",
+        QueueItemState.Review => "review-started",
+        QueueItemState.Fixing => "fix-requested",
+        _ => throw new InvalidOperationException($"Unsupported unblock target state '{targetState}'."),
+    };
+
+    /// <summary>
+    /// G545 round 2: a matching event is treated as an already-recorded
+    /// PENDING write — reused rather than duplicated — only when it is the
+    /// MOST RECENT run-log event for this execution unit AND (implicitly,
+    /// since this is only called when queue-state does NOT yet show the
+    /// target) queue-state has not caught up to it yet. If anything else
+    /// happened to this unit afterward (including a full unblock/reblock
+    /// cycle reusing the same reason text), the matching event is historical,
+    /// not pending, and a fresh event is appended instead.
+    /// </summary>
+    private static RunEvent? FindPendingRetryEvent(string runLogPath, string executionUnit, string eventName, string? reason)
+    {
+        if (!File.Exists(runLogPath))
+        {
+            return null;
+        }
+
+        IReadOnlyList<RunEvent> events;
+        try
+        {
+            events = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or JsonException)
+        {
+            // Fail OPEN: an unreadable runs.jsonl must never suppress a
+            // genuinely-needed audit event. Worst case is a redundant
+            // append once the file is repaired.
+            return null;
+        }
+
+        var lastForUnit = events.LastOrDefault(runEvent => string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal));
+        if (lastForUnit is null
+            || !string.Equals(lastForUnit.Event, eventName, StringComparison.Ordinal)
+            || !string.Equals(lastForUnit.By, TransitionActor, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        if (eventName == "blocked" && !string.Equals(lastForUnit.Reason, reason, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return lastForUnit;
+    }
+
+    private static void AppendRunEvent(string runLogPath, RunEvent runEvent)
+    {
+        if (AppendRunEventOverride is not null)
+        {
+            AppendRunEventOverride(runLogPath, runEvent);
+            return;
+        }
+
+        var runLogDirectory = Path.GetDirectoryName(runLogPath)
+            ?? throw new InvalidOperationException("Run log path did not contain a directory.");
+        Directory.CreateDirectory(runLogDirectory);
+        File.AppendAllText(runLogPath, RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
+    }
+
+    private static void WriteQueueState(string queueStatePath, QueueState state)
+    {
+        if (WriteQueueStateOverride is not null)
+        {
+            WriteQueueStateOverride(queueStatePath, state);
+            return;
+        }
+
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(state));
+    }
+
+    private static string BuildSummary(
+        string executionUnit, int issue, bool clear, bool write, QueueQueueSideResult queueResult, bool hadBlockedLabel, bool labelApplied)
+    {
+        var mode = write ? "Applied" : "Would apply";
+        var queuePart = queueResult.AlreadyConverged
+            ? "queue-state already converged"
+            : $"queue-state {(write ? "transitioned" : "would transition")} to {FormatState(queueResult.AfterState)}";
+        var labelPart = clear
+            ? (hadBlockedLabel ? $"{mode.ToLowerInvariant()} label removal" : "label already absent")
+            : (hadBlockedLabel ? "label already present" : $"{mode.ToLowerInvariant()} label addition");
+        return clear
+            ? $"Clearing the blocked transition for '{executionUnit}' (issue #{issue}): {queuePart}; {labelPart}."
+            : $"Applying the blocked transition for '{executionUnit}' (issue #{issue}): {queuePart}; {labelPart}.";
     }
 
     private static bool TryParseArguments(
         string[] args,
+        out string? executionUnit,
         out string? repo,
         out int? issue,
         out string? reason,
         out bool clear,
-        out string mode,
+        out bool write,
         out string format,
         out string error)
     {
+        executionUnit = null;
         repo = null;
         issue = null;
         reason = null;
         clear = false;
-        mode = WorkerClaimCompleteConstants.Modes.DryRun;
+        write = false;
         format = FormatText;
         error = string.Empty;
 
-        for (var index = 0; index < args.Length; index++)
+        if (args.Length == 0 || string.IsNullOrWhiteSpace(args[0]) || args[0].StartsWith("--", StringComparison.Ordinal))
+        {
+            error = "automation issue-block requires an execution unit as the first argument.";
+            return false;
+        }
+
+        executionUnit = args[0];
+
+        for (var index = 1; index < args.Length; index++)
         {
             var argument = args[index];
             switch (argument)
             {
                 case "--repo":
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { error = "--repo requires a value (e.g. owner/repo)."; return false; }
-                    repo = args[index + 1].Trim();
-                    index++;
+                    repo = args[++index].Trim();
                     break;
                 case "--issue":
                     if (index + 1 >= args.Length
@@ -201,21 +536,20 @@ internal static class AutomationIssueBlockCommand
                     break;
                 case "--reason":
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { error = "--reason requires a value."; return false; }
-                    reason = args[index + 1].Trim();
-                    index++;
+                    reason = args[++index].Trim();
                     break;
                 case "--clear":
                     clear = true;
                     break;
                 case "--write":
-                    mode = WorkerClaimCompleteConstants.Modes.Write;
+                    write = true;
                     break;
                 case "--dry-run":
-                    mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    write = false;
                     break;
                 case "--format":
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { error = "--format requires a value (text or json)."; return false; }
-                    var requestedFormat = args[index + 1];
+                    var requestedFormat = args[++index];
                     if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
                         && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
                     {
@@ -223,10 +557,9 @@ internal static class AutomationIssueBlockCommand
                         return false;
                     }
                     format = requestedFormat;
-                    index++;
                     break;
                 default:
-                    error = $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --issue <n> [--reason <text>] [--clear] [--write] [--dry-run] [--format text|json].";
+                    error = $"Unknown argument '{argument}'. Supported: <execution-unit> --repo <owner/repo> --issue <n> [--reason <text>] [--clear] [--write] [--dry-run] [--format text|json].";
                     return false;
             }
         }
@@ -258,6 +591,12 @@ internal static class AutomationIssueBlockCommand
         return true;
     }
 
+    private static string FormatState(QueueItemState state) => state switch
+    {
+        QueueItemState.ClarifyBlocked => "clarify-blocked",
+        _ => state.ToString().ToLowerInvariant(),
+    };
+
     private static string BuildIssueUrl(string repo, int issue) =>
         $"https://github.com/{repo}/issues/{issue.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
 
@@ -265,28 +604,38 @@ internal static class AutomationIssueBlockCommand
     {
         writer.WriteLine(result.Summary);
         writer.WriteLine($"mode: {result.Mode}");
+        writer.WriteLine($"execution_unit: {result.ExecutionUnit}");
         writer.WriteLine($"repo: {result.Repo}");
         writer.WriteLine($"issue: {result.Issue.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
         writer.WriteLine($"issue_url: {result.IssueUrl}");
         writer.WriteLine($"clear: {result.Clear.ToString().ToLowerInvariant()}");
-        writer.WriteLine($"blocked_label: {result.BlockedLabel}");
-        writer.WriteLine($"had_blocked_label: {result.HadBlockedLabel.ToString().ToLowerInvariant()}");
-        writer.WriteLine($"applied: {result.Applied.ToString().ToLowerInvariant()}");
         if (!string.IsNullOrWhiteSpace(result.Reason))
         {
             writer.WriteLine($"reason: {result.Reason}");
         }
+        writer.WriteLine($"queue.before_state: {result.Queue.BeforeState}");
+        writer.WriteLine($"queue.target_state: {result.Queue.TargetState}");
+        writer.WriteLine($"queue.already_converged: {result.Queue.AlreadyConverged.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"queue.applied: {result.Queue.Applied.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"queue.after_state: {result.Queue.AfterState}");
+        writer.WriteLine($"queue.after_blocked_by: {(result.Queue.AfterBlockedBy.Count == 0 ? "(none)" : string.Join(", ", result.Queue.AfterBlockedBy))}");
+        writer.WriteLine($"label.blocked_label: {result.Label.BlockedLabel}");
+        writer.WriteLine($"label.had_blocked_label: {result.Label.HadBlockedLabel.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"label.applied: {result.Label.Applied.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"converged: {result.Converged.ToString().ToLowerInvariant()}");
         writer.WriteLine($"transitioned_at: {result.TransitionedAt:O}");
     }
 
     private static void WriteHelp(TextWriter writer)
     {
         writer.WriteLine("automation issue-block");
-        writer.WriteLine("Usage: intent-cli automation issue-block --repo <owner/repo> --issue <n> --reason <text> [--write] [--dry-run] [--format text|json]");
-        writer.WriteLine("       intent-cli automation issue-block --repo <owner/repo> --issue <n> --clear [--write] [--dry-run] [--format text|json]");
-        writer.WriteLine("Applies (or, with --clear, removes) the issue-level intent-issue-blocked label (G545) so GitHub");
-        writer.WriteLine("agrees with a queue-state `blocked` transition. Coexists with intent-issue-in-progress; never");
-        writer.WriteLine("uses raw gh label mutation.");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine("The ONE canonical transition that converges BOTH queue-state (state=blocked + blocked_by");
+        writer.WriteLine("reason, via the existing queue transition mechanism) and the GitHub intent-issue-blocked");
+        writer.WriteLine("label (G545) for a single execution unit. --clear converges both back to unblocked. Each");
+        writer.WriteLine("side is converged independently and idempotently, so re-running after a partial failure");
+        writer.WriteLine("only retries whatever has not yet converged. Never uses raw gh label mutation or a direct");
+        writer.WriteLine("queue-state hand-edit.");
     }
 }
 
@@ -294,6 +643,9 @@ internal sealed record AutomationIssueBlockResult
 {
     [JsonPropertyName("repo")]
     public required string Repo { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
 
     [JsonPropertyName("issue")]
     public required int Issue { get; init; }
@@ -307,30 +659,60 @@ internal sealed record AutomationIssueBlockResult
     [JsonPropertyName("clear")]
     public required bool Clear { get; init; }
 
-    [JsonPropertyName("applied")]
-    public required bool Applied { get; init; }
-
-    [JsonPropertyName("blocked_label")]
-    public required string BlockedLabel { get; init; }
-
-    [JsonPropertyName("had_blocked_label")]
-    public required bool HadBlockedLabel { get; init; }
-
     [JsonPropertyName("reason")]
     public string? Reason { get; init; }
 
-    [JsonPropertyName("add_labels")]
-    public required IReadOnlyList<string> AddLabels { get; init; }
+    [JsonPropertyName("queue")]
+    public required AutomationIssueBlockQueueResult Queue { get; init; }
 
-    [JsonPropertyName("remove_labels")]
-    public required IReadOnlyList<string> RemoveLabels { get; init; }
+    [JsonPropertyName("label")]
+    public required AutomationIssueBlockLabelResult Label { get; init; }
 
-    [JsonPropertyName("current_labels")]
-    public required IReadOnlyList<string> CurrentLabels { get; init; }
+    [JsonPropertyName("converged")]
+    public required bool Converged { get; init; }
 
     [JsonPropertyName("transitioned_at")]
     public required DateTimeOffset TransitionedAt { get; init; }
 
     [JsonPropertyName("summary")]
     public required string Summary { get; init; }
+}
+
+internal sealed record AutomationIssueBlockQueueResult
+{
+    [JsonPropertyName("before_state")]
+    public required string BeforeState { get; init; }
+
+    [JsonPropertyName("before_blocked_by")]
+    public required IReadOnlyList<string> BeforeBlockedBy { get; init; }
+
+    [JsonPropertyName("target_state")]
+    public required string TargetState { get; init; }
+
+    [JsonPropertyName("already_converged")]
+    public required bool AlreadyConverged { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("after_state")]
+    public required string AfterState { get; init; }
+
+    [JsonPropertyName("after_blocked_by")]
+    public required IReadOnlyList<string> AfterBlockedBy { get; init; }
+}
+
+internal sealed record AutomationIssueBlockLabelResult
+{
+    [JsonPropertyName("blocked_label")]
+    public required string BlockedLabel { get; init; }
+
+    [JsonPropertyName("had_blocked_label")]
+    public required bool HadBlockedLabel { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("current_labels")]
+    public required IReadOnlyList<string> CurrentLabels { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
@@ -23,10 +23,13 @@ namespace IntentSystem.Cli.Commands;
 /// left queue-state untouched, immediately recreating the exact drift this
 /// slice exists to close. The execution unit is now a REQUIRED positional
 /// argument (never guessed from the issue title) so "which queue item does
-/// this affect" is resolved exactly, not heuristically — and, when the
-/// queue item declares a <see cref="QueueItem.LinkedIssue"/>, its number is
-/// cross-checked against <c>--issue</c>, refusing to label a possibly-wrong
-/// issue rather than trusting the caller blindly.
+/// this affect" is resolved exactly, not heuristically — and the queue item
+/// must carry a COMPLETE <see cref="QueueItem.LinkedIssue"/> whose repo
+/// (canonicalized, case-insensitive) and number BOTH agree with
+/// <c>--repo</c>/<c>--issue</c> (G545 round 3). Missing linkage, a different
+/// repo, and a different number are each refused before any interaction
+/// with the run log, queue-state, or GitHub — a missing linkage is absent
+/// evidence, not consent, and issue #818 exists in almost every repository.
 ///
 /// Fail-closed, repairable write order — mirrors <see
 /// cref="QueueReprioritizeCommand"/>'s established convention: the queue-side
@@ -130,17 +133,26 @@ internal static class AutomationIssueBlockCommand
             return 1;
         }
 
-        if (queueItem.LinkedIssue is { Number: { } linkedNumber } && linkedNumber != issue)
+        if (!TryValidateLinkedIssue(queueItem, executionUnit!, repo!, issue!.Value, out var linkageError))
         {
-            writer.WriteLine(
-                $"'{executionUnit}'s queue-state linked_issue is #{linkedNumber}, not the requested #{issue}; "
-                + "refusing to label a possibly-wrong issue. Re-invoke with the linked issue number, or fix the "
-                + "queue-state linkage first.");
+            writer.WriteLine(linkageError);
             return 1;
         }
 
         var now = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
         var runLogPath = context.GetRunLogPath();
+
+        // G545 round 3: a present-but-unreadable audit trail stops everything
+        // BEFORE any interaction — no append, no queue write, no label read or
+        // mutation. Transitioning against a run log we cannot parse would
+        // record the transition into a file whose existing content is already
+        // unknown, and would decide retry-vs-fresh-append from no evidence at
+        // all. A MISSING run log stays the valid first-event case.
+        if (!TryLoadRunEvents(runLogPath, out var runEvents, out var runLogError))
+        {
+            writer.WriteLine(runLogError);
+            return 1;
+        }
         var beforeState = queueItem.State;
         var beforeBlockedBy = queueItem.BlockedBy;
 
@@ -148,8 +160,8 @@ internal static class AutomationIssueBlockCommand
         try
         {
             queueResult = clear
-                ? ConvergeQueueSide(queueStatePath, runLogPath, queueState, queueItem, executionUnit!, UnblockTargetState, reason: null, write, now)
-                : ConvergeQueueSide(queueStatePath, runLogPath, queueState, queueItem, executionUnit!, QueueItemState.Blocked, reason, write, now);
+                ? ConvergeQueueSide(queueStatePath, runLogPath, runEvents, queueState, queueItem, executionUnit!, UnblockTargetState, reason: null, write, now)
+                : ConvergeQueueSide(queueStatePath, runLogPath, runEvents, queueState, queueItem, executionUnit!, QueueItemState.Blocked, reason, write, now);
         }
         catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
         {
@@ -289,6 +301,7 @@ internal static class AutomationIssueBlockCommand
     private static QueueQueueSideResult ConvergeQueueSide(
         string queueStatePath,
         string runLogPath,
+        IReadOnlyList<RunEvent> runEvents,
         QueueState queueState,
         QueueItem queueItem,
         string executionUnit,
@@ -334,7 +347,7 @@ internal static class AutomationIssueBlockCommand
         }
 
         var eventName = targetState == QueueItemState.Blocked ? "blocked" : MapUnblockEventName(targetState);
-        var pendingEvent = FindPendingRetryEvent(runLogPath, executionUnit, eventName, reason);
+        var pendingEvent = FindPendingRetryEvent(runEvents, executionUnit, eventName, reason);
 
         RunEvent runEvent;
         QueueState updatedState;
@@ -410,26 +423,9 @@ internal static class AutomationIssueBlockCommand
     /// cycle reusing the same reason text), the matching event is historical,
     /// not pending, and a fresh event is appended instead.
     /// </summary>
-    private static RunEvent? FindPendingRetryEvent(string runLogPath, string executionUnit, string eventName, string? reason)
+    private static RunEvent? FindPendingRetryEvent(
+        IReadOnlyList<RunEvent> events, string executionUnit, string eventName, string? reason)
     {
-        if (!File.Exists(runLogPath))
-        {
-            return null;
-        }
-
-        IReadOnlyList<RunEvent> events;
-        try
-        {
-            events = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
-        }
-        catch (Exception exception) when (exception is InvalidOperationException or JsonException)
-        {
-            // Fail OPEN: an unreadable runs.jsonl must never suppress a
-            // genuinely-needed audit event. Worst case is a redundant
-            // append once the file is repaired.
-            return null;
-        }
-
         var lastForUnit = events.LastOrDefault(runEvent => string.Equals(runEvent.ExecutionUnit, executionUnit, StringComparison.Ordinal));
         if (lastForUnit is null
             || !string.Equals(lastForUnit.Event, eventName, StringComparison.Ordinal)
@@ -444,6 +440,142 @@ internal static class AutomationIssueBlockCommand
         }
 
         return lastForUnit;
+    }
+
+    /// <summary>
+    /// G545 round 3: the queue item's <c>linked_issue</c> must be COMPLETE
+    /// (present, with both a repo and a number) and must agree with BOTH
+    /// <c>--repo</c> and <c>--issue</c>. A missing linkage is not "no
+    /// objection" — it is missing evidence, and this command is the one that
+    /// binds a queue item to a GitHub issue, so it must not guess. Repos are
+    /// compared canonically (URL/ssh/<c>.git</c>/trailing-slash shapes
+    /// normalized to <c>owner/repo</c>) and case-insensitively, since GitHub
+    /// owner/repo names are case-insensitive; the issue number is compared
+    /// exactly. Same number in a DIFFERENT repo is the dangerous case this
+    /// closes: issue #818 exists in almost every repository.
+    /// </summary>
+    private static bool TryValidateLinkedIssue(QueueItem queueItem, string executionUnit, string repo, int issue, out string error)
+    {
+        var linked = queueItem.LinkedIssue;
+        if (linked is null || string.IsNullOrWhiteSpace(linked.Repo) || linked.Number is null)
+        {
+            error =
+                $"'{executionUnit}' has no complete queue-state linked_issue (need both repo and number, found "
+                + $"{DescribeLinkage(linked)}); refusing to bind issue #{issue} in {repo} to it. Record the linkage "
+                + "in queue-state.json first, then re-run this exact command.";
+            return false;
+        }
+
+        var canonicalLinkedRepo = CanonicalizeRepo(linked.Repo);
+        var canonicalRequestedRepo = CanonicalizeRepo(repo);
+        if (canonicalLinkedRepo is null || canonicalRequestedRepo is null)
+        {
+            error =
+                $"'{executionUnit}'s queue-state linked_issue repo '{linked.Repo}' or the requested repo '{repo}' is "
+                + "not a recognizable owner/repo; refusing to act on an ambiguous repository.";
+            return false;
+        }
+
+        if (!string.Equals(canonicalLinkedRepo, canonicalRequestedRepo, StringComparison.Ordinal))
+        {
+            error =
+                $"'{executionUnit}'s queue-state linked_issue is in {linked.Repo}, not the requested {repo}; "
+                + "refusing to label an issue in a different repository (the same issue number exists in almost "
+                + "every repo). Re-invoke against the linked repo, or fix the queue-state linkage first.";
+            return false;
+        }
+
+        if (linked.Number.Value != issue)
+        {
+            error =
+                $"'{executionUnit}'s queue-state linked_issue is #{linked.Number.Value}, not the requested #{issue}; "
+                + "refusing to label a possibly-wrong issue. Re-invoke with the linked issue number, or fix the "
+                + "queue-state linkage first.";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    private static string DescribeLinkage(LinkedIssue? linked) => linked is null
+        ? "no linked_issue at all"
+        : $"repo '{(string.IsNullOrWhiteSpace(linked.Repo) ? "(none)" : linked.Repo)}', number {(linked.Number is null ? "(none)" : linked.Number.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))}";
+
+    /// <summary>
+    /// Normalizes the GitHub repository shapes queue-state has been observed
+    /// to carry (bare <c>owner/repo</c>, an https URL, an ssh remote, any of
+    /// them with a <c>.git</c> suffix or trailing slash) down to a
+    /// lowercased <c>owner/repo</c>. Returns null when the value is not a
+    /// recognizable repository, so the caller can fail closed rather than
+    /// compare two unparseable strings.
+    /// </summary>
+    private static string? CanonicalizeRepo(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var normalized = value.Trim();
+        if (normalized.Contains("://", StringComparison.Ordinal)
+            || normalized.StartsWith("git@", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                normalized = GitHubRepositoryTargetResolver.ParseRemoteUrl(normalized);
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or ArgumentException)
+            {
+                return null;
+            }
+        }
+
+        normalized = normalized.Trim('/');
+        if (normalized.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+        {
+            normalized = normalized[..^4];
+        }
+
+        var segments = normalized.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return segments.Length == 2
+            ? $"{segments[0].ToLowerInvariant()}/{segments[1].ToLowerInvariant()}"
+            : null;
+    }
+
+    /// <summary>
+    /// G545 round 3: loads the existing audit trail, failing LOUD when the
+    /// file is present but unreadable/unparseable. The previous fail-open
+    /// behavior let the command append a fresh event and mutate queue-state
+    /// against a trail whose content it could not read — deciding
+    /// "retry or fresh append" from no evidence, and writing into a file
+    /// already known to be corrupt. A MISSING run log is still the valid
+    /// first-event case and yields an empty list.
+    /// </summary>
+    private static bool TryLoadRunEvents(string runLogPath, out IReadOnlyList<RunEvent> events, out string error)
+    {
+        events = Array.Empty<RunEvent>();
+        error = string.Empty;
+
+        if (!File.Exists(runLogPath))
+        {
+            return true;
+        }
+
+        try
+        {
+            events = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+            return true;
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
+        {
+            error =
+                $"the existing run log at {runLogPath} could not be read: {exception.Message}. Refusing to transition "
+                + "against an unreadable audit trail — nothing was appended, no queue state was written, and GitHub "
+                + "labels were not read or changed. Repair the run log first (e.g. `intent-cli automation runs-audit "
+                + "--format json`), then re-run this exact command.";
+            return false;
+        }
     }
 
     private static void AppendRunEvent(string runLogPath, RunEvent runEvent)

--- a/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
@@ -1,0 +1,336 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G545: the canonical issue-level mirror of queue-state's <c>state=blocked</c>
+/// — <c>intent-cli automation issue-block --repo &lt;owner/repo&gt; --issue &lt;n&gt;
+/// --reason &lt;text&gt; [--write] [--dry-run] [--format text|json]</c> applies
+/// <see cref="WorkerNextActionConstants.Labels.IntentIssueBlocked"/>, recording
+/// the queue's own <c>blocked_by</c> reason text; the counterpart <c>--clear</c>
+/// removes it once the unit is unblocked. Coexists with
+/// <see cref="WorkerNextActionConstants.Labels.IntentIssueInProgress"/> rather
+/// than replacing it — the worker still owns the issue, it just cannot
+/// currently proceed. Dry-run by default; WITHOUT raw <c>gh ... edit
+/// --add-label</c>/<c>--remove-label</c>, mutating labels only through the
+/// installed <see cref="IGitHubLabelMutator"/>, exactly like the existing
+/// <see cref="AutomationIssueReleaseCommand"/>. Never edits queue-state or
+/// runs.jsonl, and never launches an AI provider — this command only makes
+/// GitHub agree with a `blocked` transition that already happened via
+/// <c>queue transition &lt;unit&gt; blocked --reason &lt;text&gt;</c>.
+/// </summary>
+internal static class AutomationIssueBlockCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+    private const string BlockedLabel = WorkerNextActionConstants.Labels.IntentIssueBlocked;
+
+    public static Func<IGitHubLabelMutator>? MutatorFactory { get; set; }
+
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var repo, out var issue, out var reason, out var clear, out var mode, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        IGitHubLabelMutator mutator;
+        try
+        {
+            mutator = MutatorFactory?.Invoke() ?? new GhCliGitHubLabelMutator();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to initialize GitHub mutator: {exception.Message}");
+            return 1;
+        }
+
+        IReadOnlyList<string> currentLabels;
+        try
+        {
+            currentLabels = mutator
+                .ReadLabels(repo!, GhCliGitHubLabelMutator.Kinds.Issue, issue!.Value)
+                .Select(label => label.Name)
+                .Where(name => !string.IsNullOrWhiteSpace(name))
+                .ToArray();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException)
+        {
+            writer.WriteLine($"failed to read current labels for issue #{issue} in {repo}: {exception.Message}");
+            return 1;
+        }
+
+        var hasBlockedLabel = currentLabels.Contains(BlockedLabel, StringComparer.Ordinal);
+        var applied = false;
+        var transitionAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var isWrite = string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal);
+
+        if (clear)
+        {
+            if (isWrite && hasBlockedLabel)
+            {
+                try
+                {
+                    mutator.ApplyLabelTransitions(repo!, GhCliGitHubLabelMutator.Kinds.Issue, issue!.Value, Array.Empty<string>(), [BlockedLabel]);
+                    applied = true;
+                }
+                catch (Exception exception) when (exception is InvalidOperationException or IOException)
+                {
+                    writer.WriteLine($"failed to clear the blocked transition on issue #{issue} in {repo}: {exception.Message}");
+                    return 1;
+                }
+            }
+        }
+        else if (isWrite && !hasBlockedLabel)
+        {
+            try
+            {
+                mutator.ApplyLabelTransitions(repo!, GhCliGitHubLabelMutator.Kinds.Issue, issue!.Value, [BlockedLabel], Array.Empty<string>());
+                applied = true;
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or IOException)
+            {
+                writer.WriteLine($"failed to apply the blocked transition on issue #{issue} in {repo}: {exception.Message}");
+                return 1;
+            }
+        }
+
+        var result = new AutomationIssueBlockResult
+        {
+            Repo = repo!,
+            Issue = issue!.Value,
+            IssueUrl = BuildIssueUrl(repo!, issue.Value),
+            Mode = mode,
+            Clear = clear,
+            Applied = applied,
+            BlockedLabel = BlockedLabel,
+            HadBlockedLabel = hasBlockedLabel,
+            Reason = reason,
+            AddLabels = clear ? Array.Empty<string>() : [BlockedLabel],
+            RemoveLabels = clear ? [BlockedLabel] : Array.Empty<string>(),
+            CurrentLabels = currentLabels,
+            TransitionedAt = transitionAt,
+            Summary = BuildSummary(issue.Value, clear, hasBlockedLabel, reason),
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            WriteText(writer, result);
+        }
+
+        return 0;
+    }
+
+    private static string BuildSummary(int issue, bool clear, bool hasBlockedLabel, string? reason)
+    {
+        if (clear)
+        {
+            return hasBlockedLabel
+                ? $"Would clear the blocked transition on issue #{issue} by removing {BlockedLabel}."
+                : $"Issue #{issue} does not carry {BlockedLabel}; nothing to clear.";
+        }
+
+        return hasBlockedLabel
+            ? $"Issue #{issue} already carries {BlockedLabel}; nothing to apply."
+            : $"Would apply the blocked transition on issue #{issue} by adding {BlockedLabel}"
+                + (string.IsNullOrWhiteSpace(reason) ? "." : $" (reason: {reason}).");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? repo,
+        out int? issue,
+        out string? reason,
+        out bool clear,
+        out string mode,
+        out string format,
+        out string error)
+    {
+        repo = null;
+        issue = null;
+        reason = null;
+        clear = false;
+        mode = WorkerClaimCompleteConstants.Modes.DryRun;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--repo":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { error = "--repo requires a value (e.g. owner/repo)."; return false; }
+                    repo = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--issue":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var issueNumber)
+                        || issueNumber <= 0)
+                    {
+                        error = "--issue requires a positive integer.";
+                        return false;
+                    }
+                    issue = issueNumber;
+                    index++;
+                    break;
+                case "--reason":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { error = "--reason requires a value."; return false; }
+                    reason = args[index + 1].Trim();
+                    index++;
+                    break;
+                case "--clear":
+                    clear = true;
+                    break;
+                case "--write":
+                    mode = WorkerClaimCompleteConstants.Modes.Write;
+                    break;
+                case "--dry-run":
+                    mode = WorkerClaimCompleteConstants.Modes.DryRun;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1])) { error = "--format requires a value (text or json)."; return false; }
+                    var requestedFormat = args[index + 1];
+                    if (!string.Equals(requestedFormat, FormatText, StringComparison.Ordinal)
+                        && !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'text' or 'json' (got '{requestedFormat}').";
+                        return false;
+                    }
+                    format = requestedFormat;
+                    index++;
+                    break;
+                default:
+                    error = $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --issue <n> [--reason <text>] [--clear] [--write] [--dry-run] [--format text|json].";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(repo))
+        {
+            error = "--repo is required.";
+            return false;
+        }
+
+        if (issue is null)
+        {
+            error = "--issue is required.";
+            return false;
+        }
+
+        if (clear && !string.IsNullOrWhiteSpace(reason))
+        {
+            error = "--reason is only supported when applying the blocked transition, not with --clear.";
+            return false;
+        }
+
+        if (!clear && string.IsNullOrWhiteSpace(reason))
+        {
+            error = "--reason is required unless --clear is given — a blocked transition without a recorded reason is not permitted.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string BuildIssueUrl(string repo, int issue) =>
+        $"https://github.com/{repo}/issues/{issue.ToString(System.Globalization.CultureInfo.InvariantCulture)}";
+
+    private static void WriteText(TextWriter writer, AutomationIssueBlockResult result)
+    {
+        writer.WriteLine(result.Summary);
+        writer.WriteLine($"mode: {result.Mode}");
+        writer.WriteLine($"repo: {result.Repo}");
+        writer.WriteLine($"issue: {result.Issue.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+        writer.WriteLine($"issue_url: {result.IssueUrl}");
+        writer.WriteLine($"clear: {result.Clear.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"blocked_label: {result.BlockedLabel}");
+        writer.WriteLine($"had_blocked_label: {result.HadBlockedLabel.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"applied: {result.Applied.ToString().ToLowerInvariant()}");
+        if (!string.IsNullOrWhiteSpace(result.Reason))
+        {
+            writer.WriteLine($"reason: {result.Reason}");
+        }
+        writer.WriteLine($"transitioned_at: {result.TransitionedAt:O}");
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("automation issue-block");
+        writer.WriteLine("Usage: intent-cli automation issue-block --repo <owner/repo> --issue <n> --reason <text> [--write] [--dry-run] [--format text|json]");
+        writer.WriteLine("       intent-cli automation issue-block --repo <owner/repo> --issue <n> --clear [--write] [--dry-run] [--format text|json]");
+        writer.WriteLine("Applies (or, with --clear, removes) the issue-level intent-issue-blocked label (G545) so GitHub");
+        writer.WriteLine("agrees with a queue-state `blocked` transition. Coexists with intent-issue-in-progress; never");
+        writer.WriteLine("uses raw gh label mutation.");
+    }
+}
+
+internal sealed record AutomationIssueBlockResult
+{
+    [JsonPropertyName("repo")]
+    public required string Repo { get; init; }
+
+    [JsonPropertyName("issue")]
+    public required int Issue { get; init; }
+
+    [JsonPropertyName("issue_url")]
+    public required string IssueUrl { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("clear")]
+    public required bool Clear { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("blocked_label")]
+    public required string BlockedLabel { get; init; }
+
+    [JsonPropertyName("had_blocked_label")]
+    public required bool HadBlockedLabel { get; init; }
+
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+
+    [JsonPropertyName("add_labels")]
+    public required IReadOnlyList<string> AddLabels { get; init; }
+
+    [JsonPropertyName("remove_labels")]
+    public required IReadOnlyList<string> RemoveLabels { get; init; }
+
+    [JsonPropertyName("current_labels")]
+    public required IReadOnlyList<string> CurrentLabels { get; init; }
+
+    [JsonPropertyName("transitioned_at")]
+    public required DateTimeOffset TransitionedAt { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -812,8 +812,8 @@ internal static class AutomationStalledWorkCommand
                             $"queue-state reports `{resolution.ExecutionUnit}` as blocked (blocked_by: {blockedReason}), "
                             + $"but issue #{issue.Number} does not yet carry the "
                             + $"`{WorkerNextActionConstants.Labels.IntentIssueBlocked}` label — reconcile via: "
-                            + $"intent-cli automation issue-block --repo {repo} --issue {issue.Number} "
-                            + $"--reason \"{blockedReason}\" --write --format json",
+                            + $"intent-cli automation issue-block {resolution.ExecutionUnit} --repo {repo} "
+                            + $"--issue {issue.Number} --reason \"{blockedReason}\" --write --format json",
                     });
                 }
 

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -56,7 +56,15 @@ namespace IntentSystem.Cli.Commands;
 ///   <see cref="DefaultClaimedSilentMinutes"/> minutes) — the third measured
 ///   field stall class (silent completion / dead worker after claim).
 ///   Recommends a worker status check, never assumes completion or
-///   failure from silence alone.</item>
+///   failure from silence alone. EXEMPTS a unit whose queue-state item is
+///   <see cref="QueueItemState.Blocked"/> — see <c>blocked-label-drift</c>
+///   below (G545).</item>
+/// <item><c>blocked-label-drift</c> (G545) — a queue-blocked unit
+///   (<c>state=blocked</c>) whose GitHub labels have not yet been
+///   reconciled onto <see cref="WorkerNextActionConstants.Labels.IntentIssueBlocked"/>
+///   — never <c>claimed-but-silent</c>, since the unit is legitimately
+///   waiting, not silently stalled. Names the canonical <c>automation
+///   issue-block</c> reconcile command.</item>
 /// </list>
 ///
 /// Age is approximated from the relevant GitHub entity's `createdAt` /
@@ -144,6 +152,22 @@ internal static class AutomationStalledWorkCommand
     /// from silence alone).
     /// </summary>
     public const string KindClaimedButSilent = "claimed-but-silent";
+
+    /// <summary>
+    /// G545: an issue carrying <c>intent-target</c> + <c>intent-issue-in-progress</c>
+    /// (no PR yet) whose queue-state item is <c>state=blocked</c>, but whose
+    /// GitHub labels do not yet carry <see
+    /// cref="WorkerNextActionConstants.Labels.IntentIssueBlocked"/> — a
+    /// transitional GitHub/queue-state mismatch, never a stall: the unit is
+    /// legitimately waiting on its recorded <c>blocked_by</c> reason, it
+    /// simply hasn't been reconciled onto GitHub yet. Informational;
+    /// <c>recommended_action</c> names the canonical <c>automation
+    /// issue-block</c> reconcile command. Field finding, 2026-07-21
+    /// (sekiban-as-a-service): SKS-G818 and four peers were queue-blocked on
+    /// an explicit dependency but reported as <see cref="KindClaimedButSilent"/>
+    /// every wake because <c>claimed-but-silent</c> read only GitHub labels.
+    /// </summary>
+    public const string KindBlockedLabelDrift = "blocked-label-drift";
 
     /// <summary>
     /// G544: fires when WIP is empty for the requested domain (no open
@@ -294,7 +318,7 @@ internal static class AutomationStalledWorkCommand
         CollectPublishedNotDelegated(context, domain, candidateDomains, openIssues, openPrs, repo, now, items, excluded);
         CollectPrCreatedNotReviewing(context, domain, candidateDomains, openIssues, openPrs, repo, now, items, excluded);
         CollectMergedNotClosedOut(context, domain, candidateDomains, repo, mergedPrs, now, items, excluded, warnings);
-        CollectClaimedButSilent(context, domain, candidateDomains, openIssues, openPrs, repo, now, claimedSilentMinutes, items, excluded);
+        CollectClaimedButSilent(context, domain, candidateDomains, openIssues, openPrs, repo, now, claimedSilentMinutes, items, excluded, warnings);
         CollectBacklogReadyIdle(context, domain, candidateDomains, openIssues, openPrs, repo, now, backlogIdleMinutes, items, excluded);
 
         var filtered = items
@@ -717,8 +741,16 @@ internal static class AutomationStalledWorkCommand
         DateTimeOffset now,
         int claimedSilentMinutes,
         List<StalledWorkItem> items,
-        List<StalledWorkExcluded> excluded)
+        List<StalledWorkExcluded> excluded,
+        List<string> warnings)
     {
+        // G545: consulted once per call, not per issue. Missing/unparseable
+        // queue-state is never fatal to this kind — it simply means the
+        // blocked exemption below cannot be evaluated for any candidate,
+        // preserving the exact pre-G545 behavior (a domain that never uses
+        // queue-state.json must not lose claimed-but-silent detection).
+        var queueState = TryLoadQueueStateForClaimedButSilent(context, domain, repo, warnings);
+
         foreach (var issue in openIssues)
         {
             if (!IsOpen(issue.State))
@@ -748,6 +780,46 @@ internal static class AutomationStalledWorkCommand
             // collector in this file already follows.
             var resolution = ResolveExecutionUnit(context, issue.Title);
             var issueRef = new StalledWorkRef { Number = issue.Number, Url = issue.Url };
+
+            // G545 field finding (sekiban-as-a-service, 2026-07-21,
+            // SKS-G818): a unit legitimately `state=blocked` in queue-state
+            // (an explicit `blocked_by` reason recorded via `queue
+            // transition <unit> blocked --reason <text>`) still carries
+            // `intent-issue-in-progress` on GitHub — there is no GitHub-side
+            // signal this collector previously consulted to tell "silently
+            // stalled" apart from "correctly waiting on a recorded
+            // dependency". A blocked queue item exempts its issue from
+            // claimed-but-silent entirely; if the reconcile label hasn't
+            // been applied yet, the mismatch is surfaced as the
+            // transitional, informational `blocked-label-drift` kind
+            // instead — never as a silent-stall false positive.
+            var queueItem = queueState?.Items.FirstOrDefault(
+                candidate => string.Equals(candidate.ExecutionUnit, resolution.ExecutionUnit, StringComparison.Ordinal));
+            if (queueItem is { State: QueueItemState.Blocked })
+            {
+                if (!labels.Contains(WorkerNextActionConstants.Labels.IntentIssueBlocked))
+                {
+                    var blockedReason = string.Join("; ", queueItem.BlockedBy);
+                    items.Add(new StalledWorkItem
+                    {
+                        Kind = KindBlockedLabelDrift,
+                        ExecutionUnit = resolution.ExecutionUnit,
+                        Issue = issueRef,
+                        Pr = null,
+                        AgeMinutes = ComputeAgeMinutes(issue.UpdatedAt, now),
+                        IsInformational = true,
+                        RecommendedAction =
+                            $"queue-state reports `{resolution.ExecutionUnit}` as blocked (blocked_by: {blockedReason}), "
+                            + $"but issue #{issue.Number} does not yet carry the "
+                            + $"`{WorkerNextActionConstants.Labels.IntentIssueBlocked}` label — reconcile via: "
+                            + $"intent-cli automation issue-block --repo {repo} --issue {issue.Number} "
+                            + $"--reason \"{blockedReason}\" --write --format json",
+                    });
+                }
+
+                // Legitimately blocked either way — never claimed-but-silent.
+                continue;
+            }
 
             if (!TryParseActivityTimestamp(issue.UpdatedAt, out var issueActivity, out var issueProblem))
             {
@@ -851,6 +923,34 @@ internal static class AutomationStalledWorkCommand
                     + $"for {silentMinutes}m since claim — ask the assigned worker for a status update; "
                     + "do not assume completion, failure, or transition state from silence alone.",
             });
+        }
+    }
+
+    /// <summary>
+    /// G545: tolerant queue-state load for <see cref="CollectClaimedButSilent"/>'s
+    /// blocked exemption — missing or malformed queue-state is warned about
+    /// (mirroring <see cref="CollectMergedNotClosedOut"/>'s own convention)
+    /// but never fatal to the caller: it simply means the blocked exemption
+    /// cannot be evaluated for any candidate this call, so every issue falls
+    /// through to the pre-G545 claimed-but-silent logic unchanged.
+    /// </summary>
+    private static QueueState? TryLoadQueueStateForClaimedButSilent(
+        CliContext context, string domain, string repo, List<string> warnings)
+    {
+        var queueStateLocation = RuntimeScopedStateResolver.ResolveQueueStatePathForRead(context.RepoRoot, domain, repo);
+        if (!File.Exists(queueStateLocation.Path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return QueueStateSerializer.Deserialize(File.ReadAllText(queueStateLocation.Path));
+        }
+        catch (Exception exception) when (exception is JsonException or InvalidOperationException)
+        {
+            warnings.Add($"queue-state at '{queueStateLocation.Path}' could not be parsed: {exception.Message}; skipped the claimed-but-silent blocked exemption.");
+            return null;
         }
     }
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -180,6 +180,7 @@ internal static class CommandRouter
                 ["host-queue-item-recovery"] = AutomationHostQueueItemRecoveryCommand.Execute,
                 ["host-sync-preflight"] = AutomationHostSyncPreflightCommand.Execute,
                 ["intent-target-gap-recovery"] = AutomationIntentTargetGapRecoveryCommand.Execute,
+                ["issue-block"] = AutomationIssueBlockCommand.Execute,
                 ["issue-publish"] = AutomationIssuePublishCommand.Execute,
                 ["issue-release"] = AutomationIssueReleaseCommand.Execute,
                 ["issue-retire"] = AutomationIssueRetireCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/WorkerNextActionResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerNextActionResult.cs
@@ -214,5 +214,14 @@ internal static class WorkerNextActionConstants
         public const string IntentIssueInProgress = "intent-issue-in-progress";
         public const string IntentPrCreated = "intent-pr-created";
         public const string IntentPrReviewing = "intent-pr-reviewing";
+
+        /// <summary>
+        /// G545: issue-level canonical representation of the queue's
+        /// <c>state=blocked</c> — applied/cleared only via <c>automation
+        /// issue-block</c>, never a raw <c>gh</c> label edit. Coexists with
+        /// <see cref="IntentIssueInProgress"/> (the worker still owns the
+        /// issue; it just cannot currently proceed) rather than replacing it.
+        /// </summary>
+        public const string IntentIssueBlocked = "intent-issue-blocked";
     }
 }

--- a/src/IntentSystem.Cli/Commands/WorkflowLabelPaletteContract.cs
+++ b/src/IntentSystem.Cli/Commands/WorkflowLabelPaletteContract.cs
@@ -77,6 +77,15 @@ internal static class WorkflowLabelPaletteContract
             Color = "0E8A16",
             Description = "PR is approved by intent automation review; ready to merge + close out."
         },
+        // G545: issue-level mirror of queue-state's state=blocked, applied/
+        // cleared only via `automation issue-block`. Coexists with
+        // intent-issue-in-progress rather than replacing it.
+        new()
+        {
+            Name = "intent-issue-blocked",
+            Color = "C5DEF5",
+            Description = "Issue is blocked in queue-state (see linked blocked_by reason); worker still owns it."
+        },
         // G374: structured worker-signal protocol. These two labels are
         // the durable pending/handled markers a child implementation
         // worker uses to hand a blocker / follow-up / scope-warning back

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueBlockCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueBlockCommandTests.cs
@@ -1,0 +1,236 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G545: tests for the canonical issue-level blocked transition that applies
+/// (or, with <c>--clear</c>, removes) <c>intent-issue-blocked</c> without raw
+/// gh label mutation.
+/// </summary>
+public sealed class AutomationIssueBlockCommandTests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 7, 21, 12, 0, 0, TimeSpan.Zero);
+
+    public AutomationIssueBlockCommandTests()
+    {
+        AutomationIssueBlockCommand.MutatorFactory = null;
+        AutomationIssueBlockCommand.UtcNowFactory = () => FixedNow;
+    }
+
+    public void Dispose()
+    {
+        AutomationIssueBlockCommand.MutatorFactory = null;
+        AutomationIssueBlockCommand.UtcNowFactory = null;
+    }
+
+    [Fact]
+    public void Execute_Write_AppliesBlockedLabelWithReason()
+    {
+        using var workspace = new Workspace();
+        var mutator = new FakeMutator(new[] { "intent-target", "intent-issue-in-progress" });
+        AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueBlockCommand.Execute(
+            workspace.Context,
+            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818",
+             "--reason", "SKS-G837", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.False(result.Clear);
+        Assert.False(result.HadBlockedLabel);
+        Assert.Contains("intent-issue-blocked", result.AddLabels);
+        Assert.Empty(result.RemoveLabels);
+        Assert.Equal("SKS-G837", result.Reason);
+
+        var transition = Assert.Single(mutator.Transitions);
+        Assert.Equal("issue", transition.Kind);
+        Assert.Equal(818, transition.Number);
+        Assert.Contains("intent-issue-blocked", transition.AddLabels);
+        Assert.Empty(transition.RemoveLabels);
+    }
+
+    [Fact]
+    public void Execute_Write_Clear_RemovesBlockedLabel()
+    {
+        using var workspace = new Workspace();
+        var mutator = new FakeMutator(new[] { "intent-target", "intent-issue-in-progress", "intent-issue-blocked" });
+        AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueBlockCommand.Execute(
+            workspace.Context,
+            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--clear", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
+        Assert.True(result.Applied);
+        Assert.True(result.Clear);
+        Assert.True(result.HadBlockedLabel);
+        Assert.Contains("intent-issue-blocked", result.RemoveLabels);
+        Assert.Empty(result.AddLabels);
+
+        var transition = Assert.Single(mutator.Transitions);
+        Assert.Contains("intent-issue-blocked", transition.RemoveLabels);
+        Assert.Empty(transition.AddLabels);
+    }
+
+    [Fact]
+    public void Execute_DryRun_DoesNotMutate()
+    {
+        using var workspace = new Workspace();
+        var mutator = new FakeMutator(new[] { "intent-target", "intent-issue-in-progress" });
+        AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueBlockCommand.Execute(
+            workspace.Context,
+            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--reason", "SKS-G837", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
+        Assert.False(result.Applied);
+        Assert.False(result.HadBlockedLabel);
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void Execute_AlreadyBlocked_IsIdempotent_NothingToApply()
+    {
+        using var workspace = new Workspace();
+        var mutator = new FakeMutator(new[] { "intent-target", "intent-issue-in-progress", "intent-issue-blocked" });
+        AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueBlockCommand.Execute(
+            workspace.Context,
+            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--reason", "SKS-G837", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
+        Assert.True(result.HadBlockedLabel);
+        Assert.False(result.Applied);
+        Assert.Empty(mutator.Transitions);
+        Assert.Contains("nothing to apply", result.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_ClearWithoutBlockedLabel_IsIdempotent_NothingToClear()
+    {
+        using var workspace = new Workspace();
+        var mutator = new FakeMutator(new[] { "intent-target", "intent-issue-in-progress" });
+        AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueBlockCommand.Execute(
+            workspace.Context,
+            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--clear", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
+        Assert.False(result.HadBlockedLabel);
+        Assert.False(result.Applied);
+        Assert.Empty(mutator.Transitions);
+        Assert.Contains("nothing to clear", result.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Execute_RefusesReasonWithClear()
+    {
+        using var workspace = new Workspace();
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueBlockCommand.Execute(
+            workspace.Context,
+            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--clear", "--reason", "x", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--reason is only supported when applying", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RefusesMissingReasonWithoutClear()
+    {
+        using var workspace = new Workspace();
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssueBlockCommand.Execute(
+            workspace.Context,
+            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--write"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--reason is required unless --clear", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommandRouter_RegistersAutomationIssueBlock()
+    {
+        using var workspace = new Workspace();
+        AutomationIssueBlockCommand.MutatorFactory = () => new FakeMutator(new[] { "intent-target", "intent-issue-in-progress" });
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["automation", "issue-block", "--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--reason", "SKS-G837", "--format", "json"],
+            workspace.Context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
+        Assert.Equal(818, result.Issue);
+    }
+
+    private sealed class FakeMutator : IGitHubLabelMutator
+    {
+        private readonly IReadOnlyList<string> labels;
+        public List<Transition> Transitions { get; } = new();
+        public FakeMutator(IReadOnlyList<string> labels) => this.labels = labels;
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
+            labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+
+        public void ApplyLabelTransitions(string repo, string kind, int number,
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
+            Transitions.Add(new Transition(kind, number, addLabels.ToArray(), removeLabels.ToArray()));
+
+        public void ApplyReconcileTransitions(string repo, string kind, int number,
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed record Transition(string Kind, int Number, IReadOnlyList<string> AddLabels, IReadOnlyList<string> RemoveLabels);
+
+    private sealed class Workspace : IDisposable
+    {
+        public Workspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("automation-issue-block-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig { Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" } }
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueBlockCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueBlockCommandTests.cs
@@ -2,205 +2,627 @@ using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G545: tests for the canonical issue-level blocked transition that applies
-/// (or, with <c>--clear</c>, removes) <c>intent-issue-blocked</c> without raw
-/// gh label mutation.
+/// G545 (round-2 review repair): tests for the ONE canonical bounded
+/// transition that converges BOTH authoritative representations of "blocked"
+/// — queue-state (<c>state=blocked</c> + <c>blocked_by</c> reason) and the
+/// GitHub <c>intent-issue-blocked</c> label — for a single execution unit.
+///
+/// Every write-path test asserts against the ACTUAL on-disk
+/// <c>queue-state.json</c> / <c>runs.jsonl</c> and the ACTUAL label set the
+/// mutator now holds, never merely against the command's own result record,
+/// so "both sides agree" is proven rather than reported. Failure fixtures
+/// inject a failure on each side independently and then re-run the exact same
+/// command to prove the retry converges only what has not converged yet,
+/// without duplicating the audit event.
 /// </summary>
 public sealed class AutomationIssueBlockCommandTests : IDisposable
 {
+    private const string Repo = "sekiban-as-a-service/sekiban";
+    private const string BlockedLabel = "intent-issue-blocked";
+    private const string Unit = "SKS-G818";
+    private const string Reason = "SKS-G837";
+    private const int Issue = 818;
+
     private static readonly DateTimeOffset FixedNow = new(2026, 7, 21, 12, 0, 0, TimeSpan.Zero);
 
     public AutomationIssueBlockCommandTests()
     {
-        AutomationIssueBlockCommand.MutatorFactory = null;
+        ResetSeams();
         AutomationIssueBlockCommand.UtcNowFactory = () => FixedNow;
     }
 
-    public void Dispose()
+    public void Dispose() => ResetSeams();
+
+    private static void ResetSeams()
     {
         AutomationIssueBlockCommand.MutatorFactory = null;
         AutomationIssueBlockCommand.UtcNowFactory = null;
+        AutomationIssueBlockCommand.AppendRunEventOverride = null;
+        AutomationIssueBlockCommand.WriteQueueStateOverride = null;
     }
 
+    // ---------------------------------------------------------------
+    // Happy path: one transition converges both sides.
+    // ---------------------------------------------------------------
+
     [Fact]
-    public void Execute_Write_AppliesBlockedLabelWithReason()
+    public void Execute_Write_ConvergesQueueStateAndLabelInOneTransition()
     {
-        using var workspace = new Workspace();
-        var mutator = new FakeMutator(new[] { "intent-target", "intent-issue-in-progress" });
-        AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-target", "intent-issue-in-progress");
 
-        using var writer = new StringWriter();
-        var exitCode = AutomationIssueBlockCommand.Execute(
-            workspace.Context,
-            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818",
-             "--reason", "SKS-G837", "--write", "--format", "json"],
-            writer);
+        var result = workspace.Run(BlockArgs());
 
-        Assert.Equal(0, exitCode);
-        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
-        Assert.True(result.Applied);
-        Assert.False(result.Clear);
-        Assert.False(result.HadBlockedLabel);
-        Assert.Contains("intent-issue-blocked", result.AddLabels);
-        Assert.Empty(result.RemoveLabels);
-        Assert.Equal("SKS-G837", result.Reason);
+        Assert.True(result.Converged);
+        Assert.False(result.Queue.AlreadyConverged);
+        Assert.True(result.Queue.Applied);
+        Assert.Equal(Reason, result.Reason);
 
+        // Queue side, read back from disk.
+        var item = workspace.ReadQueueItem();
+        Assert.Equal(QueueItemState.Blocked, item.State);
+        Assert.Equal([Reason], item.BlockedBy);
+
+        // Durable audit, exactly one event, carrying the reason and actor.
+        var events = workspace.ReadRunEvents();
+        var appended = Assert.Single(events);
+        Assert.Equal("blocked", appended.Event);
+        Assert.Equal(Unit, appended.ExecutionUnit);
+        Assert.Equal(Reason, appended.Reason);
+        Assert.Equal("intent-cli automation issue-block", appended.By);
+
+        // GitHub side, read back from the mutator's actual label set.
+        Assert.Contains(BlockedLabel, mutator.Labels);
         var transition = Assert.Single(mutator.Transitions);
         Assert.Equal("issue", transition.Kind);
-        Assert.Equal(818, transition.Number);
-        Assert.Contains("intent-issue-blocked", transition.AddLabels);
+        Assert.Equal(Issue, transition.Number);
+        Assert.Equal([BlockedLabel], transition.AddLabels);
         Assert.Empty(transition.RemoveLabels);
+
+        // The claim the review demands: after apply, both sides agree.
+        AssertSidesAgree(workspace, mutator, expectedBlocked: true);
     }
 
     [Fact]
-    public void Execute_Write_Clear_RemovesBlockedLabel()
+    public void Execute_Write_Clear_ConvergesBothSidesBackToUnblocked_AndEmptiesBlockedBy()
     {
-        using var workspace = new Workspace();
-        var mutator = new FakeMutator(new[] { "intent-target", "intent-issue-in-progress", "intent-issue-blocked" });
-        AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: [Reason]);
+        var mutator = workspace.UseMutator("intent-target", "intent-issue-in-progress", BlockedLabel);
 
-        using var writer = new StringWriter();
-        var exitCode = AutomationIssueBlockCommand.Execute(
-            workspace.Context,
-            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--clear", "--write", "--format", "json"],
-            writer);
+        var result = workspace.Run(ClearArgs());
 
-        Assert.Equal(0, exitCode);
-        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
-        Assert.True(result.Applied);
-        Assert.True(result.Clear);
-        Assert.True(result.HadBlockedLabel);
-        Assert.Contains("intent-issue-blocked", result.RemoveLabels);
-        Assert.Empty(result.AddLabels);
+        Assert.True(result.Converged);
+        Assert.True(result.Queue.Applied);
 
+        // blocked_by must be EMPTIED, not merely left behind with the state
+        // flipped: IntentNextSliceCommand's gate rejects any item with a
+        // non-empty blocked_by, so a stale reason would keep the "cleared"
+        // unit unselectable — the same drift, relocated into queue-state.
+        var item = workspace.ReadQueueItem();
+        Assert.Equal(QueueItemState.Queued, item.State);
+        Assert.Empty(item.BlockedBy);
+        Assert.Empty(result.Queue.AfterBlockedBy);
+
+        var appended = Assert.Single(workspace.ReadRunEvents());
+        Assert.Equal("queued", appended.Event);
+        Assert.Equal("intent-cli automation issue-block", appended.By);
+
+        Assert.DoesNotContain(BlockedLabel, mutator.Labels);
         var transition = Assert.Single(mutator.Transitions);
-        Assert.Contains("intent-issue-blocked", transition.RemoveLabels);
+        Assert.Equal([BlockedLabel], transition.RemoveLabels);
         Assert.Empty(transition.AddLabels);
+
+        AssertSidesAgree(workspace, mutator, expectedBlocked: false);
     }
 
+    // ---------------------------------------------------------------
+    // Idempotency / one-sided convergence.
+    // ---------------------------------------------------------------
+
     [Fact]
-    public void Execute_DryRun_DoesNotMutate()
+    public void Execute_Write_AlreadyConvergedBothSides_MutatesNeitherSide()
     {
-        using var workspace = new Workspace();
-        var mutator = new FakeMutator(new[] { "intent-target", "intent-issue-in-progress" });
-        AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: [Reason]);
+        var mutator = workspace.UseMutator("intent-issue-in-progress", BlockedLabel);
+        var queueBefore = workspace.ReadQueueStateBytes();
 
-        using var writer = new StringWriter();
-        var exitCode = AutomationIssueBlockCommand.Execute(
-            workspace.Context,
-            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--reason", "SKS-G837", "--format", "json"],
-            writer);
+        var result = workspace.Run(BlockArgs());
 
-        Assert.Equal(0, exitCode);
-        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
-        Assert.False(result.Applied);
-        Assert.False(result.HadBlockedLabel);
+        Assert.True(result.Converged);
+        Assert.True(result.Queue.AlreadyConverged);
+        Assert.False(result.Queue.Applied);
+        Assert.True(result.Label.HadBlockedLabel);
+        Assert.False(result.Label.Applied);
+
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Empty(workspace.ReadRunEvents());
         Assert.Empty(mutator.Transitions);
     }
 
     [Fact]
-    public void Execute_AlreadyBlocked_IsIdempotent_NothingToApply()
+    public void Execute_Write_QueueAlreadyBlockedButLabelMissing_ConvergesLabelSideOnly()
     {
-        using var workspace = new Workspace();
-        var mutator = new FakeMutator(new[] { "intent-target", "intent-issue-in-progress", "intent-issue-blocked" });
-        AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: [Reason]);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        var queueBefore = workspace.ReadQueueStateBytes();
 
-        using var writer = new StringWriter();
-        var exitCode = AutomationIssueBlockCommand.Execute(
-            workspace.Context,
-            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--reason", "SKS-G837", "--write", "--format", "json"],
-            writer);
+        var result = workspace.Run(BlockArgs());
 
-        Assert.Equal(0, exitCode);
-        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
-        Assert.True(result.HadBlockedLabel);
-        Assert.False(result.Applied);
-        Assert.Empty(mutator.Transitions);
-        Assert.Contains("nothing to apply", result.Summary, StringComparison.OrdinalIgnoreCase);
+        Assert.True(result.Converged);
+        Assert.True(result.Queue.AlreadyConverged);
+        Assert.False(result.Queue.Applied);
+        Assert.True(result.Label.Applied);
+
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Empty(workspace.ReadRunEvents());
+        Assert.Contains(BlockedLabel, mutator.Labels);
+        AssertSidesAgree(workspace, mutator, expectedBlocked: true);
     }
 
     [Fact]
-    public void Execute_ClearWithoutBlockedLabel_IsIdempotent_NothingToClear()
+    public void Execute_Write_LabelAlreadyPresentButQueueNotBlocked_ConvergesQueueSideOnly()
     {
-        using var workspace = new Workspace();
-        var mutator = new FakeMutator(new[] { "intent-target", "intent-issue-in-progress" });
-        AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-issue-in-progress", BlockedLabel);
 
-        using var writer = new StringWriter();
-        var exitCode = AutomationIssueBlockCommand.Execute(
-            workspace.Context,
-            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--clear", "--write", "--format", "json"],
-            writer);
+        var result = workspace.Run(BlockArgs());
 
-        Assert.Equal(0, exitCode);
-        var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
-        Assert.False(result.HadBlockedLabel);
-        Assert.False(result.Applied);
+        Assert.True(result.Converged);
+        Assert.True(result.Queue.Applied);
+        Assert.True(result.Label.HadBlockedLabel);
+        Assert.False(result.Label.Applied);
+
+        var item = workspace.ReadQueueItem();
+        Assert.Equal(QueueItemState.Blocked, item.State);
+        Assert.Equal([Reason], item.BlockedBy);
+        Assert.Single(workspace.ReadRunEvents());
         Assert.Empty(mutator.Transitions);
-        Assert.Contains("nothing to clear", result.Summary, StringComparison.OrdinalIgnoreCase);
+        AssertSidesAgree(workspace, mutator, expectedBlocked: true);
+    }
+
+    [Fact]
+    public void Execute_Write_ClearWhenAlreadyUnblockedOnBothSides_MutatesNeitherSide()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        var queueBefore = workspace.ReadQueueStateBytes();
+
+        var result = workspace.Run(ClearArgs());
+
+        Assert.True(result.Converged);
+        Assert.True(result.Queue.AlreadyConverged);
+        Assert.False(result.Label.Applied);
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Empty(workspace.ReadRunEvents());
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void Execute_Write_ClearWhenStateUnblockedButBlockedByStale_StillConvergesQueueSide()
+    {
+        // The exact residue QueueManager.TransitionNonBlocking leaves behind
+        // when something else moved the unit off blocked: state is no longer
+        // blocked, but blocked_by still names the blocker, so the selector
+        // still refuses the unit. --clear must finish the job.
+        using var workspace = new Workspace(QueueItemState.Queued, blockedBy: [Reason]);
+        var mutator = workspace.UseMutator("intent-issue-in-progress", BlockedLabel);
+
+        var result = workspace.Run(ClearArgs());
+
+        Assert.True(result.Converged);
+        Assert.False(result.Queue.AlreadyConverged);
+        Assert.True(result.Queue.Applied);
+        Assert.Empty(workspace.ReadQueueItem().BlockedBy);
+        Assert.DoesNotContain(BlockedLabel, mutator.Labels);
+        AssertSidesAgree(workspace, mutator, expectedBlocked: false);
+    }
+
+    [Fact]
+    public void Execute_Write_ReblockAfterFullCycle_AppendsFreshAuditEvent_NotAPendingRetry()
+    {
+        // block -> clear -> block with the SAME reason text. The final block
+        // must append a THIRD event: the matching earlier "blocked" event is
+        // historical, not a pending partial-failure retry.
+        using var workspace = new Workspace(QueueItemState.Queued);
+        workspace.UseMutator("intent-issue-in-progress");
+
+        Assert.True(workspace.Run(BlockArgs()).Converged);
+        Assert.True(workspace.Run(ClearArgs()).Converged);
+        Assert.True(workspace.Run(BlockArgs()).Converged);
+
+        var events = workspace.ReadRunEvents();
+        Assert.Equal(3, events.Count);
+        Assert.Equal(["blocked", "queued", "blocked"], events.Select(e => e.Event).ToArray());
+        Assert.Equal(QueueItemState.Blocked, workspace.ReadQueueItem().State);
+    }
+
+    // ---------------------------------------------------------------
+    // Fail-closed refusals — all BEFORE any mutation.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Execute_AlreadyBlockedWithDifferentReason_RefusesWithoutMutatingEitherSide()
+    {
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: ["some other blocker"]);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        var queueBefore = workspace.ReadQueueStateBytes();
+
+        var (exitCode, output) = workspace.RunRaw(BlockArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("already blocked with reason 'some other blocker'", output, StringComparison.Ordinal);
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Empty(workspace.ReadRunEvents());
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void Execute_LinkedIssueMismatch_RefusesBeforeAnyMutation()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued, linkedIssueNumber: 999);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        var queueBefore = workspace.ReadQueueStateBytes();
+
+        var (exitCode, output) = workspace.RunRaw(BlockArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("linked_issue is #999", output, StringComparison.Ordinal);
+        Assert.Contains("refusing to label a possibly-wrong issue", output, StringComparison.Ordinal);
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Empty(workspace.ReadRunEvents());
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void Execute_LinkedIssueMatches_Proceeds()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued, linkedIssueNumber: Issue);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+
+        var result = workspace.Run(BlockArgs());
+
+        Assert.True(result.Converged);
+        AssertSidesAgree(workspace, mutator, expectedBlocked: true);
+    }
+
+    [Fact]
+    public void Execute_UnknownExecutionUnit_RefusesBeforeAnyMutation()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+
+        var (exitCode, output) = workspace.RunRaw(
+            ["SKS-G999", "--repo", Repo, "--issue", "818", "--reason", Reason, "--write", "--format", "json"]);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("has no item with execution_unit 'SKS-G999'", output, StringComparison.Ordinal);
+        Assert.Empty(workspace.ReadRunEvents());
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void Execute_MissingExecutionUnitArgument_Refuses()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued);
+
+        var (exitCode, output) = workspace.RunRaw(
+            ["--repo", Repo, "--issue", "818", "--reason", Reason, "--write"]);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("requires an execution unit as the first argument", output, StringComparison.Ordinal);
     }
 
     [Fact]
     public void Execute_RefusesReasonWithClear()
     {
-        using var workspace = new Workspace();
-        using var writer = new StringWriter();
-        var exitCode = AutomationIssueBlockCommand.Execute(
-            workspace.Context,
-            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--clear", "--reason", "x", "--write"],
-            writer);
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: [Reason]);
+
+        var (exitCode, output) = workspace.RunRaw(
+            [Unit, "--repo", Repo, "--issue", "818", "--clear", "--reason", "x", "--write"]);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("--reason is only supported when applying", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--reason is only supported when applying", output, StringComparison.Ordinal);
     }
 
     [Fact]
     public void Execute_RefusesMissingReasonWithoutClear()
     {
-        using var workspace = new Workspace();
-        using var writer = new StringWriter();
-        var exitCode = AutomationIssueBlockCommand.Execute(
-            workspace.Context,
-            ["--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--write"],
-            writer);
+        using var workspace = new Workspace(QueueItemState.Queued);
+
+        var (exitCode, output) = workspace.RunRaw([Unit, "--repo", Repo, "--issue", "818", "--write"]);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("--reason is required unless --clear", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--reason is required unless --clear", output, StringComparison.Ordinal);
     }
+
+    // ---------------------------------------------------------------
+    // Dry-run: reports, never touches anything.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Execute_DryRun_LeavesQueueRunsAndLabelsByteIdentical()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        var queueBefore = workspace.ReadQueueStateBytes();
+
+        var result = workspace.Run([Unit, "--repo", Repo, "--issue", "818", "--reason", Reason, "--format", "json"]);
+
+        Assert.False(result.Converged);
+        Assert.True(result.Queue.Applied);          // "would apply"
+        Assert.Equal("blocked", result.Queue.AfterState);
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Empty(workspace.ReadRunEvents());
+        Assert.Empty(mutator.Transitions);
+        Assert.DoesNotContain(BlockedLabel, mutator.Labels);
+    }
+
+    [Fact]
+    public void Execute_DryRun_Clear_LeavesQueueRunsAndLabelsByteIdentical()
+    {
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: [Reason]);
+        var mutator = workspace.UseMutator("intent-issue-in-progress", BlockedLabel);
+        var queueBefore = workspace.ReadQueueStateBytes();
+
+        var result = workspace.Run([Unit, "--repo", Repo, "--issue", "818", "--clear", "--format", "json"]);
+
+        Assert.False(result.Converged);
+        Assert.Equal("queued", result.Queue.AfterState);
+        Assert.Empty(result.Queue.AfterBlockedBy);
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Empty(workspace.ReadRunEvents());
+        Assert.Empty(mutator.Transitions);
+        Assert.Contains(BlockedLabel, mutator.Labels);
+    }
+
+    // ---------------------------------------------------------------
+    // Failure fixtures + retry convergence, one per side.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void Execute_AuditAppendFails_FailsLoud_AndLeavesQueueStateAndLabelsUntouched()
+    {
+        // Audit is appended BEFORE queue-state is written, so an append
+        // failure must leave a completely unmutated system: no state write,
+        // no label call, non-zero exit with a message naming the unit.
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        var queueBefore = workspace.ReadQueueStateBytes();
+        AutomationIssueBlockCommand.AppendRunEventOverride = (_, _) => throw new IOException("runs.jsonl is read-only");
+
+        var (exitCode, output) = workspace.RunRaw(BlockArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("failed to converge queue-state for 'SKS-G818'", output, StringComparison.Ordinal);
+        Assert.Contains("runs.jsonl is read-only", output, StringComparison.Ordinal);
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Empty(workspace.ReadRunEvents());
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void Execute_QueueStateWriteFailsAfterAudit_RetryReusesPendingEventAndConverges()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        var queueBefore = workspace.ReadQueueStateBytes();
+        AutomationIssueBlockCommand.WriteQueueStateOverride = (_, _) => throw new IOException("queue-state.json is read-only");
+
+        var (exitCode, output) = workspace.RunRaw(BlockArgs());
+
+        // Fail loud: the audit event is durable, queue-state is not yet.
+        Assert.Equal(1, exitCode);
+        Assert.Contains("failed to converge queue-state for 'SKS-G818'", output, StringComparison.Ordinal);
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Single(workspace.ReadRunEvents());
+        Assert.Empty(mutator.Transitions);
+
+        // Retry the EXACT same command once the write path recovers.
+        AutomationIssueBlockCommand.WriteQueueStateOverride = null;
+        var retry = workspace.Run(BlockArgs());
+
+        Assert.True(retry.Converged);
+        var item = workspace.ReadQueueItem();
+        Assert.Equal(QueueItemState.Blocked, item.State);
+        Assert.Equal([Reason], item.BlockedBy);
+
+        // No duplicate audit: the pending event is reused, not re-appended.
+        var appended = Assert.Single(workspace.ReadRunEvents());
+        Assert.Equal("blocked", appended.Event);
+        Assert.Equal(Reason, appended.Reason);
+
+        Assert.Contains(BlockedLabel, mutator.Labels);
+        AssertSidesAgree(workspace, mutator, expectedBlocked: true);
+    }
+
+    [Fact]
+    public void Execute_LabelApplyFails_QueueSideStaysConverged_RetryConvergesLabelOnly()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        mutator.ThrowOnApply = new InvalidOperationException("gh issue edit failed with exit code 1");
+
+        var (exitCode, output) = workspace.RunRaw(BlockArgs());
+
+        // Fail loud, and say exactly what to do about it.
+        Assert.Equal(1, exitCode);
+        Assert.Contains("failed to apply the intent-issue-blocked label", output, StringComparison.Ordinal);
+        Assert.Contains("Re-run this exact command to retry the label step only", output, StringComparison.Ordinal);
+
+        // Queue side already converged and audited exactly once.
+        Assert.Equal(QueueItemState.Blocked, workspace.ReadQueueItem().State);
+        Assert.Single(workspace.ReadRunEvents());
+        Assert.DoesNotContain(BlockedLabel, mutator.Labels);
+
+        // Retry: queue side is skipped, label side is applied.
+        mutator.ThrowOnApply = null;
+        var retry = workspace.Run(BlockArgs());
+
+        Assert.True(retry.Converged);
+        Assert.True(retry.Queue.AlreadyConverged);
+        Assert.False(retry.Queue.Applied);
+        Assert.True(retry.Label.Applied);
+        Assert.Single(workspace.ReadRunEvents());
+        AssertSidesAgree(workspace, mutator, expectedBlocked: true);
+    }
+
+    [Fact]
+    public void Execute_Clear_LabelRemoveFails_RetryConvergesLabelOnly()
+    {
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: [Reason]);
+        var mutator = workspace.UseMutator("intent-issue-in-progress", BlockedLabel);
+        mutator.ThrowOnApply = new InvalidOperationException("gh issue edit failed with exit code 1");
+
+        var (exitCode, output) = workspace.RunRaw(ClearArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("failed to clear the intent-issue-blocked label", output, StringComparison.Ordinal);
+
+        // Queue side already cleared (state AND blocked_by), audited once.
+        var afterFailure = workspace.ReadQueueItem();
+        Assert.Equal(QueueItemState.Queued, afterFailure.State);
+        Assert.Empty(afterFailure.BlockedBy);
+        Assert.Single(workspace.ReadRunEvents());
+        Assert.Contains(BlockedLabel, mutator.Labels);
+
+        mutator.ThrowOnApply = null;
+        var retry = workspace.Run(ClearArgs());
+
+        Assert.True(retry.Converged);
+        Assert.True(retry.Queue.AlreadyConverged);
+        Assert.True(retry.Label.Applied);
+        Assert.Single(workspace.ReadRunEvents());
+        AssertSidesAgree(workspace, mutator, expectedBlocked: false);
+    }
+
+    [Fact]
+    public void Execute_LabelReadFails_QueueSideStaysConverged_AndRetryIsSafe()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        mutator.ThrowOnRead = new InvalidOperationException("gh issue view failed with exit code 1");
+
+        var (exitCode, output) = workspace.RunRaw(BlockArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("failed to read current labels", output, StringComparison.Ordinal);
+        Assert.Equal(QueueItemState.Blocked, workspace.ReadQueueItem().State);
+        Assert.Single(workspace.ReadRunEvents());
+
+        mutator.ThrowOnRead = null;
+        var retry = workspace.Run(BlockArgs());
+
+        Assert.True(retry.Converged);
+        Assert.Single(workspace.ReadRunEvents());
+        AssertSidesAgree(workspace, mutator, expectedBlocked: true);
+    }
+
+    // ---------------------------------------------------------------
+    // Routing / help.
+    // ---------------------------------------------------------------
 
     [Fact]
     public void CommandRouter_RegistersAutomationIssueBlock()
     {
-        using var workspace = new Workspace();
-        AutomationIssueBlockCommand.MutatorFactory = () => new FakeMutator(new[] { "intent-target", "intent-issue-in-progress" });
+        using var workspace = new Workspace(QueueItemState.Queued);
+        workspace.UseMutator("intent-issue-in-progress");
 
         using var writer = new StringWriter();
         var exitCode = CommandRouter.Execute(
-            ["automation", "issue-block", "--repo", "sekiban-as-a-service/sekiban", "--issue", "818", "--reason", "SKS-G837", "--format", "json"],
+            ["automation", "issue-block", Unit, "--repo", Repo, "--issue", "818", "--reason", Reason, "--format", "json"],
             workspace.Context,
             writer);
 
         Assert.Equal(0, exitCode);
         var result = JsonSerializer.Deserialize<AutomationIssueBlockResult>(writer.ToString())!;
-        Assert.Equal(818, result.Issue);
+        Assert.Equal(Issue, result.Issue);
+        Assert.Equal(Unit, result.ExecutionUnit);
+    }
+
+    [Fact]
+    public void Execute_Help_DocumentsThePositionalExecutionUnitAndBothSides()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued);
+        using var writer = new StringWriter();
+
+        var exitCode = AutomationIssueBlockCommand.Execute(workspace.Context, ["--help"], writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("issue-block <execution-unit> --repo", output, StringComparison.Ordinal);
+        Assert.Contains("queue-state", output, StringComparison.Ordinal);
+        Assert.Contains("intent-issue-blocked", output, StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------
+    // Helpers.
+    // ---------------------------------------------------------------
+
+    private static string[] BlockArgs() =>
+        [Unit, "--repo", Repo, "--issue", "818", "--reason", Reason, "--write", "--format", "json"];
+
+    private static string[] ClearArgs() =>
+        [Unit, "--repo", Repo, "--issue", "818", "--clear", "--write", "--format", "json"];
+
+    /// <summary>
+    /// The acceptance the round-2 review demands: the ACTUAL persisted queue
+    /// state and the ACTUAL label set say the same thing about "blocked".
+    /// </summary>
+    private static void AssertSidesAgree(Workspace workspace, FakeMutator mutator, bool expectedBlocked)
+    {
+        var item = workspace.ReadQueueItem();
+        var queueSaysBlocked = item.State == QueueItemState.Blocked;
+        var labelSaysBlocked = mutator.Labels.Contains(BlockedLabel);
+
+        Assert.Equal(expectedBlocked, queueSaysBlocked);
+        Assert.Equal(expectedBlocked, labelSaysBlocked);
+        Assert.Equal(expectedBlocked, item.BlockedBy.Count > 0);
     }
 
     private sealed class FakeMutator : IGitHubLabelMutator
     {
-        private readonly IReadOnlyList<string> labels;
+        public List<string> Labels { get; }
         public List<Transition> Transitions { get; } = new();
-        public FakeMutator(IReadOnlyList<string> labels) => this.labels = labels;
+        public Exception? ThrowOnRead { get; set; }
+        public Exception? ThrowOnApply { get; set; }
 
-        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number) =>
-            labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+        public FakeMutator(IEnumerable<string> labels) => Labels = labels.ToList();
+
+        public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number)
+        {
+            if (ThrowOnRead is not null)
+            {
+                throw ThrowOnRead;
+            }
+
+            return Labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray();
+        }
 
         public void ApplyLabelTransitions(string repo, string kind, int number,
-            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
+            IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels)
+        {
+            if (ThrowOnApply is not null)
+            {
+                throw ThrowOnApply;
+            }
+
             Transitions.Add(new Transition(kind, number, addLabels.ToArray(), removeLabels.ToArray()));
+            foreach (var remove in removeLabels)
+            {
+                Labels.Remove(remove);
+            }
+
+            foreach (var add in addLabels.Where(add => !Labels.Contains(add)))
+            {
+                Labels.Add(add);
+            }
+        }
 
         public void ApplyReconcileTransitions(string repo, string kind, int number,
             IReadOnlyCollection<string> addLabels, IReadOnlyCollection<string> removeLabels) =>
@@ -211,19 +633,87 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
 
     private sealed class Workspace : IDisposable
     {
-        public Workspace()
+        public Workspace(QueueItemState state, IReadOnlyList<string>? blockedBy = null, int? linkedIssueNumber = null)
         {
             RootPath = Directory.CreateTempSubdirectory("automation-issue-block-tests-").FullName;
             Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
             Context = new CliContext
             {
                 RepoRoot = RootPath,
-                Config = new CliConfig { Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" } }
+                Config = new CliConfig { Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" } },
             };
+
+            File.WriteAllText(QueueStatePath, QueueStateSerializer.Serialize(new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = FixedNow,
+                Items =
+                [
+                    CreateItem(Unit, state, blockedBy ?? [], linkedIssueNumber),
+                    CreateItem("SKS-G901", QueueItemState.Queued, [], null),
+                ],
+            }));
         }
 
         public string RootPath { get; }
         public CliContext Context { get; }
+        public string QueueStatePath => Path.Combine(RootPath, ".intent-cli", "queue-state.json");
+        public string RunLogPath => Path.Combine(RootPath, ".intent-cli", "runs.jsonl");
+
+        public FakeMutator UseMutator(params string[] labels)
+        {
+            var mutator = new FakeMutator(labels);
+            AutomationIssueBlockCommand.MutatorFactory = () => mutator;
+            return mutator;
+        }
+
+        public (int ExitCode, string Output) RunRaw(string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = AutomationIssueBlockCommand.Execute(Context, args, writer);
+            return (exitCode, writer.ToString());
+        }
+
+        public AutomationIssueBlockResult Run(string[] args)
+        {
+            var (exitCode, output) = RunRaw(args);
+            Assert.Equal(0, exitCode);
+            return JsonSerializer.Deserialize<AutomationIssueBlockResult>(output)!;
+        }
+
+        public QueueItem ReadQueueItem() =>
+            QueueStateSerializer.Deserialize(File.ReadAllText(QueueStatePath))
+                .Items.Single(item => item.ExecutionUnit == Unit);
+
+        public string ReadQueueStateBytes() => File.ReadAllText(QueueStatePath);
+
+        public IReadOnlyList<RunEvent> ReadRunEvents() =>
+            File.Exists(RunLogPath)
+                ? RunLogSerializer.DeserializeAll(File.ReadAllText(RunLogPath))
+                : Array.Empty<RunEvent>();
+
+        private static QueueItem CreateItem(string executionUnit, QueueItemState state, IReadOnlyList<string> blockedBy, int? linkedIssueNumber) =>
+            new()
+            {
+                ExecutionUnit = executionUnit,
+                Title = $"[{executionUnit}] Queue Item",
+                State = state,
+                Dependencies = [],
+                BlockedBy = blockedBy,
+                ClarificationReturnPath = "intents/sekiban-as-a-service/clarifications/open.md",
+                PacketPaths = new PacketPaths
+                {
+                    Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                    ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                    Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                },
+                LinkedIssue = linkedIssueNumber is null
+                    ? null
+                    : new LinkedIssue { Repo = Repo, Number = linkedIssueNumber, Url = $"https://github.com/{Repo}/issues/{linkedIssueNumber}" },
+                WorkerRole = "coder",
+                ReviewRole = "reviewer",
+                Priority = "normal",
+            };
 
         public void Dispose()
         {

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueBlockCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueBlockCommandTests.cs
@@ -263,26 +263,58 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_LinkedIssueMismatch_RefusesBeforeAnyMutation()
+    public void Execute_LinkedIssueNumberMismatch_RefusesBeforeAnyInteraction()
     {
-        using var workspace = new Workspace(QueueItemState.Queued, linkedIssueNumber: 999);
-        var mutator = workspace.UseMutator("intent-issue-in-progress");
-        var queueBefore = workspace.ReadQueueStateBytes();
+        using var workspace = new Workspace(
+            QueueItemState.Queued,
+            linkedIssue: new LinkedIssue { Repo = Repo, Number = 999 });
 
-        var (exitCode, output) = workspace.RunRaw(BlockArgs());
-
-        Assert.Equal(1, exitCode);
-        Assert.Contains("linked_issue is #999", output, StringComparison.Ordinal);
-        Assert.Contains("refusing to label a possibly-wrong issue", output, StringComparison.Ordinal);
-        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
-        Assert.Empty(workspace.ReadRunEvents());
-        Assert.Empty(mutator.Transitions);
+        AssertRefusedWithoutTouchingAnything(workspace, BlockArgs(), "linked_issue is #999");
     }
 
     [Fact]
-    public void Execute_LinkedIssueMatches_Proceeds()
+    public void Execute_LinkedIssueRepoMismatch_SameNumber_RefusesBeforeAnyInteraction()
     {
-        using var workspace = new Workspace(QueueItemState.Queued, linkedIssueNumber: Issue);
+        // The dangerous case: issue #818 exists in almost every repository,
+        // so number-only agreement is not evidence of the same issue.
+        using var workspace = new Workspace(
+            QueueItemState.Queued,
+            linkedIssue: new LinkedIssue { Repo = "some-other-org/some-other-repo", Number = Issue });
+
+        AssertRefusedWithoutTouchingAnything(
+            workspace, BlockArgs(), "refusing to label an issue in a different repository");
+    }
+
+    [Fact]
+    public void Execute_LinkedIssueMissingEntirely_RefusesBeforeAnyInteraction()
+    {
+        // Absent linkage is missing evidence, not consent.
+        using var workspace = new Workspace(QueueItemState.Queued, omitLinkedIssue: true);
+
+        AssertRefusedWithoutTouchingAnything(
+            workspace, BlockArgs(), "has no complete queue-state linked_issue");
+    }
+
+    [Fact]
+    public void Execute_LinkedIssueNumberMissing_RefusesBeforeAnyInteraction()
+    {
+        using var workspace = new Workspace(
+            QueueItemState.Queued,
+            linkedIssue: new LinkedIssue { Repo = Repo, Number = null });
+
+        AssertRefusedWithoutTouchingAnything(
+            workspace, BlockArgs(), "has no complete queue-state linked_issue");
+    }
+
+    [Fact]
+    public void Execute_LinkedIssueRepoDiffersOnlyInCaseOrUrlShape_IsCanonicallyEqual_AndProceeds()
+    {
+        // GitHub owner/repo names are case-insensitive, and queue-state has
+        // been observed carrying URL/.git shapes. Canonical equality must not
+        // be mistaken for a mismatch and block a legitimate transition.
+        using var workspace = new Workspace(
+            QueueItemState.Queued,
+            linkedIssue: new LinkedIssue { Repo = "https://github.com/Sekiban-As-A-Service/Sekiban.git", Number = Issue });
         var mutator = workspace.UseMutator("intent-issue-in-progress");
 
         var result = workspace.Run(BlockArgs());
@@ -523,6 +555,67 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
         AssertSidesAgree(workspace, mutator, expectedBlocked: true);
     }
 
+    [Fact]
+    public void Execute_ExistingRunLogUnparseable_FailsLoudBeforeAnyInteraction()
+    {
+        // A present-but-unreadable audit trail must stop everything: no
+        // append, no queue write, no label read or mutation. Appending into a
+        // file whose existing content cannot be parsed would both corrupt the
+        // trail further and decide retry-vs-fresh-append from no evidence.
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        workspace.WriteRawRunLog("{\"ts\":\"2026-07-21T10:00:00Z\",\"execution_unit\":\"SKS-G818\"" + Environment.NewLine + "not json at all" + Environment.NewLine);
+        var queueBefore = workspace.ReadQueueStateBytes();
+        var runLogBefore = workspace.ReadRunLogBytes();
+
+        var (exitCode, output) = workspace.RunRaw(BlockArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("could not be read", output, StringComparison.Ordinal);
+        Assert.Contains("Refusing to transition against an unreadable audit trail", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli automation runs-audit", output, StringComparison.Ordinal);
+
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Equal(runLogBefore, workspace.ReadRunLogBytes());
+        Assert.Equal(0, mutator.ReadCount);
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void Execute_ExistingRunLogUnparseable_AlsoFailsLoudOnClearAndDryRun()
+    {
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: [Reason]);
+        var mutator = workspace.UseMutator("intent-issue-in-progress", BlockedLabel);
+        workspace.WriteRawRunLog("}{ this is not a run event" + Environment.NewLine);
+        var runLogBefore = workspace.ReadRunLogBytes();
+
+        var (clearExit, clearOutput) = workspace.RunRaw(ClearArgs());
+        var (dryRunExit, dryRunOutput) = workspace.RunRaw(
+            [Unit, "--repo", Repo, "--issue", "818", "--reason", Reason, "--format", "json"]);
+
+        Assert.Equal(1, clearExit);
+        Assert.Equal(1, dryRunExit);
+        Assert.Contains("could not be read", clearOutput, StringComparison.Ordinal);
+        Assert.Contains("could not be read", dryRunOutput, StringComparison.Ordinal);
+        Assert.Equal(runLogBefore, workspace.ReadRunLogBytes());
+        Assert.Equal(0, mutator.ReadCount);
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void Execute_MissingRunLog_RemainsTheValidFirstEventCase()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued);
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        Assert.False(File.Exists(workspace.RunLogPath));
+
+        var result = workspace.Run(BlockArgs());
+
+        Assert.True(result.Converged);
+        Assert.Single(workspace.ReadRunEvents());
+        AssertSidesAgree(workspace, mutator, expectedBlocked: true);
+    }
+
     // ---------------------------------------------------------------
     // Routing / help.
     // ---------------------------------------------------------------
@@ -571,6 +664,27 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
         [Unit, "--repo", Repo, "--issue", "818", "--clear", "--write", "--format", "json"];
 
     /// <summary>
+    /// A fail-closed refusal must leave ALL THREE sides untouched: the
+    /// queue-state file byte-identical, the run log byte-identical, and
+    /// GitHub not even read (let alone mutated).
+    /// </summary>
+    private static void AssertRefusedWithoutTouchingAnything(Workspace workspace, string[] args, string expectedMessage)
+    {
+        var mutator = workspace.UseMutator("intent-issue-in-progress");
+        var queueBefore = workspace.ReadQueueStateBytes();
+        var runLogBefore = workspace.ReadRunLogBytes();
+
+        var (exitCode, output) = workspace.RunRaw(args);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains(expectedMessage, output, StringComparison.Ordinal);
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Equal(runLogBefore, workspace.ReadRunLogBytes());
+        Assert.Equal(0, mutator.ReadCount);
+        Assert.Empty(mutator.Transitions);
+    }
+
+    /// <summary>
     /// The acceptance the round-2 review demands: the ACTUAL persisted queue
     /// state and the ACTUAL label set say the same thing about "blocked".
     /// </summary>
@@ -592,10 +706,14 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
         public Exception? ThrowOnRead { get; set; }
         public Exception? ThrowOnApply { get; set; }
 
+        /// <summary>Any GitHub interaction at all — a fail-closed refusal must leave this at 0.</summary>
+        public int ReadCount { get; private set; }
+
         public FakeMutator(IEnumerable<string> labels) => Labels = labels.ToList();
 
         public IReadOnlyList<GitHubAutomationLabel> ReadLabels(string repo, string kind, int number)
         {
+            ReadCount++;
             if (ThrowOnRead is not null)
             {
                 throw ThrowOnRead;
@@ -633,7 +751,17 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
 
     private sealed class Workspace : IDisposable
     {
-        public Workspace(QueueItemState state, IReadOnlyList<string>? blockedBy = null, int? linkedIssueNumber = null)
+        /// <param name="linkedIssue">
+        /// Overrides the default COMPLETE, canonical linkage. Safe/happy
+        /// fixtures deliberately leave this at the default so they exercise
+        /// the same complete-linkage requirement production callers face.
+        /// </param>
+        /// <param name="omitLinkedIssue">Drops <c>linked_issue</c> entirely.</param>
+        public Workspace(
+            QueueItemState state,
+            IReadOnlyList<string>? blockedBy = null,
+            LinkedIssue? linkedIssue = null,
+            bool omitLinkedIssue = false)
         {
             RootPath = Directory.CreateTempSubdirectory("automation-issue-block-tests-").FullName;
             Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
@@ -649,7 +777,13 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
                 UpdatedAt = FixedNow,
                 Items =
                 [
-                    CreateItem(Unit, state, blockedBy ?? [], linkedIssueNumber),
+                    CreateItem(
+                        Unit,
+                        state,
+                        blockedBy ?? [],
+                        omitLinkedIssue
+                            ? null
+                            : linkedIssue ?? new LinkedIssue { Repo = Repo, Number = Issue, Url = $"https://github.com/{Repo}/issues/{Issue}" }),
                     CreateItem("SKS-G901", QueueItemState.Queued, [], null),
                 ],
             }));
@@ -687,12 +821,16 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
 
         public string ReadQueueStateBytes() => File.ReadAllText(QueueStatePath);
 
+        public string ReadRunLogBytes() => File.Exists(RunLogPath) ? File.ReadAllText(RunLogPath) : "(absent)";
+
+        public void WriteRawRunLog(string content) => File.WriteAllText(RunLogPath, content);
+
         public IReadOnlyList<RunEvent> ReadRunEvents() =>
             File.Exists(RunLogPath)
                 ? RunLogSerializer.DeserializeAll(File.ReadAllText(RunLogPath))
                 : Array.Empty<RunEvent>();
 
-        private static QueueItem CreateItem(string executionUnit, QueueItemState state, IReadOnlyList<string> blockedBy, int? linkedIssueNumber) =>
+        private static QueueItem CreateItem(string executionUnit, QueueItemState state, IReadOnlyList<string> blockedBy, LinkedIssue? linkedIssue) =>
             new()
             {
                 ExecutionUnit = executionUnit,
@@ -707,9 +845,7 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
                     ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
                     Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
                 },
-                LinkedIssue = linkedIssueNumber is null
-                    ? null
-                    : new LinkedIssue { Repo = Repo, Number = linkedIssueNumber, Url = $"https://github.com/{Repo}/issues/{linkedIssueNumber}" },
+                LinkedIssue = linkedIssue,
                 WorkerRole = "coder",
                 ReviewRole = "reviewer",
                 Priority = "normal",

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -555,6 +555,137 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
     }
 
+    // ─── G545: queue-blocked exemption + blocked-label-drift ───────────────
+
+    [Fact]
+    public void Execute_ClaimedButSilent_QueueBlockedUnit_NoBlockedLabelYet_ReportsBlockedLabelDriftNotSilent()
+    {
+        // G545 field finding (sekiban-as-a-service, 2026-07-21): SKS-G818 is
+        // state=blocked in queue-state (blocked_by SKS-G837), but the
+        // GitHub issue still only carries intent-issue-in-progress -- no
+        // reconcile label yet. Must never fire claimed-but-silent; must
+        // instead surface the transitional blocked-label-drift kind naming
+        // the reconcile command.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("SKS-G818", "sekiban-as-a-service");
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-21T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SKS-G818",
+                  "title": "SKS-G818 title",
+                  "state": "blocked",
+                  "dependencies": [],
+                  "blocked_by": ["SKS-G837"],
+                  "clarification_return_path": "intents/sekiban-as-a-service/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+        var issue = BuildIssue(818, "SKS-G818: Queue-blocked but still marked in-progress on GitHub", FixedNow.AddHours(-25),
+            updatedAt: FixedNow.AddHours(-25), labels: ["intent-target", "intent-issue-in-progress"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "sekiban-as-a-service", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindBlockedLabelDrift, item.GetProperty("kind").GetString());
+        Assert.True(item.GetProperty("is_informational").GetBoolean());
+        Assert.Equal("SKS-G818", item.GetProperty("execution_unit").GetString());
+        Assert.Equal(818, item.GetProperty("issue").GetProperty("number").GetInt32());
+        var recommendedAction = item.GetProperty("recommended_action").GetString();
+        Assert.Contains("automation issue-block", recommendedAction, StringComparison.Ordinal);
+        Assert.Contains("--issue 818", recommendedAction, StringComparison.Ordinal);
+        Assert.Contains("SKS-G837", recommendedAction, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            doc.RootElement.GetProperty("items").EnumerateArray(),
+            other => other.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindClaimedButSilent);
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_QueueBlockedUnit_AlreadyHasBlockedLabel_FullyExempt_NoItemAtAll()
+    {
+        // Once GitHub has been reconciled (intent-issue-blocked applied),
+        // labels and queue-state agree -- neither claimed-but-silent nor
+        // blocked-label-drift should fire.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("SKS-G818", "sekiban-as-a-service");
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-21T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SKS-G818",
+                  "title": "SKS-G818 title",
+                  "state": "blocked",
+                  "dependencies": [],
+                  "blocked_by": ["SKS-G837"],
+                  "clarification_return_path": "intents/sekiban-as-a-service/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+        var issue = BuildIssue(818, "SKS-G818: Reconciled", FixedNow.AddHours(-25),
+            updatedAt: FixedNow.AddHours(-25), labels: ["intent-target", "intent-issue-in-progress", "intent-issue-blocked"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "sekiban-as-a-service", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_ClaimedButSilent_QueueStatePresentButNotBlocked_StillFiresClaimedButSilent_NoWeakening()
+    {
+        // No-weakening: a claimed, non-blocked, silent-past-threshold unit
+        // must still fire claimed-but-silent even when queue-state.json
+        // exists and is readable (proving the G545 exemption is scoped
+        // strictly to state=blocked, not "queue-state exists at all").
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G540", "intent-cli");
+        workspace.WriteQueueState(BuildReadyQueueStateJson("G540"));
+        var issue = BuildIssue(1200, "G540: Something claimed and gone quiet", FixedNow.AddHours(-25),
+            updatedAt: FixedNow.AddHours(-25), labels: ["intent-target", "intent-issue-in-progress"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindClaimedButSilent, item.GetProperty("kind").GetString());
+        Assert.Equal("G540", item.GetProperty("execution_unit").GetString());
+    }
+
     [Fact]
     public void Execute_MergedPr_NeverTreatedAsPrCreatedNotReviewingOrClaimedButSilent()
     {
@@ -1868,6 +1999,52 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         Assert.Contains(AutomationStalledWorkCommand.KindBacklogReadyIdle, messageBody, StringComparison.Ordinal);
         Assert.Contains("G600", messageBody, StringComparison.Ordinal);
         Assert.Contains("issue publish-flow", messageBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Heartbeat_SurfacesBlockedLabelDriftInMessageBody_G545()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("SKS-G818", "sekiban-as-a-service");
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-07-21T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "SKS-G818",
+                  "title": "SKS-G818 title",
+                  "state": "blocked",
+                  "dependencies": [],
+                  "blocked_by": ["SKS-G837"],
+                  "clarification_return_path": "intents/sekiban-as-a-service/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+        var issue = BuildIssue(818, "SKS-G818: Queue-blocked but still marked in-progress on GitHub", FixedNow.AddHours(-25),
+            updatedAt: FixedNow.AddHours(-25), labels: ["intent-target", "intent-issue-in-progress"]);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHeartbeatCommand.Execute(
+            workspace.Context,
+            ["--domain", "sekiban-as-a-service", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.True(doc.RootElement.GetProperty("stale").GetBoolean());
+        var messageBody = doc.RootElement.GetProperty("message_body").GetString();
+        Assert.Contains(AutomationStalledWorkCommand.KindBlockedLabelDrift, messageBody, StringComparison.Ordinal);
+        Assert.Contains("SKS-G818", messageBody, StringComparison.Ordinal);
+        Assert.Contains("FYI:", messageBody, StringComparison.Ordinal);
+        Assert.DoesNotContain(AutomationStalledWorkCommand.KindClaimedButSilent, messageBody, StringComparison.Ordinal);
     }
 
     private static string BuildCompleteContractBody()

--- a/tests/IntentSystem.Cli.Tests/WorkflowLabelPaletteAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkflowLabelPaletteAnalyzerTests.cs
@@ -10,11 +10,12 @@ namespace IntentSystem.Cli.Tests;
 public sealed class WorkflowLabelPaletteAnalyzerTests
 {
     [Fact]
-    public void Canonical_PaletteContainsExactlyTenLabels()
+    public void Canonical_PaletteContainsExactlyElevenLabels()
     {
         // G366 acceptance: the canonical palette is exhaustive and stable.
         // G374: extended with the two structured worker-signal labels.
-        Assert.Equal(10, WorkflowLabelPaletteContract.Canonical.Count);
+        // G545: extended with the issue-level blocked mirror label.
+        Assert.Equal(11, WorkflowLabelPaletteContract.Canonical.Count);
         var names = WorkflowLabelPaletteContract.Canonical.Select(e => e.Name).ToHashSet();
         Assert.Contains("intent-target", names);
         Assert.Contains("intent-issue-in-progress", names);
@@ -24,6 +25,8 @@ public sealed class WorkflowLabelPaletteAnalyzerTests
         Assert.Contains("intent-pr-update-in-progress", names);
         Assert.Contains("intent-pr-rereview-ready", names);
         Assert.Contains("intent-pr-approved", names);
+        // G545: issue-level mirror of queue-state's state=blocked.
+        Assert.Contains("intent-issue-blocked", names);
         // G374: signal-protocol labels are part of the canonical palette so
         // `automation label-palette-audit` / `-sync` provision them too.
         Assert.Contains("intent-signal-sent", names);


### PR DESCRIPTION
Closes #1192

## Summary

- `AutomationStalledWorkCommand.CollectClaimedButSilent` now consults `queue-state.json` (tolerant of missing/malformed state — falls through to the pre-G545 GitHub-labels-only behavior unchanged) and never flags a unit whose queue item is `state=blocked`. A blocked unit whose GitHub labels haven't been reconciled yet (still `intent-issue-in-progress`, no `intent-issue-blocked`) is instead reported under a new informational `blocked-label-drift` kind naming the reconcile command; once reconciled, the unit disappears from `stalled-work` entirely.
- New canonical `intent-cli automation issue-block --repo <r> --issue <n> --reason <text> [--write]` (and its `--clear` counterpart) applies/removes the new `intent-issue-blocked` label — the only supported way to make GitHub agree with a queue-state `blocked` transition; no raw `gh` label edits. Coexists with `intent-issue-in-progress` rather than replacing it. Built on the existing `IGitHubLabelMutator` seam already used by `worker claim`/`complete` and `automation issue-release`. Added to the canonical label palette (`WorkflowLabelPaletteContract`) so `label-palette-audit`/`-sync` provision and validate it too.
- No-weakening fixture proves a claimed, non-blocked, silent-past-threshold unit still fires `claimed-but-silent` even when `queue-state.json` exists and is readable — the exemption is scoped strictly to `state=blocked`.
- `docs/en` and `docs/ja` `09-developer-reference.md` document the exemption, the `blocked-label-drift` kind, and the new `automation issue-block` command.
- No changes to the `blocked` queue semantics or `blocked_by` reason format, and no changes to the other `stalled-work` kinds (out of scope, per the issue).

## Test plan

- [x] SKS-G818 regression: blocked in queue (`blocked_by: SKS-G837`), `intent-issue-in-progress` on GitHub → fires `blocked-label-drift` naming the reconcile command, never `claimed-but-silent`.
- [x] Reconciled unit (blocked + `intent-issue-blocked` present) → fully exempt, no item at all.
- [x] No-weakening: claimed, non-blocked, silent-past-threshold unit with queue-state present still fires `claimed-but-silent`.
- [x] Heartbeat surfaces `blocked-label-drift` in `message_body`.
- [x] 8 new `AutomationIssueBlockCommand` tests: apply, clear, idempotent both directions, dry-run, reason validation (required unless `--clear`, forbidden with `--clear`), command routing.
- [x] Full solution suite green: `dotnet test IntentSystem.sln -c Debug` — 3759 passed, 1 skipped, 0 failed
- [x] `git diff --check` clean
- [x] Manual run of `automation issue-block --repo J-Tech-Japan/intent-system --issue 1192 --reason "manual verification test"` (dry-run, no `--write`) against real GitHub state — confirmed it reads live labels correctly (`had_blocked_label: false`) without mutating anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4yoyeXmTeJWD16RLvktQd