### PR TITLE
docs: Refresh expired Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ each answer until a stop condition is reached.
 
 ## Community
 
-Join the [J-Tech JAPAN OSS Discord](https://discord.gg/kMdv978X) for community
+Join the [J-Tech JAPAN OSS Discord](https://discord.gg/7H3nQ9SFW) for community
 discussion, questions, and lightweight support. Discord is for general chat;
 for reproducible bugs or actionable feature requests, please open a
 [GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) instead.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -25,7 +25,7 @@ problem you are trying to solve.
 
 ## Questions and community discussion
 
-For general questions, join the [J-Tech JAPAN OSS Discord](https://discord.gg/kMdv978X)
+For general questions, join the [J-Tech JAPAN OSS Discord](https://discord.gg/7H3nQ9SFW)
 for community discussion and lightweight support, or open a GitHub Discussion.
 Discord is not a formal support channel and carries no SLA.
 

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -48,4 +48,4 @@ The host can live in a **separate host repository** or in the **same repository 
 
 ## Community
 
-Join the [J-Tech JAPAN OSS Discord](https://discord.gg/kMdv978X) for community discussion and questions. For bugs or actionable feature requests, open a [GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) instead. Security reports go to [SECURITY.md](../../SECURITY.md), not Discord.
+Join the [J-Tech JAPAN OSS Discord](https://discord.gg/7H3nQ9SFW) for community discussion and questions. For bugs or actionable feature requests, open a [GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) instead. Security reports go to [SECURITY.md](../../SECURITY.md), not Discord.

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -48,6 +48,6 @@ host は **別の host リポジトリ** に置くこともできますし、**�
 
 ## コミュニティ
 
-コミュニティのディスカッションや質問には [J-Tech JAPAN OSS Discord](https://discord.gg/kMdv978X) にご参加ください。
+コミュニティのディスカッションや質問には [J-Tech JAPAN OSS Discord](https://discord.gg/7H3nQ9SFW) にご参加ください。
 
 再現可能なバグやアクションにつながる機能要望は [GitHub issue](https://github.com/J-Tech-Japan/intent-system/issues) として報告してください。セキュリティに関する報告は [SECURITY.md](../../SECURITY.md) へ。


### PR DESCRIPTION
## Summary

The J-Tech JAPAN OSS Discord invite link (`discord.gg/kMdv978X`) had expired. This updates all references to the current invite (`discord.gg/7H3nQ9SFW`).

## Changes

- `README.md`
- `SUPPORT.md`
- `docs/en/README.md`
- `docs/ja/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)