### PR TITLE
G546: Promote a silent repair claim to an actionable repair-stalled kind

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -306,13 +306,38 @@ is always a runnable `intent-cli` command):
   `stalled-work` reported `stalled: false` regardless — recovery required an
   explicit human/design WAKE message. `backlog_idle_minutes_threshold` is
   reported alongside `stale_minutes_threshold` in every result.
+- `repair-stalled` (G546) — a PR in the repair lifecycle
+  (`intent-pr-request-update`, `intent-pr-update-in-progress`, or
+  `intent-pr-rereview-ready`) with no observable activity for longer than
+  `--repair-silent-minutes` (default **180** minutes). This is the promotion
+  G533 deferred "until field data exists"; the data arrived twice. The
+  sharper incident: a G545 repair claimed `intent-pr-update-in-progress` and
+  went silent for **four days** (2026-07-23 → 07-27) after the implement
+  session died, while `stalled-work` reported `stalled: false, items: []`
+  throughout — recovery needed a manual ping. That PR was a **draft**, and
+  every other PR kind here skips draft PRs, so no kind covered it at all;
+  `repair-stalled` therefore covers drafts too (inside the threshold a draft
+  repair PR stays invisible exactly as before — no informational item is
+  invented for it). `recommended_action` is always a **status check to the
+  responsible thread** — `implement` for `intent-pr-request-update` /
+  `intent-pr-update-in-progress`, `review-dispatch` for
+  `intent-pr-rereview-ready` — and **never** a transition or a reassignment:
+  silence alone never establishes that a repair succeeded, failed, or should
+  be taken from its owner. Observable activity is the PR's own `updatedAt`,
+  the one field covering all three activity classes (GitHub bumps it on a
+  push to the head branch, on any comment, and on any label change). Fails
+  closed like `claimed-but-silent`: a missing or malformed `updatedAt` means
+  silence cannot be established, so the PR is **not** promoted rather than
+  flagged on unusable evidence.
 
 **Informational categories (G533)** — `is_informational: true`,
 `recommended_action` is descriptive prose (never a transition command), age
 is reported for visibility only:
 
 - `repair-pending` — a PR carrying `intent-pr-request-update` and/or
-  `intent-pr-update-in-progress`. Field finding: an OPEN PR in exactly this
+  `intent-pr-update-in-progress`, **inside** `--repair-silent-minutes`
+  (G546 — past it, the item is promoted to the actionable `repair-stalled`
+  kind above; inside it the output is unchanged). Field finding: an OPEN PR in exactly this
   state (PR #1750) was previously misreported as `pr-created-not-reviewing`
   with a `review-start` recommendation — semantically wrong mid-repair; a
   detector whose recommendation must be second-guessed loses its value.
@@ -323,8 +348,8 @@ is reported for visibility only:
   recent modification of any kind (which may postdate the specific label
   change) unless a dedicated label-event fetch is added.
 - `rereview-pending` — a PR carrying `intent-pr-rereview-ready` (repair
-  pushed, awaiting re-review). Same `updatedAt`-based age approximation as
-  `repair-pending`.
+  pushed, awaiting re-review), **inside** `--repair-silent-minutes` (G546).
+  Same `updatedAt`-based age approximation as `repair-pending`.
 - `claimed-but-silent` — an issue carrying `intent-issue-in-progress` with
   **no PR created yet** and no observable activity for longer than
   `--claimed-silent-minutes` (default **720** minutes / 12 hours — chosen so
@@ -437,11 +462,12 @@ Each item reports `kind`, `execution_unit`, `issue` and/or `pr` (number +
 url), `age_minutes`, `is_informational`, and `recommended_action`.
 `--stale-minutes` filters out items younger than the given threshold
 (default `0` — report everything with its age; callers pick their own
-threshold) — this applies uniformly across all eight kinds; `claimed-but-silent`
-and `backlog-ready-idle` each additionally gate on their OWN
-`--claimed-silent-minutes` / `--backlog-idle-minutes` threshold before an
-item is even considered (so raising `--stale-minutes` alone can never make
-either kind appear earlier than its own threshold allows).
+threshold) — this applies uniformly across all nine kinds; `claimed-but-silent`,
+`backlog-ready-idle` and `repair-stalled` each additionally gate on their OWN
+`--claimed-silent-minutes` / `--backlog-idle-minutes` / `--repair-silent-minutes`
+threshold before an item is even considered (so raising `--stale-minutes`
+alone can never make any of them appear earlier than its own threshold
+allows).
 `age_minutes` is approximated from the relevant GitHub entity's
 `createdAt`/`updatedAt` timestamp, since GitHub does not expose
 per-label-application timestamps or per-issue timeline events without a

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -305,13 +305,41 @@ queue-state、`runs.jsonl` を変更することは一切ありません — inf
   明示的な人間/design 側からの WAKE メッセージが必要でした。
   `backlog_idle_minutes_threshold` は、すべての result で
   `stale_minutes_threshold` と並んで報告されます。
+- `repair-stalled` (G546) — repair lifecycle にある PR
+  (`intent-pr-request-update`、`intent-pr-update-in-progress`、
+  `intent-pr-rereview-ready`)で、`--repair-silent-minutes`
+  (デフォルト **180** 分)を超えて観測可能な活動が一切ないもの。これは
+  G533 が「field data が出るまで」と保留した promotion であり、その
+  field data は 2 度得られました。より鋭いのは次のケースです: G545 の
+  repair が `intent-pr-update-in-progress` を claim したまま、implement
+  セッションの死亡により **4 日間**(2026-07-23 → 07-27)沈黙し、その間
+  `stalled-work` は `stalled: false, items: []` を報告し続け、復旧には
+  手動 ping が必要でした。その PR は **draft** であり、ここの他の PR 系
+  kind はすべて draft PR を除外するため、どの kind もこれを捕捉できて
+  いませんでした。したがって `repair-stalled` は draft も対象にします
+  (閾値内では draft の repair PR は従来どおり不可視のままで、そのために
+  informational な item を新たに捏造することはしません)。
+  `recommended_action` は常に**責任スレッドへの status check** です —
+  `intent-pr-request-update` / `intent-pr-update-in-progress` は
+  `implement`、`intent-pr-rereview-ready` は `review-dispatch` — であり、
+  transition や担当の付け替えでは**決してありません**: 沈黙だけでは、
+  repair が成功したのか失敗したのか、担当を取り上げるべきなのかを
+  確立できないためです。観測可能な活動は PR 自身の `updatedAt` で、
+  これは 3 つの活動クラスすべてをカバーする唯一のフィールドです
+  (GitHub は head branch への push、あらゆる comment、あらゆる label 変更で
+  これを更新します)。`claimed-but-silent` と同様に fail closed です:
+  `updatedAt` が欠落・不正な場合は沈黙を確立できないため、使えない証拠に
+  基づいて flag するのではなく promotion **しません**。
 
 **informational なカテゴリ (G533)** — `is_informational: true`、
 `recommended_action` は（transition コマンドではなく）説明的な prose、
 age は可視性のためだけに報告されます:
 
 - `repair-pending` — `intent-pr-request-update` および/または
-  `intent-pr-update-in-progress` を持つ PR。field finding: まさにこの
+  `intent-pr-update-in-progress` を持つ PR で、`--repair-silent-minutes`
+  の**閾値内**にあるもの(G546 — 閾値を超えると上記の actionable な
+  `repair-stalled` kind へ promotion されます。閾値内の出力は不変です)。
+  field finding: まさにこの
   状態にあった OPEN PR（PR #1750）が、以前は `pr-created-not-reviewing`
   として誤報告され、`review-start` が推奨されていました — repair の
   最中としては意味的に間違っています。推奨を毎回疑ってかからなければ
@@ -323,8 +351,9 @@ age は可視性のためだけに報告されます:
   fetch を追加しない限り）その label の変更より後になり得る、PR への
   あらゆる種類の最新の変更を反映します。
 - `rereview-pending` — `intent-pr-rereview-ready` を持つ PR（repair が
-  push され、re-review 待ち）。`repair-pending` と同じ `updatedAt` ベース
-  の age 近似です。
+  push され、re-review 待ち）で、`--repair-silent-minutes` の**閾値内**に
+  あるもの(G546)。`repair-pending` と同じ `updatedAt` ベースの age
+  近似です。
 - `claimed-but-silent` — `intent-issue-in-progress` を持つが **まだ PR が
   作成されていない** issue で、`--claimed-silent-minutes`（デフォルトは
   **720** 分 / 12 時間 — 通常の作業セッションでは決して発火しないよう
@@ -444,12 +473,12 @@ transition は拒否されます。これは `queue reprioritize` の reason 要
 （番号 + url）、`age_minutes`、`is_informational`、`recommended_action`
 を報告します。`--stale-minutes` は、指定した閾値より新しい item を
 除外します（デフォルトは `0` — すべてを age 付きで報告し、閾値は
-呼び出し側が選ぶ）— これは 8 つすべての kind に一律に適用されます。
-`claimed-but-silent` と `backlog-ready-idle` は、そもそも item が
-検討される前に、それぞれ自身の `--claimed-silent-minutes` /
-`--backlog-idle-minutes` 閾値でも追加でゲートされます（そのため
-`--stale-minutes` を上げるだけでは、いずれの kind の item も
-自身の閾値より早く現れることはありません）。`age_minutes` は、
+呼び出し側が選ぶ）— これは 9 つすべての kind に一律に適用されます。
+`claimed-but-silent`、`backlog-ready-idle`、`repair-stalled` は、そもそも
+item が検討される前に、それぞれ自身の `--claimed-silent-minutes` /
+`--backlog-idle-minutes` / `--repair-silent-minutes` 閾値でも追加で
+ゲートされます（そのため `--stale-minutes` を上げるだけでは、いずれの
+kind の item も自身の閾値より早く現れることはありません）。`age_minutes` は、
 GitHub が label 適用時刻や、専用の per-issue fetch 無しでの timeline
 event を公開していないため、該当する GitHub entity の
 `createdAt`/`updatedAt` タイムスタンプからの近似値です。

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -8,7 +8,7 @@ namespace IntentSystem.Cli.Commands;
 /// <summary>
 /// G523: <c>intent-cli automation stalled-work --domain &lt;d&gt; --repo &lt;r&gt;
 /// [--stale-minutes &lt;m&gt;] [--claimed-silent-minutes &lt;m&gt;]
-/// [--format json|markdown]</c> — read-only inventory of pending pipeline
+/// [--repair-silent-minutes &lt;m&gt;] [--format json|markdown]</c> — read-only inventory of pending pipeline
 /// transitions with ages, so a single orchestrator wake (or an external
 /// heartbeat) can detect a stall without a human cross-checking GitHub
 /// labels, PR state, and queue-state by hand.
@@ -39,6 +39,18 @@ namespace IntentSystem.Cli.Commands;
 ///   candidate, and no runs.jsonl activity for longer than
 ///   <c>--backlog-idle-minutes</c> (G544 — the last uncovered stall class:
 ///   work that is ready but never started).</item>
+/// <item><c>repair-stalled</c> — a PR in the repair lifecycle
+///   (<c>intent-pr-request-update</c>, <c>intent-pr-update-in-progress</c>,
+///   or <c>intent-pr-rereview-ready</c>) with no observable activity for
+///   longer than <c>--repair-silent-minutes</c> (default
+///   <see cref="DefaultRepairSilentMinutes"/> minutes) — G546, promoting the
+///   G533 informational repair kinds once, and only once, the silence is
+///   long enough to mean a dead worker rather than a repair in progress.
+///   Actionable, but the <c>recommended_action</c> is a status check to the
+///   responsible thread, NEVER a transition (see
+///   <see cref="BuildRepairStalledAction"/>). Covers draft PRs too, which
+///   every other PR kind here deliberately skips — the four-day G545 stall
+///   was invisible precisely because its repair PR was a draft.</item>
 /// </list>
 ///
 /// Informational categories (G533 — age for visibility only,
@@ -66,6 +78,10 @@ namespace IntentSystem.Cli.Commands;
 ///   waiting, not silently stalled. Names the canonical <c>automation
 ///   issue-block</c> reconcile command.</item>
 /// </list>
+///
+/// G546: <c>repair-pending</c> and <c>rereview-pending</c> stay exactly as
+/// described above INSIDE <c>--repair-silent-minutes</c>; past it they are
+/// promoted to the actionable <c>repair-stalled</c> kind above.
 ///
 /// Age is approximated from the relevant GitHub entity's `createdAt` /
 /// `updatedAt` timestamp (GitHub does not expose per-label-application
@@ -204,6 +220,46 @@ internal static class AutomationStalledWorkCommand
     public const int DefaultClaimedSilentMinutes = 720;
 
     /// <summary>
+    /// G546: a PR in the repair lifecycle (<c>intent-pr-request-update</c>,
+    /// <c>intent-pr-update-in-progress</c>, or <c>intent-pr-rereview-ready</c>)
+    /// with no observable activity for longer than
+    /// <see cref="DefaultRepairSilentMinutes"/> (override
+    /// <c>--repair-silent-minutes</c>). ACTIONABLE — but the recommendation is
+    /// always a status check to the responsible thread, never a transition:
+    /// the transition owner is unchanged, and silence alone never establishes
+    /// that a repair succeeded, failed, or should be taken away from its
+    /// current owner.
+    ///
+    /// G533 deliberately left <see cref="KindRepairPending"/> /
+    /// <see cref="KindRereviewPending"/> thresholdless pending field data.
+    /// The data arrived twice: a G545 repair claimed
+    /// <c>intent-pr-update-in-progress</c> went silent for FOUR DAYS
+    /// (2026-07-23 → 07-27) after the implement session died, and a G538 PR
+    /// sat <c>intent-pr-rereview-ready</c> for 105 minutes
+    /// (2026-07-20) — both recovered only by a manual ping. The G545 case is
+    /// the sharper one: its PR was a DRAFT, and
+    /// <see cref="CollectPrCreatedNotReviewing"/> skips draft PRs outright, so
+    /// <c>stalled-work</c> reported <c>stalled=false, items=[]</c> throughout.
+    /// A dead worker mid-repair was the only measured stall class the detector
+    /// could not see at all; this kind closes it on both the draft and
+    /// non-draft paths.
+    /// </summary>
+    public const string KindRepairStalled = "repair-stalled";
+
+    /// <summary>
+    /// G546: conservative default for <c>--repair-silent-minutes</c> (3
+    /// hours). A repair has a well-defined observable footprint (new head
+    /// commits, PR comments, label changes — GitHub bumps the PR's
+    /// <c>updatedAt</c> on every one of them), so a long-but-not-absurd
+    /// threshold catches a multi-hour worker death without flagging a repair
+    /// that is merely mid-thought. Both measured field incidents exceed it
+    /// (105 minutes is under it by design — G538 was recovered by a ping
+    /// before it became a genuine stall; the four-day G545 case exceeds it
+    /// by more than thirtyfold).
+    /// </summary>
+    public const int DefaultRepairSilentMinutes = 180;
+
+    /// <summary>
     /// G532 review repair: a title matched more than one distinct packet's
     /// declared <c>source_execution_unit</c> as a token — the execution unit
     /// cannot be picked without guessing, so it is reported here instead of
@@ -232,7 +288,7 @@ internal static class AutomationStalledWorkCommand
     };
 
     private const string UsageLine =
-        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--stale-minutes <m>] [--claimed-silent-minutes <m>] [--backlog-idle-minutes <m>] [--format json|markdown]";
+        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--stale-minutes <m>] [--claimed-silent-minutes <m>] [--backlog-idle-minutes <m>] [--repair-silent-minutes <m>] [--format json|markdown]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -246,7 +302,7 @@ internal static class AutomationStalledWorkCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var domain, out var repo, out var staleMinutes, out var claimedSilentMinutes, out var backlogIdleMinutes, out var format, out var error))
+        if (!TryParseArguments(args, out var domain, out var repo, out var staleMinutes, out var claimedSilentMinutes, out var backlogIdleMinutes, out var repairSilentMinutes, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -256,7 +312,7 @@ internal static class AutomationStalledWorkCommand
         AutomationStalledWorkResult result;
         try
         {
-            result = Analyze(context, domain!, repo!, staleMinutes, claimedSilentMinutes, backlogIdleMinutes);
+            result = Analyze(context, domain!, repo!, staleMinutes, claimedSilentMinutes, backlogIdleMinutes, repairSilentMinutes);
         }
         catch (Exception exception) when (exception is IOException or InvalidOperationException)
         {
@@ -298,7 +354,8 @@ internal static class AutomationStalledWorkCommand
         string repo,
         int staleMinutes,
         int claimedSilentMinutes = DefaultClaimedSilentMinutes,
-        int backlogIdleMinutes = DefaultBacklogIdleMinutes)
+        int backlogIdleMinutes = DefaultBacklogIdleMinutes,
+        int repairSilentMinutes = DefaultRepairSilentMinutes)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(domain);
@@ -316,7 +373,8 @@ internal static class AutomationStalledWorkCommand
         var warnings = new List<string>();
 
         CollectPublishedNotDelegated(context, domain, candidateDomains, openIssues, openPrs, repo, now, items, excluded);
-        CollectPrCreatedNotReviewing(context, domain, candidateDomains, openIssues, openPrs, repo, now, items, excluded);
+        CollectPrCreatedNotReviewing(context, domain, candidateDomains, openIssues, openPrs, repo, now, repairSilentMinutes, items, excluded);
+        CollectDraftRepairStalled(context, domain, candidateDomains, openIssues, openPrs, repo, now, repairSilentMinutes, items, excluded);
         CollectMergedNotClosedOut(context, domain, candidateDomains, repo, mergedPrs, now, items, excluded, warnings);
         CollectClaimedButSilent(context, domain, candidateDomains, openIssues, openPrs, repo, now, claimedSilentMinutes, items, excluded, warnings);
         CollectBacklogReadyIdle(context, domain, candidateDomains, openIssues, openPrs, repo, now, backlogIdleMinutes, items, excluded);
@@ -420,6 +478,7 @@ internal static class AutomationStalledWorkCommand
         IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
         string repo,
         DateTimeOffset now,
+        int repairSilentMinutes,
         List<StalledWorkItem> items,
         List<StalledWorkExcluded> excluded)
     {
@@ -525,6 +584,20 @@ internal static class AutomationStalledWorkCommand
             // modification of ANY kind (which may postdate the specific
             // label change) unless a dedicated label-event fetch is added.
             var ageSource = isInformational ? pr.UpdatedAt : pr.CreatedAt;
+            var ageMinutes = ComputeAgeMinutes(ageSource, now);
+
+            // G546: promote a repair-lifecycle PR that has been observably
+            // silent past the threshold. Inside the threshold — and whenever
+            // the silence cannot be established at all — the G533
+            // informational item below is emitted completely unchanged.
+            if (isInformational
+                && TryPromoteToRepairStalled(pr, prLabels, repo, now, repairSilentMinutes, out var promotedAction, out var silentMinutes))
+            {
+                kind = KindRepairStalled;
+                isInformational = false;
+                recommendedAction = promotedAction;
+                ageMinutes = silentMinutes;
+            }
 
             items.Add(new StalledWorkItem
             {
@@ -532,11 +605,196 @@ internal static class AutomationStalledWorkCommand
                 ExecutionUnit = resolution.ExecutionUnit,
                 Issue = new StalledWorkRef { Number = matchedIssue.Number, Url = matchedIssue.Url },
                 Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
-                AgeMinutes = ComputeAgeMinutes(ageSource, now),
+                AgeMinutes = ageMinutes,
                 IsInformational = isInformational,
                 RecommendedAction = recommendedAction,
             });
         }
+    }
+
+    /// <summary>
+    /// G546: the draft half of <see cref="KindRepairStalled"/>.
+    /// <see cref="CollectPrCreatedNotReviewing"/> skips draft PRs outright
+    /// (correctly — a draft PR is not "review hasn't started"), which is
+    /// exactly why the four-day G545 stall was invisible: its repair PR was a
+    /// draft carrying <c>intent-pr-update-in-progress</c>, so no kind covered
+    /// it and <c>stalled-work</c> reported healthy for four days. A draft PR
+    /// in the repair lifecycle is still a claimed repair, and a claimed repair
+    /// that stops emitting activity is still a dead worker.
+    ///
+    /// Deliberately narrow, so the draft path adds no new false positives:
+    /// it fires ONLY past the threshold. Inside the threshold a draft repair
+    /// PR stays invisible exactly as it is today — no informational item is
+    /// invented for it, keeping current output byte-compatible. The two paths
+    /// are disjoint by construction (this one handles drafts,
+    /// <see cref="CollectPrCreatedNotReviewing"/> handles non-drafts), so a PR
+    /// can never be reported twice.
+    /// </summary>
+    private static void CollectDraftRepairStalled(
+        CliContext context,
+        string domain,
+        IReadOnlyList<string> candidateDomains,
+        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues,
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
+        string repo,
+        DateTimeOffset now,
+        int repairSilentMinutes,
+        List<StalledWorkItem> items,
+        List<StalledWorkExcluded> excluded)
+    {
+        var openIssuesByNumber = openIssues
+            .Where(issue => IsOpen(issue.State))
+            .ToDictionary(issue => issue.Number);
+
+        foreach (var pr in openPrs)
+        {
+            if (!IsOpen(pr.State) || !pr.IsDraft)
+            {
+                continue;
+            }
+
+            var prLabels = LabelSet(pr.Labels);
+            if (!CarriesRepairLifecycleLabel(prLabels))
+            {
+                continue;
+            }
+
+            if (!TryPromoteToRepairStalled(pr, prLabels, repo, now, repairSilentMinutes, out var recommendedAction, out var silentMinutes))
+            {
+                continue;
+            }
+
+            // The linked issue supplies the execution unit and the domain
+            // corroboration every other collector here relies on. A repair PR
+            // with no resolvable open source issue cannot be domain-confirmed,
+            // so it is left alone rather than reported into a domain it may
+            // not belong to.
+            GitHubAutomationIssueCandidate? matchedIssue = null;
+            foreach (var reference in pr.ClosingIssuesReferences)
+            {
+                if (reference.Number > 0
+                    && ReferenceMatchesRepo(reference, repo)
+                    && openIssuesByNumber.TryGetValue(reference.Number, out var candidate))
+                {
+                    matchedIssue = candidate;
+                    break;
+                }
+            }
+
+            if (matchedIssue is null)
+            {
+                continue;
+            }
+
+            var resolution = ResolveExecutionUnit(context, matchedIssue.Title);
+            var packetDeclaredDomain = resolution.Corroborated ? ReadPacketDeclaredDomain(context, resolution.ExecutionUnit) : null;
+            if (!TryConfirmDomain(domain, resolution, packetDeclaredDomain, candidateDomains, repo,
+                    out var reason, out var detail))
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindRepairStalled,
+                    ExecutionUnit = resolution.ExecutionUnit,
+                    Issue = new StalledWorkRef { Number = matchedIssue.Number, Url = matchedIssue.Url },
+                    Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
+                    Reason = reason,
+                    Detail = detail,
+                });
+                continue;
+            }
+
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindRepairStalled,
+                ExecutionUnit = resolution.ExecutionUnit,
+                Issue = new StalledWorkRef { Number = matchedIssue.Number, Url = matchedIssue.Url },
+                Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
+                AgeMinutes = silentMinutes,
+                IsInformational = false,
+                RecommendedAction = recommendedAction,
+            });
+        }
+    }
+
+    private static bool CarriesRepairLifecycleLabel(ISet<string> prLabels) =>
+        prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrRequestUpdate)
+        || prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress)
+        || prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrRereviewReady);
+
+    /// <summary>
+    /// G546: decides whether a repair-lifecycle PR has been observably silent
+    /// past <paramref name="repairSilentMinutes"/>, and if so produces the
+    /// status-check recommendation for the responsible thread.
+    ///
+    /// "Observable activity" is the PR's own <c>updatedAt</c> — the same
+    /// proxy <see cref="CollectClaimedButSilent"/> already relies on, and the
+    /// one field that covers ALL THREE activity classes this kind cares
+    /// about: GitHub bumps a PR's <c>updatedAt</c> on a push to its head
+    /// branch, on any PR/review comment, and on any label change. The
+    /// approximation is conservative in the only direction that matters: it
+    /// can be bumped by activity that is not repair progress (making a stalled
+    /// repair look alive), but it cannot stay still while a repair is
+    /// genuinely progressing — so it never manufactures a false stall.
+    ///
+    /// Fails closed like <see cref="CollectClaimedButSilent"/>: a missing or
+    /// malformed <c>updatedAt</c> means silence cannot be established, so the
+    /// PR is NOT promoted (it keeps its existing informational treatment, or
+    /// stays invisible on the draft path) rather than being flagged on
+    /// unusable evidence. A future-dated timestamp is clamped to
+    /// <paramref name="now"/>, which can only ever make the PR look less
+    /// silent.
+    /// </summary>
+    private static bool TryPromoteToRepairStalled(
+        GitHubAutomationPrCandidate pr,
+        ISet<string> prLabels,
+        string repo,
+        DateTimeOffset now,
+        int repairSilentMinutes,
+        out string recommendedAction,
+        out int silentMinutes)
+    {
+        recommendedAction = string.Empty;
+        silentMinutes = 0;
+
+        if (!TryParseActivityTimestamp(pr.UpdatedAt, out var activity, out _))
+        {
+            return false;
+        }
+
+        var minutes = ComputeAgeMinutesFromInstant(ClampToNow(activity, now), now);
+        if (minutes < repairSilentMinutes)
+        {
+            return false;
+        }
+
+        silentMinutes = minutes;
+        recommendedAction = BuildRepairStalledAction(pr, prLabels, repo, minutes);
+        return true;
+    }
+
+    /// <summary>
+    /// G546: the recommendation is always a status check addressed to the
+    /// thread that owns the current repair state — never a transition. Which
+    /// thread depends on the label: <c>intent-pr-request-update</c> /
+    /// <c>intent-pr-update-in-progress</c> are owned by the implement thread
+    /// (a repair was requested of, or claimed by, the implementer), whereas
+    /// <c>intent-pr-rereview-ready</c> is owned by review dispatch (the repair
+    /// is pushed and it is the review side that has gone quiet).
+    /// </summary>
+    private static string BuildRepairStalledAction(
+        GitHubAutomationPrCandidate pr, ISet<string> prLabels, string repo, int silentMinutes)
+    {
+        var (state, thread) =
+            prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress)
+                ? (WorkerNextActionConstants.Labels.IntentPrUpdateInProgress, "implement")
+                : prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrRequestUpdate)
+                    ? (WorkerNextActionConstants.Labels.IntentPrRequestUpdate, "implement")
+                    : (WorkerNextActionConstants.Labels.IntentPrRereviewReady, "review-dispatch");
+
+        return
+            $"status check: PR #{pr.Number} in {repo} has carried `{state}` with no observable activity "
+            + $"(head commits, comments, label changes) for {silentMinutes}m — ask the responsible `{thread}` "
+            + "thread for a status update; do not transition the PR or reassign the repair from silence alone.";
     }
 
     private static void CollectMergedNotClosedOut(
@@ -1680,6 +1938,7 @@ internal static class AutomationStalledWorkCommand
         out int staleMinutes,
         out int claimedSilentMinutes,
         out int backlogIdleMinutes,
+        out int repairSilentMinutes,
         out string format,
         out string error)
     {
@@ -1688,6 +1947,7 @@ internal static class AutomationStalledWorkCommand
         staleMinutes = 0;
         claimedSilentMinutes = DefaultClaimedSilentMinutes;
         backlogIdleMinutes = DefaultBacklogIdleMinutes;
+        repairSilentMinutes = DefaultRepairSilentMinutes;
         format = FormatMarkdown;
         error = string.Empty;
 
@@ -1745,6 +2005,18 @@ internal static class AutomationStalledWorkCommand
                         return false;
                     }
                     backlogIdleMinutes = parsedBacklogIdleMinutes;
+                    index++;
+                    break;
+                case "--repair-silent-minutes":
+                    if (index + 1 >= args.Length
+                        || !int.TryParse(args[index + 1], System.Globalization.NumberStyles.Integer,
+                            System.Globalization.CultureInfo.InvariantCulture, out var parsedRepairSilentMinutes)
+                        || parsedRepairSilentMinutes < 0)
+                    {
+                        error = "--repair-silent-minutes requires a non-negative integer.";
+                        return false;
+                    }
+                    repairSilentMinutes = parsedRepairSilentMinutes;
                     index++;
                     break;
                 case "--format":

--- a/tests/IntentSystem.Cli.Tests/AutomationHeartbeatCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHeartbeatCommandTests.cs
@@ -253,7 +253,11 @@ public sealed class AutomationHeartbeatCommandTests : IDisposable
         using var workspace = new HeartbeatWorkspace();
         workspace.WritePacketDomain("G521", "intent-cli");
         var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
-        var pr = BuildOpenPrClosingIssue(1750, FixedNow.AddHours(-3), 1143, "intent-pr-request-update");
+        // G546: kept INSIDE --repair-silent-minutes (default 180m) so this
+        // fixture keeps pinning the G533 informational framing; the past-
+        // threshold promotion to the actionable repair-stalled kind has its
+        // own heartbeat fixture in AutomationStalledWorkCommandTests.
+        var pr = BuildOpenPrClosingIssue(1750, FixedNow.AddHours(-1), 1143, "intent-pr-request-update");
         AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
 
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -219,9 +219,13 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         using var workspace = new StalledWorkWorkspace();
         workspace.WritePacketDomain("G521", "intent-cli");
         var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
+        // G546: updatedAt is deliberately INSIDE --repair-silent-minutes so
+        // this fixture keeps pinning the G533 informational semantics; the
+        // promotion past the threshold is covered by its own fixtures below.
         var pr = BuildPr(1144, "G521: Document agmsg Codex monitor", FixedNow.AddHours(-5),
             state: "OPEN", closingIssueNumber: 1143,
-            extraLabels: ["intent-pr-request-update", "intent-pr-update-in-progress"]);
+            extraLabels: ["intent-pr-request-update", "intent-pr-update-in-progress"],
+            updatedAt: FixedNow.AddMinutes(-30));
         AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
 
         using var writer = new StringWriter();
@@ -258,6 +262,246 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         Assert.True(item.GetProperty("is_informational").GetBoolean());
         Assert.Equal(45, item.GetProperty("age_minutes").GetInt32());
         Assert.DoesNotContain("--transition", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+    }
+
+    // ── G546: repair-stalled ────────────────────────────────────────────
+
+    [Fact]
+    public void Execute_RepairStalled_ReproducesG545FourDayDraftSilence_G546()
+    {
+        // Field regression, 2026-07-23 → 07-27: the G545 repair was claimed
+        // (intent-pr-update-in-progress) and the implement session died. The
+        // PR was a DRAFT, so CollectPrCreatedNotReviewing skipped it outright
+        // and stalled-work reported `stalled=false, items=[]` for four days —
+        // the exact gap the orchestrator reported. It must now surface.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G545", "intent-cli");
+        var issue = BuildIssue(1192, "G545: Exempt queue-blocked units from claimed-but-silent",
+            FixedNow.AddDays(-5), "intent-pr-created");
+        var pr = BuildPr(1193, "G545: Exempt queue-blocked units from claimed-but-silent",
+            FixedNow.AddDays(-4), state: "OPEN", closingIssueNumber: 1192,
+            extraLabels: ["intent-pr-request-update", "intent-pr-update-in-progress"],
+            updatedAt: FixedNow.AddDays(-4), isDraft: true);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.True(doc.RootElement.GetProperty("stalled").GetBoolean());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindRepairStalled, item.GetProperty("kind").GetString());
+        Assert.False(item.GetProperty("is_informational").GetBoolean());
+        Assert.Equal(1193, item.GetProperty("pr").GetProperty("number").GetInt32());
+        Assert.Equal(4 * 24 * 60, item.GetProperty("age_minutes").GetInt32());
+
+        var action = item.GetProperty("recommended_action").GetString()!;
+        Assert.Contains("status check", action, StringComparison.Ordinal);
+        Assert.Contains("`implement`", action, StringComparison.Ordinal);
+        Assert.Contains("intent-pr-update-in-progress", action, StringComparison.Ordinal);
+        // Never a transition, and never a reassignment, from silence alone.
+        Assert.DoesNotContain("--transition", action, StringComparison.Ordinal);
+        Assert.DoesNotContain("worker claim", action, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RepairStalled_FiresForNonDraftRequestUpdate_NamingImplementThread_G546()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G521", "intent-cli");
+        var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildPr(1750, "G521: Document agmsg Codex monitor", FixedNow.AddHours(-9),
+            state: "OPEN", closingIssueNumber: 1143, extraLabels: ["intent-pr-request-update"],
+            updatedAt: FixedNow.AddHours(-6));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindRepairStalled, item.GetProperty("kind").GetString());
+        Assert.False(item.GetProperty("is_informational").GetBoolean());
+        Assert.Equal(360, item.GetProperty("age_minutes").GetInt32());
+        var action = item.GetProperty("recommended_action").GetString()!;
+        Assert.Contains("`implement`", action, StringComparison.Ordinal);
+        Assert.Contains("intent-pr-request-update", action, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RepairStalled_FiresForRereviewReady_NamingReviewDispatchThread_G546()
+    {
+        // The responsible thread differs by state: a pushed repair awaiting
+        // re-review is the REVIEW side going quiet, not the implementer.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G538", "intent-cli");
+        var issue = BuildIssue(1180, "G538: Something awaiting rereview", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildPr(1181, "G538: Something awaiting rereview", FixedNow.AddDays(-1),
+            state: "OPEN", closingIssueNumber: 1180, extraLabels: ["intent-pr-rereview-ready"],
+            updatedAt: FixedNow.AddHours(-4));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindRepairStalled, item.GetProperty("kind").GetString());
+        var action = item.GetProperty("recommended_action").GetString()!;
+        Assert.Contains("`review-dispatch`", action, StringComparison.Ordinal);
+        Assert.Contains("intent-pr-rereview-ready", action, StringComparison.Ordinal);
+        Assert.DoesNotContain("`implement`", action, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    // Each of the three observable activity classes named by the contract —
+    // a push to the head branch, a PR comment, and a label change — bumps the
+    // PR's updatedAt, which is the single field this detector reads. An
+    // actively-progressing repair must never be flagged.
+    [InlineData(5, "recent head commit")]
+    [InlineData(30, "recent PR comment")]
+    [InlineData(179, "recent label change")]
+    public void Execute_RepairStalled_DoesNotFireForActivelyProgressingRepair_G546(int minutesSinceActivity, string activity)
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G521", "intent-cli");
+        var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildPr(1750, $"G521: Document agmsg Codex monitor ({activity})", FixedNow.AddDays(-3),
+            state: "OPEN", closingIssueNumber: 1143, extraLabels: ["intent-pr-update-in-progress"],
+            updatedAt: FixedNow.AddMinutes(-minutesSinceActivity));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        // Still the G533 informational kind, byte-for-byte as before.
+        Assert.Equal(AutomationStalledWorkCommand.KindRepairPending, item.GetProperty("kind").GetString());
+        Assert.True(item.GetProperty("is_informational").GetBoolean());
+        Assert.Equal(minutesSinceActivity, item.GetProperty("age_minutes").GetInt32());
+        Assert.DoesNotContain(
+            doc.RootElement.GetProperty("items").EnumerateArray(),
+            candidate => candidate.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindRepairStalled);
+    }
+
+    [Fact]
+    public void Execute_RepairStalled_ActiveDraftRepairInsideThreshold_StaysInvisibleExactlyAsToday_G546()
+    {
+        // A draft repair PR inside the threshold must produce NO item at all
+        // — the draft path deliberately invents no informational kind, so
+        // today's output stays byte-compatible.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G545", "intent-cli");
+        var issue = BuildIssue(1192, "G545: Exempt queue-blocked units", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildPr(1193, "G545: Exempt queue-blocked units", FixedNow.AddDays(-1),
+            state: "OPEN", closingIssueNumber: 1192, extraLabels: ["intent-pr-update-in-progress"],
+            updatedAt: FixedNow.AddMinutes(-20), isDraft: true);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("stalled").GetBoolean());
+        Assert.Empty(doc.RootElement.GetProperty("items").EnumerateArray());
+    }
+
+    [Fact]
+    public void Execute_RepairStalled_ThresholdOverrideChangesPromotion_G546()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G538", "intent-cli");
+        var issue = BuildIssue(1180, "G538: Something awaiting rereview", FixedNow.AddDays(-2), "intent-pr-created");
+        // The measured G538 shape: 105 minutes — under the 180m default, so
+        // it stays informational unless an operator lowers the threshold.
+        var pr = BuildPr(1181, "G538: Something awaiting rereview", FixedNow.AddDays(-1),
+            state: "OPEN", closingIssueNumber: 1180, extraLabels: ["intent-pr-rereview-ready"],
+            updatedAt: FixedNow.AddMinutes(-105));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var defaultWriter = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            defaultWriter);
+
+        using var defaultDoc = JsonDocument.Parse(defaultWriter.ToString());
+        Assert.Equal(
+            AutomationStalledWorkCommand.KindRereviewPending,
+            Assert.Single(defaultDoc.RootElement.GetProperty("items").EnumerateArray()).GetProperty("kind").GetString());
+
+        using var overrideWriter = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system",
+             "--repair-silent-minutes", "90", "--format", "json"],
+            overrideWriter);
+
+        using var overrideDoc = JsonDocument.Parse(overrideWriter.ToString());
+        var promoted = Assert.Single(overrideDoc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindRepairStalled, promoted.GetProperty("kind").GetString());
+        Assert.Equal(105, promoted.GetProperty("age_minutes").GetInt32());
+    }
+
+    [Fact]
+    public void Execute_RepairStalled_RejectsNegativeThresholdOverride_G546()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        using var writer = new StringWriter();
+
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--repair-silent-minutes", "-1"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--repair-silent-minutes requires a non-negative integer", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_RepairStalled_UnusableActivityTimestamp_IsNeverPromoted_G546()
+    {
+        // Silence cannot be established from a malformed updatedAt, so the
+        // PR keeps its informational treatment rather than being flagged on
+        // unusable evidence — the same fail-closed rule claimed-but-silent
+        // already follows.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G521", "intent-cli");
+        var issue = BuildIssue(1143, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-2), "intent-pr-created");
+        var pr = BuildPr(1750, "G521: Document agmsg Codex monitor", FixedNow.AddDays(-3),
+            state: "OPEN", closingIssueNumber: 1143, extraLabels: ["intent-pr-update-in-progress"]) with
+        {
+            UpdatedAt = "not-a-timestamp",
+        };
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindRepairPending, item.GetProperty("kind").GetString());
+        Assert.True(item.GetProperty("is_informational").GetBoolean());
     }
 
     [Fact]
@@ -2047,6 +2291,40 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         Assert.DoesNotContain(AutomationStalledWorkCommand.KindClaimedButSilent, messageBody, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_Heartbeat_SurfacesRepairStalledAsActionableInMessageBody_G546()
+    {
+        // The four-day G545 shape again, this time through the heartbeat the
+        // orchestrator actually reads: it must be counted as a PENDING
+        // TRANSITION line (actionable), not an "FYI" note, and must name the
+        // kind so a reader can route it.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G545", "intent-cli");
+        var issue = BuildIssue(1192, "G545: Exempt queue-blocked units from claimed-but-silent",
+            FixedNow.AddDays(-5), "intent-pr-created");
+        var pr = BuildPr(1193, "G545: Exempt queue-blocked units from claimed-but-silent",
+            FixedNow.AddDays(-4), state: "OPEN", closingIssueNumber: 1192,
+            extraLabels: ["intent-pr-update-in-progress"],
+            updatedAt: FixedNow.AddDays(-4), isDraft: true);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHeartbeatCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.True(doc.RootElement.GetProperty("stale").GetBoolean());
+        var messageBody = doc.RootElement.GetProperty("message_body").GetString()!;
+        Assert.Contains(AutomationStalledWorkCommand.KindRepairStalled, messageBody, StringComparison.Ordinal);
+        Assert.Contains("G545", messageBody, StringComparison.Ordinal);
+        Assert.Contains("pr #1193", messageBody, StringComparison.Ordinal);
+        Assert.Contains("1 pending transition(s)", messageBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("FYI:", messageBody, StringComparison.Ordinal);
+    }
+
     private static string BuildCompleteContractBody()
     {
         return """
@@ -2140,7 +2418,8 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         string state,
         int? closingIssueNumber = null,
         string[]? extraLabels = null,
-        DateTimeOffset? updatedAt = null) => new()
+        DateTimeOffset? updatedAt = null,
+        bool isDraft = false) => new()
         {
             Number = number,
             Title = title,
@@ -2148,7 +2427,7 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
             CreatedAt = createdAt.ToString("O"),
             UpdatedAt = (updatedAt ?? createdAt).ToString("O"),
             State = state,
-            IsDraft = false,
+            IsDraft = isDraft,
             Labels = (extraLabels ?? Array.Empty<string>()).Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
             ClosingIssuesReferences = closingIssueNumber is int n
                 ? new[]


### PR DESCRIPTION
Closes #1196

## What

Adds a `repair-stalled` kind to `automation stalled-work`: a PR carrying `intent-pr-request-update`, `intent-pr-update-in-progress`, or `intent-pr-rereview-ready` with **no observable activity** for longer than `--repair-silent-minutes` (default **180**) is promoted from informational to actionable (`stalled: true`).

The recommendation is always a **status check to the responsible thread** — `implement` for the two repair labels, `review-dispatch` for `rereview-ready` — and **never** a transition or a reassignment. Silence alone never establishes that a repair succeeded, failed, or should be taken from its owner.

## Why now

G533 deliberately left these kinds thresholdless "until field data exists". It arrived twice, and the sharper case exposed a second gap:

- **2026-07-23 → 07-27**: a G545 repair was claimed (`intent-pr-update-in-progress`) and went silent for **four days** after the implement session died. `stalled-work` reported `stalled=false, items=[]` the whole time; recovery needed a manual ping. That PR was a **draft** — and `CollectPrCreatedNotReviewing` skips draft PRs outright, so no kind covered it at all, not even informationally. The threshold alone would not have caught it.
- **2026-07-20 (G538)**: a PR sat `intent-pr-rereview-ready` for 105 minutes while the orchestrator believed itself idle.

## How

Two **disjoint** paths, so a PR can never be reported twice:

| path | handled by | behaviour inside threshold |
| --- | --- | --- |
| non-draft | promotion in place inside `CollectPrCreatedNotReviewing` | informational item emitted byte-identically |
| draft | new `CollectDraftRepairStalled` | stays invisible exactly as today — no informational kind is invented |

"Observable activity" is the PR's own `updatedAt`: the one field covering **all three** activity classes the contract names — GitHub bumps it on a push to the head branch, on any PR/review comment, and on any label change — and the same proxy `claimed-but-silent` already relies on. The approximation is conservative in the only direction that matters: it can be bumped by activity that is not repair progress (making a stalled repair look alive), but it cannot stay still while a repair is genuinely progressing, so it never manufactures a false stall.

Fails closed like `claimed-but-silent`: a missing or malformed `updatedAt` means silence cannot be established, so the PR is **not** promoted rather than flagged on unusable evidence. A future-dated timestamp is clamped to `now`, which can only make the PR look less silent.

## Fixtures

- **Regression**: the four-day G545 shape (draft + `intent-pr-update-in-progress`, silent 4d) → `repair-stalled`, `stalled: true`, `age_minutes: 5760`, action names the `implement` thread and contains no `--transition` / `worker claim`.
- **Responsible thread**: non-draft `request-update` → `implement`; `rereview-ready` → `review-dispatch` (and explicitly *not* `implement`).
- **False positives**: three active-repair cases — recent head commit (5m), recent PR comment (30m), recent label change (179m) — each still `repair-pending`, informational, with unchanged `age_minutes`, and no `repair-stalled` anywhere in the result.
- **Byte-compatibility**: a draft repair PR inside the threshold produces `stalled: false, items: []`.
- **Threshold**: the measured 105-minute G538 shape stays `rereview-pending` at the default and promotes at `--repair-silent-minutes 90`; a negative override is rejected.
- **Fail-closed**: a malformed `updatedAt` is never promoted.
- **Heartbeat**: `message_body` carries the kind and counts it as `1 pending transition(s)` with no `FYI:` framing.

Two pre-existing fixtures were moved inside the threshold (with a comment saying why) so they keep pinning the G533 informational semantics they were written for.

## Verification

- Focused `AutomationStalledWorkCommandTests` + `AutomationHeartbeatCommandTests`: **92/92 pass** (11 new).
- Full solution suite: **4100 passed, 1 skipped, 0 failed** across 11 assemblies.
- Manual run of the freshly built CLI against live GitHub with `--repair-silent-minutes 0` — flag accepted, output shape intact (no open repair PRs at the time, so `items: []`).
- `git diff --check` clean.
- ja/en `09-developer-reference.md` category tables updated (new kind, the two informational kinds cross-referenced as "inside the threshold", and the kind count / threshold list corrected).

Out of scope and untouched: transition recommendations or automatic messaging, `claimed-but-silent` / `backlog-ready-idle` / the in-flight kinds, and any queue-state work.
