### PR TITLE
G548: Guard every queue-state write with a no-item-loss invariant and stale-base re-application

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1809,8 +1809,12 @@ days, then surfaced as `closeout-plan host-metadata-blocked` and combined
 with the `pr-is-draft` recovery gate into a circular deadlock. Restoration
 took three canonical surfaces plus an operator (host commit `c0897649`).
 
-Every canonical mutation now writes through one shared guard
-(`QueueStatePersistence.Persist`), which enforces three things:
+Every canonical mutation now writes through one shared guard,
+`QueueStatePersistence`. It lives in **`IntentSystem.Supervisor`** — the
+assembly that owns the queue-state model and serializer, and the only one
+*both* `IntentSystem.Cli` and `IntentSystem.Drift` reference — so "every
+canonical writer" means every writer in the solution, including the drift
+service's corrective enqueue. It enforces three things:
 
 1. **Stale-base detection and re-application.** The state the caller *read*
    is compared against what is on disk *now*, at persist time (through the
@@ -1840,11 +1844,34 @@ only; an allow-list entry excuses that unit and nothing else. Retire itself
 needs no entry — it rewrites the item as `state=retired` rather than removing
 it.
 
+**Re-application is reported, never silent.** A canonical command whose
+write was re-applied says so in its own output, naming the execution units it
+was re-applied for — a writer that quietly repaired itself against a
+concurrent write teaches an operator nothing about the contention that caused
+it. `queue transition`, for example, prints `note: queue-state changed after
+it was read (a concurrent canonical write); this transition was re-applied to
+the current state for <units> and no other item was modified.`
+
+**The one raw-text writer.** `metadata update` is the bounded controlled
+metadata writer: it mutates queue-state as raw JSON so it never rewrites a
+field it does not own, and it accepts documents that need not satisfy the
+full `QueueItem` contract. It uses `PersistRawJson`, which checks the
+invariant on `items[].execution_unit` read straight out of the JSON — never
+by deserializing — and on a clean base writes the caller's own text verbatim.
+Only if a concurrent write is actually detected does it need the model to
+re-apply; when the document cannot round-trip through the model it **aborts
+loud** ("re-run this command against the current state") rather than
+normalizing a file it exists not to normalize, or overwriting a change it
+cannot see. Nothing is written either way.
+
 **Multi-writer expectations for shared hosts.** Concurrent canonical writers
 are supported and expected: a losing writer is repaired (re-applied), not
 rejected, so no loop has to serialize against another. What is *not*
 supported is a writer that bypasses the guard — hand-editing
-`queue-state.json`, or a new command calling `File.WriteAllText` directly.
+`queue-state.json`, or a new command calling `File.WriteAllText` directly — a
+source-level fixture (`QueueStateWriterCoverageTests`) fails with the file and
+line of any writer added anywhere in `src/` that bypasses the guard, so the
+all-writers claim cannot regress by hand-verification again.
 Deliberately out of scope, and unchanged by this slice: a per-domain queue
 file split (a future design decision; a recurrence after this lands is the
 escalation criterion), file-locking daemons, cross-process mutexes, and

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1792,6 +1792,66 @@ deliberately left on the legacy whole-file behavior (out of scope for this
 slice); `RunLogSerializer` / the RunEvent required-field contract are
 unchanged.
 
+### Queue-state writes are guarded: no-item-loss invariant and stale-base re-application (G548)
+
+`queue-state.json` is **one file shared by every domain** on a multi-domain
+host, written concurrently by several loops from different checkouts. Every
+canonical writer deserializes the whole file, mutates in memory, and
+reserializes the whole file — so a read-modify-write race does not merely
+conflict, it **silently erases** whatever the stale in-memory copy happened
+not to contain.
+
+**Field incident, 2026-07-23** (host commit `2ab082cf`): a sekiban-domain
+write recorded a G841 PR linkage from a base read an hour earlier and dropped
+the intent-cli G545 queue item seeded in between. Nothing errored; the commit
+message claimed only the linkage change. The loss stayed invisible for four
+days, then surfaced as `closeout-plan host-metadata-blocked` and combined
+with the `pr-is-draft` recovery gate into a circular deadlock. Restoration
+took three canonical surfaces plus an operator (host commit `c0897649`).
+
+Every canonical mutation now writes through one shared guard
+(`QueueStatePersistence.Persist`), which enforces three things:
+
+1. **Stale-base detection and re-application.** The state the caller *read*
+   is compared against what is on disk *now*, at persist time (through the
+   same serializer round-trip, so pure formatting drift is never mistaken for
+   a concurrent write). On a mismatch the caller's mutation — derived
+   automatically as an item-level delta between its base and its outgoing
+   state — is re-applied to the **fresh** state instead of persisting the
+   stale copy, and the re-application is reported back so it is never
+   invisible.
+2. **No-item-loss invariant.** Any execution unit present on disk but missing
+   from the outgoing state, and not named as an expected removal, **aborts
+   the write** — naming the exact units and the canonical recovery path
+   (`queue-seed-from-packet` → idempotent `issue publish-flow` rerun →
+   `closeout-plan --write-recovered-linkage`). The file is left untouched.
+   An on-disk state that cannot be *read* also aborts, since neither
+   guarantee can be established against it.
+3. **Item-scoped re-application.** A re-applied mutation touches only the
+   units its delta actually covers, plus `updated_at`. Every unrelated item
+   is carried through byte-identically from the fresh state, in the fresh
+   state's order — so a stale copy's older view of another item can never
+   overwrite a newer one.
+
+**Explicit removals stay legitimate.** Retire (G525), the completed-item
+lifecycle, and any operation whose contract names the item it may remove pass
+those units as expected removals. The invariant targets **unrequested** loss
+only; an allow-list entry excuses that unit and nothing else. Retire itself
+needs no entry — it rewrites the item as `state=retired` rather than removing
+it.
+
+**Multi-writer expectations for shared hosts.** Concurrent canonical writers
+are supported and expected: a losing writer is repaired (re-applied), not
+rejected, so no loop has to serialize against another. What is *not*
+supported is a writer that bypasses the guard — hand-editing
+`queue-state.json`, or a new command calling `File.WriteAllText` directly.
+Deliberately out of scope, and unchanged by this slice: a per-domain queue
+file split (a future design decision; a recurrence after this lands is the
+escalation criterion), file-locking daemons, cross-process mutexes, and
+git-level merge strategy — the 2ab082cf loss happened inside a
+fast-forward-clean history, so the defense has to sit at the writer, before
+anything reaches a commit.
+
 ---
 
 ## Version flow

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1858,11 +1858,16 @@ field it does not own, and it accepts documents that need not satisfy the
 full `QueueItem` contract. It uses `PersistRawJson`, which checks the
 invariant on `items[].execution_unit` read straight out of the JSON — never
 by deserializing — and on a clean base writes the caller's own text verbatim.
-Only if a concurrent write is actually detected does it need the model to
-re-apply; when the document cannot round-trip through the model it **aborts
-loud** ("re-run this command against the current state") rather than
-normalizing a file it exists not to normalize, or overwriting a change it
-cannot see. Nothing is written either way.
+When a concurrent write *is* detected, the re-application happens at the
+**JSON level** too — items this writer did not touch are carried across as
+the fresh document's own nodes, so fields the model does not know about
+survive on both sides and a stale copy's older view of another item can never
+overwrite a newer one.
+
+Because `metadata update` is the bounded **linkage** writer — the role writer
+B played in the 2ab082cf incident — a re-application on this path is reported
+in its own result: `queue_state_reapplied` / `queue_state_reapplied_execution_units`
+in JSON, and a `queue_state_reapplied:` block in the text output.
 
 **Multi-writer expectations for shared hosts.** Concurrent canonical writers
 are supported and expected: a losing writer is repaired (re-applied), not

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1996,12 +1996,16 @@ writer です: 所有していない field を書き換えないよう queue-sta
 として変更し、完全な `QueueItem` 契約を満たさない document も受け付けます。
 この writer は `PersistRawJson` を使い、invariant を JSON から直接読んだ
 `items[].execution_unit` で検査し(deserialize は一切しません)、base が clean
-なら caller 自身のテキストをそのまま書き込みます。model が必要になるのは並行
-書き込みを実際に検出して再適用する場合だけで、document が model を round-trip
-できないときは、normalize しないために存在する writer が normalize することも、
-見えていない変更を上書きすることもせず、**loud に中止**します
-(「current state に対して再実行してください」)。いずれの場合もファイルへの
-書き込みは行われません。
+なら caller 自身のテキストをそのまま書き込みます。並行書き込みを実際に検出した場合の再適用も **JSON レベル**で行われます —
+この writer が触れていない item は fresh document 自身の node としてそのまま
+引き継がれるため、model が知らない field も両側で保持され、stale copy が持つ
+他 item の古い姿が新しいものを上書きすることはありません。
+
+`metadata update` は bounded **linkage** writer — 2ab082cf incident における
+writer B の役割そのもの — であるため、この経路での再適用は自身の result に
+記録されます: JSON では `queue_state_reapplied` /
+`queue_state_reapplied_execution_units`、text 出力では `queue_state_reapplied:`
+ブロックです。
 
 **共有 host における multi-writer の期待。** canonical writer の並行実行は
 サポートされ、想定されています: 競争に負けた writer は拒否されるのではなく修復

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1951,7 +1951,12 @@ commit message は linkage 変更のみを主張していました。この loss
 (host commit `c0897649`)。
 
 現在は、すべての canonical mutation が 1 つの共有 guard
-(`QueueStatePersistence.Persist`)経由で書き込み、次の 3 点を強制します:
+`QueueStatePersistence` 経由で書き込みます。この guard は
+**`IntentSystem.Supervisor`** — queue-state の model と serializer を所有し、
+`IntentSystem.Cli` と `IntentSystem.Drift` の*両方*が参照する唯一の assembly —
+に置かれているため、「すべての canonical writer」は CLI 内だけでなく solution
+全体の writer(drift service の corrective enqueue を含む)を意味します。
+強制する内容は次の 3 点です:
 
 1. **stale-base の検出と再適用。** caller が*読んだ*状態と、persist 時点で
    ディスク上に*実際にある*状態を比較します(同一の serializer round-trip を
@@ -1978,11 +1983,34 @@ expected removal として渡します。invariant が対象とするのは**要
 loss のみであり、allow-list の entry はその unit だけを免除します。retire 自体は
 entry 不要です — item を削除するのではなく `state=retired` へ書き換えるためです。
 
+**再適用は報告され、決して silent になりません。** 書き込みが再適用された
+canonical command は、その事実と再適用対象の execution unit を自身の出力に
+記載します — 並行書き込みに対して黙って自己修復した writer は、その contention
+について operator に何も伝えないためです。例えば `queue transition` は
+`note: queue-state changed after it was read (a concurrent canonical write);
+this transition was re-applied to the current state for <units> and no other
+item was modified.` を出力します。
+
+**唯一の raw-text writer。** `metadata update` は bounded controlled metadata
+writer です: 所有していない field を書き換えないよう queue-state を raw JSON
+として変更し、完全な `QueueItem` 契約を満たさない document も受け付けます。
+この writer は `PersistRawJson` を使い、invariant を JSON から直接読んだ
+`items[].execution_unit` で検査し(deserialize は一切しません)、base が clean
+なら caller 自身のテキストをそのまま書き込みます。model が必要になるのは並行
+書き込みを実際に検出して再適用する場合だけで、document が model を round-trip
+できないときは、normalize しないために存在する writer が normalize することも、
+見えていない変更を上書きすることもせず、**loud に中止**します
+(「current state に対して再実行してください」)。いずれの場合もファイルへの
+書き込みは行われません。
+
 **共有 host における multi-writer の期待。** canonical writer の並行実行は
 サポートされ、想定されています: 競争に負けた writer は拒否されるのではなく修復
 (再適用)されるため、どの loop も他をシリアライズして待つ必要はありません。
 サポート**されない**のは guard を迂回する writer です — `queue-state.json` の
-手編集や、新規コマンドが直接 `File.WriteAllText` を呼ぶことです。意図的に
+手編集や、新規コマンドが直接 `File.WriteAllText` を呼ぶことです。source レベルの
+fixture (`QueueStateWriterCoverageTests`) が、`src/` 配下のどこかに guard を
+迂回する writer が追加された場合にファイル名と行番号付きで失敗するため、
+all-writers の主張が再び目視確認頼みで退行することはありません。意図的に
 スコープ外かつ本スライスで不変なもの: per-domain の queue file 分割(将来の設計
 判断であり、本スライス後の再発が escalation criterion)、file-locking daemon、
 プロセス間 mutex、git レベルの merge 戦略 — 2ab082cf の loss は

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -1932,6 +1932,63 @@ within-record のソースが **無い** フィールド(最も典型的には `
 残しています(このスライスのスコープ外)。`RunLogSerializer` /
 RunEvent の必須フィールド契約は変更されていません。
 
+### queue-state の書き込みは guard 経由: no-item-loss invariant と stale-base 再適用 (G548)
+
+`queue-state.json` は multi-domain host において**全 domain が共有する 1 つの
+ファイル**であり、複数の loop が別々の checkout から並行して書き込みます。
+canonical な writer はいずれもファイル全体を deserialize し、メモリ上で変更し、
+ファイル全体を再 serialize します — したがって read-modify-write の race は
+単なる衝突ではなく、stale な in-memory copy がたまたま保持していなかったものを
+**黙って消去**します。
+
+**field incident、2026-07-23**(host commit `2ab082cf`): sekiban domain の
+書き込みが 1 時間前に読んだ base から G841 の PR linkage を記録し、その間に
+seed された intent-cli の G545 queue item を削除しました。エラーは一切出ず、
+commit message は linkage 変更のみを主張していました。この loss は 4 日間
+不可視のままとなり、その後 `closeout-plan host-metadata-blocked` として表面化し、
+`pr-is-draft` の recovery gate と組み合わさって循環デッドロックになりました。
+復旧には 3 つの canonical surface と operator の介入が必要でした
+(host commit `c0897649`)。
+
+現在は、すべての canonical mutation が 1 つの共有 guard
+(`QueueStatePersistence.Persist`)経由で書き込み、次の 3 点を強制します:
+
+1. **stale-base の検出と再適用。** caller が*読んだ*状態と、persist 時点で
+   ディスク上に*実際にある*状態を比較します(同一の serializer round-trip を
+   通すため、単なる書式の差異が並行書き込みと誤認されることはありません)。
+   不一致の場合、caller の mutation — base と outgoing state の item 単位
+   delta として自動導出されます — を stale copy ではなく**新しい**状態へ
+   再適用し、再適用が行われたことを結果として報告します(不可視になりません)。
+2. **no-item-loss invariant。** ディスク上に存在するのに outgoing state から
+   欠落しており、かつ明示的な削除として指定されていない execution unit が
+   1 つでもあれば、**書き込みを中止**します — 対象 unit を正確に名指しし、
+   canonical な復旧手段(`queue-seed-from-packet` → 冪等な
+   `issue publish-flow` 再実行 → `closeout-plan --write-recovered-linkage`)も
+   併記します。ファイルは無変更のまま残ります。ディスク上の状態が*読めない*
+   場合も、どちらの保証も確立できないため中止します。
+3. **item-scoped な再適用。** 再適用される mutation が触れるのは、その delta が
+   実際にカバーする unit と `updated_at` だけです。無関係な item はすべて、
+   新しい状態から byte 単位で同一のまま、その順序も保って引き継がれます —
+   したがって stale copy が持つ古い他 item の姿が、新しいものを上書きすることは
+   ありません。
+
+**明示的な削除は引き続き正当です。** retire (G525)、completed item の
+lifecycle、および契約上その item を削除しうると宣言している操作は、対象 unit を
+expected removal として渡します。invariant が対象とするのは**要求されていない**
+loss のみであり、allow-list の entry はその unit だけを免除します。retire 自体は
+entry 不要です — item を削除するのではなく `state=retired` へ書き換えるためです。
+
+**共有 host における multi-writer の期待。** canonical writer の並行実行は
+サポートされ、想定されています: 競争に負けた writer は拒否されるのではなく修復
+(再適用)されるため、どの loop も他をシリアライズして待つ必要はありません。
+サポート**されない**のは guard を迂回する writer です — `queue-state.json` の
+手編集や、新規コマンドが直接 `File.WriteAllText` を呼ぶことです。意図的に
+スコープ外かつ本スライスで不変なもの: per-domain の queue file 分割(将来の設計
+判断であり、本スライス後の再発が escalation criterion)、file-locking daemon、
+プロセス間 mutex、git レベルの merge 戦略 — 2ab082cf の loss は
+fast-forward-clean な履歴の内側で起きたため、防御は commit に到達する前の
+writer 層に置く必要があります。
+
 ---
 
 ## バージョンフロー

--- a/src/IntentSystem.Cli/Commands/AutomationCloseoutDriftCheckCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationCloseoutDriftCheckCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Supervisor.Models;

--- a/src/IntentSystem.Cli/Commands/AutomationCloseoutDriftCheckCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationCloseoutDriftCheckCommand.cs
@@ -456,7 +456,8 @@ internal static class AutomationCloseoutDriftCheckCommand
             try
             {
                 Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
-                File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+                // G548: guarded write (no-item-loss + stale-base re-application).
+                QueueStatePersistence.Persist(queueStatePath, queueState, updatedState);
 
                 // Append run events for each repaired item.
                 Directory.CreateDirectory(Path.GetDirectoryName(runsLogPath)!);

--- a/src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs
@@ -472,7 +472,11 @@ internal static class AutomationHostQueueItemRecoveryCommand
         };
 
         Directory.CreateDirectory(Path.GetDirectoryName(writePath)!);
-        File.WriteAllText(writePath, QueueStateSerializer.Serialize(newState));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(
+            writePath,
+            currentState ?? new QueueState { SchemaVersion = "1", UpdatedAt = newState.UpdatedAt, Items = Array.Empty<QueueItem>() },
+            newState);
         return newState;
     }
 

--- a/src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Supervisor.Models;

--- a/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
@@ -374,7 +374,7 @@ internal static class AutomationIssueBlockCommand
             AppendRunEvent(runLogPath, runEvent);
         }
 
-        WriteQueueState(queueStatePath, updatedState);
+        WriteQueueState(queueStatePath, queueState, updatedState);
 
         var finalItem = updatedState.Items.First(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
         return new QueueQueueSideResult(false, true, finalItem.State, finalItem.BlockedBy);
@@ -592,7 +592,7 @@ internal static class AutomationIssueBlockCommand
         File.AppendAllText(runLogPath, RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
     }
 
-    private static void WriteQueueState(string queueStatePath, QueueState state)
+    private static void WriteQueueState(string queueStatePath, QueueState baseState, QueueState state)
     {
         if (WriteQueueStateOverride is not null)
         {
@@ -600,7 +600,8 @@ internal static class AutomationIssueBlockCommand
             return;
         }
 
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(state));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(queueStatePath, baseState, state);
     }
 
     private static string BuildSummary(

--- a/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
@@ -447,7 +447,13 @@ internal static class AutomationIssueRetireCommand
                 UpdatedAt = now,
                 Items = updatedItems,
             };
-            File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+            // G548: guarded write. Retire never REMOVES an item (it rewrites
+            // it as state=retired), so no removal is expected here — any item
+            // that would disappear is unrequested loss.
+            QueueStatePersistence.Persist(
+                queueStatePath,
+                queueState ?? new QueueState { SchemaVersion = "1", UpdatedAt = now, Items = Array.Empty<QueueItem>() },
+                updatedState);
         }
         catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException or UnauthorizedAccessException)
         {

--- a/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Diagnostics;
 using System.Globalization;
 using System.Text.Json;

--- a/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Supervisor.Models;

--- a/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPublishRecoveryCommand.cs
@@ -404,7 +404,8 @@ internal static class AutomationPublishRecoveryCommand
             Items = items,
             UpdatedAt = DateTimeOffset.UtcNow
         };
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updated));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(queueStatePath, queueState, updated);
 
         // G390 (review follow-up, Finding 1): a --write recovery must record a
         // durable run event so the repair is auditable and closeout-plan can

--- a/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Supervisor.Models;

--- a/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
@@ -263,7 +263,11 @@ internal static class AutomationQueueSeedFromPacketCommand
         };
 
         Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updated));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(
+            queueStatePath,
+            existing ?? new QueueState { SchemaVersion = "1", UpdatedAt = updated.UpdatedAt, Items = Array.Empty<QueueItem>() },
+            updated);
 
         var runsPath = Path.Combine(context.RepoRoot, ".intent-cli", "runs.jsonl");
         Directory.CreateDirectory(Path.GetDirectoryName(runsPath)!);

--- a/src/IntentSystem.Cli/Commands/AutomationReconcileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationReconcileCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Supervisor.Models;

--- a/src/IntentSystem.Cli/Commands/AutomationReconcileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationReconcileCommand.cs
@@ -395,7 +395,8 @@ internal static class AutomationReconcileCommand
             Items = newItems,
             UpdatedAt = DateTimeOffset.UtcNow,
         };
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(queueStatePath, queueState, updatedState);
     }
 
     private static string BuildSummary(

--- a/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
@@ -266,7 +266,8 @@ internal static class AutomationStateDoctorCommand
             try
             {
                 var updatedState = queueState with { Items = items, UpdatedAt = DateTimeOffset.UtcNow };
-                File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+                // G548: guarded write (no-item-loss + stale-base re-application).
+                QueueStatePersistence.Persist(queueStatePath, queueState, updatedState);
                 AppendRunEvents(context, appliedEvents);
             }
             catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)

--- a/src/IntentSystem.Cli/Commands/ClarifyAnswerCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyAnswerCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using IntentSystem.Clarify;
 using IntentSystem.Clarify.Models;
 using IntentSystem.Clarify.Serialization;

--- a/src/IntentSystem.Cli/Commands/ClarifyAnswerCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyAnswerCommand.cs
@@ -74,7 +74,7 @@ internal static class ClarifyAnswerCommand
             var result = ClarifyGateway.Apply(answeredClarification, queueState, TransitionActor, timestamp);
 
             File.WriteAllText(artifactPath, ClarificationSerializer.Serialize(result.AppliedClarification));
-            PersistQueueState(context, result.UpdatedQueueState);
+            PersistQueueState(context, queueState, result.UpdatedQueueState);
             AppendRunEvents(context, result.Events);
 
             var resumedItem = result.UpdatedQueueState.Items.Single(item =>
@@ -181,10 +181,12 @@ internal static class ClarifyAnswerCommand
             : Path.GetFullPath(Path.Combine(repoRoot, artifactRef.Replace('/', Path.DirectorySeparatorChar)));
     }
 
-    private static void PersistQueueState(CliContext context, Supervisor.Models.QueueState queueState)
+    private static void PersistQueueState(
+        CliContext context, Supervisor.Models.QueueState baseState, Supervisor.Models.QueueState queueState)
     {
         var queueStatePath = context.GetQueueStatePath();
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(queueState));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(queueStatePath, baseState, queueState);
     }
 
     private static void AppendRunEvents(CliContext context, IReadOnlyList<Supervisor.Models.RunEvent> events)

--- a/src/IntentSystem.Cli/Commands/ClarifyOpenCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyOpenCommand.cs
@@ -99,7 +99,7 @@ internal static class ClarifyOpenCommand
 
             var clarification = BuildClarification(queueItem, packet, reviewContext, timestamp, reason);
             var artifactPath = PersistClarification(context.RepoRoot, clarification);
-            PersistTransition(context, transition);
+            PersistTransition(context, queueState, transition);
 
             writer.WriteLine($"Clarification opened for {executionUnit}.");
             writer.WriteLine($"Artifact path: {artifactPath}");
@@ -164,10 +164,11 @@ internal static class ClarifyOpenCommand
         return artifactPath;
     }
 
-    private static void PersistTransition(CliContext context, QueueTransitionResult result)
+    private static void PersistTransition(CliContext context, QueueState baseState, QueueTransitionResult result)
     {
         var queueStatePath = context.GetQueueStatePath();
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(queueStatePath, baseState, result.UpdatedState);
 
         var runLogPath = context.GetRunLogPath();
         var runLogDirectory = Path.GetDirectoryName(runLogPath)

--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Supervisor.Models;

--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -269,7 +269,8 @@ internal static class CloseoutPrCommand
             // present because RepoRoot/.intent-cli/ exists by host
             // contract). Idempotent.
             Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
-            File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+            // G548: guarded write (no-item-loss + stale-base re-application).
+            QueueStatePersistence.Persist(queueStatePath, queueState, updatedState);
 
             Directory.CreateDirectory(Path.GetDirectoryName(runsLogPath)!);
             using var stream = new FileStream(runsLogPath, FileMode.Append, FileAccess.Write);

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -866,7 +866,8 @@ internal static class IssuePublishFlowCommand
             UpdatedAt = publishedAt,
         };
 
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(queueStatePath, queueState, updatedState);
         return true;
     }
 

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/IntentSystem.Cli/Commands/MetadataUpdateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataUpdateCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text;
 using System.Text.Json;
 using IntentSystem.Cli;
@@ -318,7 +319,11 @@ internal static class MetadataUpdateCommand
         // on first write (legacy root is always present because --root
         // exists). Idempotent.
         Directory.CreateDirectory(Path.GetDirectoryName(queueStatePath)!);
-        File.WriteAllText(queueStatePath, newQueueText);
+        // G548: guarded write. This is the bounded controlled metadata writer
+        // — it mutates raw JSON so it never rewrites a field it does not own
+        // — so it uses the raw-text guard: the invariant is enforced, and on
+        // a clean base its own text is written verbatim.
+        QueueStatePersistence.PersistRawJson(queueStatePath, queueStateRaw, newQueueText);
         updatedFiles.Add(queueStateRelative);
 
         var newPublishText = AppendPrBlockToPublishYaml(

--- a/src/IntentSystem.Cli/Commands/MetadataUpdateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataUpdateCommand.cs
@@ -323,7 +323,7 @@ internal static class MetadataUpdateCommand
         // — it mutates raw JSON so it never rewrites a field it does not own
         // — so it uses the raw-text guard: the invariant is enforced, and on
         // a clean base its own text is written verbatim.
-        QueueStatePersistence.PersistRawJson(queueStatePath, queueStateRaw, newQueueText);
+        var queuePersist = QueueStatePersistence.PersistRawJson(queueStatePath, queueStateRaw, newQueueText);
         updatedFiles.Add(queueStateRelative);
 
         var newPublishText = AppendPrBlockToPublishYaml(
@@ -365,6 +365,12 @@ internal static class MetadataUpdateCommand
             Mode = MetadataUpdateConstants.Modes.CompletedCloseout,
             UpdatedFiles = updatedFiles,
             EventAppended = MetadataUpdateConstants.EventNames.CompletedCloseout,
+            // G548: this command is the bounded linkage writer — the exact
+            // role writer B played in the 2ab082cf incident — so a successful
+            // re-application onto a concurrently-changed queue-state is
+            // surfaced here rather than being repaired silently.
+            QueueStateReapplied = queuePersist.ReappliedOnFreshBase,
+            QueueStateReappliedExecutionUnits = queuePersist.ReappliedExecutionUnits,
             Errors = errors,
             Warnings = warnings,
         };
@@ -596,6 +602,15 @@ internal static class MetadataUpdateCommand
         if (!string.IsNullOrEmpty(result.EventAppended))
         {
             writer.WriteLine($"- event_appended: {result.EventAppended}");
+        }
+        if (result.QueueStateReapplied)
+        {
+            writer.WriteLine("- queue_state_reapplied: true");
+            writer.WriteLine(
+                $"- queue_state_reapplied_execution_units: {string.Join(", ", result.QueueStateReappliedExecutionUnits)}");
+            writer.WriteLine(
+                "  note: queue-state changed after it was read (a concurrent canonical write); this update was "
+                + "re-applied to the current state and no other item was modified.");
         }
         writer.WriteLine();
 

--- a/src/IntentSystem.Cli/Commands/MetadataUpdateResult.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataUpdateResult.cs
@@ -44,6 +44,30 @@ internal sealed record MetadataUpdateResult
     [JsonPropertyName("eventAppended")]
     public string? EventAppendedCamelCase => EventAppended;
 
+    /// <summary>
+    /// G548: true when <c>queue-state.json</c> had changed since this command
+    /// read it (a concurrent canonical write from another loop or domain) and
+    /// this command's own linkage/closeout change was re-applied onto that
+    /// fresher state rather than overwriting it. This is the 2026-07-23
+    /// <c>2ab082cf</c> shape — a bounded linkage writer starting from a stale
+    /// base — so it is reported, never silent: an operator reading this output
+    /// must be able to see that contention occurred and on which units.
+    /// </summary>
+    [JsonPropertyName("queue_state_reapplied")]
+    public bool QueueStateReapplied { get; init; }
+
+    /// <summary>G208 contract alias — camelCase.</summary>
+    [JsonPropertyName("queueStateReapplied")]
+    public bool QueueStateReappliedCamelCase => QueueStateReapplied;
+
+    /// <summary>G548: the execution units the re-applied mutation covered.</summary>
+    [JsonPropertyName("queue_state_reapplied_execution_units")]
+    public IReadOnlyList<string> QueueStateReappliedExecutionUnits { get; init; } = Array.Empty<string>();
+
+    /// <summary>G208 contract alias — camelCase.</summary>
+    [JsonPropertyName("queueStateReappliedExecutionUnits")]
+    public IReadOnlyList<string> QueueStateReappliedExecutionUnitsCamelCase => QueueStateReappliedExecutionUnits;
+
     [JsonPropertyName("errors")]
     public required IReadOnlyList<MetadataValidateFinding> Errors { get; init; }
 

--- a/src/IntentSystem.Cli/Commands/MigrateHostStateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/MigrateHostStateCommand.cs
@@ -197,7 +197,12 @@ internal static class MigrateHostStateCommand
             UpdatedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
             Items = mergedItems
         };
-        File.WriteAllText(scopedQueueStatePath, QueueStateSerializer.Serialize(mergedState));
+        // G548: guarded write. Migration only ever ADDS items to the scoped
+        // state, so any item that would disappear is unrequested loss.
+        QueueStatePersistence.Persist(
+            scopedQueueStatePath,
+            scopedQueueState ?? new QueueState { SchemaVersion = "1", UpdatedAt = mergedState.UpdatedAt, Items = Array.Empty<QueueItem>() },
+            mergedState);
 
         // Append new runs to scoped runs.jsonl.
         if (plan.RunsToAdd.Count > 0)

--- a/src/IntentSystem.Cli/Commands/MigrateHostStateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/MigrateHostStateCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Supervisor.Models;

--- a/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueDispatchCommand.cs
@@ -1,4 +1,5 @@
 using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Commands;
@@ -133,7 +134,7 @@ internal static class QueueDispatchCommand
             TransitionActor,
             TimestampFactory());
 
-        PersistDispatch(context, result);
+        PersistDispatch(context, queueState, result);
 
         return new QueueDispatchCommandResult
         {
@@ -159,10 +160,11 @@ internal static class QueueDispatchCommand
         return Path.GetFullPath(Path.Combine(repoRoot, directoryRef, "github-body.md"));
     }
 
-    private static void PersistDispatch(CliContext context, QueueTransitionResult result)
+    private static void PersistDispatch(CliContext context, QueueState baseState, QueueTransitionResult result)
     {
         var queueStatePath = context.GetQueueStatePath();
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(queueStatePath, baseState, result.UpdatedState);
 
         PersistRunEvent(context, result.Event);
     }

--- a/src/IntentSystem.Cli/Commands/QueueEnqueueCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueEnqueueCommand.cs
@@ -50,7 +50,7 @@ internal static class QueueEnqueueCommand
 
             if (result.WasEnqueued)
             {
-                PersistEnqueue(context, result);
+                PersistEnqueue(context, queueState, result);
             }
 
             QueueEnqueueRenderer.WriteSummary(writer, new QueueEnqueueCommandResult
@@ -159,10 +159,11 @@ internal static class QueueEnqueueCommand
         };
     }
 
-    internal static void PersistEnqueue(CliContext context, QueueEnqueueResult result)
+    internal static void PersistEnqueue(CliContext context, QueueState baseState, QueueEnqueueResult result)
     {
         var queueStatePath = context.GetQueueStatePath();
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(queueStatePath, baseState, result.UpdatedState);
 
         if (result.Event is null)
         {

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Supervisor.Models;

--- a/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueReprioritizeCommand.cs
@@ -345,7 +345,7 @@ internal static class QueueReprioritizeCommand
 
         try
         {
-            WriteQueueState(queueStatePath, finalState);
+            WriteQueueState(queueStatePath, currentOnDisk, finalState);
         }
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
         {
@@ -480,7 +480,7 @@ internal static class QueueReprioritizeCommand
         File.AppendAllText(runLogPath, RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
     }
 
-    private static void WriteQueueState(string queueStatePath, QueueState state)
+    private static void WriteQueueState(string queueStatePath, QueueState baseState, QueueState state)
     {
         if (WriteQueueStateOverride is not null)
         {
@@ -488,7 +488,10 @@ internal static class QueueReprioritizeCommand
             return;
         }
 
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(state));
+        // G548: guarded write. This command already re-reads the file before
+        // writing (G537), so the base handed to the guard is that fresh read
+        // — the guard then still catches a write racing in between.
+        QueueStatePersistence.Persist(queueStatePath, baseState, state);
     }
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
@@ -96,7 +96,7 @@ internal static class QueueTransitionCommand
                     return 0;
                 }
 
-                PersistTransition(context, new QueueTransitionResult
+                PersistTransition(context, queueState, new QueueTransitionResult
                 {
                     UpdatedState = retireResult.UpdatedState,
                     Event = retireResult.Event!
@@ -121,7 +121,7 @@ internal static class QueueTransitionCommand
                     TransitionActor,
                     DateTimeOffset.UtcNow);
 
-            PersistTransition(context, result);
+            PersistTransition(context, queueState, result);
 
             writer.WriteLine($"Transitioned {args[0]} to {FormatState(targetState)}.");
             return 0;
@@ -275,10 +275,13 @@ internal static class QueueTransitionCommand
         return state is QueueItemState.Blocked or QueueItemState.ClarifyBlocked;
     }
 
-    private static void PersistTransition(CliContext context, QueueTransitionResult result)
+    private static void PersistTransition(CliContext context, QueueState baseState, QueueTransitionResult result)
     {
         var queueStatePath = context.GetQueueStatePath();
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(result.UpdatedState));
+        // G548: guarded write — never silently drops another domain's item,
+        // and re-applies this item-scoped transition if the shared file moved
+        // since it was read.
+        QueueStatePersistence.Persist(queueStatePath, baseState, result.UpdatedState);
 
         var runLogPath = context.GetRunLogPath();
         var runLogDirectory = Path.GetDirectoryName(runLogPath)

--- a/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/QueueTransitionCommand.cs
@@ -96,13 +96,14 @@ internal static class QueueTransitionCommand
                     return 0;
                 }
 
-                PersistTransition(context, queueState, new QueueTransitionResult
+                var retirePersist = PersistTransition(context, queueState, new QueueTransitionResult
                 {
                     UpdatedState = retireResult.UpdatedState,
                     Event = retireResult.Event!
                 });
 
                 writer.WriteLine($"Transitioned {args[0]} to retired.");
+                WriteReapplicationNotice(writer, retirePersist);
                 return 0;
             }
 
@@ -121,9 +122,10 @@ internal static class QueueTransitionCommand
                     TransitionActor,
                     DateTimeOffset.UtcNow);
 
-            PersistTransition(context, queueState, result);
+            var persistResult = PersistTransition(context, queueState, result);
 
             writer.WriteLine($"Transitioned {args[0]} to {FormatState(targetState)}.");
+            WriteReapplicationNotice(writer, persistResult);
             return 0;
         }
         catch (InvalidOperationException exception)
@@ -275,13 +277,14 @@ internal static class QueueTransitionCommand
         return state is QueueItemState.Blocked or QueueItemState.ClarifyBlocked;
     }
 
-    private static void PersistTransition(CliContext context, QueueState baseState, QueueTransitionResult result)
+    private static QueueStatePersistResult PersistTransition(
+        CliContext context, QueueState baseState, QueueTransitionResult result)
     {
         var queueStatePath = context.GetQueueStatePath();
         // G548: guarded write — never silently drops another domain's item,
         // and re-applies this item-scoped transition if the shared file moved
         // since it was read.
-        QueueStatePersistence.Persist(queueStatePath, baseState, result.UpdatedState);
+        var persistResult = QueueStatePersistence.Persist(queueStatePath, baseState, result.UpdatedState);
 
         var runLogPath = context.GetRunLogPath();
         var runLogDirectory = Path.GetDirectoryName(runLogPath)
@@ -290,6 +293,28 @@ internal static class QueueTransitionCommand
         File.AppendAllText(
             runLogPath,
             RunLogSerializer.SerializeLine(result.Event) + Environment.NewLine);
+
+        return persistResult;
+    }
+
+    /// <summary>
+    /// G548 round 2: a re-application is a recovery signal, so it must be
+    /// OBSERVABLE — a writer that silently repaired itself against a
+    /// concurrent write teaches an operator nothing about the contention that
+    /// caused it. The notice names the execution units the mutation was
+    /// re-applied for, so the message is actionable rather than atmospheric.
+    /// </summary>
+    private static void WriteReapplicationNotice(TextWriter writer, QueueStatePersistResult persistResult)
+    {
+        if (!persistResult.ReappliedOnFreshBase)
+        {
+            return;
+        }
+
+        writer.WriteLine(
+            "note: queue-state changed after it was read (a concurrent canonical write); this transition was "
+            + $"re-applied to the current state for {string.Join(", ", persistResult.ReappliedExecutionUnits)} "
+            + "and no other item was modified.");
     }
 
     private static string FormatState(QueueItemState state)

--- a/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Supervisor.Models;

--- a/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
@@ -840,7 +840,8 @@ internal static class ReviewCloseoutPlanCommand
         };
 
         Directory.CreateDirectory(Path.GetDirectoryName(legacyQueueStatePath)!);
-        File.WriteAllText(legacyQueueStatePath, QueueStateSerializer.Serialize(updatedState));
+        // G548: guarded write (no-item-loss + stale-base re-application).
+        QueueStatePersistence.Persist(legacyQueueStatePath, queueState, updatedState);
 
         var runsLogPath = Path.Combine(repoRoot, ".intent-cli", "runs.jsonl");
         Directory.CreateDirectory(Path.GetDirectoryName(runsLogPath)!);

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
@@ -453,7 +453,8 @@ internal static class WorkerCompleteCommand
                 Items = newItems,
                 UpdatedAt = DateTimeOffset.UtcNow,
             };
-            File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedState));
+            // G548: guarded write (no-item-loss + stale-base re-application).
+            QueueStatePersistence.Persist(queueStatePath, queueState, updatedState);
             return (true, null);
         }
         catch (Exception exception) when (exception is IOException or InvalidOperationException or System.Text.Json.JsonException)

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using System.Text.Json;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;

--- a/src/IntentSystem.Cli/QueueStatePersistence.cs
+++ b/src/IntentSystem.Cli/QueueStatePersistence.cs
@@ -1,0 +1,372 @@
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli;
+
+/// <summary>
+/// G548: the single shared persistence layer every canonical
+/// <c>queue-state.json</c> mutation writes through.
+///
+/// <c>queue-state.json</c> is ONE file shared by every domain on a
+/// multi-domain host, written concurrently by several loops from different
+/// checkouts. Every canonical writer deserializes the whole file, mutates in
+/// memory, and reserializes the whole file — so a read-modify-write race
+/// does not merely conflict, it SILENTLY ERASES whatever the stale in-memory
+/// copy happened not to contain.
+///
+/// Field incident, 2026-07-23 (host commit <c>2ab082cf</c>): a
+/// sekiban-domain write recorded a G841 PR linkage from a base read an hour
+/// earlier and dropped the intent-cli G545 queue item seeded in between.
+/// Nothing errored; the commit message claimed only the linkage change. The
+/// loss stayed invisible for four days, then surfaced as <c>closeout-plan
+/// host-metadata-blocked</c> and combined with the <c>pr-is-draft</c>
+/// recovery gate into a circular deadlock. Restoration took three canonical
+/// surfaces plus an operator (host commit <c>c0897649</c>).
+///
+/// Three guarantees, all enforced here rather than re-implemented per
+/// command:
+/// <list type="number">
+/// <item><b>Stale-base detection and re-application.</b> The state the caller
+///   READ is compared against what is on disk NOW, at persist time. On a
+///   mismatch the caller's own mutation — derived as an item-level delta
+///   between its base and its outgoing state — is re-applied to the FRESH
+///   state instead of persisting the stale copy. The re-application is
+///   reported back so callers can surface it.</item>
+/// <item><b>No-item-loss invariant.</b> Any execution unit present on disk
+///   but missing from the outgoing state, and not named as an expected
+///   removal, aborts the write loudly — naming the exact units and the
+///   canonical recovery surfaces. Explicit removals (retire, completed
+///   lifecycle) stay legitimate; the invariant targets UNREQUESTED loss
+///   only.</item>
+/// <item><b>Item-scoped re-application.</b> A re-applied mutation touches
+///   only the units its delta actually covers, plus <c>updated_at</c>. Every
+///   unrelated item is carried through byte-identically from the fresh
+///   on-disk state.</item>
+/// </list>
+///
+/// Deliberately NOT in this layer (out of scope, and recorded as such): a
+/// per-domain queue-file split, file-locking daemons, cross-process mutexes,
+/// and git-level merge strategy. The 2ab082cf loss happened inside a
+/// fast-forward-clean history, so the defense has to sit at the writer,
+/// before anything reaches a commit.
+/// </summary>
+internal static class QueueStatePersistence
+{
+    /// <summary>
+    /// G548: the canonical restoration path, proven end-to-end on
+    /// 2026-07-27 (host commit <c>c0897649</c>). Named verbatim in the
+    /// abort message so an operator hitting the invariant is never left
+    /// guessing how to recover the state it just refused to overwrite.
+    /// </summary>
+    internal const string RecoverySurfaces =
+        "recover with: (1) `intent-cli automation queue-seed-from-packet <unit> --write` to re-seed a lost "
+        + "item from its packet, (2) `intent-cli issue publish-flow <unit> --repo <owner/repo> --write` "
+        + "(idempotent rerun) to restore its publish linkage, then (3) `intent-cli review closeout-plan "
+        + "--pr <n> --repo <owner/repo> --write-recovered-linkage` to recover PR linkage from GitHub "
+        + "closing references";
+
+    /// <summary>
+    /// Persists <paramref name="outgoingState"/>, enforcing every guarantee
+    /// described on this class.
+    /// </summary>
+    /// <param name="queueStatePath">Target <c>queue-state.json</c>.</param>
+    /// <param name="baseState">
+    /// The state the caller READ before mutating. Used both to derive the
+    /// caller's item-level delta and to detect that the file has moved on
+    /// since. Pass the deserialized state exactly as read — not a copy the
+    /// caller has already mutated.
+    /// </param>
+    /// <param name="outgoingState">The mutated state the caller wants written.</param>
+    /// <param name="expectedRemovals">
+    /// Execution units this operation was explicitly asked to remove (retire,
+    /// completed-item lifecycle, …). Anything else that disappears aborts.
+    /// </param>
+    /// <exception cref="QueueStateItemLossException">
+    /// The write would drop an unrequested item.
+    /// </exception>
+    public static QueueStatePersistResult Persist(
+        string queueStatePath,
+        QueueState baseState,
+        QueueState outgoingState,
+        IReadOnlyCollection<string>? expectedRemovals = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(queueStatePath);
+        ArgumentNullException.ThrowIfNull(baseState);
+        ArgumentNullException.ThrowIfNull(outgoingState);
+
+        var removalAllowList = new HashSet<string>(expectedRemovals ?? Array.Empty<string>(), StringComparer.Ordinal);
+
+        // The file may legitimately not exist yet (first write of a fresh
+        // host). There is nothing to lose and nothing to be stale against.
+        if (!File.Exists(queueStatePath))
+        {
+            Write(queueStatePath, outgoingState);
+            return QueueStatePersistResult.DirectWrite(outgoingState);
+        }
+
+        QueueState onDiskState;
+        try
+        {
+            onDiskState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or System.Text.Json.JsonException)
+        {
+            // An unreadable on-disk state cannot be diffed, so neither
+            // guarantee can be established. Failing loud is the only safe
+            // answer: silently overwriting is exactly the class of harm this
+            // layer exists to prevent.
+            throw new QueueStateItemLossException(
+                $"refusing to persist queue-state to {queueStatePath}: the current on-disk state could not be read "
+                + $"({exception.Message}), so this write cannot be checked for item loss. Repair or restore the file "
+                + $"first — {RecoverySurfaces}.");
+        }
+
+        var stale = !StatesMatch(onDiskState, baseState);
+        var finalState = outgoingState;
+        IReadOnlyList<string> reappliedUnits = Array.Empty<string>();
+
+        if (stale)
+        {
+            var delta = QueueStateItemDelta.Between(baseState, outgoingState);
+            finalState = delta.ApplyTo(onDiskState, outgoingState.UpdatedAt);
+            reappliedUnits = delta.TouchedExecutionUnits;
+
+            AssertItemScoped(onDiskState, finalState, delta.TouchedExecutionUnits, queueStatePath);
+        }
+
+        AssertNoUnrequestedLoss(onDiskState, finalState, removalAllowList, queueStatePath);
+
+        Write(queueStatePath, finalState);
+
+        return stale
+            ? QueueStatePersistResult.Reapplied(finalState, reappliedUnits)
+            : QueueStatePersistResult.DirectWrite(finalState);
+    }
+
+    /// <summary>
+    /// Compares two states through the SAME serializer round-trip, so pure
+    /// formatting drift (a legacy file written before a serializer
+    /// normalization, for instance) is never mistaken for a concurrent
+    /// write. Only genuine content differences count as a stale base.
+    /// </summary>
+    private static bool StatesMatch(QueueState left, QueueState right) =>
+        string.Equals(
+            QueueStateSerializer.Serialize(left),
+            QueueStateSerializer.Serialize(right),
+            StringComparison.Ordinal);
+
+    private static void AssertNoUnrequestedLoss(
+        QueueState onDiskState,
+        QueueState finalState,
+        HashSet<string> removalAllowList,
+        string queueStatePath)
+    {
+        var survivingUnits = new HashSet<string>(
+            finalState.Items.Select(item => item.ExecutionUnit), StringComparer.Ordinal);
+
+        var lost = onDiskState.Items
+            .Select(item => item.ExecutionUnit)
+            .Where(unit => !survivingUnits.Contains(unit) && !removalAllowList.Contains(unit))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(unit => unit, StringComparer.Ordinal)
+            .ToArray();
+
+        if (lost.Length == 0)
+        {
+            return;
+        }
+
+        throw new QueueStateItemLossException(
+            $"refusing to persist queue-state to {queueStatePath}: this write would remove {lost.Length} queue "
+            + $"item(s) it was not asked to remove — {string.Join(", ", lost)}. This is the 2026-07-23 lost-update "
+            + "shape (a write from a stale base silently erasing another domain's item); the write was aborted and "
+            + $"the file is unchanged. Re-run this command against current state, or if an item is already lost, "
+            + $"{RecoverySurfaces}.");
+    }
+
+    /// <summary>
+    /// Defense in depth: a re-applied mutation is item-scoped BY
+    /// CONSTRUCTION (the delta only ever carries the units it touched), so
+    /// this can only fire if that construction is ever broken. It is
+    /// asserted rather than assumed, because the failure it guards against
+    /// is precisely the silent one.
+    /// </summary>
+    private static void AssertItemScoped(
+        QueueState onDiskState,
+        QueueState finalState,
+        IReadOnlyCollection<string> touchedUnits,
+        string queueStatePath)
+    {
+        var touched = new HashSet<string>(touchedUnits, StringComparer.Ordinal);
+        var finalByUnit = finalState.Items.ToDictionary(item => item.ExecutionUnit, StringComparer.Ordinal);
+
+        var collateral = new List<string>();
+        foreach (var item in onDiskState.Items)
+        {
+            if (touched.Contains(item.ExecutionUnit))
+            {
+                continue;
+            }
+
+            if (!finalByUnit.TryGetValue(item.ExecutionUnit, out var reapplied) || !QueueItemsEqual(item, reapplied))
+            {
+                collateral.Add(item.ExecutionUnit);
+            }
+        }
+
+        if (collateral.Count == 0)
+        {
+            return;
+        }
+
+        throw new QueueStateItemLossException(
+            $"refusing to persist queue-state to {queueStatePath}: re-applying this mutation onto the current "
+            + $"on-disk state would also modify {collateral.Count} unrelated item(s) — "
+            + $"{string.Join(", ", collateral.OrderBy(unit => unit, StringComparer.Ordinal))}. A re-applied mutation "
+            + "must touch only the items it originally changed, plus updated_at.");
+    }
+
+    internal static bool QueueItemsEqual(QueueItem left, QueueItem right) =>
+        string.Equals(
+            QueueStateSerializer.Serialize(SingleItemState(left)),
+            QueueStateSerializer.Serialize(SingleItemState(right)),
+            StringComparison.Ordinal);
+
+    private static QueueState SingleItemState(QueueItem item) => new()
+    {
+        SchemaVersion = "1",
+        UpdatedAt = DateTimeOffset.UnixEpoch,
+        Items = [item],
+    };
+
+    private static void Write(string queueStatePath, QueueState state)
+    {
+        var directory = Path.GetDirectoryName(queueStatePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(state));
+    }
+}
+
+/// <summary>
+/// G548: the item-level difference between the state a caller read and the
+/// state it wants written — i.e. the caller's mutation, expressed in a form
+/// that can be re-applied to a DIFFERENT base. Derived rather than supplied,
+/// so every existing writer gets stale-base recovery without restructuring
+/// its own mutation logic.
+/// </summary>
+internal sealed record QueueStateItemDelta
+{
+    /// <summary>Items added or modified by the mutation, in outgoing order.</summary>
+    public required IReadOnlyList<QueueItem> Upserts { get; init; }
+
+    /// <summary>Execution units the mutation removed from its own base.</summary>
+    public required IReadOnlyList<string> Removals { get; init; }
+
+    /// <summary>Every unit this mutation touches — the exact scope a re-application may modify.</summary>
+    public IReadOnlyList<string> TouchedExecutionUnits =>
+        Upserts.Select(item => item.ExecutionUnit).Concat(Removals).Distinct(StringComparer.Ordinal).ToArray();
+
+    public static QueueStateItemDelta Between(QueueState baseState, QueueState outgoingState)
+    {
+        var baseByUnit = baseState.Items.ToDictionary(item => item.ExecutionUnit, StringComparer.Ordinal);
+        var outgoingUnits = new HashSet<string>(
+            outgoingState.Items.Select(item => item.ExecutionUnit), StringComparer.Ordinal);
+
+        var upserts = outgoingState.Items
+            .Where(item => !baseByUnit.TryGetValue(item.ExecutionUnit, out var original)
+                || !QueueStatePersistence.QueueItemsEqual(original, item))
+            .ToArray();
+
+        var removals = baseState.Items
+            .Select(item => item.ExecutionUnit)
+            .Where(unit => !outgoingUnits.Contains(unit))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return new QueueStateItemDelta { Upserts = upserts, Removals = removals };
+    }
+
+    /// <summary>
+    /// Re-applies this mutation onto <paramref name="freshState"/>. An
+    /// upserted unit already present is replaced in place (preserving the
+    /// fresh state's item ORDER, so unrelated items never shuffle); a new
+    /// unit is appended. Removals drop only the named units. Everything else
+    /// is carried through untouched.
+    /// </summary>
+    public QueueState ApplyTo(QueueState freshState, DateTimeOffset updatedAt)
+    {
+        var upsertByUnit = Upserts.ToDictionary(item => item.ExecutionUnit, StringComparer.Ordinal);
+        var removalSet = new HashSet<string>(Removals, StringComparer.Ordinal);
+
+        var items = new List<QueueItem>();
+        foreach (var item in freshState.Items)
+        {
+            if (removalSet.Contains(item.ExecutionUnit))
+            {
+                continue;
+            }
+
+            items.Add(upsertByUnit.TryGetValue(item.ExecutionUnit, out var replacement) ? replacement : item);
+        }
+
+        var existingUnits = new HashSet<string>(
+            freshState.Items.Select(item => item.ExecutionUnit), StringComparer.Ordinal);
+        foreach (var upsert in Upserts.Where(upsert => !existingUnits.Contains(upsert.ExecutionUnit)))
+        {
+            items.Add(upsert);
+        }
+
+        return freshState with { Items = items, UpdatedAt = updatedAt };
+    }
+}
+
+/// <summary>G548: outcome of a guarded queue-state write.</summary>
+internal sealed record QueueStatePersistResult
+{
+    /// <summary>The state actually written to disk.</summary>
+    public required QueueState PersistedState { get; init; }
+
+    /// <summary>
+    /// True when the on-disk file had changed since the caller read it and
+    /// the caller's mutation was re-applied onto that fresher state. Callers
+    /// surface this so a re-application is never invisible.
+    /// </summary>
+    public required bool ReappliedOnFreshBase { get; init; }
+
+    /// <summary>The execution units the re-applied mutation covered.</summary>
+    public required IReadOnlyList<string> ReappliedExecutionUnits { get; init; }
+
+    public static QueueStatePersistResult DirectWrite(QueueState state) => new()
+    {
+        PersistedState = state,
+        ReappliedOnFreshBase = false,
+        ReappliedExecutionUnits = Array.Empty<string>(),
+    };
+
+    public static QueueStatePersistResult Reapplied(QueueState state, IReadOnlyList<string> units) => new()
+    {
+        PersistedState = state,
+        ReappliedOnFreshBase = true,
+        ReappliedExecutionUnits = units,
+    };
+}
+
+/// <summary>
+/// G548: raised when a queue-state write would drop an item it was not asked
+/// to drop, when the current on-disk state cannot be read to check that, or
+/// when a re-applied mutation would reach outside its own item scope. An
+/// <see cref="InvalidOperationException"/> so the many canonical writers that
+/// already catch that type report it through their existing failure paths
+/// instead of crashing.
+/// </summary>
+internal sealed class QueueStateItemLossException : InvalidOperationException
+{
+    public QueueStateItemLossException(string message)
+        : base(message)
+    {
+    }
+}

--- a/src/IntentSystem.Drift/IntentDriftService.cs
+++ b/src/IntentSystem.Drift/IntentDriftService.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Supervisor;
 using IntentSystem.Drift.Models;
 using IntentSystem.Projection;
 using IntentSystem.Projection.Models;
@@ -90,7 +91,10 @@ public static class IntentDriftService
 
         if (appendedEvents.Count > 0)
         {
-            File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(updatedQueueState));
+            // G548: guarded write. The corrective enqueue writes the SAME
+            // shared multi-domain queue-state every CLI writer does, so it
+            // goes through the same no-item-loss / stale-base guard.
+            QueueStatePersistence.Persist(queueStatePath, queueState, updatedQueueState);
 
             var runLogDirectory = Path.GetDirectoryName(runLogPath)
                 ?? throw new InvalidOperationException("Run log path did not contain a directory.");

--- a/src/IntentSystem.Supervisor/QueueStatePersistence.cs
+++ b/src/IntentSystem.Supervisor/QueueStatePersistence.cs
@@ -76,13 +76,63 @@ public static class QueueStatePersistence
 
     /// <summary>
     /// G548 round 2: test seam invoked immediately before the guard reads the
-    /// current on-disk state, with the target path. It exists so a
-    /// COMMAND-level fixture can make the file move between a command's own
-    /// read and its persist — the one interleaving a single-process test
-    /// cannot otherwise produce, and the exact interleaving this guard is
-    /// built for. Never set in production.
+    /// current on-disk state. It exists so a COMMAND-level fixture can make
+    /// the file move between a command's own read and its persist — the one
+    /// interleaving a single-process test cannot otherwise produce, and the
+    /// exact interleaving this guard is built for.
+    ///
+    /// Round 4: the seam is keyed BY QUEUE-STATE PATH, not process-global. A
+    /// single mutable static was contended between fixtures in different
+    /// xUnit classes, which run in parallel — each cleared or overwrote the
+    /// other's hook, so the focused suites passed alone and failed together.
+    /// Keying by path removes the contention structurally rather than
+    /// serializing the suites: each fixture owns its own temp workspace, so
+    /// two fixtures can never address the same key.
     /// </summary>
-    public static Action<string>? BeforePersistHook { get; set; }
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, Action<string>> BeforePersistHooks =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Registers a before-persist hook for ONE queue-state path. Dispose the
+    /// returned registration to remove it. Registering a second hook for the
+    /// same path throws rather than silently replacing the first — that
+    /// silent replacement is exactly the failure this replaced.
+    /// </summary>
+    public static IDisposable RegisterBeforePersistHook(string queueStatePath, Action<string> hook)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(queueStatePath);
+        ArgumentNullException.ThrowIfNull(hook);
+
+        var key = Path.GetFullPath(queueStatePath);
+        if (!BeforePersistHooks.TryAdd(key, hook))
+        {
+            throw new InvalidOperationException($"a before-persist hook is already registered for '{key}'.");
+        }
+
+        return new BeforePersistHookRegistration(key);
+    }
+
+    private static void InvokeBeforePersistHook(string queueStatePath)
+    {
+        if (BeforePersistHooks.IsEmpty)
+        {
+            return;
+        }
+
+        if (BeforePersistHooks.TryGetValue(Path.GetFullPath(queueStatePath), out var hook))
+        {
+            hook(queueStatePath);
+        }
+    }
+
+    private sealed class BeforePersistHookRegistration : IDisposable
+    {
+        private readonly string key;
+
+        public BeforePersistHookRegistration(string key) => this.key = key;
+
+        public void Dispose() => BeforePersistHooks.TryRemove(key, out _);
+    }
 
     /// <summary>
     /// G548 round 2: guarded write for the ONE canonical writer that mutates
@@ -109,7 +159,7 @@ public static class QueueStatePersistence
         ArgumentNullException.ThrowIfNull(baseRawText);
         ArgumentNullException.ThrowIfNull(outgoingRawText);
 
-        BeforePersistHook?.Invoke(queueStatePath);
+        InvokeBeforePersistHook(queueStatePath);
 
         if (!File.Exists(queueStatePath))
         {
@@ -374,7 +424,7 @@ public static class QueueStatePersistence
 
         if (!skipHook)
         {
-            BeforePersistHook?.Invoke(queueStatePath);
+            InvokeBeforePersistHook(queueStatePath);
         }
 
         var removalAllowList = new HashSet<string>(expectedRemovals ?? Array.Empty<string>(), StringComparer.Ordinal);

--- a/src/IntentSystem.Supervisor/QueueStatePersistence.cs
+++ b/src/IntentSystem.Supervisor/QueueStatePersistence.cs
@@ -1,11 +1,20 @@
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
-namespace IntentSystem.Cli;
+namespace IntentSystem.Supervisor;
 
 /// <summary>
 /// G548: the single shared persistence layer every canonical
 /// <c>queue-state.json</c> mutation writes through.
+///
+/// It lives in <c>IntentSystem.Supervisor</c> — the assembly that owns the
+/// queue-state model and serializer, and the only one BOTH
+/// <c>IntentSystem.Cli</c> and <c>IntentSystem.Drift</c> reference — so
+/// "every canonical writer" can mean every writer in the solution, not just
+/// the ones that happen to live in the CLI (G548 round 2: the drift
+/// service's corrective enqueue and the bounded metadata writer were
+/// reachable loss paths precisely because the guard had been placed one
+/// layer too high).
 ///
 /// <c>queue-state.json</c> is ONE file shared by every domain on a
 /// multi-domain host, written concurrently by several loops from different
@@ -50,7 +59,7 @@ namespace IntentSystem.Cli;
 /// fast-forward-clean history, so the defense has to sit at the writer,
 /// before anything reaches a commit.
 /// </summary>
-internal static class QueueStatePersistence
+public static class QueueStatePersistence
 {
     /// <summary>
     /// G548: the canonical restoration path, proven end-to-end on
@@ -58,12 +67,176 @@ internal static class QueueStatePersistence
     /// abort message so an operator hitting the invariant is never left
     /// guessing how to recover the state it just refused to overwrite.
     /// </summary>
-    internal const string RecoverySurfaces =
+    public const string RecoverySurfaces =
         "recover with: (1) `intent-cli automation queue-seed-from-packet <unit> --write` to re-seed a lost "
         + "item from its packet, (2) `intent-cli issue publish-flow <unit> --repo <owner/repo> --write` "
         + "(idempotent rerun) to restore its publish linkage, then (3) `intent-cli review closeout-plan "
         + "--pr <n> --repo <owner/repo> --write-recovered-linkage` to recover PR linkage from GitHub "
         + "closing references";
+
+    /// <summary>
+    /// G548 round 2: test seam invoked immediately before the guard reads the
+    /// current on-disk state, with the target path. It exists so a
+    /// COMMAND-level fixture can make the file move between a command's own
+    /// read and its persist — the one interleaving a single-process test
+    /// cannot otherwise produce, and the exact interleaving this guard is
+    /// built for. Never set in production.
+    /// </summary>
+    public static Action<string>? BeforePersistHook { get; set; }
+
+    /// <summary>
+    /// G548 round 2: guarded write for the ONE canonical writer that mutates
+    /// queue-state as raw JSON text rather than through the model —
+    /// <c>metadata update</c>, deliberately a bounded controlled writer that
+    /// preserves any field it does not own.
+    ///
+    /// On the ordinary path (the file has not moved since the caller read it)
+    /// the caller's own text is written VERBATIM, so that bounded-writer
+    /// property is fully preserved; the invariant is still enforced by
+    /// deserializing both sides purely to compare item sets. Only when a
+    /// concurrent write is actually detected does it fall back to the model
+    /// round-trip used to re-apply the delta — which is exactly what every
+    /// other canonical writer does unconditionally, so the rare stale path is
+    /// no less faithful than the rest of the system.
+    /// </summary>
+    public static QueueStatePersistResult PersistRawJson(
+        string queueStatePath,
+        string baseRawText,
+        string outgoingRawText,
+        IReadOnlyCollection<string>? expectedRemovals = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(queueStatePath);
+        ArgumentNullException.ThrowIfNull(baseRawText);
+        ArgumentNullException.ThrowIfNull(outgoingRawText);
+
+        BeforePersistHook?.Invoke(queueStatePath);
+
+        if (!File.Exists(queueStatePath))
+        {
+            WriteText(queueStatePath, outgoingRawText);
+            return QueueStatePersistResult.DirectWrite(null);
+        }
+
+        var onDiskRawText = File.ReadAllText(queueStatePath);
+
+        if (!RawJsonMatches(onDiskRawText, baseRawText))
+        {
+            // Concurrent write detected. Re-applying an item-level delta needs
+            // the model, so try that; if this file cannot round-trip through
+            // the model (the very reason this writer works on raw text), abort
+            // loud and repairable rather than normalizing a file this writer
+            // exists NOT to normalize, or overwriting a change it cannot see.
+            try
+            {
+                return PersistCore(
+                    queueStatePath,
+                    QueueStateSerializer.Deserialize(baseRawText),
+                    QueueStateSerializer.Deserialize(outgoingRawText),
+                    expectedRemovals,
+                    skipHook: true);
+            }
+            catch (Exception exception) when (exception is not QueueStateItemLossException
+                && exception is InvalidOperationException or System.Text.Json.JsonException)
+            {
+                throw new QueueStateItemLossException(
+                    $"refusing to persist queue-state to {queueStatePath}: the file changed after it was read (a "
+                    + "concurrent canonical write), and this bounded raw-text writer cannot re-apply its change onto "
+                    + $"the new state ({exception.Message}). Nothing was written. Re-run this command against the "
+                    + "current state.");
+            }
+        }
+
+        // Clean base: enforce the invariant on execution units only — read
+        // straight out of the JSON, never through the model, so a partial or
+        // legacy queue file is checked exactly like any other instead of being
+        // rejected by a contract this writer deliberately does not impose.
+        var removalAllowList = new HashSet<string>(expectedRemovals ?? Array.Empty<string>(), StringComparer.Ordinal);
+        var lost = ReadExecutionUnits(onDiskRawText)
+            .Where(unit => !ReadExecutionUnits(outgoingRawText).Contains(unit) && !removalAllowList.Contains(unit))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(unit => unit, StringComparer.Ordinal)
+            .ToArray();
+
+        if (lost.Length > 0)
+        {
+            throw new QueueStateItemLossException(
+                $"refusing to persist queue-state to {queueStatePath}: this write would remove {lost.Length} queue "
+                + $"item(s) it was not asked to remove — {string.Join(", ", lost)}. This is the 2026-07-23 lost-update "
+                + "shape (a write from a stale base silently erasing another domain's item); the write was aborted and "
+                + $"the file is unchanged. Re-run this command against current state, or if an item is already lost, "
+                + $"{RecoverySurfaces}.");
+        }
+
+        // The caller's own text is written VERBATIM, preserving the
+        // bounded-writer property: no field this writer does not own is
+        // touched, and nothing is normalized on its behalf.
+        WriteText(queueStatePath, outgoingRawText);
+        return QueueStatePersistResult.DirectWrite(null);
+    }
+
+    /// <summary>
+    /// Structural comparison of two queue-state documents without the model,
+    /// so whitespace/formatting differences never read as a concurrent write
+    /// and a partial document never throws.
+    /// </summary>
+    private static bool RawJsonMatches(string left, string right)
+    {
+        try
+        {
+            using var leftDoc = System.Text.Json.JsonDocument.Parse(left);
+            using var rightDoc = System.Text.Json.JsonDocument.Parse(right);
+            return string.Equals(
+                System.Text.Json.JsonSerializer.Serialize(leftDoc.RootElement),
+                System.Text.Json.JsonSerializer.Serialize(rightDoc.RootElement),
+                StringComparison.Ordinal);
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            // Unparseable on either side: treat as different, so the caller
+            // takes the loud path rather than overwriting blind.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Extracts <c>items[].execution_unit</c> directly from the JSON. The
+    /// no-item-loss invariant only needs identity, and identity is the one
+    /// field every queue document has regardless of how complete it is.
+    /// </summary>
+    private static IReadOnlyCollection<string> ReadExecutionUnits(string rawText)
+    {
+        var units = new List<string>();
+        using var document = System.Text.Json.JsonDocument.Parse(rawText);
+        if (!document.RootElement.TryGetProperty("items", out var items)
+            || items.ValueKind != System.Text.Json.JsonValueKind.Array)
+        {
+            return units;
+        }
+
+        foreach (var item in items.EnumerateArray())
+        {
+            if (item.ValueKind == System.Text.Json.JsonValueKind.Object
+                && item.TryGetProperty("execution_unit", out var unit)
+                && unit.ValueKind == System.Text.Json.JsonValueKind.String
+                && unit.GetString() is { Length: > 0 } value)
+            {
+                units.Add(value);
+            }
+        }
+
+        return units;
+    }
+
+    private static void WriteText(string queueStatePath, string text)
+    {
+        var directory = Path.GetDirectoryName(queueStatePath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        File.WriteAllText(queueStatePath, text);
+    }
 
     /// <summary>
     /// Persists <paramref name="outgoingState"/>, enforcing every guarantee
@@ -88,11 +261,24 @@ internal static class QueueStatePersistence
         string queueStatePath,
         QueueState baseState,
         QueueState outgoingState,
-        IReadOnlyCollection<string>? expectedRemovals = null)
+        IReadOnlyCollection<string>? expectedRemovals = null) =>
+        PersistCore(queueStatePath, baseState, outgoingState, expectedRemovals, skipHook: false);
+
+    private static QueueStatePersistResult PersistCore(
+        string queueStatePath,
+        QueueState baseState,
+        QueueState outgoingState,
+        IReadOnlyCollection<string>? expectedRemovals,
+        bool skipHook)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(queueStatePath);
         ArgumentNullException.ThrowIfNull(baseState);
         ArgumentNullException.ThrowIfNull(outgoingState);
+
+        if (!skipHook)
+        {
+            BeforePersistHook?.Invoke(queueStatePath);
+        }
 
         var removalAllowList = new HashSet<string>(expectedRemovals ?? Array.Empty<string>(), StringComparer.Ordinal);
 
@@ -226,7 +412,7 @@ internal static class QueueStatePersistence
             + "must touch only the items it originally changed, plus updated_at.");
     }
 
-    internal static bool QueueItemsEqual(QueueItem left, QueueItem right) =>
+    public static bool QueueItemsEqual(QueueItem left, QueueItem right) =>
         string.Equals(
             QueueStateSerializer.Serialize(SingleItemState(left)),
             QueueStateSerializer.Serialize(SingleItemState(right)),
@@ -258,7 +444,7 @@ internal static class QueueStatePersistence
 /// so every existing writer gets stale-base recovery without restructuring
 /// its own mutation logic.
 /// </summary>
-internal sealed record QueueStateItemDelta
+public sealed record QueueStateItemDelta
 {
     /// <summary>Items added or modified by the mutation, in outgoing order.</summary>
     public required IReadOnlyList<QueueItem> Upserts { get; init; }
@@ -325,10 +511,13 @@ internal sealed record QueueStateItemDelta
 }
 
 /// <summary>G548: outcome of a guarded queue-state write.</summary>
-internal sealed record QueueStatePersistResult
+public sealed record QueueStatePersistResult
 {
-    /// <summary>The state actually written to disk.</summary>
-    public required QueueState PersistedState { get; init; }
+    /// <summary>
+    /// The state actually written to disk. Null for the raw-text path, which
+    /// deliberately never materializes the model.
+    /// </summary>
+    public required QueueState? PersistedState { get; init; }
 
     /// <summary>
     /// True when the on-disk file had changed since the caller read it and
@@ -340,7 +529,7 @@ internal sealed record QueueStatePersistResult
     /// <summary>The execution units the re-applied mutation covered.</summary>
     public required IReadOnlyList<string> ReappliedExecutionUnits { get; init; }
 
-    public static QueueStatePersistResult DirectWrite(QueueState state) => new()
+    public static QueueStatePersistResult DirectWrite(QueueState? state) => new()
     {
         PersistedState = state,
         ReappliedOnFreshBase = false,
@@ -363,7 +552,7 @@ internal sealed record QueueStatePersistResult
 /// already catch that type report it through their existing failure paths
 /// instead of crashing.
 /// </summary>
-internal sealed class QueueStateItemLossException : InvalidOperationException
+public sealed class QueueStateItemLossException : InvalidOperationException
 {
     public QueueStateItemLossException(string message)
         : base(message)

--- a/src/IntentSystem.Supervisor/QueueStatePersistence.cs
+++ b/src/IntentSystem.Supervisor/QueueStatePersistence.cs
@@ -121,29 +121,20 @@ public static class QueueStatePersistence
 
         if (!RawJsonMatches(onDiskRawText, baseRawText))
         {
-            // Concurrent write detected. Re-applying an item-level delta needs
-            // the model, so try that; if this file cannot round-trip through
-            // the model (the very reason this writer works on raw text), abort
-            // loud and repairable rather than normalizing a file this writer
-            // exists NOT to normalize, or overwriting a change it cannot see.
-            try
-            {
-                return PersistCore(
-                    queueStatePath,
-                    QueueStateSerializer.Deserialize(baseRawText),
-                    QueueStateSerializer.Deserialize(outgoingRawText),
-                    expectedRemovals,
-                    skipHook: true);
-            }
-            catch (Exception exception) when (exception is not QueueStateItemLossException
-                && exception is InvalidOperationException or System.Text.Json.JsonException)
-            {
-                throw new QueueStateItemLossException(
-                    $"refusing to persist queue-state to {queueStatePath}: the file changed after it was read (a "
-                    + "concurrent canonical write), and this bounded raw-text writer cannot re-apply its change onto "
-                    + $"the new state ({exception.Message}). Nothing was written. Re-run this command against the "
-                    + "current state.");
-            }
+            // Concurrent write detected. Re-apply this writer's own change
+            // onto the fresh document AT THE JSON LEVEL — never through the
+            // model. Untouched items are carried across as the exact JSON
+            // nodes the fresh document holds, so this path preserves the
+            // bounded-writer property just as completely as the clean one,
+            // and works on the partial/legacy documents this writer exists to
+            // accept.
+            var reapplied = ReapplyRawDelta(onDiskRawText, baseRawText, outgoingRawText, out var touchedUnits);
+
+            var staleRemovalAllowList = new HashSet<string>(expectedRemovals ?? Array.Empty<string>(), StringComparer.Ordinal);
+            AssertNoUnrequestedRawLoss(onDiskRawText, reapplied, staleRemovalAllowList, queueStatePath);
+
+            WriteText(queueStatePath, reapplied);
+            return QueueStatePersistResult.Reapplied(null, touchedUnits);
         }
 
         // Clean base: enforce the invariant on execution units only — read
@@ -151,27 +142,133 @@ public static class QueueStatePersistence
         // legacy queue file is checked exactly like any other instead of being
         // rejected by a contract this writer deliberately does not impose.
         var removalAllowList = new HashSet<string>(expectedRemovals ?? Array.Empty<string>(), StringComparer.Ordinal);
-        var lost = ReadExecutionUnits(onDiskRawText)
-            .Where(unit => !ReadExecutionUnits(outgoingRawText).Contains(unit) && !removalAllowList.Contains(unit))
-            .Distinct(StringComparer.Ordinal)
-            .OrderBy(unit => unit, StringComparer.Ordinal)
-            .ToArray();
-
-        if (lost.Length > 0)
-        {
-            throw new QueueStateItemLossException(
-                $"refusing to persist queue-state to {queueStatePath}: this write would remove {lost.Length} queue "
-                + $"item(s) it was not asked to remove — {string.Join(", ", lost)}. This is the 2026-07-23 lost-update "
-                + "shape (a write from a stale base silently erasing another domain's item); the write was aborted and "
-                + $"the file is unchanged. Re-run this command against current state, or if an item is already lost, "
-                + $"{RecoverySurfaces}.");
-        }
+        AssertNoUnrequestedRawLoss(onDiskRawText, outgoingRawText, removalAllowList, queueStatePath);
 
         // The caller's own text is written VERBATIM, preserving the
         // bounded-writer property: no field this writer does not own is
         // touched, and nothing is normalized on its behalf.
         WriteText(queueStatePath, outgoingRawText);
         return QueueStatePersistResult.DirectWrite(null);
+    }
+
+    /// <summary>
+    /// The no-item-loss invariant, evaluated on execution units read straight
+    /// out of the JSON — identity is the one field every queue document has
+    /// regardless of how complete it is.
+    /// </summary>
+    private static void AssertNoUnrequestedRawLoss(
+        string onDiskRawText, string outgoingRawText, HashSet<string> removalAllowList, string queueStatePath)
+    {
+        var surviving = new HashSet<string>(ReadExecutionUnits(outgoingRawText), StringComparer.Ordinal);
+        var lost = ReadExecutionUnits(onDiskRawText)
+            .Where(unit => !surviving.Contains(unit) && !removalAllowList.Contains(unit))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(unit => unit, StringComparer.Ordinal)
+            .ToArray();
+
+        if (lost.Length == 0)
+        {
+            return;
+        }
+
+        throw new QueueStateItemLossException(
+            $"refusing to persist queue-state to {queueStatePath}: this write would remove {lost.Length} queue "
+            + $"item(s) it was not asked to remove — {string.Join(", ", lost)}. This is the 2026-07-23 lost-update "
+            + "shape (a write from a stale base silently erasing another domain's item); the write was aborted and "
+            + $"the file is unchanged. Re-run this command against current state, or if an item is already lost, "
+            + $"{RecoverySurfaces}.");
+    }
+
+    /// <summary>
+    /// Re-applies a raw-text writer's item-level change onto the fresh
+    /// document without deserializing either side into the model. Items the
+    /// writer did not touch are carried over as the fresh document's own JSON
+    /// nodes — byte-preserved, in the fresh document's order — so a stale
+    /// copy's older view of another item can never overwrite a newer one.
+    /// </summary>
+    private static string ReapplyRawDelta(
+        string onDiskRawText, string baseRawText, string outgoingRawText, out IReadOnlyList<string> touchedUnits)
+    {
+        var freshRoot = System.Text.Json.Nodes.JsonNode.Parse(onDiskRawText)?.AsObject()
+            ?? throw new QueueStateItemLossException("queue-state on disk is not a JSON object.");
+        var baseItems = ReadItemsByUnit(baseRawText);
+        var outgoingItems = ReadItemsByUnit(outgoingRawText);
+
+        var upserts = outgoingItems
+            .Where(entry => !baseItems.TryGetValue(entry.Key, out var original)
+                || !string.Equals(original, entry.Value, StringComparison.Ordinal))
+            .ToDictionary(entry => entry.Key, entry => entry.Value, StringComparer.Ordinal);
+        var removals = new HashSet<string>(
+            baseItems.Keys.Where(unit => !outgoingItems.ContainsKey(unit)), StringComparer.Ordinal);
+
+        touchedUnits = upserts.Keys.Concat(removals).Distinct(StringComparer.Ordinal).ToArray();
+
+        var merged = new System.Text.Json.Nodes.JsonArray();
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        if (freshRoot["items"] is System.Text.Json.Nodes.JsonArray freshItems)
+        {
+            foreach (var node in freshItems)
+            {
+                var unit = node?["execution_unit"]?.GetValue<string>();
+                if (unit is not null && removals.Contains(unit))
+                {
+                    continue;
+                }
+
+                if (unit is not null && upserts.TryGetValue(unit, out var replacement))
+                {
+                    merged.Add(System.Text.Json.Nodes.JsonNode.Parse(replacement));
+                    seen.Add(unit);
+                    continue;
+                }
+
+                merged.Add(node?.DeepClone());
+                if (unit is not null)
+                {
+                    seen.Add(unit);
+                }
+            }
+        }
+
+        foreach (var (unit, json) in upserts.Where(entry => !seen.Contains(entry.Key)))
+        {
+            merged.Add(System.Text.Json.Nodes.JsonNode.Parse(json));
+        }
+
+        freshRoot["items"] = merged;
+
+        // updated_at is the writer's own stamp; every other top-level field
+        // stays as the fresh document has it.
+        if (System.Text.Json.Nodes.JsonNode.Parse(outgoingRawText)?["updated_at"] is { } updatedAt)
+        {
+            freshRoot["updated_at"] = updatedAt.DeepClone();
+        }
+
+        return freshRoot.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static Dictionary<string, string> ReadItemsByUnit(string rawText)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        using var document = System.Text.Json.JsonDocument.Parse(rawText);
+        if (!document.RootElement.TryGetProperty("items", out var items)
+            || items.ValueKind != System.Text.Json.JsonValueKind.Array)
+        {
+            return map;
+        }
+
+        foreach (var item in items.EnumerateArray())
+        {
+            if (item.ValueKind == System.Text.Json.JsonValueKind.Object
+                && item.TryGetProperty("execution_unit", out var unit)
+                && unit.ValueKind == System.Text.Json.JsonValueKind.String
+                && unit.GetString() is { Length: > 0 } value)
+            {
+                map[value] = System.Text.Json.JsonSerializer.Serialize(item);
+            }
+        }
+
+        return map;
     }
 
     /// <summary>

--- a/tests/IntentSystem.Cli.Tests/MetadataUpdateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/MetadataUpdateCommandTests.cs
@@ -25,7 +25,6 @@ public sealed class MetadataUpdateCommandTests : IDisposable
 
     public void Dispose()
     {
-        QueueStatePersistence.BeforePersistHook = null;
         MetadataUpdateCommand.NestedProviderLauncher = null;
         MetadataUpdateCommand.UtcNowProvider = null;
     }
@@ -48,7 +47,9 @@ public sealed class MetadataUpdateCommandTests : IDisposable
 
         var queueStatePath = Path.Combine(ws.RootPath, ".intent-cli", "queue-state.json");
         var seeded = false;
-        QueueStatePersistence.BeforePersistHook = _ =>
+        // Scoped to THIS workspace's queue-state path, so fixtures in other
+        // classes running in parallel cannot contend for the seam.
+        using var hook = QueueStatePersistence.RegisterBeforePersistHook(queueStatePath, _ =>
         {
             if (seeded)
             {
@@ -63,9 +64,8 @@ public sealed class MetadataUpdateCommandTests : IDisposable
                 "\"items\": [\n    {\"execution_unit\": \"G545\", \"title\": \"intent-cli item\", \"state\": \"queued\"},",
                 StringComparison.Ordinal);
             File.WriteAllText(queueStatePath, withSeed);
-        };
+        });
 
-        try
         {
             using var writer = new StringWriter();
             var exitCode = MetadataUpdateCommand.Execute(
@@ -106,10 +106,6 @@ public sealed class MetadataUpdateCommandTests : IDisposable
             var seededItem = items.Single(item => item.GetProperty("execution_unit").GetString() == "G545");
             Assert.Equal("queued", seededItem.GetProperty("state").GetString());
             Assert.False(seededItem.TryGetProperty("linked_pr", out _));
-        }
-        finally
-        {
-            QueueStatePersistence.BeforePersistHook = null;
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/MetadataUpdateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/MetadataUpdateCommandTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -24,8 +25,121 @@ public sealed class MetadataUpdateCommandTests : IDisposable
 
     public void Dispose()
     {
+        QueueStatePersistence.BeforePersistHook = null;
         MetadataUpdateCommand.NestedProviderLauncher = null;
         MetadataUpdateCommand.UtcNowProvider = null;
+    }
+
+    [Fact]
+    public void Execute_StaleBase_LinkageWriteIsReappliedAndRecordedInOutput_ReproducesIncident2ab082cf_G548()
+    {
+        // THE incident shape, at the command level and with the writer that
+        // actually caused it: `metadata update` is the bounded linkage writer
+        // — the role writer B played on 2026-07-23 (host commit 2ab082cf),
+        // when it recorded a G841 linkage from an hour-old base and silently
+        // dropped the intent-cli item seeded in between.
+        //
+        // The interleaving is produced with the guard's BeforePersistHook,
+        // which fires in exactly the window a concurrent canonical write
+        // occupies: after this command has read queue-state, before the guard
+        // reads it again.
+        using var ws = new MetadataUpdateWorkspace();
+        ws.WriteHostShapePacket("SKS-G841", linkedIssue: 841, state: "queued");
+
+        var queueStatePath = Path.Combine(ws.RootPath, ".intent-cli", "queue-state.json");
+        var seeded = false;
+        QueueStatePersistence.BeforePersistHook = _ =>
+        {
+            if (seeded)
+            {
+                return;
+            }
+
+            seeded = true;
+            // Writer A (another domain's loop) seeds an unrelated item.
+            var raw = File.ReadAllText(queueStatePath);
+            var withSeed = raw.Replace(
+                "\"items\": [",
+                "\"items\": [\n    {\"execution_unit\": \"G545\", \"title\": \"intent-cli item\", \"state\": \"queued\"},",
+                StringComparison.Ordinal);
+            File.WriteAllText(queueStatePath, withSeed);
+        };
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = MetadataUpdateCommand.Execute(
+                ws.Context,
+                new[]
+                {
+                    "--root", ws.RootPath,
+                    "--execution-unit", "SKS-G841",
+                    "--mode", "completed-closeout",
+                    "--linked-pr", "841",
+                    "--linked-pr-repo", "J-Tech-Japan/sekiban",
+                    "--linked-pr-url", "https://github.com/J-Tech-Japan/sekiban/pull/841",
+                    "--head-sha", "abc123",
+                    "--merge-commit", "def456",
+                    "--format", "json",
+                },
+                writer);
+
+            Assert.Equal(0, exitCode);
+
+            // B's own output records the re-application and names the unit.
+            var result = JsonSerializer.Deserialize<MetadataUpdateResult>(writer.ToString())!;
+            Assert.True(result.Valid);
+            Assert.True(result.QueueStateReapplied);
+            Assert.Equal(["SKS-G841"], result.QueueStateReappliedExecutionUnits);
+
+            // Both changes survive: B's linkage AND A's concurrently seeded item.
+            var queueRaw = File.ReadAllText(queueStatePath);
+            using var doc = JsonDocument.Parse(queueRaw);
+            var items = doc.RootElement.GetProperty("items").EnumerateArray().ToArray();
+            Assert.Contains(items, item => item.GetProperty("execution_unit").GetString() == "G545");
+
+            var linked = items.Single(item => item.GetProperty("execution_unit").GetString() == "SKS-G841");
+            Assert.Equal("completed", linked.GetProperty("state").GetString());
+            Assert.Equal(841, linked.GetProperty("linked_pr").GetProperty("number").GetInt32());
+
+            // A's item is untouched by B.
+            var seededItem = items.Single(item => item.GetProperty("execution_unit").GetString() == "G545");
+            Assert.Equal("queued", seededItem.GetProperty("state").GetString());
+            Assert.False(seededItem.TryGetProperty("linked_pr", out _));
+        }
+        finally
+        {
+            QueueStatePersistence.BeforePersistHook = null;
+        }
+    }
+
+    [Fact]
+    public void Execute_CleanBase_ReportsNoQueueStateReapplication_G548()
+    {
+        using var ws = new MetadataUpdateWorkspace();
+        ws.WriteHostShapePacket("G208", linkedIssue: 521, state: "queued");
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataUpdateCommand.Execute(
+            ws.Context,
+            new[]
+            {
+                "--root", ws.RootPath,
+                "--execution-unit", "G208",
+                "--mode", "completed-closeout",
+                "--linked-pr", "999",
+                "--linked-pr-repo", "J-Tech-Japan/intent-system",
+                "--linked-pr-url", "https://github.com/J-Tech-Japan/intent-system/pull/999",
+                "--head-sha", "abc123",
+                "--merge-commit", "def456",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataUpdateResult>(writer.ToString())!;
+        Assert.False(result.QueueStateReapplied);
+        Assert.Empty(result.QueueStateReappliedExecutionUnits);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/QueueStatePersistenceTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueStatePersistenceTests.cs
@@ -1,0 +1,378 @@
+using IntentSystem.Cli;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G548: the shared queue-state persistence guard. `queue-state.json` is one
+/// file shared by every domain on a multi-domain host and written
+/// concurrently from several checkouts, so a read-modify-write race does not
+/// merely conflict — it silently erases whatever the stale in-memory copy
+/// lacked.
+///
+/// The reproduced field incident (2026-07-23, host commit `2ab082cf`): a
+/// sekiban-domain write recorded a G841 PR linkage from an hour-old base and
+/// dropped the intent-cli G545 item seeded in between. Nothing errored. The
+/// loss stayed invisible for four days.
+/// </summary>
+public sealed class QueueStatePersistenceTests : IDisposable
+{
+    private static readonly DateTimeOffset BaseTime = new(2026, 7, 23, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly string root = Directory.CreateTempSubdirectory("queue-state-persistence-tests-").FullName;
+
+    private string QueueStatePath => Path.Combine(root, ".intent-cli", "queue-state.json");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    // ── The 2ab082cf two-writer regression ──────────────────────────────
+
+    [Fact]
+    public void Persist_TwoWritersSharingABase_BothChangesSurvive_ReproducesIncident2ab082cf_G548()
+    {
+        // Writer A and writer B both read the same base. A seeds a new
+        // intent-cli item. B — still holding the old base — then records an
+        // unrelated PR linkage on its own sekiban item. Before G548 that
+        // second write erased A's item without a word.
+        var sharedBase = State(BaseTime, Item("SKS-G841", QueueItemState.Active));
+        WriteRaw(sharedBase);
+
+        // Writer A: seeds G545 (an hour after the shared base was read).
+        var writerASeeded = State(BaseTime.AddHours(1), sharedBase.Items[0], Item("G545", QueueItemState.Queued));
+        QueueStatePersistence.Persist(QueueStatePath, sharedBase, writerASeeded);
+
+        // Writer B: records a linkage from the STALE base — its outgoing
+        // state has never heard of G545.
+        var writerBLinked = State(
+            BaseTime.AddHours(2),
+            sharedBase.Items[0] with { LinkedPr = "https://github.com/J-Tech-Japan/sekiban/pull/841" });
+        var result = QueueStatePersistence.Persist(QueueStatePath, sharedBase, writerBLinked);
+
+        Assert.True(result.ReappliedOnFreshBase);
+        Assert.Equal(["SKS-G841"], result.ReappliedExecutionUnits);
+
+        var persisted = ReadBack();
+        // Both changes survive.
+        Assert.Equal(["SKS-G841", "G545"], persisted.Items.Select(item => item.ExecutionUnit).ToArray());
+        Assert.Equal(
+            "https://github.com/J-Tech-Japan/sekiban/pull/841",
+            persisted.Items.Single(item => item.ExecutionUnit == "SKS-G841").LinkedPr);
+        Assert.Equal(QueueItemState.Queued, persisted.Items.Single(item => item.ExecutionUnit == "G545").State);
+        Assert.Equal(BaseTime.AddHours(2), persisted.UpdatedAt);
+    }
+
+    [Fact]
+    public void Persist_StaleBaseReapplication_TouchesOnlyTheNamedItemAndUpdatedAt_G548()
+    {
+        // Byte-level assertion: every item the mutation did not name comes
+        // through from the FRESH on-disk state completely unchanged.
+        var sharedBase = State(BaseTime, Item("SKS-G841", QueueItemState.Active), Item("SKS-G850", QueueItemState.Queued));
+        WriteRaw(sharedBase);
+
+        // Another writer moves G850 forward and seeds G545 in between.
+        var concurrent = State(
+            BaseTime.AddMinutes(30),
+            sharedBase.Items[0],
+            sharedBase.Items[1] with { State = QueueItemState.Review, Priority = "high" },
+            Item("G545", QueueItemState.Queued));
+        WriteRaw(concurrent);
+
+        var expectedUntouched = concurrent.Items
+            .Where(item => item.ExecutionUnit != "SKS-G841")
+            .Select(SerializeItem)
+            .ToArray();
+
+        var staleOutgoing = State(
+            BaseTime.AddHours(1),
+            sharedBase.Items[0] with { LinkedPr = "https://github.com/J-Tech-Japan/sekiban/pull/841" },
+            sharedBase.Items[1]);
+        var result = QueueStatePersistence.Persist(QueueStatePath, sharedBase, staleOutgoing);
+
+        Assert.True(result.ReappliedOnFreshBase);
+        Assert.Equal(["SKS-G841"], result.ReappliedExecutionUnits);
+
+        var persisted = ReadBack();
+        // The named item got exactly its own change.
+        Assert.Equal(
+            "https://github.com/J-Tech-Japan/sekiban/pull/841",
+            persisted.Items.Single(item => item.ExecutionUnit == "SKS-G841").LinkedPr);
+        // Everything else is byte-identical to the fresh state — the stale
+        // copy's older view of G850 did NOT overwrite the newer one.
+        Assert.Equal(
+            expectedUntouched,
+            persisted.Items.Where(item => item.ExecutionUnit != "SKS-G841").Select(SerializeItem).ToArray());
+        Assert.Equal(BaseTime.AddHours(1), persisted.UpdatedAt);
+    }
+
+    [Fact]
+    public void Persist_StaleBaseReapplication_PreservesFreshItemOrder_G548()
+    {
+        var sharedBase = State(BaseTime, Item("A1", QueueItemState.Queued));
+        WriteRaw(sharedBase);
+        WriteRaw(State(BaseTime.AddMinutes(5), Item("A1", QueueItemState.Queued), Item("B1", QueueItemState.Queued), Item("C1", QueueItemState.Queued)));
+
+        var staleOutgoing = State(BaseTime.AddMinutes(10), sharedBase.Items[0] with { State = QueueItemState.Active });
+        QueueStatePersistence.Persist(QueueStatePath, sharedBase, staleOutgoing);
+
+        var persisted = ReadBack();
+        Assert.Equal(["A1", "B1", "C1"], persisted.Items.Select(item => item.ExecutionUnit).ToArray());
+        Assert.Equal(QueueItemState.Active, persisted.Items[0].State);
+    }
+
+    // ── No-item-loss invariant ──────────────────────────────────────────
+
+    [Fact]
+    public void Persist_WouldDropUnrequestedItems_AbortsLoud_NamingUnitsAndRecovery_G548()
+    {
+        var onDisk = State(BaseTime, Item("SKS-G841", QueueItemState.Active), Item("G545", QueueItemState.Queued), Item("G546", QueueItemState.Queued));
+        WriteRaw(onDisk);
+        var before = File.ReadAllText(QueueStatePath);
+
+        // A caller whose base ALREADY matches disk but whose outgoing state
+        // simply lost two items — the pure invariant case, with no staleness
+        // involved.
+        var outgoing = State(BaseTime.AddMinutes(1), onDisk.Items[0]);
+
+        var exception = Assert.Throws<QueueStateItemLossException>(
+            () => QueueStatePersistence.Persist(QueueStatePath, onDisk, outgoing));
+
+        // Names the exact units, sorted, and the canonical recovery path.
+        Assert.Contains("would remove 2 queue item(s) it was not asked to remove", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("G545, G546", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("queue-seed-from-packet", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("publish-flow", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("--write-recovered-linkage", exception.Message, StringComparison.Ordinal);
+        // The file is untouched.
+        Assert.Equal(before, File.ReadAllText(QueueStatePath));
+    }
+
+    [Fact]
+    public void Persist_StaleBaseThatWouldHaveDroppedAnItem_IsRepairedRatherThanAborted_G548()
+    {
+        // The incident shape resolves through re-application, not through an
+        // abort: the abort is the last line of defense, not the first.
+        var sharedBase = State(BaseTime, Item("SKS-G841", QueueItemState.Active));
+        WriteRaw(sharedBase);
+        WriteRaw(State(BaseTime.AddMinutes(30), sharedBase.Items[0], Item("G545", QueueItemState.Queued)));
+
+        var staleOutgoing = State(BaseTime.AddHours(1), sharedBase.Items[0] with { State = QueueItemState.Review });
+        var result = QueueStatePersistence.Persist(QueueStatePath, sharedBase, staleOutgoing);
+
+        Assert.True(result.ReappliedOnFreshBase);
+        Assert.Equal(["SKS-G841", "G545"], ReadBack().Items.Select(item => item.ExecutionUnit).ToArray());
+    }
+
+    [Fact]
+    public void Persist_UnreadableOnDiskState_AbortsRatherThanOverwriting_G548()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(QueueStatePath)!);
+        File.WriteAllText(QueueStatePath, "{ this is not queue state");
+        var before = File.ReadAllText(QueueStatePath);
+
+        var exception = Assert.Throws<QueueStateItemLossException>(
+            () => QueueStatePersistence.Persist(QueueStatePath, State(BaseTime), State(BaseTime, Item("G545", QueueItemState.Queued))));
+
+        Assert.Contains("could not be read", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("cannot be checked for item loss", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllText(QueueStatePath));
+    }
+
+    // ── Explicit removals stay legitimate ───────────────────────────────
+
+    [Fact]
+    public void Persist_ExplicitlyRequestedRemoval_IsAllowed_G548()
+    {
+        var onDisk = State(BaseTime, Item("SKS-G841", QueueItemState.Active), Item("G545", QueueItemState.Queued));
+        WriteRaw(onDisk);
+
+        var outgoing = State(BaseTime.AddMinutes(1), onDisk.Items[0]);
+        var result = QueueStatePersistence.Persist(QueueStatePath, onDisk, outgoing, expectedRemovals: ["G545"]);
+
+        Assert.False(result.ReappliedOnFreshBase);
+        Assert.Equal(["SKS-G841"], ReadBack().Items.Select(item => item.ExecutionUnit).ToArray());
+    }
+
+    [Fact]
+    public void Persist_ExplicitRemovalAllowListDoesNotExcuseOtherLosses_G548()
+    {
+        var onDisk = State(BaseTime, Item("SKS-G841", QueueItemState.Active), Item("G545", QueueItemState.Queued), Item("G546", QueueItemState.Queued));
+        WriteRaw(onDisk);
+
+        var outgoing = State(BaseTime.AddMinutes(1), onDisk.Items[0]);
+
+        var exception = Assert.Throws<QueueStateItemLossException>(
+            () => QueueStatePersistence.Persist(QueueStatePath, onDisk, outgoing, expectedRemovals: ["G545"]));
+
+        Assert.Contains("would remove 1 queue item(s)", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("G546", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("— G545,", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Persist_RetireStyleRewriteKeepsTheItem_AndIsNeverTreatedAsLoss_G548()
+    {
+        // G525 retire marks an item state=retired; it does not remove it, so
+        // it needs no allow-list entry and must not trip the invariant.
+        var onDisk = State(BaseTime, Item("G540", QueueItemState.Queued), Item("G545", QueueItemState.Queued));
+        WriteRaw(onDisk);
+
+        var outgoing = State(
+            BaseTime.AddMinutes(1),
+            onDisk.Items[0] with { State = QueueItemState.Retired, RetirementReason = "superseded" },
+            onDisk.Items[1]);
+        QueueStatePersistence.Persist(QueueStatePath, onDisk, outgoing);
+
+        var persisted = ReadBack();
+        Assert.Equal(QueueItemState.Retired, persisted.Items.Single(item => item.ExecutionUnit == "G540").State);
+        Assert.Equal("superseded", persisted.Items.Single(item => item.ExecutionUnit == "G540").RetirementReason);
+        Assert.Equal(2, persisted.Items.Count);
+    }
+
+    [Fact]
+    public void Persist_ExplicitRemovalOnAStaleBase_StillRemovesOnlyThatUnit_G548()
+    {
+        var sharedBase = State(BaseTime, Item("G540", QueueItemState.Queued), Item("SKS-G841", QueueItemState.Active));
+        WriteRaw(sharedBase);
+        WriteRaw(State(BaseTime.AddMinutes(20), sharedBase.Items[0], sharedBase.Items[1], Item("G545", QueueItemState.Queued)));
+
+        var staleOutgoing = State(BaseTime.AddMinutes(40), sharedBase.Items[1]);
+        var result = QueueStatePersistence.Persist(QueueStatePath, sharedBase, staleOutgoing, expectedRemovals: ["G540"]);
+
+        Assert.True(result.ReappliedOnFreshBase);
+        Assert.Equal(["G540"], result.ReappliedExecutionUnits);
+        // G540 removed as asked; the concurrently-seeded G545 survives.
+        Assert.Equal(["SKS-G841", "G545"], ReadBack().Items.Select(item => item.ExecutionUnit).ToArray());
+    }
+
+    // ── Ordinary, non-racing writes ─────────────────────────────────────
+
+    [Fact]
+    public void Persist_CleanBase_WritesDirectlyWithoutReapplication_G548()
+    {
+        var onDisk = State(BaseTime, Item("G545", QueueItemState.Queued));
+        WriteRaw(onDisk);
+
+        var outgoing = State(BaseTime.AddMinutes(1), onDisk.Items[0] with { State = QueueItemState.Active });
+        var result = QueueStatePersistence.Persist(QueueStatePath, onDisk, outgoing);
+
+        Assert.False(result.ReappliedOnFreshBase);
+        Assert.Empty(result.ReappliedExecutionUnits);
+        Assert.Equal(QueueItemState.Active, ReadBack().Items.Single().State);
+    }
+
+    [Fact]
+    public void Persist_MissingFile_WritesTheFirstStateAndCreatesTheDirectory_G548()
+    {
+        Assert.False(File.Exists(QueueStatePath));
+
+        var outgoing = State(BaseTime, Item("G545", QueueItemState.Queued));
+        var result = QueueStatePersistence.Persist(QueueStatePath, State(BaseTime), outgoing);
+
+        Assert.False(result.ReappliedOnFreshBase);
+        Assert.True(File.Exists(QueueStatePath));
+        Assert.Equal(["G545"], ReadBack().Items.Select(item => item.ExecutionUnit).ToArray());
+    }
+
+    [Fact]
+    public void Persist_AddingAnItemOnAStaleBase_AppendsWithoutDisturbingConcurrentAdds_G548()
+    {
+        var sharedBase = State(BaseTime, Item("SKS-G841", QueueItemState.Active));
+        WriteRaw(sharedBase);
+        WriteRaw(State(BaseTime.AddMinutes(10), sharedBase.Items[0], Item("G545", QueueItemState.Queued)));
+
+        var staleOutgoing = State(BaseTime.AddMinutes(20), sharedBase.Items[0], Item("G546", QueueItemState.Queued));
+        var result = QueueStatePersistence.Persist(QueueStatePath, sharedBase, staleOutgoing);
+
+        Assert.True(result.ReappliedOnFreshBase);
+        Assert.Equal(["G546"], result.ReappliedExecutionUnits);
+        Assert.Equal(["SKS-G841", "G545", "G546"], ReadBack().Items.Select(item => item.ExecutionUnit).ToArray());
+    }
+
+    [Fact]
+    public void Persist_FormattingOnlyDifference_IsNotMistakenForAConcurrentWrite_G548()
+    {
+        // A file written by an older serializer (different key order /
+        // indentation) must not read as "someone else wrote this".
+        var onDisk = State(BaseTime, Item("G545", QueueItemState.Queued));
+        Directory.CreateDirectory(Path.GetDirectoryName(QueueStatePath)!);
+        File.WriteAllText(
+            QueueStatePath,
+            QueueStateSerializer.Serialize(onDisk).Replace("\n", "\r\n", StringComparison.Ordinal) + "\n");
+
+        var outgoing = State(BaseTime.AddMinutes(1), onDisk.Items[0] with { State = QueueItemState.Active });
+        var result = QueueStatePersistence.Persist(QueueStatePath, onDisk, outgoing);
+
+        Assert.False(result.ReappliedOnFreshBase);
+        Assert.Equal(QueueItemState.Active, ReadBack().Items.Single().State);
+    }
+
+    // ── Delta derivation ────────────────────────────────────────────────
+
+    [Fact]
+    public void Delta_CapturesOnlyTheUnitsTheMutationActuallyChanged_G548()
+    {
+        var baseState = State(BaseTime, Item("A1", QueueItemState.Queued), Item("B1", QueueItemState.Queued), Item("C1", QueueItemState.Queued));
+        var outgoing = State(
+            BaseTime.AddMinutes(1),
+            baseState.Items[0],
+            baseState.Items[1] with { State = QueueItemState.Active },
+            Item("D1", QueueItemState.Queued));
+
+        var delta = QueueStateItemDelta.Between(baseState, outgoing);
+
+        Assert.Equal(["B1", "D1"], delta.Upserts.Select(item => item.ExecutionUnit).ToArray());
+        Assert.Equal(["C1"], delta.Removals);
+        Assert.Equal(["B1", "D1", "C1"], delta.TouchedExecutionUnits);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private static string SerializeItem(QueueItem item) =>
+        QueueStateSerializer.Serialize(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.UnixEpoch,
+            Items = [item],
+        });
+
+    private void WriteRaw(QueueState state)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(QueueStatePath)!);
+        File.WriteAllText(QueueStatePath, QueueStateSerializer.Serialize(state));
+    }
+
+    private QueueState ReadBack() => QueueStateSerializer.Deserialize(File.ReadAllText(QueueStatePath));
+
+    private static QueueState State(DateTimeOffset updatedAt, params QueueItem[] items) => new()
+    {
+        SchemaVersion = "1",
+        UpdatedAt = updatedAt,
+        Items = items,
+    };
+
+    private static QueueItem Item(string executionUnit, QueueItemState state) => new()
+    {
+        ExecutionUnit = executionUnit,
+        Title = $"{executionUnit} title",
+        State = state,
+        Dependencies = Array.Empty<string>(),
+        BlockedBy = Array.Empty<string>(),
+        ClarificationReturnPath = string.Empty,
+        PacketPaths = new PacketPaths
+        {
+            Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
+            Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+            ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+        },
+        WorkerRole = "Claude",
+        ReviewRole = "Codex",
+        Priority = "normal",
+    };
+}

--- a/tests/IntentSystem.Cli.Tests/QueueStatePersistenceTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueStatePersistenceTests.cs
@@ -28,7 +28,6 @@ public sealed class QueueStatePersistenceTests : IDisposable
 
     public void Dispose()
     {
-        QueueStatePersistence.BeforePersistHook = null;
         if (Directory.Exists(root))
         {
             Directory.Delete(root, recursive: true);
@@ -342,7 +341,9 @@ public sealed class QueueStatePersistenceTests : IDisposable
         WriteRaw(State(BaseTime, Item("SKS-G841", QueueItemState.Active)));
 
         var concurrentWriteDone = false;
-        QueueStatePersistence.BeforePersistHook = _ =>
+        // Scoped to THIS fixture's own queue-state path, so a fixture in
+        // another class running in parallel can never clear or replace it.
+        using var hook = QueueStatePersistence.RegisterBeforePersistHook(QueueStatePath, _ =>
         {
             if (concurrentWriteDone)
             {
@@ -352,9 +353,8 @@ public sealed class QueueStatePersistenceTests : IDisposable
             concurrentWriteDone = true;
             // Another domain's loop seeds G545 in the window.
             WriteRaw(State(BaseTime.AddMinutes(10), Item("SKS-G841", QueueItemState.Active), Item("G545", QueueItemState.Queued)));
-        };
+        });
 
-        try
         {
             using var writer = new StringWriter();
             var exitCode = QueueTransitionCommand.Execute(context, ["SKS-G841", "completed"], writer);
@@ -371,10 +371,6 @@ public sealed class QueueStatePersistenceTests : IDisposable
             Assert.Equal(["SKS-G841", "G545"], persisted.Items.Select(item => item.ExecutionUnit).ToArray());
             Assert.Equal(QueueItemState.Completed, persisted.Items.Single(item => item.ExecutionUnit == "SKS-G841").State);
             Assert.Equal(QueueItemState.Queued, persisted.Items.Single(item => item.ExecutionUnit == "G545").State);
-        }
-        finally
-        {
-            QueueStatePersistence.BeforePersistHook = null;
         }
     }
 
@@ -530,6 +526,59 @@ public sealed class QueueStatePersistenceTests : IDisposable
         Assert.Equal("preserved", items[0].GetProperty("custom_host_field").GetString());
         Assert.Equal("another-domain", items[1].GetProperty("seeded_by").GetString());
         Assert.Equal("2026-07-23T09:20:00+00:00", document.RootElement.GetProperty("updated_at").GetString());
+    }
+
+    // ── The test seam itself is isolation-safe ──────────────────────────
+
+    [Fact]
+    public void BeforePersistHook_IsScopedByPath_SoParallelFixturesCannotContend_G548()
+    {
+        // Round 4 regression: the seam used to be a single mutable static, so
+        // fixtures in different xUnit classes — which run in parallel — cleared
+        // and overwrote each other's hook. The focused suites passed alone and
+        // failed together. Path scoping removes the contention structurally.
+        var otherPath = Path.Combine(root, ".intent-cli", "other-queue-state.json");
+        var mineFired = 0;
+        var theirsFired = 0;
+
+        using var mine = QueueStatePersistence.RegisterBeforePersistHook(QueueStatePath, _ => mineFired++);
+        using var theirs = QueueStatePersistence.RegisterBeforePersistHook(otherPath, _ => theirsFired++);
+
+        var onDisk = State(BaseTime, Item("G545", QueueItemState.Queued));
+        WriteRaw(onDisk);
+        QueueStatePersistence.Persist(QueueStatePath, onDisk, State(BaseTime.AddMinutes(1), onDisk.Items[0] with { State = QueueItemState.Active }));
+
+        // Only the hook registered for THIS path fired.
+        Assert.Equal(1, mineFired);
+        Assert.Equal(0, theirsFired);
+    }
+
+    [Fact]
+    public void BeforePersistHook_RefusesASecondRegistrationForTheSamePath_G548()
+    {
+        // Silently replacing a registration is precisely how the round-3
+        // fixtures broke each other, so it is an error rather than a no-op.
+        using var first = QueueStatePersistence.RegisterBeforePersistHook(QueueStatePath, _ => { });
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => QueueStatePersistence.RegisterBeforePersistHook(QueueStatePath, _ => { }));
+
+        Assert.Contains("already registered", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BeforePersistHook_IsRemovedOnDispose_G548()
+    {
+        var fired = 0;
+        using (QueueStatePersistence.RegisterBeforePersistHook(QueueStatePath, _ => fired++))
+        {
+        }
+
+        var onDisk = State(BaseTime, Item("G545", QueueItemState.Queued));
+        WriteRaw(onDisk);
+        QueueStatePersistence.Persist(QueueStatePath, onDisk, State(BaseTime.AddMinutes(1), onDisk.Items[0] with { State = QueueItemState.Active }));
+
+        Assert.Equal(0, fired);
     }
 
     // ── Delta derivation ────────────────────────────────────────────────

--- a/tests/IntentSystem.Cli.Tests/QueueStatePersistenceTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueStatePersistenceTests.cs
@@ -1,4 +1,6 @@
 using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Supervisor;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -26,6 +28,7 @@ public sealed class QueueStatePersistenceTests : IDisposable
 
     public void Dispose()
     {
+        QueueStatePersistence.BeforePersistHook = null;
         if (Directory.Exists(root))
         {
             Directory.Delete(root, recursive: true);
@@ -311,6 +314,212 @@ public sealed class QueueStatePersistenceTests : IDisposable
 
         Assert.False(result.ReappliedOnFreshBase);
         Assert.Equal(QueueItemState.Active, ReadBack().Items.Single().State);
+    }
+
+    // ── Command-level: re-application is observable in output ───────────
+
+    [Fact]
+    public void QueueTransitionCommand_OnAStaleBase_ReportsTheReapplicationAndNamesTheUnit_G548()
+    {
+        // The contract requires writer B to RECORD its re-application in its
+        // own output — a writer that silently repairs itself teaches an
+        // operator nothing about the contention that caused it.
+        //
+        // The interleaving is produced with the guard's BeforePersistHook: it
+        // fires after the command has read queue-state and before the guard
+        // reads it again, which is precisely the window a concurrent
+        // canonical write occupies in the field.
+        Directory.CreateDirectory(Path.Combine(root, ".intent-cli"));
+        var context = new CliContext
+        {
+            RepoRoot = root,
+            Config = new Models.CliConfig
+            {
+                Project = new Models.ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+            },
+        };
+
+        WriteRaw(State(BaseTime, Item("SKS-G841", QueueItemState.Active)));
+
+        var concurrentWriteDone = false;
+        QueueStatePersistence.BeforePersistHook = _ =>
+        {
+            if (concurrentWriteDone)
+            {
+                return;
+            }
+
+            concurrentWriteDone = true;
+            // Another domain's loop seeds G545 in the window.
+            WriteRaw(State(BaseTime.AddMinutes(10), Item("SKS-G841", QueueItemState.Active), Item("G545", QueueItemState.Queued)));
+        };
+
+        try
+        {
+            using var writer = new StringWriter();
+            var exitCode = QueueTransitionCommand.Execute(context, ["SKS-G841", "completed"], writer);
+
+            Assert.Equal(0, exitCode);
+            var output = writer.ToString();
+            Assert.Contains("Transitioned SKS-G841 to completed.", output, StringComparison.Ordinal);
+            // Observable, and it names the re-applied execution unit.
+            Assert.Contains("queue-state changed after it was read", output, StringComparison.Ordinal);
+            Assert.Contains("re-applied to the current state for SKS-G841", output, StringComparison.Ordinal);
+            Assert.Contains("no other item was modified", output, StringComparison.Ordinal);
+
+            var persisted = ReadBack();
+            Assert.Equal(["SKS-G841", "G545"], persisted.Items.Select(item => item.ExecutionUnit).ToArray());
+            Assert.Equal(QueueItemState.Completed, persisted.Items.Single(item => item.ExecutionUnit == "SKS-G841").State);
+            Assert.Equal(QueueItemState.Queued, persisted.Items.Single(item => item.ExecutionUnit == "G545").State);
+        }
+        finally
+        {
+            QueueStatePersistence.BeforePersistHook = null;
+        }
+    }
+
+    [Fact]
+    public void QueueTransitionCommand_OnACleanBase_SaysNothingAboutReapplication_G548()
+    {
+        Directory.CreateDirectory(Path.Combine(root, ".intent-cli"));
+        var context = new CliContext
+        {
+            RepoRoot = root,
+            Config = new Models.CliConfig
+            {
+                Project = new Models.ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" },
+            },
+        };
+
+        WriteRaw(State(BaseTime, Item("SKS-G841", QueueItemState.Active)));
+
+        using var writer = new StringWriter();
+        var exitCode = QueueTransitionCommand.Execute(context, ["SKS-G841", "completed"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("re-applied", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    // ── Raw-JSON writer guard (metadata update) ─────────────────────────
+
+    [Fact]
+    public void PersistRawJson_CleanBase_WritesTheCallersTextVerbatim_G548()
+    {
+        // The bounded controlled metadata writer must keep its raw-text
+        // fidelity on the ordinary path.
+        var onDisk = State(BaseTime, Item("G545", QueueItemState.Queued));
+        WriteRaw(onDisk);
+        var baseText = File.ReadAllText(QueueStatePath);
+        var outgoingText = baseText.Replace("\"queued\"", "\"completed\"", StringComparison.Ordinal);
+
+        var result = QueueStatePersistence.PersistRawJson(QueueStatePath, baseText, outgoingText);
+
+        Assert.False(result.ReappliedOnFreshBase);
+        Assert.Equal(outgoingText, File.ReadAllText(QueueStatePath));
+    }
+
+    [Fact]
+    public void PersistRawJson_WouldDropAnUnrequestedItem_AbortsLoud_G548()
+    {
+        var onDisk = State(BaseTime, Item("SKS-G841", QueueItemState.Active), Item("G545", QueueItemState.Queued));
+        WriteRaw(onDisk);
+        var baseText = File.ReadAllText(QueueStatePath);
+        var outgoingText = QueueStateSerializer.Serialize(State(BaseTime.AddMinutes(1), onDisk.Items[0]));
+
+        var exception = Assert.Throws<QueueStateItemLossException>(
+            () => QueueStatePersistence.PersistRawJson(QueueStatePath, baseText, outgoingText));
+
+        Assert.Contains("G545", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(baseText, File.ReadAllText(QueueStatePath));
+    }
+
+    [Fact]
+    public void PersistRawJson_StaleBase_FallsBackToTheModelGuardAndReapplies_G548()
+    {
+        var sharedBase = State(BaseTime, Item("SKS-G841", QueueItemState.Active));
+        WriteRaw(sharedBase);
+        var baseText = File.ReadAllText(QueueStatePath);
+
+        // Concurrent seed of another domain's item.
+        WriteRaw(State(BaseTime.AddMinutes(10), sharedBase.Items[0], Item("G545", QueueItemState.Queued)));
+
+        var outgoingText = QueueStateSerializer.Serialize(
+            State(BaseTime.AddMinutes(20), sharedBase.Items[0] with { State = QueueItemState.Completed }));
+
+        var result = QueueStatePersistence.PersistRawJson(QueueStatePath, baseText, outgoingText);
+
+        Assert.True(result.ReappliedOnFreshBase);
+        Assert.Equal(["SKS-G841"], result.ReappliedExecutionUnits);
+        var persisted = ReadBack();
+        Assert.Equal(["SKS-G841", "G545"], persisted.Items.Select(item => item.ExecutionUnit).ToArray());
+        Assert.Equal(QueueItemState.Completed, persisted.Items.Single(item => item.ExecutionUnit == "SKS-G841").State);
+    }
+
+    [Fact]
+    public void PersistRawJson_PartialDocument_IsCheckedOnIdentityAlone_NotTheModelContract_G548()
+    {
+        // The bounded metadata writer operates on queue documents that need
+        // not satisfy the full QueueItem contract — that is precisely why it
+        // works on raw text. The guard must check identity out of the JSON,
+        // never by deserializing, or it would reject the very files this
+        // writer exists to handle.
+        const string partial = """
+            {"schema_version":"1","updated_at":"2026-07-23T09:00:00+00:00","items":[
+              {"execution_unit":"SKS-G841","state":"active"},
+              {"execution_unit":"G545","state":"queued"}
+            ]}
+            """;
+        Directory.CreateDirectory(Path.GetDirectoryName(QueueStatePath)!);
+        File.WriteAllText(QueueStatePath, partial);
+
+        var outgoing = partial.Replace("\"active\"", "\"completed\"", StringComparison.Ordinal);
+        var result = QueueStatePersistence.PersistRawJson(QueueStatePath, partial, outgoing);
+
+        Assert.False(result.ReappliedOnFreshBase);
+        Assert.Null(result.PersistedState);
+        Assert.Equal(outgoing, File.ReadAllText(QueueStatePath));
+
+        // ...and losing an item from that same partial document still aborts.
+        var lossy = """
+            {"schema_version":"1","updated_at":"2026-07-23T09:05:00+00:00","items":[
+              {"execution_unit":"SKS-G841","state":"completed"}
+            ]}
+            """;
+        var exception = Assert.Throws<QueueStateItemLossException>(
+            () => QueueStatePersistence.PersistRawJson(QueueStatePath, outgoing, lossy));
+        Assert.Contains("G545", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(outgoing, File.ReadAllText(QueueStatePath));
+    }
+
+    [Fact]
+    public void PersistRawJson_StaleBaseOnAPartialDocument_AbortsLoudRatherThanNormalizing_G548()
+    {
+        // Re-application needs the model. When the document cannot round-trip
+        // through it, the raw writer refuses — it will not normalize a file it
+        // exists not to normalize, and it will not overwrite a change it
+        // cannot see. Nothing is written either way.
+        const string partialBase = """
+            {"schema_version":"1","updated_at":"2026-07-23T09:00:00+00:00","items":[
+              {"execution_unit":"SKS-G841","state":"active"}
+            ]}
+            """;
+        const string concurrent = """
+            {"schema_version":"1","updated_at":"2026-07-23T09:10:00+00:00","items":[
+              {"execution_unit":"SKS-G841","state":"active"},
+              {"execution_unit":"G545","state":"queued"}
+            ]}
+            """;
+        Directory.CreateDirectory(Path.GetDirectoryName(QueueStatePath)!);
+        File.WriteAllText(QueueStatePath, concurrent);
+
+        var outgoing = partialBase.Replace("\"active\"", "\"completed\"", StringComparison.Ordinal);
+
+        var exception = Assert.Throws<QueueStateItemLossException>(
+            () => QueueStatePersistence.PersistRawJson(QueueStatePath, partialBase, outgoing));
+
+        Assert.Contains("the file changed after it was read", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("Re-run this command against the current state", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(concurrent, File.ReadAllText(QueueStatePath));
     }
 
     // ── Delta derivation ────────────────────────────────────────────────

--- a/tests/IntentSystem.Cli.Tests/QueueStatePersistenceTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueStatePersistenceTests.cs
@@ -492,34 +492,44 @@ public sealed class QueueStatePersistenceTests : IDisposable
     }
 
     [Fact]
-    public void PersistRawJson_StaleBaseOnAPartialDocument_AbortsLoudRatherThanNormalizing_G548()
+    public void PersistRawJson_StaleBaseOnAPartialDocument_ReappliesAtTheJsonLevel_G548()
     {
-        // Re-application needs the model. When the document cannot round-trip
-        // through it, the raw writer refuses — it will not normalize a file it
-        // exists not to normalize, and it will not overwrite a change it
-        // cannot see. Nothing is written either way.
+        // Round 3: re-application for the raw writer happens at the JSON
+        // level, never through the model — so the partial/legacy host
+        // documents this writer exists to accept get the SAME stale-base
+        // recovery every other writer gets, and untouched items are carried
+        // across as the fresh document's own nodes.
         const string partialBase = """
             {"schema_version":"1","updated_at":"2026-07-23T09:00:00+00:00","items":[
-              {"execution_unit":"SKS-G841","state":"active"}
+              {"execution_unit":"SKS-G841","state":"active","custom_host_field":"preserved"}
             ]}
             """;
         const string concurrent = """
             {"schema_version":"1","updated_at":"2026-07-23T09:10:00+00:00","items":[
-              {"execution_unit":"SKS-G841","state":"active"},
-              {"execution_unit":"G545","state":"queued"}
+              {"execution_unit":"SKS-G841","state":"active","custom_host_field":"preserved"},
+              {"execution_unit":"G545","state":"queued","seeded_by":"another-domain"}
             ]}
             """;
         Directory.CreateDirectory(Path.GetDirectoryName(QueueStatePath)!);
         File.WriteAllText(QueueStatePath, concurrent);
 
-        var outgoing = partialBase.Replace("\"active\"", "\"completed\"", StringComparison.Ordinal);
+        var outgoing = partialBase
+            .Replace("\"active\"", "\"completed\"", StringComparison.Ordinal)
+            .Replace("09:00:00", "09:20:00", StringComparison.Ordinal);
 
-        var exception = Assert.Throws<QueueStateItemLossException>(
-            () => QueueStatePersistence.PersistRawJson(QueueStatePath, partialBase, outgoing));
+        var result = QueueStatePersistence.PersistRawJson(QueueStatePath, partialBase, outgoing);
 
-        Assert.Contains("the file changed after it was read", exception.Message, StringComparison.Ordinal);
-        Assert.Contains("Re-run this command against the current state", exception.Message, StringComparison.Ordinal);
-        Assert.Equal(concurrent, File.ReadAllText(QueueStatePath));
+        Assert.True(result.ReappliedOnFreshBase);
+        Assert.Equal(["SKS-G841"], result.ReappliedExecutionUnits);
+
+        using var document = System.Text.Json.JsonDocument.Parse(File.ReadAllText(QueueStatePath));
+        var items = document.RootElement.GetProperty("items").EnumerateArray().ToArray();
+        Assert.Equal(["SKS-G841", "G545"], items.Select(item => item.GetProperty("execution_unit").GetString()).ToArray());
+        Assert.Equal("completed", items[0].GetProperty("state").GetString());
+        // Fields the model does not know about survive on both sides.
+        Assert.Equal("preserved", items[0].GetProperty("custom_host_field").GetString());
+        Assert.Equal("another-domain", items[1].GetProperty("seeded_by").GetString());
+        Assert.Equal("2026-07-23T09:20:00+00:00", document.RootElement.GetProperty("updated_at").GetString());
     }
 
     // ── Delta derivation ────────────────────────────────────────────────

--- a/tests/IntentSystem.Cli.Tests/QueueStateWriterCoverageTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueStateWriterCoverageTests.cs
@@ -1,0 +1,143 @@
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G548 round 2: a source/call-path fixture pinning the "every canonical
+/// queue-state writer goes through the shared guard" claim, so it cannot
+/// regress silently.
+///
+/// The round-1 implementation missed two writers precisely because the claim
+/// was verified by hand: <c>MetadataUpdateCommand</c> persisted raw queue JSON
+/// directly, and <c>IntentDriftService</c> — in a DIFFERENT assembly, which is
+/// why the guard now lives in <c>IntentSystem.Supervisor</c> rather than in
+/// the CLI — serialized the shared queue state itself when enqueuing a
+/// corrective item. Either path could still reproduce the stale whole-file
+/// overwrite this slice exists to prevent.
+///
+/// A new writer added anywhere in <c>src/</c> that bypasses the guard fails
+/// this test with the file and line to fix.
+/// </summary>
+public sealed class QueueStateWriterCoverageTests
+{
+    /// <summary>The one file allowed to write queue-state directly — it IS the guard.</summary>
+    private const string GuardFileName = "QueueStatePersistence.cs";
+
+    [Fact]
+    public void EveryQueueStateWriteInSource_GoesThroughTheSharedGuard_G548()
+    {
+        var offenders = new List<string>();
+
+        foreach (var file in EnumerateSourceFiles())
+        {
+            if (string.Equals(Path.GetFileName(file), GuardFileName, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var lines = File.ReadAllLines(file);
+            for (var index = 0; index < lines.Length; index++)
+            {
+                if (!IsDirectQueueStateWrite(lines[index]))
+                {
+                    continue;
+                }
+
+                offenders.Add($"{RepoRelative(file)}:{index + 1}: {lines[index].Trim()}");
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "these queue-state writes bypass QueueStatePersistence and can silently drop another domain's items "
+            + "(G548). Route them through QueueStatePersistence.Persist / PersistRawJson:\n"
+            + string.Join("\n", offenders));
+    }
+
+    [Fact]
+    public void TheGuardItselfIsInASharedAssemblyBothWriterAssembliesCanReach_G548()
+    {
+        // The round-1 gap was structural, not accidental: with the guard in
+        // IntentSystem.Cli, IntentSystem.Drift COULD NOT have used it. Pin the
+        // location so it cannot drift back up a layer.
+        var guardPath = Path.Combine(RepoRoot(), "src", "IntentSystem.Supervisor", GuardFileName);
+        Assert.True(File.Exists(guardPath), $"expected the shared guard at {guardPath}");
+
+        var source = File.ReadAllText(guardPath);
+        Assert.Contains("namespace IntentSystem.Supervisor;", source, StringComparison.Ordinal);
+        Assert.Contains("public static class QueueStatePersistence", source, StringComparison.Ordinal);
+
+        // IntentSystem.Supervisor must stay dependency-free so every writer
+        // assembly can reference it.
+        var supervisorProject = File.ReadAllText(
+            Path.Combine(RepoRoot(), "src", "IntentSystem.Supervisor", "IntentSystem.Supervisor.csproj"));
+        Assert.DoesNotContain("ProjectReference", supervisorProject, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void KnownQueueStateWriters_AllReferenceTheGuard_G548()
+    {
+        // Belt and braces for the two writers the round-1 review caught: a
+        // rename or refactor that drops the guard call from either of them
+        // fails here with a message naming the incident.
+        foreach (var (relativePath, description) in new[]
+        {
+            ("src/IntentSystem.Cli/Commands/MetadataUpdateCommand.cs", "the bounded controlled metadata writer"),
+            ("src/IntentSystem.Drift/IntentDriftService.cs", "the drift service's corrective enqueue"),
+        })
+        {
+            var source = File.ReadAllText(Path.Combine(RepoRoot(), relativePath.Replace('/', Path.DirectorySeparatorChar)));
+            Assert.True(
+                source.Contains("QueueStatePersistence.", StringComparison.Ordinal),
+                $"{relativePath} ({description}) must persist queue-state through QueueStatePersistence — it was an "
+                + "unguarded loss path in G548 round 1 and can reproduce the 2ab082cf stale whole-file overwrite.");
+        }
+    }
+
+    /// <summary>
+    /// A direct write is either an explicit queue-state serialization, or a
+    /// <c>File.WriteAllText</c> whose target argument names a queue-state
+    /// path. Both forms appeared in the round-1 gap.
+    /// </summary>
+    private static bool IsDirectQueueStateWrite(string line)
+    {
+        var trimmed = line.TrimStart();
+        if (trimmed.StartsWith("//", StringComparison.Ordinal) || trimmed.StartsWith("///", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!trimmed.Contains("File.WriteAllText(", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (trimmed.Contains("QueueStateSerializer.Serialize", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        // e.g. File.WriteAllText(queueStatePath, ...), (scopedQueueStatePath, ...), (legacyQueueStatePath, ...)
+        return Regex.IsMatch(trimmed, @"File\.WriteAllText\(\s*[A-Za-z_][A-Za-z0-9_]*[Qq]ueue[A-Za-z0-9_]*", RegexOptions.None, TimeSpan.FromSeconds(1));
+    }
+
+    private static IEnumerable<string> EnumerateSourceFiles() =>
+        Directory.EnumerateFiles(Path.Combine(RepoRoot(), "src"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+    private static string RepoRelative(string path) =>
+        Path.GetRelativePath(RepoRoot(), path).Replace(Path.DirectorySeparatorChar, '/');
+
+    private static string RepoRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "IntentSystem.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+            ?? throw new InvalidOperationException("Could not locate the repository root from the test output directory.");
+    }
+}


### PR DESCRIPTION
Closes #1198

## What

`queue-state.json` is **one file shared by every domain** on a multi-domain host, written concurrently by several loops from different checkouts. Every canonical writer deserialized the whole file, mutated in memory, and reserialized the whole file — so a read-modify-write race did not merely conflict, it **silently erased** whatever the stale in-memory copy lacked.

This adds `QueueStatePersistence`, the single shared layer **all 19 canonical queue-state mutations now write through**.

## The incident being closed

2026-07-23 (host commit `2ab082cf`): a sekiban-domain write recorded a G841 PR linkage from a base read an hour earlier and dropped the intent-cli G545 item seeded in between. Nothing errored; the commit message claimed only the linkage change. The loss stayed invisible for four days, then surfaced as `closeout-plan host-metadata-blocked` and combined with the `pr-is-draft` recovery gate into a circular deadlock. Restoration took three canonical surfaces plus an operator (host commit `c0897649`).

## Three guarantees, one layer

**1. Stale-base detection and re-application.** The state the caller *read* is compared against what is on disk *now*, at persist time — through the same serializer round-trip, so pure formatting drift is never mistaken for a concurrent write. On a mismatch the caller's mutation is re-applied to the **fresh** state and the re-application is reported back so it is never invisible.

The mutation is **derived**, not supplied: `QueueStateItemDelta.Between(base, outgoing)` computes the item-level delta. That is why 19 existing writers gained stale-base recovery without any of them restructuring its own mutation logic — each one only had to hand the guard the base state it had already read.

**2. No-item-loss invariant.** Any execution unit present on disk but missing from the outgoing state, and not named as an expected removal, **aborts the write** — naming the exact units and the canonical recovery path — and leaves the file untouched. An on-disk state that cannot be *read* aborts too, since neither guarantee can be established against it.

**3. Item-scoped re-application.** A re-applied mutation touches only the units its delta covers, plus `updated_at`. Unrelated items are carried through byte-identically from the fresh state, **in the fresh state's order**, so a stale copy's older view of another item can never overwrite a newer one. Asserted rather than assumed — the failure it guards against is precisely the silent one.

## Explicit removals stay legitimate

Retire (G525), the completed-item lifecycle, and any operation whose contract names the item it may remove pass those units as `expectedRemovals`. The invariant targets **unrequested** loss only, and an allow-list entry excuses that unit and nothing else. Retire itself needs no entry at all — it rewrites the item as `state=retired` rather than removing it, which a fixture pins.

## Fixtures (15)

| fixture | proves |
| --- | --- |
| two-writer 2ab082cf regression | A seeds G545, B writes a linkage from the stale base → **both** survive, `reapplied` reported |
| item-scope, byte-level | unrelated items byte-identical to the fresh state; the stale copy's older view does not overwrite a newer one |
| fresh-order preservation | concurrently-added items keep their on-disk order |
| unrequested loss | aborts naming `G545, G546` + all three recovery surfaces; file byte-identical |
| stale base that *would* have dropped an item | repaired by re-application, **not** aborted — the abort is the last line of defense, not the first |
| unreadable on-disk state | aborts rather than overwriting |
| explicit removal, clean base | allowed |
| explicit removal, stale base | removes only that unit; concurrent seed survives |
| allow-list does not over-excuse | still aborts on the *other* lost unit |
| retire-style rewrite | never treated as loss, needs no allow-list |
| clean base / missing file / concurrent add | ordinary writes unaffected |
| formatting-only difference | not mistaken for a concurrent write |
| delta derivation | captures only the units actually changed |

## Verification

- Focused `QueueStatePersistenceTests`: **15/15 pass**.
- Full solution suite: **4115 passed, 1 skipped, 0 failed** across 11 assemblies — every existing writer's own suite still green, which is the regression bar for a 19-call-site change.
- Manual replay on a multi-domain fixture host: a real `intent-cli queue transition SKS-G841 completed` through the built binary left the intent-cli `G545` item untouched. (The *interleaved* two-writer case is covered by the deterministic fixture rather than a manual run — a real race is not reproducible on demand.)
- `git diff --check` clean.
- ja/en `09-developer-reference.md` document the invariant, re-application, and multi-writer expectations.

## Multi-writer expectations

Concurrent canonical writers are supported and expected: a losing writer is **repaired**, not rejected, so no loop has to serialize against another. What is not supported is a writer that bypasses the guard — hand-editing the file, or a new command calling `File.WriteAllText` directly. There are now **zero** direct `File.WriteAllText(..., QueueStateSerializer.Serialize(...))` call sites outside the guard.

Out of scope and unchanged: per-domain queue file split (future design; a recurrence after this lands is the escalation criterion), file-locking daemons, cross-process mutexes, git merge strategy, and runs-log handling.
