### PR TITLE
G549: Guide terminal-workspace team provisioning — dedicated role folders, herdr workspace topology, shim-safe launch, actas and readiness

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -105,15 +105,40 @@ shim is what arms the agmsg monitor bridge (G521), and a workspace manager that
 exec's the canonical executable directly bypasses it — the session looks healthy
 and messages are simply never delivered. claude is launched with the permission
 mode the **operator** chose. **Attend** each pane's first run: trust screens and
-permission prompts block the session until answered, and they must be answered so
-they produce **durable** allowlists rather than a per-invocation approval that
-re-prompts on the next wake.
+permission prompts block the session until answered, and where the design thread
+is authorized to answer, the answer must produce a **durable** allowlist rather
+than a per-invocation approval that re-prompts on the next wake.
+
+> **Authority boundary — unsticking is not deciding.** Attending a pane does not
+> make the design thread the decider. It may act **only on pane contents it has
+> actually read** — never a blind keystroke into a dialog it has not rendered —
+> and **only for the trust/allowlist cases the operator explicitly authorized**
+> for this provisioning, including its own hook-trust case. Every credential
+> prompt, security prompt, and permission prompt outside that authorization
+> **must be escalated to the operator** and left unanswered. If answering would
+> grant access, widen a permission mode, or accept a security warning, it is the
+> operator's call.
 
 **4. Role initialization.** Type the actas form matching the pane's CLI —
-`/agmsg actas <role>` for claude, `$agmsg actas <role>` for codex — then **wait
-for readiness** (a pane still on a trust screen is not ready), then run the
-existing [ping test](#receiver-readiness). Readiness is a precondition for the
-ping test, not a replacement for it.
+`/agmsg actas <role>` for claude, `$agmsg actas <role>` for codex — then confirm
+readiness in **three layers that must not be collapsed**:
+
+1. **Delivery configuration** — `delivery.sh status` reporting a mode (e.g.
+   `mode=monitor`) proves registration and configuration only. It does **not**
+   prove a watcher is alive or that any session is attached; a receiver can
+   report `mode=monitor` while nothing is streaming.
+2. **Live attachment — agent-specific.** For **claude**, the proof is the Claude
+   Code Monitor markers in that receiver's own session: `Monitor(agmsg inbox
+   stream)` in the transcript, footer `1 monitor` (**not** `1 shell` — a
+   background `watch.sh` is diagnostic/fallback only), and `Monitor event` lines
+   as messages arrive (see [Monitor tool vs delivery-mode](#monitor-recovery)).
+   For **codex**, it is the bridge-alive marker where the bridge applies:
+   `delivery.sh status` showing `Codex bridge: <team>/<role> alive (pid N)` —
+   noting the bridge arms on the first turn sent to the session, not at startup.
+3. **End-to-end** — the [ping test](#receiver-readiness) ack is the **only**
+   end-to-end proof. Layers 1 and 2 are preconditions, never a substitute; when
+   the live markers are unavailable, fall back explicitly (`turn` delivery or
+   manual `inbox.sh`), say so, and still require the ack.
 
 **5. Exclusivity and handover.** Exactly one live session may hold a role; a
 second actas attempt is refused, and that refusal is correct. Replacing a

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -111,13 +111,14 @@ than a per-invocation approval that re-prompts on the next wake.
 
 > **Authority boundary — unsticking is not deciding.** Attending a pane does not
 > make the design thread the decider. It may act **only on pane contents it has
-> actually read** — never a blind keystroke into a dialog it has not rendered —
-> and **only for the trust/allowlist cases the operator explicitly authorized**
-> for this provisioning, including its own hook-trust case. Every credential
-> prompt, security prompt, and permission prompt outside that authorization
-> **must be escalated to the operator** and left unanswered. If answering would
-> grant access, widen a permission mode, or accept a security warning, it is the
-> operator's call.
+> actually read** — never a blind keystroke into a dialog it has not rendered.
+> Operator authorization can extend **only to read-pane trust/allowlist cases**,
+> such as the design thread's own hook-trust case. Credential, security, and
+> permission prompts are **never** answerable by the design thread: they
+> **always** remain unanswered and are **always** escalated to the operator,
+> with or without prior authorization — no authorization makes them answerable.
+> If answering would grant access, widen a permission mode, or accept a security
+> warning, it is the operator's call.
 
 **4. Role initialization.** Type the actas form matching the pane's CLI —
 `/agmsg actas <role>` for claude, `$agmsg actas <role>` for codex — then confirm
@@ -126,7 +127,11 @@ readiness in **three layers that must not be collapsed**:
 1. **Delivery configuration** — `delivery.sh status` reporting a mode (e.g.
    `mode=monitor`) proves registration and configuration only. It does **not**
    prove a watcher is alive or that any session is attached; a receiver can
-   report `mode=monitor` while nothing is streaming.
+   report `mode=monitor` while nothing is streaming. The converse holds too: a
+   pane sitting on a trust screen is **not live-attached and not session-active**
+   but its delivery configuration — set with `delivery.sh` before launch — is
+   unaffected. Launch-UI state never erases configuration, and configuration
+   never implies attachment.
 2. **Live attachment — agent-specific.** For **claude**, the proof is the Claude
    Code Monitor markers in that receiver's own session: `Monitor(agmsg inbox
    stream)` in the transcript, footer `1 monitor` (**not** `1 shell` — a

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -72,6 +72,64 @@ The full reference checklist follows the intake:
 > message, and clean up only through the agmsg scripts. Hand-editing agmsg state
 > corrupts delivery.
 
+## Terminal-workspace provisioning (building the team)
+
+The setup checklist above assumes each role **already** has its own folder and
+its own live terminal session. When it does not — a design thread asked to "set
+this team up" from nothing — `guide orchestrator-thread` renders a
+**terminal-workspace provisioning** section that creates both, executable with
+placeholders only (`<Project>`, host metadata repo `<owner/host-repo>`, target
+repo `<owner/repo>`, agmsg team `<team>`, `<workspace-root>`). Generate it with
+the same command and work down its checklist; the summary below is orientation,
+not a substitute.
+
+**1. Role folders — create them when absent.** Host-side roles (orchestrator,
+review) run from clones of the **host metadata repo**; the implementation role
+runs from a clone of the **target repo** (implementation is GitHub-contract-only
+and never reads host `.intent-cli/` state). Two roles must **never** share a
+folder: agmsg identity and the codex monitor bridge are `(project, type)`-scoped
+(G521), so two same-type roles in one folder resolve to the same identity and one
+of them silently stops receiving. A pane opened at a missing cwd falls back to
+the shell's default directory, which produces exactly that collision — so create
+the folder first, then verify each is distinct, has the expected `origin`, and is
+clean.
+
+**2. Workspace topology.** One workspace per team; one tab named after the team;
+one pane per role, each opened with that role's folder as its cwd (set at pane
+creation — do not `cd` after launching the agent). The **design thread stays
+outside** the workspace it is constructing.
+
+**3. Launch rules.** Launch every agent by **typing into the pane's interactive
+shell** (send-text + enter). For codex this is mandatory: the `codex()` shell
+shim is what arms the agmsg monitor bridge (G521), and a workspace manager that
+exec's the canonical executable directly bypasses it — the session looks healthy
+and messages are simply never delivered. claude is launched with the permission
+mode the **operator** chose. **Attend** each pane's first run: trust screens and
+permission prompts block the session until answered, and they must be answered so
+they produce **durable** allowlists rather than a per-invocation approval that
+re-prompts on the next wake.
+
+**4. Role initialization.** Type the actas form matching the pane's CLI —
+`/agmsg actas <role>` for claude, `$agmsg actas <role>` for codex — then **wait
+for readiness** (a pane still on a trust screen is not ready), then run the
+existing [ping test](#receiver-readiness). Readiness is a precondition for the
+ping test, not a replacement for it.
+
+**5. Exclusivity and handover.** Exactly one live session may hold a role; a
+second actas attempt is refused, and that refusal is correct. Replacing a
+session goes through the **graceful drop** — the current holder drops the role
+(with its operator confirmation) and only then does the successor claim it,
+followed by readiness + ping test again.
+
+**6. herdr is the reference workspace manager.** The surfaces a design thread
+drives are `workspace create`, `pane split`, `pane send-text` / `send-keys`,
+`agent prompt`, and `agent wait`. intent-cli does not own, ship, or wrap herdr —
+consult herdr's own documentation for internals, exactly as this guide links out
+for agmsg internals. **Any** equivalent workspace manager may be substituted
+provided the same rules hold: one dedicated folder per role as the pane cwd,
+shim-safe typed launch, attended first-run prompts, actas + readiness before the
+ping test, and one holder per role with a graceful drop on handover.
+
 ## Role boundary — design authors, orchestrator coordinates
 
 **Design creates packets; the orchestrator moves ready packets through the

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -108,12 +108,14 @@ monitor bridge を arm する（G521）ため、canonical な実行ファイル�
 
 > **権限境界 — 詰まりを解くことは決定することではない。** pane に立ち会うことは、設計
 > スレッドが決定者になることを意味しません。設計スレッドは **実際に読んだ pane の内容に
-> 対してのみ** 行動でき（レンダリングしていないダイアログへのブラインド入力は禁止）、
-> **この provisioning のためにオペレーターが明示的に認可した trust/allowlist ケースに
-> 限り** 回答できます（自身の hook-trust ケースを含む）。その認可の外にある credential
-> プロンプト・security プロンプト・permission プロンプトは、すべて **オペレーターへ
-> エスカレーション** し、未回答のまま残さなければなりません。回答がアクセス付与・
-> permission mode の拡大・security 警告の受諾になるなら、それはオペレーターの判断です。
+> 対してのみ** 行動できます（レンダリングしていないダイアログへのブラインド入力は禁止）。
+> オペレーターの認可が及ぶのは **読んだ pane の trust/allowlist ケースに限られます** —
+> たとえば設計スレッド自身の hook-trust ケースです。credential プロンプト・security
+> プロンプト・permission プロンプトを設計スレッドが回答することは **決してありません**:
+> 事前認可の有無にかかわらず **常に** 未回答のまま **常に** オペレーターへ
+> エスカレーションします — どんな認可もこれらを回答可能にはしません。回答がアクセス
+> 付与・permission mode の拡大・security 警告の受諾になるなら、それはオペレーターの
+> 判断です。
 
 **4. ロール初期化。** pane の CLI に合った actas 形式をタイプします — claude は
 `/agmsg actas <role>`、codex は `$agmsg actas <role>`。その後 readiness を
@@ -122,7 +124,10 @@ monitor bridge を arm する（G521）ため、canonical な実行ファイル�
 1. **delivery 設定** — `delivery.sh status` がモード（例: `mode=monitor`）を報告することは、
    登録と設定を証明するだけです。watcher が生きていることも、セッションが attach されている
    ことも **証明しません**。`mode=monitor` を報告しながら何もストリームされていない receiver は
-   ありえます。
+   ありえます。逆も成り立ちます: trust 画面のままの pane は **live-attached でも
+   session-active でもありません** が、起動前に `delivery.sh` で設定した delivery 設定は
+   影響を受けません。起動 UI の状態が設定を消すことはなく、設定が attachment を意味することも
+   ありません。
 2. **live attachment — agent ごとに異なる。** **claude** では、その receiver 自身の
    セッションに現れる Claude Code Monitor マーカーが証拠です: transcript の
    `Monitor(agmsg inbox stream)`、フッターの `1 monitor`（`1 shell` は **不可** —

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -68,6 +68,62 @@ intake の後に、完全なリファレンスチェックリストが続きま�
 > クリーンアップはすべて agmsg スクリプト経由で行います。agmsg state の手編集は delivery を
 > 壊します。
 
+## ターミナルワークスペースの provisioning（チームを構築する）
+
+上記のセットアップチェックリストは、各ロールが **すでに** 専用フォルダーと稼働中の
+ターミナルセッションを持っていることを前提にしています。そうでない場合 — 設計スレッドが
+何もない状態から「このチームをセットアップして」と依頼された場合 —
+`guide orchestrator-thread` は両方を作る **terminal-workspace provisioning**
+セクションをレンダリングします。プレースホルダーだけで実行可能です
+（`<Project>`、host メタデータリポジトリ `<owner/host-repo>`、target repo
+`<owner/repo>`、agmsg team `<team>`、`<workspace-root>`）。同じコマンドで生成し、
+そのチェックリストを上から実行してください。以下の要約はオリエンテーションであり、
+代替ではありません。
+
+**1. ロールフォルダー — 無ければ作る。** host 側のロール（orchestrator、review）は
+**host メタデータリポジトリ** のクローンから、implementation ロールは **target repo**
+のクローンから実行します（implementation は GitHub-contract-only であり、host の
+`.intent-cli/` state を読みません）。2 つのロールが 1 つのフォルダーを共有しては
+**いけません**: agmsg identity と codex monitor bridge は `(project, type)` スコープ
+（G521）であり、同じ型の 2 ロールが 1 フォルダーにいると同一 identity に解決され、
+片方が静かに受信を停止します。存在しない cwd で開かれた pane はシェルの既定
+ディレクトリにフォールバックし、まさにこの衝突を起こします — 先にフォルダーを作成し、
+その後で各フォルダーが別パスであること、`origin` が期待どおりであること、clean である
+ことを検証してください。
+
+**2. ワークスペーストポロジー。** team ごとに 1 ワークスペース、team 名を付けた
+タブ 1 つ、ロールごとに pane 1 つ（そのロールのフォルダーを cwd として pane 作成時に
+設定する — agent 起動後に `cd` しない）。**設計スレッドは** 自分が構築している
+ワークスペースの **外に留まります**。
+
+**3. 起動ルール。** すべての agent は pane の **対話シェルにタイプして**
+（send-text + enter）起動します。codex では必須です: `codex()` シェル shim が agmsg
+monitor bridge を arm する（G521）ため、canonical な実行ファイルを直接 exec する
+ワークスペースマネージャーはこれを bypass し、セッションは健全に見えるのにメッセージが
+一切配信されません。claude は **オペレーター** が選んだ permission mode で起動します。
+各 pane の初回起動には **必ず立ち会って** ください: trust 画面と permission プロンプトは
+回答されるまでセッションをブロックし、しかも次の wake で再プロンプトされる 1 回限りの
+承認ではなく **durable な** allowlist を生むように回答する必要があります。
+
+**4. ロール初期化。** pane の CLI に合った actas 形式をタイプします — claude は
+`/agmsg actas <role>`、codex は `$agmsg actas <role>` — その後 **readiness を待ち**
+（trust 画面のままの pane は ready ではありません）、既存の
+[ping テスト](#receiver-の準備状態readiness) を実行します。readiness は ping テストの
+前提条件であって、代替ではありません。
+
+**5. 排他性とハンドオーバー。** 1 つのロールを保持できる生きたセッションはちょうど 1 つで、
+2 番目の actas は拒否されます — その拒否が正しい挙動です。セッションの置き換えは
+**graceful drop** を通します: 現保持者が（オペレーター確認つきで）ロールを drop し、
+その後にはじめて後継が claim し、readiness + ping テストを再実行します。
+
+**6. 参照ワークスペースマネージャーは herdr。** 設計スレッドが駆動する surface は
+`workspace create`、`pane split`、`pane send-text` / `send-keys`、`agent prompt`、
+`agent wait` です。intent-cli は herdr を所有・同梱・ラップしません — internals は
+agmsg internals と同じくリンクアウトし、herdr 自身のドキュメントを参照します。同じルール
+（ロールごとの専用フォルダーを pane の cwd にする、shim-safe なタイプ起動、初回プロンプトに
+立ち会う、ping テスト前の actas + readiness、1 ロール 1 保持者と handover 時の graceful
+drop）が満たされるなら、**任意の** 同等なワークスペースマネージャーで置き換えられます。
+
 ## ロール境界 — design が authoring、orchestrator は coordinate
 
 **design が packet を作成し、orchestrator は ready な packet を workflow に通します。**

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -102,14 +102,39 @@ monitor bridge を arm する（G521）ため、canonical な実行ファイル�
 ワークスペースマネージャーはこれを bypass し、セッションは健全に見えるのにメッセージが
 一切配信されません。claude は **オペレーター** が選んだ permission mode で起動します。
 各 pane の初回起動には **必ず立ち会って** ください: trust 画面と permission プロンプトは
-回答されるまでセッションをブロックし、しかも次の wake で再プロンプトされる 1 回限りの
-承認ではなく **durable な** allowlist を生むように回答する必要があります。
+回答されるまでセッションをブロックします。設計スレッドが回答を認可されている場合、その回答は
+次の wake で再プロンプトされる 1 回限りの承認ではなく **durable な** allowlist を生む必要が
+あります。
+
+> **権限境界 — 詰まりを解くことは決定することではない。** pane に立ち会うことは、設計
+> スレッドが決定者になることを意味しません。設計スレッドは **実際に読んだ pane の内容に
+> 対してのみ** 行動でき（レンダリングしていないダイアログへのブラインド入力は禁止）、
+> **この provisioning のためにオペレーターが明示的に認可した trust/allowlist ケースに
+> 限り** 回答できます（自身の hook-trust ケースを含む）。その認可の外にある credential
+> プロンプト・security プロンプト・permission プロンプトは、すべて **オペレーターへ
+> エスカレーション** し、未回答のまま残さなければなりません。回答がアクセス付与・
+> permission mode の拡大・security 警告の受諾になるなら、それはオペレーターの判断です。
 
 **4. ロール初期化。** pane の CLI に合った actas 形式をタイプします — claude は
-`/agmsg actas <role>`、codex は `$agmsg actas <role>` — その後 **readiness を待ち**
-（trust 画面のままの pane は ready ではありません）、既存の
-[ping テスト](#receiver-の準備状態readiness) を実行します。readiness は ping テストの
-前提条件であって、代替ではありません。
+`/agmsg actas <role>`、codex は `$agmsg actas <role>`。その後 readiness を
+**混同してはいけない 3 つのレイヤー** で確認します:
+
+1. **delivery 設定** — `delivery.sh status` がモード（例: `mode=monitor`）を報告することは、
+   登録と設定を証明するだけです。watcher が生きていることも、セッションが attach されている
+   ことも **証明しません**。`mode=monitor` を報告しながら何もストリームされていない receiver は
+   ありえます。
+2. **live attachment — agent ごとに異なる。** **claude** では、その receiver 自身の
+   セッションに現れる Claude Code Monitor マーカーが証拠です: transcript の
+   `Monitor(agmsg inbox stream)`、フッターの `1 monitor`（`1 shell` は **不可** —
+   バックグラウンドの `watch.sh` は診断/フォールバック専用）、メッセージ到着時の
+   `Monitor event` 行（[Monitor ツールと delivery-mode](#monitor-リカバリ) を参照）。
+   **codex** では、bridge が適用される場合の bridge-alive マーカー:
+   `delivery.sh status` の `Codex bridge: <team>/<role> alive (pid N)`。bridge は codex 起動時
+   ではなくセッションへの **最初の turn** で arm される点に注意してください。
+3. **end-to-end** — [ping テスト](#receiver-の準備状態readiness) の ack が **唯一の**
+   end-to-end の証明です。レイヤー 1・2 は前提条件であって代替ではありません。live マーカーが
+   得られない場合は明示的にフォールバックし（`turn` delivery または手動 `inbox.sh`）、その旨を
+   述べたうえで、それでも ack を必須にします。
 
 **5. 排他性とハンドオーバー。** 1 つのロールを保持できる生きたセッションはちょうど 1 つで、
 2 番目の actas は拒否されます — その拒否が正しい挙動です。セッションの置き換えは

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -941,6 +941,7 @@ internal static class GuideOrchestratorThreadCommand
                     },
                 },
             },
+            TerminalWorkspaceProvisioning = BuildTerminalWorkspaceProvisioning(repo, values["<team>"]),
             DesignTrafficController = new OrchestratorDesignTrafficController
             {
                 Summary =
@@ -1380,6 +1381,217 @@ internal static class GuideOrchestratorThreadCommand
         };
     }
 
+    // G549: the provisioning section a design thread executes BEFORE the setup
+    // checklist — it creates what the rest of the guide already assumes exists.
+    // Only the target repo and the agmsg team come from CLI inputs; the project
+    // name and the host metadata repo stay as placeholders, because a design
+    // thread asked to "set this team up" knows them from its own context and
+    // intent-cli never needs them for any mutation.
+    private static OrchestratorTerminalWorkspaceProvisioning BuildTerminalWorkspaceProvisioning(string targetRepo, string team)
+    {
+        string Fill(string template) => template
+            .Replace("<owner/repo>", targetRepo, StringComparison.Ordinal)
+            .Replace("<team>", team, StringComparison.Ordinal);
+
+        return new OrchestratorTerminalWorkspaceProvisioning
+        {
+            Summary = Fill(
+                "Provision the whole team on a terminal-workspace manager BEFORE running the setup checklist. The rest "
+                + "of this guide assumes each role already has its own folder and its own live terminal session; this "
+                + "section creates both. Work through it top to bottom — role folders (create them when absent), "
+                + "workspace topology, launch rules, role initialization, exclusivity/handover — then continue at "
+                + "`Setup (starting orchestrator mode)`. Every step below is executable with the placeholders listed "
+                + "next; nothing here requires knowledge outside this page."),
+            Placeholders = new[]
+            {
+                new OrchestratorProvisioningPlaceholder { Token = "<Project>", Meaning = "the project/product name used as the folder-name prefix (e.g. `Estivo` → `EstivoOrchestrator`)." },
+                new OrchestratorProvisioningPlaceholder { Token = "<owner/host-repo>", Meaning = "the HOST metadata repo that owns `.intent-cli/` and `intents/<domain>/` — cloned for the host-side roles (orchestrator, review)." },
+                new OrchestratorProvisioningPlaceholder { Token = Fill("<owner/repo>"), Meaning = "the TARGET repo the work lands in — cloned for the implementation role." },
+                new OrchestratorProvisioningPlaceholder { Token = Fill("<team>"), Meaning = "the agmsg team name; also the workspace tab name." },
+                new OrchestratorProvisioningPlaceholder { Token = "<workspace-root>", Meaning = "the parent directory the role folders are created under (e.g. `~/dev`)." },
+            },
+            FolderProvisioning = new OrchestratorProvisioningFolders
+            {
+                Summary = Fill(
+                    "Each role runs from its OWN dedicated folder. Host-side roles (orchestrator, review) run from a "
+                    + "clone of the host metadata repo `<owner/host-repo>`; the implementation role runs from a clone of "
+                    + "the target repo `<owner/repo>`. Create any folder that does not exist yet — do not reuse an "
+                    + "existing checkout that another role already occupies, and do not point two roles at one folder."),
+                NeverShareRule =
+                    "NEVER share a folder between two roles. agmsg identity and the codex monitor bridge are "
+                    + "(project, type)-scoped (G521): two roles of the same agent type in one folder resolve to the SAME "
+                    + "identity, so actas exclusivity, delivery, and the bridge collide and one role silently stops "
+                    + "receiving. One role = one folder, always.",
+                Roles = new[]
+                {
+                    new OrchestratorProvisioningRoleFolder
+                    {
+                        Role = "orchestrator",
+                        Folder = "<workspace-root>/<Project>Orchestrator",
+                        CloneSource = "host metadata repo `<owner/host-repo>` (owns `.intent-cli/` and `intents/<domain>/`)",
+                        CreateCommand = "git clone https://github.com/<owner/host-repo>.git <workspace-root>/<Project>Orchestrator",
+                    },
+                    new OrchestratorProvisioningRoleFolder
+                    {
+                        Role = "review",
+                        Folder = "<workspace-root>/<Project>Review",
+                        CloneSource = "host metadata repo `<owner/host-repo>` — a SECOND, separate clone (not the orchestrator's)",
+                        CreateCommand = "git clone https://github.com/<owner/host-repo>.git <workspace-root>/<Project>Review",
+                    },
+                    new OrchestratorProvisioningRoleFolder
+                    {
+                        Role = "implementation",
+                        Folder = "<workspace-root>/<Project>Implementation",
+                        CloneSource = Fill("target repo `<owner/repo>` — implementation is GitHub-contract-only and never reads host `.intent-cli/` state"),
+                        CreateCommand = Fill("git clone https://github.com/<owner/repo>.git <workspace-root>/<Project>Implementation"),
+                    },
+                },
+                AbsentFolderRule =
+                    "When a folder is absent, CREATE it with the clone command for that role before launching anything "
+                    + "in that pane — a pane opened at a missing cwd falls back to the shell's default directory, which "
+                    + "silently gives the role the wrong (or a shared) identity.",
+                Verification = new[]
+                {
+                    "Each of the three folders exists and is a distinct path — no two roles share one.",
+                    "`git -C <folder> remote get-url origin` matches the intended source for that role (host metadata repo for orchestrator/review, target repo for implementation).",
+                    "`git -C <folder> status` is clean in every folder before any role is launched.",
+                },
+            },
+            Topology = new OrchestratorProvisioningTopology
+            {
+                Summary = Fill(
+                    "One workspace per team, one tab named after the team, one pane per role, each pane opened with that "
+                    + "role's own folder as its cwd. The topology is what makes the folder rule hold in practice: the "
+                    + "pane carries the cwd, and the cwd carries the identity."),
+                Rules = new[]
+                {
+                    Fill("One WORKSPACE per agmsg team — the team `<team>` gets its own workspace, not a pane inside someone else's."),
+                    Fill("One TAB named after the team (`<team>`) so the team is identifiable at a glance."),
+                    "One PANE per role — orchestrator, implementation, review (plus design only if design is a monitored receiver in this team).",
+                    "Each pane's cwd is that role's dedicated folder — set the cwd at pane creation, do not `cd` after launching the agent.",
+                    "Panes are long-lived: a role's session lives for the whole run, so do not recycle a pane for a second role.",
+                },
+                DesignThreadPosition =
+                    "The DESIGN thread stays OUTSIDE the workspace. It is the thread doing the provisioning — it drives "
+                    + "the workspace manager from where it already runs and never claims a pane inside the team "
+                    + "workspace it is constructing.",
+            },
+            LaunchRules = new OrchestratorProvisioningLaunchRules
+            {
+                Summary =
+                    "How an agent is launched decides whether its message bridge arms and whether its first run stalls "
+                    + "on an unattended prompt. Launch every agent by TYPING into the pane's interactive shell, then "
+                    + "attend the first-run screens.",
+                CodexShimRule =
+                    "codex MUST be launched by typing into the pane's interactive shell (send-text + enter), never by "
+                    + "spawning the executable. The `codex()` shell shim is what wraps the launch and arms the agmsg "
+                    + "monitor bridge (G521); typing goes through the shell, so the shim applies.",
+                CodexDirectSpawnWarning =
+                    "a workspace manager that exec's the canonical `codex` executable directly BYPASSES the "
+                    + "shim, so the bridge never arms. The session looks healthy and messages are simply never "
+                    + "delivered. If a manager offers a \"run this command\" pane option, do NOT use it for codex; use "
+                    + "the send-text-into-the-shell path.",
+                ClaudePermissionModeRule =
+                    "claude is launched with the permission mode the OPERATOR chose for this team — the design thread "
+                    + "does not silently pick a broader mode. Type the launch into the pane's shell the same way, so "
+                    + "the session inherits the folder as cwd.",
+                AttendedFirstRunRule =
+                    "ATTEND the first run of every pane. First-run trust screens (codex hooks-trust) and permission "
+                    + "prompts block the session until answered, and an unattended pane looks \"launched\" while it is "
+                    + "actually waiting. Answer them so they produce DURABLE allowlists/trust records — a per-invocation "
+                    + "approval re-prompts on the next wake and stalls the role again.",
+            },
+            RoleInitialization = new OrchestratorProvisioningRoleInitialization
+            {
+                Summary = Fill(
+                    "Once a pane's agent is running, give it its agmsg role, wait for readiness, and only then ping-test "
+                    + "it. Use the actas form that matches the CLI in that pane; `<role>` is `orchestrator`, "
+                    + "`implementation`, or `review`, joined under team `<team>`."),
+                ActasForms = new[]
+                {
+                    new OrchestratorRoleStartup
+                    {
+                        AgentType = "claude",
+                        ActasInvocation = "/agmsg actas <role>",
+                        Note = "Type the slash-command form into the claude pane; it claims the role's exclusivity lock and re-points that session's inbox subscription at the role.",
+                    },
+                    new OrchestratorRoleStartup
+                    {
+                        AgentType = "codex",
+                        ActasInvocation = "$agmsg actas <role>",
+                        Note = "Type the `$agmsg actas <role>` form into the codex pane; the monitor bridge only attaches if the session was launched through the shim.",
+                    },
+                },
+                ReadinessWait =
+                    "WAIT for the role to report ready before sending anything — actas is submitted, not completed, at "
+                    + "the moment you type it. Treat the role as ready only when its watcher/bridge is attached (the "
+                    + "session says so, or `delivery.sh status` shows the watcher alive for that role). A pane that is "
+                    + "still on a trust screen is NOT ready.",
+                PingTestReference =
+                    "After readiness, run the existing ping test before ANY delegation: send one agmsg message to each "
+                    + "role and require the ack (see `Receiver readiness` / `ping_test`). Readiness is a precondition "
+                    + "for the ping test, not a replacement for it.",
+            },
+            ExclusivityHandover = new OrchestratorProvisioningHandover
+            {
+                OneHolderRule =
+                    "Exactly ONE live session may hold a role at a time. A second session trying to actas the same role "
+                    + "is refused (the role is reported held by the owning session) — that refusal is correct behavior, "
+                    + "not a bug to work around by joining under a near-miss name.",
+                GracefulDropRule =
+                    "Replacing a role's session goes through the GRACEFUL DROP first: the current holder drops the role "
+                    + "(releasing the exclusivity lock and its registration), and only then does the successor actas it. "
+                    + "Never kill the holder's pane and hope the lock clears.",
+                OperatorConfirmationRule =
+                    "The graceful drop carries an OPERATOR CONFIRMATION — the human running the outgoing session "
+                    + "confirms the handover. The design thread requests the drop and waits for that confirmation; it "
+                    + "does not force a role away from a live session.",
+                SuccessorClaimRule =
+                    "The successor claims the role only AFTER the drop is confirmed, then repeats readiness + ping test "
+                    + "for that role. A handover is not complete until the new holder has acked a ping.",
+            },
+            ReferenceManager = new OrchestratorProvisioningReferenceManager
+            {
+                Name = "herdr",
+                Summary =
+                    "herdr is the REFERENCE workspace manager for this flow — the surfaces below are the ones a design "
+                    + "thread drives programmatically to build the team. intent-cli does not own, ship, or wrap herdr; "
+                    + "it states the operational steps and the success criteria only.",
+                Surfaces = new[]
+                {
+                    new OrchestratorProvisioningSurface { Surface = "`workspace create`", UsedFor = "create the team's workspace and its team-named tab." },
+                    new OrchestratorProvisioningSurface { Surface = "`pane split`", UsedFor = "add one pane per role, each opened with that role's dedicated folder as cwd." },
+                    new OrchestratorProvisioningSurface { Surface = "`pane send-text` / `send-keys`", UsedFor = "type the agent launch and the actas prompt into the pane's interactive shell — this is the shim-safe path." },
+                    new OrchestratorProvisioningSurface { Surface = "`agent prompt`", UsedFor = "deliver a prompt to an agent already running in a pane." },
+                    new OrchestratorProvisioningSurface { Surface = "`agent wait`", UsedFor = "block until the pane's agent is idle/ready before the next step." },
+                },
+                InternalsLinkOut =
+                    "For herdr internals — installation, socket/API details, exact flags — consult herdr's own "
+                    + "documentation. This guide deliberately links out rather than restating them, exactly as it does "
+                    + "for agmsg internals.",
+                SubstitutionRule =
+                    "ANY equivalent workspace manager may be substituted, provided the same rules hold: one dedicated "
+                    + "folder per role as the pane cwd, launch typed into an interactive shell (shim-safe), attended "
+                    + "first-run trust/permission prompts, actas + readiness before the ping test, and one holder per "
+                    + "role with a graceful drop on handover.",
+            },
+            Checklist = new[]
+            {
+                Fill("Collect the placeholders: `<Project>`, host metadata repo `<owner/host-repo>`, target repo `<owner/repo>`, agmsg team `<team>`, `<workspace-root>`."),
+                "For each role, check whether its dedicated folder exists; CREATE any missing one with that role's clone command (host metadata repo for orchestrator/review, target repo for implementation).",
+                "Verify the three folders are distinct, have the expected `origin`, and are clean.",
+                Fill("Create one workspace for team `<team>` with a tab named after the team; keep the design thread outside it."),
+                "Split one pane per role, each opened with that role's folder as cwd.",
+                "Launch each pane's agent by TYPING into its interactive shell — codex through the shim, claude with the operator's chosen permission mode; never spawn the executable directly.",
+                "Attend the first run of each pane: answer trust screens and permission prompts so they produce durable allowlists.",
+                "Type the actas form into each pane (`/agmsg actas <role>` for claude, `$agmsg actas <role>` for codex) and wait for each role to be ready.",
+                "Ping-test every role and require an ack before the first real delegation.",
+                "Continue with `Setup (starting orchestrator mode)` — the delivery mode, role prompts, read-only first wake, and the rest of the setup checklist.",
+                "On a role handover, drop the role from the current holder (with its operator confirmation) BEFORE the successor claims it, then redo readiness + ping test.",
+            },
+        };
+    }
+
     // G500: turn an orchestrator setup request into a concrete, operational
     // intake. The visible outcome is one of missing-inputs / setup-ready /
     // blocked. When inputs are complete the intake emits copy-paste agmsg
@@ -1731,6 +1943,115 @@ internal static class GuideOrchestratorThreadCommand
         }
     }
 
+    // G549: render the provisioning section as a paste-ready checklist — the
+    // six elements in execution order, then the flat checklist a design thread
+    // can work straight down.
+    private static void WriteTerminalWorkspaceProvisioning(TextWriter writer, OrchestratorTerminalWorkspaceProvisioning provisioning)
+    {
+        writer.WriteLine("## Terminal-workspace provisioning (G549)");
+        writer.WriteLine();
+        writer.WriteLine(provisioning.Summary);
+        writer.WriteLine();
+
+        writer.WriteLine("### Placeholders");
+        writer.WriteLine();
+        foreach (var placeholder in provisioning.Placeholders)
+        {
+            writer.WriteLine($"- `{placeholder.Token}` — {placeholder.Meaning}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("### 1. Role folders (create them when absent)");
+        writer.WriteLine();
+        writer.WriteLine(provisioning.FolderProvisioning.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"> **Never share a folder:** {provisioning.FolderProvisioning.NeverShareRule}");
+        writer.WriteLine();
+        foreach (var role in provisioning.FolderProvisioning.Roles)
+        {
+            writer.WriteLine($"- **{role.Role}** — folder `{role.Folder}` — clone of the {role.CloneSource}");
+            writer.WriteLine();
+            writer.WriteLine("  ```bash");
+            writer.WriteLine($"  {role.CreateCommand}");
+            writer.WriteLine("  ```");
+            writer.WriteLine();
+        }
+        writer.WriteLine($"- **folder absent** — {provisioning.FolderProvisioning.AbsentFolderRule}");
+        writer.WriteLine();
+        writer.WriteLine("Verify before launching anything:");
+        writer.WriteLine();
+        foreach (var check in provisioning.FolderProvisioning.Verification)
+        {
+            writer.WriteLine($"- {check}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("### 2. Workspace topology");
+        writer.WriteLine();
+        writer.WriteLine(provisioning.Topology.Summary);
+        writer.WriteLine();
+        foreach (var rule in provisioning.Topology.Rules)
+        {
+            writer.WriteLine($"- {rule}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **design thread stays outside** — {provisioning.Topology.DesignThreadPosition}");
+        writer.WriteLine();
+
+        writer.WriteLine("### 3. Launch rules (and why)");
+        writer.WriteLine();
+        writer.WriteLine(provisioning.LaunchRules.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- **codex — shim-safe typed launch** — {provisioning.LaunchRules.CodexShimRule}");
+        writer.WriteLine($"- **claude — operator-chosen permission mode** — {provisioning.LaunchRules.ClaudePermissionModeRule}");
+        writer.WriteLine($"- **attended first run** — {provisioning.LaunchRules.AttendedFirstRunRule}");
+        writer.WriteLine();
+        writer.WriteLine($"> **Warning:** {provisioning.LaunchRules.CodexDirectSpawnWarning}");
+        writer.WriteLine();
+
+        writer.WriteLine("### 4. Role initialization (actas and readiness)");
+        writer.WriteLine();
+        writer.WriteLine(provisioning.RoleInitialization.Summary);
+        writer.WriteLine();
+        foreach (var form in provisioning.RoleInitialization.ActasForms)
+        {
+            writer.WriteLine($"- **{form.AgentType}** — `{form.ActasInvocation}` — {form.Note}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **readiness wait** — {provisioning.RoleInitialization.ReadinessWait}");
+        writer.WriteLine($"- **ping test** — {provisioning.RoleInitialization.PingTestReference}");
+        writer.WriteLine();
+
+        writer.WriteLine("### 5. Role exclusivity and handover");
+        writer.WriteLine();
+        writer.WriteLine($"- **one holder per role** — {provisioning.ExclusivityHandover.OneHolderRule}");
+        writer.WriteLine($"- **graceful drop first** — {provisioning.ExclusivityHandover.GracefulDropRule}");
+        writer.WriteLine($"- **operator confirmation** — {provisioning.ExclusivityHandover.OperatorConfirmationRule}");
+        writer.WriteLine($"- **successor claims after** — {provisioning.ExclusivityHandover.SuccessorClaimRule}");
+        writer.WriteLine();
+
+        writer.WriteLine($"### 6. Reference workspace manager — {provisioning.ReferenceManager.Name}");
+        writer.WriteLine();
+        writer.WriteLine(provisioning.ReferenceManager.Summary);
+        writer.WriteLine();
+        foreach (var surface in provisioning.ReferenceManager.Surfaces)
+        {
+            writer.WriteLine($"- {surface.Surface} — {surface.UsedFor}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **internals** — {provisioning.ReferenceManager.InternalsLinkOut}");
+        writer.WriteLine($"- **substitution** — {provisioning.ReferenceManager.SubstitutionRule}");
+        writer.WriteLine();
+
+        writer.WriteLine("### Provisioning checklist (paste-ready)");
+        writer.WriteLine();
+        for (var i = 0; i < provisioning.Checklist.Count; i++)
+        {
+            writer.WriteLine($"{i + 1}. {provisioning.Checklist[i]}");
+        }
+        writer.WriteLine();
+    }
+
     private static void WriteMarkdown(TextWriter writer, OrchestratorThreadGuide guide)
     {
         writer.WriteLine("# Guide — agmsg-backed orchestrator thread (G487)");
@@ -1844,6 +2165,8 @@ internal static class GuideOrchestratorThreadCommand
             writer.WriteLine($"- **{startup.AgentType}** — `{startup.ActasInvocation}` — {startup.Note}");
         }
         writer.WriteLine();
+
+        WriteTerminalWorkspaceProvisioning(writer, guide.TerminalWorkspaceProvisioning);
 
         writer.WriteLine("## Preflight (all three cwds)");
         writer.WriteLine();
@@ -2593,6 +2916,9 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("intake_form")]
     public required OrchestratorIntakeForm IntakeForm { get; init; }
 
+    [JsonPropertyName("terminal_workspace_provisioning")]
+    public required OrchestratorTerminalWorkspaceProvisioning TerminalWorkspaceProvisioning { get; init; }
+
     [JsonPropertyName("design_traffic_controller")]
     public required OrchestratorDesignTrafficController DesignTrafficController { get; init; }
 
@@ -2812,6 +3138,179 @@ internal sealed record OrchestratorRoleStartup
 
     [JsonPropertyName("note")]
     public required string Note { get; init; }
+}
+
+/// <summary>
+/// G549: terminal-workspace provisioning for a whole team — the setup step
+/// that runs BEFORE the existing setup checklist can be executed at all.
+/// Earlier guidance assumed the role folders and terminal sessions already
+/// existed ("each role runs from its own folder, clone, or worktree") and said
+/// nothing about creating them, so a design thread asked to "set this team up"
+/// had to supply the missing knowledge itself. This section makes the flow
+/// executable end to end with placeholders only: folder provisioning (with the
+/// project-scoped-identity reason from G521), workspace topology, shim-safe
+/// launch, actas + readiness, role exclusivity/handover, and herdr named as the
+/// reference workspace manager whose internals are linked out rather than owned.
+/// </summary>
+internal sealed record OrchestratorTerminalWorkspaceProvisioning
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("placeholders")]
+    public required IReadOnlyList<OrchestratorProvisioningPlaceholder> Placeholders { get; init; }
+
+    [JsonPropertyName("folder_provisioning")]
+    public required OrchestratorProvisioningFolders FolderProvisioning { get; init; }
+
+    [JsonPropertyName("topology")]
+    public required OrchestratorProvisioningTopology Topology { get; init; }
+
+    [JsonPropertyName("launch_rules")]
+    public required OrchestratorProvisioningLaunchRules LaunchRules { get; init; }
+
+    [JsonPropertyName("role_initialization")]
+    public required OrchestratorProvisioningRoleInitialization RoleInitialization { get; init; }
+
+    [JsonPropertyName("exclusivity_handover")]
+    public required OrchestratorProvisioningHandover ExclusivityHandover { get; init; }
+
+    [JsonPropertyName("reference_manager")]
+    public required OrchestratorProvisioningReferenceManager ReferenceManager { get; init; }
+
+    [JsonPropertyName("checklist")]
+    public required IReadOnlyList<string> Checklist { get; init; }
+}
+
+internal sealed record OrchestratorProvisioningPlaceholder
+{
+    [JsonPropertyName("token")]
+    public required string Token { get; init; }
+
+    [JsonPropertyName("meaning")]
+    public required string Meaning { get; init; }
+}
+
+internal sealed record OrchestratorProvisioningFolders
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    /// <summary>G521: agmsg identity and the codex monitor bridge are (project, type)-scoped, so two roles sharing one folder collide.</summary>
+    [JsonPropertyName("never_share_rule")]
+    public required string NeverShareRule { get; init; }
+
+    [JsonPropertyName("roles")]
+    public required IReadOnlyList<OrchestratorProvisioningRoleFolder> Roles { get; init; }
+
+    [JsonPropertyName("absent_folder_rule")]
+    public required string AbsentFolderRule { get; init; }
+
+    [JsonPropertyName("verification")]
+    public required IReadOnlyList<string> Verification { get; init; }
+}
+
+internal sealed record OrchestratorProvisioningRoleFolder
+{
+    [JsonPropertyName("role")]
+    public required string Role { get; init; }
+
+    [JsonPropertyName("folder")]
+    public required string Folder { get; init; }
+
+    [JsonPropertyName("clone_source")]
+    public required string CloneSource { get; init; }
+
+    [JsonPropertyName("create_command")]
+    public required string CreateCommand { get; init; }
+}
+
+internal sealed record OrchestratorProvisioningTopology
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("rules")]
+    public required IReadOnlyList<string> Rules { get; init; }
+
+    [JsonPropertyName("design_thread_position")]
+    public required string DesignThreadPosition { get; init; }
+}
+
+internal sealed record OrchestratorProvisioningLaunchRules
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    /// <summary>G521: the codex shell shim must wrap the launch or the monitor bridge never arms.</summary>
+    [JsonPropertyName("codex_shim_rule")]
+    public required string CodexShimRule { get; init; }
+
+    [JsonPropertyName("codex_direct_spawn_warning")]
+    public required string CodexDirectSpawnWarning { get; init; }
+
+    [JsonPropertyName("claude_permission_mode_rule")]
+    public required string ClaudePermissionModeRule { get; init; }
+
+    [JsonPropertyName("attended_first_run_rule")]
+    public required string AttendedFirstRunRule { get; init; }
+}
+
+internal sealed record OrchestratorProvisioningRoleInitialization
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("actas_forms")]
+    public required IReadOnlyList<OrchestratorRoleStartup> ActasForms { get; init; }
+
+    [JsonPropertyName("readiness_wait")]
+    public required string ReadinessWait { get; init; }
+
+    [JsonPropertyName("ping_test_reference")]
+    public required string PingTestReference { get; init; }
+}
+
+internal sealed record OrchestratorProvisioningHandover
+{
+    [JsonPropertyName("one_holder_rule")]
+    public required string OneHolderRule { get; init; }
+
+    [JsonPropertyName("graceful_drop_rule")]
+    public required string GracefulDropRule { get; init; }
+
+    [JsonPropertyName("operator_confirmation_rule")]
+    public required string OperatorConfirmationRule { get; init; }
+
+    [JsonPropertyName("successor_claim_rule")]
+    public required string SuccessorClaimRule { get; init; }
+}
+
+internal sealed record OrchestratorProvisioningReferenceManager
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("surfaces")]
+    public required IReadOnlyList<OrchestratorProvisioningSurface> Surfaces { get; init; }
+
+    [JsonPropertyName("internals_link_out")]
+    public required string InternalsLinkOut { get; init; }
+
+    [JsonPropertyName("substitution_rule")]
+    public required string SubstitutionRule { get; init; }
+}
+
+internal sealed record OrchestratorProvisioningSurface
+{
+    [JsonPropertyName("surface")]
+    public required string Surface { get; init; }
+
+    [JsonPropertyName("used_for")]
+    public required string UsedFor { get; init; }
 }
 
 internal sealed record OrchestratorDesignTrafficController

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -1504,13 +1504,13 @@ internal static class GuideOrchestratorThreadCommand
                 AuthorityBoundary =
                     "attending a pane is not authority to decide for the operator. The design "
                     + "thread may act ONLY on pane contents it has actually READ (never on a blind keystroke into a "
-                    + "dialog it has not rendered), and ONLY for the trust/allowlist cases the operator explicitly "
-                    + "authorized for this provisioning — including its own hook-trust case, which it may accept for "
-                    + "itself. Every credential prompt, security prompt, and permission prompt outside that explicit "
-                    + "authorization MUST be ESCALATED to the operator and left unanswered until the operator decides. "
-                    + "Unsticking a pane is not deciding for the operator: if answering the dialog would grant access, "
-                    + "widen a permission mode, or accept a security warning, it is the operator's call, not the design "
-                    + "thread's.",
+                    + "dialog it has not rendered). Operator authorization can extend ONLY to read-pane TRUST/ALLOWLIST "
+                    + "cases — such as the design thread's own hook-trust case, which it may accept for itself. "
+                    + "CREDENTIAL, SECURITY, and PERMISSION prompts are NEVER answerable by the design thread: they "
+                    + "ALWAYS remain unanswered and are ALWAYS ESCALATED to the operator, with or without prior "
+                    + "authorization — no authorization makes them answerable. Unsticking a pane is not deciding for "
+                    + "the operator: if answering the dialog would grant access, widen a permission mode, or accept a "
+                    + "security warning, it is the operator's call, not the design thread's.",
             },
             RoleInitialization = new OrchestratorProvisioningRoleInitialization
             {
@@ -1537,7 +1537,10 @@ internal static class GuideOrchestratorThreadCommand
                     "WAIT for the role to report ready before sending anything — actas is submitted, not completed, at "
                     + "the moment you type it. Readiness has THREE separate layers and they must not be collapsed: "
                     + "delivery CONFIGURATION, LIVE ATTACHMENT, and END-TO-END delivery. A pane still sitting on a trust "
-                    + "screen is not even configured yet, let alone ready.",
+                    + "screen is NOT live-attached and NOT session-active — and that says nothing about its delivery "
+                    + "configuration, which is set with `delivery.sh` before launch and stays configured regardless of "
+                    + "what the launch UI is showing. Launch-UI state never erases configuration, and configuration "
+                    + "never implies attachment.",
                 ConfigurationProof =
                     "CONFIGURATION only — `delivery.sh status` reporting a delivery mode (e.g. `mode=monitor`) proves "
                     + "the role is registered and how it is CONFIGURED to receive. It does NOT prove a watcher is alive, "
@@ -1629,7 +1632,7 @@ internal static class GuideOrchestratorThreadCommand
                 Fill("Create one workspace for team `<team>` with a tab named after the team; keep the design thread outside it."),
                 "Split one pane per role, each opened with that role's folder as cwd.",
                 "Launch each pane's agent by TYPING into its interactive shell — codex through the shim, claude with the operator's chosen permission mode; never spawn the executable directly.",
-                "Attend the first run of each pane: answer ONLY the trust/allowlist dialogs you have actually read and the operator explicitly authorized (durably, not per-invocation), and ESCALATE every credential, security, or other permission prompt to the operator instead of answering it.",
+                "Attend the first run of each pane: answer ONLY the read-pane trust/allowlist dialogs the operator explicitly authorized (durably, not per-invocation). ALWAYS leave every credential, security, and permission prompt unanswered and escalate it to the operator — no authorization makes those answerable by the design thread.",
                 "Type the actas form into each pane (`/agmsg actas <role>` for claude, `$agmsg actas <role>` for codex), then confirm readiness LAYER BY LAYER: delivery configuration (`delivery.sh status`), then the agent-specific live-attachment marker (claude: `Monitor(agmsg inbox stream)` / footer `1 monitor`; codex: `Codex bridge: <team>/<role> alive (pid N)`).",
                 "Ping-test every role and require an ack before the first real delegation — the ack is the ONLY end-to-end proof; configuration and live markers are preconditions, not readiness.",
                 "Continue with `Setup (starting orchestrator mode)` — the delivery mode, role prompts, read-only first wake, and the rest of the setup checklist.",

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -1498,8 +1498,19 @@ internal static class GuideOrchestratorThreadCommand
                 AttendedFirstRunRule =
                     "ATTEND the first run of every pane. First-run trust screens (codex hooks-trust) and permission "
                     + "prompts block the session until answered, and an unattended pane looks \"launched\" while it is "
-                    + "actually waiting. Answer them so they produce DURABLE allowlists/trust records — a per-invocation "
-                    + "approval re-prompts on the next wake and stalls the role again.",
+                    + "actually waiting. Where the design thread is authorized to answer (see the authority boundary "
+                    + "below), answer so the result is a DURABLE allowlist/trust record — a per-invocation approval "
+                    + "re-prompts on the next wake and stalls the role again.",
+                AuthorityBoundary =
+                    "attending a pane is not authority to decide for the operator. The design "
+                    + "thread may act ONLY on pane contents it has actually READ (never on a blind keystroke into a "
+                    + "dialog it has not rendered), and ONLY for the trust/allowlist cases the operator explicitly "
+                    + "authorized for this provisioning — including its own hook-trust case, which it may accept for "
+                    + "itself. Every credential prompt, security prompt, and permission prompt outside that explicit "
+                    + "authorization MUST be ESCALATED to the operator and left unanswered until the operator decides. "
+                    + "Unsticking a pane is not deciding for the operator: if answering the dialog would grant access, "
+                    + "widen a permission mode, or accept a security warning, it is the operator's call, not the design "
+                    + "thread's.",
             },
             RoleInitialization = new OrchestratorProvisioningRoleInitialization
             {
@@ -1524,9 +1535,44 @@ internal static class GuideOrchestratorThreadCommand
                 },
                 ReadinessWait =
                     "WAIT for the role to report ready before sending anything — actas is submitted, not completed, at "
-                    + "the moment you type it. Treat the role as ready only when its watcher/bridge is attached (the "
-                    + "session says so, or `delivery.sh status` shows the watcher alive for that role). A pane that is "
-                    + "still on a trust screen is NOT ready.",
+                    + "the moment you type it. Readiness has THREE separate layers and they must not be collapsed: "
+                    + "delivery CONFIGURATION, LIVE ATTACHMENT, and END-TO-END delivery. A pane still sitting on a trust "
+                    + "screen is not even configured yet, let alone ready.",
+                ConfigurationProof =
+                    "CONFIGURATION only — `delivery.sh status` reporting a delivery mode (e.g. `mode=monitor`) proves "
+                    + "the role is registered and how it is CONFIGURED to receive. It does NOT prove a watcher is alive, "
+                    + "and it does NOT prove any session is attached: a receiver can report `mode=monitor` while nothing "
+                    + "is streaming. Never treat a delivery mode as readiness.",
+                LiveAttachmentEvidence = new[]
+                {
+                    new OrchestratorProvisioningLiveEvidence
+                    {
+                        AgentType = "claude",
+                        Evidence =
+                            "Live attachment is proven by the Claude Code MONITOR markers in that receiver's own "
+                            + "session, not by `delivery.sh status`: the transcript shows `Monitor(agmsg inbox stream)`, "
+                            + "the footer shows `1 monitor` (NOT `1 shell` — a background `watch.sh` shell is "
+                            + "diagnostic/fallback only and never counts as attached), and `Monitor event` lines appear "
+                            + "as messages arrive. See `Monitor tool vs delivery-mode` for the full marker list and the "
+                            + "trust/fallback ladder when they are missing.",
+                    },
+                    new OrchestratorProvisioningLiveEvidence
+                    {
+                        AgentType = "codex",
+                        Evidence =
+                            "Live attachment is proven by the BRIDGE-ALIVE marker where the codex bridge applies: "
+                            + "`delivery.sh status` shows `Codex bridge: <team>/<role> alive (pid N)`. Note the bridge "
+                            + "arms on the FIRST turn sent to the session, not at codex startup, and an already-running "
+                            + "session stays unmonitored until it is restarted — so absence of the marker right after "
+                            + "launch is expected, and its presence is what you wait for. See `Codex monitor (beta) "
+                            + "failure modes` for the caveats.",
+                    },
+                },
+                EndToEndProof =
+                    "PING/ACK is the ONLY end-to-end proof. Configuration and live-attachment evidence are necessary "
+                    + "preconditions, never a substitute: a role counts as ready only after it has ACKED a ping. If the "
+                    + "live markers are unavailable for an agent surface, do not infer readiness — fall back explicitly "
+                    + "(e.g. `turn` delivery or manual `inbox.sh`), say so, and still require the ack.",
                 PingTestReference =
                     "After readiness, run the existing ping test before ANY delegation: send one agmsg message to each "
                     + "role and require the ack (see `Receiver readiness` / `ping_test`). Readiness is a precondition "
@@ -1583,9 +1629,9 @@ internal static class GuideOrchestratorThreadCommand
                 Fill("Create one workspace for team `<team>` with a tab named after the team; keep the design thread outside it."),
                 "Split one pane per role, each opened with that role's folder as cwd.",
                 "Launch each pane's agent by TYPING into its interactive shell — codex through the shim, claude with the operator's chosen permission mode; never spawn the executable directly.",
-                "Attend the first run of each pane: answer trust screens and permission prompts so they produce durable allowlists.",
-                "Type the actas form into each pane (`/agmsg actas <role>` for claude, `$agmsg actas <role>` for codex) and wait for each role to be ready.",
-                "Ping-test every role and require an ack before the first real delegation.",
+                "Attend the first run of each pane: answer ONLY the trust/allowlist dialogs you have actually read and the operator explicitly authorized (durably, not per-invocation), and ESCALATE every credential, security, or other permission prompt to the operator instead of answering it.",
+                "Type the actas form into each pane (`/agmsg actas <role>` for claude, `$agmsg actas <role>` for codex), then confirm readiness LAYER BY LAYER: delivery configuration (`delivery.sh status`), then the agent-specific live-attachment marker (claude: `Monitor(agmsg inbox stream)` / footer `1 monitor`; codex: `Codex bridge: <team>/<role> alive (pid N)`).",
+                "Ping-test every role and require an ack before the first real delegation — the ack is the ONLY end-to-end proof; configuration and live markers are preconditions, not readiness.",
                 "Continue with `Setup (starting orchestrator mode)` — the delivery mode, role prompts, read-only first wake, and the rest of the setup checklist.",
                 "On a role handover, drop the role from the current holder (with its operator confirmation) BEFORE the successor claims it, then redo readiness + ping test.",
             },
@@ -2008,6 +2054,8 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine();
         writer.WriteLine($"> **Warning:** {provisioning.LaunchRules.CodexDirectSpawnWarning}");
         writer.WriteLine();
+        writer.WriteLine($"> **Authority boundary:** {provisioning.LaunchRules.AuthorityBoundary}");
+        writer.WriteLine();
 
         writer.WriteLine("### 4. Role initialization (actas and readiness)");
         writer.WriteLine();
@@ -2019,6 +2067,16 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
         writer.WriteLine($"- **readiness wait** — {provisioning.RoleInitialization.ReadinessWait}");
+        writer.WriteLine();
+        writer.WriteLine("#### Readiness layers (do not collapse them)");
+        writer.WriteLine();
+        writer.WriteLine($"- **1. delivery configuration** — {provisioning.RoleInitialization.ConfigurationProof}");
+        foreach (var evidence in provisioning.RoleInitialization.LiveAttachmentEvidence)
+        {
+            writer.WriteLine($"- **2. live attachment ({evidence.AgentType})** — {evidence.Evidence}");
+        }
+        writer.WriteLine($"- **3. end-to-end** — {provisioning.RoleInitialization.EndToEndProof}");
+        writer.WriteLine();
         writer.WriteLine($"- **ping test** — {provisioning.RoleInitialization.PingTestReference}");
         writer.WriteLine();
 
@@ -3254,6 +3312,15 @@ internal sealed record OrchestratorProvisioningLaunchRules
 
     [JsonPropertyName("attended_first_run_rule")]
     public required string AttendedFirstRunRule { get; init; }
+
+    /// <summary>
+    /// G549 repair: attending a pane is not authority to decide for the
+    /// operator. Design acts only on pane contents it has read, and only for
+    /// explicitly authorized trust/allowlist cases; credential, security, and
+    /// permission prompts escalate. Unsticking is not deciding.
+    /// </summary>
+    [JsonPropertyName("authority_boundary")]
+    public required string AuthorityBoundary { get; init; }
 }
 
 internal sealed record OrchestratorProvisioningRoleInitialization
@@ -3267,8 +3334,29 @@ internal sealed record OrchestratorProvisioningRoleInitialization
     [JsonPropertyName("readiness_wait")]
     public required string ReadinessWait { get; init; }
 
+    /// <summary>G549 repair: a delivery mode proves configuration, never live attachment.</summary>
+    [JsonPropertyName("configuration_proof")]
+    public required string ConfigurationProof { get; init; }
+
+    /// <summary>G549 repair: live attachment evidence is agent-specific — Claude Monitor markers vs the codex bridge-alive marker.</summary>
+    [JsonPropertyName("live_attachment_evidence")]
+    public required IReadOnlyList<OrchestratorProvisioningLiveEvidence> LiveAttachmentEvidence { get; init; }
+
+    /// <summary>G549 repair: ping/ack remains the only end-to-end proof.</summary>
+    [JsonPropertyName("end_to_end_proof")]
+    public required string EndToEndProof { get; init; }
+
     [JsonPropertyName("ping_test_reference")]
     public required string PingTestReference { get; init; }
+}
+
+internal sealed record OrchestratorProvisioningLiveEvidence
+{
+    [JsonPropertyName("agent_type")]
+    public required string AgentType { get; init; }
+
+    [JsonPropertyName("evidence")]
+    public required string Evidence { get; init; }
 }
 
 internal sealed record OrchestratorProvisioningHandover

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -65,6 +65,49 @@ public sealed class AgentMessageOrchestrationDocsTests
     }
 
     [Fact]
+    public void BothDocs_SeparateDeliveryConfigFromLiveAttachment_AndKeepPingAckSoleProof_G549()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        // G549 repair: a delivery mode proves configuration only.
+        Assert.Contains("proves registration and configuration only", en, StringComparison.Ordinal);
+        Assert.Contains("登録と設定を証明するだけです", ja, StringComparison.Ordinal);
+
+        // Live-attachment evidence is agent-specific on both mirrors.
+        foreach (var marker in new[] { "Monitor(agmsg inbox stream)", "`1 monitor`", "`1 shell`", "Codex bridge: <team>/<role> alive (pid N)" })
+        {
+            Assert.Contains(marker, en, StringComparison.Ordinal);
+            Assert.Contains(marker, ja, StringComparison.Ordinal);
+        }
+
+        // Ping/ack stays the sole end-to-end proof on both mirrors.
+        Assert.Contains("ack is the **only** end-to-end proof", en, StringComparison.Ordinal);
+        Assert.Contains("ack が **唯一の** end-to-end の証明です", ja, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BothDocs_CarryTheAuthorityBoundary_G549()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        // G549 repair: unsticking is not deciding — read-first, explicit
+        // authorization only, escalate credential/security/permission prompts.
+        Assert.Contains("Authority boundary — unsticking is not deciding.", en, StringComparison.Ordinal);
+        Assert.Contains("only on pane contents it has actually read", en, StringComparison.Ordinal);
+        Assert.Contains("only for the trust/allowlist cases the operator explicitly authorized", en, StringComparison.Ordinal);
+        Assert.Contains("its own hook-trust case", en, StringComparison.Ordinal);
+        Assert.Contains("must be escalated to the operator", en, StringComparison.Ordinal);
+
+        Assert.Contains("権限境界 — 詰まりを解くことは決定することではない。", ja, StringComparison.Ordinal);
+        Assert.Contains("実際に読んだ pane の内容に", ja, StringComparison.Ordinal);
+        Assert.Contains("オペレーターが明示的に認可した trust/allowlist ケースに", ja, StringComparison.Ordinal);
+        Assert.Contains("hook-trust ケースを含む", ja, StringComparison.Ordinal);
+        Assert.Contains("エスカレーション", ja, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BothDocs_KeepTheSixNumberedProvisioningElements_G549()
     {
         var en = ReadDoc("en");
@@ -96,10 +139,14 @@ public sealed class AgentMessageOrchestrationDocsTests
             var candidate = Path.Combine(current.FullName, "docs", language, DocRelativePath);
             if (File.Exists(candidate))
             {
-                // Both mirrors are hard-wrapped, so a sentence spans lines.
-                // Collapse whitespace runs so the assertions below pin wording,
-                // not the wrap points.
-                return string.Join(' ', File.ReadAllText(candidate)
+                // Both mirrors are hard-wrapped and some guidance lives inside
+                // blockquotes, so a sentence spans lines and carries `> `
+                // continuation markers. Strip the markers and collapse
+                // whitespace runs so the assertions pin wording, not wrap points.
+                var unwrapped = File.ReadAllLines(candidate)
+                    .Select(line => line.TrimStart().TrimStart('>'));
+
+                return string.Join(' ', string.Join('\n', unwrapped)
                     .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
             }
 

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -1,0 +1,111 @@
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G549: the terminal-workspace provisioning guidance ships on two surfaces —
+/// the `guide orchestrator-thread` output (pinned in
+/// <see cref="GuideOrchestratorThreadCommandTests"/>) and the ja/en
+/// `12-agent-message-orchestration.md` docs mirror. These tests pin the docs
+/// surface and its ja/en parity so the mirror cannot silently drift away from
+/// the guide.
+/// </summary>
+public sealed class AgentMessageOrchestrationDocsTests
+{
+    private const string DocRelativePath = "12-agent-message-orchestration.md";
+
+    [Fact]
+    public void EnglishDoc_HasTerminalWorkspaceProvisioningSection_WithAllSixElements_G549()
+    {
+        var doc = ReadDoc("en");
+
+        Assert.Contains("## Terminal-workspace provisioning (building the team)", doc, StringComparison.Ordinal);
+        // 1. folders — host-side vs implementation clone sources, never-share + reason.
+        Assert.Contains("**1. Role folders — create them when absent.**", doc, StringComparison.Ordinal);
+        Assert.Contains("host metadata repo", doc, StringComparison.Ordinal);
+        Assert.Contains("`(project, type)`-scoped", doc, StringComparison.Ordinal);
+        Assert.Contains("G521", doc, StringComparison.Ordinal);
+        // 2. topology — one workspace / one team tab / one pane per role, design outside.
+        Assert.Contains("**2. Workspace topology.**", doc, StringComparison.Ordinal);
+        Assert.Contains("design thread stays outside** the workspace", doc, StringComparison.Ordinal);
+        // 3. launch rules — shim reason + direct-spawn warning + permission mode + attended first run.
+        Assert.Contains("**3. Launch rules.**", doc, StringComparison.Ordinal);
+        Assert.Contains("`codex()` shell shim is what arms the agmsg monitor bridge", doc, StringComparison.Ordinal);
+        Assert.Contains("exec's the canonical executable directly bypasses it", doc, StringComparison.Ordinal);
+        Assert.Contains("durable", doc, StringComparison.Ordinal);
+        // 4. role init — both actas forms, readiness, ping test.
+        Assert.Contains("**4. Role initialization.**", doc, StringComparison.Ordinal);
+        Assert.Contains("`/agmsg actas <role>`", doc, StringComparison.Ordinal);
+        Assert.Contains("`$agmsg actas <role>`", doc, StringComparison.Ordinal);
+        Assert.Contains("ping test", doc, StringComparison.Ordinal);
+        // 5. exclusivity / handover.
+        Assert.Contains("**5. Exclusivity and handover.**", doc, StringComparison.Ordinal);
+        Assert.Contains("graceful drop", doc, StringComparison.Ordinal);
+        // 6. herdr as the reference manager, internals linked out, substitutable.
+        Assert.Contains("**6. herdr is the reference workspace manager.**", doc, StringComparison.Ordinal);
+        Assert.Contains("`workspace create`", doc, StringComparison.Ordinal);
+        Assert.Contains("`pane split`", doc, StringComparison.Ordinal);
+        Assert.Contains("`agent wait`", doc, StringComparison.Ordinal);
+        Assert.Contains("does not own, ship, or wrap herdr", doc, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JapaneseDoc_MirrorsTheProvisioningSection_G549()
+    {
+        var doc = ReadDoc("ja");
+
+        Assert.Contains("## ターミナルワークスペースの provisioning（チームを構築する）", doc, StringComparison.Ordinal);
+        Assert.Contains("host メタデータリポジトリ", doc, StringComparison.Ordinal);
+        Assert.Contains("`(project, type)` スコープ", doc, StringComparison.Ordinal);
+        Assert.Contains("G521", doc, StringComparison.Ordinal);
+        Assert.Contains("`codex()` シェル shim", doc, StringComparison.Ordinal);
+        Assert.Contains("`/agmsg actas <role>`", doc, StringComparison.Ordinal);
+        Assert.Contains("`$agmsg actas <role>`", doc, StringComparison.Ordinal);
+        Assert.Contains("graceful drop", doc, StringComparison.Ordinal);
+        Assert.Contains("herdr", doc, StringComparison.Ordinal);
+        Assert.Contains("`agent wait`", doc, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BothDocs_KeepTheSixNumberedProvisioningElements_G549()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        // Parity is structural: both mirrors carry the same six numbered
+        // elements, so a future edit to one side is visible as a test failure
+        // rather than as silent drift.
+        foreach (var marker in new[] { "**1.", "**2.", "**3.", "**4.", "**5.", "**6." })
+        {
+            Assert.Contains(marker, en, StringComparison.Ordinal);
+            Assert.Contains(marker, ja, StringComparison.Ordinal);
+        }
+
+        // herdr's surfaces are named on both sides and its internals are linked
+        // out rather than restated.
+        foreach (var surface in new[] { "`workspace create`", "`pane split`", "`agent prompt`", "`agent wait`" })
+        {
+            Assert.Contains(surface, en, StringComparison.Ordinal);
+            Assert.Contains(surface, ja, StringComparison.Ordinal);
+        }
+    }
+
+    private static string ReadDoc(string language)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(current.FullName, "docs", language, DocRelativePath);
+            if (File.Exists(candidate))
+            {
+                // Both mirrors are hard-wrapped, so a sentence spans lines.
+                // Collapse whitespace runs so the assertions below pin wording,
+                // not the wrap points.
+                return string.Join(' ', File.ReadAllText(candidate)
+                    .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+            }
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not locate docs/{language}/{DocRelativePath} from {AppContext.BaseDirectory}.");
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -84,6 +84,13 @@ public sealed class AgentMessageOrchestrationDocsTests
         // Ping/ack stays the sole end-to-end proof on both mirrors.
         Assert.Contains("ack is the **only** end-to-end proof", en, StringComparison.Ordinal);
         Assert.Contains("ack が **唯一の** end-to-end の証明です", ja, StringComparison.Ordinal);
+
+        // Round-2 repair: the separation holds in both directions — launch-UI
+        // state (a trust screen) does not erase delivery configuration.
+        Assert.Contains("not live-attached and not session-active**", en, StringComparison.Ordinal);
+        Assert.Contains("Launch-UI state never erases configuration, and configuration never implies attachment", en, StringComparison.Ordinal);
+        Assert.Contains("session-active でもありません**", ja, StringComparison.Ordinal);
+        Assert.Contains("起動 UI の状態が設定を消すことはなく", ja, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -96,15 +103,22 @@ public sealed class AgentMessageOrchestrationDocsTests
         // authorization only, escalate credential/security/permission prompts.
         Assert.Contains("Authority boundary — unsticking is not deciding.", en, StringComparison.Ordinal);
         Assert.Contains("only on pane contents it has actually read", en, StringComparison.Ordinal);
-        Assert.Contains("only for the trust/allowlist cases the operator explicitly authorized", en, StringComparison.Ordinal);
-        Assert.Contains("its own hook-trust case", en, StringComparison.Ordinal);
-        Assert.Contains("must be escalated to the operator", en, StringComparison.Ordinal);
-
         Assert.Contains("権限境界 — 詰まりを解くことは決定することではない。", ja, StringComparison.Ordinal);
         Assert.Contains("実際に読んだ pane の内容に", ja, StringComparison.Ordinal);
-        Assert.Contains("オペレーターが明示的に認可した trust/allowlist ケースに", ja, StringComparison.Ordinal);
-        Assert.Contains("hook-trust ケースを含む", ja, StringComparison.Ordinal);
-        Assert.Contains("エスカレーション", ja, StringComparison.Ordinal);
+
+        // Round-2 repair: authorization reaches read-pane trust/allowlist cases
+        // only; credential/security/permission prompts are absolutely never
+        // answerable by design — on both mirrors.
+        Assert.Contains("only to read-pane trust/allowlist cases**", en, StringComparison.Ordinal);
+        Assert.Contains("own hook-trust case", en, StringComparison.Ordinal);
+        Assert.Contains("permission prompts are **never** answerable by the design thread", en, StringComparison.Ordinal);
+        Assert.Contains("**always** escalated to the operator", en, StringComparison.Ordinal);
+        Assert.Contains("no authorization makes them answerable", en, StringComparison.Ordinal);
+
+        Assert.Contains("読んだ pane の trust/allowlist ケースに限られます**", ja, StringComparison.Ordinal);
+        Assert.Contains("hook-trust ケースです", ja, StringComparison.Ordinal);
+        Assert.Contains("設計スレッドが回答することは **決してありません**", ja, StringComparison.Ordinal);
+        Assert.Contains("どんな認可もこれらを回答可能にはしません", ja, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -1923,11 +1923,33 @@ public sealed class GuideOrchestratorThreadCommandTests
         // operator — read-first, explicit-authorization-only, escalate the rest.
         Assert.Contains("> **Authority boundary:**", output, StringComparison.Ordinal);
         Assert.Contains("ONLY on pane contents it has actually READ", output, StringComparison.Ordinal);
-        Assert.Contains("ONLY for the trust/allowlist cases the operator explicitly authorized", output, StringComparison.Ordinal);
-        Assert.Contains("its own hook-trust case", output, StringComparison.Ordinal);
-        Assert.Contains("Every credential prompt, security prompt, and permission prompt", output, StringComparison.Ordinal);
-        Assert.Contains("MUST be ESCALATED to the operator", output, StringComparison.Ordinal);
         Assert.Contains("Unsticking a pane is not deciding for the operator", output, StringComparison.Ordinal);
+
+        // Round-2 repair: authorization reaches read-pane trust/allowlist cases
+        // ONLY — credential/security/permission prompts are absolutely never
+        // answerable by design, with or without prior authorization.
+        Assert.Contains("ONLY to read-pane TRUST/ALLOWLIST", output, StringComparison.Ordinal);
+        Assert.Contains("own hook-trust case, which it may accept for itself", output, StringComparison.Ordinal);
+        Assert.Contains("CREDENTIAL, SECURITY, and PERMISSION prompts are NEVER answerable", output, StringComparison.Ordinal);
+        Assert.Contains("ALWAYS remain unanswered and are ALWAYS ESCALATED to the operator", output, StringComparison.Ordinal);
+        Assert.Contains("with or without prior authorization", output, StringComparison.Ordinal);
+        Assert.Contains("no authorization makes them answerable", output, StringComparison.Ordinal);
+        // The old conditional framing ("outside that authorization") is gone.
+        Assert.DoesNotContain("outside that explicit authorization", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_Provisioning_LaunchUiState_DoesNotEraseDeliveryConfiguration_G549()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        // Round-2 repair: a trust screen means NOT live-attached / NOT
+        // session-active — it says nothing about delivery configuration, which
+        // is set before launch. The layers must stay separate in both
+        // directions.
+        Assert.Contains("NOT live-attached and NOT session-active", output, StringComparison.Ordinal);
+        Assert.Contains("Launch-UI state never erases configuration, and configuration never implies attachment", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("is not even configured yet", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1981,8 +2003,11 @@ public sealed class GuideOrchestratorThreadCommandTests
         // folded into the attended-first-run rule.
         var authorityBoundary = launchRules.GetProperty("authority_boundary").GetString()!;
         Assert.Contains("READ", authorityBoundary, StringComparison.Ordinal);
-        Assert.Contains("explicitly authorized", authorityBoundary, StringComparison.Ordinal);
-        Assert.Contains("ESCALATED to the operator", authorityBoundary, StringComparison.Ordinal);
+        Assert.Contains("read-pane TRUST/ALLOWLIST", authorityBoundary, StringComparison.Ordinal);
+        // Round-2 repair: the escalation rule is absolute in JSON too.
+        Assert.Contains("NEVER answerable", authorityBoundary, StringComparison.Ordinal);
+        Assert.Contains("ALWAYS ESCALATED to the operator", authorityBoundary, StringComparison.Ordinal);
+        Assert.Contains("no authorization makes them answerable", authorityBoundary, StringComparison.Ordinal);
 
         var roleInitialization = provisioning.GetProperty("role_initialization");
         Assert.NotEmpty(roleInitialization.GetProperty("actas_forms").EnumerateArray());
@@ -1991,6 +2016,12 @@ public sealed class GuideOrchestratorThreadCommandTests
         // the end-to-end ack are three separate JSON fields.
         Assert.Contains("does NOT prove", roleInitialization.GetProperty("configuration_proof").GetString(), StringComparison.Ordinal);
         Assert.Contains("ONLY end-to-end proof", roleInitialization.GetProperty("end_to_end_proof").GetString(), StringComparison.Ordinal);
+
+        // Round-2 repair: a trust screen is a live-attachment/session-active
+        // fact, not a configuration fact.
+        var readinessWait = roleInitialization.GetProperty("readiness_wait").GetString()!;
+        Assert.Contains("NOT live-attached and NOT session-active", readinessWait, StringComparison.Ordinal);
+        Assert.DoesNotContain("not even configured", readinessWait, StringComparison.Ordinal);
 
         var liveEvidence = roleInitialization.GetProperty("live_attachment_evidence").EnumerateArray()
             .Select(e => (AgentType: e.GetProperty("agent_type").GetString()!, Evidence: e.GetProperty("evidence").GetString()!))

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -1867,7 +1867,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("exec's the canonical `codex` executable directly BYPASSES the shim", output, StringComparison.Ordinal);
         // Operator-chosen permission mode for claude; attended first-run screens.
         Assert.Contains("permission mode the OPERATOR chose", output, StringComparison.Ordinal);
-        Assert.Contains("DURABLE allowlists", output, StringComparison.Ordinal);
+        Assert.Contains("DURABLE allowlist/trust record", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1885,6 +1885,49 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("GRACEFUL DROP", output, StringComparison.Ordinal);
         Assert.Contains("OPERATOR CONFIRMATION", output, StringComparison.Ordinal);
         Assert.Contains("only AFTER the drop is confirmed", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_Provisioning_SeparatesDeliveryConfigFromLiveAttachment_G549()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        // G549 repair: a delivery mode proves CONFIGURATION, never live
+        // attachment — the two layers must stay separate in the guidance.
+        Assert.Contains("#### Readiness layers (do not collapse them)", output, StringComparison.Ordinal);
+        Assert.Contains("**1. delivery configuration**", output, StringComparison.Ordinal);
+        Assert.Contains("It does NOT prove a watcher is alive", output, StringComparison.Ordinal);
+        Assert.Contains("Never treat a delivery mode as readiness", output, StringComparison.Ordinal);
+
+        // Live-attachment evidence is agent-specific: Claude Monitor markers…
+        Assert.Contains("**2. live attachment (claude)**", output, StringComparison.Ordinal);
+        Assert.Contains("`Monitor(agmsg inbox stream)`", output, StringComparison.Ordinal);
+        Assert.Contains("`1 monitor`", output, StringComparison.Ordinal);
+        Assert.Contains("NOT `1 shell`", output, StringComparison.Ordinal);
+        // …vs the codex bridge-alive marker.
+        Assert.Contains("**2. live attachment (codex)**", output, StringComparison.Ordinal);
+        Assert.Contains("`Codex bridge: <team>/<role> alive (pid N)`", output, StringComparison.Ordinal);
+
+        // Ping/ack stays the SOLE end-to-end proof.
+        Assert.Contains("**3. end-to-end**", output, StringComparison.Ordinal);
+        Assert.Contains("PING/ACK is the ONLY end-to-end proof", output, StringComparison.Ordinal);
+        Assert.Contains("never a substitute", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_Provisioning_AuthorityBoundary_EscalatesUnauthorizedPrompts_G549()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        // G549 repair: attending a pane is not authority to decide for the
+        // operator — read-first, explicit-authorization-only, escalate the rest.
+        Assert.Contains("> **Authority boundary:**", output, StringComparison.Ordinal);
+        Assert.Contains("ONLY on pane contents it has actually READ", output, StringComparison.Ordinal);
+        Assert.Contains("ONLY for the trust/allowlist cases the operator explicitly authorized", output, StringComparison.Ordinal);
+        Assert.Contains("its own hook-trust case", output, StringComparison.Ordinal);
+        Assert.Contains("Every credential prompt, security prompt, and permission prompt", output, StringComparison.Ordinal);
+        Assert.Contains("MUST be ESCALATED to the operator", output, StringComparison.Ordinal);
+        Assert.Contains("Unsticking a pane is not deciding for the operator", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1931,8 +1974,29 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains(roles, r => r.Role == "review" && r.Command.Contains("<owner/host-repo>", StringComparison.Ordinal));
         Assert.Contains(roles, r => r.Role == "implementation" && r.Command.Contains("owner/repo", StringComparison.Ordinal));
 
-        Assert.Contains("shim", provisioning.GetProperty("launch_rules").GetProperty("codex_shim_rule").GetString(), StringComparison.Ordinal);
-        Assert.NotEmpty(provisioning.GetProperty("role_initialization").GetProperty("actas_forms").EnumerateArray());
+        var launchRules = provisioning.GetProperty("launch_rules");
+        Assert.Contains("shim", launchRules.GetProperty("codex_shim_rule").GetString(), StringComparison.Ordinal);
+
+        // G549 repair: the authority boundary is a first-class field, not prose
+        // folded into the attended-first-run rule.
+        var authorityBoundary = launchRules.GetProperty("authority_boundary").GetString()!;
+        Assert.Contains("READ", authorityBoundary, StringComparison.Ordinal);
+        Assert.Contains("explicitly authorized", authorityBoundary, StringComparison.Ordinal);
+        Assert.Contains("ESCALATED to the operator", authorityBoundary, StringComparison.Ordinal);
+
+        var roleInitialization = provisioning.GetProperty("role_initialization");
+        Assert.NotEmpty(roleInitialization.GetProperty("actas_forms").EnumerateArray());
+
+        // G549 repair: configuration proof, agent-specific live attachment, and
+        // the end-to-end ack are three separate JSON fields.
+        Assert.Contains("does NOT prove", roleInitialization.GetProperty("configuration_proof").GetString(), StringComparison.Ordinal);
+        Assert.Contains("ONLY end-to-end proof", roleInitialization.GetProperty("end_to_end_proof").GetString(), StringComparison.Ordinal);
+
+        var liveEvidence = roleInitialization.GetProperty("live_attachment_evidence").EnumerateArray()
+            .Select(e => (AgentType: e.GetProperty("agent_type").GetString()!, Evidence: e.GetProperty("evidence").GetString()!))
+            .ToArray();
+        Assert.Contains(liveEvidence, e => e.AgentType == "claude" && e.Evidence.Contains("1 monitor", StringComparison.Ordinal));
+        Assert.Contains(liveEvidence, e => e.AgentType == "codex" && e.Evidence.Contains("Codex bridge", StringComparison.Ordinal));
         Assert.True(provisioning.GetProperty("exclusivity_handover").GetProperty("operator_confirmation_rule").GetString()!.Length > 0);
 
         var referenceManager = provisioning.GetProperty("reference_manager");

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -1811,6 +1811,136 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.True(verification.GetProperty("dead_address_example").GetString()!.Length > 0);
     }
 
+    [Fact]
+    public void Execute_Markdown_TerminalWorkspaceProvisioning_HasAllSixElements_G549()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        // AC: the section exists with all six elements in paste-ready form.
+        Assert.Contains("## Terminal-workspace provisioning (G549)", output, StringComparison.Ordinal);
+        Assert.Contains("### Placeholders", output, StringComparison.Ordinal);
+        Assert.Contains("### 1. Role folders (create them when absent)", output, StringComparison.Ordinal);
+        Assert.Contains("### 2. Workspace topology", output, StringComparison.Ordinal);
+        Assert.Contains("### 3. Launch rules (and why)", output, StringComparison.Ordinal);
+        Assert.Contains("### 4. Role initialization (actas and readiness)", output, StringComparison.Ordinal);
+        Assert.Contains("### 5. Role exclusivity and handover", output, StringComparison.Ordinal);
+        Assert.Contains("### 6. Reference workspace manager — herdr", output, StringComparison.Ordinal);
+        Assert.Contains("### Provisioning checklist (paste-ready)", output, StringComparison.Ordinal);
+        // Placeholders the design thread fills in from its own context.
+        Assert.Contains("`<Project>`", output, StringComparison.Ordinal);
+        Assert.Contains("`<owner/host-repo>`", output, StringComparison.Ordinal);
+        Assert.Contains("`<workspace-root>`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_Provisioning_FolderCommands_SplitHostSideFromImplementation_G549()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+
+        // AC: host-side roles clone the HOST metadata repo; the implementation
+        // role clones the TARGET repo — with runnable commands for each.
+        Assert.Contains("git clone https://github.com/<owner/host-repo>.git <workspace-root>/<Project>Orchestrator", output, StringComparison.Ordinal);
+        Assert.Contains("git clone https://github.com/<owner/host-repo>.git <workspace-root>/<Project>Review", output, StringComparison.Ordinal);
+        Assert.Contains("git clone https://github.com/J-Tech-Japan/intent-system.git <workspace-root>/<Project>Implementation", output, StringComparison.Ordinal);
+        // AC: the never-share rule appears WITH its (project, type)-scoping reason.
+        Assert.Contains("NEVER share a folder between two roles", output, StringComparison.Ordinal);
+        Assert.Contains("(project, type)-scoped", output, StringComparison.Ordinal);
+        Assert.Contains("G521", output, StringComparison.Ordinal);
+        // An absent folder is created, not worked around.
+        Assert.Contains("When a folder is absent, CREATE it", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_Provisioning_TopologyAndLaunchRules_WarnAgainstDirectSpawn_G549()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--team", "orch-team"]);
+
+        // AC: one workspace / one team-named tab / one pane per role, design outside.
+        Assert.Contains("One WORKSPACE per agmsg team", output, StringComparison.Ordinal);
+        Assert.Contains("One TAB named after the team (`orch-team`)", output, StringComparison.Ordinal);
+        Assert.Contains("One PANE per role", output, StringComparison.Ordinal);
+        Assert.Contains("The DESIGN thread stays OUTSIDE the workspace", output, StringComparison.Ordinal);
+        // AC: the shim-safe launch rule appears with its reason, and direct
+        // executable spawn is explicitly warned against.
+        Assert.Contains("typing into the pane's interactive shell", output, StringComparison.Ordinal);
+        Assert.Contains("`codex()` shell shim", output, StringComparison.Ordinal);
+        Assert.Contains("exec's the canonical `codex` executable directly BYPASSES the shim", output, StringComparison.Ordinal);
+        // Operator-chosen permission mode for claude; attended first-run screens.
+        Assert.Contains("permission mode the OPERATOR chose", output, StringComparison.Ordinal);
+        Assert.Contains("DURABLE allowlists", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_Provisioning_ActasReadinessAndHandover_G549()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        // AC: both actas forms, the readiness wait, and the ping-test reference.
+        Assert.Contains("`/agmsg actas <role>`", output, StringComparison.Ordinal);
+        Assert.Contains("`$agmsg actas <role>`", output, StringComparison.Ordinal);
+        Assert.Contains("**readiness wait**", output, StringComparison.Ordinal);
+        Assert.Contains("run the existing ping test before ANY delegation", output, StringComparison.Ordinal);
+        // AC: exclusivity + graceful drop with operator confirmation before the successor claims.
+        Assert.Contains("Exactly ONE live session may hold a role at a time", output, StringComparison.Ordinal);
+        Assert.Contains("GRACEFUL DROP", output, StringComparison.Ordinal);
+        Assert.Contains("OPERATOR CONFIRMATION", output, StringComparison.Ordinal);
+        Assert.Contains("only AFTER the drop is confirmed", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_Provisioning_NamesHerdrSurfaces_AndLinksOutInternals_G549()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        // AC: herdr is named as the REFERENCE manager with its surfaces listed…
+        Assert.Contains("`workspace create`", output, StringComparison.Ordinal);
+        Assert.Contains("`pane split`", output, StringComparison.Ordinal);
+        Assert.Contains("`pane send-text` / `send-keys`", output, StringComparison.Ordinal);
+        Assert.Contains("`agent prompt`", output, StringComparison.Ordinal);
+        Assert.Contains("`agent wait`", output, StringComparison.Ordinal);
+        // …internals linked out, not restated, and any equivalent manager allowed.
+        Assert.Contains("intent-cli does not own, ship, or wrap herdr", output, StringComparison.Ordinal);
+        Assert.Contains("consult herdr's own", output, StringComparison.Ordinal);
+        Assert.Contains("ANY equivalent workspace manager may be substituted", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_TerminalWorkspaceProvisioning_HasStructuredShape_G549()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var provisioning = doc.RootElement.GetProperty("terminal_workspace_provisioning");
+
+        Assert.NotEmpty(provisioning.GetProperty("placeholders").EnumerateArray());
+        Assert.NotEmpty(provisioning.GetProperty("checklist").EnumerateArray());
+
+        var folders = provisioning.GetProperty("folder_provisioning");
+        Assert.Contains("(project, type)-scoped", folders.GetProperty("never_share_rule").GetString(), StringComparison.Ordinal);
+
+        var roles = folders.GetProperty("roles").EnumerateArray()
+            .Select(r => (Role: r.GetProperty("role").GetString()!, Command: r.GetProperty("create_command").GetString()!))
+            .ToArray();
+        Assert.Equal(3, roles.Length);
+        Assert.Contains(roles, r => r.Role == "orchestrator" && r.Command.Contains("<owner/host-repo>", StringComparison.Ordinal));
+        Assert.Contains(roles, r => r.Role == "review" && r.Command.Contains("<owner/host-repo>", StringComparison.Ordinal));
+        Assert.Contains(roles, r => r.Role == "implementation" && r.Command.Contains("owner/repo", StringComparison.Ordinal));
+
+        Assert.Contains("shim", provisioning.GetProperty("launch_rules").GetProperty("codex_shim_rule").GetString(), StringComparison.Ordinal);
+        Assert.NotEmpty(provisioning.GetProperty("role_initialization").GetProperty("actas_forms").EnumerateArray());
+        Assert.True(provisioning.GetProperty("exclusivity_handover").GetProperty("operator_confirmation_rule").GetString()!.Length > 0);
+
+        var referenceManager = provisioning.GetProperty("reference_manager");
+        Assert.Equal("herdr", referenceManager.GetProperty("name").GetString());
+        Assert.NotEmpty(referenceManager.GetProperty("surfaces").EnumerateArray());
+        Assert.True(referenceManager.GetProperty("substitution_rule").GetString()!.Length > 0);
+    }
+
     private static string RunMarkdown(string[] args)
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Adds a **terminal-workspace provisioning** section to the orchestrator-thread guide so a design thread asked to "set this team up on herdr" can do it end to end with placeholders only — starting from **creating the dedicated role folders when they do not exist**.

Before this change, `guide orchestrator-thread`'s setup checklist assumed the role folders and terminal sessions already existed ("each role runs from its own folder, clone, or worktree") and said nothing about creating them. The dedicated-folder rule and the shim-safe launch rule lived only as G521-era operational lessons.

## What the section contains

All six elements, in paste-ready checklist form with placeholders (`<Project>`, `<owner/host-repo>`, `<owner/repo>`, `<team>`, `<workspace-root>`):

1. **Role folders (create when absent)** — host-side roles (orchestrator, review) clone the **host metadata repo**; the implementation role clones the **target repo**. Runnable `git clone` command per role, plus the never-share rule with its reason: agmsg identity and the codex monitor bridge are `(project, type)`-scoped (G521), so two roles in one folder resolve to the same identity and one silently stops receiving.
2. **Workspace topology** — one workspace per team, a team-named tab, one pane per role with that role's folder as the pane cwd; the design thread stays outside.
3. **Launch rules with reasons** — codex launched by *typing into the pane's interactive shell* so the `codex()` shim arms the bridge, with direct executable spawn explicitly warned against; claude with the operator's chosen permission mode; attended first-run trust screens and permission prompts that produce **durable** allowlists.
4. **Role initialization** — `/agmsg actas <role>` (claude) / `$agmsg actas <role>` (codex), the readiness wait, then the existing ping-test rule before any delegation.
5. **Exclusivity and handover** — one holder per role; a replacement goes through the graceful drop (with its operator confirmation) before the successor claims.
6. **herdr as reference manager** — surfaces named (`workspace create`, `pane split`, `pane send-text` / `send-keys`, `agent prompt`, `agent wait`), internals linked out, substitutable by any equivalent manager that satisfies the same rules.

## Surfaces touched

- `src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs` — new `terminal_workspace_provisioning` node (markdown + JSON), rendered between the setup intake form and the preflight section.
- `docs/ja/12-agent-message-orchestration.md`, `docs/en/12-agent-message-orchestration.md` — mirrored section.
- `tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs` — 6 focused tests pinning the markdown section and the JSON shape.
- `tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs` — new, pins the docs mirror and ja/en parity.

## Verification

- `dotnet test IntentSystem.sln` — **all green** (CLI suite 3831 passed / 0 failed; every other project passed).
- Focused: `--filter "FullyQualifiedName~AgentMessageOrchestrationDocsTests|FullyQualifiedName~GuideOrchestratorThreadCommandTests"` → 85 passed / 0 failed.
- Rendered `intent-cli guide orchestrator-thread --format markdown` with **no arguments** and walked the checklist: every step is executable from placeholders alone, with no outside knowledge required.
- `git diff --check` clean.

## Out of scope (untouched)

No herdr binary/scripts shipped or wrapped; no agmsg or `spawn.sh` changes; no new CLI command for provisioning (guide-level first); no release-prep content.

Closes #1201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPT7cFrCzT6ehACFez8dpE
