### PR TITLE
G551: Prepare v0.6.0 minor release metadata for G539–G550

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1897,116 +1897,119 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.4.0",
-  "nextVersion": "0.5.0"
+  "stableVersion": "0.5.0",
+  "nextVersion": "0.6.0"
 }
 ```
 
 | Stage | Version form | How it is derived |
 | --- | --- | --- |
-| Local pack / install | `0.5.0-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.5.0-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.5.0-rc.N` | Publishing the GitHub Release for tag `v0.5.0-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
-| Stable release | `0.5.0` | Publishing the GitHub Release for tag `v0.5.0` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.5.1-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.5.1` |
+| Local pack / install | `0.6.0-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.6.0-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.6.0-rc.N` | Publishing the GitHub Release for tag `v0.6.0-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
+| Stable release | `0.6.0` | Publishing the GitHub Release for tag `v0.6.0` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.6.1-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.6.1` |
 
-**After releasing `v0.5.0`**, bump both fields in `eng/version.json`:
+**After releasing `v0.6.0`**, bump both fields in `eng/version.json`:
 
 ```json
 {
-  "stableVersion": "0.5.0",
-  "nextVersion": "0.5.1"
+  "stableVersion": "0.6.0",
+  "nextVersion": "0.6.1"
 }
 ```
 
 This ensures the next main-branch CI build (and local pack) immediately produces
-`0.5.1-preview.<run>.<attempt>` / `0.5.1-<sha>-<G-unit>` rather than continuing to
-emit `0.5.0` (which would collide with the stable release version).
+`0.6.1-preview.<run>.<attempt>` / `0.6.1-<sha>-<G-unit>` rather than continuing to
+emit `0.6.0` (which would collide with the stable release version).
 
-### Next release readiness (v0.5.0)
+### Next release readiness (v0.6.0)
 
-**`v0.4.0` shipped** (GitHub Release + NuGet) and the version policy was bumped
-to the `0.5.0` development line — a **minor** bump, not a patch: the batch
-ships two new commands (`intent facet-check`, `queue reprioritize`), a new
-intent-tree schema surface (`facets`), new stalled-work kinds, and a new
-transition target (`retired`) — more than a patch release justifies. The
-repository is now on the in-development **`0.5.0`** `nextVersion`; G538 is
-**prepare-only** — it bumps the version metadata and docs and adds no publish
-steps. The version-bump merge does **not** create a GitHub Release or tag.
-After it merges and the
-[release-readiness gate](release-notes-v0.5.0.md#release-readiness-gate-g538)
+**`v0.5.0` shipped** (GitHub Release + NuGet) and the version policy was bumped
+to the `0.6.0` development line — a **minor** bump, not a patch: the batch ships
+three new stalled-work detection kinds (`backlog-ready-idle`,
+`blocked-label-drift`, `repair-stalled`), three new commands (`automation
+runs-audit`, `queue priority-drift`, `automation issue-block`), visible
+behavior changes to already-shipped commands, and the repositioning of
+four-thread agmsg orchestration as the PRIMARY documented model — more than a
+patch release justifies. The repository is now on the in-development **`0.6.0`**
+`nextVersion`; G551 is **prepare-only** — it bumps the version metadata and docs
+and adds no publish steps. The version-bump merge does **not** create a GitHub
+Release or tag. After it merges and the
+[release-readiness gate](release-notes-v0.6.0.md#release-readiness-gate-g551)
 holds, a **maintainer/operator (or external release automation) creates and
-publishes the GitHub Release** for `v0.5.0`; publishing that Release fires
+publishes the GitHub Release** for `v0.6.0`; publishing that Release fires
 `.github/workflows/release.yml` (`on: release: published`), which builds and
 publishes the NuGet package and the per-platform binary artifacts. Full
 changelog and operator checklist:
-[release-notes-v0.5.0.md](release-notes-v0.5.0.md).
+[release-notes-v0.6.0.md](release-notes-v0.6.0.md).
 
-**To ship in `v0.5.0` (changes since `v0.4.0`) — semantic facets, stalled-work
-correctness, queue robustness, label supersession, publish reliability, and
-priority override:**
+> **G547 is not part of this release.** The cycle's original release-prep unit
+> was canonically **retired** when the operator directed that G549/G550 join the
+> release scope; retirement is terminal for a unit id, so the continuation is
+> the new unit **G551** rather than a republish. G547 shipped no code and no
+> documentation. The range `G539–G550` spans twelve unit ids, **eleven** of
+> which are merged and shipped in `v0.6.0`.
 
-- **Semantic facets** (G529–G531) — a closed set of four `facets:` values
-  (`vocabulary`, `invariant`, `decider`, `acceptance-property`) an intent-tree
-  node may declare in its frontmatter; `intent-cli context collect` and
-  `packet draft` now supply a facet-classified `## Facet context` section as
-  the preferred, localized semantic context ahead of the unclassified
-  queue-state/clarification context; and read-only `intent facet-check`
-  points a change proposal at the facet nodes it should respect, surfacing
-  naming collisions and coverage gaps without ever gating.
-- **stalled-work correctness** (G532–G533) — leading-ID/nested-domain
-  execution-unit identification is corroborated against real packet/queue
-  linkage rather than trusted from a title alone; `--domain` is a required,
-  authoritative scoping input; and three new informational kinds
-  (`repair-pending`, `rereview-pending`, `claimed-but-silent`) stop
-  mid-repair and mid-rereview PRs from being misreported with a wrong
-  `review-start` recommendation.
-- **Queue robustness** (G534) — packet readers accept both YAML list-item
-  indentation conventions; `retired` is now a guarded, terminal `queue
-  transition` target (verified against the linked PR's real GitHub state
-  before applying); and `intent next-slice` combines queue-state and
-  packet-lifecycle retirement evidence explicitly, fail-closed on
-  contradiction.
-- **Label supersession** (G535) — `automation pr-transition --transition
-  request-update` now clears a stale `intent-pr-rereview-ready` in the same
-  write, closing a deadlock where `worker claim` refused a PR that
-  `request-update` had marked for repair.
-- **Publish reliability** (G536) — `issue publish-flow`'s idempotent rerun
-  now independently verifies and restores all three durable artifacts (the
-  GitHub issue, the queue-state entry, the `runs.jsonl` event) instead of
-  trusting one signal for all three, and fails loud rather than silently
-  leaving state inconsistent.
-- **Priority override** (G537) — the new `queue reprioritize` command sets a
-  queued, unpublished execution unit's priority under a durable, revision-
-  counted, lock-protected audit protocol; `intent next-slice` selects
-  eligible candidates priority-class-first (high > normal > low, stable
-  tiebreak by authoring order), with dependency/WIP/clarification/lifecycle
-  gates always dominating priority.
-- **Historical note (v0.5.0-era, pre-G540/G541):** at the time `v0.5.0` shipped,
-  orchestrator mode was described here as preview/experimental and opt-in.
-  **That framing is superseded.** As of G540/G541, four-thread agmsg
-  orchestration (design/orchestrator/implementation/review) is the **PRIMARY**
-  documented collaboration model — the practiced, maintained workflow — with
-  timer-loop mode retained as the fully supported, simpler alternative. See
-  the current guidance in
-  [Agent-message orchestration](12-agent-message-orchestration.md) and
-  [ADR 0001](../adr/0001-four-thread-orchestration-primary-model.md).
+**To ship in `v0.6.0` (changes since `v0.5.0`) — primary-model repositioning
+and provisioning, stall-detection completion, durable-state integrity, and
+operational guidance:**
 
-**Release-readiness verification (run before merging the `v0.5.0` version
+- **Primary-model repositioning and provisioning** (G540/G541, G549, G550) —
+  four-thread agmsg orchestration is the PRIMARY documented model across every
+  guide surface, the README, the NuGet description, and the docs indexes, with
+  the design↔orchestrator double-check rule and
+  [ADR 0001](../adr/0001-four-thread-orchestration-primary-model.md); timer-loop
+  mode is retained as the fully supported, simpler alternative. `guide
+  orchestrator-thread` gains a **terminal-workspace provisioning** section (role
+  folders created when absent, workspace topology, shim-safe launch, actas, and
+  three-layer readiness) and a **design-thread workspace supervision** section
+  (operator-granted session-layer authority with workflow ownership unchanged,
+  three supervision layers with cadences, the restart re-arm rule, and the
+  verified-read dialog boundary).
+- **Stall-detection completion** (G543, G544, G545, G546) — `backlog-ready-idle`
+  fires when an empty WIP coexists with a publishable candidate and an idle
+  `runs.jsonl`; a queue-`blocked` unit is exempt from `claimed-but-silent` and
+  surfaces as `blocked-label-drift` instead, with canonical `automation
+  issue-block` applying the new `intent-issue-blocked` label; `repair-stalled`
+  promotes a silent repair/rereview claim to actionable with a status-check
+  recommendation (never a transition or reassignment); and priority ranking for
+  the documented enum plus legacy out-of-enum values is unified in one shared
+  classification, with read-only `queue priority-drift` reporting the
+  distribution.
+- **Durable-state integrity** (G542, G548) — `automation runs-audit` reports and
+  repairs malformed `runs.jsonl` rows, separating within-record derivation from
+  explicitly-flagged peer-convention inference, while publish validation becomes
+  domain-scoped (another domain's malformed row warns instead of hard-blocking);
+  and every canonical queue-state mutation now writes through one layer
+  providing stale-base detection with item-scoped re-application and a
+  no-item-loss invariant that aborts rather than silently dropping units.
+- **Operational guidance** (G539) — the design-thread watchdog loop is the
+  RECOMMENDED default safety net, with an orchestrator-side long-interval
+  automation as the selectable alternative. **This supersedes the v0.5.0-era
+  external cron/launchd scheduler recommendation**, retired with field evidence
+  (silent failure on every run for five continuous days; a 105-minute stall
+  detected but unrecovered). See
+  [Agent-message orchestration](12-agent-message-orchestration.md#design-thread-watchdog-recommended-safety-net).
+- **Note on orchestration-mode framing:** the "preview/experimental" description
+  that applied through the `v0.5.0` line is fully superseded as of G540/G541 and
+  no longer appears anywhere in the shipped documentation.
+
+**Release-readiness verification (run before merging the `v0.6.0` version
 bump):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.4.0 (published), nextVersion 0.5.0 (to release)
+cat eng/version.json   # stableVersion 0.5.0 (published), nextVersion 0.6.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.5.0-<sha>-G53x   (NOT a stale literal)
+#   expected shape: intent-cli 0.6.0-<sha>-G55x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.5.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.6.0.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2014,12 +2017,13 @@ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
 ```
 
 After the version-bump merge lands on `main`, a maintainer/operator (or external
-release automation) creates and publishes the GitHub Release for `v0.5.0`;
+release automation) creates and publishes the GitHub Release for `v0.6.0`;
 publishing it triggers `release.yml` (`on: release: published`) to build and
 publish the NuGet package and the per-platform binary artifacts. Once it has
 published, apply the post-release `eng/version.json` bump above
-(`stableVersion → 0.5.0`, `nextVersion → 0.5.1`) — deferred to the NEXT
+(`stableVersion → 0.6.0`, `nextVersion → 0.6.1`) — deferred to the NEXT
 release-prep packet, not this one.
+
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.6.0.md
+++ b/docs/en/release-notes-v0.6.0.md
@@ -1,0 +1,391 @@
+# Release Notes — intent-cli v0.6.0
+
+> **Release model:** a maintainer/operator (or external release automation)
+> **creates and publishes the GitHub Release** for `v0.6.0` — the version-bump
+> merge does **not** create a Release or tag on its own. Publishing the GitHub
+> Release fires `.github/workflows/release.yml` (`on: release: published`), which
+> then builds and publishes the NuGet package and platform binary artifacts.
+> This packet is **prepare-only**: it bumps version metadata and docs and adds
+> **no** publish steps. See the
+> [pre-merge release-readiness gate](#release-readiness-gate-g551) and
+> [publishing v0.6.0](#publishing-v060).
+
+## What's in v0.6.0
+
+v0.6.0 is a **minor release** covering the eleven slices merged after `v0.5.0`:
+**G539, G540, G541, G542, G543, G544, G545, G546, G548, G549, and G550**. It is
+a minor bump rather than a patch for the same reasons v0.5.0 was: it ships **new
+stalled-work detection kinds** (`backlog-ready-idle`, `blocked-label-drift`,
+`repair-stalled`), a **new command surface** (`automation runs-audit`,
+`queue priority-drift`, `automation issue-block`), **visible behavior changes**
+to already-shipped commands, and the **repositioning of four-thread agmsg
+orchestration as the primary documented model**. The package id remains
+`JTechJapan.IntentSystem.Cli`; there are no package id, license, or
+workflow-semantics changes.
+
+> **G547 is deliberately absent from the slice list above.** The original
+> release-prep unit for this cycle (G547) was canonically **retired** via
+> `automation issue-retire` when the operator directed that G549/G550 join the
+> release scope. Retirement is terminal for a unit id, so the continuation is a
+> new unit — **G551**, this packet — rather than a republish of G547. G547
+> shipped no code and no documentation; its packet remains as the audit trail.
+> The unit range `G539–G550` therefore spans twelve unit ids of which **eleven
+> are merged and shipped here**.
+
+> **Four-thread agmsg orchestration is now the PRIMARY documented model** (see
+> [G540/G541](#primary-model-repositioning-and-provisioning-g540g541-g549-g550)),
+> superseding the preview/experimental framing carried by v0.5.0. Timer-loop
+> mode remains fully supported as the simpler alternative. intent-cli and GitHub
+> remain the authoritative source of truth; agmsg is only a message/progress/
+> completion signal layer.
+
+### Primary-model repositioning and provisioning (G540/G541, G549, G550)
+
+This cycle moves four-thread orchestration from "preview" to the practiced,
+documented default — and then supplies the two halves an operator actually
+needs to run it: how a team comes into existence, and how it keeps moving.
+
+- **Four-thread orchestration is the PRIMARY model** (G540) — `guide
+  orchestrator-thread`, `guide model`, `guide onboarding`, `guide prompt-matrix`,
+  and `guide help` all reframe orchestrator-message mode as primary and
+  timer-loop mode as the fully supported, simpler ALTERNATIVE; every
+  preview/experimental/opt-in qualifier on orchestration mode is removed. The
+  role-boundary section gains the **design↔orchestrator double-check rule**,
+  naming the four consulted decision categories (intent shaping, packet content
+  and acceptance criteria, release scope, prioritization rulings) and the
+  two-way non-bypass rule: the orchestrator never authors design content
+  unilaterally, and design never bypasses the orchestrator for workflow
+  transitions. Recorded in
+  [ADR 0001](../adr/0001-four-thread-orchestration-primary-model.md).
+- **The repositioning reaches every outward surface** (G541) — README quickstart
+  leads with the four-thread orchestration path (the implementation-loop prompt
+  is relabelled "timer-loop alternative"); the NuGet `Description` names the
+  primary model and `PackageTags` gain `agmsg`/`orchestration`/`ai-agent`; the
+  ja/en docs indexes put agent-message orchestration ahead of the timer-loop
+  entries; and the remaining "optional"/"opt-in" framing is dropped from the
+  orchestration page intro and its driver-mode table. Package id, tool command,
+  and license are unchanged.
+- **Terminal-workspace team provisioning** (G549) — `guide orchestrator-thread`
+  gains a provisioning section a design thread can execute end to end with
+  placeholders only, **starting from creating the dedicated role folders when
+  they do not exist**: host-metadata-repo clones for the host-side roles
+  (orchestrator, review) and a target-repo clone for the implementation role,
+  with the never-share rule stated together with its reason — agmsg identity and
+  the codex monitor bridge are `(project, type)`-scoped, so two roles in one
+  folder resolve to the same identity and one silently stops receiving. It also
+  pins the one-workspace/one-tab/one-pane-per-role topology, the shim-safe typed
+  launch for codex (a workspace manager that exec's the canonical executable
+  directly bypasses the shim and the bridge never arms), the actas form per CLI,
+  and readiness split into three layers that must not be collapsed — delivery
+  **configuration**, **live attachment** (agent-specific: the Claude Code
+  Monitor markers vs the `Codex bridge: … alive (pid N)` marker), and
+  **end-to-end**, where the ping/ack is the only end-to-end proof. herdr is
+  named as the reference workspace manager with its surfaces listed and its
+  internals linked out; any equivalent manager may substitute.
+- **Design-thread workspace supervision and its authority boundary** (G550) —
+  the other half: under authority the **operator grants**, the design thread
+  drives the team's **session layer** (panes, processes, role holds, blocking
+  dialogs). The **workflow layer** — labels, queue-state, publication,
+  delegation, CI/review gating, closeout — is **not granted and does not move**:
+  it stays with intent-cli, GitHub, and the orchestrator, so supervising a
+  session never authorizes a workflow transition. The section documents session
+  lifecycle (read the pane before concluding a session is dead; replace only
+  through the graceful drop that honors one-holder exclusivity, with the drop
+  confirmation operator-visible), **three supervision layers with cadences**
+  (real-time message monitor; sub-minute blocking-UI pane scan — the failure
+  mode that emits no message at all; tens-of-minutes state watchdog), and the
+  **re-arm rule**: supervision schedulers are session-scoped and die silently
+  with the design session, so each layer must survive a restart or be re-armed
+  as the first act of the new session. Blocking dialogs are governed by the
+  **verified-read rule** plus a closed four-item MAY list (each with its
+  verification condition) and a closed four-category MUST-ESCALATE list in which
+  credential, security, and permission waits are **never** answerable — with or
+  without prior authorization. The boundary sentence: *unsticking a session is
+  not deciding for it.*
+
+### Stall-detection completion (G543, G544, G545, G546)
+
+v0.5.0 shipped the first informational stalled-work kinds and deliberately left
+them thresholdless "until field data exists". The field data arrived, and this
+cycle closes the remaining blind spots.
+
+- **`backlog-ready-idle`** (G544) — fires when WIP is empty for the domain, the
+  **same canonical selector** `issue publish-flow` preflight uses reports a
+  publishable (`issue-cut-ready`) candidate, and `runs.jsonl` has recorded no
+  activity for at least `--backlog-idle-minutes` (default 45). No new heuristic:
+  the publishability judgment is the existing selector, gates included. An
+  execution unit that cannot be corroborated at all conservatively **blocks**
+  the WIP-empty check rather than being excluded — a false "idle" report is the
+  dangerous direction here. A missing or unparseable `runs.jsonl` fails closed
+  into `excluded[]` rather than guessing an age. The G524 wake contract is
+  extended so a wake must not end while a `backlog-ready-idle` item is
+  actionable.
+- **Canonical issue-level blocked representation + `claimed-but-silent`
+  exemption** (G545) — `claimed-but-silent` now consults `queue-state.json` and
+  never flags a unit whose queue item is `state=blocked`. A blocked unit whose
+  GitHub labels have not been reconciled yet is instead reported under the new
+  informational **`blocked-label-drift`** kind naming the reconcile command. The
+  new canonical `automation issue-block --repo <r> --issue <n> --reason <text>
+  [--write]` (and its `--clear` counterpart) applies the `intent-issue-blocked`
+  label — the only supported way to make GitHub agree with a queue-state
+  `blocked` transition, with no raw `gh` label edits. The label joins the
+  canonical palette, so `label-palette-audit`/`-sync` provision and validate it.
+  A no-weakening fixture proves a claimed, non-blocked, silent-past-threshold
+  unit still fires `claimed-but-silent`.
+- **`repair-stalled`** (G546) — a PR carrying `intent-pr-request-update`,
+  `intent-pr-update-in-progress`, or `intent-pr-rereview-ready` with no
+  observable activity for longer than `--repair-silent-minutes` (default 180) is
+  promoted from informational to **actionable** (`stalled: true`). The
+  recommendation is always a **status check to the responsible thread** —
+  `implement` for the two repair labels, `review-dispatch` for
+  `rereview-ready` — and never a transition or a reassignment, because silence
+  alone never establishes that a repair succeeded, failed, or should be taken
+  from its owner. Draft PRs get their own disjoint collection path, so a PR can
+  never be reported twice and a draft mid-repair is no longer invisible. Field
+  evidence: a repair claimed on 2026-07-23 went silent for **four days** after
+  the implement session died while `stalled-work` reported `stalled=false`.
+- **Priority enum reconciliation** (G543) — a single shared
+  `QueuePriorityClassification` is now the source of truth for the documented
+  `high|normal|low` enum **and** for how every value the candidate selector can
+  encounter ranks, including legacy out-of-enum values such as the
+  field-observed `medium`. The ranking rule is unchanged (unknown values rank
+  like `normal`) — it is now shared, documented, and fixture-pinned rather than
+  duplicated privately inside `intent next-slice`. New read-only `queue
+  priority-drift` reports item counts per priority value, always listing
+  `high`/`normal`/`low` for a stable shape, and flags out-of-enum values; it
+  never mutates `queue-state.json` or `runs.jsonl`. A regression test locks in
+  that `queue transition` never rewrites a pre-existing out-of-enum priority as
+  a side effect.
+
+### Durable-state integrity (G542, G548)
+
+- **`automation runs-audit` + domain-scoped publish validation** (G542) — the
+  new `automation runs-audit [--repo <r>] [--domain <d>] [--write]
+  [--apply-inferred] --format json|markdown` reports every malformed
+  `runs.jsonl` row in one pass: line, missing required fields, owning domain,
+  and a within-record repair when one is losslessly derivable. `--write` applies
+  only **within-record** repairs (`ts` from the record's own `timestamp`;
+  `execution_unit` from `wip[0].eu` or `stage1.eu` for the two documented row
+  shapes), appends one `runs-repair` audit event per repair, and preserves every
+  unrelated byte. A field with no within-record source is always
+  `non_derivable`; the separate, explicit `--apply-inferred` flag may apply a
+  peer-convention suggestion instead, recorded as
+  `derivation: inferred-peer-convention` — the two derivation classes are never
+  mixed. Publish validation is now **domain-scoped**: `issue publish-flow`
+  parses `runs.jsonl` line by line, and a malformed row belonging to a
+  **different** domain becomes a warning naming `runs-audit` instead of a hard
+  block, while a same-domain or domain-unresolvable row still fails closed
+  exactly as before.
+- **Queue-state no-item-loss invariant and stale-base re-application** (G548) —
+  `queue-state.json` is one file shared by every domain on a multi-domain host,
+  written concurrently from several checkouts. Every canonical writer previously
+  deserialized the whole file, mutated in memory, and reserialized it, so a
+  read-modify-write race did not merely conflict — it **silently erased**
+  whatever the stale in-memory copy lacked. All **19** canonical mutations now
+  write through one shared persistence layer providing three guarantees:
+  **stale-base detection and re-application** (the base the caller read is
+  compared against what is on disk at persist time through the same serializer
+  round-trip, so formatting drift is never mistaken for a concurrent write; on
+  mismatch the caller's derived item-level delta is re-applied to the fresh
+  state and the re-application is reported back so it is never invisible); the
+  **no-item-loss invariant** (any execution unit present on disk but missing
+  from the outgoing state and not named as an expected removal aborts the write,
+  naming the exact units and the canonical recovery path, leaving the file
+  untouched); and **item-scoped re-application** (a re-applied mutation touches
+  only the units its delta covers plus `updated_at`, with unrelated items
+  carried through byte-identically in the fresh state's order). Legitimate
+  removals — retire, the completed-item lifecycle — pass their units as expected
+  removals, so the invariant targets **unrequested** loss only. Closes a
+  2026-07-23 incident in which a cross-domain write dropped an item seeded an
+  hour earlier, stayed invisible for four days, and then produced a circular
+  recovery deadlock.
+
+### Operational guidance (G539)
+
+- **The design-thread watchdog is the RECOMMENDED default safety net** (G539) —
+  a watchdog loop run from the design thread at a 30-minute-class interval,
+  calling `automation heartbeat` and sending at most one canonical nudge when
+  `stale=true`, silent otherwise. An **orchestrator-side long-interval
+  automation** (the same heartbeat call run from the orchestrator's own thread
+  at a 30–60-minute-class interval) is documented as the selectable
+  ALTERNATIVE, with the loopless-vs-one-fewer-hop trade-off stated.
+  `automation heartbeat` / `automation stalled-work` behavior is unchanged and
+  stays scheduler-agnostic; the watchdog safety rules and the legacy 5-minute
+  orchestrator fallback timer are preserved verbatim.
+
+> #### Supersedes the v0.5.0 external-scheduler recommendation
+>
+> The v0.5.0-era guidance recommended an **external cron/launchd OS-scheduler
+> heartbeat runner**. G539 **retires** that recommendation. Reason, recorded
+> with field evidence: the credential store/keychain is unreachable from a cron
+> context, so the runner failed **silently on every run for five continuous
+> days** (2026-07-15..07-20), and a 105-minute stall went unrecovered even
+> though `automation stalled-work` had correctly detected it — only a human ping
+> surfaced it. An external scheduler also sits outside the agmsg model
+> entirely. A watchdog that occasionally restarts but is **visible when broken**
+> is a stronger guarantee than one that runs invisibly until someone happens to
+> check its logs. Current guidance:
+> [Agent-message orchestration — design-thread watchdog](12-agent-message-orchestration.md#design-thread-watchdog-recommended-safety-net).
+
+## Workarounds retired by this release
+
+Field consumers have been running documented workarounds that this release
+removes the need for. After installing `v0.6.0`:
+
+- **Title-convention workaround** — no longer needed. Execution-unit
+  identification is corroborated against real packet/queue linkage rather than
+  trusted from a title alone (shipped in v0.5.0 via G532; this release completes
+  the surrounding detection coverage so the workaround has no remaining
+  fallback role).
+- **Duplicated top-level `domain:` fields** — no longer needed. Domain
+  resolution and domain-scoped publish validation (G542) read the owning domain
+  through the documented resolution order, so a duplicated compatibility field
+  is not required to keep publish-flow validation from tripping on another
+  domain's malformed row.
+- **Queue-state hand-edit recovery** — retired. G548's no-item-loss invariant
+  and stale-base re-application close the class of silent loss that made
+  hand-editing necessary, and `automation runs-audit` (G542) plus the canonical
+  queue transitions cover the repair paths that previously had none.
+- **Manual repair-stall pings** — retired. `repair-stalled` (G546) promotes a
+  silent repair claim to an actionable item with a status-check recommendation
+  after `--repair-silent-minutes`, so a stalled repair no longer depends on a
+  human noticing it. `blocked-label-drift` (G545) likewise replaces manually
+  reconciling a blocked unit's GitHub labels with a named canonical command.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.0
+```
+
+Or download the self-contained binary from the
+[v0.6.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.6.0).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.5.0
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.6.0
+```
+
+This release is **compatibility-conscious and non-breaking in intent**, but a
+few slices change the behavior of already-shipped commands, and consumers
+relying on the previous behavior should read these carefully:
+
+- **Additive, no action needed**: the new commands (`automation runs-audit`,
+  `queue priority-drift`, `automation issue-block`) are opt-in surfaces, and the
+  new stalled-work kinds (`backlog-ready-idle`, `blocked-label-drift`,
+  `repair-stalled`) add finer-grained classification to an existing read-only
+  surface.
+- **Corrective — existing command behavior changes**:
+  - **G545** — `automation stalled-work` no longer reports `claimed-but-silent`
+    for a unit whose queue item is `state=blocked`. A caller that treated every
+    `claimed-but-silent` item as needing a nudge will see fewer items, and a
+    blocked-but-unreconciled unit now appears as `blocked-label-drift` instead.
+  - **G546** — a PR carrying a repair/rereview label past
+    `--repair-silent-minutes` is now **actionable** (`stalled: true`) rather
+    than informational. A caller that filtered on `stalled == true` will now see
+    these items.
+  - **G542** — `issue publish-flow` no longer hard-blocks on a malformed
+    `runs.jsonl` row belonging to a **different** domain; it warns and names
+    `runs-audit`. A same-domain or domain-unresolvable row still fails closed.
+  - **G548** — any canonical queue-state write may now **abort** with a
+    no-item-loss error naming the units it would have dropped, where it
+    previously succeeded and silently lost them. A write whose base is stale is
+    re-applied against the fresh state and **reports** the re-application. This
+    is the intended correction, but a caller that assumed queue-state writes
+    always succeed must handle the abort.
+  - **G543** — priority ordering is unchanged in behavior, but it is now shared
+    and documented; `queue priority-drift` will surface legacy out-of-enum
+    values (e.g. `medium`) that were previously invisible.
+- **Documentation framing change**: orchestrator mode is no longer described as
+  preview/experimental anywhere (G540/G541). Timer-loop mode is unchanged and
+  remains fully supported.
+
+No package id, license, or CLI argument/flag shape changes; every corrective
+change above brings behavior in line with the documented intent of its own
+command.
+
+## Release-readiness gate (G551)
+
+These items must hold **before the GitHub Release for `v0.6.0` is published**.
+This gate fails closed — if any item is unmet, do not publish the Release yet.
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G539, G540, G541, G542, G543, G544, G545, G546, G548, G549, G550 (and this
+      G551 release-notes prep). Confirm on the host/review side via the host
+      queue-state / GitHub PR state — the child implementation loop must not read
+      parent queue-state, so this is a host-owned precondition.
+- [ ] **G547 is confirmed terminally retired** and contributes nothing to this
+      release; its successor is this G551 packet.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before
+      publishing).
+- [ ] `eng/version.json` shows `stableVersion` `0.5.0` and `nextVersion` `0.6.0`
+      (the intended release version). `release.yml` builds the package version
+      from the published Release/tag; `src/IntentSystem.Cli/IntentSystem.Cli.csproj`
+      derives its local default from the same policy.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] Release notes / README describe four-thread orchestration as the
+      **PRIMARY** model with timer-loop mode as the fully supported alternative —
+      **no** preview/experimental framing remains (G540/G541).
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+- [ ] **Post-merge build + pack evidence** on the merge commit is recorded in
+      the PR (mirroring the G528/G538 readiness gate).
+
+## Publishing v0.6.0
+
+This packet does **not** publish the release and adds **no** publish steps. The
+version-bump merge does **not** create a GitHub Release or tag on its own.
+
+1. After this version bump is merged and the readiness gate above holds, a
+   **maintainer/operator (or external release automation) creates and publishes
+   the GitHub Release** for `v0.6.0` (tagging the release commit). This is a
+   post-merge host/operator/external action.
+2. Publishing that GitHub Release fires `.github/workflows/release.yml`
+   (`on: release: published`), which builds and publishes the NuGet package and
+   the per-platform binary archives (with `.sha256` checksums) and attaches them
+   to the triggering Release.
+
+Post-release verification (after the GitHub Release is published and
+`release.yml` has run):
+
+- [ ] NuGet.org package page links all resolve correctly.
+- [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+      accessible.
+- [ ] `.sha256` checksums match the downloaded artifacts.
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.0`)
+      then `intent-cli --version` reports `0.6.0`.
+- [ ] Binary artifact smoke check: download the platform archive, verify its
+      `.sha256`, extract, and run `./intent-cli --version` → `0.6.0`.
+- [ ] **New commands smoke**: `intent-cli automation runs-audit --domain <d>
+      --format json`, `intent-cli queue priority-drift --format json`, and
+      `intent-cli automation issue-block --help` all run against a real repo
+      without crashing.
+- [ ] **Stall-detection smoke** (G544/G545/G546): `intent-cli automation
+      stalled-work --domain <d> --repo <r> --format json` reports the new
+      `backlog-ready-idle` / `blocked-label-drift` / `repair-stalled` kinds where
+      applicable, with `repair-stalled` carrying `stalled: true`.
+- [ ] **Queue-state integrity smoke** (G548): a canonical queue mutation against
+      a fixture whose on-disk state contains an extra unit aborts with the
+      no-item-loss error naming that unit, and leaves the file untouched.
+- [ ] **Provisioning/supervision guidance smoke** (G549/G550): `intent-cli guide
+      orchestrator-thread --format markdown` renders both the
+      `Terminal-workspace provisioning` and `Design-thread workspace
+      supervision` sections.
+- [ ] Notify the operator to publish the `v0.6.0` GitHub Release, then notify
+      sekiban-as-a-service-orch to drop the documented workarounds listed under
+      [Workarounds retired by this release](#workarounds-retired-by-this-release)
+      after installing `v0.6.0`.
+- [ ] Local preview/dry-run version metadata uses the next development line
+      after `0.6.0` (bump `eng/version.json` per the post-release step in
+      [Version flow](09-developer-reference.md#version-flow)):
+      `stableVersion → 0.6.0`, `nextVersion → 0.6.1`. This bump is deferred to
+      the **next** release-prep packet, not this one.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2033,115 +2033,125 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.4.0",
-  "nextVersion": "0.5.0"
+  "stableVersion": "0.5.0",
+  "nextVersion": "0.6.0"
 }
 ```
 
 | ステージ | バージョン形式 | 導出方法 |
 | --- | --- | --- |
-| ローカル pack / install | `0.5.0-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.5.0-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.5.0-rc.N` | タグ `v0.5.0-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
-| 安定版リリース | `0.5.0` | タグ `v0.5.0` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.5.1-preview.<run>.<attempt>` | `nextVersion` を `0.5.1` にバンプ後 |
+| ローカル pack / install | `0.6.0-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.6.0-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.6.0-rc.N` | タグ `v0.6.0-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
+| 安定版リリース | `0.6.0` | タグ `v0.6.0` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.6.1-preview.<run>.<attempt>` | `nextVersion` を `0.6.1` にバンプ後 |
 
-**`v0.5.0` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
+**`v0.6.0` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
 
 ```json
 {
-  "stableVersion": "0.5.0",
-  "nextVersion": "0.5.1"
+  "stableVersion": "0.6.0",
+  "nextVersion": "0.6.1"
 }
 ```
 
 これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.5.1-preview.<run>.<attempt>` / `0.5.1-<sha>-<G-unit>` を生成し、`0.5.0`（安定版
+`0.6.1-preview.<run>.<attempt>` / `0.6.1-<sha>-<G-unit>` を生成し、`0.6.0`（安定版
 リリースバージョンと衝突）の出力が継続されなくなります。
 
-### 次リリース準備(v0.5.0)
+### 次リリース準備(v0.6.0)
 
-**`v0.4.0` は publish 済み**(GitHub Release + NuGet)で、バージョンポリシーは
-`0.5.0` 開発ラインにバンプされました — これは patch ではなく **minor** バンプです:
-このバッチは 2 つの新しいコマンド(`intent facet-check`、`queue reprioritize`)、新しい
-intent-tree schema サーフェス(`facets`)、新しい stalled-work kind、新しい transition
-target(`retired`)を出荷するため、patch リリース以上の扱いが妥当です。リポジトリは現在
-in-development の **`0.5.0`** `nextVersion` 上にあり、G538 は **prepare-only** です —
-version メタデータと docs をバンプするだけで publish ステップを追加しません。
-version-bump マージ自体は GitHub Release やタグを作成しません。マージされ
-[リリース準備ゲート](release-notes-v0.5.0.md#リリース準備ゲート-g538)が成り立った後、
-**メンテナ/オペレーター(または外部のリリース automation)が `v0.5.0` の GitHub Release を作成・
-publish** します。その Release の publish が `.github/workflows/release.yml`(`on: release: published`)を
-発火させ、NuGet package とプラットフォームごとのバイナリ成果物を build・publish します。
-完全な changelog と operator チェックリスト:
-[release-notes-v0.5.0.md](release-notes-v0.5.0.md)。
+**`v0.5.0` は publish 済み**(GitHub Release + NuGet)で、バージョンポリシーは
+`0.6.0` 開発ラインにバンプされました — これは patch ではなく **minor** バンプです:
+本バッチは 3 つの新しい stalled-work 検出 kind(`backlog-ready-idle`、
+`blocked-label-drift`、`repair-stalled`)、3 つの新コマンド(`automation runs-audit`、
+`queue priority-drift`、`automation issue-block`)、既出コマンドの可視な挙動変更、そして
+4 スレッド agmsg オーケストレーションの PRIMARY モデルへの再配置を出荷しており、patch
+リリースが正当化する範囲を超えています。リポジトリは in-development の **`0.6.0`**
+`nextVersion` 上にあり、G551 は **prepare-only** です — version メタデータと docs を
+バンプするだけで publish ステップを追加しません。version-bump マージは GitHub Release も
+タグも作成しません。マージ後に
+[リリース準備ゲート](release-notes-v0.6.0.md#リリース準備ゲートg551)が成り立った後、
+**メンテナ/オペレーター(または外部のリリース automation)が `v0.6.0` の GitHub Release を
+作成・publish** します。その publish が `.github/workflows/release.yml`
+(`on: release: published`)を発火させ、NuGet package とプラットフォーム別バイナリ成果物を
+build・publish します。完全な changelog とオペレーターチェックリスト:
+[release-notes-v0.6.0.md](release-notes-v0.6.0.md)。
 
-**`v0.5.0` で出荷予定（`v0.4.0` 以降の変更）— semantic facets、stalled-work の正確性、
-queue の頑健性、label supersession、publish の信頼性、priority override:**
+> **G547 は本リリースに含まれません。** 本サイクル当初の release-prep ユニットは、
+> G549/G550 をリリーススコープに加えるというオペレーター指示を受けて canonical に
+> **retire** されました。retire はユニット ID に対して terminal であるため、継続は
+> republish ではなく新ユニット **G551** です。G547 はコードもドキュメントも出荷して
+> いません。範囲 `G539–G550` は 12 個のユニット ID にまたがりますが、`v0.6.0` で
+> マージ・出荷されるのはそのうち **11 件** です。
 
-- **semantic facets**(G529–G531)— intent-tree ノードが frontmatter で宣言できる
-  4 つの closed set の `facets:` 値(`vocabulary`、`invariant`、`decider`、
-  `acceptance-property`)。`intent-cli context collect` と `packet draft` は、
-  分類されていない queue-state/clarification context より前に、facet で分類された
-  `## Facet context` セクションを優先的な局所化された semantic context として供給する
-  ようになりました。read-only な `intent facet-check` は、change proposal を facet
-  ノードに照らして、命名衝突やカバレッジのギャップを、決して gate することなく
-  表面化します。
-- **stalled-work の正確性**(G532–G533)— leading-ID/nested-domain の execution-unit
-  識別は、タイトルだけを信頼するのではなく実際の packet/queue linkage で裏付けられる
-  ようになりました。`--domain` は必須の authoritative なスコープ入力です。3 つの
-  新しい informational kind(`repair-pending`、`rereview-pending`、
-  `claimed-but-silent`)により、修理中/再レビュー待ちの PR が誤った `review-start`
-  推奨で誤報告されることがなくなりました。
-- **queue の頑健性**(G534)— packet reader は両方の YAML list-item インデント慣習を
-  受け入れるようになりました。`retired` は今や guarded かつ terminal な `queue
-  transition` target です(適用前に紐づく PR の実際の GitHub 状態を検証)。
-  `intent next-slice` は queue-state と packet-lifecycle の retirement エビデンスを
-  明示的に組み合わせ、矛盾があれば fail closed します。
-- **label supersession**(G535)— `automation pr-transition --transition
-  request-update` は、同じ write の中で古い `intent-pr-rereview-ready` を
-  クリアするようになりました。これにより、`request-update` が修理対象としてマークした
-  PR を `worker claim` が拒否してしまうデッドロックが解消されました。
-- **publish の信頼性**(G536)— `issue publish-flow` の idempotent な再実行は、
-  3 つの durable artifact(GitHub issue、queue-state エントリ、`runs.jsonl`
-  イベント)すべてを、1 つのシグナルを信頼するのではなく独立に検証・復元する
-  ようになり、state が矛盾したまま黙って残るのではなく fail loud するようになりました。
-- **priority override**(G537)— 新しい `queue reprioritize` コマンドは、queued かつ
-  未 publish の execution unit の priority を、durable かつ revision-counted、
-  lock-protected な audit protocol の下で設定します。`intent next-slice` は
-  priority class を優先(high > normal > low、authoring order による安定した
-  tiebreak)して候補を選択し、dependency/WIP/clarification/lifecycle の gate は
-  常に priority に優先します。
-- **historical な注記(v0.5.0 時点、G540/G541 以前):** `v0.5.0` の出荷時点では、
-  ここで orchestrator モードを preview/experimental かつオプトインと記述して
-  いました。**この位置づけは現在では置き換えられています。** G540/G541 以降、
-  4 スレッドの agmsg orchestration(design/orchestrator/implementation/
-  review)が **PRIMARY** な、実践され保守されているワークフローとして
-  documented collaboration model であり、timer-loop モードは完全サポートされる
-  よりシンプルな alternative として維持されます。現在のガイダンスは
-  [エージェントメッセージオーケストレーション](12-agent-message-orchestration.md)
-  と [ADR 0001](../adr/0001-four-thread-orchestration-primary-model.md) を
-  参照してください。
+**`v0.6.0` で出荷予定(`v0.5.0` 以降の変更)— primary モデルへの再配置と provisioning、
+stall 検出の完成、durable state の完全性、運用ガイダンス:**
 
-**リリース準備の検証（`v0.5.0` version bump のマージ前に実行）:**
+- **primary モデルへの再配置と provisioning**(G540/G541、G549、G550) — 4 スレッド
+  agmsg オーケストレーションが、全 guide サーフェス・README・NuGet description・docs
+  インデックスにおいて PRIMARY な文書化モデルになりました。design↔orchestrator の
+  double-check ルールと
+  [ADR 0001](../adr/0001-four-thread-orchestration-primary-model.md) を伴い、timer-loop
+  モードは完全にサポートされたよりシンプルな代替として維持されます。`guide
+  orchestrator-thread` には **terminal-workspace provisioning** セクション(不在時の
+  ロールフォルダー作成、ワークスペーストポロジー、shim-safe 起動、actas、3 レイヤーの
+  readiness)と **design-thread workspace supervision** セクション(オペレーター付与の
+  セッション層権限と不変な workflow 所有権、ケイデンス付き 3 監督レイヤー、再起動時の
+  re-arm ルール、verified-read のダイアログ境界)が追加されました。
+- **stall 検出の完成**(G543、G544、G545、G546) — `backlog-ready-idle` は空の WIP と
+  publish 可能な候補、そして idle な `runs.jsonl` が同時に成立したときに fire します。
+  queue が `blocked` のユニットは `claimed-but-silent` から除外され、代わりに
+  `blocked-label-drift` として現れ、canonical な `automation issue-block` が新しい
+  `intent-issue-blocked` label を適用します。`repair-stalled` は silent な
+  repair/rereview claim を status-check 推奨付きの actionable に昇格させます(遷移や
+  再割り当ては決してしません)。また文書化 enum と legacy な enum 外の値に対する priority
+  ランク付けが単一の共有分類に統合され、read-only な `queue priority-drift` が分布を
+  報告します。
+- **durable state の完全性**(G542、G548) — `automation runs-audit` が不正な
+  `runs.jsonl` 行を報告・修復し、record 内導出と明示フラグ付きの peer-convention 推測を
+  分離します。publish 検証はドメインスコープになり、別ドメインの不正行は hard block では
+  なく warning になります。さらに canonical な queue-state 変更はすべて 1 つの層を通り、
+  item スコープの再適用を伴う stale-base 検出と、静かにユニットを落とす代わりに中止する
+  no-item-loss 不変条件を提供します。
+- **運用ガイダンス**(G539) — design-thread watchdog ループが RECOMMENDED な既定の
+  セーフティネットになり、orchestrator 側の長間隔 automation が選択可能な代替です。
+  **これは v0.5.0 時点の外部 cron/launchd スケジューラー推奨を置き換えます** —
+  フィールド証拠(5 日間連続で毎回 silent に失敗、105 分の stall を検出しながら未復旧)
+  とともに retire されました。
+  [agent メッセージオーケストレーション](12-agent-message-orchestration.md#design-thread-watchdog推奨されるセーフティネット)
+  を参照。
+- **オーケストレーションモードの位置づけに関する注記:** `v0.5.0` ラインまで適用されていた
+  「preview/experimental」という記述は G540/G541 をもって完全に置き換えられ、出荷される
+  ドキュメントのどこにも残っていません。
+
+**リリース準備の検証(`v0.6.0` version bump のマージ前に実行):**
 
 ```bash
-cat eng/version.json   # stableVersion 0.4.0（公開済み）, nextVersion 0.5.0（リリース対象）
+# 1. バージョンポリシーがカットするリリースを記録していることを確認。
+cat eng/version.json   # stableVersion 0.5.0（公開済み）, nextVersion 0.6.0（リリース対象）
+
+# 2. ビルドして表示バージョン識別子（version + git SHA + G-unit）を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.5.0-<sha>-G53x （stale なリテラルではない）
+#   期待形: intent-cli 0.6.0-<sha>-G55x （stale なリテラルではない）
+
+# 3. pack して NuGet package のバージョンがポリシーと一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.5.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.6.0.nupkg
+
+# 4. package メタデータ（id / command / license / project URL）を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-version-bump マージが `main` に入った後、メンテナ/オペレーター（または外部のリリース automation）が
-`v0.5.0` の GitHub Release を作成・publish します。その publish が `release.yml`
-（`on: release: published`）を発火させ、NuGet package とプラットフォームごとのバイナリ成果物を
-build・publish します。publish 後、上記のリリース後 `eng/version.json` バンプ
-（`stableVersion → 0.5.0`, `nextVersion → 0.5.1`）を適用します — これは今回のパケットではなく
-NEXT のリリース準備パケットに委ねられます。
+version-bump マージが `main` に着地した後、メンテナ/オペレーター(または外部のリリース
+automation)が `v0.6.0` の GitHub Release を作成・publish します。その publish が
+`release.yml`(`on: release: published`)をトリガーし、NuGet package とプラットフォーム別
+バイナリ成果物を build・publish します。publish 済みになったら、上記のリリース後
+`eng/version.json` バンプ(`stableVersion → 0.6.0`, `nextVersion → 0.6.1`)を適用します —
+これは今回のパケットではなく **次の** release-prep パケットに委ねられます。
+
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.6.0.md
+++ b/docs/ja/release-notes-v0.6.0.md
@@ -1,0 +1,322 @@
+# リリースノート — intent-cli v0.6.0
+
+> **リリースモデル:** メンテナ/オペレーター(または外部のリリース automation)が `v0.6.0` の
+> **GitHub Release を作成・publish** します — version-bump マージ自体は Release やタグを作成しません。
+> GitHub Release の publish が `.github/workflows/release.yml`(`on: release: published`)を発火させ、
+> NuGet package とプラットフォームバイナリ成果物を build・publish します。本パケットは
+> **prepare-only** で、version メタデータと docs をバンプするだけで publish ステップを **追加しません**。
+> [マージ前 リリース準備ゲート](#リリース準備ゲートg551) と
+> [v0.6.0 の publish](#v060-の-publish) を参照。
+
+## v0.6.0 の内容
+
+v0.6.0 は **minor リリース** で、`v0.5.0` 以降にマージされた 11 件のスライス —
+**G539, G540, G541, G542, G543, G544, G545, G546, G548, G549, G550** — をカバーします。
+patch ではなく minor バンプなのは v0.5.0 と同じ理由です: **新しい stalled-work 検出 kind**
+(`backlog-ready-idle`、`blocked-label-drift`、`repair-stalled`)、**新しいコマンドサーフェス**
+(`automation runs-audit`、`queue priority-drift`、`automation issue-block`)、既出コマンドの
+**可視な挙動変更**、そして **4 スレッド agmsg オーケストレーションの primary モデルへの再配置**
+を出荷するためです。package id は `JTechJapan.IntentSystem.Cli` のままで、package id・
+ライセンス・workflow セマンティクスの変更はありません。
+
+> **G547 は上記のスライス一覧に意図的に含まれていません。** 本サイクルの当初の release-prep
+> ユニット(G547)は、G549/G550 をリリーススコープに加えるというオペレーター指示を受けて
+> `automation issue-retire` により canonical に **retire** されました。retire はユニット ID に
+> 対して terminal であるため、継続は G547 の republish ではなく、新しいユニットである本パケット
+> **G551** になります。G547 はコードもドキュメントも出荷しておらず、その packet は監査証跡として
+> 残ります。したがってユニット範囲 `G539–G550` は 12 個のユニット ID にまたがりますが、
+> **本リリースでマージ・出荷されるのはそのうち 11 件** です。
+
+> **4 スレッド agmsg オーケストレーションが PRIMARY な文書化モデルになりました**
+> ([G540/G541](#primary-モデルへの再配置と-provisioningg540g541g549g550) を参照)。
+> v0.5.0 が持っていた preview/experimental の位置づけは置き換えられます。timer-loop モードは
+> よりシンプルな代替として完全にサポートされ続けます。intent-cli と GitHub が権威 source of
+> truth であり続け、agmsg はメッセージ / 進捗 / 完了のシグナル層のみです。
+
+### primary モデルへの再配置と provisioning(G540/G541、G549、G550)
+
+本サイクルは 4 スレッドオーケストレーションを「preview」から、実践され文書化された既定へ
+移します。そのうえで、オペレーターが実際に必要とする 2 つの半分 — チームの作り方と、
+チームを動かし続ける方法 — を供給します。
+
+- **4 スレッドオーケストレーションが PRIMARY モデル**(G540) — `guide orchestrator-thread`、
+  `guide model`、`guide onboarding`、`guide prompt-matrix`、`guide help` のすべてが
+  orchestrator-message モードを primary、timer-loop モードを完全にサポートされたよりシンプルな
+  ALTERNATIVE として再構成し、オーケストレーションモードに付いていた preview/experimental/
+  opt-in の限定語はすべて除去されました。role-boundary セクションには
+  **design↔orchestrator の double-check ルール** が追加され、協議対象となる 4 つの判断カテゴリ
+  (intent shaping、packet 内容と受け入れ基準、リリーススコープ、優先度の裁定)と双方向の
+  非バイパス規則 — orchestrator は design 内容を単独で author せず、design は workflow 遷移で
+  orchestrator をバイパスしない — を明示します。
+  [ADR 0001](../adr/0001-four-thread-orchestration-primary-model.md) に記録されています。
+- **再配置は外向きの全サーフェスに到達**(G541) — README の quickstart は 4 スレッド
+  オーケストレーション経路を先頭に置き(implementation-loop プロンプトは「timer-loop
+  alternative」に改称)、NuGet の `Description` は primary モデルを明記し、`PackageTags` に
+  `agmsg`/`orchestration`/`ai-agent` を追加。ja/en の docs インデックスは agent-message
+  orchestration を timer-loop 系エントリより前に置き、オーケストレーションページの導入と
+  driver-mode 表から残っていた "optional"/"opt-in" 表現を除去しました。package id・ツール
+  コマンド・ライセンスは不変です。
+- **ターミナルワークスペースのチーム provisioning**(G549) — `guide orchestrator-thread` に、
+  設計スレッドがプレースホルダーだけで end-to-end 実行できる provisioning セクションを追加。
+  **存在しない専用ロールフォルダーの作成から始まります**: host 側ロール(orchestrator、review)は
+  host メタデータリポジトリのクローン、implementation ロールは target repo のクローン。
+  never-share ルールはその理由とともに明記されます — agmsg identity と codex monitor bridge は
+  `(project, type)` スコープであり、1 フォルダーに 2 ロールがいると同一 identity に解決され、
+  片方が静かに受信を停止します。さらに 1 workspace / 1 タブ / ロールごとに 1 pane のトポロジー、
+  codex の shim-safe なタイプ起動(canonical な実行ファイルを直接 exec するワークスペース
+  マネージャーは shim を bypass し bridge が arm されません)、CLI ごとの actas 形式、そして
+  混同してはいけない 3 レイヤーに分割された readiness — delivery **設定**、**live attachment**
+  (agent 別: Claude Code の Monitor マーカー / `Codex bridge: … alive (pid N)` マーカー)、
+  **end-to-end**(ping/ack が唯一の end-to-end 証明)— を pin します。herdr は参照ワークスペース
+  マネージャーとして surface を列挙しつつ internals はリンクアウトされ、同等のマネージャーで
+  置き換え可能です。
+- **設計スレッドによるワークスペース監督と権限境界**(G550) — もう半分です。**オペレーターが
+  付与した** 権限のもとで、設計スレッドはチームの **セッション層**(pane、プロセス、ロール保持、
+  ブロッキングダイアログ)を運用します。**workflow 層** — label、queue-state、publish、委譲、
+  CI/review ゲート、closeout — は **付与対象ではなく動きません**: intent-cli・GitHub・
+  orchestrator が所有し続け、セッションの監督が workflow 遷移を authorize することはありません。
+  本セクションはセッションのライフサイクル(死亡判定の前に pane を読む。置き換えは 1 ロール 1
+  保持者を守る graceful drop のみで、drop の確認はオペレーターに可視)、**ケイデンス付きの 3 監督
+  レイヤー**(リアルタイム message monitor / サブ分オーダーの blocking-UI pane スキャン —
+  メッセージを一切出さない failure mode / 数十分オーダーの state watchdog)、そして
+  **re-arm ルール** — 監督スケジューラーはセッションスコープで設計セッションとともに静かに死ぬため、
+  各レイヤーは再起動を生き延びるか新セッションの最初の行動として re-arm される — を文書化します。
+  ブロッキングダイアログは **verified-read ルール** に加え、closed な 4 項目の MAY リスト
+  (各項目に検証条件付き)と closed な 4 カテゴリの MUST-ESCALATE リストに支配され、credential・
+  security・permission の待ちは事前承認の有無にかかわらず **決して** 回答できません。境界文:
+  *セッションの詰まりを解くことは、そのセッションの代わりに決定することではない。*
+
+### stall 検出の完成(G543、G544、G545、G546)
+
+v0.5.0 は最初の informational な stalled-work kind を出荷し、「フィールドデータが出るまで」
+しきい値を意図的に持たせませんでした。フィールドデータが到着し、本サイクルは残る死角を塞ぎます。
+
+- **`backlog-ready-idle`**(G544) — 対象ドメインの WIP が空で、`issue publish-flow` の preflight
+  自身が使う **同じ canonical セレクター** が publish 可能(`issue-cut-ready`)な候補を報告し、かつ
+  `runs.jsonl` に少なくとも `--backlog-idle-minutes`(既定 45)の間 activity が記録されていない
+  ときに fire します。新しいヒューリスティクスはありません — publish 可否の判断はゲートを含む
+  既存セレクターそのものです。まったく corroborate できない execution unit は除外ではなく
+  WIP-empty チェックを **保守的にブロック** します(ここでは誤った "idle" 報告こそが危険な方向
+  だからです)。`runs.jsonl` の欠落・パース不能は年齢を推測せず `excluded[]` へ fail-closed。
+  G524 の wake contract も拡張され、`backlog-ready-idle` が actionable な間は wake を終了できません。
+- **canonical な issue-level blocked 表現 + `claimed-but-silent` の除外**(G545) —
+  `claimed-but-silent` は `queue-state.json` を参照するようになり、queue item が `state=blocked` の
+  ユニットを決して flag しません。GitHub の label がまだ reconcile されていない blocked ユニットは
+  代わりに新しい informational kind **`blocked-label-drift`** として reconcile コマンド名とともに
+  報告されます。新しい canonical コマンド `automation issue-block --repo <r> --issue <n> --reason
+  <text> [--write]`(および `--clear`)が `intent-issue-blocked` label を適用します — queue-state の
+  `blocked` 遷移に GitHub を一致させる唯一のサポート手段で、生の `gh` label 編集はしません。
+  この label は canonical palette に加わり、`label-palette-audit`/`-sync` も provision・検証します。
+  claimed かつ非 blocked でしきい値超過の silent なユニットは引き続き `claimed-but-silent` を fire
+  することを、no-weakening fixture が証明します。
+- **`repair-stalled`**(G546) — `intent-pr-request-update`、`intent-pr-update-in-progress`、
+  `intent-pr-rereview-ready` のいずれかを持つ PR が `--repair-silent-minutes`(既定 180)を超えて
+  観測可能な activity を持たない場合、informational から **actionable**(`stalled: true`)へ昇格
+  します。推奨は常に **責任スレッドへの status check** — 2 つの repair label は `implement`、
+  `rereview-ready` は `review-dispatch` — であって、遷移や再割り当てでは決してありません。沈黙だけ
+  では repair が成功した・失敗した・所有者から取り上げるべきだ、のいずれも成立しないからです。
+  draft PR は独立した収集経路を持つため、PR が二重に報告されることはなく、repair 中の draft が
+  不可視になることもなくなりました。フィールド証拠: 2026-07-23 に claim された repair が implement
+  セッションの死後 **4 日間** 沈黙し続けたにもかかわらず、`stalled-work` は `stalled=false` を報告
+  し続けました。
+- **priority enum の整合**(G543) — 共有される `QueuePriorityClassification` が、文書化された
+  `high|normal|low` enum と、候補セレクターが遭遇しうるあらゆる値(フィールドで観測された
+  `medium` のような legacy な enum 外の値を含む)のランク付けの、単一の source of truth になりました。
+  ランク規則自体は不変(未知の値は `normal` と同じランク)で、`intent next-slice` の内部に private に
+  重複していたものが共有・文書化・fixture で pin されるようになりました。新しい read-only な
+  `queue priority-drift` は priority 値ごとの item 数を報告し、安定した形のため `high`/`normal`/`low`
+  を常に列挙し、enum 外の値を flag します。`queue-state.json` も `runs.jsonl` も変更しません。
+  `queue transition` が既存の enum 外 priority を副作用で書き換えないことも回帰テストで固定しました。
+
+### durable state の完全性(G542、G548)
+
+- **`automation runs-audit` + ドメインスコープの publish 検証**(G542) — 新コマンド
+  `automation runs-audit [--repo <r>] [--domain <d>] [--write] [--apply-inferred]
+  --format json|markdown` が、`runs.jsonl` の不正な行を 1 パスで全件報告します: 行番号、欠落必須
+  フィールド、所有ドメイン、そして無損失に導出できる場合の record 内修復。`--write` は
+  **record 内** の修復のみを適用し(`ts` はその record 自身の `timestamp` から、`execution_unit` は
+  文書化された 2 つの行形における `wip[0].eu` / `stage1.eu` から)、修復ごとに `runs-repair` 監査
+  イベントを 1 件追記し、無関係なバイトをすべて保存します。record 内に導出元が無いフィールドは常に
+  `non_derivable` であり、別個の明示的な `--apply-inferred` フラグのみが peer-convention による
+  推測を適用し `derivation: inferred-peer-convention` として記録します — 2 つの導出クラスが混ざる
+  ことはありません。publish 検証は **ドメインスコープ** になりました: `issue publish-flow` は
+  `runs.jsonl` を 1 行ずつパースし、**別ドメイン** に属する不正行は hard block ではなく
+  `runs-audit` を名指しする warning になります。同一ドメインまたはドメイン解決不能な行は従来どおり
+  fail-closed です。
+- **queue-state の no-item-loss 不変条件と stale-base 再適用**(G548) — `queue-state.json` は
+  マルチドメイン host において全ドメインが共有する 1 ファイルであり、複数のチェックアウトから並行に
+  書き込まれます。従来はどの canonical writer もファイル全体を deserialize し、メモリ上で変更し、
+  全体を再 serialize していたため、read-modify-write の競合は単に衝突するのではなく、stale な
+  メモリ上のコピーに欠けていたものを **静かに消去** していました。いまや **19 件** の canonical
+  な変更がすべて 1 つの共有永続化層を通り、3 つの保証を提供します: **stale-base 検出と再適用**
+  (呼び出し側が読んだ base を persist 時点のディスク上の状態と同じ serializer ラウンドトリップで
+  比較するため、単なる整形ゆらぎを並行書き込みと誤認しません。不一致時は呼び出し側の item 単位の
+  delta を fresh state に再適用し、その再適用を呼び出し側へ報告するので不可視になりません)、
+  **no-item-loss 不変条件**(ディスク上に存在するが outgoing state に無く、expected removal として
+  名指しもされていない execution unit があれば書き込みを中止し、該当ユニットと canonical な復旧
+  経路を名指ししたうえでファイルを一切変更しません)、**item スコープの再適用**(再適用は delta が
+  カバーするユニットと `updated_at` のみに触れ、無関係な item は fresh state の順序のまま
+  バイト同一で引き継がれます)。retire や completed-item ライフサイクルなど正当な削除は対象ユニットを
+  expected removal として渡すため、不変条件が対象とするのは **要求されていない** 損失のみです。
+  2026-07-23 の、クロスドメインの書き込みが 1 時間前に seed された item を落とし、4 日間不可視の
+  まま循環的な復旧デッドロックを生んだインシデントを閉じます。
+
+### 運用ガイダンス(G539)
+
+- **design-thread watchdog が RECOMMENDED な既定のセーフティネット**(G539) — 設計スレッドから
+  30 分オーダーの間隔で回す watchdog ループが `automation heartbeat` を呼び、`stale=true` のときに
+  canonical な nudge を最大 1 通送り、それ以外は沈黙します。**orchestrator 側の長間隔 automation**
+  (同じ heartbeat 呼び出しを orchestrator 自身のスレッドから 30〜60 分オーダーで回す)は選択可能な
+  ALTERNATIVE として文書化され、loopless か hop が 1 つ少ないかのトレードオフが明示されます。
+  `automation heartbeat` / `automation stalled-work` の挙動は不変でスケジューラー非依存のままです。
+  watchdog の安全ルールと legacy な 5 分の orchestrator フォールバックタイマーはそのまま保存されます。
+
+> #### v0.5.0 の外部スケジューラー推奨を置き換えます
+>
+> v0.5.0 時点のガイダンスは **外部 cron/launchd の OS スケジューラーによる heartbeat runner** を
+> 推奨していました。G539 はこの推奨を **retire** します。理由はフィールド証拠とともに記録されて
+> います: cron コンテキストからは credential store / keychain に到達できないため、runner は
+> **5 日間連続で毎回 silent に失敗** し(2026-07-15..07-20)、`automation stalled-work` が正しく
+> 検出していたにもかかわらず 105 分の stall が復旧されず、人間の ping でようやく表面化しました。
+> 外部スケジューラーはそもそも agmsg モデルの外側にも位置します。ときどき再起動するが
+> **壊れたときに可視** な watchdog のほうが、誰かがログを見に行くまで不可視に走り続けるものより
+> 強い保証です。現行ガイダンス:
+> [agent メッセージオーケストレーション — design-thread watchdog](12-agent-message-orchestration.md#design-thread-watchdog推奨されるセーフティネット)。
+
+## 本リリースで retire される workaround
+
+フィールドの利用者が運用してきた文書化済みの workaround を、本リリースは不要にします。
+`v0.6.0` インストール後:
+
+- **title-convention workaround** — 不要になります。execution unit の識別は title 単独を信用せず
+  実際の packet/queue linkage で corroborate されます(v0.5.0 の G532 で出荷済み。本リリースは
+  周辺の検出カバレッジを完成させ、この workaround に残っていたフォールバック的役割もなくします)。
+- **top-level `domain:` フィールドの重複** — 不要になります。ドメイン解決とドメインスコープの
+  publish 検証(G542)が文書化された解決順で所有ドメインを読むため、別ドメインの不正行で
+  publish-flow の検証が転ばないようにするための互換フィールド重複は必要ありません。
+- **queue-state の手編集による復旧** — retire されます。G548 の no-item-loss 不変条件と stale-base
+  再適用が、手編集を必要にしていた silent な損失のクラスを塞ぎ、`automation runs-audit`(G542)と
+  canonical な queue 遷移が、従来手段の無かった修復経路をカバーします。
+- **repair stall の手動 ping** — retire されます。`repair-stalled`(G546)が、`--repair-silent-minutes`
+  経過後の silent な repair claim を status-check 推奨付きの actionable な item に昇格させるため、
+  stall した repair が人間の気づきに依存しなくなります。`blocked-label-drift`(G545)も同様に、
+  blocked ユニットの GitHub label の手動 reconcile を canonical コマンド名の提示に置き換えます。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.0
+```
+
+または
+[v0.6.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.6.0)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを検証します。
+
+## v0.5.0 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.6.0
+```
+
+本リリースは **互換性に配慮しており意図として非破壊** ですが、いくつかのスライスは既出コマンドの
+挙動を変更します。従来の挙動に依存している場合は以下を必ず確認してください:
+
+- **追加のみ・対応不要**: 新コマンド(`automation runs-audit`、`queue priority-drift`、
+  `automation issue-block`)はオプトインのサーフェスであり、新しい stalled-work kind
+  (`backlog-ready-idle`、`blocked-label-drift`、`repair-stalled`)は既存の read-only サーフェスに
+  より細かい分類を追加するだけです。
+- **是正的 — 既出コマンドの挙動変更**:
+  - **G545** — `automation stalled-work` は queue item が `state=blocked` のユニットについて
+    `claimed-but-silent` を報告しなくなります。すべての `claimed-but-silent` を要 nudge として
+    扱っていた呼び出し側は item が減り、blocked だが未 reconcile のユニットは代わりに
+    `blocked-label-drift` として現れます。
+  - **G546** — repair/rereview label を持つ PR が `--repair-silent-minutes` を超えると、
+    informational ではなく **actionable**(`stalled: true`)になります。`stalled == true` で
+    フィルタしていた呼び出し側にはこれらの item が新たに見えます。
+  - **G542** — `issue publish-flow` は **別ドメイン** に属する不正な `runs.jsonl` 行で hard block
+    しなくなり、warning を出して `runs-audit` を名指しします。同一ドメイン・ドメイン解決不能な行は
+    従来どおり fail-closed です。
+  - **G548** — canonical な queue-state 書き込みは、落とすことになるユニットを名指しした
+    no-item-loss エラーで **中止** されうるようになりました(従来は成功して静かに失っていました)。
+    base が stale な書き込みは fresh state に対して再適用され、その再適用が **報告** されます。
+    これは意図した是正ですが、queue-state 書き込みが常に成功すると仮定していた呼び出し側は
+    中止を扱う必要があります。
+  - **G543** — priority の順序付け自体は挙動不変ですが、共有・文書化されました。
+    `queue priority-drift` は従来見えなかった legacy な enum 外の値(例: `medium`)を可視化します。
+- **ドキュメント上の位置づけ変更**: orchestrator モードはどこにおいても preview/experimental とは
+  記述されなくなりました(G540/G541)。timer-loop モードは不変で、引き続き完全にサポートされます。
+
+package id・ライセンス・CLI の引数/フラグ形の変更はありません。上記の是正的変更はいずれも、
+各コマンド自身の文書化された意図に挙動を一致させるものです。
+
+## リリース準備ゲート(G551)
+
+以下は `v0.6.0` の **GitHub Release を publish する前に** 成立していなければなりません。
+このゲートは fail-closed です — 1 つでも満たされないなら Release を publish しないでください。
+
+- [ ] リリース対象の全 packet が **完了し、その PR が `main` にマージ済み**:
+      G539, G540, G541, G542, G543, G544, G545, G546, G548, G549, G550(および本 G551
+      release-notes prep)。host/review 側で host queue-state / GitHub PR 状態を用いて確認します —
+      child implementation loop は parent queue-state を読めないため、これは host 所有の前提条件です。
+- [ ] **G547 が terminally retired であることの確認** と、本リリースに何も寄与しないこと。
+      その後継が本 G551 パケットです。
+- [ ] 本リリース向けの open PR / WIP packet が誤って漏れていないこと(publish 前に host queue /
+      open PR 一覧を確認)。
+- [ ] `eng/version.json` が `stableVersion` `0.5.0`、`nextVersion` `0.6.0`(リリース対象)を示すこと。
+      `release.yml` は publish された Release/タグから package version を組み立て、
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` は同じポリシーからローカル既定を導出します。
+- [ ] package メタデータが正しいこと: `PackageId = JTechJapan.IntentSystem.Cli`、
+      `RepositoryUrl` / `PackageProjectUrl` が
+      `https://github.com/J-Tech-Japan/intent-system` を指し、
+      `PackageLicenseExpression = Apache-2.0`、README/docs のリンクが解決し、公式サービスサイト
+      `https://www.intent-driven-development.com/` が README からリンクされていること。
+- [ ] リリースノート / README が 4 スレッドオーケストレーションを **PRIMARY** モデル、timer-loop
+      モードを完全にサポートされた代替として記述し、preview/experimental の表現が **残っていない**
+      こと(G540/G541)。
+- [ ] **Main CI が green**(`Build and test (source contract)`)であること、および **preview-pack**
+      ワークフローが green であること。
+- [ ] **マージ後の build + pack 証跡** がマージコミットに対して PR に記録されていること
+      (G528/G538 の準備ゲートに準拠)。
+
+## v0.6.0 の publish
+
+本パケットはリリースを publish せず、publish ステップを **追加しません**。version-bump マージ自体は
+GitHub Release もタグも作成しません。
+
+1. 本 version bump がマージされ上記の準備ゲートが成立した後、**メンテナ/オペレーター(または外部の
+   リリース automation)が `v0.6.0` の GitHub Release を作成・publish** します(リリースコミットに
+   タグ付け)。これはマージ後の host/オペレーター/外部のアクションです。
+2. その GitHub Release の publish が `.github/workflows/release.yml`(`on: release: published`)を
+   発火させ、NuGet package とプラットフォーム別バイナリアーカイブ(`.sha256` チェックサム付き)を
+   build・publish し、トリガーとなった Release に添付します。
+
+publish 後の検証(GitHub Release が publish され `release.yml` が実行された後):
+
+- [ ] NuGet.org の package ページのリンクがすべて正しく解決すること。
+- [ ] GitHub release の成果物リンク(`.tar.gz`、`.zip`、`.exe`、`.nupkg`)にアクセスできること。
+- [ ] `.sha256` チェックサムがダウンロードした成果物と一致すること。
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`(または
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.0`)の後、
+      `intent-cli --version` が `0.6.0` を報告すること。
+- [ ] バイナリ成果物のスモークチェック: プラットフォームアーカイブをダウンロードし `.sha256` を
+      検証、展開して `./intent-cli --version` → `0.6.0`。
+- [ ] **新コマンドのスモーク**: `intent-cli automation runs-audit --domain <d> --format json`、
+      `intent-cli queue priority-drift --format json`、`intent-cli automation issue-block --help`
+      がいずれも実リポジトリに対してクラッシュせず実行できること。
+- [ ] **stall 検出のスモーク**(G544/G545/G546): `intent-cli automation stalled-work --domain <d>
+      --repo <r> --format json` が該当時に新 kind `backlog-ready-idle` / `blocked-label-drift` /
+      `repair-stalled` を報告し、`repair-stalled` が `stalled: true` を持つこと。
+- [ ] **queue-state 完全性のスモーク**(G548): ディスク上の state に余分なユニットを含む fixture に
+      対する canonical な queue 変更が、そのユニットを名指しした no-item-loss エラーで中止し、
+      ファイルを一切変更しないこと。
+- [ ] **provisioning / supervision ガイダンスのスモーク**(G549/G550): `intent-cli guide
+      orchestrator-thread --format markdown` が `Terminal-workspace provisioning` と
+      `Design-thread workspace supervision` の両セクションをレンダリングすること。
+- [ ] オペレーターに `v0.6.0` GitHub Release の publish を通知し、続いて
+      sekiban-as-a-service-orch に対して
+      [本リリースで retire される workaround](#本リリースで-retire-される-workaround)
+      に列挙した workaround を `v0.6.0` インストール後に外すよう通知すること。
+- [ ] ローカル preview/dry-run の version メタデータを `0.6.0` の次の開発ラインにすること
+      ([バージョンフロー](09-developer-reference.md#バージョンフロー) のリリース後手順に従い
+      `eng/version.json` をバンプ): `stableVersion → 0.6.0`、`nextVersion → 0.6.1`。この bump は
+      本パケットではなく **次の** release-prep パケットに委ねられます。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.4.0",
-  "nextVersion": "0.5.0"
+  "stableVersion": "0.5.0",
+  "nextVersion": "0.6.0"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV060DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV060DocsTests.cs
@@ -1,0 +1,239 @@
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G551: the v0.6.0 release-prep deliverable is documentation, so these tests
+/// pin it the way code is pinned — both language mirrors exist, they cover
+/// exactly the slices that actually merged, they carry the prepare-only
+/// publishing contract, and they state the two things a reader would otherwise
+/// get wrong: that G547 is retired rather than shipped, and that the v0.5.0
+/// external-scheduler recommendation is superseded.
+/// </summary>
+public sealed class ReleaseNotesV060DocsTests
+{
+    /// <summary>
+    /// The eleven unit ids that actually merged after v0.5.0. G547 is
+    /// deliberately absent — it was terminally retired and re-cut as G551, so
+    /// listing it would describe unshipped work as shipped.
+    /// </summary>
+    private static readonly string[] MergedSlices =
+    [
+        "G539", "G540", "G541", "G542", "G543",
+        "G544", "G545", "G546", "G548", "G549", "G550",
+    ];
+
+    [Fact]
+    public void VersionPolicy_RecordsTheV060ReleaseToBeCut_G551()
+    {
+        var policy = VersionPolicy.TryReadFromRepo(RepoRoot());
+
+        Assert.NotNull(policy);
+        Assert.Equal("0.5.0", policy.StableVersion);
+        Assert.Equal("0.6.0", policy.NextVersion);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_CoverEveryMergedSlice_AndNeverListG547AsShipped(string language)
+    {
+        var notes = ReadReleaseNotes(language);
+
+        foreach (var slice in MergedSlices)
+        {
+            Assert.Contains(slice, notes, StringComparison.Ordinal);
+        }
+
+        // G547 may only appear in the retired/not-shipped explanation, never in
+        // the shipped-slice enumeration.
+        Assert.Contains("G547", notes, StringComparison.Ordinal);
+        Assert.Contains("G551", notes, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EnglishNotes_ExplainG547AsRetiredAndRecutAsG551_G551()
+    {
+        var notes = ReadReleaseNotes("en");
+
+        Assert.Contains("**G547 is deliberately absent from the slice list above.**", notes, StringComparison.Ordinal);
+        Assert.Contains("terminal for a unit id", notes, StringComparison.Ordinal);
+        Assert.Contains("**G551**, this packet", notes, StringComparison.Ordinal);
+        Assert.Contains("G547 shipped no code and no documentation", notes, StringComparison.Ordinal);
+        // The unit range is described honestly: twelve ids, eleven shipped.
+        Assert.Contains("twelve unit ids of which **eleven are merged and shipped here**", notes, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void JapaneseNotes_ExplainG547AsRetiredAndRecutAsG551_G551()
+    {
+        var notes = ReadReleaseNotes("ja");
+
+        Assert.Contains("**G547 は上記のスライス一覧に意図的に含まれていません。**", notes, StringComparison.Ordinal);
+        Assert.Contains("retire はユニット ID に 対して terminal", notes, StringComparison.Ordinal);
+        Assert.Contains("新しいユニットである本パケット **G551** になります", notes, StringComparison.Ordinal);
+        Assert.Contains("**本リリースでマージ・出荷されるのはそのうち 11 件**", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_GroupSlicesByTheme_AndStateTheMinorBumpRationale(string language)
+    {
+        var notes = ReadReleaseNotes(language);
+
+        // Four themes, in both mirrors.
+        foreach (var themeMarker in ThemeMarkers(language))
+        {
+            Assert.Contains(themeMarker, notes, StringComparison.Ordinal);
+        }
+
+        // Minor-bump rationale: new detection kinds, new command surface,
+        // visible behavior changes, primary-model repositioning.
+        foreach (var kind in new[] { "backlog-ready-idle", "blocked-label-drift", "repair-stalled" })
+        {
+            Assert.Contains(kind, notes, StringComparison.Ordinal);
+        }
+
+        foreach (var command in new[] { "automation runs-audit", "queue priority-drift", "automation issue-block" })
+        {
+            Assert.Contains(command, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains(language == "en" ? "**minor release**" : "**minor リリース**", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_SupersedeTheV050ExternalSchedulerRecommendation(string language)
+    {
+        var notes = ReadReleaseNotes(language);
+
+        if (language == "en")
+        {
+            Assert.Contains("#### Supersedes the v0.5.0 external-scheduler recommendation", notes, StringComparison.Ordinal);
+            Assert.Contains("external cron/launchd OS-scheduler", notes, StringComparison.Ordinal);
+            // The reason and its field evidence, not just the fact.
+            Assert.Contains("credential store/keychain is unreachable from a cron", notes, StringComparison.Ordinal);
+            Assert.Contains("silently on every run for five continuous", notes, StringComparison.Ordinal);
+        }
+        else
+        {
+            Assert.Contains("#### v0.5.0 の外部スケジューラー推奨を置き換えます", notes, StringComparison.Ordinal);
+            Assert.Contains("外部 cron/launchd の OS スケジューラー", notes, StringComparison.Ordinal);
+            Assert.Contains("credential store / keychain に到達できない", notes, StringComparison.Ordinal);
+            Assert.Contains("5 日間連続で毎回 silent に失敗", notes, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_ListTheRetiredWorkarounds(string language)
+    {
+        var notes = ReadReleaseNotes(language);
+
+        if (language == "en")
+        {
+            Assert.Contains("## Workarounds retired by this release", notes, StringComparison.Ordinal);
+            Assert.Contains("**Title-convention workaround**", notes, StringComparison.Ordinal);
+            Assert.Contains("**Duplicated top-level `domain:` fields**", notes, StringComparison.Ordinal);
+            Assert.Contains("**Queue-state hand-edit recovery**", notes, StringComparison.Ordinal);
+            Assert.Contains("**Manual repair-stall pings**", notes, StringComparison.Ordinal);
+        }
+        else
+        {
+            Assert.Contains("## 本リリースで retire される workaround", notes, StringComparison.Ordinal);
+            Assert.Contains("**title-convention workaround**", notes, StringComparison.Ordinal);
+            Assert.Contains("**top-level `domain:` フィールドの重複**", notes, StringComparison.Ordinal);
+            Assert.Contains("**queue-state の手編集による復旧**", notes, StringComparison.Ordinal);
+            Assert.Contains("**repair stall の手動 ping**", notes, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_ArePrepareOnly_NoTagOrReleaseOrPublishStep(string language)
+    {
+        var notes = ReadReleaseNotes(language);
+
+        // The prepare-only contract and the readiness gate are both present.
+        Assert.Contains("prepare-only", notes, StringComparison.Ordinal);
+        Assert.Contains("G551", notes, StringComparison.Ordinal);
+        Assert.Contains("release.yml", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "## Release-readiness gate (G551)" : "## リリース準備ゲート(G551)",
+            notes,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "## Publishing v0.6.0" : "## v0.6.0 の publish",
+            notes,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrepareOnlyDiff_AddsNoTagOrPublishAutomation_G551()
+    {
+        // The packet is documentation + version metadata only. If a future edit
+        // ever adds a publish step to this repo's release path, the release
+        // model changes and this packet's contract no longer holds — so pin
+        // that release.yml still triggers on a published Release rather than on
+        // the version-bump merge landing.
+        var releaseWorkflow = Path.Combine(RepoRoot(), ".github", "workflows", "release.yml");
+        Assert.True(File.Exists(releaseWorkflow), $"Expected {releaseWorkflow} to exist.");
+
+        var workflow = File.ReadAllText(releaseWorkflow);
+        Assert.Contains("release:", workflow, StringComparison.Ordinal);
+        Assert.Contains("published", workflow, StringComparison.Ordinal);
+    }
+
+    private static string[] ThemeMarkers(string language) => language == "en"
+        ?
+        [
+            "### Primary-model repositioning and provisioning",
+            "### Stall-detection completion",
+            "### Durable-state integrity",
+            "### Operational guidance",
+        ]
+        :
+        [
+            "### primary モデルへの再配置と provisioning",
+            "### stall 検出の完成",
+            "### durable state の完全性",
+            "### 運用ガイダンス",
+        ];
+
+    private static string ReadReleaseNotes(string language)
+    {
+        var path = Path.Combine(RepoRoot(), "docs", language, "release-notes-v0.6.0.md");
+        Assert.True(File.Exists(path), $"Expected {path} to exist.");
+
+        // Both mirrors are hard-wrapped and much of the guidance lives inside
+        // blockquotes, so a sentence spans lines and carries `> ` continuation
+        // markers. Strip the markers and collapse whitespace runs so the
+        // assertions pin wording, not wrap points.
+        var unwrapped = File.ReadAllLines(path)
+            .Select(line => line.TrimStart().TrimStart('>'));
+
+        return string.Join(' ', string.Join('\n', unwrapped)
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    private static string RepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "eng", "version.json")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate the repository root from {AppContext.BaseDirectory}.");
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,14 +124,16 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.5.0 as the next development line
-        // (post-v0.4.0 release bump, see G538 — v0.4.0 was published to
+        // be parseable and must point to 0.6.0 as the next development line
+        // (post-v0.5.0 release bump, see G551 — v0.5.0 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.5.0 — a minor bump, since the batch ships two new
-        // commands (`intent facet-check`, `queue reprioritize`), a new
-        // intent-tree schema surface (`facets`), new stalled-work kinds, and
-        // a new transition target (`retired`) — while recording 0.4.0 as
-        // the published stable).
+        // forward to 0.6.0 — a minor bump, since the batch ships three new
+        // stalled-work kinds (`backlog-ready-idle`, `blocked-label-drift`,
+        // `repair-stalled`), three new commands (`automation runs-audit`,
+        // `queue priority-drift`, `automation issue-block`), visible behavior
+        // changes to already-shipped commands, and the repositioning of
+        // four-thread agmsg orchestration as the primary documented model —
+        // while recording 0.5.0 as the published stable).
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -141,8 +143,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.5.0", policy.NextVersion);
-        Assert.Equal("0.4.0", policy.StableVersion);
+        Assert.Equal("0.6.0", policy.NextVersion);
+        Assert.Equal("0.5.0", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

**Prepare-only** release metadata for intent-cli **v0.6.0**. Advances `eng/version.json` to `stableVersion 0.5.0` / `nextVersion 0.6.0` and authors ja/en release notes for the slices merged since v0.5.0. Per the G528/G538 release model this PR creates **no tag, no GitHub Release, and no publish step** — a maintainer/operator publishes the Release afterwards, which fires `release.yml`.

## Slice coverage — and why G547 is absent

The notes cover the **eleven slices that actually merged**: G539, G540, G541, G542, G543, G544, G545, G546, G548, G549, G550.

> ⚠️ **The packet says "twelve slices G539–G550"; eleven merged.** The count does not subtract **G547**, which was terminally retired when the operator directed that G549/G550 join the release scope — G547 merged no code and no documentation, and its continuation is this G551 unit. Listing it among the shipped slices would misreport unshipped work, which the packet's own baseline forbids ("release notes must reflect merged behavior exactly"). This was raised with the orchestrator, which **escalated it to host/design as a packet/AC arithmetic inconsistency** and confirmed the truthful representation used here. The explanation is isolated in **one blockquote per mirror** so a different canonical phrase can replace it without touching anything else.

## Release notes content

Grouped by theme, per the packet:

- **Primary-model repositioning and provisioning** (G540/G541, G549, G550) — four-thread orchestration as the PRIMARY documented model with the double-check rule and ADR 0001; terminal-workspace provisioning; design-thread supervision authority.
- **Stall-detection completion** (G543, G544, G545, G546) — `backlog-ready-idle`, the queue-`blocked` exemption plus `blocked-label-drift` and `automation issue-block`, `repair-stalled`, and the unified priority classification with `queue priority-drift`.
- **Durable-state integrity** (G542, G548) — `automation runs-audit` with domain-scoped publish validation; the queue-state no-item-loss invariant with stale-base re-application across all 19 canonical mutations.
- **Operational guidance** (G539) — the design-thread watchdog as the recommended default.

Plus:

- **Minor-bump rationale** — three new stalled-work kinds, three new commands, visible behavior changes to shipped commands, and the primary-model repositioning.
- **Supersession of the v0.5.0 external-scheduler recommendation** — stated with G539's reason (credential store unreachable from cron) and its field evidence (silent failure on every run for five continuous days; a 105-minute stall detected but unrecovered).
- **Workarounds retired by this release** — title convention, duplicated top-level `domain:` fields, queue-state hand-edit recovery, manual repair-stall pings.
- **Upgrade section** separating additive surfaces from the five corrective behavior changes (G542, G543, G545, G546, G548) a consumer must read.
- **Release-readiness gate (G551)** and the **prepare-only publishing** section per the G528 pattern.

## Surfaces touched

- `eng/version.json` — `0.4.0/0.5.0` → `0.5.0/0.6.0`.
- `docs/en/release-notes-v0.6.0.md`, `docs/ja/release-notes-v0.6.0.md` — new.
- `docs/en/09-developer-reference.md`, `docs/ja/09-developer-reference.md` — version-flow tables/snippets move to the 0.6.0 line; the "next release readiness" sections are re-cut for v0.6.0.
- `tests/IntentSystem.Cli.Tests/ReleaseNotesV060DocsTests.cs` — new, 14 tests.
- `tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs` — the in-repo version smoke test now expects `0.5.0`/`0.6.0`.

**No `src/` changes and no `.github/` changes** — verified on the staged diff.

## Verification (release-readiness gate, run pre-merge)

```
$ cat eng/version.json                 # stableVersion 0.5.0, nextVersion 0.6.0 ✔
$ dotnet build … -c Release            # Build succeeded ✔
$ dotnet run … -c Release -- --version # intent-cli 0.6.0-3368209-G550 ✔ (not a stale literal)
$ dotnet pack … -c Release             # JTechJapan.IntentSystem.Cli.0.6.0.nupkg ✔
$ dotnet test … -c Release --filter ReleasePackageMetadataTests   # 5/5 ✔
```

- `dotnet test IntentSystem.sln` — **all green** (CLI suite 3858 passed / 0 failed; every other project passed).
- Focused: `ReleaseNotesV060DocsTests` → **14 passed / 0 failed**.
- Internal anchors in both release-notes mirrors verified to resolve against their own headings.
- `git diff --check` clean.

## Note for the operator (out of scope here)

`.artifacts/` is **not** in `.gitignore`, so the `dotnet pack -o .artifacts/packages` step this gate prescribes leaves a committable `.nupkg` in the working tree. I removed mine before committing. Adding the ignore entry is outside this packet's target paths — flagging it rather than expanding scope.

Closes #1205

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPT7cFrCzT6ehACFez8dpE
