### PR TITLE
G552: Make blocked-on-design visible and bounded — design-decision-pending detection, clarification-backed holds, bounded default authority

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -329,6 +329,30 @@ is always a runnable `intent-cli` command):
   closed like `claimed-but-silent`: a missing or malformed `updatedAt` means
   silence cannot be established, so the PR is **not** promoted rather than
   flagged on unusable evidence.
+- `design-decision-pending` (G552) — a hold blocked on a **design decision**,
+  recorded as an OPEN clarification artifact through the canonical clarify
+  surface (`intent-cli clarify open`). Reports the blocking execution unit,
+  the clarification's age (from the artifact's own `createdAt` — the moment
+  the block was recorded), and a one-line question summary.
+  `recommended_action` names the exact clarification to answer
+  (`intent-cli clarify answer --execution-unit <unit> --question-id <id>
+  --answer "<decision>"`) plus the operator escalation path; it **never**
+  auto-answers, because the answer is design's content. Answering (or
+  applying, or cancelling) the clarification is what clears the item — no
+  threshold and no separate transition. This is the only kind here with no
+  GitHub entity of its own, which is exactly why the stall it detects was
+  invisible: field incident 2026-07-28 16:11 → 07-29 01:29, where the G551
+  review held its final verdict for **nine hours** on a one-line wording
+  ruling while every technical check was green, the hold lived only in agmsg
+  messages, and `stalled-work` reported `stalled: false` throughout — the
+  fourth design-absence stall in the field record. Fails closed in both
+  directions: an artifact that cannot be read or deserialized goes to
+  `excluded[]` with its path (`clarification-unreadable`) rather than being
+  skipped as answered, and a clarification whose packet declares a different
+  domain is excluded rather than attributed to the requested domain. The
+  guide's clarification-backed hold rule is what puts the artifact on disk
+  for this kind to read — an agmsg-only hold is a contract violation, and if
+  the hold is real but this kind is absent, the artifact was never recorded.
 
 **Informational categories (G533)** — `is_informational: true`,
 `recommended_action` is descriptive prose (never a transition command), age

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -266,6 +266,21 @@ makes the hold detectable; the message is only a notification.
 > artifact exists; if the artifact does not exist, you are not waiting, you are
 > stalled.
 
+The OPEN artifact itself carries that content — an agmsg message may notify,
+but it can never substitute for the durable record:
+
+```bash
+intent-cli clarify open <execution-unit> \
+  --question "<the actual design-blocking question, answerable by someone outside the thread>" \
+  --recommended-answer "<what you believe the answer is, when you believe you know it>" \
+  --evidence "<the repository facts that support the recommendation>"
+```
+
+The question lands in the artifact's `QuestionText`; the recommendation and its
+evidence land in the artifact's `Reason` under `Recommended answer:` and
+`Evidence:` labels. All three flags are optional — omit them and the pre-G552
+packet-derived behavior is unchanged. **No clarification schema change.**
+
 **Reviewer hold rule (refined).** Technical checks green and the only pending
 item non-semantic and mechanically fact-checkable → resolve it under bounded
 default authority, log the verifying facts, and proceed. Anything else →
@@ -291,6 +306,30 @@ records what was decided, which facts entail it, and which threads agreed — an
 unlogged resolution is a violation, not a resolution), and **amendable**
 (design may review the evidence afterwards and reverse it; the authority buys
 latency, not finality).
+
+**The evidence sink is `clarify record --from-file`** — the entry lands under
+`## Recently Resolved` in the domain's clarification return path
+(`intents/<domain>/clarifications/open.md`), where **Question** identifies the
+pending item, **Decision** records the decided value, and **Rationale** records
+the verified repository facts plus the reviewer/orchestrator agreement. The
+entry stays readable there, which is what makes design's post-hoc amendment
+possible — and a later amendment adds to the trail rather than erasing what it
+amends:
+
+```bash
+cat > /tmp/authority-decision.md <<'EOF'
+## Question
+<the pending item, identified so design can find it later>
+
+## Decision
+<the decided value>
+
+## Rationale
+<the verified repository facts that entail it, and which threads agreed>
+EOF
+
+intent-cli clarify record --domain <domain> --from-file /tmp/authority-decision.md
+```
 
 > **Semantic and product decisions are excluded, absolutely.** Intent shaping,
 > packet content and acceptance criteria, release scope, and prioritization

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -243,6 +243,79 @@ apply to all supervision verbatim: no duplicate delegation, no clearing a
 permission prompt, no cancelling or resetting in-flight work, no force-closing an
 issue/PR, and no speculative durable-state surgery.
 
+## Design-decision holds and bounded authority
+
+A hold blocked on a **design decision** must be **visible** and **bounded**.
+Measured cost of neither: the G551 review held its final verdict for **nine
+hours** on a one-line wording ruling while every technical check was green, the
+pending item was mechanically fact-checkable, both threads knew the answer — and
+the hold lived only in agmsg messages, so `automation stalled-work` reported
+`stalled: false` throughout. Fourth design-absence stall in the field record.
+
+**Clarification-backed holds.** When the orchestrator or reviewer blocks on a
+design decision it **records a clarification artifact** through the canonical
+clarify surface (`intent-cli clarify open`), in addition to any agmsg message:
+domain, blocking execution unit, the question stated so someone outside the
+thread can answer it, and — when the asking thread believes it knows the answer
+— the recommended answer with the facts supporting it. The artifact is what
+makes the hold detectable; the message is only a notification.
+
+> **An agmsg-only hold is a contract violation.** A block that exists only as
+> messages is invisible to `stalled-work`, to `heartbeat`, and therefore to
+> every watchdog and every operator glance. If you are waiting on design, the
+> artifact exists; if the artifact does not exist, you are not waiting, you are
+> stalled.
+
+**Reviewer hold rule (refined).** Technical checks green and the only pending
+item non-semantic and mechanically fact-checkable → resolve it under bounded
+default authority, log the verifying facts, and proceed. Anything else →
+record the clarification and keep the hold as a **visible pending state**.
+There is no third option in which the reviewer simply waits and says so in a
+message.
+
+**Bounded default authority.** The operator may pre-delegate a small
+enumerated set of decision classes that are settled by *checking repository
+facts* rather than by judgment:
+
+| decision class | what verifies it |
+| --- | --- |
+| count and enumeration corrections | the count is derivable from repository facts both threads can read (e.g. a slice count from the merged PR list) |
+| wording corrections that follow from a cited fact | the wording is entailed by a repository fact, and reviewer and orchestrator agree on both the fact and the correction |
+| cross-reference and link corrections | the target exists (or does not) as cited — verifiable by reading it |
+| identifier and metadata mismatches against a canonical source | the canonical source is named and read; it wins, and the resolution cites it |
+
+It is bounded in every direction: **granted** (never assumed — absent an
+operator grant every design decision goes to design as before), **enumerated**
+(the table above is the whole MAY scope), **evidence-logged** (a resolution
+records what was decided, which facts entail it, and which threads agreed — an
+unlogged resolution is a violation, not a resolution), and **amendable**
+(design may review the evidence afterwards and reverse it; the authority buys
+latency, not finality).
+
+> **Semantic and product decisions are excluded, absolutely.** Intent shaping,
+> packet content and acceptance criteria, release scope, and prioritization
+> rulings always go to design through the
+> [design↔orchestrator double-check rule](#role-boundary--design-authors-orchestrator-coordinates),
+> whose scope this contract does not touch. If settling the question requires
+> deciding what *should* be true rather than checking what *is* true, this
+> authority does not reach it.
+
+**Periodic design-reminder loop.** While a clarification stays open the
+**orchestrator** re-sends a reminder to design from its existing long-interval
+automation — no new scheduler, receivers stay loopless — at a **30–60 minute
+class** interval, **at most one reminder per interval per open clarification**,
+**stopping when it is answered**. The design thread runs in the **operator app**
+by preference, which makes the reminder land either way: an open session
+receives it immediately through its monitor, a closed one finds it in the inbox
+on resume. Nothing here requires design to be resident in the team workspace.
+
+**Detection.** `automation stalled-work` reports each open clarification as
+`design-decision-pending` with its age, blocking unit, and question summary,
+and `automation heartbeat` carries it in `message_body` like any other kind —
+see [09-developer-reference.md](09-developer-reference.md). If a hold is real
+but the kind is absent, the artifact was never recorded: that is the contract
+violation above, not a detector bug.
+
 ## Role boundary — design authors, orchestrator coordinates
 
 **Design creates packets; the orchestrator moves ready packets through the

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -330,6 +330,29 @@ queue-state、`runs.jsonl` を変更することは一切ありません — inf
   これを更新します)。`claimed-but-silent` と同様に fail closed です:
   `updatedAt` が欠落・不正な場合は沈黙を確立できないため、使えない証拠に
   基づいて flag するのではなく promotion **しません**。
+- `design-decision-pending` (G552) — **design の判断** で止まっている hold で、
+  canonical な clarify surface (`intent-cli clarify open`) を通じて OPEN な
+  clarification artifact として記録されたもの。ブロックされている execution
+  unit、clarification の age(artifact 自身の `createdAt` — ブロックが記録された
+  瞬間)、質問の 1 行サマリを報告します。`recommended_action` は、回答すべき
+  clarification を正確に名指しし(`intent-cli clarify answer --execution-unit
+  <unit> --question-id <id> --answer "<decision>"`)、オペレーターへの
+  エスカレーション経路も併記します。**自動回答は決してしません** — 回答は
+  design の content だからです。clarification に回答する(または applied /
+  cancelled にする)ことが item を消す唯一の方法で、閾値も別の transition も
+  ありません。これはここで唯一、自分自身の GitHub エンティティを持たない kind
+  であり、まさにそれが検出対象の stall が不可視だった理由です: field incident
+  2026-07-28 16:11 → 07-29 01:29 — G551 のレビューが、技術チェックがすべて
+  green のまま 1 行の wording 判断のために **9 時間** final verdict を保留し、
+  hold は agmsg メッセージ上にしか存在せず、`stalled-work` はその間ずっと
+  `stalled: false` を報告していました(field record で 4 件目の design 不在
+  stall)。両方向に fail closed です: 読めない・deserialize できない artifact は
+  「回答済み」として飛ばすのではなくパス付きで `excluded[]`
+  (`clarification-unreadable`)へ、packet が別 domain を宣言している
+  clarification は要求 domain に帰属させず除外します。この kind が読む artifact を
+  ディスク上に置くのは guide の clarification-backed hold ルールです — agmsg
+  だけの hold は contract violation であり、hold が実在するのにこの kind が
+  出ないなら、それは artifact が記録されなかったということです。
 
 **informational なカテゴリ (G533)** — `is_informational: true`、
 `recommended_action` は（transition コマンドではなく）説明的な prose、

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -229,6 +229,75 @@ permission の待ち** — 事前承認の有無にかかわらず回答不可�
 適用されます: 委譲の重複禁止、permission プロンプトの自動クリア禁止、進行中作業の cancel/reset
 禁止、issue/PR の force-close 禁止、durable state の投機的な手編集禁止。
 
+## design 判断による hold と bounded authority
+
+**design の判断** で止まっている hold は、**可視** かつ **bounded** でなければ
+なりません。どちらも欠けた場合の実測コスト: G551 のレビューは、技術チェックが
+すべて green で、保留項目は機械的に事実確認可能で、両スレッドとも答えを知って
+いたにもかかわらず、1 行の wording 判断のために final verdict を **9 時間**
+保留しました。hold は agmsg メッセージ上にしか存在しなかったため、
+`automation stalled-work` はその間ずっと `stalled: false` を報告していました
+(field record で 4 件目の design 不在 stall)。
+
+**clarification-backed hold。** orchestrator または reviewer が design の判断で
+ブロックされたとき、agmsg メッセージに加えて canonical な clarify surface
+(`intent-cli clarify open`)を通じて **clarification artifact を記録** します:
+domain、ブロックされている execution unit、スレッドの外にいる人でも答えられる
+形に書いた質問、そして — 質問側が答えを分かっていると考える場合は — 根拠となる
+事実つきの推奨回答。artifact が hold を検出可能にするものであり、メッセージは
+通知にすぎません。
+
+> **agmsg だけの hold は contract violation です。** メッセージ上にしか存在しない
+> ブロックは `stalled-work` にも `heartbeat` にも見えず、したがってあらゆる
+> watchdog とオペレーターの目視からも見えません。design を待っているなら artifact が
+> 存在するはずで、artifact が無いならそれは待っているのではなく stall しています。
+
+**reviewer hold ルール(refined)。** 技術チェックが green で、保留項目が
+非セマンティックかつ機械的に事実確認可能 → bounded default authority のもとで
+解決し、検証事実をログに残して先へ進みます。それ以外 → clarification を記録し、
+hold を **可視な pending state** として保ちます。reviewer が単に待ち、それを
+メッセージで述べるだけ、という第 3 の選択肢はありません。
+
+**bounded default authority。** オペレーターは、判断ではなく *リポジトリの事実を
+確認する* ことで決着する、少数の列挙された判断クラスを事前委譲できます:
+
+| 判断クラス | 何が検証するか |
+| --- | --- |
+| 件数・列挙の訂正 | 両スレッドが読めるリポジトリの事実から件数が導出できる(例: マージ済み PR 一覧からのスライス数) |
+| 引用された事実から導かれる wording 訂正 | wording がリポジトリの事実から entail され、reviewer と orchestrator が事実と訂正の両方に合意している |
+| 相互参照・リンクの訂正 | 参照先が記載どおり存在する(しない)ことを、読んで検証できる |
+| canonical source との識別子・メタデータ不一致 | canonical source を名指しして読む。canonical source が勝ち、解決はそれを引用する |
+
+これはあらゆる方向に bounded です: **付与される**(前提ではない — オペレーターの
+付与が無ければ、すべての design 判断は従来どおり design へ)、**列挙されている**
+(上表が MAY のスコープのすべて)、**証拠がログされる**(何を決めたか・どの事実が
+それを entail するか・どのスレッドが合意したかを記録する。ログの無い解決は解決では
+なく違反)、**修正可能**(design は後から証拠を確認して覆せる。この権限が買うのは
+レイテンシであって finality ではない)。
+
+> **セマンティック・プロダクトの判断は絶対に除外されます。** intent shaping、
+> packet 内容と受け入れ基準、リリーススコープ、優先度の裁定は、常に
+> [design↔orchestrator の double-check ルール](#ロール境界--design-が-authoringorchestrator-は-coordinate)
+> を通じて design へ行きます。本 contract はそのスコープに触れません。問いの決着に
+> 「何が *真である* かを確認する」のではなく「何が *真であるべきか* を決める」ことが
+> 必要なら、この権限は及びません。
+
+**定期的な design リマインダーループ。** clarification が open である間、
+**orchestrator** が既存の長間隔 automation からリマインダーを design に再送します
+— 新しいスケジューラーは不要で、receiver は loopless のまま。間隔は
+**30〜60 分オーダー**、**open な clarification 1 件につき 1 間隔あたり最大 1 通**、
+**回答されたら停止** します。design スレッドは既定で **オペレーターアプリ** 上で
+動くため、リマインダーはどちらの状態でも届きます: 開いているセッションは monitor
+経由で即座に受け取り、閉じているセッションは再開時に inbox で見つけます。design が
+チームのワークスペースに常駐している必要はありません。
+
+**検出。** `automation stalled-work` は open な clarification を
+`design-decision-pending` として age・ブロックされているユニット・質問サマリつきで
+報告し、`automation heartbeat` は他の kind と同様に `message_body` でそれを運びます
+— [09-developer-reference.md](09-developer-reference.md) を参照。hold が実在するのに
+この kind が出ないなら、artifact が記録されていないということです。それは上記の
+contract violation であって、detector のバグではありません。
+
 ## ロール境界 — design が authoring、orchestrator は coordinate
 
 **design が packet を作成し、orchestrator は ready な packet を workflow に通します。**

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -252,6 +252,21 @@ domain、ブロックされている execution unit、スレッドの外にい�
 > watchdog とオペレーターの目視からも見えません。design を待っているなら artifact が
 > 存在するはずで、artifact が無いならそれは待っているのではなく stall しています。
 
+その内容を運ぶのは OPEN artifact 自身です — agmsg メッセージは通知はできますが、
+durable な記録の代わりには決してなりません:
+
+```bash
+intent-cli clarify open <execution-unit> \
+  --question "<スレッドの外にいる人でも答えられる形の、実際にブロックしている設計質問>" \
+  --recommended-answer "<答えが分かっていると考える場合の推奨回答>" \
+  --evidence "<推奨回答を支えるリポジトリ上の事実>"
+```
+
+質問は artifact の `QuestionText` に、推奨回答と根拠は artifact の `Reason` に
+`Recommended answer:` / `Evidence:` ラベル付きで格納されます。3 つのフラグはすべて
+任意で、省略すれば G552 以前の packet 由来挙動のままです。**clarification の schema
+変更はありません。**
+
 **reviewer hold ルール(refined)。** 技術チェックが green で、保留項目が
 非セマンティックかつ機械的に事実確認可能 → bounded default authority のもとで
 解決し、検証事実をログに残して先へ進みます。それ以外 → clarification を記録し、
@@ -274,6 +289,29 @@ hold を **可視な pending state** として保ちます。reviewer が単に�
 それを entail するか・どのスレッドが合意したかを記録する。ログの無い解決は解決では
 なく違反)、**修正可能**(design は後から証拠を確認して覆せる。この権限が買うのは
 レイテンシであって finality ではない)。
+
+**evidence の sink は `clarify record --from-file`** です — エントリは domain の
+clarification return path(`intents/<domain>/clarifications/open.md`)の
+`## Recently Resolved` セクションに入り、**Question** が保留項目を特定し、
+**Decision** が決定値を記録し、**Rationale** が検証済みのリポジトリ事実と
+reviewer/orchestrator の合意を記録します。エントリはそこに読める形で残り続け、
+それが design による post-hoc amendment を可能にします。後からの amendment は
+trail に追加されるだけで、修正対象を消すことはありません:
+
+```bash
+cat > /tmp/authority-decision.md <<'EOF'
+## Question
+<後から design が見つけられる形で特定した保留項目>
+
+## Decision
+<決定値>
+
+## Rationale
+<それを entail する検証済みのリポジトリ事実と、合意したスレッド>
+EOF
+
+intent-cli clarify record --domain <domain> --from-file /tmp/authority-decision.md
+```
 
 > **セマンティック・プロダクトの判断は絶対に除外されます。** intent shaping、
 > packet 内容と受け入れ基準、リリーススコープ、優先度の裁定は、常に

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using IntentSystem.Clarify.Models;
+using IntentSystem.Clarify.Serialization;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -277,6 +279,38 @@ internal static class AutomationStalledWorkCommand
     /// </summary>
     public const string ReasonActivityDataUnusable = "activity-data-unusable";
 
+    /// <summary>
+    /// G552: an open clarification artifact is on disk but cannot be read or
+    /// deserialized. The hold it represents is real — that is exactly why it
+    /// must never be dropped silently — so the artifact is reported here with
+    /// its path rather than skipped, and never guessed into
+    /// <see cref="StalledWorkItem"/>s on unusable evidence.
+    /// </summary>
+    public const string ReasonClarificationUnreadable = "clarification-unreadable";
+
+    /// <summary>
+    /// G552: a hold blocked on a DESIGN DECISION, recorded as an open
+    /// clarification artifact through the canonical clarify surface. Reports
+    /// the blocking execution unit, the clarification's age, and its question
+    /// summary; <c>recommended_action</c> names the exact clarification to
+    /// answer (design) or the escalation path (operator). ACTIONABLE — like
+    /// <see cref="KindRepairStalled"/>, the recommendation is a directed
+    /// request rather than a state transition this command could run itself:
+    /// the answer is human content, and nothing here ever auto-answers a
+    /// clarification.
+    ///
+    /// Field incident (2026-07-28 16:11 → 07-29 01:29): the G551 review held
+    /// its final verdict for NINE HOURS on a one-line wording ruling while
+    /// every technical check was green. The hold lived only in agmsg
+    /// messages, so <c>stalled-work</c> reported <c>stalled=false</c>
+    /// throughout and no supervision layer could see it — the fourth
+    /// design-absence stall in the field record. This kind is the detection
+    /// half of the fix; the guide's clarification-backed hold rule (an
+    /// agmsg-only hold is a contract violation) is what puts the artifact on
+    /// disk for it to read.
+    /// </summary>
+    public const string KindDesignDecisionPending = "design-decision-pending";
+
     public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
 
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
@@ -378,6 +412,7 @@ internal static class AutomationStalledWorkCommand
         CollectMergedNotClosedOut(context, domain, candidateDomains, repo, mergedPrs, now, items, excluded, warnings);
         CollectClaimedButSilent(context, domain, candidateDomains, openIssues, openPrs, repo, now, claimedSilentMinutes, items, excluded, warnings);
         CollectBacklogReadyIdle(context, domain, candidateDomains, openIssues, openPrs, repo, now, backlogIdleMinutes, items, excluded);
+        CollectDesignDecisionPending(context, domain, candidateDomains, repo, now, items, excluded);
 
         var filtered = items
             .Where(item => item.AgeMinutes >= staleMinutes)
@@ -1482,6 +1517,176 @@ internal static class AutomationStalledWorkCommand
             IsInformational = false,
             RecommendedAction = $"intent-cli issue publish-flow {executionUnit} --repo {repo} --write --format json",
         });
+    }
+
+    /// <summary>
+    /// G552: reads the domain's OPEN clarification artifacts and reports each
+    /// as <see cref="KindDesignDecisionPending"/> with its age, blocking
+    /// execution unit, and question summary.
+    ///
+    /// This collector is deliberately GitHub-free: a design-decision hold has
+    /// no GitHub entity of its own, which is precisely why the nine-hour G551
+    /// hold was invisible to every other kind here. Its evidence is the
+    /// clarification artifact the canonical clarify surface wrote, and its
+    /// age is that artifact's own <c>createdAt</c> — the moment the block was
+    /// recorded, which is the interval an operator actually cares about.
+    ///
+    /// Fail-closed, in the same direction as every other collector: an
+    /// artifact that cannot be read or deserialized goes to
+    /// <c>excluded[]</c> with its path (<see cref="ReasonClarificationUnreadable"/>),
+    /// and a clarification whose domain cannot be confirmed against its own
+    /// packet-declared domain is excluded rather than attributed to the
+    /// requested domain. An ANSWERED, applied, or cancelled clarification is
+    /// simply not open, so it produces nothing at all — answering is what
+    /// clears the item.
+    /// </summary>
+    private static void CollectDesignDecisionPending(
+        CliContext context,
+        string domain,
+        IReadOnlyList<string> candidateDomains,
+        string repo,
+        DateTimeOffset now,
+        List<StalledWorkItem> items,
+        List<StalledWorkExcluded> excluded)
+    {
+        var clarificationsRoot = Path.Combine(context.RepoRoot, ".intent-cli", "clarifications");
+        if (!Directory.Exists(clarificationsRoot))
+        {
+            // No clarification surface in this checkout — nothing to report.
+            // Absence is never a stall signal on its own.
+            return;
+        }
+
+        string[] artifactPaths;
+        try
+        {
+            artifactPaths = Directory
+                .EnumerateFiles(clarificationsRoot, "request.json", SearchOption.AllDirectories)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray();
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            excluded.Add(new StalledWorkExcluded
+            {
+                Kind = KindDesignDecisionPending,
+                ExecutionUnit = string.Empty,
+                Issue = null,
+                Pr = null,
+                Reason = ReasonClarificationUnreadable,
+                Detail =
+                    $"could not enumerate clarification artifacts under `{clarificationsRoot}`: {exception.Message}. "
+                    + "A design-decision hold may be present but unreadable — resolve the read failure rather than "
+                    + "treating this as a healthy pipeline.",
+            });
+            return;
+        }
+
+        foreach (var artifactPath in artifactPaths)
+        {
+            ClarificationItem clarification;
+            try
+            {
+                clarification = ClarificationSerializer.Deserialize(File.ReadAllText(artifactPath));
+            }
+            catch (Exception exception) when (exception is IOException or JsonException or InvalidOperationException or NotSupportedException)
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindDesignDecisionPending,
+                    ExecutionUnit = string.Empty,
+                    Issue = null,
+                    Pr = null,
+                    Reason = ReasonClarificationUnreadable,
+                    Detail =
+                        $"clarification artifact `{artifactPath}` could not be read: {exception.Message}. "
+                        + "Excluded rather than assumed answered — an unreadable artifact is not evidence of an "
+                        + "unblocked pipeline.",
+                });
+                continue;
+            }
+
+            if (clarification.Status != ClarificationStatus.Open)
+            {
+                // Answered / applied / cancelled: the hold is over. This is
+                // the clearing path — no item, no exclusion, no noise.
+                continue;
+            }
+
+            // The artifact itself is the corroborating linkage: it was
+            // written by the canonical clarify surface against a named
+            // execution unit, not guessed from an issue/PR title. Domain
+            // confirmation still applies, so a clarification whose packet
+            // declares a different domain never leaks into this domain's
+            // report.
+            var resolution = new ExecutionUnitResolution(
+                clarification.ExecutionUnit, Corroborated: true, IsAmbiguous: false, CandidatePacketPaths: Array.Empty<string>());
+            var packetDeclaredDomain = ReadPacketDeclaredDomain(context, clarification.ExecutionUnit);
+            if (!TryConfirmDomain(domain, resolution, packetDeclaredDomain, candidateDomains, repo,
+                    out var reason, out var detail))
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindDesignDecisionPending,
+                    ExecutionUnit = clarification.ExecutionUnit,
+                    Issue = null,
+                    Pr = null,
+                    Reason = reason,
+                    Detail = detail,
+                });
+                continue;
+            }
+
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindDesignDecisionPending,
+                ExecutionUnit = clarification.ExecutionUnit,
+                Issue = null,
+                Pr = null,
+                AgeMinutes = ComputeAgeMinutesFromInstant(ClampToNow(clarification.CreatedAt, now), now),
+                IsInformational = false,
+                RecommendedAction = BuildDesignDecisionPendingAction(clarification, domain),
+            });
+        }
+    }
+
+    /// <summary>
+    /// G552: names the exact clarification to answer (design) and the
+    /// escalation path (operator). Never an auto-answer: the answer is human
+    /// content, and this command only ever emits text.
+    /// </summary>
+    private static string BuildDesignDecisionPendingAction(ClarificationItem clarification, string domain)
+    {
+        var summary = SummarizeQuestion(clarification.QuestionText);
+        return
+            $"answer clarification `{clarification.QuestionId}` on `{clarification.ExecutionUnit}` (\"{summary}\") — "
+            + $"design: `intent-cli clarify answer --execution-unit {clarification.ExecutionUnit} "
+            + $"--question-id {clarification.QuestionId} --answer \"<decision>\"`; "
+            + $"operator: escalate for domain `{domain}` if design is unavailable. "
+            + "Never auto-answer: the decision is design's, and a resolution taken under bounded default authority "
+            + "must cite its verifying facts and remain amendable by design.";
+    }
+
+    /// <summary>
+    /// G552: a one-line question summary for the report. Collapses whitespace
+    /// (a clarification question is often multi-line prose) and truncates so a
+    /// single long question cannot swamp a heartbeat message body.
+    /// </summary>
+    private static string SummarizeQuestion(string questionText)
+    {
+        const int MaxLength = 120;
+
+        var collapsed = string.Join(' ', (questionText ?? string.Empty)
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+        if (collapsed.Length == 0)
+        {
+            return "(no question text recorded)";
+        }
+
+        return collapsed.Length <= MaxLength
+            ? collapsed
+            : collapsed[..MaxLength].TrimEnd() + "…";
     }
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/ClarifyOpenCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyOpenCommand.cs
@@ -23,9 +23,9 @@ internal static class ClarifyOpenCommand
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
 
-        if (args.Length != 1 || string.IsNullOrWhiteSpace(args[0]))
+        if (!TryParseArguments(args, out var parsed, out var parseError))
         {
-            writer.WriteLine("Clarify open command requires an execution unit.");
+            writer.WriteLine(parseError);
             return 1;
         }
 
@@ -35,7 +35,7 @@ internal static class ClarifyOpenCommand
             return 1;
         }
 
-        var executionUnit = args[0];
+        var executionUnit = parsed.ExecutionUnit;
         var queueItem = queueState.Items.FirstOrDefault(item =>
             string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal));
 
@@ -97,13 +97,18 @@ internal static class ClarifyOpenCommand
                 TransitionActor,
                 timestamp);
 
-            var clarification = BuildClarification(queueItem, packet, reviewContext, timestamp, reason);
+            var clarification = BuildClarification(queueItem, packet, reviewContext, timestamp, reason, parsed);
             var artifactPath = PersistClarification(context.RepoRoot, clarification);
             PersistTransition(context, queueState, transition);
 
             writer.WriteLine($"Clarification opened for {executionUnit}.");
             writer.WriteLine($"Artifact path: {artifactPath}");
-            writer.WriteLine($"Reason: {reason}");
+            // G552: echo what was actually PERSISTED (question, and the reason
+            // including any labeled recommendation/evidence), not the
+            // pre-composition reason — the operator needs to see the durable
+            // record, since that is what the detector and design will read.
+            writer.WriteLine($"Question: {clarification.QuestionText}");
+            writer.WriteLine($"Reason: {clarification.Reason}");
             writer.WriteLine($"Clarification return path: {clarification.ClarificationReturnPath}");
             return 0;
         }
@@ -119,15 +124,22 @@ internal static class ClarifyOpenCommand
         Projection.Models.ProjectionPacketContract packet,
         Review.Models.ReviewContextSnapshot reviewContext,
         DateTimeOffset timestamp,
-        string reason)
+        string reason,
+        ClarifyOpenInputs inputs)
     {
         return new ClarificationItem
         {
             ClarificationSource = ClarificationSource,
             QuestionId = QuestionId,
             ExecutionUnit = queueItem.ExecutionUnit,
-            QuestionText = BuildQuestionText(packet.ImplementationIssuePacket, reviewContext),
-            Reason = reason,
+            // G552: an explicitly supplied question is the REAL design-blocking
+            // question and always wins over the packet-derived synthesis. The
+            // OPEN artifact itself must carry it — an agmsg message may notify,
+            // but it can never substitute for the durable record.
+            QuestionText = string.IsNullOrWhiteSpace(inputs.Question)
+                ? BuildQuestionText(packet.ImplementationIssuePacket, reviewContext)
+                : inputs.Question!,
+            Reason = AppendRecommendation(reason, inputs),
             AffectedIntents = packet.ReviewContextPacket.IntentReferences,
             AffectedExecutionUnits = [queueItem.ExecutionUnit],
             BlockingOrNonblocking = BlockingValue,
@@ -135,6 +147,132 @@ internal static class ClarifyOpenCommand
             Status = ClarificationStatus.Open,
             CreatedAt = timestamp
         };
+    }
+
+    /// <summary>
+    /// G552: the explicit inputs that let a design-decision hold record its
+    /// REAL question (and, when the asking thread already believes it knows the
+    /// answer, its recommendation and the facts behind it) in the OPEN
+    /// clarification artifact. All optional — omitting them preserves the
+    /// pre-G552 packet-derived behavior byte for byte, so every existing caller
+    /// and fixture is unaffected. No clarification schema change: the question
+    /// lands in <c>QuestionText</c> and the recommendation/evidence land in the
+    /// already-serialized <c>Reason</c> field under explicit labels.
+    /// </summary>
+    private sealed record ClarifyOpenInputs
+    {
+        public required string ExecutionUnit { get; init; }
+
+        public string? Question { get; init; }
+
+        public string? RecommendedAnswer { get; init; }
+
+        public string? Evidence { get; init; }
+    }
+
+    private const string RecommendedAnswerLabel = "Recommended answer:";
+
+    private const string EvidenceLabel = "Evidence:";
+
+    private const string UsageLine =
+        "Usage: intent-cli clarify open <execution-unit> [--question <text>] [--recommended-answer <text>] [--evidence <text>]";
+
+    /// <summary>
+    /// G552: composes the durable <c>Reason</c> so the recommendation and its
+    /// evidence survive in the OPEN artifact under labels a reader (and a
+    /// reviewer) can find. The packet-derived reason always stays first, so the
+    /// existing content is never displaced — only extended.
+    /// </summary>
+    private static string AppendRecommendation(string reason, ClarifyOpenInputs inputs)
+    {
+        var builder = new System.Text.StringBuilder(reason);
+
+        if (!string.IsNullOrWhiteSpace(inputs.RecommendedAnswer))
+        {
+            builder.Append(' ').Append(RecommendedAnswerLabel).Append(' ').Append(inputs.RecommendedAnswer!.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(inputs.Evidence))
+        {
+            builder.Append(' ').Append(EvidenceLabel).Append(' ').Append(inputs.Evidence!.Trim());
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool TryParseArguments(string[] args, out ClarifyOpenInputs parsed, out string error)
+    {
+        parsed = new ClarifyOpenInputs { ExecutionUnit = string.Empty };
+        error = string.Empty;
+
+        string? executionUnit = null;
+        string? question = null;
+        string? recommendedAnswer = null;
+        string? evidence = null;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--question":
+                case "--recommended-answer":
+                case "--evidence":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = $"{argument} requires a value.";
+                        return false;
+                    }
+
+                    var value = args[index + 1];
+                    if (argument == "--question")
+                    {
+                        question = value;
+                    }
+                    else if (argument == "--recommended-answer")
+                    {
+                        recommendedAnswer = value;
+                    }
+                    else
+                    {
+                        evidence = value;
+                    }
+
+                    index++;
+                    break;
+
+                default:
+                    if (argument.StartsWith("--", StringComparison.Ordinal))
+                    {
+                        error = $"Unknown argument '{argument}'. {UsageLine}";
+                        return false;
+                    }
+
+                    if (executionUnit is not null)
+                    {
+                        error = $"Clarify open command accepts a single execution unit. {UsageLine}";
+                        return false;
+                    }
+
+                    executionUnit = argument;
+                    break;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            error = "Clarify open command requires an execution unit.";
+            return false;
+        }
+
+        parsed = new ClarifyOpenInputs
+        {
+            ExecutionUnit = executionUnit,
+            Question = question,
+            RecommendedAnswer = recommendedAnswer,
+            Evidence = evidence,
+        };
+        return true;
     }
 
     private static string BuildQuestionText(

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -1897,6 +1897,11 @@ internal static class GuideOrchestratorThreadCommand
                     "answer it — `intent-cli clarify answer` (design, or the operator on escalation)",
                     Fill("confirm it is visible — `intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json` reports `design-decision-pending`"),
                 },
+                PasteReadyInvocation =
+                    "intent-cli clarify open <execution-unit> \\\n"
+                    + "  --question \"<the actual design-blocking question, answerable by someone outside the thread>\" \\\n"
+                    + "  --recommended-answer \"<what you believe the answer is, when you believe you know it>\" \\\n"
+                    + "  --evidence \"<the repository facts that support the recommendation>\"",
             },
             ReviewerHoldRule = new OrchestratorReviewerHoldRule
             {
@@ -1969,6 +1974,28 @@ internal static class GuideOrchestratorThreadCommand
                     + "trail with the facts that verify it — what was decided, which repository facts entail it, and "
                     + "which threads agreed. An unlogged resolution is not a granted-authority resolution; it is an "
                     + "undocumented decision, and it is a violation of this contract.",
+                EvidenceSink =
+                    "The sink is the CANONICAL `clarify record` surface: the entry lands under `## Recently Resolved` "
+                    + "in the domain's clarification return path (`intents/<domain>/clarifications/open.md`), where "
+                    + "`Question` identifies the pending item, `Decision` records the decided value, and `Rationale` "
+                    + "records the verified repository facts plus the reviewer/orchestrator agreement. The entry is "
+                    + "durable and stays readable there, which is exactly what makes design's post-hoc amendment "
+                    + "possible — design reads the recorded evidence and amends or reverses from it.",
+                EvidenceOperation =
+                    "# 1. write the decision artifact (## Question / ## Decision / ## Rationale)\n"
+                    + "cat > /tmp/authority-decision.md <<'EOF'\n"
+                    + "## Question\n"
+                    + "<the pending item, identified so design can find it later>\n"
+                    + "\n"
+                    + "## Decision\n"
+                    + "<the decided value>\n"
+                    + "\n"
+                    + "## Rationale\n"
+                    + "<the verified repository facts that entail it, and which threads agreed>\n"
+                    + "EOF\n"
+                    + "\n"
+                    + "# 2. record it in the durable trail (--dry-run first shows the intended update)\n"
+                    + "intent-cli clarify record --domain <domain> --from-file /tmp/authority-decision.md",
                 PostHocAmendmentRule =
                     "DESIGN MAY AMEND POST HOC. A granted-authority resolution is provisional in design's eyes: "
                     + "design can review the logged evidence afterwards and amend or reverse the decision. The "
@@ -2598,6 +2625,12 @@ internal static class GuideOrchestratorThreadCommand
             writer.WriteLine($"- {command}");
         }
         writer.WriteLine();
+        writer.WriteLine("Paste-ready — the OPEN artifact carries the real content, not a packet-derived synthesis:");
+        writer.WriteLine();
+        writer.WriteLine("```bash");
+        writer.WriteLine(holds.ClarificationBackedHold.PasteReadyInvocation);
+        writer.WriteLine("```");
+        writer.WriteLine();
 
         writer.WriteLine("### Reviewer hold rule (refined)");
         writer.WriteLine();
@@ -2623,7 +2656,14 @@ internal static class GuideOrchestratorThreadCommand
         }
         writer.WriteLine();
         writer.WriteLine($"- **evidence logging** — {holds.BoundedDefaultAuthority.EvidenceLoggingRule}");
+        writer.WriteLine($"- **evidence sink** — {holds.BoundedDefaultAuthority.EvidenceSink}");
         writer.WriteLine($"- **post-hoc amendment** — {holds.BoundedDefaultAuthority.PostHocAmendmentRule}");
+        writer.WriteLine();
+        writer.WriteLine("Paste-ready evidence operation:");
+        writer.WriteLine();
+        writer.WriteLine("```bash");
+        writer.WriteLine(holds.BoundedDefaultAuthority.EvidenceOperation);
+        writer.WriteLine("```");
         writer.WriteLine();
         writer.WriteLine($"> **Semantic exclusion:** {holds.BoundedDefaultAuthority.SemanticExclusionRule}");
         writer.WriteLine();
@@ -3881,6 +3921,10 @@ internal sealed record OrchestratorClarificationBackedHold
 
     [JsonPropertyName("canonical_commands")]
     public required IReadOnlyList<string> CanonicalCommands { get; init; }
+
+    /// <summary>G552 repair: a paste-ready `clarify open` invocation that persists the REAL question and its recommendation/evidence in the OPEN artifact.</summary>
+    [JsonPropertyName("paste_ready_invocation")]
+    public required string PasteReadyInvocation { get; init; }
 }
 
 internal sealed record OrchestratorReviewerHoldRule
@@ -3911,6 +3955,14 @@ internal sealed record OrchestratorBoundedDefaultAuthority
 
     [JsonPropertyName("evidence_logging_rule")]
     public required string EvidenceLoggingRule { get; init; }
+
+    /// <summary>G552 repair: the concrete durable sink for a granted-authority resolution — `clarify record --from-file`, whose entry lands under `## Recently Resolved`.</summary>
+    [JsonPropertyName("evidence_sink")]
+    public required string EvidenceSink { get; init; }
+
+    /// <summary>G552 repair: the paste-ready operation that writes that evidence.</summary>
+    [JsonPropertyName("evidence_operation")]
+    public required string EvidenceOperation { get; init; }
 
     [JsonPropertyName("post_hoc_amendment_rule")]
     public required string PostHocAmendmentRule { get; init; }

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -943,6 +943,7 @@ internal static class GuideOrchestratorThreadCommand
             },
             TerminalWorkspaceProvisioning = BuildTerminalWorkspaceProvisioning(repo, values["<team>"]),
             DesignWorkspaceSupervision = BuildDesignWorkspaceSupervision(domain, repo),
+            DesignDecisionHolds = BuildDesignDecisionHolds(domain, repo),
             DesignTrafficController = new OrchestratorDesignTrafficController
             {
                 Summary =
@@ -1849,6 +1850,176 @@ internal static class GuideOrchestratorThreadCommand
         };
     }
 
+    // G552: the design-decision hold contract. Everything here is guide-level
+    // — the only code half of this slice is the `design-decision-pending`
+    // detector, which reads what these rules put on disk. The MAY scope is
+    // deliberately narrow: enumerated, mechanically fact-checkable classes
+    // only, and the double-check rule's semantic scope is untouched.
+    private static OrchestratorDesignDecisionHolds BuildDesignDecisionHolds(string domain, string targetRepo)
+    {
+        string Fill(string template) => template
+            .Replace("<domain>", domain, StringComparison.Ordinal)
+            .Replace("<owner/repo>", targetRepo, StringComparison.Ordinal);
+
+        return new OrchestratorDesignDecisionHolds
+        {
+            Summary = Fill(
+                "A hold blocked on a DESIGN DECISION must be visible and bounded. Visible: it is recorded as a "
+                + "clarification artifact through the canonical clarify surface, so `automation stalled-work` and "
+                + "`automation heartbeat` can see it — an agmsg message alone is invisible to every supervision "
+                + "layer. Bounded: the operator may pre-delegate enumerated, mechanically fact-checkable decision "
+                + "classes so a correction both threads can verify from repository facts does not wait on design at "
+                + "all. Measured cost of getting this wrong: a nine-hour hold on a one-line wording ruling while "
+                + "every technical check was green and `stalled-work` reported `stalled=false` throughout."),
+            ClarificationBackedHold = new OrchestratorClarificationBackedHold
+            {
+                Summary = Fill(
+                    "When the orchestrator or the reviewer blocks on a design decision, it RECORDS A CLARIFICATION "
+                    + "ARTIFACT through the canonical clarify surface, in addition to whatever agmsg message it "
+                    + "sends. The artifact is what makes the hold detectable; the message is only a notification."),
+                RequiredFields = new[]
+                {
+                    Fill("domain — the blocked domain (`<domain>`), so the artifact is scoped to the right pipeline."),
+                    "blocking execution unit — the unit that cannot proceed until this is answered.",
+                    "question — what design must decide, stated so someone who was not in the thread can answer it.",
+                    "recommended answer — when the asking thread already believes it knows the answer, state it and cite the facts that support it; design then confirms or overrides rather than starting from scratch.",
+                },
+                ContractViolationRule =
+                    "An agmsg-only hold is a CONTRACT VIOLATION, not a shortcut. A block that exists only as messages "
+                    + "is invisible to `stalled-work`, to `heartbeat`, and therefore to every watchdog and every "
+                    + "operator glance — which is exactly how a nine-hour hold passed unnoticed with the pipeline "
+                    + "reporting healthy. If you are waiting on design, the artifact exists; if the artifact does not "
+                    + "exist, you are not waiting, you are stalled.",
+                CanonicalCommands = new[]
+                {
+                    "record the hold — `intent-cli clarify open` (the canonical clarify surface; never hand-write the artifact)",
+                    "see what is open — `intent-cli clarify list`",
+                    "answer it — `intent-cli clarify answer` (design, or the operator on escalation)",
+                    Fill("confirm it is visible — `intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json` reports `design-decision-pending`"),
+                },
+            },
+            ReviewerHoldRule = new OrchestratorReviewerHoldRule
+            {
+                Summary =
+                    "The reviewer's hold rule is refined so a green-technical review never becomes an untracked wait. "
+                    + "Evaluate what is actually pending before holding.",
+                ResolveUnderAuthorityWhen =
+                    "Technical checks are GREEN and the only pending item is NON-SEMANTIC and MECHANICALLY "
+                    + "FACT-CHECKABLE from repository facts — resolve it under bounded default authority (below), "
+                    + "log the resolution with the verifying facts, and proceed. Do not hold a green review on a "
+                    + "question whose answer both threads can derive and cite.",
+                RecordClarificationOtherwise =
+                    "Anything else — a semantic or product question, a fact you cannot verify, or a class the "
+                    + "operator has not delegated — becomes a recorded clarification and a VISIBLE pending state. The "
+                    + "review is still held; the difference is that the hold is now on disk and detectable.",
+                NeverUntrackedWait =
+                    "there is no third option where the reviewer simply waits and says so in "
+                    + "a message: either the item is resolved under granted authority with its evidence, or a "
+                    + "clarification artifact exists. Silence with a message attached is the failure mode this rule "
+                    + "exists to remove.",
+            },
+            BoundedDefaultAuthority = new OrchestratorBoundedDefaultAuthority
+            {
+                Summary =
+                    "BOUNDED DEFAULT AUTHORITY lets the operator pre-delegate a small, enumerated set of decision "
+                    + "classes that can be settled by checking repository facts rather than by judgment. It exists so "
+                    + "a count correction does not cost nine hours. It is bounded in every direction: granted, "
+                    + "enumerated, evidence-logged, amendable, and never semantic.",
+                OperatorGrantRequirement =
+                    "GRANTED, never assumed. The authority applies only to classes the OPERATOR has explicitly "
+                    + "pre-delegated for this domain. Absent a grant, every design decision goes to design as before "
+                    + "— the default is unchanged, and no thread may infer a delegation from the fact that an answer "
+                    + "seems obvious.",
+                FactCheckableClasses = new[]
+                {
+                    new OrchestratorFactCheckableClass
+                    {
+                        DecisionClass = "count and enumeration corrections",
+                        VerifyingFacts =
+                            "the count is derivable from repository facts both threads can read — e.g. a slice count "
+                            + "derived from the merged PR list and the issue's own enumeration. Cite the list and the "
+                            + "derivation.",
+                    },
+                    new OrchestratorFactCheckableClass
+                    {
+                        DecisionClass = "wording corrections that follow from a cited fact",
+                        VerifyingFacts =
+                            "the corrected wording is entailed by a fact in the repository (a merged PR title, a "
+                            + "label state, a retired unit's own record), and the reviewer and orchestrator AGREE on "
+                            + "both the fact and the correction. Disagreement is not fact-checkable — it escalates.",
+                    },
+                    new OrchestratorFactCheckableClass
+                    {
+                        DecisionClass = "cross-reference and link corrections",
+                        VerifyingFacts =
+                            "the target exists (or does not) in the repository as cited — verifiable by reading the "
+                            + "referenced file, heading, issue, or PR.",
+                    },
+                    new OrchestratorFactCheckableClass
+                    {
+                        DecisionClass = "identifier and metadata mismatches against a canonical source",
+                        VerifyingFacts =
+                            "the canonical source is named and read — e.g. a version in `eng/version.json`, a unit id "
+                            + "in a packet, a label in the canonical palette. The canonical source wins; the "
+                            + "resolution cites it.",
+                    },
+                },
+                EvidenceLoggingRule =
+                    "MANDATORY EVIDENCE LOGGING. A resolution taken under this authority is recorded in the durable "
+                    + "trail with the facts that verify it — what was decided, which repository facts entail it, and "
+                    + "which threads agreed. An unlogged resolution is not a granted-authority resolution; it is an "
+                    + "undocumented decision, and it is a violation of this contract.",
+                PostHocAmendmentRule =
+                    "DESIGN MAY AMEND POST HOC. A granted-authority resolution is provisional in design's eyes: "
+                    + "design can review the logged evidence afterwards and amend or reverse the decision. The "
+                    + "authority buys latency, not finality — proceeding does not close the question against design.",
+                SemanticExclusionRule =
+                    "SEMANTIC AND PRODUCT DECISIONS ARE EXCLUDED, absolutely. Intent shaping, packet content and "
+                    + "acceptance criteria, release scope, prioritization rulings, and anything requiring product or "
+                    + "design judgment always go to design through the design↔orchestrator double-check rule, whose "
+                    + "scope this contract does not touch. If settling the question requires deciding what SHOULD be "
+                    + "true rather than checking what IS true, it is not fact-checkable and this authority does not "
+                    + "reach it.",
+            },
+            DesignReminderLoop = new OrchestratorDesignReminderLoop
+            {
+                Summary =
+                    "While a clarification stays open, the design thread is reminded on a fixed cadence. A recorded "
+                    + "hold that nobody re-surfaces is still a slow hold — the artifact makes it detectable, the "
+                    + "reminder makes it noticed.",
+                Sender =
+                    "The ORCHESTRATOR sends the reminder from its long-interval automation — the same wake that "
+                    + "already runs the heartbeat check. No new scheduler, and the receivers stay loopless.",
+                IntervalClass =
+                    "30–60 minute class — the same low-frequency band as the heartbeat and the design-thread "
+                    + "watchdog. Faster polling recreates the churn the message-driven model removes; slower lets a "
+                    + "hold sit past the point an operator would want to know.",
+                OnePerIntervalRule =
+                    "AT MOST ONE reminder per interval PER OPEN CLARIFICATION. Two open clarifications produce at "
+                    + "most two reminders in a wake; one clarification never produces two reminders in the same "
+                    + "interval no matter how many wakes fire. This is the same one-message discipline the watchdog "
+                    + "already follows.",
+                StopCondition =
+                    "STOP ON ANSWER. Once the clarification is answered (or applied, or cancelled) it is no longer "
+                    + "open, `design-decision-pending` clears on its own, and the reminders stop. Never keep "
+                    + "reminding against an answered clarification, and never re-open one to keep a thread's "
+                    + "attention.",
+                OperatorAppNote =
+                    "The design thread runs in the OPERATOR APP by preference, which is what makes a reminder land "
+                    + "either way: an OPEN design session receives the reminder immediately through its monitor, and "
+                    + "a CLOSED one finds it waiting in the inbox on resume. Neither case requires design to be "
+                    + "resident in the team workspace — there is no workspace-residency requirement here.",
+            },
+            DetectionReference = Fill(
+                "Detection is `design-decision-pending` in `automation stalled-work`: it reads the domain's OPEN "
+                + "clarification artifacts and reports each with its age, blocking execution unit, and question "
+                + "summary, and `automation heartbeat` carries it in `message_body` like any other kind. Confirm a "
+                + "hold is visible with `intent-cli automation stalled-work --domain <domain> --repo <owner/repo> "
+                + "--format json`; if the hold is real but the kind is absent, the clarification artifact was never "
+                + "recorded — which is the contract violation above, not a detector bug."),
+        };
+    }
+
     // G500: turn an orchestrator setup request into a concrete, operational
     // intake. The visible outcome is one of missing-inputs / setup-ready /
     // blocked. When inputs are complete the intake emits copy-paste agmsg
@@ -2399,6 +2570,79 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine();
     }
 
+    // G552: render the design-decision hold contract — the hold rule first
+    // (it is what makes everything else observable), then the reviewer
+    // refinement, the bounded authority, and the reminder cadence.
+    private static void WriteDesignDecisionHolds(TextWriter writer, OrchestratorDesignDecisionHolds holds)
+    {
+        writer.WriteLine("## Design-decision holds and bounded authority (G552)");
+        writer.WriteLine();
+        writer.WriteLine(holds.Summary);
+        writer.WriteLine();
+
+        writer.WriteLine("### Clarification-backed holds");
+        writer.WriteLine();
+        writer.WriteLine(holds.ClarificationBackedHold.Summary);
+        writer.WriteLine();
+        writer.WriteLine("Record these fields:");
+        writer.WriteLine();
+        foreach (var field in holds.ClarificationBackedHold.RequiredFields)
+        {
+            writer.WriteLine($"- {field}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"> **Contract violation:** {holds.ClarificationBackedHold.ContractViolationRule}");
+        writer.WriteLine();
+        foreach (var command in holds.ClarificationBackedHold.CanonicalCommands)
+        {
+            writer.WriteLine($"- {command}");
+        }
+        writer.WriteLine();
+
+        writer.WriteLine("### Reviewer hold rule (refined)");
+        writer.WriteLine();
+        writer.WriteLine(holds.ReviewerHoldRule.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- **resolve under granted authority when** — {holds.ReviewerHoldRule.ResolveUnderAuthorityWhen}");
+        writer.WriteLine($"- **record a clarification otherwise** — {holds.ReviewerHoldRule.RecordClarificationOtherwise}");
+        writer.WriteLine();
+        writer.WriteLine($"> **Never an untracked wait:** {holds.ReviewerHoldRule.NeverUntrackedWait}");
+        writer.WriteLine();
+
+        writer.WriteLine("### Bounded default authority");
+        writer.WriteLine();
+        writer.WriteLine(holds.BoundedDefaultAuthority.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- **operator grant required** — {holds.BoundedDefaultAuthority.OperatorGrantRequirement}");
+        writer.WriteLine();
+        writer.WriteLine("#### Enumerated fact-checkable classes (the whole MAY scope)");
+        writer.WriteLine();
+        foreach (var entry in holds.BoundedDefaultAuthority.FactCheckableClasses)
+        {
+            writer.WriteLine($"- **{entry.DecisionClass}** — verify: {entry.VerifyingFacts}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **evidence logging** — {holds.BoundedDefaultAuthority.EvidenceLoggingRule}");
+        writer.WriteLine($"- **post-hoc amendment** — {holds.BoundedDefaultAuthority.PostHocAmendmentRule}");
+        writer.WriteLine();
+        writer.WriteLine($"> **Semantic exclusion:** {holds.BoundedDefaultAuthority.SemanticExclusionRule}");
+        writer.WriteLine();
+
+        writer.WriteLine("### Periodic design-reminder loop");
+        writer.WriteLine();
+        writer.WriteLine(holds.DesignReminderLoop.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"- **sender** — {holds.DesignReminderLoop.Sender}");
+        writer.WriteLine($"- **interval** — {holds.DesignReminderLoop.IntervalClass}");
+        writer.WriteLine($"- **one per interval per clarification** — {holds.DesignReminderLoop.OnePerIntervalRule}");
+        writer.WriteLine($"- **stop on answer** — {holds.DesignReminderLoop.StopCondition}");
+        writer.WriteLine($"- **operator app** — {holds.DesignReminderLoop.OperatorAppNote}");
+        writer.WriteLine();
+
+        writer.WriteLine($"- **detection** — {holds.DetectionReference}");
+        writer.WriteLine();
+    }
+
     private static void WriteMarkdown(TextWriter writer, OrchestratorThreadGuide guide)
     {
         writer.WriteLine("# Guide — agmsg-backed orchestrator thread (G487)");
@@ -2516,6 +2760,8 @@ internal static class GuideOrchestratorThreadCommand
         WriteTerminalWorkspaceProvisioning(writer, guide.TerminalWorkspaceProvisioning);
 
         WriteDesignWorkspaceSupervision(writer, guide.DesignWorkspaceSupervision);
+
+        WriteDesignDecisionHolds(writer, guide.DesignDecisionHolds);
 
         writer.WriteLine("## Preflight (all three cwds)");
         writer.WriteLine();
@@ -3271,6 +3517,9 @@ internal sealed record OrchestratorThreadGuide
     [JsonPropertyName("design_workspace_supervision")]
     public required OrchestratorDesignWorkspaceSupervision DesignWorkspaceSupervision { get; init; }
 
+    [JsonPropertyName("design_decision_holds")]
+    public required OrchestratorDesignDecisionHolds DesignDecisionHolds { get; init; }
+
     [JsonPropertyName("design_traffic_controller")]
     public required OrchestratorDesignTrafficController DesignTrafficController { get; init; }
 
@@ -3579,6 +3828,127 @@ internal sealed record OrchestratorDesignWorkspaceSupervision
 
     [JsonPropertyName("watchdog_safety_rules_reference")]
     public required string WatchdogSafetyRulesReference { get; init; }
+}
+
+/// <summary>
+/// G552: the design-decision half of the stall problem. G550 keeps the team's
+/// sessions alive; nothing kept a DESIGN DECISION from stalling the pipeline
+/// invisibly. Field incident (2026-07-28 16:11 → 07-29 01:29): the G551 review
+/// held its final verdict for nine hours on a one-line wording ruling while
+/// every technical check was green, the pending item was mechanically
+/// fact-checkable, both threads knew the answer — and the hold lived only in
+/// agmsg messages, so `automation stalled-work` reported `stalled=false`
+/// throughout. Fourth design-absence stall in the field record.
+///
+/// Three layers, all guide-level except the detector: a hold blocked on design
+/// MUST become a clarification artifact (agmsg-only is a contract violation);
+/// `design-decision-pending` reads those artifacts so watchdogs see them; and
+/// bounded default authority lets the operator pre-delegate enumerated,
+/// mechanically fact-checkable classes — never semantic ones.
+/// </summary>
+internal sealed record OrchestratorDesignDecisionHolds
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("clarification_backed_hold")]
+    public required OrchestratorClarificationBackedHold ClarificationBackedHold { get; init; }
+
+    [JsonPropertyName("reviewer_hold_rule")]
+    public required OrchestratorReviewerHoldRule ReviewerHoldRule { get; init; }
+
+    [JsonPropertyName("bounded_default_authority")]
+    public required OrchestratorBoundedDefaultAuthority BoundedDefaultAuthority { get; init; }
+
+    [JsonPropertyName("design_reminder_loop")]
+    public required OrchestratorDesignReminderLoop DesignReminderLoop { get; init; }
+
+    [JsonPropertyName("detection_reference")]
+    public required string DetectionReference { get; init; }
+}
+
+internal sealed record OrchestratorClarificationBackedHold
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("required_fields")]
+    public required IReadOnlyList<string> RequiredFields { get; init; }
+
+    /// <summary>G552: the sentence that makes an agmsg-only hold a contract violation rather than a style preference.</summary>
+    [JsonPropertyName("contract_violation_rule")]
+    public required string ContractViolationRule { get; init; }
+
+    [JsonPropertyName("canonical_commands")]
+    public required IReadOnlyList<string> CanonicalCommands { get; init; }
+}
+
+internal sealed record OrchestratorReviewerHoldRule
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("resolve_under_authority_when")]
+    public required string ResolveUnderAuthorityWhen { get; init; }
+
+    [JsonPropertyName("record_clarification_otherwise")]
+    public required string RecordClarificationOtherwise { get; init; }
+
+    [JsonPropertyName("never_untracked_wait")]
+    public required string NeverUntrackedWait { get; init; }
+}
+
+internal sealed record OrchestratorBoundedDefaultAuthority
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("operator_grant_requirement")]
+    public required string OperatorGrantRequirement { get; init; }
+
+    [JsonPropertyName("fact_checkable_classes")]
+    public required IReadOnlyList<OrchestratorFactCheckableClass> FactCheckableClasses { get; init; }
+
+    [JsonPropertyName("evidence_logging_rule")]
+    public required string EvidenceLoggingRule { get; init; }
+
+    [JsonPropertyName("post_hoc_amendment_rule")]
+    public required string PostHocAmendmentRule { get; init; }
+
+    /// <summary>G552: semantic and product decisions are excluded outright — the double-check rule's scope is unchanged.</summary>
+    [JsonPropertyName("semantic_exclusion_rule")]
+    public required string SemanticExclusionRule { get; init; }
+}
+
+internal sealed record OrchestratorFactCheckableClass
+{
+    [JsonPropertyName("decision_class")]
+    public required string DecisionClass { get; init; }
+
+    [JsonPropertyName("verifying_facts")]
+    public required string VerifyingFacts { get; init; }
+}
+
+internal sealed record OrchestratorDesignReminderLoop
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("sender")]
+    public required string Sender { get; init; }
+
+    [JsonPropertyName("interval_class")]
+    public required string IntervalClass { get; init; }
+
+    [JsonPropertyName("one_per_interval_rule")]
+    public required string OnePerIntervalRule { get; init; }
+
+    [JsonPropertyName("stop_condition")]
+    public required string StopCondition { get; init; }
+
+    /// <summary>G552: the design thread runs in the operator app by preference — an open session gets the reminder live, a closed one finds it on resume.</summary>
+    [JsonPropertyName("operator_app_note")]
+    public required string OperatorAppNote { get; init; }
 }
 
 internal sealed record OrchestratorSupervisionAuthority

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -245,6 +245,20 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("**agmsg だけの hold は contract violation です。**", ja, StringComparison.Ordinal);
         Assert.Contains("待っているのではなく stall しています", ja, StringComparison.Ordinal);
 
+        // G552 repair: the paste-ready `clarify open` invocation that persists
+        // the real question and its recommendation/evidence in the OPEN
+        // artifact, and the explicit no-schema-change statement.
+        foreach (var flag in new[] { "--question", "--recommended-answer", "--evidence" })
+        {
+            Assert.Contains(flag, en, StringComparison.Ordinal);
+            Assert.Contains(flag, ja, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("can never substitute for the durable record", en, StringComparison.Ordinal);
+        Assert.Contains("**No clarification schema change.**", en, StringComparison.Ordinal);
+        Assert.Contains("durable な記録の代わりには決してなりません", ja, StringComparison.Ordinal);
+        Assert.Contains("**clarification の schema 変更はありません。**", ja, StringComparison.Ordinal);
+
         // The refined reviewer hold rule — no untracked third option.
         Assert.Contains("**Reviewer hold rule (refined).**", en, StringComparison.Ordinal);
         Assert.Contains("no third option in which the reviewer simply waits", en, StringComparison.Ordinal);
@@ -296,6 +310,18 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("**証拠がログされる**", ja, StringComparison.Ordinal);
         Assert.Contains("ログの無い解決は解決では なく違反", ja, StringComparison.Ordinal);
         Assert.Contains("買うのは レイテンシであって finality ではない", ja, StringComparison.Ordinal);
+
+        // G552 repair: the concrete durable evidence sink, its three sections,
+        // and the post-hoc amendment property — on both mirrors.
+        Assert.Contains("**The evidence sink is `clarify record --from-file`**", en, StringComparison.Ordinal);
+        Assert.Contains("`## Recently Resolved`", en, StringComparison.Ordinal);
+        Assert.Contains("intent-cli clarify record --domain <domain> --from-file", en, StringComparison.Ordinal);
+        Assert.Contains("adds to the trail rather than erasing what it amends", en, StringComparison.Ordinal);
+
+        Assert.Contains("**evidence の sink は `clarify record --from-file`**", ja, StringComparison.Ordinal);
+        Assert.Contains("`## Recently Resolved`", ja, StringComparison.Ordinal);
+        Assert.Contains("intent-cli clarify record --domain <domain> --from-file", ja, StringComparison.Ordinal);
+        Assert.Contains("trail に追加されるだけで、修正対象を消すことはありません", ja, StringComparison.Ordinal);
 
         // Semantic exclusion, with the double-check scope explicitly untouched.
         Assert.Contains("**Semantic and product decisions are excluded, absolutely.**", en, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -225,6 +225,110 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("委譲の重複禁止、permission プロンプトの自動クリア禁止", ja, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void BothDocs_CarryTheDesignDecisionHoldContract_G552()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        Assert.Contains("## Design-decision holds and bounded authority", en, StringComparison.Ordinal);
+        Assert.Contains("## design 判断による hold と bounded authority", ja, StringComparison.Ordinal);
+
+        // The clarification-backed hold rule, with the contract-violation
+        // sentence that makes an agmsg-only hold a violation rather than a
+        // style preference.
+        Assert.Contains("records a clarification artifact**", en, StringComparison.Ordinal);
+        Assert.Contains("`intent-cli clarify open`", en, StringComparison.Ordinal);
+        Assert.Contains("**An agmsg-only hold is a contract violation.**", en, StringComparison.Ordinal);
+        Assert.Contains("you are not waiting, you are stalled", en, StringComparison.Ordinal);
+        Assert.Contains("clarification artifact を記録**", ja, StringComparison.Ordinal);
+        Assert.Contains("**agmsg だけの hold は contract violation です。**", ja, StringComparison.Ordinal);
+        Assert.Contains("待っているのではなく stall しています", ja, StringComparison.Ordinal);
+
+        // The refined reviewer hold rule — no untracked third option.
+        Assert.Contains("**Reviewer hold rule (refined).**", en, StringComparison.Ordinal);
+        Assert.Contains("no third option in which the reviewer simply waits", en, StringComparison.Ordinal);
+        Assert.Contains("**reviewer hold ルール(refined)。**", ja, StringComparison.Ordinal);
+        Assert.Contains("第 3 の選択肢はありません", ja, StringComparison.Ordinal);
+
+        // The measured cost that motivates the slice is stated on both sides.
+        Assert.Contains("**nine hours**", en, StringComparison.Ordinal);
+        Assert.Contains("**9 時間**", ja, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BothDocs_BoundTheDefaultAuthority_AndKeepSemanticDecisionsWithDesign_G552()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        // All four enumerated fact-checkable classes appear on both mirrors —
+        // the enumeration is what bounds the authority, so a missing row
+        // would silently widen it.
+        foreach (var row in new[]
+                 {
+                     "count and enumeration corrections",
+                     "wording corrections that follow from a cited fact",
+                     "cross-reference and link corrections",
+                     "identifier and metadata mismatches against a canonical source",
+                 })
+        {
+            Assert.Contains(row, en, StringComparison.Ordinal);
+        }
+
+        foreach (var row in new[]
+                 {
+                     "件数・列挙の訂正",
+                     "引用された事実から導かれる wording 訂正",
+                     "相互参照・リンクの訂正",
+                     "canonical source との識別子・メタデータ不一致",
+                 })
+        {
+            Assert.Contains(row, ja, StringComparison.Ordinal);
+        }
+
+        // Granted / enumerated / evidence-logged / amendable.
+        Assert.Contains("**granted** (never assumed", en, StringComparison.Ordinal);
+        Assert.Contains("**evidence-logged**", en, StringComparison.Ordinal);
+        Assert.Contains("an unlogged resolution is a violation, not a resolution", en, StringComparison.Ordinal);
+        Assert.Contains("buys latency, not finality", en, StringComparison.Ordinal);
+        Assert.Contains("**付与される**", ja, StringComparison.Ordinal);
+        Assert.Contains("**証拠がログされる**", ja, StringComparison.Ordinal);
+        Assert.Contains("ログの無い解決は解決では なく違反", ja, StringComparison.Ordinal);
+        Assert.Contains("買うのは レイテンシであって finality ではない", ja, StringComparison.Ordinal);
+
+        // Semantic exclusion, with the double-check scope explicitly untouched.
+        Assert.Contains("**Semantic and product decisions are excluded, absolutely.**", en, StringComparison.Ordinal);
+        Assert.Contains("whose scope this contract does not touch", en, StringComparison.Ordinal);
+        Assert.Contains("**セマンティック・プロダクトの判断は絶対に除外されます。**", ja, StringComparison.Ordinal);
+        Assert.Contains("本 contract はそのスコープに触れません", ja, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BothDocs_DescribeTheDesignReminderLoop_AndTheDetector_G552()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        // Interval class, one-per-interval cap, stop-on-answer, and the
+        // operator-app reminder model.
+        Assert.Contains("**30–60 minute class**", en, StringComparison.Ordinal);
+        Assert.Contains("**at most one reminder per interval per open clarification**", en, StringComparison.Ordinal);
+        Assert.Contains("**stopping when it is answered**", en, StringComparison.Ordinal);
+        Assert.Contains("**operator app**", en, StringComparison.Ordinal);
+        Assert.Contains("finds it in the inbox on resume", en, StringComparison.Ordinal);
+
+        Assert.Contains("**30〜60 分オーダー**", ja, StringComparison.Ordinal);
+        Assert.Contains("**open な clarification 1 件につき 1 間隔あたり最大 1 通**", ja, StringComparison.Ordinal);
+        Assert.Contains("**回答されたら停止**", ja, StringComparison.Ordinal);
+        Assert.Contains("**オペレーターアプリ**", ja, StringComparison.Ordinal);
+        Assert.Contains("再開時に inbox で見つけます", ja, StringComparison.Ordinal);
+
+        // The detector both mirrors point at.
+        Assert.Contains("`design-decision-pending`", en, StringComparison.Ordinal);
+        Assert.Contains("`design-decision-pending`", ja, StringComparison.Ordinal);
+    }
+
     private static string ReadDoc(string language)
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);

--- a/tests/IntentSystem.Cli.Tests/AutomationHeartbeatCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHeartbeatCommandTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Clarify.Models;
+using IntentSystem.Clarify.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -352,6 +354,37 @@ public sealed class AutomationHeartbeatCommandTests : IDisposable
         public IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => mergedPrs;
     }
 
+    [Fact]
+    public void Execute_DesignDecisionPending_IsCarriedInMessageBody_G552()
+    {
+        // G552 AC: the heartbeat carries the new kind, so a watchdog reading
+        // only `message_body` still sees a design-decision hold. The message
+        // builder is kind-agnostic by construction — this pins that it stays
+        // that way.
+        using var workspace = new HeartbeatWorkspace();
+        workspace.WritePacketDomain("G551", "intent-cli");
+        workspace.WriteOpenClarification("G551", "Eleven or twelve slices?", FixedNow.AddMinutes(-540));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHeartbeatCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.True(doc.RootElement.GetProperty("stale").GetBoolean());
+
+        var messageBody = doc.RootElement.GetProperty("message_body").GetString()!;
+        Assert.Contains(AutomationStalledWorkCommand.KindDesignDecisionPending, messageBody, StringComparison.Ordinal);
+        Assert.Contains("G551", messageBody, StringComparison.Ordinal);
+        Assert.Contains("540m", messageBody, StringComparison.Ordinal);
+        // Actionable, so it is counted as a pending transition rather than an
+        // informational note.
+        Assert.Contains("1 pending transition(s)", messageBody, StringComparison.Ordinal);
+    }
+
     private sealed class HeartbeatWorkspace : IDisposable
     {
         public HeartbeatWorkspace()
@@ -382,6 +415,32 @@ public sealed class AutomationHeartbeatCommandTests : IDisposable
             var dir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
             Directory.CreateDirectory(dir);
             File.WriteAllText(Path.Combine(dir, "packet.yaml"), $"domain: {domain}\n");
+        }
+
+        /// <summary>
+        /// G552: writes an OPEN clarification artifact where the canonical
+        /// clarify surface puts one, so the heartbeat wrapper is exercised
+        /// against a real <c>design-decision-pending</c> item.
+        /// </summary>
+        public void WriteOpenClarification(string executionUnit, string questionText, DateTimeOffset createdAt)
+        {
+            var dir = Path.Combine(RootPath, ".intent-cli", "clarifications", executionUnit);
+            Directory.CreateDirectory(dir);
+            var item = new ClarificationItem
+            {
+                ClarificationSource = "execution",
+                QuestionId = "request",
+                ExecutionUnit = executionUnit,
+                QuestionText = questionText,
+                Reason = "blocked on a design decision",
+                AffectedIntents = [],
+                AffectedExecutionUnits = [executionUnit],
+                BlockingOrNonblocking = "blocking",
+                ClarificationReturnPath = $".intent-cli/clarifications/{executionUnit}/",
+                Status = ClarificationStatus.Open,
+                CreatedAt = createdAt,
+            };
+            File.WriteAllText(Path.Combine(dir, "request.json"), ClarificationSerializer.Serialize(item));
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Clarify.Models;
+using IntentSystem.Clarify.Serialization;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -1727,6 +1729,173 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         Assert.Equal(queueStateBefore, File.ReadAllText(queueStatePath));
     }
 
+    // ─── G552: design-decision-pending ──────────────────────────────────────
+
+    [Fact]
+    public void Execute_DesignDecisionPending_FiresForOpenClarification_WithAgeUnitAndQuestion()
+    {
+        // G552 field incident (2026-07-28 16:11 -> 07-29 01:29): a nine-hour
+        // hold on a one-line wording ruling reported stalled=false throughout
+        // because the block lived only in agmsg messages. Recorded as a
+        // clarification artifact, the same hold is visible.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G551", "intent-cli");
+        workspace.WriteClarification(
+            "G551",
+            "Does the release note say eleven or twelve slices?",
+            FixedNow.AddMinutes(-540));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.True(doc.RootElement.GetProperty("stalled").GetBoolean());
+        var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindDesignDecisionPending, item.GetProperty("kind").GetString());
+        Assert.Equal("G551", item.GetProperty("execution_unit").GetString());
+        Assert.Equal(540, item.GetProperty("age_minutes").GetInt32());
+        Assert.False(item.GetProperty("is_informational").GetBoolean());
+
+        var recommendedAction = item.GetProperty("recommended_action").GetString()!;
+        // Names the clarification to answer (design) and the escalation path
+        // (operator) — and never auto-answers.
+        Assert.Contains("Does the release note say eleven or twelve slices?", recommendedAction, StringComparison.Ordinal);
+        Assert.Contains("clarify answer", recommendedAction, StringComparison.Ordinal);
+        Assert.Contains("--execution-unit G551", recommendedAction, StringComparison.Ordinal);
+        Assert.Contains("escalate", recommendedAction, StringComparison.Ordinal);
+        Assert.Contains("Never auto-answer", recommendedAction, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DesignDecisionPending_ClearsOnceTheClarificationIsAnswered()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G551", "intent-cli");
+        workspace.WriteClarification(
+            "G551",
+            "Does the release note say eleven or twelve slices?",
+            FixedNow.AddMinutes(-540),
+            ClarificationStatus.Answered);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("stalled").GetBoolean());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        // Answering clears it entirely — not into excluded[], which would be
+        // its own kind of noise.
+        Assert.Equal(0, doc.RootElement.GetProperty("excluded").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_DesignDecisionPending_NoClarificationSurface_ProducesNothing()
+    {
+        // The no-false-positive case: absence of a clarification is never a
+        // stall signal on its own.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G551", "intent-cli");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("stalled").GetBoolean());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        Assert.Equal(0, doc.RootElement.GetProperty("excluded").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_DesignDecisionPending_UnreadableArtifact_IsExcludedNeverAssumedAnswered()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WriteFile(".intent-cli/clarifications/G551/request.json", "{ not valid json }");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("stalled").GetBoolean());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+
+        var excluded = Assert.Single(doc.RootElement.GetProperty("excluded").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindDesignDecisionPending, excluded.GetProperty("kind").GetString());
+        Assert.Equal(AutomationStalledWorkCommand.ReasonClarificationUnreadable, excluded.GetProperty("reason").GetString());
+        var detail = excluded.GetProperty("detail").GetString()!;
+        Assert.Contains("request.json", detail, StringComparison.Ordinal);
+        Assert.Contains("not evidence of an unblocked pipeline", detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DesignDecisionPending_OtherDomainClarification_IsExcludedNotAttributed()
+    {
+        // Domain isolation: a clarification whose packet declares a different
+        // domain never leaks into this domain's report.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("SKS-G900", "sekiban-as-a-service");
+        workspace.WriteClarification("SKS-G900", "Which aggregate owns this invariant?", FixedNow.AddMinutes(-300));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        var excluded = Assert.Single(doc.RootElement.GetProperty("excluded").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindDesignDecisionPending, excluded.GetProperty("kind").GetString());
+        Assert.Equal("SKS-G900", excluded.GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void Execute_DesignDecisionPending_ReportsEveryOpenClarification_Independently()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G551", "intent-cli");
+        workspace.WritePacketDomain("G552", "intent-cli");
+        workspace.WriteClarification("G551", "Eleven or twelve slices?", FixedNow.AddMinutes(-540));
+        workspace.WriteClarification("G552", "Does bounded authority cover wording?", FixedNow.AddMinutes(-60));
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var items = doc.RootElement.GetProperty("items").EnumerateArray()
+            .Select(i => (Unit: i.GetProperty("execution_unit").GetString()!, Age: i.GetProperty("age_minutes").GetInt32()))
+            .ToArray();
+        Assert.Equal(2, items.Length);
+        Assert.Contains(items, i => i.Unit == "G551" && i.Age == 540);
+        Assert.Contains(items, i => i.Unit == "G552" && i.Age == 60);
+    }
+
     // ─── G544: backlog-ready-idle ───────────────────────────────────────────
 
     [Fact]
@@ -2574,6 +2743,42 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
             var dir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
             Directory.CreateDirectory(dir);
             File.WriteAllText(Path.Combine(dir, "packet.yaml"), $"domain: {domain}\n");
+        }
+
+        /// <summary>
+        /// G552: writes a clarification artifact exactly where the canonical
+        /// clarify surface puts one
+        /// (<c>.intent-cli/clarifications/&lt;execution-unit&gt;/request.json</c>),
+        /// so <c>design-decision-pending</c> reads a real artifact shape
+        /// rather than a test-only stand-in.
+        /// </summary>
+        public void WriteClarification(
+            string executionUnit,
+            string questionText,
+            DateTimeOffset createdAt,
+            ClarificationStatus status = ClarificationStatus.Open,
+            string questionId = "request")
+        {
+            var item = new ClarificationItem
+            {
+                ClarificationSource = "execution",
+                QuestionId = questionId,
+                ExecutionUnit = executionUnit,
+                QuestionText = questionText,
+                Reason = "blocked on a design decision",
+                AffectedIntents = [],
+                AffectedExecutionUnits = [executionUnit],
+                BlockingOrNonblocking = "blocking",
+                ClarificationReturnPath = $".intent-cli/clarifications/{executionUnit}/",
+                Status = status,
+                CreatedAt = createdAt,
+                Answer = status == ClarificationStatus.Open ? null : "answered",
+                AnsweredAt = status == ClarificationStatus.Open ? null : createdAt.AddMinutes(1),
+            };
+
+            WriteFile(
+                $".intent-cli/clarifications/{executionUnit}/request.json",
+                ClarificationSerializer.Serialize(item));
         }
 
         /// <summary>

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -1896,6 +1896,260 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         Assert.Contains(items, i => i.Unit == "G552" && i.Age == 60);
     }
 
+    // ─── G552 repair: end-to-end through the REAL canonical commands ────────
+
+    [Fact]
+    public void EndToEnd_ClarifyOpen_CarriesTheRealQuestionAndRecommendation_ThroughDetectorHeartbeatAndAnswer_G552()
+    {
+        // G552 repair acceptance: the canonical flow must be executable end to
+        // end through the REAL commands — direct JSON serialization is not
+        // sufficient proof. Drives: clarify open (with the actual design
+        // question, its recommended answer, and the verifying evidence) ->
+        // stalled-work detects the EXACT persisted content -> heartbeat carries
+        // it -> clarify answer clears it.
+        using var workspace = new StalledWorkWorkspace();
+        // NOTE: WritePacketDomain must NOT be called here — it rewrites
+        // packet.yaml with a bare `domain:` line, which would destroy the full
+        // projection packet the real `clarify open` needs. The packet written
+        // below declares its own domain instead.
+        workspace.WriteClarifiablePacket("G552");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        const string Question = "Does the v0.6.0 release note say eleven or twelve slices?";
+        const string RecommendedAnswer = "Eleven — G547 was terminally retired and re-cut as G551.";
+        const string Evidence = "Merged PR list #1181-#1204 enumerates eleven slices; G547 has no merged PR.";
+
+        var originalTimestamp = ClarifyOpenCommand.TimestampFactory;
+        try
+        {
+            ClarifyOpenCommand.TimestampFactory = () => FixedNow.AddMinutes(-540);
+
+            // 1. Open the hold through the real command, carrying real content.
+            using (var openWriter = new StringWriter())
+            {
+                var openExit = ClarifyOpenCommand.Execute(
+                    workspace.Context,
+                    ["G552", "--question", Question, "--recommended-answer", RecommendedAnswer, "--evidence", Evidence],
+                    openWriter);
+
+                Assert.True(openExit == 0, openWriter.ToString());
+                // The command echoes what it PERSISTED, not a pre-composition
+                // value — the operator must see the durable record.
+                Assert.Contains(Question, openWriter.ToString(), StringComparison.Ordinal);
+                Assert.Contains(RecommendedAnswer, openWriter.ToString(), StringComparison.Ordinal);
+            }
+
+            // The OPEN artifact itself carries the content — no agmsg
+            // substitution, no packet synthesis.
+            var artifact = ClarificationSerializer.Deserialize(
+                File.ReadAllText(Path.Combine(workspace.RootPath, ".intent-cli", "clarifications", "G552", "request.json")));
+            Assert.Equal(ClarificationStatus.Open, artifact.Status);
+            Assert.Equal(Question, artifact.QuestionText);
+            Assert.Contains($"Recommended answer: {RecommendedAnswer}", artifact.Reason, StringComparison.Ordinal);
+            Assert.Contains($"Evidence: {Evidence}", artifact.Reason, StringComparison.Ordinal);
+
+            // 2. The detector reports the EXACT persisted question.
+            using (var stalledWriter = new StringWriter())
+            {
+                var exitCode = AutomationStalledWorkCommand.Execute(
+                    workspace.Context,
+                    ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+                    stalledWriter);
+
+                Assert.Equal(0, exitCode);
+                using var doc = JsonDocument.Parse(stalledWriter.ToString());
+                Assert.True(doc.RootElement.GetProperty("stalled").GetBoolean());
+                var item = Assert.Single(doc.RootElement.GetProperty("items").EnumerateArray());
+                Assert.Equal(AutomationStalledWorkCommand.KindDesignDecisionPending, item.GetProperty("kind").GetString());
+                Assert.Equal("G552", item.GetProperty("execution_unit").GetString());
+                Assert.Equal(540, item.GetProperty("age_minutes").GetInt32());
+                Assert.Contains(Question, item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+            }
+
+            // 3. The heartbeat carries it.
+            using (var heartbeatWriter = new StringWriter())
+            {
+                var exitCode = AutomationHeartbeatCommand.Execute(
+                    workspace.Context,
+                    ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+                    heartbeatWriter);
+
+                Assert.Equal(0, exitCode);
+                using var doc = JsonDocument.Parse(heartbeatWriter.ToString());
+                Assert.True(doc.RootElement.GetProperty("stale").GetBoolean());
+                var messageBody = doc.RootElement.GetProperty("message_body").GetString()!;
+                Assert.Contains(AutomationStalledWorkCommand.KindDesignDecisionPending, messageBody, StringComparison.Ordinal);
+                Assert.Contains("G552", messageBody, StringComparison.Ordinal);
+            }
+
+            // 4. Answering through the real command clears the item.
+            var answerPath = Path.Combine(workspace.RootPath, "answer.txt");
+            File.WriteAllText(answerPath, "Eleven. G547 is retired, not shipped.");
+            using (var answerWriter = new StringWriter())
+            {
+                var answerExit = ClarifyAnswerCommand.Execute(
+                    workspace.Context,
+                    ["G552", "--from-file", answerPath],
+                    answerWriter);
+
+                Assert.True(answerExit == 0, answerWriter.ToString());
+            }
+
+            using (var clearedWriter = new StringWriter())
+            {
+                var exitCode = AutomationStalledWorkCommand.Execute(
+                    workspace.Context,
+                    ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+                    clearedWriter);
+
+                Assert.Equal(0, exitCode);
+                using var doc = JsonDocument.Parse(clearedWriter.ToString());
+                Assert.False(doc.RootElement.GetProperty("stalled").GetBoolean());
+                Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+                Assert.Equal(0, doc.RootElement.GetProperty("excluded").GetArrayLength());
+            }
+        }
+        finally
+        {
+            ClarifyOpenCommand.TimestampFactory = originalTimestamp;
+        }
+    }
+
+    [Fact]
+    public void ClarifyOpen_WithoutExplicitInputs_KeepsThePreG552DerivedBehavior()
+    {
+        // The new inputs are optional: omitting them must leave the
+        // packet-derived question and the plain reason exactly as before, so no
+        // existing caller changes behavior.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WriteClarifiablePacket("G552");
+
+        var originalTimestamp = ClarifyOpenCommand.TimestampFactory;
+        try
+        {
+            ClarifyOpenCommand.TimestampFactory = () => FixedNow.AddMinutes(-30);
+            using var openWriter = new StringWriter();
+            var openExit = ClarifyOpenCommand.Execute(workspace.Context, ["G552"], openWriter);
+            Assert.True(openExit == 0, openWriter.ToString());
+        }
+        finally
+        {
+            ClarifyOpenCommand.TimestampFactory = originalTimestamp;
+        }
+
+        var artifact = ClarificationSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(workspace.RootPath, ".intent-cli", "clarifications", "G552", "request.json")));
+        // Derived from the packet's first deterministic review check.
+        Assert.Contains("Clarify blocker for", artifact.QuestionText, StringComparison.Ordinal);
+        Assert.DoesNotContain("Recommended answer:", artifact.Reason, StringComparison.Ordinal);
+        Assert.DoesNotContain("Evidence:", artifact.Reason, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(ClarificationStatus.Answered)]
+    [InlineData(ClarificationStatus.Applied)]
+    [InlineData(ClarificationStatus.Cancelled)]
+    public void DesignDecisionPending_ClearsOnEveryTerminalStatus_G552(ClarificationStatus terminalStatus)
+    {
+        // G552 repair acceptance: every terminal status clears the item, not
+        // just `answered`. `clarify answer` produces Answered/Applied through
+        // the canonical gateway (covered end to end above); Cancelled has no
+        // command of its own today, so it is proven here against the same
+        // canonical model path the detector reads.
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G552", "intent-cli");
+        workspace.WriteClarification(
+            "G552",
+            "Eleven or twelve slices?",
+            FixedNow.AddMinutes(-540),
+            terminalStatus);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        Assert.False(doc.RootElement.GetProperty("stalled").GetBoolean());
+        Assert.Equal(0, doc.RootElement.GetProperty("items").GetArrayLength());
+        Assert.Equal(0, doc.RootElement.GetProperty("excluded").GetArrayLength());
+    }
+
+    [Fact]
+    public void BoundedAuthorityResolution_IsRecordedUnderRecentlyResolved_AndStaysForPostHocAmendment_G552()
+    {
+        // G552 repair acceptance: the bounded-authority evidence log has a
+        // concrete durable sink — `clarify record --from-file` — and the entry
+        // must REMAIN readable afterwards so design can amend post hoc.
+        using var workspace = new StalledWorkWorkspace();
+        var returnPath = Path.Combine(workspace.RootPath, "intents", "intent-cli", "clarifications", "open.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(returnPath)!);
+        File.WriteAllText(returnPath, "# Clarifications\n\n## Open\n\n(none)\n\n## Recently Resolved\n\n");
+
+        var decisionPath = Path.Combine(workspace.RootPath, "authority-decision.md");
+        File.WriteAllText(decisionPath, """
+            ## Question
+            G552 release-note slice count: eleven or twelve?
+
+            ## Decision
+            Eleven.
+
+            ## Rationale
+            Merged PR list #1181-#1204 enumerates eleven slices; G547 has no merged PR. Reviewer and orchestrator agreed.
+            """);
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyRecordCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--from-file", decisionPath],
+            writer);
+
+        Assert.True(exitCode == 0, writer.ToString());
+
+        // The entry lands under `## Recently Resolved` with the exact content
+        // of all three sections.
+        var recorded = File.ReadAllText(returnPath);
+        var recentlyResolvedIndex = recorded.IndexOf("## Recently Resolved", StringComparison.Ordinal);
+        Assert.True(recentlyResolvedIndex >= 0);
+        var recentlyResolved = recorded[recentlyResolvedIndex..];
+        Assert.Contains("G552 release-note slice count: eleven or twelve?", recentlyResolved, StringComparison.Ordinal);
+        Assert.Contains("Eleven.", recentlyResolved, StringComparison.Ordinal);
+        Assert.Contains("Merged PR list #1181-#1204 enumerates eleven slices", recentlyResolved, StringComparison.Ordinal);
+        Assert.Contains("Reviewer and orchestrator agreed", recentlyResolved, StringComparison.Ordinal);
+
+        // Post-hoc amendment: the entry is still there on a later read, and a
+        // second recorded decision never displaces the first — design can read
+        // both and amend from the evidence.
+        var amendmentPath = Path.Combine(workspace.RootPath, "amendment.md");
+        File.WriteAllText(amendmentPath, """
+            ## Question
+            G552 release-note slice count: eleven or twelve?
+
+            ## Decision
+            Confirmed eleven (design amendment review).
+
+            ## Rationale
+            Design reviewed the recorded evidence and confirmed the granted-authority resolution.
+            """);
+
+        using var amendWriter = new StringWriter();
+        var amendExit = ClarifyRecordCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--from-file", amendmentPath],
+            amendWriter);
+
+        Assert.True(amendExit == 0, amendWriter.ToString());
+
+        var afterAmendment = File.ReadAllText(returnPath);
+        Assert.Contains("Confirmed eleven (design amendment review).", afterAmendment, StringComparison.Ordinal);
+        // The original resolution and its verifying facts survive — an
+        // amendment adds to the trail rather than erasing what it amends.
+        Assert.Contains("Merged PR list #1181-#1204 enumerates eleven slices", afterAmendment, StringComparison.Ordinal);
+    }
+
     // ─── G544: backlog-ready-idle ───────────────────────────────────────────
 
     [Fact]
@@ -2743,6 +2997,101 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
             var dir = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
             Directory.CreateDirectory(dir);
             File.WriteAllText(Path.Combine(dir, "packet.yaml"), $"domain: {domain}\n");
+        }
+
+        /// <summary>
+        /// G552 repair: writes everything the REAL <c>clarify open</c> needs —
+        /// a queue item, its packet.yaml, and its review-context.md — so the
+        /// canonical flow can be driven end to end instead of hand-serializing
+        /// an artifact.
+        /// </summary>
+        public void WriteClarifiablePacket(string executionUnit)
+        {
+            WriteQueueState($$"""
+                {
+                  "schema_version": "1",
+                  "updated_at": "2026-07-14T11:00:00+00:00",
+                  "items": [
+                    {
+                      "execution_unit": "{{executionUnit}}",
+                      "title": "[{{executionUnit}}] Design-decision hold",
+                      "state": "review",
+                      "dependencies": [],
+                      "blocked_by": [],
+                      "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                      "packet_paths": {
+                        "implementation": ".intent-cli/issues/{{executionUnit}}/implementation.md",
+                        "review_context": ".intent-cli/issues/{{executionUnit}}/review-context.md",
+                        "yaml": ".intent-cli/issues/{{executionUnit}}/packet.yaml"
+                      },
+                      "worker_role": "coder",
+                      "review_role": "reviewer",
+                      "priority": "normal"
+                    }
+                  ]
+                }
+                """);
+
+            WriteFile($".intent-cli/issues/{executionUnit}/packet.yaml", $$"""
+                implementation_issue_packet:
+                  issue_title: "[{{executionUnit}}] Design-decision hold"
+                  issue_kind: "feature"
+                  source_execution_unit: "{{executionUnit}}"
+                  goal: "Record a design-decision hold."
+                  domain: "intent-cli"
+                  in_scope:
+                    - "clarification-backed holds"
+                  out_of_scope:
+                    - "schema changes"
+                  target_repo: "J-Tech-Japan/intent-system"
+                  target_path: "."
+                  target_part: "clarify open"
+                  dependencies: []
+                  technical_baseline:
+                    - "C# / .NET"
+                  project_local_guide:
+                    - "AGENTS.md"
+                  intent_baseline:
+                    - "design absence must not invisibly block"
+                  intent_references:
+                    - "ICL.P.PRODUCT_GOAL"
+                  rules_and_specs:
+                    - "intents/intent-cli/specs/06-interview-and-clarification-artifact-contract.md"
+                  acceptance_criteria:
+                    - "clarification artifact generated"
+                  verification_evidence:
+                    - "dotnet test IntentSystem.sln"
+                  review_mode: "deterministic-review"
+                  completion_action: "wait-for-deterministic-review"
+                  landing_policy: "merge-after-review"
+
+                review_context_packet:
+                  source_execution_unit: "{{executionUnit}}"
+                  parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+                  intent_references:
+                    - "ICL.P.PRODUCT_GOAL"
+                  rules_and_specs:
+                    - "intents/intent-cli/specs/06-interview-and-clarification-artifact-contract.md"
+                  acceptance_criteria:
+                    - "clarification artifact generated"
+                  deterministic_review_checks:
+                    - "clarify open stays entry-only"
+                  clarification_return_path: "intents/intent-cli/clarifications/open.md"
+                """);
+
+            WriteFile($".intent-cli/issues/{executionUnit}/review-context.md", $$"""
+                # Execution Unit
+
+                `{{executionUnit}}`
+
+                # Acceptance Criteria
+
+                - clarification artifact generated
+
+                # Deterministic Review Checks
+
+                - clarify open stays entry-only
+                """);
         }
 
         /// <summary>

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2217,6 +2217,15 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("> **Contract violation:**", output, StringComparison.Ordinal);
         Assert.Contains("An agmsg-only hold is a CONTRACT VIOLATION", output, StringComparison.Ordinal);
         Assert.Contains("if the artifact does not exist, you are not waiting, you are stalled", output, StringComparison.Ordinal);
+
+        // G552 repair: a paste-ready invocation that actually persists the real
+        // question and its recommendation/evidence in the OPEN artifact —
+        // agmsg may notify, but it can never substitute for the artifact.
+        Assert.Contains("Paste-ready — the OPEN artifact carries the real content", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli clarify open <execution-unit>", output, StringComparison.Ordinal);
+        Assert.Contains("--question ", output, StringComparison.Ordinal);
+        Assert.Contains("--recommended-answer ", output, StringComparison.Ordinal);
+        Assert.Contains("--evidence ", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -2255,6 +2264,15 @@ public sealed class GuideOrchestratorThreadCommandTests
         // AC element 4: post-hoc amendment right.
         Assert.Contains("DESIGN MAY AMEND POST HOC", output, StringComparison.Ordinal);
         Assert.Contains("buys latency, not finality", output, StringComparison.Ordinal);
+        // G552 repair: the evidence log has a CONCRETE durable sink and a
+        // paste-ready operation, not just prose.
+        Assert.Contains("**evidence sink**", output, StringComparison.Ordinal);
+        Assert.Contains("CANONICAL `clarify record` surface", output, StringComparison.Ordinal);
+        Assert.Contains("`## Recently Resolved`", output, StringComparison.Ordinal);
+        Assert.Contains("intents/<domain>/clarifications/open.md", output, StringComparison.Ordinal);
+        Assert.Contains("Paste-ready evidence operation:", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli clarify record --domain <domain> --from-file", output, StringComparison.Ordinal);
+        Assert.Contains("## Rationale", output, StringComparison.Ordinal);
         // AC element 5: semantic exclusion, with the double-check scope untouched.
         Assert.Contains("> **Semantic exclusion:**", output, StringComparison.Ordinal);
         Assert.Contains("SEMANTIC AND PRODUCT DECISIONS ARE EXCLUDED, absolutely", output, StringComparison.Ordinal);
@@ -2297,6 +2315,10 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Equal(4, hold.GetProperty("required_fields").GetArrayLength());
         Assert.Contains("CONTRACT VIOLATION", hold.GetProperty("contract_violation_rule").GetString(), StringComparison.Ordinal);
         Assert.NotEmpty(hold.GetProperty("canonical_commands").EnumerateArray());
+        var invocation = hold.GetProperty("paste_ready_invocation").GetString()!;
+        Assert.Contains("--question", invocation, StringComparison.Ordinal);
+        Assert.Contains("--recommended-answer", invocation, StringComparison.Ordinal);
+        Assert.Contains("--evidence", invocation, StringComparison.Ordinal);
 
         var reviewer = holds.GetProperty("reviewer_hold_rule");
         Assert.Contains("FACT-CHECKABLE", reviewer.GetProperty("resolve_under_authority_when").GetString(), StringComparison.Ordinal);
@@ -2314,6 +2336,8 @@ public sealed class GuideOrchestratorThreadCommandTests
         // verification condition would silently widen it.
         Assert.All(classes, c => Assert.NotEmpty(c.Facts));
         Assert.Contains("MANDATORY EVIDENCE LOGGING", authority.GetProperty("evidence_logging_rule").GetString(), StringComparison.Ordinal);
+        Assert.Contains("Recently Resolved", authority.GetProperty("evidence_sink").GetString(), StringComparison.Ordinal);
+        Assert.Contains("clarify record --domain", authority.GetProperty("evidence_operation").GetString(), StringComparison.Ordinal);
         Assert.Contains("AMEND POST HOC", authority.GetProperty("post_hoc_amendment_rule").GetString(), StringComparison.Ordinal);
         Assert.Contains("EXCLUDED", authority.GetProperty("semantic_exclusion_rule").GetString(), StringComparison.Ordinal);
 

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2199,6 +2199,134 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("Design-thread watchdog", supervision.GetProperty("watchdog_safety_rules_reference").GetString(), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_Markdown_ClarificationBackedHold_MakesAgmsgOnlyHoldsAContractViolation_G552()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("## Design-decision holds and bounded authority (G552)", output, StringComparison.Ordinal);
+        Assert.Contains("### Clarification-backed holds", output, StringComparison.Ordinal);
+        // AC: the hold is recorded through the canonical clarify surface, with
+        // the four fields.
+        Assert.Contains("RECORDS A CLARIFICATION ARTIFACT through the canonical clarify surface", output, StringComparison.Ordinal);
+        Assert.Contains("blocking execution unit", output, StringComparison.Ordinal);
+        Assert.Contains("recommended answer", output, StringComparison.Ordinal);
+        Assert.Contains("`intent-cli clarify open`", output, StringComparison.Ordinal);
+        Assert.Contains("`intent-cli clarify answer`", output, StringComparison.Ordinal);
+        // AC: the contract-violation sentence.
+        Assert.Contains("> **Contract violation:**", output, StringComparison.Ordinal);
+        Assert.Contains("An agmsg-only hold is a CONTRACT VIOLATION", output, StringComparison.Ordinal);
+        Assert.Contains("if the artifact does not exist, you are not waiting, you are stalled", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_ReviewerHoldRule_NeverAnUntrackedWait_G552()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("### Reviewer hold rule (refined)", output, StringComparison.Ordinal);
+        // Green technical + fact-checkable non-semantic -> resolve under authority.
+        Assert.Contains("Technical checks are GREEN and the only pending item is NON-SEMANTIC and MECHANICALLY FACT-CHECKABLE", output, StringComparison.Ordinal);
+        // Otherwise -> recorded clarification and a visible pending state.
+        Assert.Contains("becomes a recorded clarification and a VISIBLE pending state", output, StringComparison.Ordinal);
+        // Never a third option.
+        Assert.Contains("> **Never an untracked wait:**", output, StringComparison.Ordinal);
+        Assert.Contains("there is no third option", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_BoundedDefaultAuthority_IsGrantedEnumeratedLoggedAmendableAndNonSemantic_G552()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("### Bounded default authority", output, StringComparison.Ordinal);
+        // AC element 1: operator grant requirement.
+        Assert.Contains("GRANTED, never assumed", output, StringComparison.Ordinal);
+        Assert.Contains("classes the OPERATOR has explicitly pre-delegated", output, StringComparison.Ordinal);
+        // AC element 2: the enumeration is the whole MAY scope, each with its facts.
+        Assert.Contains("#### Enumerated fact-checkable classes (the whole MAY scope)", output, StringComparison.Ordinal);
+        Assert.Contains("**count and enumeration corrections** — verify:", output, StringComparison.Ordinal);
+        Assert.Contains("**wording corrections that follow from a cited fact** — verify:", output, StringComparison.Ordinal);
+        Assert.Contains("**cross-reference and link corrections** — verify:", output, StringComparison.Ordinal);
+        Assert.Contains("**identifier and metadata mismatches against a canonical source** — verify:", output, StringComparison.Ordinal);
+        // AC element 3: mandatory evidence logging.
+        Assert.Contains("MANDATORY EVIDENCE LOGGING", output, StringComparison.Ordinal);
+        Assert.Contains("An unlogged resolution is not a granted-authority resolution", output, StringComparison.Ordinal);
+        // AC element 4: post-hoc amendment right.
+        Assert.Contains("DESIGN MAY AMEND POST HOC", output, StringComparison.Ordinal);
+        Assert.Contains("buys latency, not finality", output, StringComparison.Ordinal);
+        // AC element 5: semantic exclusion, with the double-check scope untouched.
+        Assert.Contains("> **Semantic exclusion:**", output, StringComparison.Ordinal);
+        Assert.Contains("SEMANTIC AND PRODUCT DECISIONS ARE EXCLUDED, absolutely", output, StringComparison.Ordinal);
+        Assert.Contains("double-check rule, whose scope this contract does not touch", output, StringComparison.Ordinal);
+        Assert.Contains("deciding what SHOULD be true rather than checking what IS true", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_DesignReminderLoop_HasIntervalCapAndStopCondition_G552()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("### Periodic design-reminder loop", output, StringComparison.Ordinal);
+        // AC: interval class, one-per-interval cap, stop-on-answer.
+        Assert.Contains("30–60 minute class", output, StringComparison.Ordinal);
+        Assert.Contains("AT MOST ONE reminder per interval PER OPEN CLARIFICATION", output, StringComparison.Ordinal);
+        Assert.Contains("STOP ON ANSWER", output, StringComparison.Ordinal);
+        // Sent by the orchestrator's existing long-interval automation — no new scheduler.
+        Assert.Contains("The ORCHESTRATOR sends the reminder from its long-interval automation", output, StringComparison.Ordinal);
+        // The operator-app reminder model, with no workspace-residency requirement.
+        Assert.Contains("OPERATOR APP", output, StringComparison.Ordinal);
+        Assert.Contains("finds it waiting in the inbox on resume", output, StringComparison.Ordinal);
+        Assert.Contains("no workspace-residency requirement", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_DesignDecisionHolds_HasStructuredShape_G552()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var holds = doc.RootElement.GetProperty("design_decision_holds");
+
+        var hold = holds.GetProperty("clarification_backed_hold");
+        Assert.Equal(4, hold.GetProperty("required_fields").GetArrayLength());
+        Assert.Contains("CONTRACT VIOLATION", hold.GetProperty("contract_violation_rule").GetString(), StringComparison.Ordinal);
+        Assert.NotEmpty(hold.GetProperty("canonical_commands").EnumerateArray());
+
+        var reviewer = holds.GetProperty("reviewer_hold_rule");
+        Assert.Contains("FACT-CHECKABLE", reviewer.GetProperty("resolve_under_authority_when").GetString(), StringComparison.Ordinal);
+        Assert.Contains("VISIBLE pending state", reviewer.GetProperty("record_clarification_otherwise").GetString(), StringComparison.Ordinal);
+        Assert.Contains("no third option", reviewer.GetProperty("never_untracked_wait").GetString(), StringComparison.Ordinal);
+
+        var authority = holds.GetProperty("bounded_default_authority");
+        Assert.Contains("GRANTED, never assumed", authority.GetProperty("operator_grant_requirement").GetString(), StringComparison.Ordinal);
+        var classes = authority.GetProperty("fact_checkable_classes").EnumerateArray()
+            .Select(c => (Class: c.GetProperty("decision_class").GetString()!, Facts: c.GetProperty("verifying_facts").GetString()!))
+            .ToArray();
+        Assert.Equal(4, classes.Length);
+        // Every enumerated class carries the facts that verify it — the
+        // enumeration is what bounds the authority, so an entry without a
+        // verification condition would silently widen it.
+        Assert.All(classes, c => Assert.NotEmpty(c.Facts));
+        Assert.Contains("MANDATORY EVIDENCE LOGGING", authority.GetProperty("evidence_logging_rule").GetString(), StringComparison.Ordinal);
+        Assert.Contains("AMEND POST HOC", authority.GetProperty("post_hoc_amendment_rule").GetString(), StringComparison.Ordinal);
+        Assert.Contains("EXCLUDED", authority.GetProperty("semantic_exclusion_rule").GetString(), StringComparison.Ordinal);
+
+        var reminder = holds.GetProperty("design_reminder_loop");
+        Assert.Contains("30–60 minute class", reminder.GetProperty("interval_class").GetString(), StringComparison.Ordinal);
+        Assert.Contains("AT MOST ONE", reminder.GetProperty("one_per_interval_rule").GetString(), StringComparison.Ordinal);
+        Assert.Contains("STOP ON ANSWER", reminder.GetProperty("stop_condition").GetString(), StringComparison.Ordinal);
+        Assert.Contains("OPERATOR APP", reminder.GetProperty("operator_app_note").GetString(), StringComparison.Ordinal);
+
+        // The guide points at the detector that reads what these rules write.
+        Assert.Contains("design-decision-pending", holds.GetProperty("detection_reference").GetString(), StringComparison.Ordinal);
+    }
+
     private static string RunMarkdown(string[] args)
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Makes a **design-decision hold visible and bounded**, so a design-thread absence can never invisibly stall the pipeline again.

**Field incident** (2026-07-28 16:11 → 07-29 01:29): the G551 review held its final verdict for **nine hours** on a one-line wording ruling while every technical check was green. The pending item was mechanically fact-checkable — a slice count derivable from the merged PR list — and both threads knew the answer, but no authority delegation existed. The hold lived only in agmsg messages, so `stalled-work` reported `stalled=false` throughout. Fourth design-absence stall in the field record.

## Three layers

**1. Clarification-backed holds (guide).** An orchestrator/reviewer hold blocked on a design decision is recorded as a clarification artifact through the canonical clarify surface — domain, blocking unit, question, and the recommended answer when one exists.

> **An agmsg-only hold is a contract violation.** If you are waiting on design, the artifact exists; if the artifact does not exist, you are not waiting, you are stalled.

**2. `design-decision-pending` (detector).** `automation stalled-work` reads the domain's **open** clarification artifacts and reports each with age (from the artifact's own `createdAt`), blocking execution unit, and a one-line question summary. `automation heartbeat` carries it in `message_body` — kind-agnostic by construction, now pinned by a test.

- **Actionable** (`is_informational: false`), following the `repair-stalled` precedent: the recommendation names the exact clarification to answer *plus* the operator escalation path, and **never auto-answers** — the answer is design's content.
- **Only kind with no GitHub entity of its own**, which is exactly why the stall it detects was invisible to every other kind.
- **Fails closed both ways**: an unreadable/undeserializable artifact goes to `excluded[]` with its path (`clarification-unreadable`) rather than being skipped as answered; a clarification whose packet declares a different domain is excluded rather than attributed.
- **Answering clears it** — no threshold, no separate transition.

**3. Bounded default authority (guide).** The operator may pre-delegate four enumerated decision classes settled by *checking repository facts* rather than by judgment, each with its verification condition:

| decision class | what verifies it |
| --- | --- |
| count and enumeration corrections | derivable from repository facts both threads can read |
| wording corrections that follow from a cited fact | entailed by a repository fact, with reviewer + orchestrator agreement |
| cross-reference and link corrections | the target exists (or does not) as cited |
| identifier and metadata mismatches | the named canonical source is read and wins |

Bounded in every direction: **granted** (never assumed), **enumerated** (that table is the whole MAY scope), **evidence-logged** (an unlogged resolution is a violation, not a resolution), **amendable** (design may reverse it post hoc — the authority buys latency, not finality), and **never semantic** (intent shaping, packet content, release scope, prioritization always go to design; the double-check rule's scope is untouched).

Plus the **refined reviewer hold rule** — green technical + fact-checkable pending resolves under authority, everything else becomes a visible pending state, never an untracked wait — and the **periodic design-reminder loop**: the orchestrator's *existing* long-interval automation (no new scheduler), 30–60 minute class, at most one reminder per interval per open clarification, stop on answer. The design thread runs in the **operator app** by preference, so an open session gets the reminder live and a closed one finds it in the inbox on resume — no workspace-residency requirement.

## Surfaces touched

- `src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs` — `KindDesignDecisionPending`, `ReasonClarificationUnreadable`, `CollectDesignDecisionPending`.
- `src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs` — `design_decision_holds` node (markdown + JSON).
- `docs/{en,ja}/12-agent-message-orchestration.md` — hold rule, authority contract, reminder loop.
- `docs/{en,ja}/09-developer-reference.md` — the new kind.
- Tests: 6 stalled-work fixtures, 1 heartbeat, 5 guide, 3 docs-parity.

`automation heartbeat` needed **no code change** — its `message_body` builder is kind-agnostic (same as G544).

## Verification

- `dotnet test IntentSystem.sln` — **all green** (CLI suite 3873 passed / 0 failed; every other project passed).
- Focused: `AutomationStalledWorkCommandTests` 86/86, `AutomationHeartbeatCommandTests` 13/13, `GuideOrchestratorThreadCommandTests` 96/96, `AgentMessageOrchestrationDocsTests` 10/10.
- Rendered `intent-cli guide orchestrator-thread --format markdown` and checked the section against the ruling it encodes.
- `git diff --check` clean.

## Out of scope (untouched)

No new artifact types or clarify-surface schema changes; no auto-answering of any decision; no design-residency tooling; no change to the double-check rule's semantic scope.

Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPT7cFrCzT6ehACFez8dpE
