### PR TITLE
G554: Prepare v0.6.1 patch release metadata for G552–G553 and add the post-release version-roll rule

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2006,93 +2006,63 @@ update` works again.
 Existing preview artifacts are **not** renumbered retroactively; the rule fixes
 the channel going forward.
 
-### Next release readiness (v0.6.0)
+### Next release readiness (v0.6.1)
 
-**`v0.5.0` shipped** (GitHub Release + NuGet) and the version policy was bumped
-to the `0.6.0` development line — a **minor** bump, not a patch: the batch ships
-three new stalled-work detection kinds (`backlog-ready-idle`,
-`blocked-label-drift`, `repair-stalled`), three new commands (`automation
-runs-audit`, `queue priority-drift`, `automation issue-block`), visible
-behavior changes to already-shipped commands, and the repositioning of
-four-thread agmsg orchestration as the PRIMARY documented model — more than a
-patch release justifies. The repository is now on the in-development **`0.6.0`**
-`nextVersion`; G551 is **prepare-only** — it bumps the version metadata and docs
-and adds no publish steps. The version-bump merge does **not** create a GitHub
-Release or tag. After it merges and the
-[release-readiness gate](release-notes-v0.6.0.md#release-readiness-gate-g551)
+**`v0.6.0` shipped** (GitHub Release + NuGet) and the version policy was rolled
+to the `0.6.1` development line — a **patch** bump, not a minor: neither slice in
+this batch ships a new command surface. G553 is a WIP-gate bugfix
+(converged-blocked units no longer starve `host-review-preflight`), and G552
+extends the existing `automation stalled-work` / `automation heartbeat`
+detection surfaces and the orchestrator-thread guide (clarification-backed
+holds, the `design-decision-pending` kind, the periodic design-reminder loop,
+and bounded default authority). Minor stays reserved for new command surfaces
+and broad behavior changes.
+
+The repository is now on the in-development **`0.6.1`** `nextVersion`; G554 is
+**prepare-only** — it bumps the version metadata and docs and adds no publish
+steps. The version-bump merge does **not** create a GitHub Release or tag. After
+it merges and the
+[release-readiness gate](release-notes-v0.6.1.md#release-readiness-gate-g554)
 holds, a **maintainer/operator (or external release automation) creates and
-publishes the GitHub Release** for `v0.6.0`; publishing that Release fires
+publishes the GitHub Release** for `v0.6.1`; publishing that Release fires
 `.github/workflows/release.yml` (`on: release: published`), which builds and
 publishes the NuGet package and the per-platform binary artifacts. Full
 changelog and operator checklist:
-[release-notes-v0.6.0.md](release-notes-v0.6.0.md).
+[release-notes-v0.6.1.md](release-notes-v0.6.1.md).
 
-> **G547 is not part of this release.** The cycle's original release-prep unit
-> was canonically **retired** when the operator directed that G549/G550 join the
-> release scope; retirement is terminal for a unit id, so the continuation is
-> the new unit **G551** rather than a republish. G547 shipped no code and no
-> documentation. The range `G539–G550` spans twelve unit ids, **eleven** of
-> which are merged and shipped in `v0.6.0`.
+**To ship in `v0.6.1` (changes since `v0.6.0`):**
 
-**To ship in `v0.6.0` (changes since `v0.5.0`) — primary-model repositioning
-and provisioning, stall-detection completion, durable-state integrity, and
-operational guidance:**
+- **Design-decision holds are visible and bounded** (G552) — a hold blocked on a
+  design decision is recorded as a clarification artifact through the canonical
+  clarify surface, which now accepts the real question and an optional
+  recommended answer/evidence in the OPEN artifact (no schema change);
+  `automation stalled-work` reports each open clarification as
+  `design-decision-pending` and `automation heartbeat` carries it; and the guide
+  defines bounded default authority — operator-granted, enumerated,
+  evidence-logged, amendable, and never semantic — plus the periodic
+  design-reminder loop and the refined reviewer hold rule.
+- **Queue-blocked units no longer starve the WIP gate** (G553) — an issue whose
+  queue item is in the converged blocked state (`state=blocked` AND non-empty
+  `blocked_by`) is excluded from `in_flight_issues`, with two-sided convergence
+  required, half-converged items still counted and diagnosed, exempted units
+  listed in `wip_exempt_blocked_units`, repo-qualified `linked_issue` linkage,
+  and fail-closed behavior on unreadable host state.
 
-- **Primary-model repositioning and provisioning** (G540/G541, G549, G550) —
-  four-thread agmsg orchestration is the PRIMARY documented model across every
-  guide surface, the README, the NuGet description, and the docs indexes, with
-  the design↔orchestrator double-check rule and
-  [ADR 0001](../adr/0001-four-thread-orchestration-primary-model.md); timer-loop
-  mode is retained as the fully supported, simpler alternative. `guide
-  orchestrator-thread` gains a **terminal-workspace provisioning** section (role
-  folders created when absent, workspace topology, shim-safe launch, actas, and
-  three-layer readiness) and a **design-thread workspace supervision** section
-  (operator-granted session-layer authority with workflow ownership unchanged,
-  three supervision layers with cadences, the restart re-arm rule, and the
-  verified-read dialog boundary).
-- **Stall-detection completion** (G543, G544, G545, G546) — `backlog-ready-idle`
-  fires when an empty WIP coexists with a publishable candidate and an idle
-  `runs.jsonl`; a queue-`blocked` unit is exempt from `claimed-but-silent` and
-  surfaces as `blocked-label-drift` instead, with canonical `automation
-  issue-block` applying the new `intent-issue-blocked` label; `repair-stalled`
-  promotes a silent repair/rereview claim to actionable with a status-check
-  recommendation (never a transition or reassignment); and priority ranking for
-  the documented enum plus legacy out-of-enum values is unified in one shared
-  classification, with read-only `queue priority-drift` reporting the
-  distribution.
-- **Durable-state integrity** (G542, G548) — `automation runs-audit` reports and
-  repairs malformed `runs.jsonl` rows, separating within-record derivation from
-  explicitly-flagged peer-convention inference, while publish validation becomes
-  domain-scoped (another domain's malformed row warns instead of hard-blocking);
-  and every canonical queue-state mutation now writes through one layer
-  providing stale-base detection with item-scoped re-application and a
-  no-item-loss invariant that aborts rather than silently dropping units.
-- **Operational guidance** (G539) — the design-thread watchdog loop is the
-  RECOMMENDED default safety net, with an orchestrator-side long-interval
-  automation as the selectable alternative. **This supersedes the v0.5.0-era
-  external cron/launchd scheduler recommendation**, retired with field evidence
-  (silent failure on every run for five continuous days; a 105-minute stall
-  detected but unrecovered). See
-  [Agent-message orchestration](12-agent-message-orchestration.md#design-thread-watchdog-recommended-safety-net).
-- **Note on orchestration-mode framing:** the "preview/experimental" description
-  that applied through the `v0.5.0` line is fully superseded as of G540/G541 and
-  no longer appears anywhere in the shipped documentation.
-
-**Release-readiness verification (run before merging the `v0.6.0` version
+**Release-readiness verification (run before merging the `v0.6.1` version
 bump):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.5.0 (published), nextVersion 0.6.0 (to release)
+cat eng/version.json   # stableVersion 0.6.0 (published), nextVersion 0.6.1 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.6.0-<sha>-G55x   (NOT a stale literal)
+#   expected shape: intent-cli 0.6.1-<sha>-G55x   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.6.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.6.1.nupkg
 
 # 4. Confirm package metadata (id / command / license / project URL).
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2100,12 +2070,14 @@ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
 ```
 
 After the version-bump merge lands on `main`, a maintainer/operator (or external
-release automation) creates and publishes the GitHub Release for `v0.6.0`;
+release automation) creates and publishes the GitHub Release for `v0.6.1`;
 publishing it triggers `release.yml` (`on: release: published`) to build and
-publish the NuGet package and the per-platform binary artifacts. Once it has
-published, apply the post-release `eng/version.json` bump above
-(`stableVersion → 0.6.0`, `nextVersion → 0.6.1`) — deferred to the NEXT
-release-prep packet, not this one.
+publish the NuGet package and the per-platform binary artifacts. **Then roll
+`eng/version.json` immediately** — `stableVersion → 0.6.1`, `nextVersion →
+0.6.2` — per step 4 of the
+[post-release version roll](#post-release-version-roll-g554--required-immediate).
+The roll is no longer deferred to a later release-prep packet: deferring it is
+exactly the 2026-07-29 defect that broke the preview channel.
 
 
 ### Re-creating a deleted release tag (`v0.3.3`)

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1956,31 +1956,55 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.5.0",
-  "nextVersion": "0.6.0"
-}
-```
-
-| Stage | Version form | How it is derived |
-| --- | --- | --- |
-| Local pack / install | `0.6.0-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.6.0-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.6.0-rc.N` | Publishing the GitHub Release for tag `v0.6.0-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
-| Stable release | `0.6.0` | Publishing the GitHub Release for tag `v0.6.0` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.6.1-preview.<run>.<attempt>` | After bumping `nextVersion` to `0.6.1` |
-
-**After releasing `v0.6.0`**, bump both fields in `eng/version.json`:
-
-```json
-{
   "stableVersion": "0.6.0",
   "nextVersion": "0.6.1"
 }
 ```
 
-This ensures the next main-branch CI build (and local pack) immediately produces
-`0.6.1-preview.<run>.<attempt>` / `0.6.1-<sha>-<G-unit>` rather than continuing to
-emit `0.6.0` (which would collide with the stable release version).
+| Stage | Version form | How it is derived |
+| --- | --- | --- |
+| Local pack / install | `0.6.1-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `0.6.1-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `0.6.1-rc.N` | Publishing the GitHub Release for tag `v0.6.1-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
+| Stable release | `0.6.1` | Publishing the GitHub Release for tag `v0.6.1` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
+| Post-release main builds | `0.6.2-preview.<run>.<attempt>` | After rolling `nextVersion` to `0.6.2` |
+
+### Post-release version roll (G554) — required, immediate
+
+**The moment a GitHub Release is published and verified, roll `eng/version.json`
+in a follow-up commit**: `stableVersion` = the version just released,
+`nextVersion` = the next patch. This is not an optional tidy-up; it is a step of
+release closeout, and skipping it breaks the preview channel.
+
+```json
+{
+  "stableVersion": "0.6.1",
+  "nextVersion": "0.6.2"
+}
+```
+
+**Why it is required.** `nextVersion` is what preview and local-pack builds are
+derived from. If it still names the version that was just released, every
+subsequent preview builds as `<released>-preview.N` — and a prerelease sorts
+**below** its own release version in SemVer. Field incident, 2026-07-29: after
+`v0.6.0` was published the roll was skipped, so previews kept building as
+`0.6.0-preview.N`; `dotnet tool update` refused the newer build as older, and a
+manual uninstall/install was the only way forward. Rolling immediately makes the
+next preview `0.6.2-preview.N`, which sorts above `0.6.1`, and `dotnet tool
+update` works again.
+
+**Release closeout checklist** (the roll is step 4 — do not stop at step 3):
+
+1. Publish the GitHub Release for the version (this fires `release.yml`).
+2. Verify the published artifacts: NuGet page, release assets, `.sha256`
+   checksums, and `intent-cli --version` after `dotnet tool update`.
+3. Notify the operator and any waiting downstream consumers.
+4. **Roll `eng/version.json` in a follow-up commit** — `stableVersion` = the
+   released version, `nextVersion` = the next patch — and confirm the next main
+   CI preview builds above the release.
+
+Existing preview artifacts are **not** renumbered retroactively; the rule fixes
+the channel going forward.
 
 ### Next release readiness (v0.6.0)
 

--- a/docs/en/release-notes-v0.6.1.md
+++ b/docs/en/release-notes-v0.6.1.md
@@ -241,6 +241,8 @@ Post-release verification (after the GitHub Release is published and
       ABOVE the release. Skipping this is exactly the 2026-07-29 defect this
       release documents. See
       [Version flow](09-developer-reference.md#version-flow).
-- [ ] Notify the operator to publish the `v0.6.1` GitHub Release, then notify
-      sekiban-as-a-service-orch that the `#1783`-class WIP starvation is fixed
-      once `v0.6.1` is installed.
+- [ ] Notify the operator and downstream consumers that publication **and**
+      verification of `v0.6.1` are complete — including sekiban-as-a-service-orch,
+      for whom the `#1783`-class WIP starvation is fixed once `v0.6.1` is
+      installed. (The publish request itself belongs to the pre-release phase
+      above; by this point the Release is already published.)

--- a/docs/en/release-notes-v0.6.1.md
+++ b/docs/en/release-notes-v0.6.1.md
@@ -1,0 +1,246 @@
+# Release Notes — intent-cli v0.6.1
+
+> **Release model:** a maintainer/operator (or external release automation)
+> **creates and publishes the GitHub Release** for `v0.6.1` — the version-bump
+> merge does **not** create a Release or tag on its own. Publishing the GitHub
+> Release fires `.github/workflows/release.yml` (`on: release: published`), which
+> then builds and publishes the NuGet package and platform binary artifacts.
+> This packet is **prepare-only**: it bumps version metadata and docs and adds
+> **no** publish steps. See the
+> [pre-merge release-readiness gate](#release-readiness-gate-g554) and
+> [publishing v0.6.1](#publishing-v061).
+
+## What's in v0.6.1
+
+v0.6.1 is a **patch release** covering exactly the two slices merged after
+`v0.6.0`: **G552** and **G553**. It is a patch rather than a minor because
+neither slice ships a new command surface: G553 is a gate bugfix, and G552
+extends the existing `automation stalled-work` / `automation heartbeat`
+detection surfaces and the orchestrator-thread guide. Minor bumps stay reserved
+for new command surfaces and broad behavior changes. The package id remains
+`JTechJapan.IntentSystem.Cli`; there are no package id, license, or
+workflow-semantics changes.
+
+Both slices close a measured field incident, and field consumers are waiting on
+both.
+
+### Design-decision holds are visible and bounded (G552)
+
+A design-thread absence could stall the pipeline invisibly. Field incident,
+2026-07-28 16:11 → 07-29 01:29: a review held its final verdict for **nine
+hours** on a one-line wording ruling while every technical check was green. The
+pending item was mechanically fact-checkable and both threads knew the answer,
+but no authority delegation existed — and the hold lived only in agmsg messages,
+so `automation stalled-work` reported `stalled: false` throughout. Fourth
+design-absence stall in the field record.
+
+- **Clarification-backed holds.** An orchestrator/reviewer hold blocked on a
+  design decision is recorded as a clarification artifact through the canonical
+  clarify surface. `clarify open` gains optional explicit inputs so the OPEN
+  artifact carries the **real** content: `--question` lands in the artifact's
+  `QuestionText` and always wins over the packet-derived synthesis, while
+  `--recommended-answer` and `--evidence` land in the already-serialized
+  `Reason` field under explicit labels. **No clarification schema change**, and
+  omitting all three preserves the previous packet-derived behavior exactly. An
+  agmsg-only hold is a **contract violation**: a block that exists only as
+  messages is invisible to every supervision layer.
+- **`design-decision-pending` detection.** `automation stalled-work` reads the
+  domain's OPEN clarification artifacts and reports each with its age (from the
+  artifact's own `createdAt`), blocking execution unit, and question summary;
+  `automation heartbeat` carries it in `message_body` like any other kind. The
+  recommendation names the exact clarification to answer plus the operator
+  escalation path and **never** auto-answers. This is the only kind with no
+  GitHub entity of its own — precisely why the stall it detects was invisible.
+  Fails closed both ways: an unreadable artifact is excluded with its path
+  rather than skipped as answered, and a clarification whose packet declares a
+  different domain is excluded rather than attributed. Answering (or applying,
+  or cancelling) clears it.
+- **Bounded default authority.** The operator may pre-delegate four enumerated
+  decision classes that are settled by *checking repository facts* rather than
+  by judgment — count/enumeration corrections, wording corrections entailed by a
+  cited fact, cross-reference corrections, and identifier mismatches against a
+  named canonical source — each with its verification condition. Bounded in
+  every direction: **granted** (never assumed), **enumerated** (that list is the
+  whole scope), **evidence-logged** through the existing `clarify record
+  --from-file` sink (Question / Decision / Rationale under `## Recently
+  Resolved`, which stays readable for post-hoc amendment), **amendable** by
+  design afterwards, and **never semantic** — intent shaping, packet content,
+  release scope, and prioritization always go to design.
+- **Periodic design-reminder loop.** While a clarification stays open the
+  orchestrator re-sends a reminder from its existing long-interval automation —
+  no new scheduler — at a 30–60 minute class interval, at most one reminder per
+  interval per open clarification, stopping when it is answered.
+- **Refined reviewer hold rule.** Green technical checks plus a fact-checkable
+  non-semantic pending item resolve under granted authority with logged
+  evidence; anything else becomes a recorded clarification and a visible pending
+  state. There is no third option in which the reviewer simply waits.
+
+### Queue-blocked units no longer starve the WIP gate (G553)
+
+`automation host-review-preflight` counted every OPEN `intent-target` issue
+toward `in_flight_issues`, blocked or not. Field finding
+(sekiban-as-a-service, 2026-07-26 on 0.5.0): the gate returned
+`skip-next-slice-due-to-wip` citing issue #1783, whose unit SKS-G818 had been
+parked through the supported claim-preserving block transition. A blocked unit
+is parked by design and cannot progress until it is unblocked, so counting it
+starves publication exactly when the operator deliberately set work aside. G545
+had exempted blocked units from `claimed-but-silent`, but only on the
+stalled-work side — this gate was never covered.
+
+- An issue whose queue item is in the **converged blocked state** (queue
+  `state=blocked` **and** non-empty `blocked_by`) is excluded from
+  `in_flight_issues`, so a next-slice candidate flips from
+  `skip-next-slice-due-to-wip` to `candidate-ready` when the only in-flight
+  items are blocked.
+- **Convergence is required and two-sided.** `state=blocked` with an empty
+  `blocked_by`, or a reason on an item that is not blocked, is **drift** per
+  G545 — not an exemption. Half-converged items keep counting (fail-closed), and
+  each direction emits a warning naming the canonical converging command
+  (`automation issue-block … --reason "<why>" --write`, or the same command with
+  `--clear --write` to release the unit).
+- **The exemption is never silent.** Each exempted unit appears in the new
+  `wip_exempt_blocked_units` diagnostics field with its execution unit, issue
+  number, and `blocked_by` reasons, in both the JSON and text renderings.
+- **Linkage is the queue item's own `linked_issue`** — repo **and** number. A
+  blank or missing repo is not a wildcard (issue numbers are unique only within
+  a repository), so such an item skips the exemption and says why.
+- **Fail-closed on unreadable host state.** A missing queue-state exempts
+  nothing silently; an unparseable one exempts nothing and warns. Unblocking
+  restores counting on the very next call.
+- `intent next-slice` already counted only `active`/`review`/`fixing` items as
+  WIP, so blocked units were never counted there — no divergent copy of the rule
+  was added.
+
+## Post-release version roll (new flow rule)
+
+A version-flow gap bit the field on 2026-07-29. After the `v0.6.0` Release was
+published, `eng/version.json` was not rolled, so previews kept building as
+`0.6.0-preview.N` — which sorts **below** the released `0.6.0` in SemVer.
+`dotnet tool update` refused the newer build, and a manual uninstall/install was
+required.
+
+The fix is a flow rule, now part of the release closeout checklist: **the moment
+a GitHub Release is published and verified, roll `eng/version.json` in a
+follow-up commit** — `stableVersion` = the version just released, `nextVersion` =
+the next patch. See
+[Version flow](09-developer-reference.md#version-flow).
+
+**If you track the preview channel**, this is the release that starts the new
+discipline: after `v0.6.1` is published, the operator rolls `version.json` to
+`stableVersion 0.6.1 / nextVersion 0.6.2` in a follow-up commit, and subsequent
+previews build as `0.6.2-preview.N` — above the release, so
+`dotnet tool update` works again without an uninstall. Preview artifacts
+produced before this rule are **not** renumbered retroactively; if you are
+currently pinned to a `0.6.0-preview.N` build, install `0.6.1` explicitly once
+the Release is published.
+
+## Install
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.1
+```
+
+Or download the self-contained binary from the
+[v0.6.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.6.1).
+Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.6.0
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.6.1
+```
+
+This release is **additive and corrective within existing surfaces**; there are
+no new commands and no argument/flag removals.
+
+- **Additive, no action needed**: `clarify open`'s `--question` /
+  `--recommended-answer` / `--evidence` are optional — omitting them preserves
+  the previous packet-derived behavior byte for byte. The new
+  `design-decision-pending` stalled-work kind and the
+  `wip_exempt_blocked_units` diagnostics field add output rather than changing
+  existing output.
+- **Corrective — existing command behavior changes**:
+  - **G553** — `automation host-review-preflight` no longer counts a
+    converged-blocked issue toward `in_flight_issues`. A caller that expected
+    `skip-next-slice-due-to-wip` while a deliberately parked unit was open will
+    now see `candidate-ready`, with the exempted unit named in
+    `wip_exempt_blocked_units`. Half-converged items are unchanged (still
+    counted) but now emit a repair warning.
+  - **G552** — `automation stalled-work` reports a new actionable kind, so a
+    caller filtering on `stalled == true` will see `design-decision-pending`
+    items where a domain has open clarification artifacts.
+
+No package id, license, or CLI argument/flag shape changes.
+
+## Release-readiness gate (G554)
+
+These items must hold **before the GitHub Release for `v0.6.1` is published**.
+This gate fails closed — if any item is unmet, do not publish the Release yet.
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G552 (PR #1208) and G553 (PR #1210), plus this G554 release-notes prep.
+      Confirm on the host/review side via the host queue-state / GitHub PR
+      state — the child implementation loop must not read parent queue-state, so
+      this is a host-owned precondition.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before
+      publishing).
+- [ ] `eng/version.json` shows `stableVersion` `0.6.0` and `nextVersion` `0.6.1`
+      (the intended release version). `release.yml` builds the package version
+      from the published Release/tag;
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` derives its local default
+      from the same policy.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+- [ ] **Post-merge build + pack evidence** on the merge commit is recorded in
+      the PR (mirroring the G528/G538/G551 readiness gate).
+
+## Publishing v0.6.1
+
+This packet does **not** publish the release and adds **no** publish steps. The
+version-bump merge does **not** create a GitHub Release or tag on its own.
+
+1. After this version bump is merged and the readiness gate above holds, a
+   **maintainer/operator (or external release automation) creates and publishes
+   the GitHub Release** for `v0.6.1` (tagging the release commit). This is a
+   post-merge host/operator/external action.
+2. Publishing that GitHub Release fires `.github/workflows/release.yml`
+   (`on: release: published`), which builds and publishes the NuGet package and
+   the per-platform binary archives (with `.sha256` checksums) and attaches them
+   to the triggering Release.
+
+Post-release verification (after the GitHub Release is published and
+`release.yml` has run):
+
+- [ ] NuGet.org package page links all resolve correctly.
+- [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+      accessible.
+- [ ] `.sha256` checksums match the downloaded artifacts.
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.1`)
+      then `intent-cli --version` reports `0.6.1`.
+- [ ] Binary artifact smoke check: download the platform archive, verify its
+      `.sha256`, extract, and run `./intent-cli --version` → `0.6.1`.
+- [ ] **Design-decision visibility smoke** (G552): `intent-cli clarify open
+      --help` shows the `--question` / `--recommended-answer` / `--evidence`
+      inputs, and `intent-cli automation stalled-work --domain <d> --repo <r>
+      --format json` reports `design-decision-pending` where a domain has an
+      open clarification.
+- [ ] **WIP-gate smoke** (G553): `intent-cli automation host-review-preflight
+      --repo <r> --format json` renders the `wip_exempt_blocked_units` field
+      (empty when nothing is parked).
+- [ ] **ROLL `eng/version.json` NOW** — per the new post-release rule, advance
+      it in a follow-up commit immediately: `stableVersion → 0.6.1`,
+      `nextVersion → 0.6.2`, so previews build as `0.6.2-preview.N` and sort
+      ABOVE the release. Skipping this is exactly the 2026-07-29 defect this
+      release documents. See
+      [Version flow](09-developer-reference.md#version-flow).
+- [ ] Notify the operator to publish the `v0.6.1` GitHub Release, then notify
+      sekiban-as-a-service-orch that the `#1783`-class WIP starvation is fixed
+      once `v0.6.1` is installed.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2144,98 +2144,75 @@ closeout の 1 ステップであり、飛ばすと preview チャンネルが�
 既存の preview 成果物は **遡って番号を振り直しません**。このルールはチャンネルを今後に
 向けて修正するものです。
 
-### 次リリース準備(v0.6.0)
+### 次リリース準備(v0.6.1)
 
-**`v0.5.0` は publish 済み**(GitHub Release + NuGet)で、バージョンポリシーは
-`0.6.0` 開発ラインにバンプされました — これは patch ではなく **minor** バンプです:
-本バッチは 3 つの新しい stalled-work 検出 kind(`backlog-ready-idle`、
-`blocked-label-drift`、`repair-stalled`)、3 つの新コマンド(`automation runs-audit`、
-`queue priority-drift`、`automation issue-block`)、既出コマンドの可視な挙動変更、そして
-4 スレッド agmsg オーケストレーションの PRIMARY モデルへの再配置を出荷しており、patch
-リリースが正当化する範囲を超えています。リポジトリは in-development の **`0.6.0`**
-`nextVersion` 上にあり、G551 は **prepare-only** です — version メタデータと docs を
-バンプするだけで publish ステップを追加しません。version-bump マージは GitHub Release も
-タグも作成しません。マージ後に
-[リリース準備ゲート](release-notes-v0.6.0.md#リリース準備ゲートg551)が成り立った後、
-**メンテナ/オペレーター(または外部のリリース automation)が `v0.6.0` の GitHub Release を
-作成・publish** します。その publish が `.github/workflows/release.yml`
-(`on: release: published`)を発火させ、NuGet package とプラットフォーム別バイナリ成果物を
-build・publish します。完全な changelog とオペレーターチェックリスト:
-[release-notes-v0.6.0.md](release-notes-v0.6.0.md)。
+**`v0.6.0` は publish 済み**(GitHub Release + NuGet)で、バージョンポリシーは
+`0.6.1` 開発ラインへ roll されました — これは minor ではなく **patch** バンプです:
+本バッチのどちらのスライスも新しいコマンドサーフェスを出荷しません。G553 は
+WIP-gate のバグ修正(converged-blocked のユニットが `host-review-preflight` を
+枯渇させなくなる)であり、G552 は既存の `automation stalled-work` /
+`automation heartbeat` の検出サーフェスと orchestrator-thread guide を拡張する
+もの(clarification-backed hold、`design-decision-pending` kind、定期 design
+リマインダーループ、bounded default authority)です。minor は新コマンド
+サーフェスと広範な挙動変更のために留保されています。
 
-> **G547 は本リリースに含まれません。** 本サイクル当初の release-prep ユニットは、
-> G549/G550 をリリーススコープに加えるというオペレーター指示を受けて canonical に
-> **retire** されました。retire はユニット ID に対して terminal であるため、継続は
-> republish ではなく新ユニット **G551** です。G547 はコードもドキュメントも出荷して
-> いません。範囲 `G539–G550` は 12 個のユニット ID にまたがりますが、`v0.6.0` で
-> マージ・出荷されるのはそのうち **11 件** です。
+リポジトリは in-development の **`0.6.1`** `nextVersion` 上にあり、G554 は
+**prepare-only** です — version メタデータと docs をバンプするだけで publish
+ステップを追加しません。version-bump マージは GitHub Release もタグも作成
+しません。マージ後に
+[リリース準備ゲート](release-notes-v0.6.1.md#リリース準備ゲートg554)が成り立った後、
+**メンテナ/オペレーター(または外部のリリース automation)が `v0.6.1` の GitHub
+Release を作成・publish** します。その publish が `.github/workflows/release.yml`
+(`on: release: published`)を発火させ、NuGet package とプラットフォーム別バイナリ
+成果物を build・publish します。完全な changelog とオペレーターチェックリスト:
+[release-notes-v0.6.1.md](release-notes-v0.6.1.md)。
 
-**`v0.6.0` で出荷予定(`v0.5.0` 以降の変更)— primary モデルへの再配置と provisioning、
-stall 検出の完成、durable state の完全性、運用ガイダンス:**
+**`v0.6.1` で出荷予定(`v0.6.0` 以降の変更):**
 
-- **primary モデルへの再配置と provisioning**(G540/G541、G549、G550) — 4 スレッド
-  agmsg オーケストレーションが、全 guide サーフェス・README・NuGet description・docs
-  インデックスにおいて PRIMARY な文書化モデルになりました。design↔orchestrator の
-  double-check ルールと
-  [ADR 0001](../adr/0001-four-thread-orchestration-primary-model.md) を伴い、timer-loop
-  モードは完全にサポートされたよりシンプルな代替として維持されます。`guide
-  orchestrator-thread` には **terminal-workspace provisioning** セクション(不在時の
-  ロールフォルダー作成、ワークスペーストポロジー、shim-safe 起動、actas、3 レイヤーの
-  readiness)と **design-thread workspace supervision** セクション(オペレーター付与の
-  セッション層権限と不変な workflow 所有権、ケイデンス付き 3 監督レイヤー、再起動時の
-  re-arm ルール、verified-read のダイアログ境界)が追加されました。
-- **stall 検出の完成**(G543、G544、G545、G546) — `backlog-ready-idle` は空の WIP と
-  publish 可能な候補、そして idle な `runs.jsonl` が同時に成立したときに fire します。
-  queue が `blocked` のユニットは `claimed-but-silent` から除外され、代わりに
-  `blocked-label-drift` として現れ、canonical な `automation issue-block` が新しい
-  `intent-issue-blocked` label を適用します。`repair-stalled` は silent な
-  repair/rereview claim を status-check 推奨付きの actionable に昇格させます(遷移や
-  再割り当ては決してしません)。また文書化 enum と legacy な enum 外の値に対する priority
-  ランク付けが単一の共有分類に統合され、read-only な `queue priority-drift` が分布を
-  報告します。
-- **durable state の完全性**(G542、G548) — `automation runs-audit` が不正な
-  `runs.jsonl` 行を報告・修復し、record 内導出と明示フラグ付きの peer-convention 推測を
-  分離します。publish 検証はドメインスコープになり、別ドメインの不正行は hard block では
-  なく warning になります。さらに canonical な queue-state 変更はすべて 1 つの層を通り、
-  item スコープの再適用を伴う stale-base 検出と、静かにユニットを落とす代わりに中止する
-  no-item-loss 不変条件を提供します。
-- **運用ガイダンス**(G539) — design-thread watchdog ループが RECOMMENDED な既定の
-  セーフティネットになり、orchestrator 側の長間隔 automation が選択可能な代替です。
-  **これは v0.5.0 時点の外部 cron/launchd スケジューラー推奨を置き換えます** —
-  フィールド証拠(5 日間連続で毎回 silent に失敗、105 分の stall を検出しながら未復旧)
-  とともに retire されました。
-  [agent メッセージオーケストレーション](12-agent-message-orchestration.md#design-thread-watchdog推奨されるセーフティネット)
-  を参照。
-- **オーケストレーションモードの位置づけに関する注記:** `v0.5.0` ラインまで適用されていた
-  「preview/experimental」という記述は G540/G541 をもって完全に置き換えられ、出荷される
-  ドキュメントのどこにも残っていません。
+- **design 判断による hold が可視かつ bounded に**(G552) — design の判断で
+  ブロックされた hold は canonical な clarify surface を通じて clarification
+  artifact として記録され、その surface は実際の質問と任意の推奨回答/根拠を
+  OPEN artifact に受け取れるようになりました(schema 変更なし)。
+  `automation stalled-work` は open な clarification を `design-decision-pending`
+  として報告し、`automation heartbeat` がそれを運びます。さらに guide が
+  bounded default authority(オペレーター付与・列挙・証拠ログ・修正可能・
+  決してセマンティックでない)と、定期 design リマインダーループ、refined
+  reviewer hold ルールを定義します。
+- **queue で blocked のユニットが WIP gate を枯渇させない**(G553) — queue item が
+  converged blocked state(`state=blocked` かつ `blocked_by` 非空)にある issue は
+  `in_flight_issues` から除外されます。convergence は two-sided が必須で、
+  half-converged な item はカウントされ続けたうえで診断され、除外されたユニットは
+  `wip_exempt_blocked_units` に列挙され、linkage は repo 修飾された `linked_issue`、
+  読めない host state では fail-closed です。
 
-**リリース準備の検証(`v0.6.0` version bump のマージ前に実行):**
+**リリース準備の検証(`v0.6.1` version bump のマージ前に実行):**
 
 ```bash
 # 1. バージョンポリシーがカットするリリースを記録していることを確認。
-cat eng/version.json   # stableVersion 0.5.0（公開済み）, nextVersion 0.6.0（リリース対象）
+cat eng/version.json   # stableVersion 0.6.0（公開済み）, nextVersion 0.6.1（リリース対象）
 
 # 2. ビルドして表示バージョン識別子（version + git SHA + G-unit）を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待形: intent-cli 0.6.0-<sha>-G55x （stale なリテラルではない）
+#   期待形: intent-cli 0.6.1-<sha>-G55x （stale なリテラルではない）
 
 # 3. pack して NuGet package のバージョンがポリシーと一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.6.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.6.1.nupkg
 
 # 4. package メタデータ（id / command / license / project URL）を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
 ```
 
-version-bump マージが `main` に着地した後、メンテナ/オペレーター(または外部のリリース
-automation)が `v0.6.0` の GitHub Release を作成・publish します。その publish が
-`release.yml`(`on: release: published`)をトリガーし、NuGet package とプラットフォーム別
-バイナリ成果物を build・publish します。publish 済みになったら、上記のリリース後
-`eng/version.json` バンプ(`stableVersion → 0.6.0`, `nextVersion → 0.6.1`)を適用します —
-これは今回のパケットではなく **次の** release-prep パケットに委ねられます。
+version-bump マージが `main` に着地した後、メンテナ/オペレーター(または外部の
+リリース automation)が `v0.6.1` の GitHub Release を作成・publish します。その
+publish が `release.yml`(`on: release: published`)をトリガーし、NuGet package と
+プラットフォーム別バイナリ成果物を build・publish します。**その後ただちに
+`eng/version.json` を roll します** — `stableVersion → 0.6.1`、`nextVersion →
+0.6.2` — [リリース後の version roll](#リリース後の-version-rollg554--必須即時)
+のステップ 4 に従います。roll を後続の release-prep パケットへ先送りすることは
+もうしません: 先送りこそが preview チャンネルを壊した 2026-07-29 の不具合です。
 
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2095,31 +2095,54 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.5.0",
-  "nextVersion": "0.6.0"
-}
-```
-
-| ステージ | バージョン形式 | 導出方法 |
-| --- | --- | --- |
-| ローカル pack / install | `0.6.0-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.6.0-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.6.0-rc.N` | タグ `v0.6.0-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
-| 安定版リリース | `0.6.0` | タグ `v0.6.0` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.6.1-preview.<run>.<attempt>` | `nextVersion` を `0.6.1` にバンプ後 |
-
-**`v0.6.0` リリース後**、`eng/version.json` の両フィールドをバンプしてください:
-
-```json
-{
   "stableVersion": "0.6.0",
   "nextVersion": "0.6.1"
 }
 ```
 
-これにより次の main ブランチ CI ビルド（およびローカル pack）が
-`0.6.1-preview.<run>.<attempt>` / `0.6.1-<sha>-<G-unit>` を生成し、`0.6.0`（安定版
-リリースバージョンと衝突）の出力が継続されなくなります。
+| ステージ | バージョン形式 | 導出方法 |
+| --- | --- | --- |
+| ローカル pack / install | `0.6.1-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `0.6.1-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `0.6.1-rc.N` | タグ `v0.6.1-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
+| 安定版リリース | `0.6.1` | タグ `v0.6.1` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `0.6.2-preview.<run>.<attempt>` | `nextVersion` を `0.6.2` に roll した後 |
+
+### リリース後の version roll(G554) — 必須・即時
+
+**GitHub Release を publish して検証した直後に、follow-up commit で
+`eng/version.json` を roll してください**: `stableVersion` = 今リリースした
+バージョン、`nextVersion` = 次の patch。これは任意の後片付けではなく、リリース
+closeout の 1 ステップであり、飛ばすと preview チャンネルが壊れます。
+
+```json
+{
+  "stableVersion": "0.6.1",
+  "nextVersion": "0.6.2"
+}
+```
+
+**なぜ必須か。** preview とローカル pack の build は `nextVersion` から導出されます。
+`nextVersion` が今リリースしたばかりのバージョンを指したままだと、以降の preview は
+すべて `<released>-preview.N` として build され、prerelease は SemVer 上そのリリース
+バージョンより **下** にソートされます。field incident、2026-07-29: `v0.6.0` を publish
+した後に roll を飛ばしたため preview は `0.6.0-preview.N` のまま build され続け、
+`dotnet tool update` は新しい build を「より古い」として拒否し、手動 uninstall/install
+以外に手段がありませんでした。直ちに roll すれば次の preview は `0.6.2-preview.N` となり
+`0.6.1` より上にソートされるため、`dotnet tool update` が再び機能します。
+
+**リリース closeout チェックリスト**(roll はステップ 4 — ステップ 3 で止めないこと):
+
+1. 対象バージョンの GitHub Release を publish する(これが `release.yml` を発火させる)。
+2. publish された成果物を検証する: NuGet ページ、release assets、`.sha256` チェックサム、
+   `dotnet tool update` 後の `intent-cli --version`。
+3. オペレーターと、待っている下流の利用者へ通知する。
+4. **follow-up commit で `eng/version.json` を roll する** — `stableVersion` = リリース
+   したバージョン、`nextVersion` = 次の patch — そして次の main CI preview がリリースより
+   上に build されることを確認する。
+
+既存の preview 成果物は **遡って番号を振り直しません**。このルールはチャンネルを今後に
+向けて修正するものです。
 
 ### 次リリース準備(v0.6.0)
 

--- a/docs/ja/release-notes-v0.6.1.md
+++ b/docs/ja/release-notes-v0.6.1.md
@@ -1,0 +1,216 @@
+# リリースノート — intent-cli v0.6.1
+
+> **リリースモデル:** メンテナ/オペレーター(または外部のリリース automation)が `v0.6.1` の
+> **GitHub Release を作成・publish** します — version-bump マージ自体は Release やタグを作成しません。
+> GitHub Release の publish が `.github/workflows/release.yml`(`on: release: published`)を発火させ、
+> NuGet package とプラットフォームバイナリ成果物を build・publish します。本パケットは
+> **prepare-only** で、version メタデータと docs をバンプするだけで publish ステップを **追加しません**。
+> [マージ前 リリース準備ゲート](#リリース準備ゲートg554) と
+> [v0.6.1 の publish](#v061-の-publish) を参照。
+
+## v0.6.1 の内容
+
+v0.6.1 は **patch リリース** で、`v0.6.0` 以降にマージされた 2 スライス — **G552** と
+**G553** — のみをカバーします。minor ではなく patch なのは、どちらのスライスも新しい
+コマンドサーフェスを出荷しないためです: G553 は gate のバグ修正で、G552 は既存の
+`automation stalled-work` / `automation heartbeat` の検出サーフェスと orchestrator-thread
+guide を拡張するものです。minor バンプは新コマンドサーフェスと広範な挙動変更のために
+留保されています。package id は `JTechJapan.IntentSystem.Cli` のままで、package id・
+ライセンス・workflow セマンティクスの変更はありません。
+
+どちらのスライスも実測されたフィールドインシデントを閉じるもので、フィールドの利用者は
+両方を待っています。
+
+### design 判断による hold が可視かつ bounded になりました(G552)
+
+design スレッドの不在がパイプラインを不可視に stall させうる状態でした。field incident、
+2026-07-28 16:11 → 07-29 01:29: 技術チェックがすべて green のまま、1 行の wording 判断の
+ために review が final verdict を **9 時間** 保留しました。保留項目は機械的に事実確認可能で
+両スレッドとも答えを知っていましたが、権限委譲が存在せず、しかも hold は agmsg メッセージ上に
+しか存在しなかったため、`automation stalled-work` はその間ずっと `stalled: false` を報告して
+いました(field record で 4 件目の design 不在 stall)。
+
+- **clarification-backed hold。** design の判断でブロックされた orchestrator/reviewer の
+  hold は、canonical な clarify surface を通じて clarification artifact として記録されます。
+  `clarify open` に任意の明示入力が追加され、OPEN artifact が **実際の** 内容を運べるように
+  なりました: `--question` は artifact の `QuestionText` に入り packet 由来の synthesis より
+  常に優先され、`--recommended-answer` と `--evidence` は既存の serialized field である
+  `Reason` にラベル付きで格納されます。**clarification の schema 変更はなく**、3 つとも省略
+  すれば従来の packet 由来挙動そのままです。agmsg だけの hold は **contract violation** です:
+  メッセージ上にしか存在しないブロックは、あらゆる supervision レイヤーから見えません。
+- **`design-decision-pending` の検出。** `automation stalled-work` が domain の OPEN な
+  clarification artifact を読み、age(artifact 自身の `createdAt` 由来)・ブロックされている
+  execution unit・質問サマリつきで報告します。`automation heartbeat` は他の kind と同様に
+  `message_body` でそれを運びます。推奨アクションは回答すべき clarification を正確に名指しし、
+  オペレーターへのエスカレーション経路も併記します。**自動回答は決してしません**。これは
+  自分自身の GitHub エンティティを持たない唯一の kind であり、まさにそれが検出対象の stall が
+  不可視だった理由です。両方向に fail closed: 読めない artifact は「回答済み」として飛ばさず
+  パス付きで除外し、packet が別 domain を宣言する clarification は帰属させず除外します。
+  回答(または applied / cancelled)で item は消えます。
+- **bounded default authority。** オペレーターは、判断ではなく *リポジトリの事実を確認する*
+  ことで決着する 4 つの列挙された判断クラス — 件数・列挙の訂正、引用された事実から導かれる
+  wording 訂正、相互参照の訂正、名指しした canonical source との識別子不一致 — を事前委譲
+  できます(各クラスに検証条件つき)。あらゆる方向に bounded です: **付与される**(前提では
+  ない)、**列挙されている**(その一覧がスコープのすべて)、既存の `clarify record --from-file`
+  sink による **証拠ログ**(Question / Decision / Rationale が `## Recently Resolved` に入り、
+  post-hoc amendment のために読める形で残る)、design による **後からの修正が可能**、そして
+  **決してセマンティックではない** — intent shaping・packet 内容・リリーススコープ・優先度は
+  常に design へ行きます。
+- **定期的な design リマインダーループ。** clarification が open である間、orchestrator が
+  既存の長間隔 automation からリマインダーを再送します — 新しいスケジューラーは不要 —
+  30〜60 分オーダーの間隔で、open な clarification 1 件につき 1 間隔あたり最大 1 通、回答
+  されたら停止します。
+- **refined reviewer hold ルール。** 技術チェックが green かつ保留項目が非セマンティックで
+  事実確認可能なら、付与された権限のもとで証拠をログして解決します。それ以外は記録された
+  clarification と可視な pending state になります。reviewer が単に待つ、という第 3 の選択肢は
+  ありません。
+
+### queue で blocked のユニットが WIP gate を枯渇させなくなりました(G553)
+
+`automation host-review-preflight` は OPEN な `intent-target` issue を blocked かどうかに
+関わらずすべて `in_flight_issues` にカウントしていました。field finding
+(sekiban-as-a-service、2026-07-26、0.5.0 上): gate が issue #1783 を挙げて
+`skip-next-slice-due-to-wip` を返しましたが、そのユニット SKS-G818 は claim を保持したままの
+supported な block transition で parked されていました。blocked のユニットは設計上 parked で
+あり unblock されるまで進行できないため、それをカウントすることは、オペレーターが意図的に
+work を脇に置いたまさにそのときに publish を枯渇させます。G545 は blocked ユニットを
+`claimed-but-silent` から除外していましたが、それは stalled-work 側だけで、この gate は
+カバーされていませんでした。
+
+- queue item が **converged blocked state**(queue `state=blocked` **かつ** `blocked_by` が
+  非空)にある issue は `in_flight_issues` から除外されます。in-flight が blocked のものだけに
+  なった時点で next-slice candidate は `skip-next-slice-due-to-wip` から `candidate-ready` へ
+  切り替わります。
+- **convergence は必須で two-sided です。** `state=blocked` なのに `blocked_by` が空、または
+  blocked でない item に理由がある状態は G545 の言う **drift** であって exemption では
+  ありません。half-converged な item はカウントされ続け(fail-closed)、各方向とも canonical な
+  converging コマンド(`automation issue-block … --reason "<why>" --write`、または同コマンドの
+  `--clear --write` によるユニット解放)を名指しする warning を出します。
+- **exemption が silent になることはありません。** 除外された各ユニットは新しい
+  `wip_exempt_blocked_units` diagnostics フィールドに execution unit・issue 番号・
+  `blocked_by` の理由つきで現れます(JSON / text 両方の出力)。
+- **linkage は queue item 自身の `linked_issue`** — repo **と** number の両方です。blank や
+  missing の repo は wildcard ではなく(issue 番号は repository 内でのみ一意)、そのような
+  item は exemption をスキップし理由を述べます。
+- **読めない host state では fail-closed。** queue-state が存在しない場合は何も exempt せず、
+  パースできない場合も何も exempt せず warning を出します。unblock した場合は次の呼び出しから
+  即座にカウントが戻ります。
+- `intent next-slice` は元々 `active`/`review`/`fixing` の item だけを WIP として数えており
+  blocked はカウントしていなかったため、このルールの divergent copy は追加していません。
+
+## リリース後の version roll(新しいフロールール)
+
+2026-07-29 に version flow のギャップがフィールドで問題を起こしました。`v0.6.0` の Release を
+publish した後、`eng/version.json` が roll されなかったため preview は `0.6.0-preview.N` の
+まま build され続け、これは SemVer 上リリース済みの `0.6.0` より **下** にソートされます。
+`dotnet tool update` は新しい build を拒否し、手動での uninstall/install が必要になりました。
+
+修正はフロールールで、リリース closeout チェックリストに組み込まれました:
+**GitHub Release を publish して検証した直後に、follow-up commit で `eng/version.json` を
+roll する** — `stableVersion` = 今リリースしたバージョン、`nextVersion` = 次の patch。
+[バージョンフロー](09-developer-reference.md#バージョンフロー) を参照。
+
+**preview チャンネルを追っている場合**、この新しい規律が始まるのは本リリースからです:
+`v0.6.1` の publish 後、オペレーターが follow-up commit で `version.json` を
+`stableVersion 0.6.1 / nextVersion 0.6.2` に roll し、以降の preview は `0.6.2-preview.N`
+として build されます — リリースより上にソートされるため、`dotnet tool update` が uninstall
+なしで再び機能します。このルール以前に生成された preview 成果物は **遡って番号を振り直しません**。
+現在 `0.6.0-preview.N` の build に固定されている場合は、Release publish 後に `0.6.1` を
+明示的にインストールしてください。
+
+## インストール
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.1
+```
+
+または
+[v0.6.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.6.1)
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを検証します。
+
+## v0.6.0 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.6.1
+```
+
+本リリースは **既存サーフェス内での追加と是正** です。新コマンドはなく、引数/フラグの削除も
+ありません。
+
+- **追加のみ・対応不要**: `clarify open` の `--question` / `--recommended-answer` /
+  `--evidence` は任意で、省略すれば従来の packet 由来挙動そのままです。新しい
+  `design-decision-pending` kind と `wip_exempt_blocked_units` diagnostics フィールドは
+  既存出力を変更するのではなく出力を追加します。
+- **是正的 — 既出コマンドの挙動変更**:
+  - **G553** — `automation host-review-preflight` は converged-blocked の issue を
+    `in_flight_issues` にカウントしなくなります。意図的に parked されたユニットが open な間
+    `skip-next-slice-due-to-wip` を期待していた呼び出し側は `candidate-ready` を見ることに
+    なり、除外されたユニットは `wip_exempt_blocked_units` に名指しされます。half-converged な
+    item は不変(引き続きカウント)ですが、修復 warning を出すようになります。
+  - **G552** — `automation stalled-work` が新しい actionable kind を報告するため、
+    `stalled == true` でフィルタしていた呼び出し側には、open な clarification artifact を持つ
+    domain で `design-decision-pending` item が新たに見えます。
+
+package id・ライセンス・CLI の引数/フラグ形の変更はありません。
+
+## リリース準備ゲート(G554)
+
+以下は `v0.6.1` の **GitHub Release を publish する前に** 成立していなければなりません。
+このゲートは fail-closed です — 1 つでも満たされないなら Release を publish しないでください。
+
+- [ ] リリース対象の全 packet が **完了し、その PR が `main` にマージ済み**:
+      G552(PR #1208)と G553(PR #1210)、および本 G554 release-notes prep。host/review 側で
+      host queue-state / GitHub PR 状態を用いて確認します — child implementation loop は
+      parent queue-state を読めないため、これは host 所有の前提条件です。
+- [ ] 本リリース向けの open PR / WIP packet が誤って漏れていないこと(publish 前に host queue /
+      open PR 一覧を確認)。
+- [ ] `eng/version.json` が `stableVersion` `0.6.0`、`nextVersion` `0.6.1`(リリース対象)を
+      示すこと。`release.yml` は publish された Release/タグから package version を組み立て、
+      `src/IntentSystem.Cli/IntentSystem.Cli.csproj` は同じポリシーからローカル既定を導出します。
+- [ ] package メタデータが正しいこと: `PackageId = JTechJapan.IntentSystem.Cli`、
+      `RepositoryUrl` / `PackageProjectUrl` が
+      `https://github.com/J-Tech-Japan/intent-system` を指し、
+      `PackageLicenseExpression = Apache-2.0`、README/docs のリンクが解決し、公式サービスサイト
+      `https://www.intent-driven-development.com/` が README からリンクされていること。
+- [ ] **Main CI が green**(`Build and test (source contract)`)であること、および
+      **preview-pack** ワークフローが green であること。
+- [ ] **マージ後の build + pack 証跡** がマージコミットに対して PR に記録されていること
+      (G528/G538/G551 の準備ゲートに準拠)。
+
+## v0.6.1 の publish
+
+本パケットはリリースを publish せず、publish ステップを **追加しません**。version-bump マージ
+自体は GitHub Release もタグも作成しません。
+
+1. 本 version bump がマージされ上記の準備ゲートが成立した後、**メンテナ/オペレーター(または
+   外部のリリース automation)が `v0.6.1` の GitHub Release を作成・publish** します
+   (リリースコミットにタグ付け)。これはマージ後の host/オペレーター/外部のアクションです。
+2. その GitHub Release の publish が `.github/workflows/release.yml`(`on: release: published`)を
+   発火させ、NuGet package とプラットフォーム別バイナリアーカイブ(`.sha256` チェックサム付き)を
+   build・publish し、トリガーとなった Release に添付します。
+
+publish 後の検証(GitHub Release が publish され `release.yml` が実行された後):
+
+- [ ] NuGet.org の package ページのリンクがすべて正しく解決すること。
+- [ ] GitHub release の成果物リンク(`.tar.gz`、`.zip`、`.exe`、`.nupkg`)にアクセスできること。
+- [ ] `.sha256` チェックサムがダウンロードした成果物と一致すること。
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`(または
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.1`)の後、
+      `intent-cli --version` が `0.6.1` を報告すること。
+- [ ] バイナリ成果物のスモークチェック: プラットフォームアーカイブをダウンロードし `.sha256` を
+      検証、展開して `./intent-cli --version` → `0.6.1`。
+- [ ] **design 判断の可視化スモーク**(G552): `intent-cli clarify open --help` が
+      `--question` / `--recommended-answer` / `--evidence` を表示し、
+      `intent-cli automation stalled-work --domain <d> --repo <r> --format json` が
+      open な clarification のある domain で `design-decision-pending` を報告すること。
+- [ ] **WIP gate スモーク**(G553): `intent-cli automation host-review-preflight --repo <r>
+      --format json` が `wip_exempt_blocked_units` フィールドをレンダリングすること
+      (何も parked されていなければ空)。
+- [ ] **`eng/version.json` を今すぐ ROLL する** — 新しいリリース後ルールに従い、follow-up
+      commit で直ちに進めます: `stableVersion → 0.6.1`、`nextVersion → 0.6.2`。これにより
+      preview は `0.6.2-preview.N` として build され、リリースより上にソートされます。これを
+      飛ばすことが、本リリースが記録している 2026-07-29 の不具合そのものです。
+      [バージョンフロー](09-developer-reference.md#バージョンフロー) を参照。
+- [ ] オペレーターに `v0.6.1` GitHub Release の publish を通知し、続いて
+      sekiban-as-a-service-orch に対して `#1783` クラスの WIP 枯渇が `v0.6.1` インストールで
+      解消されることを通知すること。

--- a/docs/ja/release-notes-v0.6.1.md
+++ b/docs/ja/release-notes-v0.6.1.md
@@ -211,6 +211,7 @@ publish 後の検証(GitHub Release が publish され `release.yml` が実行�
       preview は `0.6.2-preview.N` として build され、リリースより上にソートされます。これを
       飛ばすことが、本リリースが記録している 2026-07-29 の不具合そのものです。
       [バージョンフロー](09-developer-reference.md#バージョンフロー) を参照。
-- [ ] オペレーターに `v0.6.1` GitHub Release の publish を通知し、続いて
-      sekiban-as-a-service-orch に対して `#1783` クラスの WIP 枯渇が `v0.6.1` インストールで
-      解消されることを通知すること。
+- [ ] `v0.6.1` の publish **および** 検証が完了したことを、オペレーターと下流の利用者へ
+      通知すること — sekiban-as-a-service-orch を含み、同チームには `#1783` クラスの WIP
+      枯渇が `v0.6.1` インストールで解消されることを伝えます。(publish の依頼自体は上記の
+      リリース前フェーズに属します。この時点では Release は既に publish 済みです。)

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.5.0",
-  "nextVersion": "0.6.0"
+  "stableVersion": "0.6.0",
+  "nextVersion": "0.6.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV060DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV060DocsTests.cs
@@ -24,13 +24,16 @@ public sealed class ReleaseNotesV060DocsTests
     ];
 
     [Fact]
-    public void VersionPolicy_RecordsTheV060ReleaseToBeCut_G551()
+    public void VersionPolicy_RecordsTheReleaseToBeCut_G551()
     {
+        // G554 rolled the line to 0.6.1 after v0.6.0 shipped; this test keeps
+        // pinning that the policy names a release-to-be-cut strictly ahead of
+        // the published stable, which is what the readiness gate depends on.
         var policy = VersionPolicy.TryReadFromRepo(RepoRoot());
 
         Assert.NotNull(policy);
-        Assert.Equal("0.5.0", policy.StableVersion);
-        Assert.Equal("0.6.0", policy.NextVersion);
+        Assert.Equal("0.6.0", policy.StableVersion);
+        Assert.Equal("0.6.1", policy.NextVersion);
     }
 
     [Theory]

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
@@ -163,6 +163,92 @@ public sealed class ReleaseNotesV061DocsTests
         Assert.Contains("0.6.2-preview.<run>.<attempt>", reference, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperReference_ActiveReadinessIsTheV061Section_NotAStaleV060One(string language)
+    {
+        var reference = ReadDeveloperReference(language);
+
+        Assert.Contains(
+            language == "en" ? "### Next release readiness (v0.6.1)" : "### 次リリース準備(v0.6.1)",
+            reference,
+            StringComparison.Ordinal);
+        // The superseded section is re-cut, not left standing beside the new one.
+        Assert.DoesNotContain(
+            language == "en" ? "### Next release readiness (v0.6.0)" : "### 次リリース準備(v0.6.0)",
+            reference,
+            StringComparison.Ordinal);
+
+        // It states what actually shipped and what is being cut.
+        Assert.Contains(
+            language == "en" ? "**`v0.6.0` shipped**" : "**`v0.6.0` は publish 済み**",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "a **patch** bump, not a minor" : "minor ではなく **patch** バンプ",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.6.1.md", reference, StringComparison.Ordinal);
+        foreach (var slice in ReleasedSlices)
+        {
+            Assert.Contains(slice, reference, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperReference_CarriesNoStaleActiveVersionGuidance(string language)
+    {
+        var reference = ReadDeveloperReference(language);
+
+        // Negative coverage: the pre-roll policy values and the deferral that
+        // caused the 2026-07-29 preview-channel break must not reappear as
+        // active guidance.
+        Assert.DoesNotContain("\"stableVersion\": \"0.5.0\"", reference, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            language == "en" ? "stableVersion 0.5.0 (published)" : "stableVersion 0.5.0（公開済み）",
+            reference,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            language == "en" ? "deferred to the NEXT release-prep packet" : "次の release-prep パケットに委ねられます",
+            reference,
+            StringComparison.Ordinal);
+
+        // And the readiness checks name the current line.
+        Assert.Contains(
+            language == "en" ? "stableVersion 0.6.0 (published), nextVersion 0.6.1 (to release)" : "stableVersion 0.6.0（公開済み）, nextVersion 0.6.1（リリース対象）",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains("JTechJapan.IntentSystem.Cli.0.6.1.nupkg", reference, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_PostReleaseChecklistNotifiesCompletion_RatherThanRequestingPublication(string language)
+    {
+        var notes = ReadReleaseNotes(language);
+
+        // The checklist is defined as post-Release, so by the time it runs the
+        // Release is already published — the item reports completion.
+        Assert.Contains(
+            language == "en" ? "publication **and** verification of `v0.6.1` are complete" : "`v0.6.1` の publish **および** 検証が完了したことを",
+            notes,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "belongs to the pre-release phase" : "リリース前フェーズに属します",
+            notes,
+            StringComparison.Ordinal);
+
+        // The stale publish-request wording is gone from the post-release list.
+        Assert.DoesNotContain(
+            language == "en" ? "Notify the operator to publish the `v0.6.1` GitHub Release" : "オペレーターに `v0.6.1` GitHub Release の publish を通知し",
+            notes,
+            StringComparison.Ordinal);
+    }
+
     [Fact]
     public void PrepareOnlyDiff_AddsNoPublishAutomation_G554()
     {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
@@ -1,0 +1,216 @@
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G554: the v0.6.1 release-prep deliverable is documentation, so it is pinned
+/// the way code is pinned — both language mirrors exist, they cover exactly the
+/// two slices that shipped after v0.6.0, they carry the patch rationale and the
+/// prepare-only publishing contract, and the post-release version-roll rule is
+/// present in the developer reference AND in its closeout checklist. The roll
+/// rule is the one a skipped step already broke in the field, so it is pinned
+/// on every surface that states it.
+/// </summary>
+public sealed class ReleaseNotesV061DocsTests
+{
+    /// <summary>The two slices merged after v0.6.0 — and the only ones this release covers.</summary>
+    private static readonly string[] ReleasedSlices = ["G552", "G553"];
+
+    [Fact]
+    public void VersionPolicy_RecordsTheV061ReleaseToBeCut_G554()
+    {
+        var policy = VersionPolicy.TryReadFromRepo(RepoRoot());
+
+        Assert.NotNull(policy);
+        Assert.Equal("0.6.0", policy.StableVersion);
+        Assert.Equal("0.6.1", policy.NextVersion);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_CoverExactlyG552AndG553(string language)
+    {
+        var notes = ReadReleaseNotes(language);
+
+        foreach (var slice in ReleasedSlices)
+        {
+            Assert.Contains(slice, notes, StringComparison.Ordinal);
+        }
+
+        // Exactly these two: no slice from the v0.6.0 batch is re-listed as
+        // shipping here.
+        foreach (var earlier in new[] { "G549", "G550", "G551" })
+        {
+            Assert.DoesNotContain($"({earlier})", notes, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_StateThePatchRationale_AndThePrepareOnlyContract(string language)
+    {
+        var notes = ReadReleaseNotes(language);
+
+        Assert.Contains(language == "en" ? "**patch release**" : "**patch リリース**", notes, StringComparison.Ordinal);
+        // The rationale is stated, not merely the label: no new command surface.
+        Assert.Contains(
+            language == "en" ? "neither slice ships a new command surface" : "どちらのスライスも新しい コマンドサーフェスを出荷しない",
+            notes,
+            StringComparison.Ordinal);
+
+        Assert.Contains("prepare-only", notes, StringComparison.Ordinal);
+        Assert.Contains("release.yml", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "## Release-readiness gate (G554)" : "## リリース準備ゲート(G554)",
+            notes,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "## Publishing v0.6.1" : "## v0.6.1 の publish",
+            notes,
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_NameTheFieldIncidentsBehindBothSlices(string language)
+    {
+        var notes = ReadReleaseNotes(language);
+
+        // G552: the nine-hour design hold.
+        Assert.Contains(language == "en" ? "**nine hours**" : "**9 時間**", notes, StringComparison.Ordinal);
+        // G553: the sekiban #1783 WIP starvation.
+        Assert.Contains("#1783", notes, StringComparison.Ordinal);
+        Assert.Contains("sekiban-as-a-service", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_CarryThePreviewChannelNoteAboutTheRollRule(string language)
+    {
+        var notes = ReadReleaseNotes(language);
+
+        // The preview-sorts-below-release incident, its cause, and what a
+        // preview-channel user should do about it.
+        Assert.Contains("0.6.0-preview", notes, StringComparison.Ordinal);
+        Assert.Contains("0.6.2-preview", notes, StringComparison.Ordinal);
+        Assert.Contains("dotnet tool update", notes, StringComparison.Ordinal);
+
+        if (language == "en")
+        {
+            Assert.Contains("sorts **below** the released", notes, StringComparison.Ordinal);
+            Assert.Contains("roll `eng/version.json` in a follow-up commit", notes, StringComparison.Ordinal);
+            Assert.Contains("not** renumbered retroactively", notes, StringComparison.Ordinal);
+        }
+        else
+        {
+            Assert.Contains("リリース済みの `0.6.0` より **下** にソート", notes, StringComparison.Ordinal);
+            Assert.Contains("follow-up commit で `eng/version.json` を roll", notes, StringComparison.Ordinal);
+            Assert.Contains("遡って番号を振り直しません", notes, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperReference_CarriesTheRollRule_AndItsCloseoutChecklistStep(string language)
+    {
+        var reference = ReadDeveloperReference(language);
+
+        Assert.Contains(
+            language == "en" ? "### Post-release version roll (G554) — required, immediate" : "### リリース後の version roll(G554) — 必須・即時",
+            reference,
+            StringComparison.Ordinal);
+
+        // stable = released, next = next patch.
+        Assert.Contains(
+            language == "en" ? "`stableVersion` = the version just released" : "`stableVersion` = 今リリースした バージョン",
+            reference,
+            StringComparison.Ordinal);
+
+        // The reason, with the field incident that proves it matters.
+        Assert.Contains("2026-07-29", reference, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "sorts **below** its own release version" : "そのリリース バージョンより **下** にソート",
+            reference,
+            StringComparison.Ordinal);
+
+        // And it is a numbered closeout step, not advice floating next to one.
+        Assert.Contains(
+            language == "en" ? "**Release closeout checklist** (the roll is step 4" : "**リリース closeout チェックリスト**(roll はステップ 4",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "4. **Roll `eng/version.json` in a follow-up commit**" : "4. **follow-up commit で `eng/version.json` を roll する**",
+            reference,
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperReference_VersionFlowIsOnThe061Line(string language)
+    {
+        var reference = ReadDeveloperReference(language);
+
+        Assert.Contains("\"stableVersion\": \"0.6.0\"", reference, StringComparison.Ordinal);
+        Assert.Contains("\"nextVersion\": \"0.6.1\"", reference, StringComparison.Ordinal);
+        // Post-release main builds are described on the NEXT line, above the
+        // release — the whole point of the rule.
+        Assert.Contains("0.6.2-preview.<run>.<attempt>", reference, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrepareOnlyDiff_AddsNoPublishAutomation_G554()
+    {
+        // The packet is documentation + version metadata only. Pin that
+        // release.yml still triggers on a published Release rather than on the
+        // version-bump merge landing.
+        var releaseWorkflow = Path.Combine(RepoRoot(), ".github", "workflows", "release.yml");
+        Assert.True(File.Exists(releaseWorkflow), $"Expected {releaseWorkflow} to exist.");
+
+        var workflow = File.ReadAllText(releaseWorkflow);
+        Assert.Contains("release:", workflow, StringComparison.Ordinal);
+        Assert.Contains("published", workflow, StringComparison.Ordinal);
+    }
+
+    private static string ReadReleaseNotes(string language) =>
+        ReadCollapsed(Path.Combine(RepoRoot(), "docs", language, "release-notes-v0.6.1.md"));
+
+    private static string ReadDeveloperReference(string language) =>
+        ReadCollapsed(Path.Combine(RepoRoot(), "docs", language, "09-developer-reference.md"));
+
+    private static string ReadCollapsed(string path)
+    {
+        Assert.True(File.Exists(path), $"Expected {path} to exist.");
+
+        // Both mirrors are hard-wrapped and some guidance lives inside
+        // blockquotes, so a sentence spans lines and carries `> ` continuation
+        // markers. Strip the markers and collapse whitespace runs so the
+        // assertions pin wording, not wrap points.
+        var unwrapped = File.ReadAllLines(path)
+            .Select(line => line.TrimStart().TrimStart('>'));
+
+        return string.Join(' ', string.Join('\n', unwrapped)
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    private static string RepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "eng", "version.json")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate the repository root from {AppContext.BaseDirectory}.");
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -124,16 +124,16 @@ public sealed class VersionPolicyTests : IDisposable
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
         // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.6.0 as the next development line
-        // (post-v0.5.0 release bump, see G551 — v0.5.0 was published to
+        // be parseable and must point to 0.6.1 as the next development line
+        // (post-v0.6.0 release bump, see G554 — v0.6.0 was published to
         // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.6.0 — a minor bump, since the batch ships three new
-        // stalled-work kinds (`backlog-ready-idle`, `blocked-label-drift`,
-        // `repair-stalled`), three new commands (`automation runs-audit`,
-        // `queue priority-drift`, `automation issue-block`), visible behavior
-        // changes to already-shipped commands, and the repositioning of
-        // four-thread agmsg orchestration as the primary documented model —
-        // while recording 0.5.0 as the published stable).
+        // forward to 0.6.1 — a patch bump, since neither shipped slice adds a
+        // command surface: G553 is a WIP-gate bugfix and G552 extends the
+        // existing stalled-work/heartbeat detection surfaces and the
+        // orchestrator-thread guide — while recording 0.6.0 as the published
+        // stable. G554 also makes this roll a REQUIRED, immediate release
+        // closeout step: leaving nextVersion at the released version makes
+        // every preview sort below its own release.
         var repoRoot = FindRepoRoot();
         if (repoRoot is null)
         {
@@ -143,8 +143,8 @@ public sealed class VersionPolicyTests : IDisposable
         var policy = VersionPolicy.TryReadFromRepo(repoRoot);
 
         Assert.NotNull(policy);
-        Assert.Equal("0.6.0", policy.NextVersion);
-        Assert.Equal("0.5.0", policy.StableVersion);
+        Assert.Equal("0.6.1", policy.NextVersion);
+        Assert.Equal("0.6.0", policy.StableVersion);
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

**Prepare-only** release metadata for intent-cli **v0.6.1**. Advances `eng/version.json` to `stableVersion 0.6.0 / nextVersion 0.6.1`, authors ja/en release notes covering exactly **G552** and **G553**, and adds the **post-release version-roll rule** to the developer-reference release flow. No tag, no GitHub Release, no publish step — the operator publishes the Release afterwards.

## Why a patch

Neither slice ships a new command surface: **G553** is a WIP-gate bugfix, and **G552** extends the existing `automation stalled-work` / `automation heartbeat` detection surfaces and the orchestrator-thread guide. Minor stays reserved for new command surfaces and broad behavior changes.

## Release notes content

- **G552** — clarification-backed holds (the OPEN artifact carries the *real* question via `clarify open --question/--recommended-answer/--evidence`, with no schema change), the `design-decision-pending` kind carried by heartbeat, the periodic design-reminder loop, and bounded default authority with its `clarify record --from-file` evidence sink.
- **G553** — converged-blocked units exempted from the WIP gate, with two-sided convergence, visible `wip_exempt_blocked_units` diagnostics, repo-qualified `linked_issue` linkage, and fail-closed reads.
- Both **field incidents named**: the nine-hour design hold (2026-07-28..29) and the sekiban `#1783` WIP starvation (2026-07-26).
- Upgrade section separating the additive surfaces from the two corrective behavior changes a consumer must read.
- Prepare-only publishing section and the readiness gate, per the G528/G538/G551 pattern.

## The post-release version-roll rule

On 2026-07-29, `v0.6.0` shipped without rolling `eng/version.json`, so previews kept building as `0.6.0-preview.N` — which sorts **below** the released `0.6.0` in SemVer. `dotnet tool update` refused the newer build and a manual uninstall/install was the only way forward.

The developer reference (ja/en) now states the rule with its reason and makes it **step 4 of a numbered release closeout checklist**: the moment a Release is published and verified, roll `version.json` in a follow-up commit — `stableVersion` = the released version, `nextVersion` = the next patch. Existing preview artifacts are **not** renumbered retroactively. The v0.6.1 notes carry a preview-channel note plus a **ROLL NOW** item in their own post-release checklist.

## Verification (release-readiness gate, run pre-merge)

```
$ cat eng/version.json                 # stableVersion 0.6.0, nextVersion 0.6.1 ✔
$ dotnet build … -c Release            # Build succeeded ✔
$ dotnet run … -c Release -- --version # intent-cli 0.6.1-7fbd69c-G553 ✔ (not a stale literal)
$ dotnet pack … -c Release             # JTechJapan.IntentSystem.Cli.0.6.1.nupkg ✔
$ dotnet test … -c Release --filter ReleasePackageMetadataTests   # 5/5 ✔
```

- `dotnet test IntentSystem.sln` — **all green** (CLI suite 3904 passed / 0 failed; every other project passed).
- Focused: `ReleaseNotesV061DocsTests` → **14 passed / 0 failed** (new); version smoke tests moved to the 0.6.1 line.
- `git diff --check` clean.
- **No `src/` changes and no `.github/` changes** — verified on the staged diff.

## Out of scope (untouched)

No tag/Release creation or publish automation (operator action — the operator also performs the first roll after v0.6.1 per the new rule); no command behavior changes; no retroactive renumbering of existing preview artifacts.

Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPT7cFrCzT6ehACFez8dpE
