### PR TITLE
G557: Hotfix red main after the v0.6.1 version roll — version-agnostic assertions, draft next-version notes, roll-rule amendment

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1993,18 +1993,35 @@ manual uninstall/install was the only way forward. Rolling immediately makes the
 next preview `0.6.2-preview.N`, which sorts above `0.6.1`, and `dotnet tool
 update` works again.
 
-**Release closeout checklist** (the roll is step 4 — do not stop at step 3):
+**Release closeout checklist** (the roll is step 4 — do not stop at step 3, and
+the roll is not done until step 5):
 
 1. Publish the GitHub Release for the version (this fires `release.yml`).
 2. Verify the published artifacts: NuGet page, release assets, `.sha256`
    checksums, and `intent-cli --version` after `dotnet tool update`.
 3. Notify the operator and any waiting downstream consumers.
 4. **Roll `eng/version.json` in a follow-up commit** — `stableVersion` = the
-   released version, `nextVersion` = the next patch — and confirm the next main
-   CI preview builds above the release.
+   released version, `nextVersion` = the next patch — **and, in the same
+   commit, add DRAFT `docs/{en,ja}/release-notes-v<nextVersion>.md` stubs.**
+   The G475 guard requires notes to exist for whatever `nextVersion` names, so
+   a roll that moves the field without the stubs turns main red the moment it
+   lands. The stubs carry no changelog content — the next release-prep packet
+   authors that.
+5. **Verify child main CI is green after pushing the roll.** The roll is
+   complete only when CI is: a red main blocks every unrelated PR that inherits
+   it, so the roller owns the result, not just the commit.
 
 Existing preview artifacts are **not** renumbered retroactively; the rule fixes
 the channel going forward.
+
+> **Why steps 4-5 read this way (G557).** The roll's first live execution
+> (commit `00936844`, `nextVersion` 0.6.1 → 0.6.2) moved the field alone and
+> turned main red on four checks: three tests pinned the version pair by value,
+> and the G475 guard demanded `release-notes-v0.6.2.md`. An unrelated PR
+> inherited the red main and was frozen until a hotfix landed. The assertions
+> are now derived from `eng/version.json` so a correct roll cannot break them,
+> and the two steps above close the rest: create the stubs with the roll, and
+> confirm green before calling it done.
 
 ### Next release readiness (v0.6.1)
 

--- a/docs/en/release-notes-v0.6.2.md
+++ b/docs/en/release-notes-v0.6.2.md
@@ -1,0 +1,41 @@
+# Release Notes — intent-cli v0.6.2 (DRAFT — UNRELEASED)
+
+> **⚠️ DRAFT / UNRELEASED.** This is a **stub**, not release notes. It exists
+> because `eng/version.json` names `0.6.2` as the release-to-be-cut, and the
+> G475 guard requires notes to exist for that version before it can be
+> published. **The v0.6.2 release-prep packet authors the real content**;
+> nothing here describes shipped behavior, and this file must not be treated as
+> a changelog.
+
+## Status
+
+Created by the post-release version roll (G554 rule as amended by G557) at the
+moment `nextVersion` became `0.6.2`. Until the release-prep packet fills it in:
+
+- **No slices are listed yet.** What ships in `v0.6.2` is decided by the
+  release-prep packet, not by this stub.
+- **No bump rationale yet** (patch vs minor is a release-prep decision).
+- **No readiness gate yet.** Do **not** publish a `v0.6.2` GitHub Release while
+  this file is still a draft — an unfilled stub means release-prep has not run.
+
+## What the release-prep packet must replace this with
+
+Follow the shape of the previous notes
+([v0.6.1](release-notes-v0.6.1.md), [v0.6.0](release-notes-v0.6.0.md)):
+
+- what shipped, grouped by theme, covering exactly the merged slices;
+- the bump rationale (patch vs minor) stated, not just labelled;
+- the prepare-only publishing section and the release-readiness gate;
+- an upgrade section separating additive surfaces from corrective behavior
+  changes;
+- the post-release roll reminder.
+
+## Install (placeholder — the version below is what the guard checks)
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.2
+```
+
+Once published, the self-contained binaries will be attached to the
+[v0.6.2 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.6.2).
+Verify the `.sha256` sidecar before use.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2131,18 +2131,33 @@ closeout の 1 ステップであり、飛ばすと preview チャンネルが�
 以外に手段がありませんでした。直ちに roll すれば次の preview は `0.6.2-preview.N` となり
 `0.6.1` より上にソートされるため、`dotnet tool update` が再び機能します。
 
-**リリース closeout チェックリスト**(roll はステップ 4 — ステップ 3 で止めないこと):
+**リリース closeout チェックリスト**(roll はステップ 4 — ステップ 3 で止めないこと。
+そして roll はステップ 5 まで終えて初めて完了です):
 
 1. 対象バージョンの GitHub Release を publish する(これが `release.yml` を発火させる)。
 2. publish された成果物を検証する: NuGet ページ、release assets、`.sha256` チェックサム、
    `dotnet tool update` 後の `intent-cli --version`。
 3. オペレーターと、待っている下流の利用者へ通知する。
 4. **follow-up commit で `eng/version.json` を roll する** — `stableVersion` = リリース
-   したバージョン、`nextVersion` = 次の patch — そして次の main CI preview がリリースより
-   上に build されることを確認する。
+   したバージョン、`nextVersion` = 次の patch — **さらに同じ commit で DRAFT の
+   `docs/{en,ja}/release-notes-v<nextVersion>.md` stub を追加する。** G475 のガードは
+   `nextVersion` が指すバージョンのノートの存在を要求するため、stub 無しでフィールドだけを
+   動かす roll は、着地した瞬間に main を red にします。stub に changelog の中身は不要で、
+   実際の内容は次の release-prep パケットが author します。
+5. **push 後に child main の CI が green であることを検証する。** roll は CI が green に
+   なって初めて完了です: red な main は、それを継承するすべての無関係な PR をブロックする
+   ため、roll した人は commit だけでなく結果まで責任を持ちます。
 
 既存の preview 成果物は **遡って番号を振り直しません**。このルールはチャンネルを今後に
 向けて修正するものです。
+
+> **ステップ 4-5 がこの形である理由(G557)。** roll の最初の実運用(commit `00936844`、
+> `nextVersion` 0.6.1 → 0.6.2)はフィールドだけを動かし、4 つのチェックで main を red に
+> しました: 3 つのテストがバージョンの組を値で固定しており、G475 のガードが
+> `release-notes-v0.6.2.md` を要求したためです。無関係な PR が red な main を継承して
+> 凍結され、hotfix が着地するまで解除されませんでした。assertion は `eng/version.json`
+> から導出するようになり、正しい roll がそれらを壊すことはなくなりました。残りを塞ぐのが
+> 上記 2 ステップです: roll と同時に stub を作り、green を確認してから完了とする。
 
 ### 次リリース準備(v0.6.1)
 

--- a/docs/ja/release-notes-v0.6.2.md
+++ b/docs/ja/release-notes-v0.6.2.md
@@ -1,0 +1,40 @@
+# リリースノート — intent-cli v0.6.2（DRAFT — 未リリース）
+
+> **⚠️ DRAFT / 未リリース。** これはリリースノートではなく **stub** です。
+> `eng/version.json` が `0.6.2` を「これからカットするリリース」として指しており、
+> G475 のガードが publish 前にそのバージョンのノートの存在を要求するため置かれています。
+> **実際の内容は v0.6.2 の release-prep パケットが author します**。ここには出荷済みの
+> 挙動は一切書かれておらず、このファイルを changelog として扱ってはいけません。
+
+## ステータス
+
+`nextVersion` が `0.6.2` になった時点で、リリース後の version roll（G554 のルール、
+G557 による改訂版）によって作成されました。release-prep パケットが埋めるまでは:
+
+- **スライスは未記載です。** `v0.6.2` で何が出荷されるかを決めるのはこの stub ではなく
+  release-prep パケットです。
+- **バンプ根拠も未記載です**（patch か minor かは release-prep の判断です）。
+- **リリース準備ゲートも未記載です。** このファイルが draft のままの間は `v0.6.2` の
+  GitHub Release を publish **しないでください** — 埋まっていない stub は release-prep が
+  未実行であることを意味します。
+
+## release-prep パケットがこれを置き換える際に必要なもの
+
+過去のノート（[v0.6.1](release-notes-v0.6.1.md)、[v0.6.0](release-notes-v0.6.0.md)）の
+形に従ってください:
+
+- 出荷内容をテーマ別にグループ化し、マージされたスライスを正確にカバーする;
+- バンプ根拠（patch か minor か）をラベルだけでなく理由まで記述する;
+- prepare-only の publishing セクションとリリース準備ゲート;
+- 追加サーフェスと是正的な挙動変更を分離した upgrade セクション;
+- リリース後の roll のリマインド。
+
+## インストール（プレースホルダー — 下記バージョンがガードの検査対象です）
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.2
+```
+
+publish 後、self-contained バイナリは
+[v0.6.2 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.6.2)
+に添付されます。使用前に `.sha256` サイドカーを検証してください。

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV060DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV060DocsTests.cs
@@ -26,14 +26,12 @@ public sealed class ReleaseNotesV060DocsTests
     [Fact]
     public void VersionPolicy_RecordsTheReleaseToBeCut_G551()
     {
-        // G554 rolled the line to 0.6.1 after v0.6.0 shipped; this test keeps
-        // pinning that the policy names a release-to-be-cut strictly ahead of
-        // the published stable, which is what the readiness gate depends on.
-        var policy = VersionPolicy.TryReadFromRepo(RepoRoot());
-
-        Assert.NotNull(policy);
-        Assert.Equal("0.6.0", policy.StableVersion);
-        Assert.Equal("0.6.1", policy.NextVersion);
+        // G557: derived from eng/version.json rather than pinned by value. The
+        // readiness gate depends on the PROPERTY (a release-to-be-cut strictly
+        // ahead of the published stable), and that property survives every
+        // post-release roll — a hardcoded pair does not.
+        RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(
+            RepoVersionPolicySource.Read());
     }
 
     [Theory]

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
@@ -17,13 +17,13 @@ public sealed class ReleaseNotesV061DocsTests
     private static readonly string[] ReleasedSlices = ["G552", "G553"];
 
     [Fact]
-    public void VersionPolicy_RecordsTheV061ReleaseToBeCut_G554()
+    public void VersionPolicy_RecordsTheReleaseToBeCut_G554()
     {
-        var policy = VersionPolicy.TryReadFromRepo(RepoRoot());
-
-        Assert.NotNull(policy);
-        Assert.Equal("0.6.0", policy.StableVersion);
-        Assert.Equal("0.6.1", policy.NextVersion);
+        // G557: derived from eng/version.json rather than pinned by value —
+        // see RepoVersionPolicySource for why a literal pair is the wrong
+        // assertion for a field the post-release roll is required to change.
+        RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(
+            RepoVersionPolicySource.Read());
     }
 
     [Theory]
@@ -247,6 +247,70 @@ public sealed class ReleaseNotesV061DocsTests
             language == "en" ? "Notify the operator to publish the `v0.6.1` GitHub Release" : "オペレーターに `v0.6.1` GitHub Release の publish を通知し",
             notes,
             StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperReference_RollRuleRequiresStubsAndGreenCi_G557(string language)
+    {
+        var reference = ReadDeveloperReference(language);
+
+        // G557 step 4: the roll commit creates the next-version DRAFT stubs, or
+        // it turns main red the moment it lands.
+        Assert.Contains(
+            language == "en" ? "add DRAFT `docs/{en,ja}/release-notes-v<nextVersion>.md` stubs" : "DRAFT の\n`docs/{en,ja}/release-notes-v<nextVersion>.md` stub を追加する".Replace("\n", " "),
+            reference,
+            StringComparison.Ordinal);
+
+        // G557 step 5: the roll is not complete until child main CI is green.
+        Assert.Contains(
+            language == "en" ? "Verify child main CI is green after pushing the roll" : "push 後に child main の CI が green であることを検証する",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "the roll is not done until step 5" : "roll はステップ 5 まで終えて初めて完了",
+            reference,
+            StringComparison.Ordinal);
+
+        // The incident that produced the amendment is recorded with it.
+        Assert.Contains("00936844", reference, StringComparison.Ordinal);
+        Assert.Contains("G475", reference, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NextVersionNotes_ExistAsClearlyMarkedDrafts_G557(string language)
+    {
+        var policy = RepoVersionPolicySource.Read();
+        var path = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, $"release-notes-v{policy.NextVersion}.md");
+
+        Assert.True(File.Exists(path), $"missing next-version notes: docs/{language}/release-notes-v{policy.NextVersion}.md");
+
+        var notes = ReadCollapsed(path);
+
+        // The stub must be unmistakably a draft — G475 checks existence, and a
+        // stub that reads like a changelog would be worse than a missing file.
+        Assert.Contains(language == "en" ? "DRAFT" : "DRAFT", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "**⚠️ DRAFT / UNRELEASED.**" : "**⚠️ DRAFT / 未リリース。**",
+            notes,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "release-prep packet authors the real content" : "release-prep パケットが author します",
+            notes,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "must not be treated as a changelog" : "changelog として扱ってはいけません",
+            notes,
+            StringComparison.Ordinal);
+
+        // And it still satisfies the G475 guard's own two requirements, so the
+        // guard's semantics are unchanged rather than relaxed.
+        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", notes, StringComparison.Ordinal);
+        Assert.Contains($"releases/tag/v{policy.NextVersion}", notes, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/RepoVersionPolicySource.cs
+++ b/tests/IntentSystem.Cli.Tests/RepoVersionPolicySource.cs
@@ -1,0 +1,97 @@
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G557: the single source tests derive version expectations from.
+///
+/// Before this, three tests hardcoded the `stableVersion` / `nextVersion` pair
+/// as literals. The first live execution of the G554 post-release roll
+/// (commit 00936844, nextVersion 0.6.1 → 0.6.2) turned child main red on all
+/// three at once, and an unrelated PR inherited the red main and was frozen.
+/// A literal is the wrong thing to assert here: the roll is a REQUIRED,
+/// recurring step, so any test that pins the pair by value is a test that a
+/// correct roll is guaranteed to break.
+///
+/// What actually needs guarding is the INVARIANT — the policy parses, and the
+/// release-to-be-cut is strictly ahead of the published stable — which holds
+/// across every roll. This helper reads <c>eng/version.json</c> and asserts
+/// that property, so the expectations move with the file rather than against
+/// it.
+/// </summary>
+internal static class RepoVersionPolicySource
+{
+    /// <summary>Reads the repository's own <c>eng/version.json</c>.</summary>
+    public static VersionPolicy Read() => ReadFrom(RepoRoot());
+
+    /// <summary>
+    /// Reads a policy from an arbitrary root — used by the roll-simulation
+    /// fixture, which writes a bumped <c>eng/version.json</c> and proves the
+    /// derived assertions stay green against it.
+    /// </summary>
+    public static VersionPolicy ReadFrom(string root)
+    {
+        var policy = VersionPolicy.TryReadFromRepo(root);
+        Assert.True(policy is not null, $"eng/version.json under '{root}' must be present and parseable.");
+        return policy!;
+    }
+
+    /// <summary>
+    /// The property every release-prep depends on: <c>nextVersion</c> (the
+    /// release being cut) is strictly ahead of <c>stableVersion</c> (the last
+    /// published line), so the tag cannot collide with the current stable.
+    /// Version-agnostic by construction — a roll advances both fields and the
+    /// assertion keeps holding.
+    /// </summary>
+    public static void AssertReleaseToBeCutIsAheadOfPublishedStable(VersionPolicy policy)
+    {
+        ArgumentNullException.ThrowIfNull(policy);
+
+        var stable = ParseSemver(policy.StableVersion);
+        var next = ParseSemver(policy.NextVersion);
+
+        Assert.True(
+            Compare(next, stable) > 0,
+            $"eng/version.json nextVersion ({policy.NextVersion}) must be strictly ahead of stableVersion "
+            + $"({policy.StableVersion}) to be release-ready.");
+    }
+
+    public static string RepoRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "eng", "version.json")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate the repository root from {AppContext.BaseDirectory}.");
+    }
+
+    private static (int Major, int Minor, int Patch) ParseSemver(string version)
+    {
+        var core = (version ?? string.Empty).Split('-', 2)[0];
+        var parts = core.Split('.');
+        Assert.True(parts.Length >= 3, $"version '{version}' is not semver-shaped");
+        return (int.Parse(parts[0]), int.Parse(parts[1]), int.Parse(parts[2]));
+    }
+
+    private static int Compare((int Major, int Minor, int Patch) a, (int Major, int Minor, int Patch) b)
+    {
+        if (a.Major != b.Major)
+        {
+            return a.Major.CompareTo(b.Major);
+        }
+
+        if (a.Minor != b.Minor)
+        {
+            return a.Minor.CompareTo(b.Minor);
+        }
+
+        return a.Patch.CompareTo(b.Patch);
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
+++ b/tests/IntentSystem.Cli.Tests/VersionPolicyTests.cs
@@ -123,28 +123,72 @@ public sealed class VersionPolicyTests : IDisposable
     [Fact]
     public void EngVersionJson_InThisRepo_IsReadableAndHasExpectedNextVersion()
     {
-        // Smoke-test: the actual eng/version.json in the repository must
-        // be parseable and must point to 0.6.1 as the next development line
-        // (post-v0.6.0 release bump, see G554 — v0.6.0 was published to
-        // GitHub Releases + NuGet, so the policy moves the development line
-        // forward to 0.6.1 — a patch bump, since neither shipped slice adds a
-        // command surface: G553 is a WIP-gate bugfix and G552 extends the
-        // existing stalled-work/heartbeat detection surfaces and the
-        // orchestrator-thread guide — while recording 0.6.0 as the published
-        // stable. G554 also makes this roll a REQUIRED, immediate release
-        // closeout step: leaving nextVersion at the released version makes
-        // every preview sort below its own release.
-        var repoRoot = FindRepoRoot();
-        if (repoRoot is null)
+        // G557: this smoke test used to hardcode the stable/next pair. The
+        // first live execution of the G554 post-release roll (commit 00936844,
+        // nextVersion 0.6.1 -> 0.6.2) broke it — along with two peers — and
+        // turned child main red, freezing an unrelated PR that inherited it.
+        // A literal pair is the wrong assertion for a field a REQUIRED
+        // recurring step is supposed to change. What must hold across every
+        // roll is that the policy parses and names a release-to-be-cut
+        // strictly ahead of the published stable, so the expectation is
+        // derived from eng/version.json itself.
+        var policy = RepoVersionPolicySource.Read();
+
+        Assert.False(string.IsNullOrWhiteSpace(policy.StableVersion));
+        Assert.False(string.IsNullOrWhiteSpace(policy.NextVersion));
+        RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
+    }
+
+    [Fact]
+    public void EngVersionJson_DerivedExpectations_SurviveASimulatedRoll_G557()
+    {
+        // Roll simulation: a bumped version.json must keep the derived
+        // assertions green. This is the regression the hardcoded literals
+        // could not express — it fails only if an expectation is baked in
+        // again.
+        using var temp = new TemporaryRepoRoot();
+        temp.WriteVersionPolicy(stableVersion: "0.6.1", nextVersion: "0.6.2");
+        RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(
+            RepoVersionPolicySource.ReadFrom(temp.RootPath));
+
+        // …and again after the NEXT roll, and across a minor and a major line.
+        foreach (var (stable, next) in new[] { ("0.6.2", "0.6.3"), ("0.6.9", "0.7.0"), ("0.9.9", "1.0.0") })
         {
-            return; // Running outside a checkout — skip.
+            temp.WriteVersionPolicy(stable, next);
+            var rolled = RepoVersionPolicySource.ReadFrom(temp.RootPath);
+            Assert.Equal(stable, rolled.StableVersion);
+            Assert.Equal(next, rolled.NextVersion);
+            RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(rolled);
+        }
+    }
+
+    private sealed class TemporaryRepoRoot : IDisposable
+    {
+        public TemporaryRepoRoot()
+        {
+            RootPath = Directory.CreateTempSubdirectory("version-policy-roll-simulation-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, "eng"));
         }
 
-        var policy = VersionPolicy.TryReadFromRepo(repoRoot);
+        public string RootPath { get; }
 
-        Assert.NotNull(policy);
-        Assert.Equal("0.6.1", policy.NextVersion);
-        Assert.Equal("0.6.0", policy.StableVersion);
+        public void WriteVersionPolicy(string stableVersion, string nextVersion) =>
+            File.WriteAllText(
+                Path.Combine(RootPath, "eng", "version.json"),
+                $$"""
+                {
+                  "stableVersion": "{{stableVersion}}",
+                  "nextVersion": "{{nextVersion}}"
+                }
+                """);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
     }
 
     private static string? FindRepoRoot()


### PR DESCRIPTION
## Summary

Restores child main to green after the first live execution of the G554 post-release version roll (commit `00936844`, `nextVersion` 0.6.1 → 0.6.2), which turned main red on four checks and froze the unrelated G555 PR #1214.

**Fix forward, bounded.** The roll is **not** rolled back.

## The three fixes

**1. Version-agnostic assertions.** A literal version pair is the wrong assertion for a field a *required recurring step* is supposed to change — pinning it guarantees that a correct roll breaks the test. The three failing assertions now derive from `eng/version.json` through one shared source (`RepoVersionPolicySource`) and assert the property that actually holds across every roll: the policy parses, and the release-to-be-cut is **strictly ahead** of the published stable.

A **roll-simulation fixture** writes bumped `version.json` files — next patch, minor rollover, major rollover — and proves the derived assertions stay green. The regression is now *expressible*, not merely fixed.

**2. DRAFT next-version stubs.** `docs/{en,ja}/release-notes-v0.6.2.md` exist and are unmistakably marked **DRAFT / UNRELEASED**: they state that release-prep authors the real content, that they are not a changelog, and that a v0.6.2 Release must not be published while the stub is unfilled.

They satisfy both of the G475 guard's own requirements (the install line and the release tag) with **its semantics unchanged** — existence is still required; it is simply now possible to satisfy at roll time.

**3. Roll rule completed (ja/en).** Step 4 now creates the DRAFT stubs **in the same commit** as the version bump, and a new **step 5** requires the roller to verify child main CI green after pushing — a red main blocks every unrelated PR that inherits it, so the roll is complete only when CI is. The incident that produced the amendment is recorded alongside it.

## Verification

- Previously-failing tests now green: `VersionPolicyTests`, `ReleaseNotesV060DocsTests`, `ReleaseNotesV061DocsTests`, `ReleasePackageMetadataTests`.
- Focused: `ReleaseNotesV061DocsTests` **24/24**; version/notes/package filter **39/39**.
- `dotnet test IntentSystem.sln` — **all green** (CLI suite 3915 passed / 0 failed / 1 pre-existing skip; every other project passed).
- `git diff --check` clean.

## Out of scope (untouched)

No release-note **content** for v0.6.2 (release-prep authors it); no weakening of the G475 guard; no command behavior changes; no changes to G555 (#1214, frozen at `43ca2c5`) or G556.

Closes #1215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPT7cFrCzT6ehACFez8dpE
