### PR TITLE
G556: Guide verified liveness — a startup report is not readiness

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -145,6 +145,46 @@ readiness in **three layers that must not be collapsed**:
    the live markers are unavailable, fall back explicitly (`turn` delivery or
    manual `inbox.sh`), say so, and still require the ack.
 
+**Verified liveness — a startup report is not readiness.** Provisioning
+concludes on verified liveness, not on a message. A role is provisioned when its
+startup report has arrived **and**, after a **settle delay**, all three of these
+still pass:
+
+1. **The pane still hosts the agent TUI** — read the pane. A shell prompt means
+   the agent exited, however recently it reported. The pane is ground truth; a
+   message is a claim about the past.
+2. **An agmsg ping-pong round trip succeeds** — ping now, require the pong now.
+   The earlier readiness ack proves only that the receiver was alive *then*.
+3. **For codex, the bridge is armed and the app-server attachment is stable** —
+   a codex TUI attaches to a per-folder app-server over a `--remote` websocket,
+   so the attachment can die while the pane and the bridge both looked fine a
+   moment ago.
+
+> **A startup report is not readiness.** Field incident (2026-07-29): two codex
+> agents reported startup-complete and died **seconds** later when their shared
+> app-server was lost — and the supervising thread went on *"waiting for startup
+> reports"* while every agent was already dead. Never conclude provisioning on
+> the report alone.
+
+The settle delay matters: the failure this catches happens seconds *after* the
+report, so verifying instantly re-observes the moment the report described and
+proves nothing new.
+
+**Early death is a normal mode.** Its signature is the TUI **exiting to a shell
+prompt**, typically leaving a resume hint on screen, after a websocket
+**transport reset** dropped its app-server connection — a pane that looks like
+an ordinary terminal, which is why a scan looking only for dialogs misses it.
+When a check fails, **re-check and recover; do not wait for another report** — a
+dead agent sends nothing, so waiting is waiting forever.
+
+> **Shared app-server death mode.** Killing an app-server **takes down every
+> attached TUI at once**, including agents belonging to other teams that had
+> nothing to do with whatever prompted the kill. The 2026-07-29 double death was
+> exactly this. Prevention is the attribution rule below: verify a process's own
+> cwd before stopping any app-server, and never act on a process you cannot
+> attribute. This is the second-order cost of an attribution violation — the
+> victim is not the process you killed, it is everything attached to it.
+
 **5. Exclusivity and handover.** Exactly one live session may hold a role; a
 second actas attempt is refused, and that refusal is correct. Replacing a
 session goes through the **graceful drop** — the current holder drops the role
@@ -197,8 +237,22 @@ decision, and the confirmation records it.
 | layer | purpose | cadence |
 | --- | --- | --- |
 | real-time message monitor | inbound agmsg replies, blockers, escalations | continuous (a live attached stream) |
-| blocking-UI pane scan | panes stuck on approval / selection / trust prompts — the failure mode that emits no message at all | sub-minute class |
+| blocking-UI pane scan | panes stuck on approval / selection / trust prompts, **and panes showing a shell prompt where an agent should be** (`agent-absent`) — the failure modes that emit no message at all | sub-minute class |
 | periodic state watchdog | canonical intent-cli/GitHub state vs expected progress; the existing [design-thread watchdog](#design-thread-watchdog-recommended-safety-net) | tens-of-minutes class |
+
+**What the pane scan is looking for.** Two stuck states rank together:
+
+- **blocking dialog** — an approval, selection, or trust prompt waiting for
+  input; handle it under the dialog rules below.
+- **`agent-absent`** — a shell prompt where an agent should be. Recovery is a
+  **shim-based relaunch**: type the launch into the pane's interactive shell
+  (never spawn the executable), recreating the app-server first when that is
+  what died, then run the **full verified-liveness sequence** again. Set the
+  permission mode with the **launch flag** (e.g. `--permission-mode`) rather
+  than switching it afterwards — a workspace manager's synthetic key injection
+  cannot be relied on for mode switching: plain keys are delivered, but modifier
+  chords such as shift+tab are not delivered faithfully (observed across
+  multiple teams).
 
 > **Re-arm across restarts.** Supervision schedulers are session-scoped: a
 > `/loop`, an automation, or an attached monitor dies with the design session

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -141,6 +141,43 @@ monitor bridge を arm する（G521）ため、canonical な実行ファイル�
    得られない場合は明示的にフォールバックし（`turn` delivery または手動 `inbox.sh`）、その旨を
    述べたうえで、それでも ack を必須にします。
 
+**verified liveness — startup report は readiness ではない。** provisioning は
+メッセージではなく verified liveness で完了します。ロールが provisioned となるのは、
+startup report が届き **かつ**、**settle delay** の後に次の 3 つがいずれもまだ通る
+場合です:
+
+1. **pane が依然として agent の TUI をホストしている** — pane を読みます。shell
+   プロンプトが出ていれば、どれほど直前に report していても agent は終了しています。
+   pane が ground truth であり、メッセージは過去についての主張にすぎません。
+2. **agmsg の ping-pong 往復が成功する** — 今 ping し、今 pong を要求します。先ほどの
+   readiness ack が証明するのは「その時点で」生きていたことだけです。
+3. **codex では bridge が armed で app-server attachment が安定している** — codex の
+   TUI は per-folder の app-server に `--remote` websocket で attach するため、pane も
+   bridge も直前まで正常に見えていたのに attachment だけが死ぬことがあります。
+
+> **startup report は readiness ではありません。** field incident(2026-07-29):
+> 2 体の codex agent が startup-complete を report した **数秒後** に、共有していた
+> app-server の喪失で死亡しました。それでも監督スレッドは「startup report を待っている」
+> と言い続け、その時点で全 agent は既に死んでいました。report だけで provisioning を
+> 完了と結論してはいけません。
+
+settle delay が重要です: この検査が捕まえる失敗は report の **数秒後** に起きるため、
+即座に検証しても report が述べたのと同じ瞬間を再観測するだけで、新しいことは何も
+証明できません。
+
+**early death は normal mode です。** そのシグネチャは、websocket の **transport
+reset** が app-server 接続を落とした結果、TUI が **shell プロンプトへ抜ける**(多くは
+resume ヒントを画面に残す)ことです。ただの端末に見える pane になるため、ダイアログだけを
+探すスキャンでは見逃します。チェックが失敗したら **再チェックして復旧します。次の report を
+待ってはいけません** — 死んだ agent は何も送らないので、待つことは永遠に待つことです。
+
+> **共有 app-server の death mode。** app-server を kill すると、**attach している
+> すべての TUI が一斉に落ちます** — kill の理由と無関係な、他チームの agent も含めて。
+> 2026-07-29 の 2 体同時死はまさにこれでした。予防策は下記の attribution ルールです:
+> app-server を停止する前にプロセス自身の cwd を確認し、attribute できないプロセスには
+> 手を出さないこと。これは attribution 違反の二次被害です — 被害者は kill したプロセス
+> ではなく、それに attach していたすべてです。
+
 **5. 排他性とハンドオーバー。** 1 つのロールを保持できる生きたセッションはちょうど 1 つで、
 2 番目の actas は拒否されます — その拒否が正しい挙動です。セッションの置き換えは
 **graceful drop** を通します: 現保持者が（オペレーター確認つきで）ロールを drop し、
@@ -188,8 +225,20 @@ drop の確認は **オペレーターに可視** です: 生きたセッショ�
 | レイヤー | 目的 | ケイデンス |
 | --- | --- | --- |
 | リアルタイム message monitor | 受信する agmsg の返信・blocker・エスカレーション | 継続的（attach された live stream） |
-| blocking-UI の pane スキャン | approval / selection / trust プロンプトで止まった pane — メッセージを一切出さない failure mode | サブ分オーダー |
+| blocking-UI の pane スキャン | approval / selection / trust プロンプトで止まった pane、**および agent がいるべき場所に shell プロンプトが出ている pane**(`agent-absent`)— メッセージを一切出さない failure mode | サブ分オーダー |
 | 定期 state watchdog | canonical な intent-cli/GitHub 状態と期待進捗の比較。既存の [design-thread watchdog](#design-thread-watchdog推奨されるセーフティネット) | 数十分オーダー |
+
+**pane スキャンが探しているもの。** 2 つの stuck state が同列に並びます:
+
+- **blocking dialog** — 入力待ちの approval / selection / trust プロンプト。下記の
+  ダイアログルールに従って扱います。
+- **`agent-absent`** — agent がいるべき場所に shell プロンプトが出ている状態。復旧は
+  **shim 経由の relaunch** です: pane の対話シェルにタイプして起動し(実行ファイルの
+  直接 spawn は禁止)、死んだのが app-server ならそれを先に再作成し、その後
+  **verified-liveness の全手順** をやり直します。permission mode は起動後に切り替えるのでは
+  なく **launch フラグ**(例: `--permission-mode`)で設定してください — ワークスペース
+  マネージャーの合成キー注入は mode 切り替えに使えません: 平文キーは届きますが、
+  shift+tab のような modifier chord は忠実に届きません(複数チームで観測)。
 
 > **再起動をまたいだ re-arm。** 監督スケジューラーはセッションスコープです: `/loop`・automation・
 > attach された monitor は、それをホストしている設計セッションと一緒に死に、しかも停止したことを

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -1812,14 +1812,22 @@ internal static class GuideOrchestratorThreadCommand
                 {
                     Layer = "blocking-UI pane scan",
                     Purpose =
-                        "Notice panes blocked on approval, selection, or trust prompts — the failure mode that "
-                        + "produces no message at all, so no message-driven layer can ever detect it.",
+                        "Notice panes that are stuck with nothing to say. TWO EQUAL stuck states: a pane blocked on "
+                        + "an approval, selection, or trust prompt, AND a pane showing a shell prompt where an agent "
+                        + "should be (`agent-absent`, G556). Both produce no message at all — a blocked agent is "
+                        + "waiting and a dead one cannot speak — so no message-driven layer can ever detect either.",
                     Cadence =
-                        "sub-minute class (e.g. every few tens of seconds) — blocking dialogs stall a role for their "
-                        + "entire lifetime, so this layer is the fast one.",
+                        "sub-minute class (e.g. every few tens of seconds) — a blocking dialog stalls a role for its "
+                        + "entire lifetime, and an agent that died seconds after reporting stays dead until someone "
+                        + "looks, so this layer is the fast one.",
                     Note =
-                        "Scanning is READING. What the scan finds is then handled by the dialog rules below: answer "
-                        + "only what the MAY list covers after the verified read, and escalate the rest.",
+                        "Scanning is READING, and what the scan finds routes by STATE, not by one rule for "
+                        + "everything. A blocking dialog goes to the dialog rules below — answer only what the MAY "
+                        + "list covers after the verified read, and escalate the rest. An `agent-absent` shell "
+                        + "prompt is NOT a dialog and must never be routed through dialog handling: it goes to the "
+                        + "shim-safe relaunch recovery (recreating the app-server when that is what died), followed "
+                        + "by the COMPLETE verified-liveness re-check — report, settle delay, all three checks. See "
+                        + "`What the pane scan is looking for` for both recoveries.",
                 },
                 new OrchestratorSupervisionLayer
                 {

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -1583,6 +1583,87 @@ internal static class GuideOrchestratorThreadCommand
                     "After readiness, run the existing ping test before ANY delegation: send one agmsg message to each "
                     + "role and require the ack (see `Receiver readiness` / `ping_test`). Readiness is a precondition "
                     + "for the ping test, not a replacement for it.",
+                VerifiedLiveness = new OrchestratorVerifiedLiveness
+                {
+                    Summary =
+                        "Provisioning concludes on VERIFIED LIVENESS, not on a message. A role is provisioned when its "
+                        + "startup report has arrived AND, after a settle delay, all three checks below still pass. "
+                        + "Until then the pane is a candidate, not a receiver.",
+                    ReportIsNotReadiness =
+                        "the report says the agent reached the point of sending a "
+                        + "message; it says nothing about whether the agent is still running now. Field incident "
+                        + "(2026-07-29): two codex agents reported startup-complete and died SECONDS later when their "
+                        + "shared app-server was lost — and the supervising thread went on \"waiting for startup "
+                        + "reports\" while every agent was already dead. Never conclude provisioning on the report "
+                        + "alone.",
+                    SettleDelay =
+                        "wait after the report before verifying — long enough for an early death to "
+                        + "have happened, since the failure this catches occurs seconds after the report, not at the "
+                        + "moment of it. Verifying instantly re-observes the same moment the report described and "
+                        + "proves nothing new.",
+                    PostReportChecks = new[]
+                    {
+                        new OrchestratorLivenessCheck
+                        {
+                            Check = "the pane still hosts the agent TUI",
+                            HowToVerify =
+                                "READ the pane. The agent's own interface must be there — a shell prompt means the "
+                                + "agent exited, however recently it reported. The pane is ground truth; a message is "
+                                + "a claim about the past.",
+                        },
+                        new OrchestratorLivenessCheck
+                        {
+                            Check = "an agmsg ping-pong round trip succeeds",
+                            HowToVerify =
+                                "send a ping NOW and require the pong NOW. A round trip completed after the settle "
+                                + "delay is the only evidence that the receiver is alive at THIS moment; the earlier "
+                                + "readiness ack proves only that it was alive then.",
+                        },
+                        new OrchestratorLivenessCheck
+                        {
+                            Check = "codex: the bridge is armed and the app-server attachment is stable",
+                            HowToVerify =
+                                "confirm the bridge-alive marker AND that the app-server attachment has not dropped "
+                                + "since the report — a codex TUI attaches to a per-folder app-server over a "
+                                + "`--remote` websocket, so the attachment is a separate thing that can die while the "
+                                + "pane and the bridge both looked fine a moment ago.",
+                        },
+                    },
+                    EarlyDeathIsNormal = new OrchestratorEarlyDeathMode
+                    {
+                        Summary =
+                            "an agent can die within "
+                            + "seconds of reporting, and the provisioning flow is expected to detect it rather than "
+                            + "assume it away — this is a normal mode, not an anomaly to be surprised by.",
+                        TransportResetSignature =
+                            "Signature: the TUI EXITS TO A SHELL PROMPT, typically leaving a resume hint on screen, "
+                            + "after a websocket TRANSPORT RESET dropped its app-server connection. The pane looks "
+                            + "like an ordinary terminal — which is exactly why a scan that only looks for dialogs "
+                            + "misses it.",
+                        RecheckObligation =
+                            "re-check; do not wait for another report. A dead agent sends nothing, so waiting for a "
+                            + "further message is waiting forever. When a check fails, treat the role as not "
+                            + "provisioned and recover (see the `agent-absent` stuck state) — then run the full "
+                            + "verified-liveness sequence again from the start.",
+                    },
+                    SharedAppServerDeathMode = new OrchestratorSharedAppServerDeath
+                    {
+                        Summary =
+                            "Codex TUIs attach to PER-FOLDER app-servers over `--remote` websockets, and an "
+                            + "app-server is shared by every TUI attached to it.",
+                        BlastRadius =
+                            "KILLING AN APP-SERVER TAKES DOWN EVERY ATTACHED TUI at once — including agents that "
+                            + "belong to other teams and had nothing to do with whatever prompted the kill. The "
+                            + "2026-07-29 double death was exactly this: a lost app-server, two dead agents, neither "
+                            + "of which was the intended target of anything.",
+                        PreventionReference =
+                            "Prevention is the cross-project attribution rule: verify the process's own cwd before "
+                            + "stopping any app-server, and never act on a process you cannot attribute (see "
+                            + "`Cross-project isolation on a shared machine`). This death mode is the second-order "
+                            + "cost of an attribution violation — the victim is not the process you killed, it is "
+                            + "every agent that was attached to it.",
+                    },
+                },
             },
             ExclusivityHandover = new OrchestratorProvisioningHandover
             {
@@ -1753,6 +1834,33 @@ internal static class GuideOrchestratorThreadCommand
                     Note =
                         "This is the existing watchdog, not a second one: its safety rules apply verbatim (see the "
                         + "watchdog safety-rules reference below). One canonical nudge per wake, never a batch.",
+                },
+            },
+            PaneScanStuckStates = new[]
+            {
+                new OrchestratorPaneStuckState
+                {
+                    State = "blocking dialog",
+                    WhatTheScanSees = "an approval, selection, or trust prompt waiting for input.",
+                    Recovery =
+                        "handle it under the dialog rules — answer only what the MAY list covers after the verified "
+                        + "read, escalate the rest.",
+                },
+                new OrchestratorPaneStuckState
+                {
+                    State = "agent-absent",
+                    WhatTheScanSees =
+                        "a SHELL PROMPT where an agent should be — the pane looks like an ordinary terminal, often "
+                        + "with a resume hint left on screen. The agent exited; it may have reported startup "
+                        + "successfully seconds earlier.",
+                    Recovery =
+                        "RELAUNCH THROUGH THE SHIM: type the launch into the pane's interactive shell (never spawn "
+                        + "the executable), recreating the app-server first when it is the thing that died. Set the "
+                        + "permission mode with the LAUNCH FLAG (e.g. `--permission-mode`) rather than trying to "
+                        + "switch it afterwards: a workspace manager's synthetic key injection cannot be relied on "
+                        + "for mode switching — plain keys are delivered, but modifier chords such as shift+tab are "
+                        + "not delivered faithfully (observed across multiple teams). Then run the FULL "
+                        + "verified-liveness sequence again — report, settle delay, all three checks.",
                 },
             },
             RearmRule =
@@ -2629,6 +2737,29 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"- **ping test** — {provisioning.RoleInitialization.PingTestReference}");
         writer.WriteLine();
 
+        var liveness = provisioning.RoleInitialization.VerifiedLiveness;
+        writer.WriteLine("#### Verified liveness — a startup report is not readiness (G556)");
+        writer.WriteLine();
+        writer.WriteLine(liveness.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"> **A startup report is NOT readiness:** {liveness.ReportIsNotReadiness}");
+        writer.WriteLine();
+        writer.WriteLine($"- **settle delay** — {liveness.SettleDelay}");
+        writer.WriteLine();
+        writer.WriteLine("After the settle delay, ALL THREE must still pass:");
+        writer.WriteLine();
+        foreach (var check in liveness.PostReportChecks)
+        {
+            writer.WriteLine($"- **{check.Check}** — {check.HowToVerify}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- **early death is normal** — {liveness.EarlyDeathIsNormal.Summary}");
+        writer.WriteLine($"- **transport-reset signature** — {liveness.EarlyDeathIsNormal.TransportResetSignature}");
+        writer.WriteLine($"- **re-check obligation** — {liveness.EarlyDeathIsNormal.RecheckObligation}");
+        writer.WriteLine();
+        writer.WriteLine($"> **Shared app-server death mode:** {liveness.SharedAppServerDeathMode.Summary} {liveness.SharedAppServerDeathMode.BlastRadius} {liveness.SharedAppServerDeathMode.PreventionReference}");
+        writer.WriteLine();
+
         writer.WriteLine("### 5. Role exclusivity and handover");
         writer.WriteLine();
         writer.WriteLine($"- **one holder per role** — {provisioning.ExclusivityHandover.OneHolderRule}");
@@ -2707,6 +2838,13 @@ internal static class GuideOrchestratorThreadCommand
             writer.WriteLine($"  - purpose — {layer.Purpose}");
             writer.WriteLine($"  - cadence — {layer.Cadence}");
             writer.WriteLine($"  - note — {layer.Note}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("#### What the pane scan is looking for");
+        writer.WriteLine();
+        foreach (var stuck in supervision.PaneScanStuckStates)
+        {
+            writer.WriteLine($"- **{stuck.State}** — the scan sees: {stuck.WhatTheScanSees} Recovery: {stuck.Recovery}");
         }
         writer.WriteLine();
         writer.WriteLine($"> **Re-arm across restarts:** {supervision.RearmRule}");
@@ -4140,6 +4278,10 @@ internal sealed record OrchestratorDesignWorkspaceSupervision
     [JsonPropertyName("supervision_layers")]
     public required IReadOnlyList<OrchestratorSupervisionLayer> SupervisionLayers { get; init; }
 
+    /// <summary>G556: what the blocking-UI pane scan is looking FOR — including a pane showing a shell prompt where an agent should be.</summary>
+    [JsonPropertyName("pane_scan_stuck_states")]
+    public required IReadOnlyList<OrchestratorPaneStuckState> PaneScanStuckStates { get; init; }
+
     /// <summary>G550: session-scoped supervision schedulers die with the design session — they must survive or be re-armed.</summary>
     [JsonPropertyName("rearm_rule")]
     public required string RearmRule { get; init; }
@@ -4330,6 +4472,18 @@ internal sealed record OrchestratorSupervisionSessionLifecycle
     public required string OperatorVisibleConfirmation { get; init; }
 }
 
+internal sealed record OrchestratorPaneStuckState
+{
+    [JsonPropertyName("state")]
+    public required string State { get; init; }
+
+    [JsonPropertyName("what_the_scan_sees")]
+    public required string WhatTheScanSees { get; init; }
+
+    [JsonPropertyName("recovery")]
+    public required string Recovery { get; init; }
+}
+
 internal sealed record OrchestratorSupervisionLayer
 {
     [JsonPropertyName("layer")]
@@ -4471,6 +4625,76 @@ internal sealed record OrchestratorProvisioningRoleInitialization
 
     [JsonPropertyName("ping_test_reference")]
     public required string PingTestReference { get; init; }
+
+    /// <summary>
+    /// G556: a self-reported startup is NOT liveness. Provisioning concludes
+    /// only after re-verification, at a settle delay past the report.
+    /// </summary>
+    [JsonPropertyName("verified_liveness")]
+    public required OrchestratorVerifiedLiveness VerifiedLiveness { get; init; }
+}
+
+/// <summary>
+/// G556: field incident (SekibanWasmRuntime team, 2026-07-29) — two codex
+/// agents sent startup-complete reports and died seconds later when their
+/// shared remote app-server was lost, dropping both TUIs to shell prompts. The
+/// supervising thread kept "waiting for startup reports" while every agent was
+/// already dead. The operator named the recurring pattern: threads claim to be
+/// waiting for startup while nothing is actually running.
+/// </summary>
+internal sealed record OrchestratorVerifiedLiveness
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    /// <summary>G556: the sentence that makes a report insufficient on its own.</summary>
+    [JsonPropertyName("report_is_not_readiness")]
+    public required string ReportIsNotReadiness { get; init; }
+
+    [JsonPropertyName("settle_delay")]
+    public required string SettleDelay { get; init; }
+
+    [JsonPropertyName("post_report_checks")]
+    public required IReadOnlyList<OrchestratorLivenessCheck> PostReportChecks { get; init; }
+
+    [JsonPropertyName("early_death_is_normal")]
+    public required OrchestratorEarlyDeathMode EarlyDeathIsNormal { get; init; }
+
+    [JsonPropertyName("shared_app_server_death_mode")]
+    public required OrchestratorSharedAppServerDeath SharedAppServerDeathMode { get; init; }
+}
+
+internal sealed record OrchestratorLivenessCheck
+{
+    [JsonPropertyName("check")]
+    public required string Check { get; init; }
+
+    [JsonPropertyName("how_to_verify")]
+    public required string HowToVerify { get; init; }
+}
+
+internal sealed record OrchestratorEarlyDeathMode
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("transport_reset_signature")]
+    public required string TransportResetSignature { get; init; }
+
+    [JsonPropertyName("recheck_obligation")]
+    public required string RecheckObligation { get; init; }
+}
+
+internal sealed record OrchestratorSharedAppServerDeath
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("blast_radius")]
+    public required string BlastRadius { get; init; }
+
+    [JsonPropertyName("prevention_reference")]
+    public required string PreventionReference { get; init; }
 }
 
 internal sealed record OrchestratorProvisioningLiveEvidence

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -454,6 +454,94 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("**復旧の既定は cleanup ではなく recreate です。**", ja, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void BothDocs_RequireVerifiedLiveness_AfterASettleDelay_G556()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        Assert.Contains("**Verified liveness — a startup report is not readiness.**", en, StringComparison.Ordinal);
+        Assert.Contains("**verified liveness — startup report は readiness ではない。**", ja, StringComparison.Ordinal);
+
+        // The load-bearing sentence, on both mirrors.
+        Assert.Contains("**A startup report is not readiness.**", en, StringComparison.Ordinal);
+        Assert.Contains("Never conclude provisioning on the report alone", en, StringComparison.Ordinal);
+        Assert.Contains("**startup report は readiness ではありません。**", ja, StringComparison.Ordinal);
+        Assert.Contains("report だけで provisioning を 完了と結論してはいけません", ja, StringComparison.Ordinal);
+
+        // The settle delay and all three post-report checks.
+        Assert.Contains("**settle delay**", en, StringComparison.Ordinal);
+        Assert.Contains("**The pane still hosts the agent TUI**", en, StringComparison.Ordinal);
+        Assert.Contains("**An agmsg ping-pong round trip succeeds**", en, StringComparison.Ordinal);
+        Assert.Contains("**For codex, the bridge is armed and the app-server attachment is stable**", en, StringComparison.Ordinal);
+
+        Assert.Contains("**settle delay**", ja, StringComparison.Ordinal);
+        Assert.Contains("**pane が依然として agent の TUI をホストしている**", ja, StringComparison.Ordinal);
+        Assert.Contains("**agmsg の ping-pong 往復が成功する**", ja, StringComparison.Ordinal);
+        Assert.Contains("**codex では bridge が armed で app-server attachment が安定している**", ja, StringComparison.Ordinal);
+
+        // The field incident that motivates it.
+        Assert.Contains("**seconds** later", en, StringComparison.Ordinal);
+        Assert.Contains("**数秒後**", ja, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BothDocs_DocumentEarlyDeath_AndTheSharedAppServerDeathMode_G556()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        // Early death is a NORMAL mode with a named signature.
+        Assert.Contains("**Early death is a normal mode.**", en, StringComparison.Ordinal);
+        Assert.Contains("**exiting to a shell prompt**", en, StringComparison.Ordinal);
+        Assert.Contains("**transport reset**", en, StringComparison.Ordinal);
+        Assert.Contains("do not wait for another report", en, StringComparison.Ordinal);
+
+        Assert.Contains("**early death は normal mode です。**", ja, StringComparison.Ordinal);
+        Assert.Contains("**shell プロンプトへ抜ける**", ja, StringComparison.Ordinal);
+        Assert.Contains("**transport reset**", ja, StringComparison.Ordinal);
+        Assert.Contains("次の report を 待ってはいけません", ja, StringComparison.Ordinal);
+
+        // The shared app-server blast radius, with the attribution pointer.
+        Assert.Contains("**Shared app-server death mode.**", en, StringComparison.Ordinal);
+        Assert.Contains("**takes down every attached TUI at once**", en, StringComparison.Ordinal);
+        Assert.Contains("never act on a process you cannot attribute", en, StringComparison.Ordinal);
+
+        Assert.Contains("**共有 app-server の death mode。**", ja, StringComparison.Ordinal);
+        Assert.Contains("**attach している すべての TUI が一斉に落ちます**", ja, StringComparison.Ordinal);
+        Assert.Contains("attribute できないプロセスには 手を出さないこと", ja, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BothDocs_PaneScanLists_AgentAbsent_WithShimRelaunchAndLaunchFlagMode_G556()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        // agent-absent is a named scan target alongside blocking dialogs, in
+        // the cadence table and in its own list.
+        Assert.Contains("(`agent-absent`)", en, StringComparison.Ordinal);
+        Assert.Contains("**What the pane scan is looking for.**", en, StringComparison.Ordinal);
+        Assert.Contains("**`agent-absent`** — a shell prompt where an agent should be", en, StringComparison.Ordinal);
+
+        Assert.Contains("(`agent-absent`)", ja, StringComparison.Ordinal);
+        Assert.Contains("**pane スキャンが探しているもの。**", ja, StringComparison.Ordinal);
+        Assert.Contains("**`agent-absent`** — agent がいるべき場所に shell プロンプトが出ている状態", ja, StringComparison.Ordinal);
+
+        // Recovery: shim relaunch, app-server recreation, full re-verification.
+        Assert.Contains("**shim-based relaunch**", en, StringComparison.Ordinal);
+        Assert.Contains("**full verified-liveness sequence**", en, StringComparison.Ordinal);
+        Assert.Contains("**shim 経由の relaunch**", ja, StringComparison.Ordinal);
+        Assert.Contains("**verified-liveness の全手順**", ja, StringComparison.Ordinal);
+
+        // The permission mode goes on the launch flag, because modifier chords
+        // are not delivered faithfully by synthetic key injection.
+        Assert.Contains("`--permission-mode`", en, StringComparison.Ordinal);
+        Assert.Contains("shift+tab are not delivered faithfully", en, StringComparison.Ordinal);
+        Assert.Contains("`--permission-mode`", ja, StringComparison.Ordinal);
+        Assert.Contains("shift+tab のような modifier chord は忠実に届きません", ja, StringComparison.Ordinal);
+    }
+
     private static string ReadDoc(string language)
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2081,6 +2081,16 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("continuous / real-time", output, StringComparison.Ordinal);
         Assert.Contains("**blocking-UI pane scan**", output, StringComparison.Ordinal);
         Assert.Contains("sub-minute class", output, StringComparison.Ordinal);
+        // G556 repair: the LAYER's own purpose/note must cover both stuck
+        // states, not just dialogs — the rendered layer is what a reader of the
+        // cadence table sees, so it cannot lag behind pane_scan_stuck_states.
+        Assert.Contains("TWO EQUAL stuck states", output, StringComparison.Ordinal);
+        Assert.Contains("shell prompt where an agent should be (`agent-absent`, G556)", output, StringComparison.Ordinal);
+        Assert.Contains("routes by STATE, not by one rule for everything", output, StringComparison.Ordinal);
+        // agent-absent is explicitly routed AWAY from dialog handling.
+        Assert.Contains("is NOT a dialog and must never be routed through dialog handling", output, StringComparison.Ordinal);
+        Assert.Contains("shim-safe relaunch recovery", output, StringComparison.Ordinal);
+        Assert.Contains("COMPLETE verified-liveness re-check", output, StringComparison.Ordinal);
         Assert.Contains("**periodic state watchdog**", output, StringComparison.Ordinal);
         Assert.Contains("tens-of-minutes class", output, StringComparison.Ordinal);
         // The watchdog layer resolves to the existing heartbeat command.
@@ -2160,13 +2170,28 @@ public sealed class GuideOrchestratorThreadCommandTests
 
         // Exactly three layers, each carrying a purpose and a cadence.
         var layers = supervision.GetProperty("supervision_layers").EnumerateArray()
-            .Select(l => (Layer: l.GetProperty("layer").GetString()!, Cadence: l.GetProperty("cadence").GetString()!, Purpose: l.GetProperty("purpose").GetString()!))
+            .Select(l => (
+                Layer: l.GetProperty("layer").GetString()!,
+                Cadence: l.GetProperty("cadence").GetString()!,
+                Purpose: l.GetProperty("purpose").GetString()!,
+                Note: l.GetProperty("note").GetString()!))
             .ToArray();
         Assert.Equal(3, layers.Length);
         Assert.All(layers, l => Assert.NotEmpty(l.Purpose));
         Assert.All(layers, l => Assert.NotEmpty(l.Cadence));
         Assert.Contains(layers, l => l.Layer == "real-time message monitor");
-        Assert.Contains(layers, l => l.Layer == "blocking-UI pane scan" && l.Cadence.Contains("sub-minute", StringComparison.Ordinal));
+        var blockingUi = Assert.Single(layers, l => l.Layer == "blocking-UI pane scan");
+        Assert.Contains("sub-minute", blockingUi.Cadence, StringComparison.Ordinal);
+        // G556 repair: the structured layer covers BOTH stuck states and routes
+        // them differently — dialogs to the dialog rules, agent-absent to the
+        // shim-safe relaunch plus the complete verified-liveness re-check.
+        Assert.Contains("TWO EQUAL stuck states", blockingUi.Purpose, StringComparison.Ordinal);
+        Assert.Contains("agent-absent", blockingUi.Purpose, StringComparison.Ordinal);
+        Assert.Contains("approval, selection, or trust prompt", blockingUi.Purpose, StringComparison.Ordinal);
+        Assert.Contains("routes by STATE", blockingUi.Note, StringComparison.Ordinal);
+        Assert.Contains("NOT a dialog and must never be routed through dialog handling", blockingUi.Note, StringComparison.Ordinal);
+        Assert.Contains("shim-safe relaunch recovery", blockingUi.Note, StringComparison.Ordinal);
+        Assert.Contains("COMPLETE verified-liveness re-check", blockingUi.Note, StringComparison.Ordinal);
         Assert.Contains(layers, l => l.Layer == "periodic state watchdog" && l.Cadence.Contains("tens-of-minutes", StringComparison.Ordinal));
 
         Assert.Contains("5.5 HOURS", supervision.GetProperty("rearm_rule").GetString(), StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2471,6 +2471,122 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("RECREATE, NOT CLEANUP", recovery.GetProperty("default_is_recreate_not_cleanup").GetString(), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_Markdown_VerifiedLiveness_RequiresThreePostReportChecks_G556()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("#### Verified liveness — a startup report is not readiness (G556)", output, StringComparison.Ordinal);
+        // AC: the report-alone-is-not-readiness sentence.
+        Assert.Contains("> **A startup report is NOT readiness:**", output, StringComparison.Ordinal);
+        Assert.Contains("Never conclude provisioning on the report alone", output, StringComparison.Ordinal);
+        // AC: settle delay, and why an instant re-check proves nothing.
+        Assert.Contains("**settle delay**", output, StringComparison.Ordinal);
+        Assert.Contains("re-observes the same moment the report described", output, StringComparison.Ordinal);
+        // AC: the three post-report checks.
+        Assert.Contains("After the settle delay, ALL THREE must still pass:", output, StringComparison.Ordinal);
+        Assert.Contains("**the pane still hosts the agent TUI**", output, StringComparison.Ordinal);
+        Assert.Contains("**an agmsg ping-pong round trip succeeds**", output, StringComparison.Ordinal);
+        Assert.Contains("**codex: the bridge is armed and the app-server attachment is stable**", output, StringComparison.Ordinal);
+        // The pane is ground truth; a message is a claim about the past.
+        Assert.Contains("The pane is ground truth", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_EarlyDeath_IsANormalMode_WithTheTransportResetSignature_G556()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("**early death is normal**", output, StringComparison.Ordinal);
+        Assert.Contains("normal mode, not an anomaly", output, StringComparison.Ordinal);
+        // AC: the transport-reset signature is NAMED.
+        Assert.Contains("**transport-reset signature**", output, StringComparison.Ordinal);
+        Assert.Contains("EXITS TO A SHELL PROMPT", output, StringComparison.Ordinal);
+        Assert.Contains("resume hint", output, StringComparison.Ordinal);
+        Assert.Contains("TRANSPORT RESET", output, StringComparison.Ordinal);
+        // AC: the re-check obligation — waiting for another report is waiting forever.
+        Assert.Contains("**re-check obligation**", output, StringComparison.Ordinal);
+        Assert.Contains("A dead agent sends nothing", output, StringComparison.Ordinal);
+        // AC: the shared app-server death mode with its G555 prevention pointer.
+        Assert.Contains("> **Shared app-server death mode:**", output, StringComparison.Ordinal);
+        Assert.Contains("KILLING AN APP-SERVER TAKES DOWN EVERY ATTACHED TUI", output, StringComparison.Ordinal);
+        Assert.Contains("`Cross-project isolation on a shared machine`", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Markdown_PaneScan_ListsAgentAbsent_WithShimRelaunchRecovery_G556()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("#### What the pane scan is looking for", output, StringComparison.Ordinal);
+        Assert.Contains("- **blocking dialog**", output, StringComparison.Ordinal);
+        // AC: agent-absent ranks with blocking dialogs.
+        Assert.Contains("- **agent-absent**", output, StringComparison.Ordinal);
+        Assert.Contains("a SHELL PROMPT where an agent should be", output, StringComparison.Ordinal);
+        // AC: shim-based relaunch, app-server recreation, full re-verification.
+        Assert.Contains("RELAUNCH THROUGH THE SHIM", output, StringComparison.Ordinal);
+        Assert.Contains("never spawn the executable", output, StringComparison.Ordinal);
+        Assert.Contains("recreating the app-server first", output, StringComparison.Ordinal);
+        Assert.Contains("run the FULL verified-liveness sequence again", output, StringComparison.Ordinal);
+        // The permission mode goes on the launch flag — synthetic key injection
+        // cannot be relied on for modifier chords.
+        Assert.Contains("`--permission-mode`", output, StringComparison.Ordinal);
+        Assert.Contains("modifier chords such as shift+tab are not delivered faithfully", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_Json_VerifiedLivenessAndPaneStuckStates_HaveStructuredShape_G556()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            CreateContext(),
+            ["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+
+        var liveness = doc.RootElement
+            .GetProperty("terminal_workspace_provisioning")
+            .GetProperty("role_initialization")
+            .GetProperty("verified_liveness");
+
+        Assert.Contains("report alone", liveness.GetProperty("report_is_not_readiness").GetString(), StringComparison.Ordinal);
+        Assert.NotEmpty(liveness.GetProperty("settle_delay").GetString());
+
+        // EXACTLY three post-report checks, each with a verification method —
+        // the set is the contract, so a missing one would weaken readiness.
+        var checks = liveness.GetProperty("post_report_checks").EnumerateArray()
+            .Select(c => (Check: c.GetProperty("check").GetString()!, How: c.GetProperty("how_to_verify").GetString()!))
+            .ToArray();
+        Assert.Equal(3, checks.Length);
+        Assert.All(checks, c => Assert.NotEmpty(c.How));
+        Assert.Contains(checks, c => c.Check.Contains("agent TUI", StringComparison.Ordinal));
+        Assert.Contains(checks, c => c.Check.Contains("ping-pong", StringComparison.Ordinal));
+        Assert.Contains(checks, c => c.Check.Contains("app-server attachment is stable", StringComparison.Ordinal));
+
+        var earlyDeath = liveness.GetProperty("early_death_is_normal");
+        Assert.Contains("SHELL PROMPT", earlyDeath.GetProperty("transport_reset_signature").GetString(), StringComparison.Ordinal);
+        Assert.Contains("do not wait for another report", earlyDeath.GetProperty("recheck_obligation").GetString(), StringComparison.Ordinal);
+
+        var appServer = liveness.GetProperty("shared_app_server_death_mode");
+        Assert.Contains("EVERY ATTACHED TUI", appServer.GetProperty("blast_radius").GetString(), StringComparison.Ordinal);
+        Assert.Contains("Cross-project isolation", appServer.GetProperty("prevention_reference").GetString(), StringComparison.Ordinal);
+
+        var stuckStates = doc.RootElement
+            .GetProperty("design_workspace_supervision")
+            .GetProperty("pane_scan_stuck_states")
+            .EnumerateArray()
+            .Select(x => (State: x.GetProperty("state").GetString()!, Sees: x.GetProperty("what_the_scan_sees").GetString()!, Recovery: x.GetProperty("recovery").GetString()!))
+            .ToArray();
+        Assert.Equal(2, stuckStates.Length);
+        Assert.All(stuckStates, x => Assert.NotEmpty(x.Recovery));
+        Assert.Contains(stuckStates, x => x.State == "blocking dialog");
+        var agentAbsent = Assert.Single(stuckStates, x => x.State == "agent-absent");
+        Assert.Contains("SHELL PROMPT", agentAbsent.Sees, StringComparison.Ordinal);
+        Assert.Contains("--permission-mode", agentAbsent.Recovery, StringComparison.Ordinal);
+    }
+
     private static string RunMarkdown(string[] args)
     {
         using var writer = new StringWriter();


### PR DESCRIPTION
## Summary

Amends the orchestrator-thread guide so **self-reported startup is never treated as liveness**.

**Field incident** (SekibanWasmRuntime team, 2026-07-29): two codex agents sent startup-complete reports and died **seconds** later when their shared remote app-server was lost to a websocket transport reset, dropping both TUIs to shell prompts. The supervising design thread went on *"waiting for startup reports"* while every agent was already dead. The operator named the recurring pattern: **threads claim to be waiting for startup while nothing is actually running.**

G549's flow ended at actas + the readiness ping — nothing required re-verification **after** the report. G550's pane scan named blocking dialogs but not a pane showing a shell prompt where an agent should be.

## What changes

**1. Verified liveness (provisioning).** A role is provisioned when its startup report has arrived **and**, after a **settle delay**, all three still pass:

| check | how it is verified |
| --- | --- |
| the pane still hosts the agent TUI | **read the pane** — it is ground truth; a message is a claim about the past |
| an agmsg ping-pong round trip succeeds | ping **now**, require the pong **now** — the earlier ack proves only that it was alive *then* |
| codex: bridge armed + app-server attachment stable | the TUI attaches over a `--remote` websocket, so the attachment can die while pane and bridge both looked fine |

> **A startup report is not readiness.** Never conclude provisioning on the report alone.

The settle delay is load-bearing: the failure occurs **seconds after** the report, so an instant re-check merely re-observes the moment the report already described.

**2. Early death is a normal mode**, with its signature named — the TUI **exits to a shell prompt**, typically leaving a resume hint, after a **transport reset** drops the app-server connection. That pane looks like an ordinary terminal, which is exactly why a dialog-only scan misses it. On a failed check the thread **re-checks and recovers rather than waiting for another report**: a dead agent sends nothing, so waiting is waiting forever.

**3. `agent-absent`** joins the supervision pane-scan list alongside blocking dialogs. Recovery is a **shim-based relaunch** — typed into the pane's interactive shell, recreating the app-server when that is what died — followed by the **full verified-liveness sequence** again. The permission mode is set with the **launch flag** (`--permission-mode`) rather than switched afterwards: synthetic key injection cannot be relied on for mode switching, because **modifier chords such as shift+tab are not delivered faithfully** (observed across multiple teams).

**4. Shared app-server death mode** documented with its blast radius: killing an app-server **takes down every attached TUI at once**, including other teams' agents that had nothing to do with the kill. Prevention points at the cross-project attribution rules — this is the **second-order cost of an attribution violation**, where the victim is everything attached to the process rather than the process itself.

## Surfaces touched

- `src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs` — `verified_liveness` under provisioning role-initialization; `pane_scan_stuck_states` under supervision (markdown + JSON).
- `docs/{en,ja}/12-agent-message-orchestration.md` — mirrored amendments.
- Tests: 4 guide (3 markdown + 1 JSON shape) + 3 docs-parity.

The JSON test asserts **exactly three** post-report checks and **exactly two** pane stuck states, each with its verification/recovery — the sets are the contract, so a dropped entry would silently weaken readiness.

## Verification

- `dotnet test IntentSystem.sln` — **all green** (CLI suite 3930 passed / 0 failed / 1 pre-existing skip; every other project passed).
- Focused: `GuideOrchestratorThreadCommandTests` **105/105**, `AgentMessageOrchestrationDocsTests` **16/16**.
- Rendered the guide and checked the amendments against the node-08 ruling and the field-incident sequence.
- `git diff --check` clean.

## Out of scope (untouched)

No enforcement tooling or automated liveness probes as CLI commands; no herdr/agmsg/codex behavior changes; G555 content is referenced, not restated.

Closes #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPT7cFrCzT6ehACFez8dpE
