### PR TITLE
G558: Prepare v0.6.2 release — real EN/JA notes over the draft stubs (prepare-only)

### DIFF
--- a/docs/en/release-notes-v0.6.2.md
+++ b/docs/en/release-notes-v0.6.2.md
@@ -1,41 +1,224 @@
-# Release Notes — intent-cli v0.6.2 (DRAFT — UNRELEASED)
+# Release Notes — intent-cli v0.6.2
 
-> **⚠️ DRAFT / UNRELEASED.** This is a **stub**, not release notes. It exists
-> because `eng/version.json` names `0.6.2` as the release-to-be-cut, and the
-> G475 guard requires notes to exist for that version before it can be
-> published. **The v0.6.2 release-prep packet authors the real content**;
-> nothing here describes shipped behavior, and this file must not be treated as
-> a changelog.
+> **Release model:** a maintainer/operator (or external release automation)
+> **creates and publishes the GitHub Release** for `v0.6.2` — the version-bump
+> merge does **not** create a Release or tag on its own. Publishing the GitHub
+> Release fires `.github/workflows/release.yml` (`on: release: published`), which
+> then builds and publishes the NuGet package and platform binary artifacts.
+> This packet is **prepare-only**: it authors the notes and adds **no** publish
+> steps. See the [pre-merge release-readiness gate](#release-readiness-gate-g558)
+> and [publishing v0.6.2](#publishing-v062).
 
-## Status
+## What's in v0.6.2
 
-Created by the post-release version roll (G554 rule as amended by G557) at the
-moment `nextVersion` became `0.6.2`. Until the release-prep packet fills it in:
+v0.6.2 is a **patch release** covering exactly the three slices merged after
+`v0.6.1`: **G555**, **G556**, and **G557**. It is a patch rather than a minor
+because nothing here changes a CLI surface: G555 and G556 are guide amendments,
+and G557 is a test/release-flow hotfix. No new commands, no removed or renamed
+arguments. The package id remains `JTechJapan.IntentSystem.Cli`; there are no
+package id, license, or workflow-semantics changes.
 
-- **No slices are listed yet.** What ships in `v0.6.2` is decided by the
-  release-prep packet, not by this stub.
-- **No bump rationale yet** (patch vs minor is a release-prep decision).
-- **No readiness gate yet.** Do **not** publish a `v0.6.2` GitHub Release while
-  this file is still a draft — an unfilled stub means release-prep has not run.
+Two of the three close field incidents from the same day, and the third closes
+the failure that those incidents' own fix produced.
 
-## What the release-prep packet must replace this with
+### Cross-project isolation on a shared machine (G555)
 
-Follow the shape of the previous notes
-([v0.6.1](release-notes-v0.6.1.md), [v0.6.0](release-notes-v0.6.0.md)):
+The provisioning and supervision guidance described how to build and keep **one**
+team; nothing said that other teams are running on the same machine. Operator
+incident (2026-07-29): with several project teams live at once, one project's
+design thread damaged another project's resources and the operator had to
+intervene by hand. A near-miss of the same class was avoided earlier that week
+only by ad-hoc discipline — verifying each pid's cwd before killing anything —
+discipline that lived in one session transcript rather than in the guide.
 
-- what shipped, grouped by theme, covering exactly the merged slices;
-- the bump rationale (patch vs minor) stated, not just labelled;
-- the prepare-only publishing section and the release-readiness gate;
-- an upgrade section separating additive surfaces from corrective behavior
-  changes;
-- the post-release roll reminder.
+`guide orchestrator-thread` gains a cross-project isolation section. It narrows
+the **objects** a supervising thread may act on to its own team's; it does not
+change what it may **do**, so the supervision authority boundary is unchanged.
 
-## Install (placeholder — the version below is what the guard checks)
+- **Attribution before mutation** — before injecting keys into a pane, killing a
+  process, closing or restructuring a workspace, or removing/rewriting a state
+  file, ownership is established from four keys: **workspace label**, **pane
+  cwd**, **process cwd** (read per pid — a pid list filtered by process *name*
+  attributes nothing), and **agmsg `(team, role)` file naming**. Attribution is a
+  positive result, not the absence of counter-evidence, and **unverifiable
+  attribution is read-only**: look, report, escalate — never mutate on a guess.
+- **One workspace per team** (labelled with the team name, never reused or
+  borrowed) and **team-exclusive role folders**, with the folder-scoping reason
+  stated: agmsg identity and the codex bridge are folder-scoped, so an agent
+  started in another team's folder takes over *their* identity and delivery.
+- **A shared-substrate ownership table** naming the sharing unit and ownership
+  rule for the workspace-manager server (per workspace, never the server), the
+  agmsg run directory (per `(team, role)` file, never a wholesale clear), codex
+  app-servers (per folder, cwd-verified), and the host repo (per domain path).
+- **Non-destructive recovery** — preserve and set aside another project's damaged
+  artifacts (a broken artifact is still its owner's evidence), rebuild your own
+  fresh. **Recovery defaults to recreate, not cleanup.**
+
+### Verified liveness — a startup report is not readiness (G556)
+
+Field incident (2026-07-29): two codex agents sent startup-complete reports and
+died **seconds** later when their shared remote app-server was lost to a
+websocket transport reset, dropping both TUIs to shell prompts. The supervising
+design thread went on *"waiting for startup reports"* while every agent was
+already dead. The provisioning flow ended at the readiness ping — nothing
+required re-verification **after** the report — and the supervision pane scan
+named blocking dialogs but not a pane showing a shell prompt where an agent
+should be.
+
+- **Verified liveness.** A role is provisioned when its startup report has
+  arrived **and**, after a **settle delay**, all three still pass: the pane still
+  hosts the agent TUI (read the pane — it is ground truth; a message is a claim
+  about the past), an agmsg ping-pong round trip succeeds **now**, and for codex
+  the bridge is armed with a stable app-server attachment. The settle delay is
+  load-bearing: the failure happens seconds *after* the report, so an instant
+  re-check merely re-observes the moment the report already described.
+- **Early death is a normal mode**, with its signature named — the TUI exits to a
+  shell prompt, typically leaving a resume hint, after a **transport reset**
+  drops the app-server connection. That pane looks like an ordinary terminal,
+  which is why a dialog-only scan misses it. On a failed check the thread
+  **re-checks and recovers rather than waiting for another report**: a dead agent
+  sends nothing, so waiting is waiting forever.
+- **`agent-absent`** joins the supervision pane-scan list as an equal stuck state
+  beside blocking dialogs, and routes by state rather than through dialog
+  handling — there is no dialog to answer. Recovery is a **shim-based relaunch**
+  (typed into the pane's interactive shell, recreating the app-server when that
+  is what died) followed by the **complete verified-liveness sequence** again.
+  The permission mode is set with the **launch flag** rather than switched
+  afterwards: synthetic key injection cannot be relied on for mode switching,
+  because modifier chords such as shift+tab are not delivered faithfully
+  (observed across multiple teams).
+- **Shared app-server death mode** — killing an app-server takes down **every
+  attached TUI at once**, including other teams' agents that had nothing to do
+  with the kill. Prevention points at G555's attribution rules: this is the
+  second-order cost of an attribution violation, where the victim is everything
+  attached to the process rather than the process itself.
+
+### Release-flow hardening (G557)
+
+The first live execution of the v0.6.1 post-release version roll turned child
+main red on four checks: three tests pinned the `stableVersion` / `nextVersion`
+pair **by value**, and the G475 guard requires release notes to exist for
+whatever `nextVersion` names. An unrelated PR inherited the red main and was
+frozen until this landed.
+
+- **Version-agnostic assertions.** A literal version pair is the wrong assertion
+  for a field a *required recurring step* is supposed to change — pinning it
+  guarantees that a correct roll breaks the test. The three assertions now derive
+  from `eng/version.json` through one shared source and assert the property that
+  holds across every roll: the policy parses, and the release-to-be-cut is
+  strictly ahead of the published stable. A **roll-simulation fixture** (next
+  patch, minor rollover, major rollover) proves they stay green, so the
+  regression is expressible rather than merely fixed.
+- **The draft-stub mechanism.** The roll now creates clearly-marked **DRAFT**
+  `release-notes-v<nextVersion>.md` stubs in the same commit. They satisfy the
+  G475 guard with **its semantics unchanged** — existence is still required; it
+  is simply now possible to satisfy at roll time — and they block a Release by
+  their own contract until release-prep fills them in. *(These notes are that
+  release-prep for v0.6.2.)*
+- **The roll rule completed.** The release closeout checklist now includes stub
+  creation with the version bump **and** a final step requiring the roller to
+  verify child main CI green after pushing: a red main blocks every unrelated PR
+  that inherits it, so the roll is complete only when CI is.
+
+## Install
 
 ```bash
 dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.2
 ```
 
-Once published, the self-contained binaries will be attached to the
+Or download the self-contained binary from the
 [v0.6.2 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.6.2).
 Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.6.1
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.6.2
+```
+
+This release is **additive on the guide surfaces and corrective in the release
+flow**. There are no new commands and no argument/flag changes.
+
+- **Additive — guidance only, no action needed.** G555 and G556 extend
+  `intent-cli guide orchestrator-thread` output (and the mirrored ja/en
+  orchestration docs) with new sections and fields. Nothing that consumed the
+  guide before behaves differently; there is simply more of it. If you supervise
+  a shared machine or provision teams, **read the two new sections** — they
+  encode incidents that cost other teams outages.
+- **Corrective — release-flow only.** G557 changes how the repository's own
+  release tooling is asserted and how the post-release roll is performed. It
+  affects maintainers cutting a release, not consumers of the CLI:
+  - the version-policy assertions no longer pin a literal version pair, so a
+    correct roll no longer breaks them;
+  - the post-release roll now creates DRAFT notes stubs and requires a green-CI
+    check before it counts as complete.
+
+No package id, license, or CLI argument/flag shape changes.
+
+## Release-readiness gate (G558)
+
+These items must hold **before the GitHub Release for `v0.6.2` is published**.
+This gate fails closed — if any item is unmet, do not publish the Release yet.
+
+- [ ] Every release-bound packet is **complete and its PR merged to `main`**:
+      G555 (PR #1214), G556 (PR #1218), and G557 (PR #1216), plus this G558
+      release-prep. Confirm on the host/review side via the host queue-state /
+      GitHub PR state — the child implementation loop must not read parent
+      queue-state, so this is a host-owned precondition.
+- [ ] **These notes are no longer a draft.** The G557 stub contract blocks a
+      Release while the file still carries its DRAFT banner; this file replacing
+      it is what lifts that block.
+- [ ] No open intent-system PR or WIP packet intended for this release is
+      accidentally skipped (check the host queue / open PR list before
+      publishing).
+- [ ] `eng/version.json` shows `stableVersion` `0.6.1` and `nextVersion` `0.6.2`
+      (the intended release version), **unchanged by this packet**.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      `RepositoryUrl` / `PackageProjectUrl` point to
+      `https://github.com/J-Tech-Japan/intent-system`,
+      `PackageLicenseExpression = Apache-2.0`, README/docs links resolve, and
+      the official service site `https://www.intent-driven-development.com/` is
+      linked from the README.
+- [ ] **Main CI is green** (`Build and test (source contract)`) on the release
+      commit, and the **preview-pack** workflow is green.
+- [ ] **Post-merge build + pack evidence** on the merge commit is recorded in
+      the PR (mirroring the G528/G538/G551/G554 readiness gate).
+
+## Publishing v0.6.2
+
+This packet does **not** publish the release and adds **no** publish steps. The
+merge of these notes does **not** create a GitHub Release or tag on its own.
+
+1. After this packet is merged and the readiness gate above holds, a
+   **maintainer/operator (or external release automation) creates and publishes
+   the GitHub Release** for `v0.6.2` (tagging the release commit). This is a
+   post-merge host/operator/external action.
+2. Publishing that GitHub Release fires `.github/workflows/release.yml`
+   (`on: release: published`), which builds and publishes the NuGet package and
+   the per-platform binary archives (with `.sha256` checksums) and attaches them
+   to the triggering Release.
+
+Post-release verification (after the GitHub Release is published and
+`release.yml` has run):
+
+- [ ] NuGet.org package page links all resolve correctly.
+- [ ] GitHub release asset links (`.tar.gz`, `.zip`, `.exe`, `.nupkg`) are
+      accessible.
+- [ ] `.sha256` checksums match the downloaded artifacts.
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli` (or
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.2`)
+      then `intent-cli --version` reports `0.6.2`.
+- [ ] Binary artifact smoke check: download the platform archive, verify its
+      `.sha256`, extract, and run `./intent-cli --version` → `0.6.2`.
+- [ ] **Guide smoke** (G555/G556): `intent-cli guide orchestrator-thread
+      --format markdown` renders both the `Cross-project isolation on a shared
+      machine` section and the `Verified liveness` subsection.
+- [ ] **ROLL `eng/version.json` NOW**, per the G554 rule as amended by G557:
+      `stableVersion → 0.6.2`, `nextVersion → 0.6.3`, **in the same commit as
+      new DRAFT `release-notes-v0.6.3.md` stubs (EN/JA)**, then **verify child
+      main CI is green** before calling the roll complete. See
+      [Version flow](09-developer-reference.md#version-flow).
+- [ ] Notify the operator and downstream consumers that publication **and**
+      verification of `v0.6.2` are complete. (The publish request itself belongs
+      to the pre-release phase above; by this point the Release is already
+      published.)

--- a/docs/ja/release-notes-v0.6.2.md
+++ b/docs/ja/release-notes-v0.6.2.md
@@ -1,40 +1,205 @@
-# リリースノート — intent-cli v0.6.2（DRAFT — 未リリース）
+# リリースノート — intent-cli v0.6.2
 
-> **⚠️ DRAFT / 未リリース。** これはリリースノートではなく **stub** です。
-> `eng/version.json` が `0.6.2` を「これからカットするリリース」として指しており、
-> G475 のガードが publish 前にそのバージョンのノートの存在を要求するため置かれています。
-> **実際の内容は v0.6.2 の release-prep パケットが author します**。ここには出荷済みの
-> 挙動は一切書かれておらず、このファイルを changelog として扱ってはいけません。
+> **リリースモデル:** メンテナ/オペレーター(または外部のリリース automation)が `v0.6.2` の
+> **GitHub Release を作成・publish** します — version-bump マージ自体は Release やタグを作成しません。
+> GitHub Release の publish が `.github/workflows/release.yml`(`on: release: published`)を発火させ、
+> NuGet package とプラットフォームバイナリ成果物を build・publish します。本パケットは
+> **prepare-only** で、ノートを author するだけで publish ステップを **追加しません**。
+> [マージ前 リリース準備ゲート](#リリース準備ゲートg558) と
+> [v0.6.2 の publish](#v062-の-publish) を参照。
 
-## ステータス
+## v0.6.2 の内容
 
-`nextVersion` が `0.6.2` になった時点で、リリース後の version roll（G554 のルール、
-G557 による改訂版）によって作成されました。release-prep パケットが埋めるまでは:
+v0.6.2 は **patch リリース** で、`v0.6.1` 以降にマージされた 3 スライス — **G555**、
+**G556**、**G557** — のみをカバーします。minor ではなく patch なのは、CLI サーフェスを
+変えるものが何もないためです: G555 と G556 は guide の追記であり、G557 は
+テスト/リリースフローの hotfix です。新コマンドはなく、引数の削除・改名もありません。
+package id は `JTechJapan.IntentSystem.Cli` のままで、package id・ライセンス・workflow
+セマンティクスの変更はありません。
 
-- **スライスは未記載です。** `v0.6.2` で何が出荷されるかを決めるのはこの stub ではなく
-  release-prep パケットです。
-- **バンプ根拠も未記載です**（patch か minor かは release-prep の判断です）。
-- **リリース準備ゲートも未記載です。** このファイルが draft のままの間は `v0.6.2` の
-  GitHub Release を publish **しないでください** — 埋まっていない stub は release-prep が
-  未実行であることを意味します。
+3 つのうち 2 つは同じ日のフィールドインシデントを閉じるもので、残る 1 つは、その修正自体が
+生んだ失敗を閉じるものです。
 
-## release-prep パケットがこれを置き換える際に必要なもの
+### 共有マシン上での cross-project isolation(G555)
 
-過去のノート（[v0.6.1](release-notes-v0.6.1.md)、[v0.6.0](release-notes-v0.6.0.md)）の
-形に従ってください:
+provisioning と supervision のガイダンスは **1 つの** チームの構築と維持を説明していましたが、
+同じマシン上で他チームも動いていることには触れていませんでした。オペレーターインシデント
+(2026-07-29): 複数のプロジェクトチームが同時に動いている状況で、あるプロジェクトの設計
+スレッドが別プロジェクトのリソースを破壊し、オペレーターが手で介入する必要がありました。
+同種のニアミスは同じ週の前半にも起きており、回避できたのは「kill の前に pid ごとの cwd を
+確認する」という場当たり的な規律のおかげでした — その規律は 1 つのセッション記録の中にしか
+存在していませんでした。
 
-- 出荷内容をテーマ別にグループ化し、マージされたスライスを正確にカバーする;
-- バンプ根拠（patch か minor か）をラベルだけでなく理由まで記述する;
-- prepare-only の publishing セクションとリリース準備ゲート;
-- 追加サーフェスと是正的な挙動変更を分離した upgrade セクション;
-- リリース後の roll のリマインド。
+`guide orchestrator-thread` に cross-project isolation セクションが追加されます。監督
+スレッドが行動できる **オブジェクト** を自チームのものに絞るだけで、**何をしてよいか** は
+変えないため、監督の権限境界は不変です。
 
-## インストール（プレースホルダー — 下記バージョンがガードの検査対象です）
+- **mutation の前に attribution** — pane へのキー入力、プロセスの kill、ワークスペースの
+  クローズ/再構成、state ファイルの削除・書き換えの前に、**workspace label**、**pane cwd**、
+  **process cwd**(pid ごとに読む — プロセス *名* だけで絞った pid 一覧は何も attribute
+  しない)、**agmsg の `(team, role)` ファイル命名** の 4 キーで所有を確定します。attribution は
+  積極的な確認であって「他人のものだという証拠が無い」ことではなく、**attribution できない
+  場合は read-only** です: 見て、報告し、エスカレーションする — 推測で mutate しない。
+- **team ごとに 1 ワークスペース**(チーム名でラベル付けし、再利用・借用しない)と
+  **チーム専用ロールフォルダー**。folder-scoping の理由も明記: agmsg identity と codex
+  bridge はフォルダースコープなので、他チームのフォルダーで起動した agent は *相手の*
+  identity と delivery を乗っ取ります。
+- **共有 substrate の所有テーブル** — ワークスペースマネージャーのサーバー(ワークスペース
+  単位。サーバーには触れない)、agmsg run ディレクトリ(`(team, role)` ファイル単位。
+  ディレクトリごと消さない)、codex app-server(フォルダー単位。cwd で確認)、host repo
+  (domain パス単位)について、共有の単位と所有ルールを明示します。
+- **非破壊的な復旧** — 他プロジェクトの破損した成果物は保全して脇に置き(壊れた成果物も
+  所有者にとっては証拠)、自分のものは作り直します。**復旧の既定は cleanup ではなく
+  recreate です。**
+
+### verified liveness — startup report は readiness ではない(G556)
+
+フィールドインシデント(2026-07-29): 2 体の codex agent が startup-complete を report した
+**数秒後** に、共有していたリモート app-server が websocket の transport reset で失われ、
+両方の TUI が shell プロンプトへ落ちました。それでも監督している設計スレッドは
+「startup report を待っている」と言い続け、その時点で全 agent は既に死んでいました。
+provisioning のフローは readiness ping で終わっており、report の **後** の再検証を要求して
+おらず、supervision の pane スキャンは blocking ダイアログは列挙していたものの、agent が
+いるべき場所に shell プロンプトが出ている pane は対象にしていませんでした。
+
+- **verified liveness。** ロールが provisioned となるのは、startup report が届き **かつ**
+  **settle delay** の後に次の 3 つがまだ通る場合です: pane が依然 agent の TUI をホストして
+  いる(pane を読む — pane が ground truth であり、メッセージは過去についての主張)、
+  agmsg の ping-pong 往復が **今** 成功する、そして codex では bridge が armed で app-server
+  attachment が安定している。settle delay は load-bearing です: この失敗は report の
+  **数秒後** に起きるため、即座に検証しても report が述べたのと同じ瞬間を再観測するだけです。
+- **early death は normal mode** であり、シグネチャも命名されました — **transport reset** が
+  app-server 接続を落とした結果、TUI が resume ヒントを残して shell プロンプトへ抜けます。
+  ただの端末に見える pane になるため、ダイアログだけを探すスキャンでは見逃します。チェックが
+  失敗したら **再チェックして復旧し、次の report を待ちません**: 死んだ agent は何も送らない
+  ので、待つことは永遠に待つことです。
+- **`agent-absent`** が supervision の pane スキャン一覧に blocking ダイアログと同等の
+  stuck state として加わり、dialog handling ではなく state に応じてルーティングされます —
+  答えるべきダイアログが存在しないからです。復旧は **shim 経由の relaunch**(pane の対話
+  シェルにタイプし、死んだのが app-server ならそれを再作成)に続いて **verified-liveness の
+  全手順** をやり直すことです。permission mode は起動後の切り替えではなく **launch フラグ**
+  で設定します: 合成キー注入は mode 切り替えに使えません — shift+tab のような modifier
+  chord は忠実に届かないためです(複数チームで観測)。
+- **共有 app-server の death mode** — app-server を kill すると **attach しているすべての
+  TUI が一斉に落ちます**。kill と無関係な他チームの agent も含めてです。予防策は G555 の
+  attribution ルールで、これは attribution 違反の二次被害です: 被害者は kill したプロセス
+  ではなく、それに attach していたすべてです。
+
+### リリースフローの堅牢化(G557)
+
+v0.6.1 のリリース後 version roll が初めて実運用されたとき、child main は 4 つのチェックで
+red になりました: 3 つのテストが `stableVersion` / `nextVersion` の組を **値で** 固定して
+おり、G475 のガードは `nextVersion` が指すバージョンのリリースノートの存在を要求するため
+です。無関係な PR が red な main を継承して凍結され、この修正が着地するまで解除されません
+でした。
+
+- **version-agnostic な assertion。** バージョンの組をリテラルで固定するのは、*必須の
+  繰り返しステップ* が変更することになっているフィールドに対する assertion としては誤りです —
+  固定すれば、正しい roll が必ずテストを壊します。3 つの assertion は共有ソースを介して
+  `eng/version.json` から導出するようになり、あらゆる roll をまたいで成立する property を
+  assert します: policy がパースでき、release-to-be-cut が published stable より厳密に前で
+  あること。**roll シミュレーション fixture**(次 patch / minor ロールオーバー / major
+  ロールオーバー)が green のままであることを証明するため、この回帰は「直した」だけでなく
+  「表現できる」状態になりました。
+- **DRAFT stub の仕組み。** roll は同じ commit で、明確に **DRAFT** と記した
+  `release-notes-v<nextVersion>.md` stub を作成するようになりました。G475 のガードは
+  **意味を変えずに** 満たされ(存在要求はそのままで、roll 時点で満たせるようになっただけ)、
+  stub 自身の契約により release-prep が埋めるまで Release をブロックします。
+  *(本ノートが v0.6.2 の release-prep です。)*
+- **roll ルールの完成。** リリース closeout チェックリストに、version bump と同じ commit で
+  stub を作ること **および** push 後に child main の CI が green であることを roller が検証
+  する最終ステップが加わりました: red な main はそれを継承するすべての無関係な PR を
+  ブロックするため、roll は CI が green になって初めて完了です。
+
+## インストール
 
 ```bash
 dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.2
 ```
 
-publish 後、self-contained バイナリは
+または
 [v0.6.2 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.6.2)
-に添付されます。使用前に `.sha256` サイドカーを検証してください。
+から self-contained バイナリをダウンロードしてください。使用前に `.sha256` サイドカーを検証します。
+
+## v0.6.1 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.6.2
+```
+
+本リリースは **guide サーフェスへの追加** と **リリースフローの是正** です。新コマンドはなく、
+引数/フラグの変更もありません。
+
+- **追加のみ — ガイダンスであり対応不要。** G555 と G556 は
+  `intent-cli guide orchestrator-thread` の出力(および ja/en のオーケストレーションドキュメント)に
+  新しいセクションとフィールドを追加します。従来 guide を利用していたものの挙動は変わらず、
+  単に内容が増えるだけです。共有マシンを監督している、またはチームを provisioning する場合は
+  **新しい 2 セクションを読んでください** — 他チームに障害を出したインシデントが記録されています。
+- **是正的 — リリースフローのみ。** G557 は本リポジトリ自身のリリースツーリングの assert 方法と
+  リリース後 roll の実施方法を変更します。影響を受けるのはリリースをカットするメンテナであり、
+  CLI の利用者ではありません:
+  - version policy の assertion がリテラルのバージョン組を固定しなくなったため、正しい roll が
+    それらを壊すことはなくなりました;
+  - リリース後の roll は DRAFT ノート stub を作成し、完了とみなす前に green CI の確認を
+    要求するようになりました。
+
+package id・ライセンス・CLI の引数/フラグ形の変更はありません。
+
+## リリース準備ゲート(G558)
+
+以下は `v0.6.2` の **GitHub Release を publish する前に** 成立していなければなりません。
+このゲートは fail-closed です — 1 つでも満たされないなら Release を publish しないでください。
+
+- [ ] リリース対象の全 packet が **完了し、その PR が `main` にマージ済み**:
+      G555(PR #1214)、G556(PR #1218)、G557(PR #1216)、および本 G558 release-prep。
+      host/review 側で host queue-state / GitHub PR 状態を用いて確認します — child
+      implementation loop は parent queue-state を読めないため、これは host 所有の前提条件です。
+- [ ] **本ノートが draft でなくなっていること。** G557 の stub 契約は、DRAFT バナーが残っている
+      間は Release をブロックします。本ファイルがそれを置き換えることがブロック解除です。
+- [ ] 本リリース向けの open PR / WIP packet が誤って漏れていないこと(publish 前に host queue /
+      open PR 一覧を確認)。
+- [ ] `eng/version.json` が `stableVersion` `0.6.1`、`nextVersion` `0.6.2`(リリース対象)を
+      示すこと。**本パケットでは変更していません。**
+- [ ] package メタデータが正しいこと: `PackageId = JTechJapan.IntentSystem.Cli`、
+      `RepositoryUrl` / `PackageProjectUrl` が
+      `https://github.com/J-Tech-Japan/intent-system` を指し、
+      `PackageLicenseExpression = Apache-2.0`、README/docs のリンクが解決し、公式サービスサイト
+      `https://www.intent-driven-development.com/` が README からリンクされていること。
+- [ ] **Main CI が green**(`Build and test (source contract)`)であること、および
+      **preview-pack** ワークフローが green であること。
+- [ ] **マージ後の build + pack 証跡** がマージコミットに対して PR に記録されていること
+      (G528/G538/G551/G554 の準備ゲートに準拠)。
+
+## v0.6.2 の publish
+
+本パケットはリリースを publish せず、publish ステップを **追加しません**。本ノートのマージ自体は
+GitHub Release もタグも作成しません。
+
+1. 本パケットがマージされ上記の準備ゲートが成立した後、**メンテナ/オペレーター(または外部の
+   リリース automation)が `v0.6.2` の GitHub Release を作成・publish** します(リリース
+   コミットにタグ付け)。これはマージ後の host/オペレーター/外部のアクションです。
+2. その GitHub Release の publish が `.github/workflows/release.yml`(`on: release: published`)を
+   発火させ、NuGet package とプラットフォーム別バイナリアーカイブ(`.sha256` チェックサム付き)を
+   build・publish し、トリガーとなった Release に添付します。
+
+publish 後の検証(GitHub Release が publish され `release.yml` が実行された後):
+
+- [ ] NuGet.org の package ページのリンクがすべて正しく解決すること。
+- [ ] GitHub release の成果物リンク(`.tar.gz`、`.zip`、`.exe`、`.nupkg`)にアクセスできること。
+- [ ] `.sha256` チェックサムがダウンロードした成果物と一致すること。
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli`(または
+      `dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.6.2`)の後、
+      `intent-cli --version` が `0.6.2` を報告すること。
+- [ ] バイナリ成果物のスモークチェック: プラットフォームアーカイブをダウンロードし `.sha256` を
+      検証、展開して `./intent-cli --version` → `0.6.2`。
+- [ ] **guide スモーク**(G555/G556): `intent-cli guide orchestrator-thread --format markdown` が
+      `Cross-project isolation on a shared machine` セクションと `Verified liveness` サブ
+      セクションの両方をレンダリングすること。
+- [ ] **`eng/version.json` を今すぐ ROLL する** — G554 のルール(G557 による改訂版)に従い、
+      `stableVersion → 0.6.2`、`nextVersion → 0.6.3` を、**新しい DRAFT
+      `release-notes-v0.6.3.md` stub(EN/JA)と同じ commit で** 適用し、その後
+      **child main の CI が green であることを検証** してから roll 完了とすること。
+      [バージョンフロー](09-developer-reference.md#バージョンフロー) を参照。
+- [ ] `v0.6.2` の publish **および** 検証が完了したことを、オペレーターと下流の利用者へ通知
+      すること。(publish の依頼自体は上記のリリース前フェーズに属します。この時点では
+      Release は既に publish 済みです。)

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
@@ -281,8 +281,17 @@ public sealed class ReleaseNotesV061DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void NextVersionNotes_ExistAsClearlyMarkedDrafts_G557(string language)
+    public void NextVersionNotes_AreEitherAClearlyMarkedDraftOrRealNotes_G558(string language)
     {
+        // G557 created DRAFT stubs at roll time; G558 (release-prep) replaces
+        // them with real notes. Both are legal states of the same file, so
+        // pinning either one by itself would break the moment the other
+        // arrives — the same trap the hardcoded version pair fell into.
+        //
+        // What must always hold is that the file is unambiguously ONE of them:
+        // a stub that says so loudly, or real notes carrying the readiness
+        // gate. A file with neither marker is the dangerous middle — it reads
+        // like a changelog while nobody authored it.
         var policy = RepoVersionPolicySource.Read();
         var path = Path.Combine(
             RepoVersionPolicySource.RepoRoot(), "docs", language, $"release-notes-v{policy.NextVersion}.md");
@@ -291,26 +300,161 @@ public sealed class ReleaseNotesV061DocsTests
 
         var notes = ReadCollapsed(path);
 
-        // The stub must be unmistakably a draft — G475 checks existence, and a
-        // stub that reads like a changelog would be worse than a missing file.
-        Assert.Contains(language == "en" ? "DRAFT" : "DRAFT", notes, StringComparison.Ordinal);
+        var draftBanner = language == "en" ? "**⚠️ DRAFT / UNRELEASED.**" : "**⚠️ DRAFT / 未リリース。**";
+        var isDraft = notes.Contains(draftBanner, StringComparison.Ordinal);
+
+        if (isDraft)
+        {
+            // Stub state: it must refuse to be mistaken for a changelog.
+            Assert.Contains(
+                language == "en" ? "release-prep packet authors the real content" : "release-prep パケットが author します",
+                notes,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                language == "en" ? "must not be treated as a changelog" : "changelog として扱ってはいけません",
+                notes,
+                StringComparison.Ordinal);
+        }
+        else
+        {
+            // Authored state: real notes carry the operator's readiness gate,
+            // which is what a release is cut from.
+            Assert.Contains(
+                language == "en" ? "Release-readiness gate" : "リリース準備ゲート",
+                notes,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                language == "en" ? "Publishing v" : " の publish",
+                notes,
+                StringComparison.Ordinal);
+        }
+
+        // Either way the G475 guard's own two requirements hold, so its
+        // semantics are unchanged across both states.
+        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", notes, StringComparison.Ordinal);
+        Assert.Contains($"releases/tag/v{policy.NextVersion}", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void V062Notes_CoverExactlyG555G556G557_WithThePatchRationale_G558(string language)
+    {
+        var notes = ReadCollapsed(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.6.2.md"));
+
+        // Exactly the three merged slices — no missing, no extra.
+        foreach (var slice in new[] { "G555", "G556", "G557" })
+        {
+            Assert.Contains(slice, notes, StringComparison.Ordinal);
+        }
+
+        foreach (var earlier in new[] { "(G552)", "(G553)", "(G554)" })
+        {
+            Assert.DoesNotContain(earlier, notes, StringComparison.Ordinal);
+        }
+
+        // The bump rationale is stated, not merely labelled.
+        Assert.Contains(language == "en" ? "**patch release**" : "**patch リリース**", notes, StringComparison.Ordinal);
         Assert.Contains(
-            language == "en" ? "**⚠️ DRAFT / UNRELEASED.**" : "**⚠️ DRAFT / 未リリース。**",
-            notes,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            language == "en" ? "release-prep packet authors the real content" : "release-prep パケットが author します",
-            notes,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            language == "en" ? "must not be treated as a changelog" : "changelog として扱ってはいけません",
+            language == "en" ? "nothing here changes a CLI surface" : "CLI サーフェスを 変えるものが何もない",
             notes,
             StringComparison.Ordinal);
 
-        // And it still satisfies the G475 guard's own two requirements, so the
-        // guard's semantics are unchanged rather than relaxed.
-        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", notes, StringComparison.Ordinal);
-        Assert.Contains($"releases/tag/v{policy.NextVersion}", notes, StringComparison.Ordinal);
+        // The draft banner is gone — this file is what lifts the stub's own
+        // release block.
+        Assert.DoesNotContain(
+            language == "en" ? "**⚠️ DRAFT / UNRELEASED.**" : "**⚠️ DRAFT / 未リリース。**",
+            notes,
+            StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void V062Notes_DescribeEachSliceAccurately_G558(string language)
+    {
+        var notes = ReadCollapsed(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.6.2.md"));
+
+        if (language == "en")
+        {
+            // G555: the four attribution keys, workspace/folder exclusivity,
+            // the substrate table, and the recovery default.
+            Assert.Contains("workspace label", notes, StringComparison.Ordinal);
+            Assert.Contains("agmsg `(team, role)` file naming", notes, StringComparison.Ordinal);
+            Assert.Contains("unverifiable attribution is read-only", notes, StringComparison.Ordinal);
+            Assert.Contains("Recovery defaults to recreate, not cleanup.", notes, StringComparison.Ordinal);
+
+            // G556: settle delay + three checks, early death, agent-absent,
+            // shared app-server death mode.
+            Assert.Contains("settle delay", notes, StringComparison.Ordinal);
+            Assert.Contains("Early death is a normal mode", notes, StringComparison.Ordinal);
+            Assert.Contains("`agent-absent`", notes, StringComparison.Ordinal);
+            Assert.Contains("takes down **every attached TUI at once**", notes, StringComparison.Ordinal);
+
+            // G557: derived assertions, the stub mechanism, the amended rule.
+            Assert.Contains("Version-agnostic assertions", notes, StringComparison.Ordinal);
+            Assert.Contains("roll-simulation fixture", notes, StringComparison.Ordinal);
+            Assert.Contains("draft-stub mechanism", notes, StringComparison.Ordinal);
+            Assert.Contains("verify child main CI green after pushing", notes, StringComparison.Ordinal);
+        }
+        else
+        {
+            Assert.Contains("workspace label", notes, StringComparison.Ordinal);
+            Assert.Contains("agmsg の `(team, role)` ファイル命名", notes, StringComparison.Ordinal);
+            Assert.Contains("read-only", notes, StringComparison.Ordinal);
+            Assert.Contains("復旧の既定は cleanup ではなく recreate です。", notes, StringComparison.Ordinal);
+
+            Assert.Contains("settle delay", notes, StringComparison.Ordinal);
+            Assert.Contains("early death は normal mode", notes, StringComparison.Ordinal);
+            Assert.Contains("`agent-absent`", notes, StringComparison.Ordinal);
+            Assert.Contains("attach しているすべての TUI が一斉に落ちます", notes, StringComparison.Ordinal);
+
+            Assert.Contains("version-agnostic な assertion", notes, StringComparison.Ordinal);
+            Assert.Contains("roll シミュレーション fixture", notes, StringComparison.Ordinal);
+            Assert.Contains("DRAFT stub の仕組み", notes, StringComparison.Ordinal);
+            Assert.Contains("child main の CI が green であることを roller が検証", notes, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void V062Notes_KeepThePrepareOnlyContract_AndTheUpgradeSplit_G558(string language)
+    {
+        var notes = ReadCollapsed(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.6.2.md"));
+
+        Assert.Contains("prepare-only", notes, StringComparison.Ordinal);
+        Assert.Contains("release.yml", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "## Release-readiness gate (G558)" : "## リリース準備ゲート(G558)",
+            notes,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "## Publishing v0.6.2" : "## v0.6.2 の publish",
+            notes,
+            StringComparison.Ordinal);
+
+        // The upgrade section separates additive guide surfaces from the
+        // corrective release-flow change, so a consumer can tell which applies.
+        Assert.Contains(
+            language == "en" ? "Additive — guidance only, no action needed" : "追加のみ — ガイダンスであり対応不要",
+            notes,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "Corrective — release-flow only" : "是正的 — リリースフローのみ",
+            notes,
+            StringComparison.Ordinal);
+
+        // The post-release roll reminder carries the G557 amendment, so the
+        // next roll does not repeat the incident this release documents.
+        Assert.Contains("0.6.3", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "in the same commit as" : "同じ commit で",
+            notes,
+            StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Replaces the G557 **DRAFT stubs** with real EN/JA `release-notes-v0.6.2.md` covering exactly the three slices merged after v0.6.1: **G555**, **G556**, **G557**.

The stubs blocked a Release by their own contract — *"an unfilled stub means release-prep has not run"* — and this packet **is** that release-prep, so replacing them is what lifts the block.

**Prepare-only:** no Release, no tag, no publish, no version roll. `eng/version.json` is untouched at `stableVersion 0.6.1 / nextVersion 0.6.2` (verified absent from the staged diff).

## Why patch

Nothing here changes a CLI surface. G555 and G556 are guide amendments; G557 is a test/release-flow hotfix. No new commands, no removed or renamed arguments. The notes state the reason, not just the label.

## Slice coverage — exactly three

| slice | what the notes describe |
| --- | --- |
| **G555** | the four attribution keys with the read-only default, workspace/folder exclusivity with its folder-scoping reason, the substrate ownership table, and recreate-not-cleanup |
| **G556** | settle delay + three post-report checks, early death as a normal mode with the transport-reset signature, `agent-absent` with shim relaunch and launch-flag permission mode, and the shared app-server blast radius |
| **G557** | derived assertions with the roll-simulation fixture, the draft-stub mechanism, and the completed roll rule |

The upgrade section splits accordingly: the guide surfaces are **additive** (no action needed), while the **corrective** change is release-flow only and affects maintainers cutting a release, not CLI consumers. The post-release checklist carries the G557-amended roll (stubs in the same commit, then a green-CI check) so the next roll does not repeat the incident this release documents.

## One test moved with the file it guards

`NextVersionNotes_ExistAsClearlyMarkedDrafts_G557` required the DRAFT banner — exactly the transient state this packet removes, which is the same trap the hardcoded version pair fell into. It now asserts the **invariant**: the next-version notes are unambiguously **either** a clearly-marked stub **or** real notes carrying the readiness gate — never the dangerous middle that reads like a changelog nobody authored. The G475 guard's two requirements are asserted in **both** states, so its semantics are unchanged.

## Verification

- `eng/version.json` **unchanged** — not in the staged diff.
- **G475 guard green** against the real notes.
- Focused: release/version/notes filter **53/53**; `ReleaseNotesV061DocsTests` **30/30** (6 new G558 assertions covering slice coverage, per-slice accuracy, and the prepare-only/upgrade structure).
- `dotnet test IntentSystem.sln` — **all green** (CLI suite 3936 passed / 0 failed / 1 pre-existing skip; every other project passed).
- `git diff --check` clean. Diff is **3 files**: the two notes plus the one test.
- README and docs carry **no** stale latest-version references, so none were changed.

## Out of scope (untouched)

No GitHub Release, tag, or package publish (operator action); no post-release roll to 0.6.3; no CLI code or guide content change; no announcement drafts.

Closes #1219

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPT7cFrCzT6ehACFez8dpE
