### PR TITLE
G560: Hotfix red main after the 0.6.3 roll — version-agnostic current-state doc guards, roll-rule readiness step, release-prep pin rule

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2097,9 +2097,12 @@ release automation) creates and publishes the GitHub Release for `v0.6.3`;
 publishing it triggers `release.yml` (`on: release: published`) to build and
 publish the NuGet package and the per-platform binary artifacts. **Then roll
 `eng/version.json` immediately** — `stableVersion → 0.6.3`, `nextVersion →
-0.6.4` — with the DRAFT note stubs in the same commit and a post-roll CI-green
-check, per steps 4–5 of the
-[post-release version roll](#post-release-version-roll-g554--required-immediate).
+0.6.4` — carrying, per **steps 4–6** of the
+[post-release version roll](#post-release-version-roll-g554--required-immediate):
+the **DRAFT note stubs in the same commit** (step 4), the **"Next release
+readiness" section refreshed to the new line in both language mirrors** (step
+5), and a **post-roll green child-main CI check** before the roll counts as
+complete (step 6).
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1956,18 +1956,24 @@ literal:
 
 ```json
 {
-  "stableVersion": "0.6.0",
-  "nextVersion": "0.6.1"
+  "stableVersion": "<stableVersion>",
+  "nextVersion": "<nextVersion>"
 }
 ```
 
+The shape is written with placeholders on purpose: **read the actual values from
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness)
+for the line currently being cut. A worked example here would be a second copy
+of the version pair that goes stale on the next roll — the defect G557/G560
+exist to remove.
+
 | Stage | Version form | How it is derived |
 | --- | --- | --- |
-| Local pack / install | `0.6.1-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
-| Main CI preview | `0.6.1-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
-| Release candidate (optional) | `0.6.1-rc.N` | Publishing the GitHub Release for tag `v0.6.1-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
-| Stable release | `0.6.1` | Publishing the GitHub Release for tag `v0.6.1` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
-| Post-release main builds | `0.6.2-preview.<run>.<attempt>` | After rolling `nextVersion` to `0.6.2` |
+| Local pack / install | `<nextVersion>-<sha>-<G-unit>` | `nextVersion` from `eng/version.json` (G468) |
+| Main CI preview | `<nextVersion>-preview.<run>.<attempt>` | `nextVersion` from `eng/version.json` |
+| Release candidate (optional) | `<nextVersion>-rc.N` | Publishing the GitHub Release for tag `v<nextVersion>-rc.N` triggers `release.yml` (`on: release: published`); the tag supplies the version |
+| Stable release | `<nextVersion>` | Publishing the GitHub Release for tag `v<nextVersion>` triggers `release.yml` (`on: release: published`); the tag supplies the version (`-p:Version=<tag>` wins) |
+| Post-release main builds | `<nextPatch>-preview.<run>.<attempt>` | After rolling `nextVersion` to `<nextPatch>` |
 
 ### Post-release version roll (G554) — required, immediate
 
@@ -1978,8 +1984,8 @@ release closeout, and skipping it breaks the preview channel.
 
 ```json
 {
-  "stableVersion": "0.6.1",
-  "nextVersion": "0.6.2"
+  "stableVersion": "<the version just released>",
+  "nextVersion": "<the next patch>"
 }
 ```
 
@@ -1994,7 +2000,7 @@ next preview `0.6.2-preview.N`, which sorts above `0.6.1`, and `dotnet tool
 update` works again.
 
 **Release closeout checklist** (the roll is step 4 — do not stop at step 3, and
-the roll is not done until step 5):
+the roll is not done until step 6):
 
 1. Publish the GitHub Release for the version (this fires `release.yml`).
 2. Verify the published artifacts: NuGet page, release assets, `.sha256`
@@ -2007,14 +2013,18 @@ the roll is not done until step 5):
    a roll that moves the field without the stubs turns main red the moment it
    lands. The stubs carry no changelog content — the next release-prep packet
    authors that.
-5. **Verify child main CI is green after pushing the roll.** The roll is
+5. **Refresh the "Next release readiness" section to the new line** in the same
+   roll — it names the release being cut, so a roll that moves `nextVersion`
+   without it leaves the section describing the previous cycle. Update both
+   language mirrors.
+6. **Verify child main CI is green after pushing the roll.** The roll is
    complete only when CI is: a red main blocks every unrelated PR that inherits
    it, so the roller owns the result, not just the commit.
 
 Existing preview artifacts are **not** renumbered retroactively; the rule fixes
 the channel going forward.
 
-> **Why steps 4-5 read this way (G557).** The roll's first live execution
+> **Why steps 4-6 read this way (G557, G560).** The roll's first live execution
 > (commit `00936844`, `nextVersion` 0.6.1 → 0.6.2) moved the field alone and
 > turned main red on four checks: three tests pinned the version pair by value,
 > and the G475 guard demanded `release-notes-v0.6.2.md`. An unrelated PR
@@ -2022,6 +2032,28 @@ the channel going forward.
 > are now derived from `eng/version.json` so a correct roll cannot break them,
 > and the two steps above close the rest: create the stubs with the roll, and
 > confirm green before calling it done.
+>
+> **Second incident (G560), roll 0.6.2 → 0.6.3.** The amended rule worked — the
+> post-roll CI check caught that the readiness section still described the
+> previous line, which had been passing only incidentally because the new
+> version happened to appear in unrelated preview examples. Refreshing it then
+> flipped four transitional test theories that pinned the *previous* cycle's
+> readiness heading by literal. Hence step 5 above, and the rule below.
+
+**Release-prep guidance: never add a current-state version literal.** When a
+release-prep packet writes or updates a guard over the developer reference, the
+README, or any other file describing the repository *as it is now*, the expected
+version comes from `eng/version.json` — never from a typed-in string. Two live
+incidents came from breaking this rule, and both cost an unrelated PR its CI:
+the first pinned the version pair itself (G557), the second pinned the readiness
+section's heading (G560). A literal is only safe where the artifact is **frozen**:
+`release-notes-v<X>.md` for an already-released `X` will never change, so
+asserting its content is stable by construction — as are incident records like
+the paragraphs above, which describe what happened rather than what is.
+
+For the same reason the version-flow example above uses placeholders rather than
+a worked version pair: a second copy of the current versions is a second thing
+to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
 ### Next release readiness (v0.6.3)
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2095,18 +2095,23 @@ truth です。G468 以降、ローカル `dotnet pack` のデフォルト `<Ver
 
 ```json
 {
-  "stableVersion": "0.6.0",
-  "nextVersion": "0.6.1"
+  "stableVersion": "<stableVersion>",
+  "nextVersion": "<nextVersion>"
 }
 ```
 
+形だけをプレースホルダーで示しているのは意図的です: **実際の値は `eng/version.json`
+から読んでください**。現在カット中のラインは下記の「次リリース準備」セクションを参照します。
+ここに具体値の例を置くと、バージョンの組の 2 つ目のコピーができ、次の roll で必ず stale に
+なります — それこそ G557/G560 が取り除こうとしている欠陥です。
+
 | ステージ | バージョン形式 | 導出方法 |
 | --- | --- | --- |
-| ローカル pack / install | `0.6.1-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
-| Main CI preview | `0.6.1-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
-| リリース候補（任意） | `0.6.1-rc.N` | タグ `v0.6.1-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
-| 安定版リリース | `0.6.1` | タグ `v0.6.1` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
-| リリース後の main ビルド | `0.6.2-preview.<run>.<attempt>` | `nextVersion` を `0.6.2` に roll した後 |
+| ローカル pack / install | `<nextVersion>-<sha>-<G-unit>` | `eng/version.json` の `nextVersion`（G468） |
+| Main CI preview | `<nextVersion>-preview.<run>.<attempt>` | `eng/version.json` の `nextVersion` |
+| リリース候補（任意） | `<nextVersion>-rc.N` | タグ `v<nextVersion>-rc.N` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する |
+| 安定版リリース | `<nextVersion>` | タグ `v<nextVersion>` の GitHub Release を publish すると `release.yml`（`on: release: published`）がトリガーされる。タグはバージョンを供給する（`-p:Version=<tag>` が優先） |
+| リリース後の main ビルド | `<nextPatch>-preview.<run>.<attempt>` | `nextVersion` を `<nextPatch>` に roll した後 |
 
 ### リリース後の version roll(G554) — 必須・即時
 
@@ -2117,8 +2122,8 @@ closeout の 1 ステップであり、飛ばすと preview チャンネルが�
 
 ```json
 {
-  "stableVersion": "0.6.1",
-  "nextVersion": "0.6.2"
+  "stableVersion": "<今リリースしたバージョン>",
+  "nextVersion": "<次の patch>"
 }
 ```
 
@@ -2132,7 +2137,7 @@ closeout の 1 ステップであり、飛ばすと preview チャンネルが�
 `0.6.1` より上にソートされるため、`dotnet tool update` が再び機能します。
 
 **リリース closeout チェックリスト**(roll はステップ 4 — ステップ 3 で止めないこと。
-そして roll はステップ 5 まで終えて初めて完了です):
+そして roll はステップ 6 まで終えて初めて完了です):
 
 1. 対象バージョンの GitHub Release を publish する(これが `release.yml` を発火させる)。
 2. publish された成果物を検証する: NuGet ページ、release assets、`.sha256` チェックサム、
@@ -2144,20 +2149,45 @@ closeout の 1 ステップであり、飛ばすと preview チャンネルが�
    `nextVersion` が指すバージョンのノートの存在を要求するため、stub 無しでフィールドだけを
    動かす roll は、着地した瞬間に main を red にします。stub に changelog の中身は不要で、
    実際の内容は次の release-prep パケットが author します。
-5. **push 後に child main の CI が green であることを検証する。** roll は CI が green に
+5. **同じ roll で「次リリース準備」セクションを新しいラインへ更新する。** このセクションは
+   カット対象のリリースを名指しするため、`nextVersion` だけを動かす roll はセクションを
+   前サイクルの記述のまま残します。ja/en 両方のミラーを更新してください。
+6. **push 後に child main の CI が green であることを検証する。** roll は CI が green に
    なって初めて完了です: red な main は、それを継承するすべての無関係な PR をブロックする
    ため、roll した人は commit だけでなく結果まで責任を持ちます。
 
 既存の preview 成果物は **遡って番号を振り直しません**。このルールはチャンネルを今後に
 向けて修正するものです。
 
-> **ステップ 4-5 がこの形である理由(G557)。** roll の最初の実運用(commit `00936844`、
+> **ステップ 4-6 がこの形である理由(G557, G560)。** roll の最初の実運用(commit `00936844`、
 > `nextVersion` 0.6.1 → 0.6.2)はフィールドだけを動かし、4 つのチェックで main を red に
 > しました: 3 つのテストがバージョンの組を値で固定しており、G475 のガードが
 > `release-notes-v0.6.2.md` を要求したためです。無関係な PR が red な main を継承して
 > 凍結され、hotfix が着地するまで解除されませんでした。assertion は `eng/version.json`
 > から導出するようになり、正しい roll がそれらを壊すことはなくなりました。残りを塞ぐのが
 > 上記 2 ステップです: roll と同時に stub を作り、green を確認してから完了とする。
+>
+> **2 件目のインシデント(G560、roll 0.6.2 → 0.6.3)。** 改訂したルールは機能しました —
+> roll 後の CI チェックが、readiness セクションが前のラインを記述したままであることを
+> 検出したのです。それまで通っていたのは、新しいバージョンがたまたま無関係な preview の
+> 例に現れていたからにすぎませんでした。そこでセクションを更新すると、今度は *前サイクル* の
+> readiness 見出しをリテラルで固定していた 4 つの transitional な test theory が落ちました。
+> それが上記ステップ 5 と、下記のルールの理由です。
+
+**release-prep のガイダンス: current-state のバージョンリテラルを新たに書かない。**
+release-prep パケットが developer reference・README・その他「今のリポジトリの状態」を
+記述するファイルに対するガードを書く/更新するときは、期待するバージョンを
+`eng/version.json` から導出します — タイプした文字列からではありません。このルールを
+破ったことで実運用のインシデントが 2 件起き、いずれも無関係な PR の CI を落としました:
+1 件目はバージョンの組そのものを固定(G557)、2 件目は readiness セクションの見出しを
+固定(G560)。リテラルが安全なのは成果物が **凍結** されている場合だけです:
+リリース済みの `X` に対する `release-notes-v<X>.md` は今後変わらないため、その内容を
+assert するのは構造的に安定です — 上記のようなインシデント記録も同様で、「今どうであるか」
+ではなく「何が起きたか」を記述しています。
+
+同じ理由で、上の version flow の例は具体的なバージョンの組ではなくプレースホルダーを
+使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
+意味し、しかも誰も見ていない roll でこそ stale になります。
 
 ### 次リリース準備(v0.6.3)
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2230,9 +2230,11 @@ version バンプのマージが `main` に入った後、メンテナ/オペレ
 publish が `release.yml`(`on: release: published`)をトリガーし、NuGet package と
 プラットフォームバイナリ成果物を build・publish します。**その後すぐに
 `eng/version.json` を roll します** — `stableVersion → 0.6.3`、`nextVersion →
-0.6.4` — 同一コミットに DRAFT note スタブを含め、roll 後に CI green を確認する、
-[リリース後の version roll](#リリース後の-version-rollg554--必須即時) のステップ
-4–5 に従います。
+0.6.4` — [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
+**ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
+**「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、
+そして roll を完了とみなす前の **roll 後の child main CI green 確認**(ステップ 6)を
+すべて含めます。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
@@ -152,76 +152,99 @@ public sealed class ReleaseNotesV061DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void DeveloperReference_VersionFlowIsOnThe061Line(string language)
+    public void DeveloperReference_VersionFlowUsesPlaceholders_NotACurrentVersionPair_G560(string language)
     {
+        // G560: this theory used to pin the worked example's version pair by
+        // literal, which made it a SECOND copy of eng/version.json that goes
+        // stale on the roll nobody is watching. The example is now written with
+        // placeholders, so the assertion is about shape and can never flip.
         var reference = ReadDeveloperReference(language);
 
-        Assert.Contains("\"stableVersion\": \"0.6.0\"", reference, StringComparison.Ordinal);
-        Assert.Contains("\"nextVersion\": \"0.6.1\"", reference, StringComparison.Ordinal);
-        // Post-release main builds are described on the NEXT line, above the
-        // release — the whole point of the rule.
-        Assert.Contains("0.6.2-preview.<run>.<attempt>", reference, StringComparison.Ordinal);
-    }
+        Assert.Contains("\"stableVersion\": \"<stableVersion>\"", reference, StringComparison.Ordinal);
+        Assert.Contains("\"nextVersion\": \"<nextVersion>\"", reference, StringComparison.Ordinal);
+        Assert.Contains("<nextVersion>-preview.<run>.<attempt>", reference, StringComparison.Ordinal);
+        Assert.Contains("<nextPatch>-preview.<run>.<attempt>", reference, StringComparison.Ordinal);
 
-    [Theory]
-    [InlineData("en")]
-    [InlineData("ja")]
-    public void DeveloperReference_ActiveReadinessIsTheV061Section_NotAStaleV060One(string language)
-    {
-        var reference = ReadDeveloperReference(language);
-
-        Assert.Contains(
-            language == "en" ? "### Next release readiness (v0.6.1)" : "### 次リリース準備(v0.6.1)",
-            reference,
+        // And the example does not reintroduce the current pair as prose.
+        var policy = RepoVersionPolicySource.Read();
+        var flowStart = reference.IndexOf(
+            language == "en" ? "The repository version policy lives in" : "リポジトリのバージョンポリシーは",
             StringComparison.Ordinal);
-        // The superseded section is re-cut, not left standing beside the new one.
-        Assert.DoesNotContain(
-            language == "en" ? "### Next release readiness (v0.6.0)" : "### 次リリース準備(v0.6.0)",
-            reference,
+        var flowEnd = reference.IndexOf(
+            language == "en" ? "Post-release version roll" : "リリース後の version roll",
             StringComparison.Ordinal);
-
-        // It states what actually shipped and what is being cut.
-        Assert.Contains(
-            language == "en" ? "**`v0.6.0` shipped**" : "**`v0.6.0` は publish 済み**",
-            reference,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            language == "en" ? "a **patch** bump, not a minor" : "minor ではなく **patch** バンプ",
-            reference,
-            StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.6.1.md", reference, StringComparison.Ordinal);
-        foreach (var slice in ReleasedSlices)
+        if (flowStart >= 0 && flowEnd > flowStart)
         {
-            Assert.Contains(slice, reference, StringComparison.Ordinal);
+            var flowSection = reference[flowStart..flowEnd];
+            Assert.DoesNotContain($"\"{policy.NextVersion}\"", flowSection, StringComparison.Ordinal);
+            Assert.DoesNotContain($"\"{policy.StableVersion}\"", flowSection, StringComparison.Ordinal);
         }
     }
 
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void DeveloperReference_CarriesNoStaleActiveVersionGuidance(string language)
+    public void DeveloperReference_ActiveReadinessNamesTheReleaseBeingCut_G560(string language)
     {
+        // G560: the active readiness heading is derived from eng/version.json
+        // rather than pinned to a cycle. The previous incarnation hardcoded the
+        // v0.6.1 heading and "v0.6.0 shipped", so the roll that refreshed the
+        // section flipped it — the same class of defect G557 removed from the
+        // metadata guards.
         var reference = ReadDeveloperReference(language);
+        var policy = RepoVersionPolicySource.Read();
 
-        // Negative coverage: the pre-roll policy values and the deferral that
-        // caused the 2026-07-29 preview-channel break must not reappear as
-        // active guidance.
-        Assert.DoesNotContain("\"stableVersion\": \"0.5.0\"", reference, StringComparison.Ordinal);
-        Assert.DoesNotContain(
-            language == "en" ? "stableVersion 0.5.0 (published)" : "stableVersion 0.5.0（公開済み）",
+        Assert.Contains(
+            language == "en"
+                ? $"### Next release readiness (v{policy.NextVersion})"
+                : $"### 次リリース準備(v{policy.NextVersion})",
             reference,
             StringComparison.Ordinal);
+
+        // The section states which line just shipped. Asserted by the VERSION
+        // it names rather than by a phrasing: whoever refreshes the section on
+        // a roll should not have to match a sentence, only to keep it true.
+        var readiness = ReadinessSection(reference, language);
+        Assert.Contains($"v{policy.StableVersion}", readiness, StringComparison.Ordinal);
+
+        // And it points at the notes for the release being cut.
+        Assert.Contains($"release-notes-v{policy.NextVersion}.md", reference, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperReference_CarriesNoSupersededReadinessSection_G560(string language)
+    {
+        // Only ONE active readiness section may stand: the one for the release
+        // being cut. Any heading for a version at or below the published stable
+        // is a superseded section left behind by a roll.
+        var reference = ReadDeveloperReference(language);
+        var policy = RepoVersionPolicySource.Read();
+
+        var headingPrefix = language == "en" ? "### Next release readiness (v" : "### 次リリース準備(v";
+        var headings = reference
+            .Split(headingPrefix)
+            .Skip(1)
+            .Select(chunk => chunk.Split(')')[0])
+            .ToArray();
+
+        var activeHeading = Assert.Single(headings);
+        Assert.Equal(policy.NextVersion, activeHeading);
+
+        // The readiness verification block names the current line too, derived
+        // from the same source and matched on the version-bearing tokens so the
+        // surrounding wording stays the refresher's choice.
+        Assert.Contains($"stableVersion {policy.StableVersion}", reference, StringComparison.Ordinal);
+        Assert.Contains($"nextVersion {policy.NextVersion}", reference, StringComparison.Ordinal);
+        Assert.Contains($"JTechJapan.IntentSystem.Cli.{policy.NextVersion}.nupkg", reference, StringComparison.Ordinal);
+
+        // Negative coverage that does NOT depend on a version: the deferral
+        // wording G554 removed must not return as active guidance.
         Assert.DoesNotContain(
             language == "en" ? "deferred to the NEXT release-prep packet" : "次の release-prep パケットに委ねられます",
             reference,
             StringComparison.Ordinal);
-
-        // And the readiness checks name the current line.
-        Assert.Contains(
-            language == "en" ? "stableVersion 0.6.0 (published), nextVersion 0.6.1 (to release)" : "stableVersion 0.6.0（公開済み）, nextVersion 0.6.1（リリース対象）",
-            reference,
-            StringComparison.Ordinal);
-        Assert.Contains("JTechJapan.IntentSystem.Cli.0.6.1.nupkg", reference, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -269,7 +292,7 @@ public sealed class ReleaseNotesV061DocsTests
             reference,
             StringComparison.Ordinal);
         Assert.Contains(
-            language == "en" ? "the roll is not done until step 5" : "roll はステップ 5 まで終えて初めて完了",
+            language == "en" ? "the roll is not done until step 6" : "roll はステップ 6 まで終えて初めて完了",
             reference,
             StringComparison.Ordinal);
 
@@ -457,6 +480,71 @@ public sealed class ReleaseNotesV061DocsTests
             StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void RollSimulation_BumpedPolicyPlusRefreshedReadiness_FlipsNothing_G560(string language)
+    {
+        // G560 roll simulation. The regression this slice closes is not "these
+        // four theories were wrong once" — it is that current-state doc guards
+        // FLIP ON EVERY ROLL. So the proof has to be a roll: bump the policy,
+        // refresh the readiness section the way the roller does (step 5), and
+        // show that every current-state assertion still holds. If any of them
+        // regains a version literal, this fails.
+        var reference = ReadDeveloperReference(language);
+        var policy = RepoVersionPolicySource.Read();
+
+        foreach (var (stable, next) in new[] { (policy.NextVersion, "0.6.4"), ("0.6.9", "0.7.0"), ("0.9.9", "1.0.0") })
+        {
+            var rolled = SimulateRoll(reference, language, policy, stable, next);
+
+            // The three current-state expectations, re-derived at the new line.
+            Assert.Contains(
+                language == "en" ? $"### Next release readiness (v{next})" : $"### 次リリース準備(v{next})",
+                rolled,
+                StringComparison.Ordinal);
+            Assert.Contains($"stableVersion {stable}", rolled, StringComparison.Ordinal);
+            Assert.Contains($"nextVersion {next}", rolled, StringComparison.Ordinal);
+            Assert.Contains($"JTechJapan.IntentSystem.Cli.{next}.nupkg", rolled, StringComparison.Ordinal);
+            Assert.Contains($"release-notes-v{next}.md", rolled, StringComparison.Ordinal);
+
+            // Exactly one active readiness heading survives the roll.
+            var headingPrefix = language == "en" ? "### Next release readiness (v" : "### 次リリース準備(v";
+            var headings = rolled.Split(headingPrefix).Skip(1).Select(chunk => chunk.Split(')')[0]).ToArray();
+            Assert.Equal(next, Assert.Single(headings));
+
+            // The version-flow example stays placeholder-based — it is not part
+            // of what a roll has to rewrite, which is the point of G560.
+            Assert.Contains("\"nextVersion\": \"<nextVersion>\"", rolled, StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// G560: rewrites the developer reference the way the roller does at step 4-5
+    /// — the policy pair and every current-state mention of the cycle move to
+    /// the new line. Deliberately a blunt textual substitution: if a guard
+    /// depends on anything this does not touch, that guard is not current-state
+    /// and should not be asserting a version.
+    /// </summary>
+    private static string SimulateRoll(
+        string reference, string language, IntentSystem.Cli.Infrastructure.VersionPolicy policy, string stable, string next)
+    {
+        var oldHeading = language == "en"
+            ? $"### Next release readiness (v{policy.NextVersion})"
+            : $"### 次リリース準備(v{policy.NextVersion})";
+        var newHeading = language == "en"
+            ? $"### Next release readiness (v{next})"
+            : $"### 次リリース準備(v{next})";
+
+        return reference
+            .Replace(oldHeading, newHeading, StringComparison.Ordinal)
+            .Replace($"stableVersion {policy.StableVersion}", $"stableVersion {stable}", StringComparison.Ordinal)
+            .Replace($"nextVersion {policy.NextVersion}", $"nextVersion {next}", StringComparison.Ordinal)
+            .Replace($"JTechJapan.IntentSystem.Cli.{policy.NextVersion}.nupkg", $"JTechJapan.IntentSystem.Cli.{next}.nupkg", StringComparison.Ordinal)
+            .Replace($"release-notes-v{policy.NextVersion}.md", $"release-notes-v{next}.md", StringComparison.Ordinal)
+            .Replace($"v{policy.StableVersion}", $"v{stable}", StringComparison.Ordinal);
+    }
+
     [Fact]
     public void PrepareOnlyDiff_AddsNoPublishAutomation_G554()
     {
@@ -469,6 +557,22 @@ public sealed class ReleaseNotesV061DocsTests
         var workflow = File.ReadAllText(releaseWorkflow);
         Assert.Contains("release:", workflow, StringComparison.Ordinal);
         Assert.Contains("published", workflow, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G560: the slice of the developer reference under the ACTIVE readiness
+    /// heading, so assertions about that section cannot accidentally be
+    /// satisfied by text elsewhere in the file — which is exactly how the
+    /// previous guard passed incidentally until a roll exposed it.
+    /// </summary>
+    private static string ReadinessSection(string reference, string language)
+    {
+        var heading = language == "en" ? "### Next release readiness (v" : "### 次リリース準備(v";
+        var start = reference.IndexOf(heading, StringComparison.Ordinal);
+        Assert.True(start >= 0, "the developer reference must carry an active readiness section");
+
+        var end = reference.IndexOf("### ", start + heading.Length, StringComparison.Ordinal);
+        return end > start ? reference[start..end] : reference[start..];
     }
 
     private static string ReadReleaseNotes(string language) =>

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
@@ -152,99 +152,211 @@ public sealed class ReleaseNotesV061DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void DeveloperReference_VersionFlowUsesPlaceholders_NotACurrentVersionPair_G560(string language)
+    public void DeveloperReference_VersionFlowDoesNotReintroduceTheCurrentPair_G560(string language)
     {
-        // G560: this theory used to pin the worked example's version pair by
-        // literal, which made it a SECOND copy of eng/version.json that goes
-        // stale on the roll nobody is watching. The example is now written with
-        // placeholders, so the assertion is about shape and can never flip.
+        // The placeholder shape itself is asserted by the shared invariant
+        // helper. What is unique here is the NEGATIVE: the example must not
+        // quietly regain a worked version pair, which would recreate the second
+        // copy of eng/version.json that goes stale on the next roll.
         var reference = ReadDeveloperReference(language);
-
-        Assert.Contains("\"stableVersion\": \"<stableVersion>\"", reference, StringComparison.Ordinal);
-        Assert.Contains("\"nextVersion\": \"<nextVersion>\"", reference, StringComparison.Ordinal);
-        Assert.Contains("<nextVersion>-preview.<run>.<attempt>", reference, StringComparison.Ordinal);
-        Assert.Contains("<nextPatch>-preview.<run>.<attempt>", reference, StringComparison.Ordinal);
-
-        // And the example does not reintroduce the current pair as prose.
         var policy = RepoVersionPolicySource.Read();
+
         var flowStart = reference.IndexOf(
             language == "en" ? "The repository version policy lives in" : "リポジトリのバージョンポリシーは",
             StringComparison.Ordinal);
         var flowEnd = reference.IndexOf(
             language == "en" ? "Post-release version roll" : "リリース後の version roll",
             StringComparison.Ordinal);
-        if (flowStart >= 0 && flowEnd > flowStart)
-        {
-            var flowSection = reference[flowStart..flowEnd];
-            Assert.DoesNotContain($"\"{policy.NextVersion}\"", flowSection, StringComparison.Ordinal);
-            Assert.DoesNotContain($"\"{policy.StableVersion}\"", flowSection, StringComparison.Ordinal);
-        }
+        Assert.True(flowStart >= 0 && flowEnd > flowStart, "the developer reference must carry a version-flow section");
+
+        var flowSection = reference[flowStart..flowEnd];
+        Assert.DoesNotContain($"\"{policy.NextVersion}\"", flowSection, StringComparison.Ordinal);
+        Assert.DoesNotContain($"\"{policy.StableVersion}\"", flowSection, StringComparison.Ordinal);
     }
 
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void DeveloperReference_ActiveReadinessNamesTheReleaseBeingCut_G560(string language)
+    public void DeveloperReference_SatisfiesTheCurrentStateInvariant_G560(string language)
     {
-        // G560: the active readiness heading is derived from eng/version.json
-        // rather than pinned to a cycle. The previous incarnation hardcoded the
-        // v0.6.1 heading and "v0.6.0 shipped", so the roll that refreshed the
-        // section flipped it — the same class of defect G557 removed from the
-        // metadata guards.
-        var reference = ReadDeveloperReference(language);
-        var policy = RepoVersionPolicySource.Read();
+        // G560: the ONE current-state invariant, asserted against the real
+        // developer reference and the real eng/version.json. The identical
+        // helper runs in the roll simulation below, so "it holds now" and "it
+        // holds after a roll" are the same check rather than two drifting
+        // copies of one.
+        AssertCurrentStateInvariant(ReadDeveloperReference(language), language, RepoVersionPolicySource.Read());
+    }
 
-        Assert.Contains(
-            language == "en"
-                ? $"### Next release readiness (v{policy.NextVersion})"
-                : $"### 次リリース準備(v{policy.NextVersion})",
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperReference_CarriesNoSupersededGuidance_G560(string language)
+    {
+        // Version-free negative coverage: wording G554 removed must not return
+        // as active guidance, and the closeout cross-reference must name the
+        // full step range with what each step carries.
+        var reference = ReadDeveloperReference(language);
+
+        Assert.DoesNotContain(
+            language == "en" ? "deferred to the NEXT release-prep packet" : "次の release-prep パケットに委ねられます",
             reference,
             StringComparison.Ordinal);
 
-        // The section states which line just shipped. Asserted by the VERSION
-        // it names rather than by a phrasing: whoever refreshes the section on
-        // a roll should not have to match a sentence, only to keep it true.
-        var readiness = ReadinessSection(reference, language);
-        Assert.Contains($"v{policy.StableVersion}", readiness, StringComparison.Ordinal);
-
-        // And it points at the notes for the release being cut.
-        Assert.Contains($"release-notes-v{policy.NextVersion}.md", reference, StringComparison.Ordinal);
+        // Regression for the stale steps 4-5 cross-reference: the readiness
+        // closeout must point at steps 4-6 and spell out same-commit stubs, the
+        // readiness refresh, and the post-roll green-CI check.
+        Assert.DoesNotContain(
+            language == "en" ? "per steps 4–5 of the" : "のステップ 4–5 に従います",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "**steps 4–6** of the" : "**ステップ 4–6** に従い",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "DRAFT note stubs in the same commit** (step 4)" : "同一コミットに DRAFT note スタブ**(ステップ 4)",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "refreshed to the new line in both language mirrors** (step" : "両ミラーで新しいラインへ更新**(ステップ 5)",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "post-roll green child-main CI check** before the roll counts as" : "roll 後の child main CI green 確認**(ステップ 6)",
+            reference,
+            StringComparison.Ordinal);
     }
 
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void DeveloperReference_CarriesNoSupersededReadinessSection_G560(string language)
+    public void RollSimulation_BumpedPolicyPlusRefreshedReadiness_SatisfiesTheSameInvariant_G560(string language)
     {
-        // Only ONE active readiness section may stand: the one for the release
-        // being cut. Any heading for a version at or below the published stable
-        // is a superseded section left behind by a roll.
+        // The regression this slice closes is not "four theories were wrong
+        // once" — it is that current-state guards FLIP ON EVERY ROLL. So the
+        // proof is a roll, driven through the real policy reader against a
+        // temporary bumped eng/version.json, and checked with the SAME helper
+        // the current-state theory uses. A guard that regains a literal fails
+        // here even while it still passes against today's docs.
         var reference = ReadDeveloperReference(language);
         var policy = RepoVersionPolicySource.Read();
 
+        foreach (var (stable, next) in new[]
+                 {
+                     (policy.NextVersion, NextPatch(policy.NextVersion)),
+                     ("0.6.9", "0.7.0"),
+                     ("0.9.9", "1.0.0"),
+                 })
+        {
+            using var rolledRepo = new TemporaryVersionPolicyRoot(stable, next);
+            var rolledPolicy = RepoVersionPolicySource.ReadFrom(rolledRepo.RootPath);
+            Assert.Equal(stable, rolledPolicy.StableVersion);
+            Assert.Equal(next, rolledPolicy.NextVersion);
+
+            var refreshed = RefreshReadinessForRoll(reference, language, policy, rolledPolicy);
+
+            AssertCurrentStateInvariant(refreshed, language, rolledPolicy);
+        }
+    }
+
+    /// <summary>
+    /// G560: the single current-state invariant. Everything it asserts is
+    /// derived from <paramref name="policy"/>, and the version-bearing checks
+    /// are scoped to the active readiness section so they cannot be satisfied
+    /// incidentally by text elsewhere in the file — which is exactly how the
+    /// superseded guard passed until a roll exposed it.
+    /// </summary>
+    private static void AssertCurrentStateInvariant(
+        string reference, string language, IntentSystem.Cli.Infrastructure.VersionPolicy policy)
+    {
         var headingPrefix = language == "en" ? "### Next release readiness (v" : "### 次リリース準備(v";
+
+        // Exactly ONE active readiness heading, naming the release being cut.
         var headings = reference
             .Split(headingPrefix)
             .Skip(1)
             .Select(chunk => chunk.Split(')')[0])
             .ToArray();
+        Assert.Equal(policy.NextVersion, Assert.Single(headings));
 
-        var activeHeading = Assert.Single(headings);
-        Assert.Equal(policy.NextVersion, activeHeading);
+        var section = ReadinessSection(reference, language);
 
-        // The readiness verification block names the current line too, derived
-        // from the same source and matched on the version-bearing tokens so the
-        // surrounding wording stays the refresher's choice.
-        Assert.Contains($"stableVersion {policy.StableVersion}", reference, StringComparison.Ordinal);
-        Assert.Contains($"nextVersion {policy.NextVersion}", reference, StringComparison.Ordinal);
-        Assert.Contains($"JTechJapan.IntentSystem.Cli.{policy.NextVersion}.nupkg", reference, StringComparison.Ordinal);
+        // Section-scoped: the line that just shipped, the notes for the release
+        // being cut, the policy pair, and the pack artifact.
+        Assert.Contains($"v{policy.StableVersion}", section, StringComparison.Ordinal);
+        Assert.Contains($"release-notes-v{policy.NextVersion}.md", section, StringComparison.Ordinal);
+        Assert.Contains($"stableVersion {policy.StableVersion}", section, StringComparison.Ordinal);
+        Assert.Contains($"nextVersion {policy.NextVersion}", section, StringComparison.Ordinal);
+        Assert.Contains($"JTechJapan.IntentSystem.Cli.{policy.NextVersion}.nupkg", section, StringComparison.Ordinal);
 
-        // Negative coverage that does NOT depend on a version: the deferral
-        // wording G554 removed must not return as active guidance.
-        Assert.DoesNotContain(
-            language == "en" ? "deferred to the NEXT release-prep packet" : "次の release-prep パケットに委ねられます",
-            reference,
-            StringComparison.Ordinal);
+        // The version-flow example stays placeholder-based: it is not something
+        // a roll has to rewrite, which is the point of the conversion.
+        Assert.Contains("\"stableVersion\": \"<stableVersion>\"", reference, StringComparison.Ordinal);
+        Assert.Contains("\"nextVersion\": \"<nextVersion>\"", reference, StringComparison.Ordinal);
+        Assert.Contains("<nextVersion>-preview.<run>.<attempt>", reference, StringComparison.Ordinal);
+        Assert.Contains("<nextPatch>-preview.<run>.<attempt>", reference, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G560: rewrites the developer reference the way the roller does at steps
+    /// 4-5 — the readiness heading and every current-state mention of the cycle
+    /// move to the new line. Deliberately blunt: anything this does not touch
+    /// is not current state, and must not be asserting a version.
+    /// </summary>
+    private static string RefreshReadinessForRoll(
+        string reference,
+        string language,
+        IntentSystem.Cli.Infrastructure.VersionPolicy from,
+        IntentSystem.Cli.Infrastructure.VersionPolicy to)
+    {
+        var oldHeading = language == "en"
+            ? $"### Next release readiness (v{from.NextVersion})"
+            : $"### 次リリース準備(v{from.NextVersion})";
+        var newHeading = language == "en"
+            ? $"### Next release readiness (v{to.NextVersion})"
+            : $"### 次リリース準備(v{to.NextVersion})";
+
+        return reference
+            .Replace(oldHeading, newHeading, StringComparison.Ordinal)
+            .Replace($"stableVersion {from.StableVersion}", $"stableVersion {to.StableVersion}", StringComparison.Ordinal)
+            .Replace($"nextVersion {from.NextVersion}", $"nextVersion {to.NextVersion}", StringComparison.Ordinal)
+            .Replace($"JTechJapan.IntentSystem.Cli.{from.NextVersion}.nupkg", $"JTechJapan.IntentSystem.Cli.{to.NextVersion}.nupkg", StringComparison.Ordinal)
+            .Replace($"release-notes-v{from.NextVersion}.md", $"release-notes-v{to.NextVersion}.md", StringComparison.Ordinal)
+            .Replace($"v{from.StableVersion}", $"v{to.StableVersion}", StringComparison.Ordinal);
+    }
+
+    private static string NextPatch(string version)
+    {
+        var parts = version.Split('.');
+        return $"{parts[0]}.{parts[1]}.{int.Parse(parts[2]) + 1}";
+    }
+
+    /// <summary>G560: a temporary repo root holding only a bumped eng/version.json, read through the real policy reader.</summary>
+    private sealed class TemporaryVersionPolicyRoot : IDisposable
+    {
+        public TemporaryVersionPolicyRoot(string stableVersion, string nextVersion)
+        {
+            RootPath = Directory.CreateTempSubdirectory("g560-roll-simulation-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, "eng"));
+            File.WriteAllText(
+                Path.Combine(RootPath, "eng", "version.json"),
+                $$"""
+                {
+                  "stableVersion": "{{stableVersion}}",
+                  "nextVersion": "{{nextVersion}}"
+                }
+                """);
+        }
+
+        public string RootPath { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
     }
 
     [Theory]
@@ -478,71 +590,6 @@ public sealed class ReleaseNotesV061DocsTests
             language == "en" ? "in the same commit as" : "同じ commit で",
             notes,
             StringComparison.Ordinal);
-    }
-
-    [Theory]
-    [InlineData("en")]
-    [InlineData("ja")]
-    public void RollSimulation_BumpedPolicyPlusRefreshedReadiness_FlipsNothing_G560(string language)
-    {
-        // G560 roll simulation. The regression this slice closes is not "these
-        // four theories were wrong once" — it is that current-state doc guards
-        // FLIP ON EVERY ROLL. So the proof has to be a roll: bump the policy,
-        // refresh the readiness section the way the roller does (step 5), and
-        // show that every current-state assertion still holds. If any of them
-        // regains a version literal, this fails.
-        var reference = ReadDeveloperReference(language);
-        var policy = RepoVersionPolicySource.Read();
-
-        foreach (var (stable, next) in new[] { (policy.NextVersion, "0.6.4"), ("0.6.9", "0.7.0"), ("0.9.9", "1.0.0") })
-        {
-            var rolled = SimulateRoll(reference, language, policy, stable, next);
-
-            // The three current-state expectations, re-derived at the new line.
-            Assert.Contains(
-                language == "en" ? $"### Next release readiness (v{next})" : $"### 次リリース準備(v{next})",
-                rolled,
-                StringComparison.Ordinal);
-            Assert.Contains($"stableVersion {stable}", rolled, StringComparison.Ordinal);
-            Assert.Contains($"nextVersion {next}", rolled, StringComparison.Ordinal);
-            Assert.Contains($"JTechJapan.IntentSystem.Cli.{next}.nupkg", rolled, StringComparison.Ordinal);
-            Assert.Contains($"release-notes-v{next}.md", rolled, StringComparison.Ordinal);
-
-            // Exactly one active readiness heading survives the roll.
-            var headingPrefix = language == "en" ? "### Next release readiness (v" : "### 次リリース準備(v";
-            var headings = rolled.Split(headingPrefix).Skip(1).Select(chunk => chunk.Split(')')[0]).ToArray();
-            Assert.Equal(next, Assert.Single(headings));
-
-            // The version-flow example stays placeholder-based — it is not part
-            // of what a roll has to rewrite, which is the point of G560.
-            Assert.Contains("\"nextVersion\": \"<nextVersion>\"", rolled, StringComparison.Ordinal);
-        }
-    }
-
-    /// <summary>
-    /// G560: rewrites the developer reference the way the roller does at step 4-5
-    /// — the policy pair and every current-state mention of the cycle move to
-    /// the new line. Deliberately a blunt textual substitution: if a guard
-    /// depends on anything this does not touch, that guard is not current-state
-    /// and should not be asserting a version.
-    /// </summary>
-    private static string SimulateRoll(
-        string reference, string language, IntentSystem.Cli.Infrastructure.VersionPolicy policy, string stable, string next)
-    {
-        var oldHeading = language == "en"
-            ? $"### Next release readiness (v{policy.NextVersion})"
-            : $"### 次リリース準備(v{policy.NextVersion})";
-        var newHeading = language == "en"
-            ? $"### Next release readiness (v{next})"
-            : $"### 次リリース準備(v{next})";
-
-        return reference
-            .Replace(oldHeading, newHeading, StringComparison.Ordinal)
-            .Replace($"stableVersion {policy.StableVersion}", $"stableVersion {stable}", StringComparison.Ordinal)
-            .Replace($"nextVersion {policy.NextVersion}", $"nextVersion {next}", StringComparison.Ordinal)
-            .Replace($"JTechJapan.IntentSystem.Cli.{policy.NextVersion}.nupkg", $"JTechJapan.IntentSystem.Cli.{next}.nupkg", StringComparison.Ordinal)
-            .Replace($"release-notes-v{policy.NextVersion}.md", $"release-notes-v{next}.md", StringComparison.Ordinal)
-            .Replace($"v{policy.StableVersion}", $"v{stable}", StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Restores child main to green after the **second** live version roll (0.6.2 → 0.6.3) and finishes the version-agnostic guard work G557 started.

The amended rule itself worked: the post-roll CI check caught that the readiness section still described the previous line — it had been passing only **incidentally**, because the new version happened to appear in unrelated preview examples. Refreshing the section then flipped four transitional theories that pinned the **previous** cycle's readiness heading by literal (CI run 30577998151, 4 failed / 3932 passed).

Same class G557 removed from the metadata guards, left behind in the current-state doc guards: **a doc guard that names a version by literal is guaranteed to break on the next correct roll.** These are theories I wrote in G554 and did not re-cut in G557; this finishes that work.

## What changes

**1. The current-state theories derive from `eng/version.json`.** The active readiness heading, the shipped line, the policy pair in the verification block, the nupkg name, and the notes link are all derived. A new theory additionally asserts that **exactly one** active readiness heading stands — so a roll that forgets to re-cut the previous section fails loudly instead of leaving two side by side.

**2. Assertions match version-bearing tokens, not sentences.** The ja refresh used different phrasing from the previous cycle (`出荷済み` rather than `publish 済み`), which a prose pin would have reported as a failure while the doc was in fact correct. Whoever refreshes the section should have to keep it **true**, not match a sentence.

**3. The version-flow example is placeholder-based** in both mirrors. It was a second copy of the version pair that nothing kept in sync — and it was already stale, showing `0.6.0/0.6.1` against a `0.6.2/0.6.3` policy. Placeholders cannot go stale, and the concrete numbers already live in the readiness section that the roll refreshes.

**4. Roll rule gains step 5** (refresh the readiness section in the same roll, both mirrors); closeout now runs to step 6. The G557 why-block records the second incident, and new **release-prep guidance** states the rule directly: a guard over *current* repository state derives its version from `eng/version.json`; literals are reserved for **frozen** artifacts — released notes files, and incident records, which describe what happened rather than what is.

**5. A roll-simulation theory proves it** rather than asserting it: bump the policy, refresh the section the way the roller does, and re-check every current-state expectation across a patch, a minor rollover, and a major rollover. If any guard regains a literal, it fails.

## Audit

Current-state pins: **none left.** The only version literals remaining in dev-reference assertions are the roll simulation's synthetic target versions, which are inputs rather than expectations.

Historical pins: **untouched.** `ReleaseNotesV060DocsTests` reads only `release-notes-v0.6.0.md`; the v0.6.1 notes assertions read only `release-notes-v0.6.1.md`. Frozen files cannot flip on a roll.

## Verification

- Previously-failing theories green; `ReleaseNotesV06x` **46/46**.
- `dotnet test IntentSystem.sln` — **all green** (CLI suite 3938 passed / 0 failed / 1 pre-existing skip; every other project passed).
- `git diff --check` clean. Diff is **3 files**: the two developer-reference mirrors and one test file.
- `eng/version.json` **untouched** at `0.6.2 / 0.6.3` — verified absent from the staged diff.

## Scope note (flagged, not assumed)

Making the version-flow example placeholder-based is not named in the issue's In Scope. I judged it the minimal permanent way to satisfy the audit requirement — the dev reference is in the target paths, the example was genuinely stale, and the alternative (refresh it to 0.6.2/0.6.3 **and** add another refresh obligation to the roll rule) increases the number of things that must stay in sync. Happy to revert this part if the reviewer prefers the narrower reading.

## Out of scope (untouched)

No release-note content, no 0.6.3 stubs, no `eng/version.json` change; no command behavior or guide command output change; nothing touching G559 or the next release-prep.

Closes #1221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPT7cFrCzT6ehACFez8dpE
