### PR TITLE
G559: Ship the agent skill as one embedded source with an `intent-cli skill` installer

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1992,10 +1992,18 @@ Four properties are the contract:
    a script notices. `--force` is the explicit opt-in to replace it. Line-ending
    differences are not drift, so a Windows checkout does not report every
    install as edited.
-3. **The plan is validated before any write.** Under `--target all`, an
-   unsupported target/scope pair fails the whole run rather than installing two
-   platforms and reporting an error for the third — a partial install leaves the
-   operator guessing which platforms are current.
+3. **The whole plan is resolved and inspected before the first write.**
+   Install runs in two phases: it validates every target/scope pair, resolves
+   every destination path, and inspects every destination's state — and only
+   then writes. An unsupported target/scope pair *or* a drifted destination
+   **anywhere** in the plan aborts the entire run with nothing created and
+   nothing changed; the writable destinations are reported
+   `skipped-plan-aborted` so it is clear they were part of the plan and were
+   deliberately not written. Inspecting and writing in one pass is not
+   "validated before any write" — under `--target all` an earlier missing
+   target would already be on disk by the time a later drifted one was found,
+   leaving a partial install behind an exit code that claims nothing happened.
+   `--force` is what makes that same plan succeed end to end.
 4. **Nothing is written that is already current.** A matching copy reports
    `already-current` and the file is not touched.
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -1945,6 +1945,77 @@ anything reaches a commit.
 
 ---
 
+### Cross-platform agent skill: one embedded source, `intent-cli skill` (G559)
+
+Claude Code, Codex, and Copilot all read the **same** `SKILL.md` format. Only
+the **location** differs:
+
+| Target | Scope(s) | Path |
+| --- | --- | --- |
+| `claude` | `repo` (default), `user` | `<repo>/.claude/skills/<name>/SKILL.md`, `~/.claude/skills/<name>/SKILL.md` |
+| `codex` | `user` | `~/.codex/skills/<name>/SKILL.md` |
+| `copilot` | `repo` | `<repo>/.github/skills/<name>/SKILL.md` |
+
+Because only the location differs, hand-copying is what people actually do —
+and hand-copied skills drift. The evidence was in this project's own host: the
+`host-review-loop` skill existed as separate copies under `~/.claude/skills`
+and `~/.codex/skills`, and the copies had already diverged. Two files claiming
+to be the same skill, neither one authoritative, is a worse failure than no
+skill at all: an agent follows the stale one and reports a workflow the tool no
+longer runs.
+
+So the skill ships as **one source**: `skills/<name>/SKILL.md` in the
+repository, embedded into the tool package at build time. There is exactly one
+file to edit, it is versioned with the code it describes, and it travels with
+the released package.
+
+```bash
+intent-cli skill list                              # every target/scope, and its state
+intent-cli skill install --target all              # install into every platform's own location
+intent-cli skill install --target claude --scope user
+intent-cli skill diff --target claude              # what an edited copy changed
+```
+
+`list` and `diff` accept `--format text|json`; `install` accepts
+`--target claude|codex|copilot|all`, `--scope user|repo`, `--skill <name>`,
+`--force`, and `--format`.
+
+Four properties are the contract:
+
+1. **A scope the platform does not define is refused, not written.** `--scope
+   repo` for `codex` fails with the supported scopes named. Writing to a
+   plausible-looking directory the platform never reads would look like a
+   successful install and behave like no install at all.
+2. **An edited copy is never replaced silently.** Install compares the
+   installed file against the embedded source; on a difference it reports
+   `refused-drifted`, leaves the file byte-identical, and **exits non-zero** so
+   a script notices. `--force` is the explicit opt-in to replace it. Line-ending
+   differences are not drift, so a Windows checkout does not report every
+   install as edited.
+3. **The plan is validated before any write.** Under `--target all`, an
+   unsupported target/scope pair fails the whole run rather than installing two
+   platforms and reporting an error for the third — a partial install leaves the
+   operator guessing which platforms are current.
+4. **Nothing is written that is already current.** A matching copy reports
+   `already-current` and the file is not touched.
+
+**The skill itself is a dispatcher, not a manual.** It restates none of the
+workflow. It carries the rule *"installed guide output wins"* and a table
+mapping what the user wants to the `intent-cli guide ...` command that answers
+it. That is deliberate: a skill file that copies out the workflow is a second
+source of truth that ages against the tool, which is the drift problem one
+level up. The guide surfaces move with the CLI; a pointer to them does not go
+stale.
+
+`SkillCommandTests` proves the behaviour against real writes into a throwaway
+repo root and a throwaway user home — including that a refused install leaves
+the operator's edited file untouched, and that the embedded resource is
+byte-identical to `skills/intent-cli/SKILL.md` (a build that failed to package
+the asset fails the test rather than shipping an installer that writes
+nothing).
+
+---
+
 ## Version flow
 
 The repository version policy lives in `eng/version.json` — the single source of

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2130,10 +2130,17 @@ intent-cli skill diff --target claude              # 編集済みコピーの差
    変えずに残し、**非ゼロで終了**します(script が検知できるように)。置き換えは
    `--force` による明示的な opt-in です。改行コードの違いは drift 扱いしないため、
    Windows checkout ですべての install が編集済みと報告されることはありません。
-3. **書き込み前に plan 全体を検証する。** `--target all` の下で不正な target/scope の
-   組み合わせがあれば、2 つだけ install して 3 つ目でエラーを出すのではなく、
-   実行全体を失敗させます。部分 install は、どのプラットフォームが最新なのかを
-   operator に推測させます。
+3. **最初の書き込み前に plan 全体を解決・検査する。** install は 2 フェーズで動きます。
+   まず全 target/scope の組み合わせを検証し、全 destination のパスを解決し、全
+   destination の状態を検査します。書き込みはその後です。不正な target/scope の
+   組み合わせ**または** drift した destination が plan の**どこかに**1 つでもあれば、
+   何も作らず何も変更せずに実行全体を中止します。書き込み可能だった destination は
+   `skipped-plan-aborted` として報告され、plan に含まれていたが意図的に書かれなかった
+   ことが分かるようになっています。検査と書き込みを 1 パスで行うのは「書き込み前の
+   検証」ではありません。`--target all` の下では、後続の drift が見つかった時点で
+   先行する未 install の target はすでにディスク上にあり、「何も起きていない」と主張する
+   exit code の裏で部分 install が残ります。同じ plan を最後まで成功させるのが
+   `--force` です。
 4. **すでに最新のものは書かない。** 一致するコピーは `already-current` を報告し、
    ファイルには触れません。
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2085,6 +2085,74 @@ writer 層に置く必要があります。
 
 ---
 
+### クロスプラットフォーム agent skill: 単一の埋め込みソースと `intent-cli skill` (G559)
+
+Claude Code / Codex / Copilot はいずれも**同じ** `SKILL.md` フォーマットを読みます。
+異なるのは**設置場所だけ**です:
+
+| Target | Scope | パス |
+| --- | --- | --- |
+| `claude` | `repo`(既定) / `user` | `<repo>/.claude/skills/<name>/SKILL.md`、`~/.claude/skills/<name>/SKILL.md` |
+| `codex` | `user` | `~/.codex/skills/<name>/SKILL.md` |
+| `copilot` | `repo` | `<repo>/.github/skills/<name>/SKILL.md` |
+
+場所しか違わないからこそ、実際には手でコピーされます。そして手コピーした skill は
+drift します。証拠はこのプロジェクト自身の host にありました。`host-review-loop`
+skill が `~/.claude/skills` と `~/.codex/skills` に別々のコピーとして存在し、
+すでに内容が乖離していたのです。同じ skill を名乗る 2 つのファイルがあり、
+どちらも権威ではない状態は、skill が無いことより悪い失敗です。agent は古い方に
+従い、ツールがもう実行しない workflow を報告します。
+
+そこで skill は**単一ソース**として出荷します。リポジトリの
+`skills/<name>/SKILL.md` を build 時に tool package へ埋め込みます。編集対象の
+ファイルはちょうど 1 つ、記述対象のコードと同じバージョン管理下にあり、
+リリースされた package と一緒に移動します。
+
+```bash
+intent-cli skill list                              # 全 target/scope とその状態
+intent-cli skill install --target all              # 各プラットフォーム固有の場所へ install
+intent-cli skill install --target claude --scope user
+intent-cli skill diff --target claude              # 編集済みコピーの差分
+```
+
+`list` と `diff` は `--format text|json` を受け取ります。`install` は
+`--target claude|codex|copilot|all`、`--scope user|repo`、`--skill <name>`、
+`--force`、`--format` を受け取ります。
+
+契約は次の 4 点です:
+
+1. **プラットフォームが定義していない scope は、書かずに拒否する。** `codex` に対する
+   `--scope repo` は、サポートされる scope を明示して失敗します。そのプラットフォームが
+   決して読まない、それらしいディレクトリへ書くことは、install 成功に見えて
+   install していないのと同じ挙動になります。
+2. **編集済みコピーを黙って置き換えない。** install は installed ファイルを埋め込み
+   ソースと比較し、差分があれば `refused-drifted` を報告し、ファイルを 1 バイトも
+   変えずに残し、**非ゼロで終了**します(script が検知できるように)。置き換えは
+   `--force` による明示的な opt-in です。改行コードの違いは drift 扱いしないため、
+   Windows checkout ですべての install が編集済みと報告されることはありません。
+3. **書き込み前に plan 全体を検証する。** `--target all` の下で不正な target/scope の
+   組み合わせがあれば、2 つだけ install して 3 つ目でエラーを出すのではなく、
+   実行全体を失敗させます。部分 install は、どのプラットフォームが最新なのかを
+   operator に推測させます。
+4. **すでに最新のものは書かない。** 一致するコピーは `already-current` を報告し、
+   ファイルには触れません。
+
+**skill 自体は dispatcher であって manual ではありません。** workflow を一切
+再記述しません。持っているのは *「installed guide output wins」* というルールと、
+ユーザーがやりたいことを、それに答える `intent-cli guide ...` コマンドへ対応づける
+表だけです。これは意図的です。workflow を書き写した skill ファイルは、ツールに対して
+古びていく 2 つ目の source of truth であり、それこそが一段上のレイヤーで起きる
+drift 問題そのものだからです。guide surface は CLI と一緒に動きますが、
+そこへのポインタは陳腐化しません。
+
+`SkillCommandTests` は、使い捨ての repo root と使い捨ての user home に対する実際の
+書き込みで挙動を証明します。拒否された install が operator の編集済みファイルを
+そのまま残すこと、および埋め込みリソースが `skills/intent-cli/SKILL.md` と
+バイト単位で一致すること(asset の同梱に失敗した build は、何も書かない installer を
+出荷するのではなくテストで落ちる)を含みます。
+
+---
+
 ## バージョンフロー
 
 リポジトリのバージョンポリシーは `eng/version.json` に記載されています。`stableVersion`

--- a/skills/intent-cli/SKILL.md
+++ b/skills/intent-cli/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: intent-cli
+description: Drive intent-driven development on GitHub with intent-cli. Use when the user wants to shape an intent, cut the next slice, publish an issue, implement or review a packet, close out a PR, or set up the four-thread orchestration loop — or asks what intent-cli can do.
+---
+
+# intent-cli
+
+This skill is a **dispatcher, not a manual**. It tells you which `intent-cli`
+command to ask for the guidance you need. It deliberately restates none of the
+workflow: the installed CLI's `guide` output is the single source of truth, and
+it moves with the tool while a copied-out description would not.
+
+**Rule: installed guide output wins.** If anything you remember — including
+anything in this file — disagrees with what `intent-cli guide ...` prints, the
+guide output is correct. Run the command; do not answer from memory.
+
+## Before anything else
+
+Confirm the tool is available and see what it offers:
+
+```bash
+intent-cli --version
+intent-cli guide model
+```
+
+`guide model` describes the collaboration model the rest of the workflow
+assumes. Read it before acting on any other guidance.
+
+## Which guide command to run
+
+Ask the guide, then follow exactly what it prints.
+
+| The user wants to… | Run |
+| --- | --- |
+| get oriented / set up for the first time | `intent-cli guide onboarding` |
+| see every available command surface | `intent-cli guide commands list` |
+| find the right workflow for a goal | `intent-cli guide workflow suggest --goal "<what they said>"` |
+| shape or deepen an intent | `intent-cli guide collaborate` |
+| interview the user to draw out intent | `intent-cli grill` |
+| decide what to work on next | `intent-cli guide next` |
+| take a slice from issue to PR | `intent-cli guide worker issue-to-pr` |
+| review a pull request | `intent-cli guide review --pr <n> --repo <r> --domain <d>` |
+| close out a merged PR | `intent-cli guide closeout` |
+| run the four-thread orchestration loop | `intent-cli guide orchestrator-thread` |
+| understand the rules that bind a surface | `intent-cli guide rules list` |
+
+When none of these obviously fits, run `intent-cli guide workflow suggest --goal
+"<the user's own words>"` and let it route.
+
+Most guide commands accept `--format markdown|json`. Prefer `markdown` when you
+are going to read and act on the output; `json` when you need to extract a
+specific field.
+
+## How to use what it prints
+
+1. **Run the guide command first.** Do not plan the work from this file.
+2. **Follow its steps literally**, including any preflight or verification it
+   names. Guides state their own gates; skipping one is how a loop breaks.
+3. **Prefer the canonical command it names** over hand-editing files or calling
+   `gh` directly. Where a guide names an `intent-cli` command for a state
+   change, that command is the supported path.
+4. **Report what the command actually returned** — exit code, and the fields the
+   guide told you to check. Do not summarize a result you did not observe.
+
+## Keeping this skill current
+
+This file ships inside the `intent-cli` package. Update it with the tool:
+
+```bash
+intent-cli skill list              # what is installed, and whether it has drifted
+intent-cli skill diff              # what differs between installed and shipped
+intent-cli skill install --target all
+```
+
+`skill install` refuses to overwrite a copy you have edited unless you pass
+`--force`, so local changes are never lost silently.

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -28,7 +28,8 @@ internal static class CommandRouter
         "intent",
         "packet",
         "closeout",
-        "migrate"
+        "migrate",
+        "skill"
     ];
 
     /// <summary>
@@ -105,6 +106,13 @@ internal static class CommandRouter
                 ["next-question"] = InterviewNextQuestionCommand.Execute,
                 ["record-answer"] = InterviewRecordAnswerCommand.Execute,
                 ["compile"] = InterviewCompileCommand.Execute
+            },
+            // G559: cross-platform agent skill install surface.
+            ["skill"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["list"] = SkillCommand.ExecuteList,
+                ["install"] = SkillCommand.ExecuteInstall,
+                ["diff"] = SkillCommand.ExecuteDiff
             },
             ["clarify"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
             {
@@ -550,7 +558,8 @@ internal static class CommandRouter
             ["tasking"] = "`intent-cli tasking handoff` / `task-packet` / `handoff-bundle` (cross-thread tasking; experimental).",
             ["safety"] = "`intent-cli safety nested-provider-handoff` (artifact-only nested-provider handoffs).",
             ["projection"] = "`intent-cli projection generate` / `regenerate` (internal tooling).",
-            ["project"] = "`intent-cli project status` (older surface; prefer `intent status`)."
+            ["project"] = "`intent-cli project status` (older surface; prefer `intent status`).",
+            ["skill"] = "`intent-cli skill list` / `install --target claude|codex|copilot|all [--scope user|repo] [--force]` / `diff` (installs the embedded SKILL.md into each platform's skill location)."
         };
 
     private static void WriteHelp(TextWriter writer) => WriteHelp(writer, includeAll: false);

--- a/src/IntentSystem.Cli/Commands/SkillAssets.cs
+++ b/src/IntentSystem.Cli/Commands/SkillAssets.cs
@@ -1,0 +1,174 @@
+using System.Reflection;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G559: the embedded skill assets and the per-platform install targets.
+///
+/// The skill ships as ONE source — <c>skills/&lt;name&gt;/SKILL.md</c> in the
+/// repository, embedded into the tool package at build — because the field
+/// evidence is that hand-copied skills drift: the operator's own
+/// <c>host-review-loop</c> skill exists as separate copies under
+/// <c>~/.claude/skills</c> and <c>~/.codex/skills</c> and the copies have
+/// already diverged. One embedded source plus an installer that detects drift
+/// is the shape that keeps every platform reading the same file.
+/// </summary>
+internal static class SkillAssets
+{
+    /// <summary>The single embedded skill. A list rather than a constant so a second skill needs no structural change.</summary>
+    public static IReadOnlyList<EmbeddedSkill> All { get; } =
+    [
+        new EmbeddedSkill(
+            Name: "intent-cli",
+            Summary: "Dispatcher skill: routes an agent to the canonical `intent-cli guide ...` surfaces."),
+    ];
+
+    public static EmbeddedSkill? Find(string name) =>
+        All.FirstOrDefault(skill => string.Equals(skill.Name, name, StringComparison.Ordinal));
+
+    /// <summary>
+    /// Reads the embedded SKILL.md body. Throws
+    /// <see cref="InvalidOperationException"/> when the resource is missing —
+    /// a packaging defect the caller must surface rather than paper over with
+    /// an empty install.
+    ///
+    /// The resource name is resolved by matching the skill's directory segment
+    /// rather than by a hardcoded string: MSBuild's <c>%(RecursiveDir)</c>
+    /// keeps a path separator in the logical name, and which separator survives
+    /// depends on the build host. Matching on the parts we control keeps the
+    /// csproj a single glob — a second skill needs no build change.
+    /// </summary>
+    public static string ReadBody(EmbeddedSkill skill)
+    {
+        ArgumentNullException.ThrowIfNull(skill);
+
+        var assembly = typeof(SkillAssets).Assembly;
+        var resourceName = ResolveResourceName(assembly, skill.Name)
+            ?? throw new InvalidOperationException(
+                $"embedded skill resource for '{skill.Name}' is missing from {assembly.GetName().Name}; "
+                + "the package was built without its skill assets. "
+                + $"Available resources: {string.Join(", ", assembly.GetManifestResourceNames())}");
+
+        using var stream = assembly.GetManifestResourceStream(resourceName)!;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    private static string? ResolveResourceName(Assembly assembly, string skillName) =>
+        assembly.GetManifestResourceNames().FirstOrDefault(name =>
+            name.EndsWith("SKILL.md", StringComparison.Ordinal)
+            && name.Contains($".skills.{skillName}", StringComparison.Ordinal));
+}
+
+internal sealed record EmbeddedSkill(string Name, string Summary);
+
+/// <summary>
+/// G559: where each platform reads skills from. Only the LOCATION differs —
+/// all three accept the same SKILL.md, which is why one embedded source can
+/// serve them.
+/// </summary>
+internal static class SkillTargets
+{
+    public const string Claude = "claude";
+    public const string Codex = "codex";
+    public const string Copilot = "copilot";
+    public const string All = "all";
+
+    public const string ScopeUser = "user";
+    public const string ScopeRepo = "repo";
+
+    public static IReadOnlyList<string> Installable { get; } = [Claude, Codex, Copilot];
+
+    /// <summary>
+    /// The scopes each platform actually defines. Codex reads a user-level
+    /// skills directory only, so a repo-scoped request for it is rejected
+    /// rather than silently written somewhere the platform will never look.
+    /// </summary>
+    public static IReadOnlyList<string> SupportedScopes(string target) => target switch
+    {
+        Claude => [ScopeRepo, ScopeUser],
+        Codex => [ScopeUser],
+        Copilot => [ScopeRepo],
+        _ => [],
+    };
+
+    /// <summary>The scope used when the caller does not name one.</summary>
+    public static string DefaultScope(string target) => target switch
+    {
+        Claude => ScopeRepo,
+        Codex => ScopeUser,
+        Copilot => ScopeRepo,
+        _ => ScopeRepo,
+    };
+
+    public static bool IsKnownTarget(string target) =>
+        Installable.Contains(target, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Resolves the SKILL.md path for a target/scope. <paramref name="repoRoot"/>
+    /// anchors repo scope; <paramref name="userHome"/> anchors user scope (a
+    /// parameter rather than an ambient lookup so tests install into a
+    /// temporary home instead of the developer's real one).
+    /// </summary>
+    public static string ResolveSkillFilePath(string target, string scope, string skillName, string repoRoot, string userHome)
+    {
+        var directory = ResolveSkillDirectory(target, scope, skillName, repoRoot, userHome);
+        return Path.Combine(directory, "SKILL.md");
+    }
+
+    public static string ResolveSkillDirectory(string target, string scope, string skillName, string repoRoot, string userHome) =>
+        (target, scope) switch
+        {
+            (Claude, ScopeRepo) => Path.Combine(repoRoot, ".claude", "skills", skillName),
+            (Claude, ScopeUser) => Path.Combine(userHome, ".claude", "skills", skillName),
+            (Codex, ScopeUser) => Path.Combine(userHome, ".codex", "skills", skillName),
+            (Copilot, ScopeRepo) => Path.Combine(repoRoot, ".github", "skills", skillName),
+            _ => throw new InvalidOperationException($"unsupported target/scope combination: {target}/{scope}"),
+        };
+
+    /// <summary>
+    /// Validates a target/scope pair, producing the operator-facing error the
+    /// contract requires for an unsupported combination.
+    /// </summary>
+    public static bool TryValidate(string target, string? scope, out string resolvedScope, out string error)
+    {
+        resolvedScope = string.Empty;
+        error = string.Empty;
+
+        if (!IsKnownTarget(target))
+        {
+            error = $"unknown target '{target}'. Supported: {string.Join(", ", Installable)}, or 'all'.";
+            return false;
+        }
+
+        var supported = SupportedScopes(target);
+        if (string.IsNullOrWhiteSpace(scope))
+        {
+            resolvedScope = DefaultScope(target);
+            return true;
+        }
+
+        if (!supported.Contains(scope, StringComparer.Ordinal))
+        {
+            error =
+                $"target '{target}' does not support scope '{scope}'. "
+                + $"Supported scope(s) for '{target}': {string.Join(", ", supported)}. "
+                + "The scope is the platform's own skill location, not a preference — writing elsewhere "
+                + "would put the file where that platform never looks.";
+            return false;
+        }
+
+        resolvedScope = scope;
+        return true;
+    }
+
+    /// <summary>
+    /// G559: the user home used for user-scoped installs. A settable seam so
+    /// tests never write into the developer's real home directory.
+    /// </summary>
+    public static Func<string>? UserHomeFactory { get; set; }
+
+    public static string ResolveUserHome() =>
+        UserHomeFactory?.Invoke()
+        ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+}

--- a/src/IntentSystem.Cli/Commands/SkillCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SkillCommand.cs
@@ -1,0 +1,601 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G559: <c>intent-cli skill list | install | diff</c> — installs the embedded
+/// single-source SKILL.md into each platform's own skill location.
+///
+/// The installer exists because the format is already shared and only the
+/// LOCATION differs: Claude Code, Codex, and Copilot all read the same
+/// SKILL.md. Copying by hand is what produced the drifted copies this slice
+/// replaces, so the commands here always compare against the embedded source
+/// and never overwrite an edited copy without <c>--force</c>.
+/// </summary>
+internal static class SkillCommand
+{
+    private const string FormatText = "text";
+    private const string FormatJson = "json";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    private const string ListUsage =
+        "Usage: intent-cli skill list [--format text|json]";
+
+    private const string InstallUsage =
+        "Usage: intent-cli skill install --target claude|codex|copilot|all [--scope user|repo] [--skill <name>] [--force] [--format text|json]";
+
+    private const string DiffUsage =
+        "Usage: intent-cli skill diff [--target claude|codex|copilot|all] [--scope user|repo] [--skill <name>] [--format text|json]";
+
+    public static int ExecuteList(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (IsHelp(args))
+        {
+            writer.WriteLine(ListUsage);
+            return 0;
+        }
+
+        if (!TryParseFormat(args, ListUsage, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            return 1;
+        }
+
+        var report = BuildReport(context, skillFilter: null, targetFilter: null, scopeOverride: null, out var reportError);
+        if (report is null)
+        {
+            writer.WriteLine(reportError);
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(report, JsonOptions));
+            return 0;
+        }
+
+        WriteListText(writer, report);
+        return 0;
+    }
+
+    public static int ExecuteInstall(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (IsHelp(args))
+        {
+            writer.WriteLine(InstallUsage);
+            return 0;
+        }
+
+        if (!TryParseInstallArguments(args, out var target, out var scope, out var skillName, out var force, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(InstallUsage);
+            return 1;
+        }
+
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            writer.WriteLine("--target is required (claude, codex, copilot, or all).");
+            writer.WriteLine(InstallUsage);
+            return 1;
+        }
+
+        var skills = ResolveSkills(skillName, out var skillError);
+        if (skills is null)
+        {
+            writer.WriteLine(skillError);
+            return 1;
+        }
+
+        var targets = string.Equals(target, SkillTargets.All, StringComparison.Ordinal)
+            ? SkillTargets.Installable
+            : [target!];
+
+        // Validate every target/scope pair BEFORE writing anything: a partial
+        // install that stops halfway leaves the operator guessing which
+        // platforms are current.
+        var plan = new List<(string Target, string Scope, EmbeddedSkill Skill)>();
+        foreach (var candidate in targets)
+        {
+            if (!SkillTargets.TryValidate(candidate, scope, out var resolvedScope, out var validationError))
+            {
+                // An explicit --scope that a platform does not define is an
+                // error even under --target all: silently skipping it would
+                // report success for an install that never happened.
+                writer.WriteLine(validationError);
+                return 1;
+            }
+
+            foreach (var skill in skills)
+            {
+                plan.Add((candidate, resolvedScope, skill));
+            }
+        }
+
+        var repoRoot = context.RepoRoot;
+        var userHome = SkillTargets.ResolveUserHome();
+        var results = new List<SkillInstallResult>();
+        var blocked = false;
+
+        foreach (var (candidateTarget, candidateScope, skill) in plan)
+        {
+            var path = SkillTargets.ResolveSkillFilePath(candidateTarget, candidateScope, skill.Name, repoRoot, userHome);
+            var embedded = SkillAssets.ReadBody(skill);
+            var state = InspectState(path, embedded);
+
+            if (state == SkillState.Drifted && !force)
+            {
+                results.Add(new SkillInstallResult
+                {
+                    Skill = skill.Name,
+                    Target = candidateTarget,
+                    Scope = candidateScope,
+                    Path = path,
+                    Outcome = "refused-drifted",
+                    Detail =
+                        "the installed copy differs from the embedded skill and was NOT overwritten. "
+                        + "Re-run with --force to replace it, or run `intent-cli skill diff` to see what differs.",
+                });
+                blocked = true;
+                continue;
+            }
+
+            if (state == SkillState.Current)
+            {
+                results.Add(new SkillInstallResult
+                {
+                    Skill = skill.Name,
+                    Target = candidateTarget,
+                    Scope = candidateScope,
+                    Path = path,
+                    Outcome = "already-current",
+                    Detail = "the installed copy already matches the embedded skill; nothing was written.",
+                });
+                continue;
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, embedded);
+            results.Add(new SkillInstallResult
+            {
+                Skill = skill.Name,
+                Target = candidateTarget,
+                Scope = candidateScope,
+                Path = path,
+                Outcome = state == SkillState.NotInstalled ? "installed" : "overwritten",
+                Detail = state == SkillState.NotInstalled
+                    ? "written for the first time."
+                    : "an edited copy was replaced because --force was given.",
+            });
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(new SkillInstallReport { Results = results }, JsonOptions));
+        }
+        else
+        {
+            foreach (var result in results)
+            {
+                writer.WriteLine($"- {result.Skill} → {result.Target} ({result.Scope}): {result.Outcome} — {result.Path}");
+                writer.WriteLine($"  {result.Detail}");
+            }
+        }
+
+        // A refusal is a non-zero exit: the caller asked for an install that
+        // did not fully happen, and a script must be able to notice.
+        return blocked ? 1 : 0;
+    }
+
+    public static int ExecuteDiff(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (IsHelp(args))
+        {
+            writer.WriteLine(DiffUsage);
+            return 0;
+        }
+
+        if (!TryParseInstallArguments(args, out var target, out var scope, out var skillName, out _, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(DiffUsage);
+            return 1;
+        }
+
+        var report = BuildReport(context, skillName, target, scope, out var reportError);
+        if (report is null)
+        {
+            writer.WriteLine(reportError);
+            return 1;
+        }
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(report, JsonOptions));
+            return 0;
+        }
+
+        foreach (var skill in report.Skills)
+        {
+            foreach (var installation in skill.Installations)
+            {
+                writer.WriteLine($"## {skill.Name} → {installation.Target} ({installation.Scope}) — {installation.State}");
+                writer.WriteLine($"- path: {installation.Path}");
+                if (installation.Diff is { Count: > 0 })
+                {
+                    foreach (var line in installation.Diff)
+                    {
+                        writer.WriteLine(line);
+                    }
+                }
+                writer.WriteLine();
+            }
+        }
+
+        return 0;
+    }
+
+    private static SkillReport? BuildReport(
+        CliContext context, string? skillFilter, string? targetFilter, string? scopeOverride, out string error)
+    {
+        error = string.Empty;
+
+        var skills = ResolveSkills(skillFilter, out var skillError);
+        if (skills is null)
+        {
+            error = skillError;
+            return null;
+        }
+
+        var targets = string.IsNullOrWhiteSpace(targetFilter) || string.Equals(targetFilter, SkillTargets.All, StringComparison.Ordinal)
+            ? SkillTargets.Installable
+            : [targetFilter!];
+
+        var repoRoot = context.RepoRoot;
+        var userHome = SkillTargets.ResolveUserHome();
+        var entries = new List<SkillReportEntry>();
+
+        foreach (var skill in skills)
+        {
+            var embedded = SkillAssets.ReadBody(skill);
+            var installations = new List<SkillInstallationState>();
+
+            foreach (var candidate in targets)
+            {
+                if (!SkillTargets.TryValidate(candidate, scopeOverride, out var resolvedScope, out var validationError))
+                {
+                    error = validationError;
+                    return null;
+                }
+
+                // Report every scope the platform defines unless one was named,
+                // so `skill list` shows a repo-scoped Claude install and a
+                // user-scoped one as the distinct things they are.
+                var scopes = string.IsNullOrWhiteSpace(scopeOverride)
+                    ? SkillTargets.SupportedScopes(candidate)
+                    : [resolvedScope];
+
+                foreach (var candidateScope in scopes)
+                {
+                    var path = SkillTargets.ResolveSkillFilePath(candidate, candidateScope, skill.Name, repoRoot, userHome);
+                    var state = InspectState(path, embedded);
+                    installations.Add(new SkillInstallationState
+                    {
+                        Target = candidate,
+                        Scope = candidateScope,
+                        Path = path,
+                        State = Describe(state),
+                        Diff = state == SkillState.Drifted ? BuildDiff(embedded, File.ReadAllText(path)) : null,
+                    });
+                }
+            }
+
+            entries.Add(new SkillReportEntry
+            {
+                Name = skill.Name,
+                Summary = skill.Summary,
+                Installations = installations,
+            });
+        }
+
+        return new SkillReport { Skills = entries };
+    }
+
+    private static IReadOnlyList<EmbeddedSkill>? ResolveSkills(string? name, out string error)
+    {
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return SkillAssets.All;
+        }
+
+        var skill = SkillAssets.Find(name!);
+        if (skill is null)
+        {
+            error = $"unknown skill '{name}'. Embedded skill(s): {string.Join(", ", SkillAssets.All.Select(s => s.Name))}.";
+            return null;
+        }
+
+        return [skill];
+    }
+
+    private static SkillState InspectState(string path, string embedded)
+    {
+        if (!File.Exists(path))
+        {
+            return SkillState.NotInstalled;
+        }
+
+        var installed = File.ReadAllText(path);
+        return Normalize(installed) == Normalize(embedded) ? SkillState.Current : SkillState.Drifted;
+    }
+
+    /// <summary>
+    /// Line-ending differences are not drift — a checkout on Windows would
+    /// otherwise report every install as edited.
+    /// </summary>
+    private static string Normalize(string content) =>
+        content.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd('\n');
+
+    private static string Describe(SkillState state) => state switch
+    {
+        SkillState.NotInstalled => "not-installed",
+        SkillState.Current => "installed",
+        _ => "drifted",
+    };
+
+    /// <summary>
+    /// A minimal line-level diff: enough for an operator to see WHAT differs
+    /// without pulling in a diff library for a file this small.
+    /// </summary>
+    private static IReadOnlyList<string> BuildDiff(string embedded, string installed)
+    {
+        var embeddedLines = Normalize(embedded).Split('\n');
+        var installedLines = Normalize(installed).Split('\n');
+        var lines = new List<string>();
+
+        for (var index = 0; index < Math.Max(embeddedLines.Length, installedLines.Length); index++)
+        {
+            var left = index < embeddedLines.Length ? embeddedLines[index] : null;
+            var right = index < installedLines.Length ? installedLines[index] : null;
+
+            if (string.Equals(left, right, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (right is not null)
+            {
+                lines.Add($"- installed:{index + 1}: {right}");
+            }
+
+            if (left is not null)
+            {
+                lines.Add($"+ embedded:{index + 1}: {left}");
+            }
+        }
+
+        return lines;
+    }
+
+    private static void WriteListText(TextWriter writer, SkillReport report)
+    {
+        foreach (var skill in report.Skills)
+        {
+            writer.WriteLine($"# {skill.Name}");
+            writer.WriteLine($"- summary: {skill.Summary}");
+            foreach (var installation in skill.Installations)
+            {
+                writer.WriteLine($"- {installation.Target} ({installation.Scope}): {installation.State} — {installation.Path}");
+            }
+
+            writer.WriteLine();
+        }
+    }
+
+    private static bool IsHelp(string[] args) =>
+        args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal);
+
+    private static bool TryParseFormat(string[] args, string usage, out string format, out string error)
+    {
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            if (!string.Equals(args[index], "--format", StringComparison.Ordinal))
+            {
+                error = $"Unknown argument '{args[index]}'. {usage}";
+                return false;
+            }
+
+            if (index + 1 >= args.Length)
+            {
+                error = "--format requires a value (text or json).";
+                return false;
+            }
+
+            format = args[index + 1];
+            index++;
+
+            if (!string.Equals(format, FormatText, StringComparison.Ordinal)
+                && !string.Equals(format, FormatJson, StringComparison.Ordinal))
+            {
+                error = $"unknown format '{format}'. Supported: text, json.";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryParseInstallArguments(
+        string[] args,
+        out string? target,
+        out string? scope,
+        out string? skill,
+        out bool force,
+        out string format,
+        out string error)
+    {
+        target = null;
+        scope = null;
+        skill = null;
+        force = false;
+        format = FormatText;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--force":
+                    force = true;
+                    break;
+
+                case "--target":
+                case "--scope":
+                case "--skill":
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = $"{argument} requires a value.";
+                        return false;
+                    }
+
+                    var value = args[index + 1];
+                    index++;
+                    switch (argument)
+                    {
+                        case "--target":
+                            target = value;
+                            break;
+                        case "--scope":
+                            scope = value;
+                            break;
+                        case "--skill":
+                            skill = value;
+                            break;
+                        default:
+                            format = value;
+                            break;
+                    }
+
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (!string.Equals(format, FormatText, StringComparison.Ordinal)
+            && !string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            error = $"unknown format '{format}'. Supported: text, json.";
+            return false;
+        }
+
+        if (scope is not null
+            && !string.Equals(scope, SkillTargets.ScopeUser, StringComparison.Ordinal)
+            && !string.Equals(scope, SkillTargets.ScopeRepo, StringComparison.Ordinal))
+        {
+            error = $"unknown scope '{scope}'. Supported: {SkillTargets.ScopeUser}, {SkillTargets.ScopeRepo}.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private enum SkillState
+    {
+        NotInstalled,
+        Current,
+        Drifted,
+    }
+}
+
+internal sealed record SkillReport
+{
+    [JsonPropertyName("skills")]
+    public required IReadOnlyList<SkillReportEntry> Skills { get; init; }
+}
+
+internal sealed record SkillReportEntry
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("installations")]
+    public required IReadOnlyList<SkillInstallationState> Installations { get; init; }
+}
+
+internal sealed record SkillInstallationState
+{
+    [JsonPropertyName("target")]
+    public required string Target { get; init; }
+
+    [JsonPropertyName("scope")]
+    public required string Scope { get; init; }
+
+    [JsonPropertyName("path")]
+    public required string Path { get; init; }
+
+    /// <summary>One of <c>not-installed</c>, <c>installed</c>, <c>drifted</c>.</summary>
+    [JsonPropertyName("state")]
+    public required string State { get; init; }
+
+    [JsonPropertyName("diff")]
+    public IReadOnlyList<string>? Diff { get; init; }
+}
+
+internal sealed record SkillInstallReport
+{
+    [JsonPropertyName("results")]
+    public required IReadOnlyList<SkillInstallResult> Results { get; init; }
+}
+
+internal sealed record SkillInstallResult
+{
+    [JsonPropertyName("skill")]
+    public required string Skill { get; init; }
+
+    [JsonPropertyName("target")]
+    public required string Target { get; init; }
+
+    [JsonPropertyName("scope")]
+    public required string Scope { get; init; }
+
+    [JsonPropertyName("path")]
+    public required string Path { get; init; }
+
+    /// <summary>One of <c>installed</c>, <c>overwritten</c>, <c>already-current</c>, <c>refused-drifted</c>.</summary>
+    [JsonPropertyName("outcome")]
+    public required string Outcome { get; init; }
+
+    [JsonPropertyName("detail")]
+    public required string Detail { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/SkillCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SkillCommand.cs
@@ -105,9 +105,7 @@ internal static class SkillCommand
             ? SkillTargets.Installable
             : [target!];
 
-        // Validate every target/scope pair BEFORE writing anything: a partial
-        // install that stops halfway leaves the operator guessing which
-        // platforms are current.
+        // PHASE 1 (a): validate every target/scope pair.
         var plan = new List<(string Target, string Scope, EmbeddedSkill Skill)>();
         foreach (var candidate in targets)
         {
@@ -128,61 +126,89 @@ internal static class SkillCommand
 
         var repoRoot = context.RepoRoot;
         var userHome = SkillTargets.ResolveUserHome();
+
+        // PHASE 1 (b): resolve every destination, read every embedded body, and
+        // inspect every planned path — all BEFORE the first write. Inspecting
+        // and writing in the same loop is not "validated before any write": an
+        // earlier missing target would already be on disk by the time a later
+        // drifted one was discovered, leaving a partial install behind an
+        // exit-1 that claims nothing happened.
+        var inspected = plan
+            .Select(entry =>
+            {
+                var path = SkillTargets.ResolveSkillFilePath(entry.Target, entry.Scope, entry.Skill.Name, repoRoot, userHome);
+                var embedded = SkillAssets.ReadBody(entry.Skill);
+                return (entry.Target, entry.Scope, entry.Skill, Path: path, Embedded: embedded, State: InspectState(path, embedded));
+            })
+            .ToList();
+
         var results = new List<SkillInstallResult>();
-        var blocked = false;
 
-        foreach (var (candidateTarget, candidateScope, skill) in plan)
+        // PHASE 2: a drifted destination anywhere in the plan aborts the WHOLE
+        // run without touching the filesystem. --force is the opt-in that turns
+        // every drifted destination into an overwrite instead.
+        if (!force && inspected.Any(entry => entry.State == SkillState.Drifted))
         {
-            var path = SkillTargets.ResolveSkillFilePath(candidateTarget, candidateScope, skill.Name, repoRoot, userHome);
-            var embedded = SkillAssets.ReadBody(skill);
-            var state = InspectState(path, embedded);
-
-            if (state == SkillState.Drifted && !force)
+            foreach (var entry in inspected)
             {
                 results.Add(new SkillInstallResult
                 {
-                    Skill = skill.Name,
-                    Target = candidateTarget,
-                    Scope = candidateScope,
-                    Path = path,
-                    Outcome = "refused-drifted",
-                    Detail =
-                        "the installed copy differs from the embedded skill and was NOT overwritten. "
-                        + "Re-run with --force to replace it, or run `intent-cli skill diff` to see what differs.",
+                    Skill = entry.Skill.Name,
+                    Target = entry.Target,
+                    Scope = entry.Scope,
+                    Path = entry.Path,
+                    Outcome = entry.State == SkillState.Drifted ? "refused-drifted" : "skipped-plan-aborted",
+                    Detail = entry.State == SkillState.Drifted
+                        ? "the installed copy differs from the embedded skill and was NOT overwritten. "
+                          + "Re-run with --force to replace it, or run `intent-cli skill diff` to see what differs."
+                        : "not written: another destination in this plan has an edited copy, so the whole "
+                          + "install was abandoned before any file was created or changed.",
                 });
-                blocked = true;
-                continue;
             }
 
-            if (state == SkillState.Current)
+            WriteInstallResults(writer, format, results);
+            return 1;
+        }
+
+        // PHASE 3: every destination is now known to be writable, so the writes
+        // that follow cannot be interrupted by a refusal.
+        foreach (var entry in inspected)
+        {
+            if (entry.State == SkillState.Current)
             {
                 results.Add(new SkillInstallResult
                 {
-                    Skill = skill.Name,
-                    Target = candidateTarget,
-                    Scope = candidateScope,
-                    Path = path,
+                    Skill = entry.Skill.Name,
+                    Target = entry.Target,
+                    Scope = entry.Scope,
+                    Path = entry.Path,
                     Outcome = "already-current",
                     Detail = "the installed copy already matches the embedded skill; nothing was written.",
                 });
                 continue;
             }
 
-            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-            File.WriteAllText(path, embedded);
+            Directory.CreateDirectory(Path.GetDirectoryName(entry.Path)!);
+            File.WriteAllText(entry.Path, entry.Embedded);
             results.Add(new SkillInstallResult
             {
-                Skill = skill.Name,
-                Target = candidateTarget,
-                Scope = candidateScope,
-                Path = path,
-                Outcome = state == SkillState.NotInstalled ? "installed" : "overwritten",
-                Detail = state == SkillState.NotInstalled
+                Skill = entry.Skill.Name,
+                Target = entry.Target,
+                Scope = entry.Scope,
+                Path = entry.Path,
+                Outcome = entry.State == SkillState.NotInstalled ? "installed" : "overwritten",
+                Detail = entry.State == SkillState.NotInstalled
                     ? "written for the first time."
                     : "an edited copy was replaced because --force was given.",
             });
         }
 
+        WriteInstallResults(writer, format, results);
+        return 0;
+    }
+
+    private static void WriteInstallResults(TextWriter writer, string format, IReadOnlyList<SkillInstallResult> results)
+    {
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
             writer.WriteLine(JsonSerializer.Serialize(new SkillInstallReport { Results = results }, JsonOptions));
@@ -195,10 +221,6 @@ internal static class SkillCommand
                 writer.WriteLine($"  {result.Detail}");
             }
         }
-
-        // A refusal is a non-zero exit: the caller asked for an install that
-        // did not fully happen, and a script must be able to notice.
-        return blocked ? 1 : 0;
     }
 
     public static int ExecuteDiff(CliContext context, string[] args, TextWriter writer)
@@ -592,7 +614,12 @@ internal sealed record SkillInstallResult
     [JsonPropertyName("path")]
     public required string Path { get; init; }
 
-    /// <summary>One of <c>installed</c>, <c>overwritten</c>, <c>already-current</c>, <c>refused-drifted</c>.</summary>
+    /// <summary>
+    /// One of <c>installed</c>, <c>overwritten</c>, <c>already-current</c>,
+    /// <c>refused-drifted</c>, or <c>skipped-plan-aborted</c> — the last one
+    /// meaning this destination was writable but a sibling in the same plan was
+    /// drifted, so nothing at all was written.
+    /// </summary>
     [JsonPropertyName("outcome")]
     public required string Outcome { get; init; }
 

--- a/src/IntentSystem.Cli/IntentSystem.Cli.csproj
+++ b/src/IntentSystem.Cli/IntentSystem.Cli.csproj
@@ -90,6 +90,19 @@
   </PropertyGroup>
 
   <!--
+    G559: the skill ships as ONE source. `skills/<name>/SKILL.md` in the
+    repository is embedded into the tool package so `intent-cli skill install`
+    writes the same bytes to every platform's own skill location. The logical
+    resource name keeps the repo-relative shape
+    (IntentSystem.Cli.skills.<name>.SKILL.md) so a second skill needs no
+    csproj change.
+  -->
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildProjectDirectory)/../../skills/**/SKILL.md" LogicalName="IntentSystem.Cli.skills.%(RecursiveDir)SKILL.md" />
+  </ItemGroup>
+
+
+  <!--
     G378: derive the latest implemented intent-system execution unit from
     source-controlled git history at build time, replacing the previous
     stale hard-coded `G360` fallback. The latest merged unit is the

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -47,6 +47,7 @@ internal static class Program
                 || IsNextCommand(args)
                 || IsInspectCommand(args)
                 || IsWorkerCommand(args)
+                || IsSkillCommand(args)
                 || IsHelpCommand(args))
             {
                 return CommandRouter.Execute(args, CreateBootstrapContext(currentDirectory, args), Console.Out);
@@ -119,6 +120,20 @@ internal static class Program
                 || string.Equals(args[1], "stalled-work", StringComparison.Ordinal)
                 || string.Equals(args[1], "summary", StringComparison.Ordinal)
                 || string.Equals(args[1], "workspace-guard", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// G559: the <c>skill</c> group is the on-ramp — a newcomer runs
+    /// <c>intent-cli skill install</c> in a fresh repository that has no
+    /// <c>.intent-cli/</c> at all, which is the entire point of shipping a
+    /// skill. It reads only the embedded asset and the platform skill
+    /// directories, never parent durable state, so it must bootstrap from any
+    /// cwd rather than fail the host-state gate and send a first-time user to
+    /// a recovery command.
+    /// </summary>
+    private static bool IsSkillCommand(string[] args)
+    {
+        return args.Length >= 1 && string.Equals(args[0], "skill", StringComparison.Ordinal);
     }
 
     private static bool IsGuideOneshotCommand(string[] args)

--- a/tests/IntentSystem.Cli.Tests/SkillCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/SkillCommandTests.cs
@@ -128,6 +128,71 @@ public sealed class SkillCommandTests
     }
 
     [Fact]
+    public void TargetAll_WithADriftedDestinationAnywhere_WritesNothingAtAll_G559()
+    {
+        using var workspace = new SkillWorkspace();
+
+        // The plan order is claude → codex → copilot, so this is the shape the
+        // per-item loop got wrong: an EARLIER missing target, a LATER drifted
+        // one, and another missing target after it. Inspecting and writing in
+        // one pass installed claude, refused codex, installed copilot, and then
+        // exited 1 — a partial install behind an exit code that claims nothing
+        // happened.
+        var claude = Path.Combine(workspace.RepoRoot, ".claude", "skills", "intent-cli", "SKILL.md");
+        var codex = Path.Combine(workspace.UserHome, ".codex", "skills", "intent-cli", "SKILL.md");
+        var copilot = Path.Combine(workspace.RepoRoot, ".github", "skills", "intent-cli", "SKILL.md");
+
+        var edited = "an operator's own copy, deliberately different\n";
+        Directory.CreateDirectory(Path.GetDirectoryName(codex)!);
+        File.WriteAllText(codex, edited);
+
+        var exit = workspace.Install(["--target", "all"], out var output);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("refused-drifted", output, StringComparison.Ordinal);
+        Assert.Contains("skipped-plan-aborted", output, StringComparison.Ordinal);
+
+        // The drifted file is byte-identical, and neither missing destination
+        // was created — not even its directory.
+        Assert.Equal(edited, File.ReadAllText(codex));
+        Assert.False(File.Exists(claude), $"claude must not have been written: {output}");
+        Assert.False(File.Exists(copilot), $"copilot must not have been written: {output}");
+        Assert.False(Directory.Exists(Path.GetDirectoryName(claude)!), output);
+        Assert.False(Directory.Exists(Path.GetDirectoryName(copilot)!), output);
+    }
+
+    [Fact]
+    public void TargetAllWithForce_InstallsEveryDestination_IncludingTheDriftedOne_G559()
+    {
+        using var workspace = new SkillWorkspace();
+
+        var codex = Path.Combine(workspace.UserHome, ".codex", "skills", "intent-cli", "SKILL.md");
+        Directory.CreateDirectory(Path.GetDirectoryName(codex)!);
+        File.WriteAllText(codex, "an operator's own copy, deliberately different\n");
+
+        var exit = workspace.Install(["--target", "all", "--force"], out var output);
+
+        // --force is the opt-in that makes the same plan succeed end to end:
+        // the abort must not survive as a --force regression.
+        Assert.Equal(0, exit);
+        Assert.Contains("overwritten", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("refused-drifted", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("skipped-plan-aborted", output, StringComparison.Ordinal);
+
+        var embedded = Normalize(SkillAssets.ReadBody(SkillAssets.Find("intent-cli")!));
+        foreach (var path in new[]
+                 {
+                     Path.Combine(workspace.RepoRoot, ".claude", "skills", "intent-cli", "SKILL.md"),
+                     codex,
+                     Path.Combine(workspace.RepoRoot, ".github", "skills", "intent-cli", "SKILL.md"),
+                 })
+        {
+            Assert.True(File.Exists(path), $"expected {path}. Output:\n{output}");
+            Assert.Equal(embedded, Normalize(File.ReadAllText(path)));
+        }
+    }
+
+    [Fact]
     public void Force_ReplacesAnEditedCopy_G559()
     {
         using var workspace = new SkillWorkspace();

--- a/tests/IntentSystem.Cli.Tests/SkillCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/SkillCommandTests.cs
@@ -1,0 +1,337 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G559: the cross-platform agent skill install surface.
+///
+/// The tests exercise the installer's actual writes rather than its wording:
+/// what matters is that each platform's own location receives the embedded
+/// file, that an edited copy is never replaced silently, and that a scope a
+/// platform does not define is refused instead of written somewhere that
+/// platform will never read.
+/// </summary>
+public sealed class SkillCommandTests
+{
+    [Fact]
+    public void EmbeddedSkill_IsTheRepositoryFile_SoThereIsOneSource_G559()
+    {
+        var repoFile = Path.Combine(RepoRoot(), "skills", "intent-cli", "SKILL.md");
+        Assert.True(File.Exists(repoFile), $"expected the single skill source at {repoFile}");
+
+        var skill = SkillAssets.Find("intent-cli");
+        Assert.NotNull(skill);
+
+        // Reading the embedded resource is the proof that the build actually
+        // packaged it: a missing asset throws here rather than shipping an
+        // installer that writes nothing.
+        var embedded = SkillAssets.ReadBody(skill!);
+        Assert.Equal(Normalize(File.ReadAllText(repoFile)), Normalize(embedded));
+    }
+
+    [Fact]
+    public void Skill_IsADispatcher_AndDefersToInstalledGuideOutput_G559()
+    {
+        var body = SkillAssets.ReadBody(SkillAssets.Find("intent-cli")!);
+
+        // The whole point of the thin dispatcher is that it does not restate
+        // the workflow: it must say so, and it must route to guide surfaces.
+        Assert.Contains("dispatcher", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli guide model", body, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide workflow suggest", body, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide worker issue-to-pr", body, StringComparison.Ordinal);
+        Assert.Contains("intent-cli guide review", body, StringComparison.Ordinal);
+
+        // "installed guide output wins" is the rule that keeps a stale copy
+        // from overriding the tool the agent is actually running.
+        Assert.Contains("guide output", body, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli skill install", body, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("claude", null, new[] { ".claude", "skills", "intent-cli", "SKILL.md" }, false)]
+    [InlineData("claude", "repo", new[] { ".claude", "skills", "intent-cli", "SKILL.md" }, false)]
+    [InlineData("claude", "user", new[] { ".claude", "skills", "intent-cli", "SKILL.md" }, true)]
+    [InlineData("codex", null, new[] { ".codex", "skills", "intent-cli", "SKILL.md" }, true)]
+    [InlineData("codex", "user", new[] { ".codex", "skills", "intent-cli", "SKILL.md" }, true)]
+    [InlineData("copilot", null, new[] { ".github", "skills", "intent-cli", "SKILL.md" }, false)]
+    [InlineData("copilot", "repo", new[] { ".github", "skills", "intent-cli", "SKILL.md" }, false)]
+    public void Install_WritesTheEmbeddedSkill_IntoEachPlatformsOwnLocation_G559(
+        string target, string? scope, string[] relativePath, bool underUserHome)
+    {
+        using var workspace = new SkillWorkspace();
+
+        var args = scope is null ? new[] { "--target", target } : ["--target", target, "--scope", scope];
+        var exit = workspace.Install(args, out var output);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("installed", output, StringComparison.Ordinal);
+
+        var expected = Path.Combine(
+            [underUserHome ? workspace.UserHome : workspace.RepoRoot, .. relativePath]);
+        Assert.True(File.Exists(expected), $"expected the skill at {expected}. Output:\n{output}");
+        Assert.Equal(
+            Normalize(SkillAssets.ReadBody(SkillAssets.Find("intent-cli")!)),
+            Normalize(File.ReadAllText(expected)));
+    }
+
+    [Fact]
+    public void InstallTargetAll_ReachesEveryPlatform_InOnePass_G559()
+    {
+        using var workspace = new SkillWorkspace();
+
+        var exit = workspace.Install(["--target", "all"], out var output);
+
+        Assert.Equal(0, exit);
+        Assert.True(File.Exists(Path.Combine(workspace.RepoRoot, ".claude", "skills", "intent-cli", "SKILL.md")), output);
+        Assert.True(File.Exists(Path.Combine(workspace.UserHome, ".codex", "skills", "intent-cli", "SKILL.md")), output);
+        Assert.True(File.Exists(Path.Combine(workspace.RepoRoot, ".github", "skills", "intent-cli", "SKILL.md")), output);
+    }
+
+    [Fact]
+    public void ReinstallingAnUnchangedCopy_WritesNothing_G559()
+    {
+        using var workspace = new SkillWorkspace();
+        Assert.Equal(0, workspace.Install(["--target", "copilot"], out _));
+
+        var path = Path.Combine(workspace.RepoRoot, ".github", "skills", "intent-cli", "SKILL.md");
+        var stamp = File.GetLastWriteTimeUtc(path);
+
+        var exit = workspace.Install(["--target", "copilot"], out var output);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("already-current", output, StringComparison.Ordinal);
+        Assert.Equal(stamp, File.GetLastWriteTimeUtc(path));
+    }
+
+    [Fact]
+    public void AnEditedCopy_IsRefused_AndLeftExactlyAsTheOperatorLeftIt_G559()
+    {
+        using var workspace = new SkillWorkspace();
+        Assert.Equal(0, workspace.Install(["--target", "copilot"], out _));
+
+        var path = Path.Combine(workspace.RepoRoot, ".github", "skills", "intent-cli", "SKILL.md");
+        var edited = File.ReadAllText(path) + "\nLocal note the operator added.\n";
+        File.WriteAllText(path, edited);
+
+        var exit = workspace.Install(["--target", "copilot"], out var output);
+
+        // Refusing is only useful if it is observable to a script AND the file
+        // is genuinely untouched.
+        Assert.Equal(1, exit);
+        Assert.Contains("refused-drifted", output, StringComparison.Ordinal);
+        Assert.Equal(edited, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void Force_ReplacesAnEditedCopy_G559()
+    {
+        using var workspace = new SkillWorkspace();
+        Assert.Equal(0, workspace.Install(["--target", "copilot"], out _));
+
+        var path = Path.Combine(workspace.RepoRoot, ".github", "skills", "intent-cli", "SKILL.md");
+        File.WriteAllText(path, "replaced by hand\n");
+
+        var exit = workspace.Install(["--target", "copilot", "--force"], out var output);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("overwritten", output, StringComparison.Ordinal);
+        Assert.Equal(
+            Normalize(SkillAssets.ReadBody(SkillAssets.Find("intent-cli")!)),
+            Normalize(File.ReadAllText(path)));
+    }
+
+    [Fact]
+    public void LineEndingDifferencesAreNotDrift_G559()
+    {
+        using var workspace = new SkillWorkspace();
+        Assert.Equal(0, workspace.Install(["--target", "copilot"], out _));
+
+        var path = Path.Combine(workspace.RepoRoot, ".github", "skills", "intent-cli", "SKILL.md");
+        File.WriteAllText(path, File.ReadAllText(path).Replace("\n", "\r\n", StringComparison.Ordinal));
+
+        var exit = workspace.Install(["--target", "copilot"], out var output);
+
+        // A Windows checkout must not report every install as edited.
+        Assert.Equal(0, exit);
+        Assert.Contains("already-current", output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("codex", "repo")]
+    [InlineData("copilot", "user")]
+    public void AScopeThePlatformDoesNotDefine_IsRefused_WithoutWritingAnything_G559(string target, string scope)
+    {
+        using var workspace = new SkillWorkspace();
+
+        var exit = workspace.Install(["--target", target, "--scope", scope], out var output);
+
+        Assert.Equal(1, exit);
+        Assert.Contains($"does not support scope '{scope}'", output, StringComparison.Ordinal);
+        Assert.Empty(FindSkillFiles(workspace.RepoRoot));
+        Assert.Empty(FindSkillFiles(workspace.UserHome));
+    }
+
+    [Fact]
+    public void AnUnsupportedScopeUnderTargetAll_FailsTheWholeRun_RatherThanPartiallyInstalling_G559()
+    {
+        using var workspace = new SkillWorkspace();
+
+        // `--scope repo` is valid for claude and copilot but not for codex.
+        // Skipping codex silently would report success for an install the
+        // operator never got, so the plan is validated before any write.
+        var exit = workspace.Install(["--target", "all", "--scope", "repo"], out var output);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("codex", output, StringComparison.Ordinal);
+        Assert.Empty(FindSkillFiles(workspace.RepoRoot));
+        Assert.Empty(FindSkillFiles(workspace.UserHome));
+    }
+
+    [Fact]
+    public void UnknownTarget_IsRejected_G559()
+    {
+        using var workspace = new SkillWorkspace();
+
+        var exit = workspace.Install(["--target", "vscode"], out var output);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("unknown target 'vscode'", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InstallWithoutATarget_IsRejected_G559()
+    {
+        using var workspace = new SkillWorkspace();
+
+        var exit = workspace.Install([], out var output);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--target is required", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void List_ReportsEveryScopeAPlatformDefines_AndItsInstalledState_G559()
+    {
+        using var workspace = new SkillWorkspace();
+        Assert.Equal(0, workspace.Install(["--target", "copilot"], out _));
+
+        var exit = workspace.Run(SkillCommand.ExecuteList, ["--format", "json"], out var output);
+        Assert.Equal(0, exit);
+
+        using var document = JsonDocument.Parse(output);
+        var installations = document.RootElement
+            .GetProperty("skills")[0]
+            .GetProperty("installations")
+            .EnumerateArray()
+            .Select(element => (
+                Target: element.GetProperty("target").GetString(),
+                Scope: element.GetProperty("scope").GetString(),
+                State: element.GetProperty("state").GetString()))
+            .ToList();
+
+        // Claude reads both a repo-scoped and a user-scoped directory; listing
+        // only one would hide an install the agent is actually loading.
+        Assert.Contains(("claude", "repo", "not-installed"), installations);
+        Assert.Contains(("claude", "user", "not-installed"), installations);
+        Assert.Contains(("codex", "user", "not-installed"), installations);
+        Assert.Contains(("copilot", "repo", "installed"), installations);
+    }
+
+    [Fact]
+    public void Diff_ShowsWhatDiffers_WhenACopyHasDrifted_G559()
+    {
+        using var workspace = new SkillWorkspace();
+        Assert.Equal(0, workspace.Install(["--target", "copilot"], out _));
+
+        var path = Path.Combine(workspace.RepoRoot, ".github", "skills", "intent-cli", "SKILL.md");
+        File.WriteAllText(path, File.ReadAllText(path) + "\nOperator addition worth seeing.\n");
+
+        var exit = workspace.Run(SkillCommand.ExecuteDiff, ["--target", "copilot"], out var output);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("drifted", output, StringComparison.Ordinal);
+        Assert.Contains("Operator addition worth seeing.", output, StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyList<string> FindSkillFiles(string root) =>
+        Directory.Exists(root)
+            ? Directory.GetFiles(root, "SKILL.md", SearchOption.AllDirectories)
+            : [];
+
+    private static string Normalize(string content) =>
+        content.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd('\n');
+
+    private static string RepoRoot() => RepoVersionPolicySource.RepoRoot();
+
+    /// <summary>
+    /// A throwaway repo root plus a throwaway user home. User-scoped installs
+    /// write under a real home directory in production, so the tests redirect
+    /// that seam rather than touching the developer's own skills.
+    /// </summary>
+    private sealed class SkillWorkspace : IDisposable
+    {
+        private readonly string _root;
+        private readonly Func<string>? _previousUserHome;
+
+        public SkillWorkspace()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "intent-cli-skill-tests", Guid.NewGuid().ToString("n"));
+            RepoRoot = Path.Combine(_root, "repo");
+            UserHome = Path.Combine(_root, "home");
+            Directory.CreateDirectory(RepoRoot);
+            Directory.CreateDirectory(UserHome);
+
+            _previousUserHome = SkillTargets.UserHomeFactory;
+            SkillTargets.UserHomeFactory = () => UserHome;
+        }
+
+        public string RepoRoot { get; }
+
+        public string UserHome { get; }
+
+        public int Install(string[] args, out string output) =>
+            Run(SkillCommand.ExecuteInstall, args, out output);
+
+        public int Run(Func<CliContext, string[], TextWriter, int> command, string[] args, out string output)
+        {
+            var builder = new StringBuilder();
+            using var writer = new StringWriter(builder);
+            var exit = command(BuildContext(), args, writer);
+            output = builder.ToString();
+            return exit;
+        }
+
+        public void Dispose()
+        {
+            SkillTargets.UserHomeFactory = _previousUserHome;
+
+            try
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A leftover temp directory is not worth failing a test over.
+            }
+        }
+
+        private CliContext BuildContext() => new()
+        {
+            RepoRoot = RepoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #1223

## Why

Claude Code, Codex, and Copilot all read the **same** `SKILL.md` format — only the *location* differs. That is exactly why the file gets hand-copied, and hand-copied skills drift. The evidence is in this project's own host: `host-review-loop` exists as two already-divergent copies under `~/.claude/skills` and `~/.codex/skills`. Two files claiming to be the same skill, neither authoritative, is worse than no skill at all — an agent follows the stale one and reports a workflow the tool no longer runs.

## What

One source: `skills/intent-cli/SKILL.md`, embedded into the tool package at build. One installer that puts it in each platform's own location:

```bash
intent-cli skill list                    # every target/scope and its state
intent-cli skill install --target all
intent-cli skill diff --target claude
```

| Target | Scope(s) | Path |
| --- | --- | --- |
| `claude` | `repo` (default), `user` | `<repo>/.claude/skills/<name>/`, `~/.claude/skills/<name>/` |
| `codex` | `user` | `~/.codex/skills/<name>/` |
| `copilot` | `repo` | `<repo>/.github/skills/<name>/` |

The installer's contract:

1. **A scope the platform does not define is refused, not written.** `--scope repo` for `codex` fails with the supported scopes named — writing to a plausible directory the platform never reads looks like a successful install and behaves like none.
2. **An edited copy is never replaced silently.** Install reports `refused-drifted`, leaves the file byte-identical, and **exits non-zero** so a script notices. `--force` is the explicit opt-in. Line-ending differences are not drift.
3. **The plan is validated before any write** — `--target all` cannot install two platforms and error on the third.
4. **A matching copy is `already-current`** and not touched.

**The skill is a dispatcher, not a manual.** It restates no workflow: it carries the rule *"installed guide output wins"* and maps user intents to the `intent-cli guide ...` command that answers them. A skill that copies out the workflow is a second source of truth that ages against the tool — the same drift problem one level up.

`skill` is on the bootstrap allow-list, because installing a skill must work from a checkout with no `.intent-cli/` yet — that is precisely when an agent needs it.

## Notes

- The embedded resource name is resolved by matching the skill's directory segment rather than a hardcoded string: MSBuild's `%(RecursiveDir)` leaves a path separator in the logical name. This keeps the csproj a single glob, so a second skill needs no build change.
- No copy of the skill is installed into this repo — that would recreate the drift the slice removes.

## Verification

- `dotnet test IntentSystem.sln` — all green (Cli suite 3959 passed + 21 new).
- New `SkillCommandTests` exercises **real writes** into a throwaway repo root and a throwaway user home: per-target install paths, drift refusal leaving the operator's edited file untouched, `--force`, CRLF tolerance, unsupported-scope rejection with nothing written, `--target all` partial-install prevention, and that the embedded resource is byte-identical to `skills/intent-cli/SKILL.md` (a build that failed to package the asset fails the test rather than shipping an installer that writes nothing).
- Manual run against a scratch directory confirmed `installed` → `already-current` → `refused-drifted` (exit 1) → `diff` → `--force` overwrite → unsupported-scope and unknown-target rejections.
- EN/JA developer-reference sections added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPT7cFrCzT6ehACFez8dpE