### PR TITLE
G561: Close two publish-priority machinery gaps — pre-publish unblock, clarify open on scaffolded packets

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2024,6 +2024,103 @@ nothing).
 
 ---
 
+### Publish-priority ordering as a lifecycle (G561)
+
+When a slice must jump the queue, the sanctioned way to express that is **not**
+hand-picking the next unit and **not** retiring the one that would have gone
+first. It is a lifecycle with three states, and each one has a canonical
+command:
+
+1. **Block the unpublished unit** — the unit that should wait is set to
+   `state=blocked` with the reason recorded in `blocked_by`. The reason is
+   normally the execution unit it is waiting on.
+2. **The selector skips it while blocked.** `intent next-slice` excludes any
+   item in a blocked state *and* any item with a non-empty `blocked_by`. Both
+   conditions matter: an item that reports itself unblocked while still
+   carrying a stale reason is, in effect, still blocked, and will never be
+   picked.
+3. **Clear it once the priority reason is gone** — the exit that makes the unit
+   selectable again.
+
+Step 3 is where the pattern used to break. `automation issue-block --clear`
+requires a **complete** `linked_issue` before touching anything, and rightly so:
+it also converges the GitHub `intent-issue-blocked` label, and issue #818 exists
+in almost every repository. But a unit blocked *before publish* has no issue at
+all — `linked_issue` is null — so that path could not run. A bare
+`queue transition` would move the state and strand `blocked_by` populated,
+producing exactly the half-converged unit step 2 excludes. There was no
+canonical exit, and the design thread had to issue a one-off ruling to get a
+single unit moving (field incident, 2026-07-31, G559 wake).
+
+The pre-publish exit closes that:
+
+```bash
+intent-cli automation issue-block <execution-unit> --clear --pre-publish --write
+```
+
+It converges the queue side **only** — `state=queued` and `blocked_by` emptied
+in one guarded write, with the run-log event naming the wait reason it cleared —
+and performs no GitHub interaction at all, because there is no issue to
+interact with. It does not read labels, and it does not construct a mutator.
+
+It fails closed in two ways, both deliberately:
+
+- **The unit has a `linked_issue`.** Then it is published and the two-sided
+  path owns it; that path also converges the label, and taking the queue-only
+  shortcut for a published unit would leave the label behind — the precise
+  drift the two-sided command exists to prevent. A *partial* linkage is refused
+  too: half a linkage is evidence of a publish attempt, not evidence of its
+  absence.
+- **`--repo` / `--issue` were supplied.** They are refused rather than ignored,
+  because a caller who passes identifiers expects them to be acted on, and this
+  path touches no GitHub side. Silently accepting them would let the caller
+  believe a GitHub side was converged when none was.
+
+`--pre-publish` is an *exit* only: it requires `--clear`. Blocking a unit before
+publish already worked; what was missing was the way back.
+
+**The next use of this pattern needs no design ruling.** Block, let the selector
+skip, clear pre-publish, publish — all four steps are canonical commands.
+
+### `clarify open` works on scaffolded packets (G561)
+
+Recording a blocking design question is most valuable **early** — while the
+packet is still a draft and the wrong answer has not yet been built. Until G561
+that was exactly when it was impossible: `clarify open` deserialized `packet.yaml`
+through the full projection contract, which requires a `review_context_packet`
+section and twenty populated `implementation_issue_packet` fields. A packet from
+`intent-cli packet draft` has neither — it carries
+`implementation_issue_packet` / `intent_placement` / `knowledge_updates` /
+`closeout_learning`, and review context lives in `review-context.md` rather than
+in the packet. Every freshly scaffolded packet was rejected before any mutation,
+so the G552 design-decision flow was structurally unavailable at the moment it
+exists for.
+
+`clarify open` now reads only the facts a clarification record actually
+contains, and the strictness is asymmetric on purpose:
+
+- the packet's `source_execution_unit` is **required** and must match the queue
+  item — a clarification filed against the wrong unit is worse than none, so
+  identity never degrades;
+- every other packet field is optional, because a scaffold has not filled it in
+  yet and an unfilled TODO is not a reason to refuse to record a blocking
+  question. Derived question/reason text degrades field by field and makes the
+  gap explicit rather than asserting detail the packet does not contain;
+- when the packet **does** carry `review_context_packet`, every previous
+  cross-check still runs, in the same order, with the same messages — a
+  complete packet is validated exactly as strictly as before;
+- `review-context.md` is read by the same canonical parser, so its
+  execution-unit rules are unchanged (a present-but-malformed `# Execution Unit`
+  section still fails). The one accommodation is the `# Deterministic Review
+  Checks` section the scaffold does not yet have, whose absence costs only the
+  derived question text — and `--question` overrides that anyway.
+
+The strict projection serializer is **unchanged**. Publish-flow and review
+legitimately require a complete contract; loosening it there would let an
+incomplete packet through publication. The tolerance is scoped to `clarify open`.
+
+---
+
 ## Version flow
 
 The repository version policy lives in `eng/version.json` — the single source of

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2065,12 +2065,18 @@ interact with. It does not read labels, and it does not construct a mutator.
 
 It fails closed in two ways, both deliberately:
 
-- **The unit has a `linked_issue`.** Then it is published and the two-sided
-  path owns it; that path also converges the label, and taking the queue-only
-  shortcut for a published unit would leave the label behind — the precise
-  drift the two-sided command exists to prevent. A *partial* linkage is refused
-  too: half a linkage is evidence of a publish attempt, not evidence of its
-  absence.
+- **The unit has a `linked_issue` at all.** The rule is **absolute absence**:
+  only `linked_issue: null` is a pre-publish unit. A published unit is owned by
+  the two-sided path, which also converges the label; taking the queue-only
+  shortcut for it would leave the label behind — the precise drift the
+  two-sided command exists to prevent. A *partial* linkage is refused for the
+  same reason, and so is an **empty object** `{repo: "", number: null}`: the
+  object's presence is evidence that something recorded a linkage, and "the
+  fields happen to be blank" is not the same claim as "this unit was never
+  published". An empty object is refused by the two-sided path too (it demands
+  a complete linkage), so such an item has no exit until the linkage is
+  repaired — deliberately. Malformed linkage is a data defect to fix, not a
+  state to route around, and the error message says which repair to make.
 - **`--repo` / `--issue` were supplied.** They are refused rather than ignored,
   because a caller who passes identifiers expects them to be acted on, and this
   path touches no GitHub side. Silently accepting them would let the caller
@@ -2106,9 +2112,17 @@ contains, and the strictness is asymmetric on purpose:
   yet and an unfilled TODO is not a reason to refuse to record a blocking
   question. Derived question/reason text degrades field by field and makes the
   gap explicit rather than asserting detail the packet does not contain;
-- when the packet **does** carry `review_context_packet`, every previous
-  cross-check still runs, in the same order, with the same messages — a
-  complete packet is validated exactly as strictly as before;
+- routing is decided by the **declaration**, not by what the declaration turns
+  out to contain. A packet that declares a `review_context_packet` section is
+  claiming to be a complete projection packet, so it is deserialized by the
+  **unchanged** `ProjectionPacketSerializer` — same required fields, same type
+  checks, same validation order and messages, same failures — and every
+  previous cross-check still runs on top. A declared-but-broken packet
+  (missing a required field, a wrong-typed field, or a section declared with a
+  scalar body) fails exactly as loudly as it always did, before any mutation.
+  Tolerance is never applied to a packet that says it is complete;
+- only a packet with **no such declaration** — the `packet draft` scaffold,
+  which never claimed completeness — takes the tolerant path;
 - `review-context.md` is read by the same canonical parser, so its
   execution-unit rules are unchanged (a present-but-malformed `# Execution Unit`
   section still fails). The one accommodation is the `# Deterministic Review

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2160,6 +2160,96 @@ drift 問題そのものだからです。guide surface は CLI と一緒に動�
 
 ---
 
+### publish 優先順位を lifecycle として扱う (G561)
+
+あるスライスを優先して先に流したいとき、正規のやり方は次の unit を**手で選ぶこと
+でも**、先に流れるはずだった unit を**retire することでも**ありません。3 つの状態を
+持つ lifecycle であり、それぞれに canonical なコマンドがあります。
+
+1. **未 publish の unit を block する** — 待たせたい unit を `state=blocked` にし、
+   理由を `blocked_by` に記録します。理由は通常、待ち先の execution unit です。
+2. **block 中は selector がスキップする。** `intent next-slice` は blocked 状態の
+   item と、`blocked_by` が空でない item の**両方**を除外します。両方が重要です。
+   自分では unblock されたと主張しつつ古い理由を抱えたままの item は、事実上まだ
+   blocked であり、永久に選ばれません。
+3. **優先理由が消えたら clear する** — unit を再び選択可能にする exit です。
+
+壊れていたのは手順 3 でした。`automation issue-block --clear` は何かに触れる前に
+**完全な** `linked_issue` を要求します。これは正しい設計です(このコマンドは GitHub の
+`intent-issue-blocked` label も収束させますし、issue #818 はほぼどのリポジトリにも
+存在します)。しかし **publish 前**に block された unit には issue が存在せず、
+`linked_issue` は null なので、この経路は動きません。素の `queue transition` は state
+だけ動かして `blocked_by` を残すため、手順 2 が除外するまさに半収束状態の unit を
+作ります。canonical な exit が存在せず、たった 1 つの unit を動かすために design thread が
+one-off ruling を出す必要がありました(field incident 2026-07-31、G559 wake)。
+
+pre-publish exit がこれを閉じます:
+
+```bash
+intent-cli automation issue-block <execution-unit> --clear --pre-publish --write
+```
+
+queue 側**のみ**を収束させ(`state=queued` と `blocked_by` の空化を 1 回の guarded write
+で行い、run-log event に解除した wait reason を記録します)、GitHub とは一切やり取り
+しません。触る issue が存在しないからです。label の読み取りも行わず、mutator も
+生成しません。
+
+fail closed するのは次の 2 ケースで、いずれも意図的です。
+
+- **unit に `linked_issue` がある場合。** それは publish 済みであり two-sided path が
+  所有します。two-sided path は label も収束させるため、publish 済み unit に
+  queue-only のショートカットを使うと label が取り残されます — これは two-sided
+  コマンドが防ぐために存在する、まさにその drift です。**部分的な** linkage も拒否
+  します。半分だけの linkage は publish 試行の証跡であって、publish していない証拠では
+  ありません。
+- **`--repo` / `--issue` が渡された場合。** 無視ではなく拒否します。identifier を渡す
+  呼び出し側はそれが処理されることを期待しますが、この経路は GitHub 側に触れません。
+  黙って受け取れば、何も触っていないのに GitHub 側が収束したと誤認させます。
+
+`--pre-publish` は **exit 専用**であり `--clear` を必須とします。publish 前に block する
+こと自体はすでに動いていました。欠けていたのは戻り道です。
+
+**このパターンの次回利用に design ruling は不要です。** block → selector のスキップ →
+pre-publish clear → publish の 4 手順がすべて canonical コマンドで揃いました。
+
+### `clarify open` が scaffold 済み packet で動く (G561)
+
+design 上の blocking question は、packet がまだ draft で、誤った答えをまだ実装して
+いない**早い段階**で記録するのが最も価値があります。G561 以前は、まさにその段階で
+それが不可能でした。`clarify open` は `packet.yaml` を projection の完全な契約で
+デシリアライズしており、`review_context_packet` セクションと 20 個の
+`implementation_issue_packet` 必須フィールドを要求していたからです。
+`intent-cli packet draft` が作る packet にはどちらもありません
+(`implementation_issue_packet` / `intent_placement` / `knowledge_updates` /
+`closeout_learning` を持ち、review context は packet ではなく `review-context.md` に
+あります)。scaffold 直後の packet は mutation 前にすべて拒否され、G552 の
+design-decision フローは、それが存在する理由そのものの瞬間に構造的に使えませんでした。
+
+`clarify open` は clarification レコードが実際に含む事実だけを読むようになり、
+strictness は意図的に非対称です。
+
+- packet の `source_execution_unit` は**必須**で、queue item と一致しなければ
+  なりません。誤った unit に対して clarification を記録することは記録しないことより
+  悪いため、identity は決して緩めません。
+- それ以外の packet フィールドは optional です。scaffold はまだ埋まっておらず、
+  未記入の TODO は blocking question の記録を拒否する理由になりません。導出される
+  question / reason のテキストはフィールド単位で degrade し、packet に存在しない
+  詳細を断定するのではなく、欠落を明示します。
+- packet が `review_context_packet` を**持つ**場合、従来の cross-check はすべて、
+  同じ順序・同じメッセージで実行されます。完全な packet の検証は以前とまったく
+  同じ厳しさです。
+- `review-context.md` は同じ canonical parser が読むため、execution-unit の規則は
+  不変です(`# Execution Unit` セクションが存在して不正な場合は従来どおり失敗します)。
+  唯一の緩和は scaffold にまだ無い `# Deterministic Review Checks` セクションで、
+  その不在が影響するのは導出 question テキストだけです — そしてそれは `--question` で
+  上書きできます。
+
+strict な projection serializer は**変更していません**。publish-flow と review は
+完全な契約を要求して当然であり、そこを緩めれば不完全な packet が publish を通過して
+しまいます。許容は `clarify open` にスコープされています。
+
+---
+
 ## バージョンフロー
 
 リポジトリのバージョンポリシーは `eng/version.json` に記載されています。`stableVersion`

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2196,12 +2196,17 @@ queue 側**のみ**を収束させ(`state=queued` と `blocked_by` の空化を 
 
 fail closed するのは次の 2 ケースで、いずれも意図的です。
 
-- **unit に `linked_issue` がある場合。** それは publish 済みであり two-sided path が
-  所有します。two-sided path は label も収束させるため、publish 済み unit に
-  queue-only のショートカットを使うと label が取り残されます — これは two-sided
-  コマンドが防ぐために存在する、まさにその drift です。**部分的な** linkage も拒否
-  します。半分だけの linkage は publish 試行の証跡であって、publish していない証拠では
-  ありません。
+- **unit に `linked_issue` が少しでもある場合。** ルールは**完全な不在**です。
+  pre-publish unit と認めるのは `linked_issue: null` のみです。publish 済み unit は
+  two-sided path が所有し、そちらは label も収束させます。queue-only のショートカットを
+  使えば label が取り残されます — two-sided コマンドが防ぐために存在する、まさにその
+  drift です。**部分的な** linkage も同じ理由で拒否し、**空オブジェクト**
+  `{repo: "", number: null}` も拒否します。オブジェクトが存在すること自体が「何かが
+  linkage を記録した」証跡であり、「フィールドがたまたま空である」ことは
+  「この unit は publish されていない」という主張とは別物だからです。空オブジェクトは
+  two-sided path でも拒否されるため(完全な linkage を要求するため)、linkage を修復する
+  までその item に exit はありません — これは意図的です。壊れた linkage は迂回する状態では
+  なく修正すべきデータ欠陥であり、エラーメッセージがどちらの修復を行うべきかを示します。
 - **`--repo` / `--issue` が渡された場合。** 無視ではなく拒否します。identifier を渡す
   呼び出し側はそれが処理されることを期待しますが、この経路は GitHub 側に触れません。
   黙って受け取れば、何も触っていないのに GitHub 側が収束したと誤認させます。
@@ -2235,9 +2240,16 @@ strictness は意図的に非対称です。
   未記入の TODO は blocking question の記録を拒否する理由になりません。導出される
   question / reason のテキストはフィールド単位で degrade し、packet に存在しない
   詳細を断定するのではなく、欠落を明示します。
-- packet が `review_context_packet` を**持つ**場合、従来の cross-check はすべて、
-  同じ順序・同じメッセージで実行されます。完全な packet の検証は以前とまったく
-  同じ厳しさです。
+- 経路は**宣言**で決まります。宣言の中身がどうであるかでは決まりません。
+  `review_context_packet` セクションを宣言している packet は「完全な projection
+  packet である」と主張しているので、**変更していない** `ProjectionPacketSerializer`
+  でデシリアライズされます(必須フィールド、型チェック、検証順序とメッセージ、失敗の
+  仕方はすべて従来どおり)。その上で従来の cross-check もすべて実行されます。
+  宣言はしているが壊れている packet(必須フィールド欠落、型違い、スカラー本体で宣言された
+  セクション)は、従来とまったく同じ大きさで、mutation の前に失敗します。完全だと
+  主張する packet に許容は一切適用しません。
+- **その宣言が無い** packet — 完全性を主張したことがない `packet draft` の scaffold —
+  だけが許容経路を通ります。
 - `review-context.md` は同じ canonical parser が読むため、execution-unit の規則は
   不変です(`# Execution Unit` セクションが存在して不正な場合は従来どおり失敗します)。
   唯一の緩和は scaffold にまだ無い `# Deterministic Review Checks` セクションで、

--- a/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
@@ -58,6 +58,25 @@ namespace IntentSystem.Cli.Commands;
 /// cref="IntentNextSliceCommand"/>'s dependency/blocked-by gate rejects any
 /// item with a non-empty <c>blocked_by</c> regardless of its state — i.e. a
 /// "cleared" unit that is still, in effect, blocked.
+///
+/// G561: <c>--clear --pre-publish</c> is the PRE-PUBLISH exit. Publish-priority
+/// ordering works by blocking a not-yet-published unit so the selector skips it
+/// and the priority unit is picked instead — but an unpublished unit has no
+/// GitHub issue, so its <c>linked_issue</c> is null and the two-sided path above
+/// cannot run: it requires a complete linkage before touching anything, and
+/// correctly so. Before this flag there was no canonical exit at all. A bare
+/// <c>queue transition</c> would strand <c>blocked_by</c> populated, leaving the
+/// unit selector-ineligible while claiming to be unblocked, and the design
+/// thread had to issue a one-off ruling to get a single unit moving (field
+/// incident 2026-07-31, G559 wake).
+///
+/// The pre-publish path converges the queue side ONLY — same run-log-first
+/// ordering, same guarded write, same idempotency — and performs no GitHub
+/// interaction whatsoever, because there is no issue to interact with. It fails
+/// closed when the unit HAS a <c>linked_issue</c> (the two-sided path applies
+/// and must not be bypassed) and when <c>--repo</c>/<c>--issue</c> are supplied
+/// (identifiers this path can neither verify nor act on: accepting them would
+/// let a caller believe a GitHub side was converged when none was touched).
 /// </summary>
 internal static class AutomationIssueBlockCommand
 {
@@ -87,7 +106,8 @@ internal static class AutomationIssueBlockCommand
 
     private const string UsageLine =
         "Usage: intent-cli automation issue-block <execution-unit> --repo <owner/repo> --issue <n> --reason <text> [--write] [--dry-run] [--format text|json]\n"
-        + "       intent-cli automation issue-block <execution-unit> --repo <owner/repo> --issue <n> --clear [--write] [--dry-run] [--format text|json]";
+        + "       intent-cli automation issue-block <execution-unit> --repo <owner/repo> --issue <n> --clear [--write] [--dry-run] [--format text|json]\n"
+        + "       intent-cli automation issue-block <execution-unit> --clear --pre-publish [--write] [--dry-run] [--format text|json]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -101,7 +121,7 @@ internal static class AutomationIssueBlockCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var executionUnit, out var repo, out var issue, out var reason, out var clear, out var write, out var format, out var error))
+        if (!TryParseArguments(args, out var executionUnit, out var repo, out var issue, out var reason, out var clear, out var prePublish, out var write, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -133,9 +153,20 @@ internal static class AutomationIssueBlockCommand
             return 1;
         }
 
-        if (!TryValidateLinkedIssue(queueItem, executionUnit!, repo!, issue!.Value, out var linkageError))
+        if (!prePublish && !TryValidateLinkedIssue(queueItem, executionUnit!, repo!, issue!.Value, out var linkageError))
         {
             writer.WriteLine(linkageError);
+            return 1;
+        }
+
+        // G561: the pre-publish path exists precisely BECAUSE there is no
+        // linkage. A unit that has one must go through the two-sided path, which
+        // converges the GitHub label as well — silently taking the queue-only
+        // shortcut for a published unit would recreate the exact label/queue
+        // drift G545 closed.
+        if (prePublish && !TryValidateNoLinkedIssue(queueItem, executionUnit!, out var prePublishLinkageError))
+        {
+            writer.WriteLine(prePublishLinkageError);
             return 1;
         }
 
@@ -155,6 +186,12 @@ internal static class AutomationIssueBlockCommand
         }
         var beforeState = queueItem.State;
         var beforeBlockedBy = queueItem.BlockedBy;
+
+        if (prePublish)
+        {
+            return ExecutePrePublishClear(
+                writer, queueStatePath, runLogPath, runEvents, queueState, queueItem, executionUnit!, beforeState, beforeBlockedBy, write, format, now);
+        }
 
         QueueQueueSideResult queueResult;
         try
@@ -293,6 +330,105 @@ internal static class AutomationIssueBlockCommand
         bool AlreadyConverged, bool Applied, QueueItemState AfterState, IReadOnlyList<string> AfterBlockedBy);
 
     /// <summary>
+    /// G561: the pre-publish exit. Converges the queue side ONLY — state to
+    /// <see cref="UnblockTargetState"/> and <c>blocked_by</c> to empty, in one
+    /// guarded write, through the SAME <see cref="ConvergeQueueSide"/> used by
+    /// the two-sided path (run-log event appended first, queue-state second,
+    /// idempotent retry reuse). No GitHub mutator is constructed and no labels
+    /// are read: an unpublished unit has no issue, and a command that reached
+    /// for one would fail on absent evidence rather than on a real problem.
+    ///
+    /// The durable event names WHAT was cleared, not merely that something was:
+    /// the wait reason is the whole content of a publish-priority block, and a
+    /// run log recording only "queued" would leave the priority decision
+    /// unauditable after the fact.
+    /// </summary>
+    private static int ExecutePrePublishClear(
+        TextWriter writer,
+        string queueStatePath,
+        string runLogPath,
+        IReadOnlyList<RunEvent> runEvents,
+        QueueState queueState,
+        QueueItem queueItem,
+        string executionUnit,
+        QueueItemState beforeState,
+        IReadOnlyList<string> beforeBlockedBy,
+        bool write,
+        string format,
+        DateTimeOffset now)
+    {
+        var clearedReason = beforeBlockedBy.Count == 0
+            ? null
+            : $"pre-publish unblock; cleared wait reason: {string.Join("; ", beforeBlockedBy)}";
+
+        QueueQueueSideResult queueResult;
+        try
+        {
+            queueResult = ConvergeQueueSide(
+                queueStatePath, runLogPath, runEvents, queueState, queueItem, executionUnit,
+                UnblockTargetState, reason: null, write, now, unblockEventReason: clearedReason);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or JsonException)
+        {
+            writer.WriteLine($"failed to converge queue-state for '{executionUnit}': {exception.Message}");
+            return 1;
+        }
+
+        // Converged means the queue side — the only side this path owns — now
+        // shows a selectable unit. Dry-run never claims it, since nothing was
+        // written.
+        var converged = write
+            && queueResult.AfterState != QueueItemState.Blocked
+            && queueResult.AfterBlockedBy.Count == 0;
+
+        var result = new AutomationIssueBlockPrePublishResult
+        {
+            ExecutionUnit = executionUnit,
+            Mode = write ? WorkerClaimCompleteConstants.Modes.Write : WorkerClaimCompleteConstants.Modes.DryRun,
+            ClearedBlockedBy = beforeBlockedBy,
+            Queue = new AutomationIssueBlockQueueResult
+            {
+                BeforeState = FormatState(beforeState),
+                BeforeBlockedBy = beforeBlockedBy,
+                TargetState = FormatState(UnblockTargetState),
+                AlreadyConverged = queueResult.AlreadyConverged,
+                Applied = queueResult.Applied,
+                AfterState = FormatState(queueResult.AfterState),
+                AfterBlockedBy = queueResult.AfterBlockedBy,
+            },
+            Converged = converged,
+            TransitionedAt = now,
+            Summary = queueResult.AlreadyConverged
+                ? $"Pre-publish unblock for '{executionUnit}': queue-state already converged (no linked issue; no GitHub side to converge)."
+                : $"Pre-publish unblock for '{executionUnit}': queue-state {(write ? "transitioned" : "would transition")} to "
+                  + $"{FormatState(queueResult.AfterState)} with blocked_by emptied (no linked issue; no GitHub side to converge).",
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+        }
+        else
+        {
+            writer.WriteLine(result.Summary);
+            writer.WriteLine($"mode: {result.Mode}");
+            writer.WriteLine($"execution_unit: {result.ExecutionUnit}");
+            writer.WriteLine("pre_publish: true");
+            writer.WriteLine($"cleared_blocked_by: {(result.ClearedBlockedBy.Count == 0 ? "(none)" : string.Join(", ", result.ClearedBlockedBy))}");
+            writer.WriteLine($"queue.before_state: {result.Queue.BeforeState}");
+            writer.WriteLine($"queue.target_state: {result.Queue.TargetState}");
+            writer.WriteLine($"queue.already_converged: {result.Queue.AlreadyConverged.ToString().ToLowerInvariant()}");
+            writer.WriteLine($"queue.applied: {result.Queue.Applied.ToString().ToLowerInvariant()}");
+            writer.WriteLine($"queue.after_state: {result.Queue.AfterState}");
+            writer.WriteLine($"queue.after_blocked_by: {(result.Queue.AfterBlockedBy.Count == 0 ? "(none)" : string.Join(", ", result.Queue.AfterBlockedBy))}");
+            writer.WriteLine($"converged: {result.Converged.ToString().ToLowerInvariant()}");
+            writer.WriteLine($"transitioned_at: {result.TransitionedAt:O}");
+        }
+
+        return 0;
+    }
+
+    /// <summary>
     /// Converges the queue-side state toward <paramref name="targetState"/>
     /// (Blocked with <paramref name="reason"/>, or the unblock target with no
     /// reason). Idempotent: a no-op when already converged. Dry-run reports
@@ -308,7 +444,8 @@ internal static class AutomationIssueBlockCommand
         QueueItemState targetState,
         string? reason,
         bool write,
-        DateTimeOffset now)
+        DateTimeOffset now,
+        string? unblockEventReason = null)
     {
         // Convergence is judged on BOTH queue fields this command owns:
         // blocked means state=blocked AND blocked_by == [reason]; unblocked
@@ -367,6 +504,17 @@ internal static class AutomationIssueBlockCommand
                 ? QueueManager.TransitionBlocking(queueState, executionUnit, targetState, reason!, TransitionActor, now)
                 : QueueManager.TransitionNonBlocking(queueState, executionUnit, targetState, TransitionActor, now);
             runEvent = transitionResult.Event;
+
+            // G561: QueueManager's non-blocking transition deliberately records
+            // no reason (it is a general-purpose transition). The pre-publish
+            // exit supplies one so the audit trail says which wait was cleared
+            // — without changing QueueManager, whose published-unit semantics
+            // are out of scope here.
+            if (targetState != QueueItemState.Blocked && !string.IsNullOrWhiteSpace(unblockEventReason))
+            {
+                runEvent = runEvent with { Reason = unblockEventReason };
+            }
+
             updatedState = targetState == QueueItemState.Blocked
                 ? transitionResult.UpdatedState
                 : ClearQueueSideBlocking(transitionResult.UpdatedState, executionUnit, targetState);
@@ -498,6 +646,33 @@ internal static class AutomationIssueBlockCommand
         return true;
     }
 
+    /// <summary>
+    /// G561: the pre-publish path's own fail-closed guard — the exact inverse of
+    /// <see cref="TryValidateLinkedIssue"/>. ANY trace of linkage (a repo, a
+    /// number, or both) means this unit is or was published, so the two-sided
+    /// path owns it: that path also converges the GitHub label, and routing a
+    /// linked unit through the queue-only shortcut would leave the label behind
+    /// — the precise drift G545 exists to prevent. A partial linkage is refused
+    /// too: it is evidence of a publish attempt, not evidence of its absence.
+    /// </summary>
+    private static bool TryValidateNoLinkedIssue(QueueItem queueItem, string executionUnit, out string error)
+    {
+        var linked = queueItem.LinkedIssue;
+        if (linked is null || (string.IsNullOrWhiteSpace(linked.Repo) && linked.Number is null))
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        error =
+            $"'{executionUnit}' has a queue-state linked_issue ({DescribeLinkage(linked)}), so it is not a pre-publish "
+            + "unit; refusing the queue-only pre-publish clear. Use the two-sided form "
+            + $"(`intent-cli automation issue-block {executionUnit} --repo <owner/repo> --issue <n> --clear --write`), "
+            + "which also converges the GitHub blocked label — clearing only the queue side for a published unit is "
+            + "exactly the label/queue drift the two-sided command exists to prevent.";
+        return false;
+    }
+
     private static string DescribeLinkage(LinkedIssue? linked) => linked is null
         ? "no linked_issue at all"
         : $"repo '{(string.IsNullOrWhiteSpace(linked.Repo) ? "(none)" : linked.Repo)}', number {(linked.Number is null ? "(none)" : linked.Number.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))}";
@@ -626,6 +801,7 @@ internal static class AutomationIssueBlockCommand
         out int? issue,
         out string? reason,
         out bool clear,
+        out bool prePublish,
         out bool write,
         out string format,
         out string error)
@@ -635,6 +811,7 @@ internal static class AutomationIssueBlockCommand
         issue = null;
         reason = null;
         clear = false;
+        prePublish = false;
         write = false;
         format = FormatText;
         error = string.Empty;
@@ -674,6 +851,9 @@ internal static class AutomationIssueBlockCommand
                 case "--clear":
                     clear = true;
                     break;
+                case "--pre-publish":
+                    prePublish = true;
+                    break;
                 case "--write":
                     write = true;
                     break;
@@ -692,18 +872,37 @@ internal static class AutomationIssueBlockCommand
                     format = requestedFormat;
                     break;
                 default:
-                    error = $"Unknown argument '{argument}'. Supported: <execution-unit> --repo <owner/repo> --issue <n> [--reason <text>] [--clear] [--write] [--dry-run] [--format text|json].";
+                    error = $"Unknown argument '{argument}'. Supported: <execution-unit> --repo <owner/repo> --issue <n> [--reason <text>] [--clear] [--pre-publish] [--write] [--dry-run] [--format text|json].";
                     return false;
             }
         }
 
-        if (string.IsNullOrWhiteSpace(repo))
+        // G561: --pre-publish is an unblock-only path. Blocking a unit already
+        // works before publish; what was missing was the exit.
+        if (prePublish && !clear)
+        {
+            error = "--pre-publish is only supported together with --clear — it is the pre-publish EXIT from a blocked state, not a way to block.";
+            return false;
+        }
+
+        // Refused rather than ignored: a caller who passes identifiers expects
+        // them to be acted on, and this path touches no GitHub side at all.
+        if (prePublish && (!string.IsNullOrWhiteSpace(repo) || issue is not null))
+        {
+            error =
+                "--pre-publish takes no --repo/--issue: a pre-publish unit has no GitHub issue, and this path converges "
+                + "the queue side only. If the unit does have a linked issue, use the two-sided form "
+                + "(--repo <owner/repo> --issue <n> --clear), which also converges the blocked label.";
+            return false;
+        }
+
+        if (!prePublish && string.IsNullOrWhiteSpace(repo))
         {
             error = "--repo is required.";
             return false;
         }
 
-        if (issue is null)
+        if (!prePublish && issue is null)
         {
             error = "--issue is required.";
             return false;
@@ -769,7 +968,48 @@ internal static class AutomationIssueBlockCommand
         writer.WriteLine("side is converged independently and idempotently, so re-running after a partial failure");
         writer.WriteLine("only retries whatever has not yet converged. Never uses raw gh label mutation or a direct");
         writer.WriteLine("queue-state hand-edit.");
+        writer.WriteLine();
+        writer.WriteLine("--clear --pre-publish (G561) is the exit for a unit blocked BEFORE publish to encode publish");
+        writer.WriteLine("priority. Such a unit has no linked issue, so there is no GitHub side to converge: the queue");
+        writer.WriteLine("side alone moves to queued with blocked_by emptied, in one guarded write, and the run-log");
+        writer.WriteLine("event names the wait reason that was cleared. It refuses a unit that HAS a linked issue (use");
+        writer.WriteLine("the two-sided form) and refuses --repo/--issue, which it can neither verify nor act on.");
     }
+}
+
+/// <summary>
+/// G561: the pre-publish clear's own result shape. Deliberately NOT the
+/// two-sided <see cref="AutomationIssueBlockResult"/>: that record requires a
+/// repo, an issue number, an issue URL, and a label block, and emitting
+/// placeholder values for a unit that has no issue would put a fabricated
+/// GitHub reference into a durable, machine-read output.
+/// </summary>
+internal sealed record AutomationIssueBlockPrePublishResult
+{
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("pre_publish")]
+    public bool PrePublish => true;
+
+    /// <summary>The wait reason(s) this clear removed — the content of the publish-priority decision being unwound.</summary>
+    [JsonPropertyName("cleared_blocked_by")]
+    public required IReadOnlyList<string> ClearedBlockedBy { get; init; }
+
+    [JsonPropertyName("queue")]
+    public required AutomationIssueBlockQueueResult Queue { get; init; }
+
+    [JsonPropertyName("converged")]
+    public required bool Converged { get; init; }
+
+    [JsonPropertyName("transitioned_at")]
+    public required DateTimeOffset TransitionedAt { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
 }
 
 internal sealed record AutomationIssueBlockResult

--- a/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueBlockCommand.cs
@@ -648,28 +648,41 @@ internal static class AutomationIssueBlockCommand
 
     /// <summary>
     /// G561: the pre-publish path's own fail-closed guard — the exact inverse of
-    /// <see cref="TryValidateLinkedIssue"/>. ANY trace of linkage (a repo, a
-    /// number, or both) means this unit is or was published, so the two-sided
-    /// path owns it: that path also converges the GitHub label, and routing a
-    /// linked unit through the queue-only shortcut would leave the label behind
-    /// — the precise drift G545 exists to prevent. A partial linkage is refused
-    /// too: it is evidence of a publish attempt, not evidence of its absence.
+    /// <see cref="TryValidateLinkedIssue"/>. The contract is ABSOLUTE ABSENCE:
+    /// only <c>linked_issue: null</c> qualifies. Any linked_issue OBJECT is
+    /// refused, including an empty <c>{repo:"", number:null}</c> — the presence
+    /// of the object is itself evidence that something recorded a linkage, and
+    /// "the fields inside happen to be blank" is not the same claim as "this
+    /// unit was never published". Treating a blank object as absence would let
+    /// the queue-only shortcut run for a unit whose GitHub label may still say
+    /// blocked, which is the precise drift G545 exists to prevent.
+    ///
+    /// A blank object is refused by the two-sided path too (it demands a
+    /// COMPLETE linkage), so such an item has no exit until the linkage is
+    /// repaired — deliberately. Malformed linkage is a data defect to fix, not
+    /// a state to route around, and the message says so.
     /// </summary>
     private static bool TryValidateNoLinkedIssue(QueueItem queueItem, string executionUnit, out string error)
     {
         var linked = queueItem.LinkedIssue;
-        if (linked is null || (string.IsNullOrWhiteSpace(linked.Repo) && linked.Number is null))
+        if (linked is null)
         {
             error = string.Empty;
             return true;
         }
 
-        error =
-            $"'{executionUnit}' has a queue-state linked_issue ({DescribeLinkage(linked)}), so it is not a pre-publish "
-            + "unit; refusing the queue-only pre-publish clear. Use the two-sided form "
-            + $"(`intent-cli automation issue-block {executionUnit} --repo <owner/repo> --issue <n> --clear --write`), "
-            + "which also converges the GitHub blocked label — clearing only the queue side for a published unit is "
-            + "exactly the label/queue drift the two-sided command exists to prevent.";
+        var isBlank = string.IsNullOrWhiteSpace(linked.Repo) && linked.Number is null;
+        error = isBlank
+            ? $"'{executionUnit}' carries a linked_issue OBJECT with no usable content ({DescribeLinkage(linked)}); "
+              + "refusing the pre-publish clear, which requires linked_issue to be absent (null) — not merely blank. "
+              + "The object's presence is evidence that something recorded a linkage, so this is a queue-state defect "
+              + "to repair (set linked_issue to null if the unit is genuinely unpublished, or record the real repo and "
+              + "number and use the two-sided form), not a state to route around."
+            : $"'{executionUnit}' has a queue-state linked_issue ({DescribeLinkage(linked)}), so it is not a pre-publish "
+              + "unit; refusing the queue-only pre-publish clear. Use the two-sided form "
+              + $"(`intent-cli automation issue-block {executionUnit} --repo <owner/repo> --issue <n> --clear --write`), "
+              + "which also converges the GitHub blocked label — clearing only the queue side for a published unit is "
+              + "exactly the label/queue drift the two-sided command exists to prevent.";
         return false;
     }
 

--- a/src/IntentSystem.Cli/Commands/ClarifyOpenCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyOpenCommand.cs
@@ -61,26 +61,51 @@ internal static class ClarifyOpenCommand
 
         try
         {
-            var packet = ProjectionPacketSerializer.Deserialize(File.ReadAllText(packetPath));
-            if (!string.Equals(
-                    packet.ReviewContextPacket.SourceExecutionUnit,
-                    queueItem.ExecutionUnit,
-                    StringComparison.Ordinal))
+            // G561: read only the facts a clarification record needs. The full
+            // projection contract is NOT applied here — a packet freshly
+            // scaffolded by `packet draft` has no review_context_packet section
+            // and has not filled in most implementation fields, and refusing to
+            // record a blocking question because the packet is still a draft
+            // defeats the point of asking early. The identity check below is
+            // kept absolute; only the incidental fields became optional.
+            var packet = ClarifyPacketFacts.Read(File.ReadAllText(packetPath));
+
+            // A packet that DOES carry the review-context section is still
+            // validated exactly as strictly as before, in the same order and
+            // with the same messages — an existing artifact loses no guard and
+            // sees no changed diagnostic.
+            if (packet.HasReviewContextSection)
             {
-                throw new InvalidOperationException(
-                    $"Review context packet execution unit '{packet.ReviewContextPacket.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+                if (!string.Equals(
+                        packet.ReviewContextSourceExecutionUnit,
+                        queueItem.ExecutionUnit,
+                        StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Review context packet execution unit '{packet.ReviewContextSourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
+                }
+
+                if (!string.Equals(
+                        packet.ReviewContextClarificationReturnPath,
+                        queueItem.ClarificationReturnPath,
+                        StringComparison.Ordinal))
+                {
+                    throw new InvalidOperationException(
+                        $"Review context packet clarification return path '{packet.ReviewContextClarificationReturnPath}' must match queue item clarification return path '{queueItem.ClarificationReturnPath}'.");
+                }
             }
 
-            if (!string.Equals(
-                    packet.ReviewContextPacket.ClarificationReturnPath,
-                    queueItem.ClarificationReturnPath,
-                    StringComparison.Ordinal))
+            // The strict serializer used to assert that the two sections named
+            // the SAME unit; checking each of them against the queue item is
+            // equivalent for a complete packet and is the only available guard
+            // for a scaffold, which has one section.
+            if (!string.Equals(packet.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
-                    $"Review context packet clarification return path '{packet.ReviewContextPacket.ClarificationReturnPath}' must match queue item clarification return path '{queueItem.ClarificationReturnPath}'.");
+                    $"Projection packet execution unit '{packet.SourceExecutionUnit}' must match queue item execution unit '{queueItem.ExecutionUnit}'.");
             }
 
-            var reviewContext = ReviewContextMarkdownParser.Parse(File.ReadAllText(reviewContextPath));
+            var reviewContext = ReadReviewContext(File.ReadAllText(reviewContextPath), queueItem.ExecutionUnit);
             if (!string.Equals(reviewContext.SourceExecutionUnit, queueItem.ExecutionUnit, StringComparison.Ordinal))
             {
                 throw new InvalidOperationException(
@@ -88,7 +113,7 @@ internal static class ClarifyOpenCommand
             }
 
             var timestamp = TimestampFactory();
-            var reason = BuildReason(packet.ImplementationIssuePacket);
+            var reason = BuildReason(packet);
             var transition = QueueManager.TransitionBlocking(
                 queueState,
                 executionUnit,
@@ -119,9 +144,44 @@ internal static class ClarifyOpenCommand
         }
     }
 
+    /// <summary>
+    /// G561: reads review-context.md for the two things a clarification needs —
+    /// the execution-unit identity and the first deterministic check (used only
+    /// to derive a question when the caller did not supply one).
+    ///
+    /// The canonical parser is still what reads it, so its execution-unit
+    /// semantics are unchanged, including the G373 rule that a PRESENT but
+    /// malformed <c># Execution Unit</c> section throws rather than silently
+    /// falling back. The one accommodation is the required
+    /// <c>## Deterministic Review Checks</c> section, which `packet draft`'s
+    /// scaffold does not yet contain: an empty one is supplied so the rest can
+    /// be read. An absent list of checks is a draft that has not been filled in,
+    /// not a malformed artifact — and it costs only the derived question text,
+    /// which <c>--question</c> overrides anyway.
+    /// </summary>
+    private static Review.Models.ReviewContextSnapshot ReadReviewContext(string markdown, string fallbackExecutionUnit)
+    {
+        const string requiredHeading = "Deterministic Review Checks";
+
+        // Detected with the canonical parser's OWN heading rule (a line
+        // starting with "# ", heading text after stripping '#'/' '), so this
+        // never disagrees with what the parser will find.
+        var hasChecksSection = markdown
+            .Split('\n')
+            .Select(line => line.TrimEnd('\r'))
+            .Any(line => line.StartsWith("# ", StringComparison.Ordinal)
+                && string.Equals(line.TrimStart('#', ' '), requiredHeading, StringComparison.Ordinal));
+
+        var readable = hasChecksSection
+            ? markdown
+            : markdown + Environment.NewLine + Environment.NewLine + "# " + requiredHeading + Environment.NewLine;
+
+        return ReviewContextMarkdownParser.Parse(readable, fallbackExecutionUnit);
+    }
+
     private static ClarificationItem BuildClarification(
         QueueItem queueItem,
-        Projection.Models.ProjectionPacketContract packet,
+        ClarifyPacketFacts packet,
         Review.Models.ReviewContextSnapshot reviewContext,
         DateTimeOffset timestamp,
         string reason,
@@ -137,10 +197,13 @@ internal static class ClarifyOpenCommand
             // OPEN artifact itself must carry it — an agmsg message may notify,
             // but it can never substitute for the durable record.
             QuestionText = string.IsNullOrWhiteSpace(inputs.Question)
-                ? BuildQuestionText(packet.ImplementationIssuePacket, reviewContext)
+                ? BuildQuestionText(packet, reviewContext)
                 : inputs.Question!,
             Reason = AppendRecommendation(reason, inputs),
-            AffectedIntents = packet.ReviewContextPacket.IntentReferences,
+            // The review-context section stays the source when the packet has
+            // one, so a complete packet produces the same record it always did;
+            // a scaffold falls back to the implementation section's own list.
+            AffectedIntents = packet.ReviewContextIntentReferences ?? packet.IntentReferences,
             AffectedExecutionUnits = [queueItem.ExecutionUnit],
             BlockingOrNonblocking = BlockingValue,
             ClarificationReturnPath = queueItem.ClarificationReturnPath,
@@ -275,20 +338,32 @@ internal static class ClarifyOpenCommand
         return true;
     }
 
+    /// <summary>
+    /// G561: the derived texts degrade field by field rather than refusing. A
+    /// scaffold has an execution unit and usually a title, and that is enough to
+    /// name what is blocked; the placeholders below make the gap visible in the
+    /// artifact instead of asserting detail the packet does not contain.
+    /// Supplying <c>--question</c> bypasses this entirely.
+    /// </summary>
     private static string BuildQuestionText(
-        Projection.Models.ImplementationIssuePacket issuePacket,
+        ClarifyPacketFacts packet,
         Review.Models.ReviewContextSnapshot reviewContext)
     {
+        var subject = Describe(packet.TargetPart, packet.SourceExecutionUnit);
         var firstCheck = reviewContext.DeterministicReviewChecks.FirstOrDefault();
         return string.IsNullOrWhiteSpace(firstCheck)
-            ? $"Clarify blocker for {issuePacket.TargetPart}: {issuePacket.Goal}"
-            : $"Clarify blocker for {issuePacket.TargetPart}: {firstCheck}";
+            ? $"Clarify blocker for {subject}: {Describe(packet.Goal, "(goal not yet recorded in the packet)")}"
+            : $"Clarify blocker for {subject}: {firstCheck}";
     }
 
-    private static string BuildReason(Projection.Models.ImplementationIssuePacket issuePacket)
+    private static string BuildReason(ClarifyPacketFacts packet)
     {
-        return $"Clarification requested for {issuePacket.IssueTitle}: {issuePacket.Goal}";
+        var title = Describe(packet.IssueTitle, packet.SourceExecutionUnit);
+        return $"Clarification requested for {title}: {Describe(packet.Goal, "(goal not yet recorded in the packet)")}";
     }
+
+    private static string Describe(string? value, string fallback) =>
+        string.IsNullOrWhiteSpace(value) ? fallback : value!;
 
     private static string PersistClarification(string repoRoot, ClarificationItem clarification)
     {

--- a/src/IntentSystem.Cli/Commands/ClarifyPacketFacts.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyPacketFacts.cs
@@ -1,3 +1,4 @@
+using IntentSystem.Projection.Serialization;
 using YamlDotNet.RepresentationModel;
 
 namespace IntentSystem.Cli.Commands;
@@ -19,21 +20,25 @@ namespace IntentSystem.Cli.Commands;
 /// whole point is to record a blocking question EARLY, was structurally
 /// unavailable at exactly the moment it is needed.
 ///
-/// The strict serializer is left untouched: publish-flow and review legitimately
-/// demand a complete contract, and loosening it there would let an incomplete
-/// packet through publication. This reader is scoped to what a clarification
-/// record contains, and it is deliberately asymmetric about strictness:
+/// The strict serializer is left untouched — publish-flow and review
+/// legitimately demand a complete contract — and, review repair, it remains the
+/// ONLY reader for any packet that DECLARES itself complete. Tolerance is not a
+/// property of this reader; it is a property of the scaffold shape:
 ///
-/// - the source execution unit is REQUIRED, because it is the identity the
-///   caller's queue item is checked against; guessing it would defeat the
-///   mismatch guard that keeps a clarification from being filed against the
-///   wrong unit;
-/// - everything else is optional, because a scaffold has not filled it in yet
-///   and a missing TODO is not a reason to refuse to record a blocking question;
-/// - when the optional <c>review_context_packet</c> section IS present, its
-///   values are surfaced so the caller can keep applying every cross-check it
-///   applied before — an existing complete packet is validated exactly as
-///   strictly as it always was.
+/// - a packet declaring a <c>review_context_packet</c> section is claiming to be
+///   a complete projection packet, and is deserialized by
+///   <c>ProjectionPacketSerializer</c> unchanged — same required fields, same
+///   type checks, same validation order and messages, same failures. A
+///   declared-but-broken packet fails exactly as loudly as it always did, and it
+///   fails before any mutation;
+/// - only a packet with NO such declaration takes the tolerant path below, and
+///   there the source execution unit is still REQUIRED, because it is the
+///   identity the caller's queue item is checked against; guessing it would
+///   defeat the mismatch guard that keeps a clarification from being filed
+///   against the wrong unit;
+/// - everything else on that path is optional, because a scaffold has not filled
+///   it in yet and an unfilled TODO is not a reason to refuse to record a
+///   blocking question.
 /// </summary>
 internal sealed record ClarifyPacketFacts
 {
@@ -57,15 +62,74 @@ internal sealed record ClarifyPacketFacts
     public IReadOnlyList<string>? ReviewContextIntentReferences { get; init; }
 
     /// <summary>
-    /// Reads <paramref name="yaml"/>. Throws <see cref="InvalidOperationException"/>
-    /// only for the two things that genuinely block recording a clarification:
-    /// YAML that does not parse at all, and a missing/blank
-    /// <c>implementation_issue_packet.source_execution_unit</c>.
+    /// Reads <paramref name="yaml"/>, routing on ONE question: does the packet
+    /// DECLARE a <c>review_context_packet</c> section?
+    ///
+    /// A packet that declares it is claiming to be a complete projection
+    /// packet, so it is deserialized by the unchanged
+    /// <see cref="ProjectionPacketSerializer"/> — same required fields, same
+    /// type and ordering checks, same validation sequence, same messages, same
+    /// failures. Tolerance must never be applied to a packet that says it is
+    /// complete: a declared-but-broken packet has to fail exactly as loudly as
+    /// it did before, and it fails before any mutation.
+    ///
+    /// Only a packet with NO such declaration takes the tolerant path — that
+    /// is the `packet draft` scaffold, which never claimed completeness.
+    ///
+    /// The routing decision is made by scanning for the top-level section line
+    /// itself, deliberately WITHOUT parsing: a complete packet must reach the
+    /// strict serializer through the same bytes it always did, so no second
+    /// parser can reject a packet the strict one would have accepted.
     /// </summary>
     public static ClarifyPacketFacts Read(string yaml)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
 
+        if (DeclaresReviewContextSection(yaml))
+        {
+            var contract = ProjectionPacketSerializer.Deserialize(yaml);
+            return new ClarifyPacketFacts
+            {
+                SourceExecutionUnit = contract.ImplementationIssuePacket.SourceExecutionUnit,
+                IssueTitle = contract.ImplementationIssuePacket.IssueTitle,
+                Goal = contract.ImplementationIssuePacket.Goal,
+                TargetPart = contract.ImplementationIssuePacket.TargetPart,
+                IntentReferences = contract.ImplementationIssuePacket.IntentReferences,
+                HasReviewContextSection = true,
+                ReviewContextSourceExecutionUnit = contract.ReviewContextPacket.SourceExecutionUnit,
+                ReviewContextClarificationReturnPath = contract.ReviewContextPacket.ClarificationReturnPath,
+                ReviewContextIntentReferences = contract.ReviewContextPacket.IntentReferences,
+            };
+        }
+
+        return ReadScaffold(yaml);
+    }
+
+    /// <summary>
+    /// True when a top-level <c>review_context_packet:</c> section line is
+    /// present, using the strict parser's own rule for a section header (a line
+    /// that starts at column 0). Presence is judged on the DECLARATION, never on
+    /// what the value turns out to be — a section declared with a scalar or a
+    /// sequence body is present-and-wrong, and must reach the strict serializer
+    /// to fail there rather than being mistaken for an absent section and
+    /// silently tolerated.
+    /// </summary>
+    private static bool DeclaresReviewContextSection(string yaml) =>
+        yaml.Split('\n')
+            .Select(line => line.TrimEnd('\r'))
+            .Any(line => line.Length > 0
+                && !char.IsWhiteSpace(line[0])
+                && line.StartsWith("review_context_packet:", StringComparison.Ordinal));
+
+    /// <summary>
+    /// The tolerant path, for a packet that never declared a review-context
+    /// section. Throws <see cref="InvalidOperationException"/> only for the two
+    /// things that genuinely block recording a clarification: YAML that does not
+    /// parse at all, and a missing/blank
+    /// <c>implementation_issue_packet.source_execution_unit</c>.
+    /// </summary>
+    private static ClarifyPacketFacts ReadScaffold(string yaml)
+    {
         YamlMappingNode? root;
         try
         {
@@ -98,8 +162,9 @@ internal sealed record ClarifyPacketFacts
                 + "it is the identity a clarification is filed against and must never be guessed.");
         }
 
-        var reviewContext = GetMapping(root, "review_context_packet");
-
+        // No review-context values here by construction: this path only runs
+        // for a packet that declared no such section, so there is nothing to
+        // read and nothing to conflate.
         return new ClarifyPacketFacts
         {
             SourceExecutionUnit = sourceExecutionUnit!,
@@ -107,10 +172,7 @@ internal sealed record ClarifyPacketFacts
             Goal = GetScalar(implementation, "goal"),
             TargetPart = GetScalar(implementation, "target_part"),
             IntentReferences = GetList(implementation, "intent_references"),
-            HasReviewContextSection = reviewContext is not null,
-            ReviewContextSourceExecutionUnit = reviewContext is null ? null : GetScalar(reviewContext, "source_execution_unit"),
-            ReviewContextClarificationReturnPath = reviewContext is null ? null : GetScalar(reviewContext, "clarification_return_path"),
-            ReviewContextIntentReferences = reviewContext is null ? null : GetList(reviewContext, "intent_references"),
+            HasReviewContextSection = false,
         };
     }
 

--- a/src/IntentSystem.Cli/Commands/ClarifyPacketFacts.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyPacketFacts.cs
@@ -1,0 +1,132 @@
+using YamlDotNet.RepresentationModel;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G561: the few packet facts <c>clarify open</c> actually needs, read
+/// tolerantly.
+///
+/// <c>clarify open</c> used to deserialize packet.yaml through the FULL
+/// projection contract (<c>IntentSystem.Projection</c>'s
+/// <c>ProjectionPacketSerializer</c>), which requires a
+/// <c>review_context_packet</c> section plus twenty required
+/// <c>implementation_issue_packet</c> fields. Packets produced by
+/// <c>intent-cli packet draft</c> have neither: the scaffold carries
+/// <c>implementation_issue_packet</c> / <c>intent_placement</c> /
+/// <c>knowledge_updates</c> / <c>closeout_learning</c>, and review context lives
+/// in <c>review-context.md</c> rather than in the packet. So every freshly
+/// scaffolded packet was rejected — and the G552 design-decision flow, whose
+/// whole point is to record a blocking question EARLY, was structurally
+/// unavailable at exactly the moment it is needed.
+///
+/// The strict serializer is left untouched: publish-flow and review legitimately
+/// demand a complete contract, and loosening it there would let an incomplete
+/// packet through publication. This reader is scoped to what a clarification
+/// record contains, and it is deliberately asymmetric about strictness:
+///
+/// - the source execution unit is REQUIRED, because it is the identity the
+///   caller's queue item is checked against; guessing it would defeat the
+///   mismatch guard that keeps a clarification from being filed against the
+///   wrong unit;
+/// - everything else is optional, because a scaffold has not filled it in yet
+///   and a missing TODO is not a reason to refuse to record a blocking question;
+/// - when the optional <c>review_context_packet</c> section IS present, its
+///   values are surfaced so the caller can keep applying every cross-check it
+///   applied before — an existing complete packet is validated exactly as
+///   strictly as it always was.
+/// </summary>
+internal sealed record ClarifyPacketFacts
+{
+    public required string SourceExecutionUnit { get; init; }
+
+    public string? IssueTitle { get; init; }
+
+    public string? Goal { get; init; }
+
+    public string? TargetPart { get; init; }
+
+    public required IReadOnlyList<string> IntentReferences { get; init; }
+
+    /// <summary>True when the packet carries the full projection review-context section.</summary>
+    public required bool HasReviewContextSection { get; init; }
+
+    public string? ReviewContextSourceExecutionUnit { get; init; }
+
+    public string? ReviewContextClarificationReturnPath { get; init; }
+
+    public IReadOnlyList<string>? ReviewContextIntentReferences { get; init; }
+
+    /// <summary>
+    /// Reads <paramref name="yaml"/>. Throws <see cref="InvalidOperationException"/>
+    /// only for the two things that genuinely block recording a clarification:
+    /// YAML that does not parse at all, and a missing/blank
+    /// <c>implementation_issue_packet.source_execution_unit</c>.
+    /// </summary>
+    public static ClarifyPacketFacts Read(string yaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(yaml);
+
+        YamlMappingNode? root;
+        try
+        {
+            var stream = new YamlStream();
+            using var reader = new StringReader(yaml);
+            stream.Load(reader);
+            root = stream.Documents.Count == 0 ? null : stream.Documents[0].RootNode as YamlMappingNode;
+        }
+        catch (YamlDotNet.Core.YamlException exception)
+        {
+            throw new InvalidOperationException(
+                $"Projection packet YAML could not be parsed: {exception.Message}");
+        }
+
+        if (root is null)
+        {
+            throw new InvalidOperationException("Projection packet YAML is empty or is not a mapping.");
+        }
+
+        var implementation = GetMapping(root, "implementation_issue_packet")
+            ?? throw new InvalidOperationException(
+                "Projection packet YAML must contain an 'implementation_issue_packet' section — "
+                + "clarify open reads the execution-unit identity from it.");
+
+        var sourceExecutionUnit = GetScalar(implementation, "source_execution_unit");
+        if (string.IsNullOrWhiteSpace(sourceExecutionUnit))
+        {
+            throw new InvalidOperationException(
+                "Projection packet YAML field 'implementation_issue_packet.source_execution_unit' is required — "
+                + "it is the identity a clarification is filed against and must never be guessed.");
+        }
+
+        var reviewContext = GetMapping(root, "review_context_packet");
+
+        return new ClarifyPacketFacts
+        {
+            SourceExecutionUnit = sourceExecutionUnit!,
+            IssueTitle = GetScalar(implementation, "issue_title"),
+            Goal = GetScalar(implementation, "goal"),
+            TargetPart = GetScalar(implementation, "target_part"),
+            IntentReferences = GetList(implementation, "intent_references"),
+            HasReviewContextSection = reviewContext is not null,
+            ReviewContextSourceExecutionUnit = reviewContext is null ? null : GetScalar(reviewContext, "source_execution_unit"),
+            ReviewContextClarificationReturnPath = reviewContext is null ? null : GetScalar(reviewContext, "clarification_return_path"),
+            ReviewContextIntentReferences = reviewContext is null ? null : GetList(reviewContext, "intent_references"),
+        };
+    }
+
+    private static YamlMappingNode? GetMapping(YamlMappingNode parent, string key) =>
+        parent.Children.TryGetValue(new YamlScalarNode(key), out var node) ? node as YamlMappingNode : null;
+
+    private static string? GetScalar(YamlMappingNode parent, string key) =>
+        parent.Children.TryGetValue(new YamlScalarNode(key), out var node) && node is YamlScalarNode scalar
+            ? scalar.Value
+            : null;
+
+    private static IReadOnlyList<string> GetList(YamlMappingNode parent, string key) =>
+        parent.Children.TryGetValue(new YamlScalarNode(key), out var node) && node is YamlSequenceNode sequence
+            ? sequence.Children.OfType<YamlScalarNode>()
+                .Select(scalar => scalar.Value ?? string.Empty)
+                .Where(value => value.Length > 0)
+                .ToArray()
+            : Array.Empty<string>();
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueBlockCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueBlockCommandTests.cs
@@ -661,6 +661,178 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
     // Helpers.
     // ---------------------------------------------------------------
 
+    // ---------------------------------------------------------------
+    // G561: the PRE-PUBLISH exit — a unit blocked before publish to encode
+    // publish priority has no linked issue, so the two-sided path above
+    // cannot clear it. Before this flag there was no canonical exit at all.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void PrePublishClear_OnALinkedIssueLessBlockedUnit_QueuesItAndEmptiesBlockedBy_G561()
+    {
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: ["G560"], omitLinkedIssue: true);
+
+        var (exitCode, output) = workspace.RunRaw(PrePublishClearArgs());
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueBlockPrePublishResult>(output)!;
+
+        Assert.True(result.PrePublish);
+        Assert.True(result.Converged);
+        Assert.True(result.Queue.Applied);
+        Assert.False(result.Queue.AlreadyConverged);
+        Assert.Equal(["G560"], result.ClearedBlockedBy);
+
+        // Read back from disk: both fields the selector reads must move
+        // together. A cleared state with a stale blocked_by is a unit that is
+        // still, in effect, blocked.
+        var item = workspace.ReadQueueItem();
+        Assert.Equal(QueueItemState.Queued, item.State);
+        Assert.Empty(item.BlockedBy);
+
+        // The durable event names WHAT was cleared — a run log recording only
+        // "queued" would leave the publish-priority decision unauditable.
+        var appended = Assert.Single(workspace.ReadRunEvents());
+        Assert.Equal("queued", appended.Event);
+        Assert.Equal(Unit, appended.ExecutionUnit);
+        Assert.Equal("intent-cli automation issue-block", appended.By);
+        Assert.Contains("G560", appended.Reason ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrePublishClear_NeverTouchesGitHub_BecauseThereIsNoIssue_G561()
+    {
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: ["G560"], omitLinkedIssue: true);
+        var mutator = workspace.UseMutator("whatever");
+
+        Assert.Equal(0, workspace.RunRaw(PrePublishClearArgs()).ExitCode);
+
+        // Not merely "did not mutate" — did not even READ. An unpublished unit
+        // has no issue to read, so reaching for one could only fail on absent
+        // evidence rather than on a real problem.
+        Assert.Equal(0, mutator.ReadCount);
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
+    public void PrePublishClear_DryRun_ReportsTheTransitionWithoutWritingAnything_G561()
+    {
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: ["G560"], omitLinkedIssue: true);
+        var queueBefore = workspace.ReadQueueStateBytes();
+        var runLogBefore = workspace.ReadRunLogBytes();
+
+        var (exitCode, output) = workspace.RunRaw([Unit, "--clear", "--pre-publish", "--dry-run", "--format", "json"]);
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueBlockPrePublishResult>(output)!;
+
+        Assert.Equal("queued", result.Queue.AfterState);
+        Assert.Empty(result.Queue.AfterBlockedBy);
+        // Dry-run never claims convergence — nothing was written.
+        Assert.False(result.Converged);
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Equal(runLogBefore, workspace.ReadRunLogBytes());
+    }
+
+    [Fact]
+    public void PrePublishClear_IsIdempotent_OnAnAlreadyQueuedUnit_G561()
+    {
+        using var workspace = new Workspace(QueueItemState.Queued, blockedBy: [], omitLinkedIssue: true);
+
+        var (exitCode, output) = workspace.RunRaw(PrePublishClearArgs());
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssueBlockPrePublishResult>(output)!;
+
+        Assert.True(result.Queue.AlreadyConverged);
+        Assert.False(result.Queue.Applied);
+        Assert.Empty(workspace.ReadRunEvents());
+    }
+
+    [Fact]
+    public void PrePublishClear_OnAUnitThatHasALinkedIssue_FailsClosed_G561()
+    {
+        // Fail-closed case 1. The two-sided path also converges the GitHub
+        // label; taking the queue-only shortcut for a published unit would
+        // leave the label behind — the exact drift G545 exists to prevent.
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: ["G560"]);
+
+        AssertRefusedWithoutTouchingAnything(
+            workspace,
+            PrePublishClearArgs(),
+            "has a queue-state linked_issue");
+    }
+
+    [Fact]
+    public void PrePublishClear_OnAUnitWithPartialLinkage_FailsClosed_G561()
+    {
+        // A half-recorded linkage is evidence of a publish attempt, not
+        // evidence of its absence.
+        using var workspace = new Workspace(
+            QueueItemState.Blocked,
+            blockedBy: ["G560"],
+            linkedIssue: new LinkedIssue { Repo = Repo, Number = null, Url = null });
+
+        AssertRefusedWithoutTouchingAnything(
+            workspace,
+            PrePublishClearArgs(),
+            "has a queue-state linked_issue");
+    }
+
+    [Fact]
+    public void PrePublishClear_WithRepoAndIssue_FailsClosed_G561()
+    {
+        // Fail-closed case 2: identifiers this path can neither verify nor act
+        // on. Ignoring them would let a caller believe a GitHub side was
+        // converged when none was touched.
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: ["G560"], omitLinkedIssue: true);
+
+        AssertRefusedWithoutTouchingAnything(
+            workspace,
+            [Unit, "--repo", Repo, "--issue", "818", "--clear", "--pre-publish", "--write", "--format", "json"],
+            "--pre-publish takes no --repo/--issue");
+    }
+
+    [Fact]
+    public void PrePublish_WithoutClear_IsRejected_G561()
+    {
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: ["G560"], omitLinkedIssue: true);
+
+        AssertRefusedWithoutTouchingAnything(
+            workspace,
+            [Unit, "--pre-publish", "--write", "--format", "json"],
+            "--pre-publish is only supported together with --clear");
+    }
+
+    [Fact]
+    public void PublishPriorityLifecycle_BlockPrePublish_ThenClear_MakesTheUnitSelectorEligible_G561()
+    {
+        // The demo sequence the slice exists for, end to end on real state:
+        // a unit blocked before publish is invisible to the selector, and the
+        // canonical pre-publish clear is what makes it selectable again.
+        using var workspace = new Workspace(QueueItemState.Blocked, blockedBy: ["G560"], omitLinkedIssue: true);
+
+        var blocked = workspace.ReadQueueItem();
+        Assert.False(IsSelectorEligible(blocked));
+
+        Assert.Equal(0, workspace.RunRaw(PrePublishClearArgs()).ExitCode);
+
+        var cleared = workspace.ReadQueueItem();
+        Assert.True(
+            IsSelectorEligible(cleared),
+            $"expected a selectable unit, got state={cleared.State} blocked_by=[{string.Join(", ", cleared.BlockedBy)}]");
+    }
+
+    /// <summary>
+    /// The two conditions <c>intent next-slice</c> applies before a queued item
+    /// is a candidate: it must not be in a blocked state, and its
+    /// <c>blocked_by</c> must be empty — the second is the one a bare queue
+    /// transition leaves behind, producing a unit that reports itself unblocked
+    /// while remaining unselectable.
+    /// </summary>
+    private static bool IsSelectorEligible(QueueItem item) =>
+        item.State == QueueItemState.Queued && item.BlockedBy.Count == 0;
+
+    private static string[] PrePublishClearArgs() =>
+        [Unit, "--clear", "--pre-publish", "--write", "--format", "json"];
+
     private static string[] BlockArgs() =>
         [Unit, "--repo", Repo, "--issue", "818", "--reason", Reason, "--write", "--format", "json"];
 

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueBlockCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueBlockCommandTests.cs
@@ -777,6 +777,45 @@ public sealed class AutomationIssueBlockCommandTests : IDisposable
     }
 
     [Fact]
+    public void PrePublishClear_OnAnEmptyLinkedIssueObject_FailsClosed_G561()
+    {
+        // The contract is ABSOLUTE ABSENCE — only `linked_issue: null` is a
+        // pre-publish unit. An empty object `{repo:"", number:null}` is NOT
+        // absence: its presence is evidence that something recorded a linkage,
+        // and treating "the fields happen to be blank" as "never published"
+        // would let the queue-only shortcut run for a unit whose GitHub label
+        // may still say blocked.
+        using var workspace = new Workspace(
+            QueueItemState.Blocked,
+            blockedBy: ["G560"],
+            linkedIssue: new LinkedIssue { Repo = string.Empty, Number = null, Url = null });
+
+        // Stronger than "did not read": the mutator is never CONSTRUCTED. The
+        // factory records every call, so a refusal that still reached for
+        // GitHub would fail here even if it read nothing.
+        var constructions = 0;
+        var mutator = new FakeMutator(["intent-issue-in-progress"]);
+        AutomationIssueBlockCommand.MutatorFactory = () =>
+        {
+            constructions++;
+            return mutator;
+        };
+
+        var queueBefore = workspace.ReadQueueStateBytes();
+        var runLogBefore = workspace.ReadRunLogBytes();
+
+        var (exitCode, output) = workspace.RunRaw(PrePublishClearArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("carries a linked_issue OBJECT with no usable content", output, StringComparison.Ordinal);
+        Assert.Equal(queueBefore, workspace.ReadQueueStateBytes());
+        Assert.Equal(runLogBefore, workspace.ReadRunLogBytes());
+        Assert.Equal(0, constructions);
+        Assert.Equal(0, mutator.ReadCount);
+        Assert.Empty(mutator.Transitions);
+    }
+
+    [Fact]
     public void PrePublishClear_WithRepoAndIssue_FailsClosed_G561()
     {
         // Fail-closed case 2: identifiers this path can neither verify nor act

--- a/tests/IntentSystem.Cli.Tests/ClarifyOpenScaffoldedPacketTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClarifyOpenScaffoldedPacketTests.cs
@@ -11,7 +11,8 @@ namespace IntentSystem.Cli.Tests;
 
 /// <summary>
 /// G561: <c>clarify open</c> must work on a packet produced by
-/// <c>intent-cli packet draft</c>.
+/// <c>intent-cli packet draft</c> — and must NOT become more permissive toward
+/// any packet that declares itself complete.
 ///
 /// Field incident (2026-07-31, G559 wake): the orchestrator tried to record the
 /// required design clarification and <c>clarify open</c> failed pre-mutation
@@ -27,30 +28,28 @@ namespace IntentSystem.Cli.Tests;
 /// rather than by a hand-written fixture. A fixture copy of the scaffold would
 /// keep passing after the scaffold changed shape, which is precisely how this
 /// gap survived: every existing clarify fixture was a complete packet.
+///
+/// Review repair: routing is decided by the DECLARATION alone. A packet that
+/// declares <c>review_context_packet</c> — whatever shape that declaration turns
+/// out to have — goes through the unchanged strict serializer, so a
+/// declared-but-broken packet fails exactly as loudly as before, and before any
+/// mutation. The fixtures below prove both directions.
 /// </summary>
 [Collection(RunSubmitCommandCollection.Name)]
 public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
 {
-    private const string Unit = "G900";
-    private const string Domain = "intent-cli";
-    private const string ReturnPath = "intents/intent-cli/clarifications/open.md";
-
-    private static readonly DateTimeOffset FixedNow = new(2026, 7, 31, 9, 0, 0, TimeSpan.Zero);
-
-    private readonly string rootPath = Directory.CreateTempSubdirectory("clarify-open-scaffold-tests-").FullName;
+    private readonly ScaffoldWorkspace workspace = new();
     private readonly Func<DateTimeOffset> originalTimestampFactory = ClarifyOpenCommand.TimestampFactory;
 
     public void Dispose()
     {
         ClarifyOpenCommand.TimestampFactory = originalTimestampFactory;
-        AutomationStalledWorkCommand.UtcNowFactory = null;
-        AutomationStalledWorkCommand.CandidateListerFactory = null;
-
-        if (Directory.Exists(rootPath))
-        {
-            Directory.Delete(rootPath, recursive: true);
-        }
+        workspace.Dispose();
     }
+
+    // ---------------------------------------------------------------
+    // The scaffold path.
+    // ---------------------------------------------------------------
 
     [Fact]
     public void ScaffoldedPacket_HasNoReviewContextSection_AndIsIncomplete_G561()
@@ -58,10 +57,9 @@ public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
         // The premise of the whole slice, asserted rather than assumed — if the
         // scaffold ever grows a full contract, this test says so instead of the
         // rest of the file silently proving nothing.
-        var context = CreateContext();
-        Assert.Equal(0, RunPacketDraft(context));
+        Assert.Equal(0, workspace.RunPacketDraft());
 
-        var yaml = File.ReadAllText(PacketYamlPath());
+        var yaml = File.ReadAllText(workspace.PacketYamlPath);
         Assert.DoesNotContain("review_context_packet:", yaml, StringComparison.Ordinal);
         Assert.Contains("implementation_issue_packet:", yaml, StringComparison.Ordinal);
         // Also missing most of the strict contract's required implementation
@@ -69,7 +67,7 @@ public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
         // have been enough.
         Assert.DoesNotContain("landing_policy:", yaml, StringComparison.Ordinal);
 
-        var reviewContext = File.ReadAllText(ReviewContextPath());
+        var reviewContext = File.ReadAllText(workspace.ReviewContextPath);
         Assert.DoesNotContain("# Deterministic Review Checks", reviewContext, StringComparison.Ordinal);
         Assert.DoesNotContain("# Execution Unit", reviewContext, StringComparison.Ordinal);
     }
@@ -77,36 +75,30 @@ public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
     [Fact]
     public void ClarifyOpen_OnAFreshlyScaffoldedPacket_RecordsTheClarification_G561()
     {
-        var context = CreateContext();
-        Assert.Equal(0, RunPacketDraft(context));
-        WriteQueueState(QueueItemState.Queued);
-        ClarifyOpenCommand.TimestampFactory = () => FixedNow;
+        Assert.Equal(0, workspace.RunPacketDraft());
+        workspace.WriteQueueState(QueueItemState.Queued);
+        ClarifyOpenCommand.TimestampFactory = () => ScaffoldWorkspace.FixedNow;
 
         using var writer = new StringWriter();
         var exitCode = ClarifyOpenCommand.Execute(
-            context,
-            [Unit, "--question", "Should the pre-publish exit be a flag or its own command?"],
+            workspace.Context,
+            [ScaffoldWorkspace.Unit, "--question", "Should the pre-publish exit be a flag or its own command?"],
             writer);
 
         Assert.Equal(0, exitCode);
-        Assert.Contains($"Clarification opened for {Unit}", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains($"Clarification opened for {ScaffoldWorkspace.Unit}", writer.ToString(), StringComparison.Ordinal);
 
-        // The durable artifact — the thing detection and design actually read.
-        var artifactPath = Path.Combine(rootPath, ".intent-cli", "clarifications", Unit, "request.json");
-        Assert.True(File.Exists(artifactPath), writer.ToString());
-        var artifact = ClarificationSerializer.Deserialize(File.ReadAllText(artifactPath));
-        Assert.Equal(Unit, artifact.ExecutionUnit);
+        var artifact = workspace.ReadClarification();
+        Assert.Equal(ScaffoldWorkspace.Unit, artifact.ExecutionUnit);
         Assert.Equal(ClarificationStatus.Open, artifact.Status);
         Assert.Equal("blocking", artifact.BlockingOrNonblocking);
-        Assert.Equal(
-            "Should the pre-publish exit be a flag or its own command?",
-            artifact.QuestionText);
+        Assert.Equal("Should the pre-publish exit be a flag or its own command?", artifact.QuestionText);
         // The return path comes from the queue item, which is authoritative for
         // it; the scaffold has no review-context packet to carry a copy.
-        Assert.Equal(ReturnPath, artifact.ClarificationReturnPath);
+        Assert.Equal(ScaffoldWorkspace.ReturnPath, artifact.ClarificationReturnPath);
 
         // And the queue side moved, exactly as it does for a complete packet.
-        var item = ReadQueueItem();
+        var item = workspace.ReadQueueItem();
         Assert.Equal(QueueItemState.ClarifyBlocked, item.State);
         Assert.NotEmpty(item.BlockedBy);
     }
@@ -114,22 +106,174 @@ public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
     [Fact]
     public void ClarifyOpen_OnAScaffold_WithoutAnExplicitQuestion_StillRecordsSomethingReadable_G561()
     {
-        var context = CreateContext();
-        Assert.Equal(0, RunPacketDraft(context));
-        WriteQueueState(QueueItemState.Queued);
-        ClarifyOpenCommand.TimestampFactory = () => FixedNow;
+        Assert.Equal(0, workspace.RunPacketDraft());
+        workspace.WriteQueueState(QueueItemState.Queued);
+        ClarifyOpenCommand.TimestampFactory = () => ScaffoldWorkspace.FixedNow;
 
         using var writer = new StringWriter();
-        Assert.Equal(0, ClarifyOpenCommand.Execute(context, [Unit], writer));
+        Assert.Equal(0, ClarifyOpenCommand.Execute(workspace.Context, [ScaffoldWorkspace.Unit], writer));
 
-        var artifact = ClarificationSerializer.Deserialize(
-            File.ReadAllText(Path.Combine(rootPath, ".intent-cli", "clarifications", Unit, "request.json")));
+        var artifact = workspace.ReadClarification();
 
         // A scaffold has not filled in a goal yet. The derived text makes that
         // gap explicit rather than asserting detail the packet does not
         // contain, and the reason still names the unit being held.
         Assert.Contains("not yet recorded in the packet", artifact.QuestionText, StringComparison.Ordinal);
-        Assert.Contains(Unit, artifact.Reason, StringComparison.Ordinal);
+        Assert.Contains(ScaffoldWorkspace.Unit, artifact.Reason, StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------
+    // Identity — the one guard that must never relax.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void APacketWhoseExecutionUnitDisagreesWithTheQueueItem_IsStillRefused_G561()
+    {
+        // A clarification filed against the wrong unit is worse than none.
+        Assert.Equal(0, workspace.RunPacketDraft());
+        workspace.WriteQueueState(QueueItemState.Queued);
+        workspace.RewritePacket(yaml => yaml.Replace(
+            $"source_execution_unit: {ScaffoldWorkspace.Unit}", "source_execution_unit: G999", StringComparison.Ordinal));
+
+        workspace.AssertRefusedBeforeMutation([ScaffoldWorkspace.Unit], "must match queue item execution unit");
+    }
+
+    [Fact]
+    public void APacketMissingItsExecutionUnitEntirely_IsRefused_G561()
+    {
+        Assert.Equal(0, workspace.RunPacketDraft());
+        workspace.WriteQueueState(QueueItemState.Queued);
+        workspace.RewritePacket(yaml => yaml.Replace(
+            $"source_execution_unit: {ScaffoldWorkspace.Unit}", "# the identity line, removed", StringComparison.Ordinal));
+
+        workspace.AssertRefusedBeforeMutation([ScaffoldWorkspace.Unit], "source_execution_unit");
+    }
+
+    // ---------------------------------------------------------------
+    // Review repair: a DECLARED review_context_packet routes through the
+    // unchanged strict serializer, whatever shape the declaration has.
+    // ---------------------------------------------------------------
+
+    [Fact]
+    public void ADeclaredCompletePacket_StillSucceeds_AndUsesItsReviewContextIntents_G561()
+    {
+        // Positive control for the strict route: the complete-packet path is
+        // still the path a complete packet takes, and it still works.
+        workspace.WriteCompletePacketArtifacts();
+        workspace.WriteQueueState(QueueItemState.Queued);
+        ClarifyOpenCommand.TimestampFactory = () => ScaffoldWorkspace.FixedNow;
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, ClarifyOpenCommand.Execute(workspace.Context, [ScaffoldWorkspace.Unit], writer));
+
+        var artifact = workspace.ReadClarification();
+        // Sourced from review_context_packet, not from the implementation
+        // section — the complete-packet behaviour is unchanged.
+        Assert.Equal(["RCP.ONLY.REFERENCE"], artifact.AffectedIntents);
+    }
+
+    [Fact]
+    public void ADeclaredPacketMissingARequiredField_FailsBeforeMutation_G561()
+    {
+        workspace.WriteCompletePacketArtifacts();
+        workspace.WriteQueueState(QueueItemState.Queued);
+        workspace.RewritePacket(yaml => yaml.Replace(
+            "  landing_policy: \"merge-after-review\"\n", string.Empty, StringComparison.Ordinal));
+
+        // The strict serializer's own message, unchanged — tolerance is not
+        // applied to a packet that declared itself complete.
+        workspace.AssertRefusedBeforeMutation(
+            [ScaffoldWorkspace.Unit], "must contain required field 'landing_policy'");
+    }
+
+    [Fact]
+    public void ADeclaredPacketWithAWrongTypedField_FailsBeforeMutation_G561()
+    {
+        workspace.WriteCompletePacketArtifacts();
+        workspace.WriteQueueState(QueueItemState.Queued);
+        // review_context_packet.intent_references declared as a scalar.
+        workspace.RewritePacket(yaml => yaml.Replace(
+            "  intent_references:\n    - \"RCP.ONLY.REFERENCE\"\n",
+            "  intent_references: \"RCP.ONLY.REFERENCE\"\n",
+            StringComparison.Ordinal));
+
+        workspace.AssertRefusedBeforeMutation([ScaffoldWorkspace.Unit], "must be a list");
+    }
+
+    [Fact]
+    public void ADeclaredSectionThatIsNotAMapping_FailsBeforeMutation_G561()
+    {
+        // Present-but-wrong-shape. This is the case a "is it a mapping?" check
+        // would have silently treated as ABSENT and then tolerated — which is
+        // how a broken complete packet could have slipped through.
+        Assert.Equal(0, workspace.RunPacketDraft());
+        workspace.WriteQueueState(QueueItemState.Queued);
+        workspace.RewritePacket(yaml => yaml + "\nreview_context_packet: oops\n");
+
+        var (exitCode, output) = workspace.RunClarifyOpen([ScaffoldWorkspace.Unit]);
+        Assert.Equal(1, exitCode);
+        // It reached the strict serializer rather than the tolerant path: the
+        // tolerant path would have IGNORED a non-mapping section and succeeded.
+        Assert.DoesNotContain("Clarification opened", output, StringComparison.Ordinal);
+        workspace.AssertNothingMutated();
+    }
+
+    [Fact]
+    public void AScaffoldThatMerelyDeclaresTheSection_LosesTolerance_G561()
+    {
+        // The declaration alone decides the route. A scaffold that claims to be
+        // a complete packet is held to the complete contract and fails on the
+        // implementation fields it never filled in.
+        Assert.Equal(0, workspace.RunPacketDraft());
+        workspace.WriteQueueState(QueueItemState.Queued);
+        workspace.RewritePacket(yaml => yaml + """
+
+            review_context_packet:
+              source_execution_unit: G900
+              parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+              intent_references:
+                - "RCP.ONLY.REFERENCE"
+              rules_and_specs: []
+              acceptance_criteria: []
+              deterministic_review_checks: []
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """);
+
+        // It fails inside the strict serializer, which is the whole point. The
+        // exact stop is the scaffold's own top-level comment lines — the strict
+        // parser treats any column-0 line as a section header — which is a
+        // second, independent reason the scaffold could never have travelled
+        // this route. Either way: refused, before any mutation.
+        workspace.AssertRefusedBeforeMutation(
+            [ScaffoldWorkspace.Unit], "Projection packet YAML contains invalid section header");
+    }
+}
+
+/// <summary>
+/// G561 review repair: the detection half lives in its own class because it
+/// mutates <c>AutomationStalledWorkCommand</c>'s process-global seams, which are
+/// owned by <see cref="AutomationStalledWorkSharedStateCollection"/>. A class can
+/// join only one xUnit collection, and putting these assertions in the clarify
+/// collection let the full suite run them in parallel with the stalled-work
+/// suite — each resetting the other's factories mid-run. That is what turned a
+/// focused-green fixture into a required-CI failure.
+///
+/// It deliberately does NOT touch <c>ClarifyOpenCommand.TimestampFactory</c>: it
+/// reads the timestamp the artifact actually recorded and anchors the detector's
+/// clock to that. So it owns exactly one collection's seams, and the age
+/// assertion is relative to real recorded data rather than to a clock the test
+/// imposed on two commands at once.
+/// </summary>
+[Collection(AutomationStalledWorkSharedStateCollection.Name)]
+public sealed class ClarifyOpenScaffoldedPacketDetectionTests : IDisposable
+{
+    private readonly ScaffoldWorkspace workspace = new();
+
+    public void Dispose()
+    {
+        AutomationStalledWorkCommand.UtcNowFactory = null;
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        workspace.Dispose();
     }
 
     [Fact]
@@ -137,20 +281,29 @@ public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
     {
         // Recording the clarification is only useful if the detector that
         // surfaces held design decisions can read what was written.
-        var context = CreateContext();
-        Assert.Equal(0, RunPacketDraft(context));
-        WriteQueueState(QueueItemState.Queued);
-        ClarifyOpenCommand.TimestampFactory = () => FixedNow.AddMinutes(-120);
+        Assert.Equal(0, workspace.RunPacketDraft());
+        workspace.WriteQueueState(QueueItemState.Queued);
 
         using var openWriter = new StringWriter();
         Assert.Equal(0, ClarifyOpenCommand.Execute(
-            context, [Unit, "--question", "Flag or command?"], openWriter));
+            workspace.Context, [ScaffoldWorkspace.Unit, "--question", "Flag or command?"], openWriter));
 
-        AutomationStalledWorkCommand.UtcNowFactory = () => FixedNow;
+        // Anchor the detector's clock to what the artifact actually recorded,
+        // rather than imposing a fixed clock on clarify open as well.
+        var createdAt = workspace.ReadClarification().CreatedAt;
+        AutomationStalledWorkCommand.UtcNowFactory = () => createdAt.AddMinutes(120);
+        // Without this the command shells out to `gh` for its issue/PR
+        // candidates. That happens to succeed on a developer machine with a
+        // logged-in gh and fails on a CI runner — a test that depends on
+        // ambient credentials is not a test. The design-decision lane reads the
+        // clarification artifact off disk, so an empty candidate list is
+        // exactly the right input.
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new EmptyCandidateLister();
+
         using var writer = new StringWriter();
         var exitCode = AutomationStalledWorkCommand.Execute(
-            context,
-            ["--domain", Domain, "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            workspace.Context,
+            ["--domain", ScaffoldWorkspace.Domain, "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
             writer);
 
         Assert.Equal(0, exitCode);
@@ -158,60 +311,38 @@ public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
         var item = document.RootElement.GetProperty("items").EnumerateArray()
             .Single(entry => entry.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindDesignDecisionPending);
 
-        Assert.Equal(Unit, item.GetProperty("execution_unit").GetString());
+        Assert.Equal(ScaffoldWorkspace.Unit, item.GetProperty("execution_unit").GetString());
         Assert.Equal(120, item.GetProperty("age_minutes").GetInt32());
         Assert.Contains("Flag or command?", item.GetProperty("recommended_action").GetString()!, StringComparison.Ordinal);
     }
 
-    [Fact]
-    public void APacketWhoseExecutionUnitDisagreesWithTheQueueItem_IsStillRefused_G561()
+    /// <summary>Keeps <c>stalled-work</c> off the network: no GitHub candidates, no `gh` invocation.</summary>
+    private sealed class EmptyCandidateLister : IGitHubAutomationCandidateLister
     {
-        // The one guard that must NOT relax: identity. A clarification filed
-        // against the wrong unit is worse than none.
-        var context = CreateContext();
-        Assert.Equal(0, RunPacketDraft(context));
-        WriteQueueState(QueueItemState.Queued);
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo, IReadOnlyCollection<string> requiredLabels) => [];
 
-        var yaml = File.ReadAllText(PacketYamlPath())
-            .Replace($"source_execution_unit: {Unit}", "source_execution_unit: G999", StringComparison.Ordinal);
-        File.WriteAllText(PacketYamlPath(), yaml);
-
-        var queueBefore = File.ReadAllText(QueueStatePath());
-        using var writer = new StringWriter();
-        var exitCode = ClarifyOpenCommand.Execute(context, [Unit], writer);
-
-        Assert.Equal(1, exitCode);
-        Assert.Contains("must match queue item execution unit", writer.ToString(), StringComparison.Ordinal);
-        Assert.Equal(queueBefore, File.ReadAllText(QueueStatePath()));
-        Assert.False(Directory.Exists(Path.Combine(rootPath, ".intent-cli", "clarifications", Unit)));
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo, IReadOnlyCollection<string> requiredLabels) => [];
     }
+}
 
-    [Fact]
-    public void APacketMissingItsExecutionUnitEntirely_IsRefused_G561()
-    {
-        var context = CreateContext();
-        Assert.Equal(0, RunPacketDraft(context));
-        WriteQueueState(QueueItemState.Queued);
+/// <summary>
+/// A throwaway repo root plus the packet/queue helpers both G561 clarify suites
+/// need. Shared rather than duplicated so the two classes — which must live in
+/// different xUnit collections — still exercise the same fixtures.
+/// </summary>
+internal sealed class ScaffoldWorkspace : IDisposable
+{
+    public const string Unit = "G900";
+    public const string Domain = "intent-cli";
+    public const string ReturnPath = "intents/intent-cli/clarifications/open.md";
 
-        var yaml = File.ReadAllText(PacketYamlPath())
-            .Replace($"source_execution_unit: {Unit}", "# the identity line, removed", StringComparison.Ordinal);
-        File.WriteAllText(PacketYamlPath(), yaml);
+    public static readonly DateTimeOffset FixedNow = new(2026, 7, 31, 9, 0, 0, TimeSpan.Zero);
 
-        using var writer = new StringWriter();
-        Assert.Equal(1, ClarifyOpenCommand.Execute(context, [Unit], writer));
-        Assert.Contains("source_execution_unit", writer.ToString(), StringComparison.Ordinal);
-    }
+    private readonly string rootPath = Directory.CreateTempSubdirectory("clarify-open-scaffold-tests-").FullName;
 
-    private static int RunPacketDraft(CliContext context)
-    {
-        using var writer = new StringWriter();
-        return PacketDraftCommand.Execute(
-            context,
-            ["--execution-unit", Unit, "--target-repo", "J-Tech-Japan/intent-system"],
-            writer);
-    }
-
-    private CliContext CreateContext() => new()
+    public CliContext Context => new()
     {
         RepoRoot = rootPath,
         Config = new CliConfig
@@ -225,20 +356,73 @@ public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
         },
     };
 
-    private string PacketYamlPath() => Path.Combine(rootPath, ".intent-cli", "issues", Unit, "packet.yaml");
+    public string PacketYamlPath => Path.Combine(rootPath, ".intent-cli", "issues", Unit, "packet.yaml");
 
-    private string ReviewContextPath() => Path.Combine(rootPath, ".intent-cli", "issues", Unit, "review-context.md");
+    public string ReviewContextPath => Path.Combine(rootPath, ".intent-cli", "issues", Unit, "review-context.md");
 
-    private string QueueStatePath() => Path.Combine(rootPath, ".intent-cli", "queue-state.json");
+    public string QueueStatePath => Path.Combine(rootPath, ".intent-cli", "queue-state.json");
 
-    private QueueItem ReadQueueItem() =>
-        QueueStateSerializer.Deserialize(File.ReadAllText(QueueStatePath()))
+    public string ClarificationPath => Path.Combine(rootPath, ".intent-cli", "clarifications", Unit, "request.json");
+
+    public int RunPacketDraft()
+    {
+        using var writer = new StringWriter();
+        return PacketDraftCommand.Execute(
+            Context,
+            ["--execution-unit", Unit, "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+    }
+
+    public (int ExitCode, string Output) RunClarifyOpen(string[] args)
+    {
+        using var writer = new StringWriter();
+        var exitCode = ClarifyOpenCommand.Execute(Context, args, writer);
+        return (exitCode, writer.ToString());
+    }
+
+    public void RewritePacket(Func<string, string> rewrite) =>
+        File.WriteAllText(PacketYamlPath, rewrite(File.ReadAllText(PacketYamlPath)));
+
+    public ClarificationItem ReadClarification() =>
+        ClarificationSerializer.Deserialize(File.ReadAllText(ClarificationPath));
+
+    public QueueItem ReadQueueItem() =>
+        QueueStateSerializer.Deserialize(File.ReadAllText(QueueStatePath))
             .Items.Single(item => item.ExecutionUnit == Unit);
 
-    private void WriteQueueState(QueueItemState state)
+    /// <summary>
+    /// A refusal must happen BEFORE any mutation: exit 1, the named diagnostic,
+    /// queue-state byte-identical, and no clarification artifact at all.
+    /// </summary>
+    public void AssertRefusedBeforeMutation(string[] args, string expectedMessage)
+    {
+        var queueBefore = File.ReadAllText(QueueStatePath);
+        var (exitCode, output) = RunClarifyOpen(args);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains(expectedMessage, output, StringComparison.Ordinal);
+        Assert.Equal(queueBefore, File.ReadAllText(QueueStatePath));
+        Assert.False(Directory.Exists(Path.GetDirectoryName(ClarificationPath)!), output);
+    }
+
+    public void AssertNothingMutated() =>
+        Assert.False(Directory.Exists(Path.GetDirectoryName(ClarificationPath)!));
+
+    /// <summary>
+    /// A packet that DECLARES review_context_packet — the complete-contract
+    /// shape, used to prove the strict route is still the strict route.
+    /// </summary>
+    public void WriteCompletePacketArtifacts()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(PacketYamlPath)!);
+        File.WriteAllText(PacketYamlPath, CompletePacketYaml);
+        File.WriteAllText(ReviewContextPath, CompleteReviewContextMarkdown);
+    }
+
+    public void WriteQueueState(QueueItemState state)
     {
         Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
-        File.WriteAllText(QueueStatePath(), QueueStateSerializer.Serialize(new QueueState
+        File.WriteAllText(QueueStatePath, QueueStateSerializer.Serialize(new QueueState
         {
             SchemaVersion = "1",
             UpdatedAt = FixedNow,
@@ -265,4 +449,68 @@ public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
             ],
         }));
     }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(rootPath))
+        {
+            Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
+    private const string CompletePacketYaml = """
+        implementation_issue_packet:
+          issue_title: "[G900] Complete packet"
+          issue_kind: "feature"
+          source_execution_unit: "G900"
+          goal: "Prove the strict route stays strict."
+          in_scope:
+            - "clarify open"
+          out_of_scope:
+            - "everything else"
+          target_repo: "J-Tech-Japan/intent-system"
+          target_path: "."
+          target_part: "cli clarify open command"
+          dependencies: []
+          technical_baseline:
+            - "C# / .NET"
+          project_local_guide:
+            - "AGENTS.md"
+          intent_baseline:
+            - "clarify open stays entry-only"
+          intent_references:
+            - "IIP.ONLY.REFERENCE"
+          rules_and_specs:
+            - "intents/intent-cli/specs/06-interview-and-clarification-artifact-contract.md"
+          acceptance_criteria:
+            - "clarification artifact generated"
+          verification_evidence:
+            - "dotnet test IntentSystem.sln"
+          review_mode: "deterministic-review"
+          completion_action: "wait-for-deterministic-review"
+          landing_policy: "merge-after-review"
+
+        review_context_packet:
+          source_execution_unit: "G900"
+          parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+          intent_references:
+            - "RCP.ONLY.REFERENCE"
+          rules_and_specs:
+            - "intents/intent-cli/specs/06-interview-and-clarification-artifact-contract.md"
+          acceptance_criteria:
+            - "clarification artifact generated"
+          deterministic_review_checks:
+            - "clarify open command remains entry-only"
+          clarification_return_path: "intents/intent-cli/clarifications/open.md"
+        """;
+
+    private const string CompleteReviewContextMarkdown = """
+        # Execution Unit
+
+        `G900`
+
+        # Deterministic Review Checks
+
+        - clarify open command remains entry-only
+        """;
 }

--- a/tests/IntentSystem.Cli.Tests/ClarifyOpenScaffoldedPacketTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClarifyOpenScaffoldedPacketTests.cs
@@ -1,0 +1,268 @@
+using System.Text.Json;
+using IntentSystem.Clarify.Models;
+using IntentSystem.Clarify.Serialization;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G561: <c>clarify open</c> must work on a packet produced by
+/// <c>intent-cli packet draft</c>.
+///
+/// Field incident (2026-07-31, G559 wake): the orchestrator tried to record the
+/// required design clarification and <c>clarify open</c> failed pre-mutation
+/// with "Projection packet YAML must contain required section
+/// review_context_packet". Scaffolded packets carry
+/// <c>implementation_issue_packet</c> / <c>intent_placement</c> /
+/// <c>knowledge_updates</c> / <c>closeout_learning</c> — review context lives in
+/// <c>review-context.md</c>, not in packet.yaml — so the G552 design-decision
+/// flow was structurally blocked at exactly the moment it exists for: recording
+/// a blocking question EARLY, before the packet is complete.
+///
+/// The scaffold here is produced by the REAL <see cref="PacketDraftCommand"/>
+/// rather than by a hand-written fixture. A fixture copy of the scaffold would
+/// keep passing after the scaffold changed shape, which is precisely how this
+/// gap survived: every existing clarify fixture was a complete packet.
+/// </summary>
+[Collection(RunSubmitCommandCollection.Name)]
+public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
+{
+    private const string Unit = "G900";
+    private const string Domain = "intent-cli";
+    private const string ReturnPath = "intents/intent-cli/clarifications/open.md";
+
+    private static readonly DateTimeOffset FixedNow = new(2026, 7, 31, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly string rootPath = Directory.CreateTempSubdirectory("clarify-open-scaffold-tests-").FullName;
+    private readonly Func<DateTimeOffset> originalTimestampFactory = ClarifyOpenCommand.TimestampFactory;
+
+    public void Dispose()
+    {
+        ClarifyOpenCommand.TimestampFactory = originalTimestampFactory;
+        AutomationStalledWorkCommand.UtcNowFactory = null;
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+
+        if (Directory.Exists(rootPath))
+        {
+            Directory.Delete(rootPath, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ScaffoldedPacket_HasNoReviewContextSection_AndIsIncomplete_G561()
+    {
+        // The premise of the whole slice, asserted rather than assumed — if the
+        // scaffold ever grows a full contract, this test says so instead of the
+        // rest of the file silently proving nothing.
+        var context = CreateContext();
+        Assert.Equal(0, RunPacketDraft(context));
+
+        var yaml = File.ReadAllText(PacketYamlPath());
+        Assert.DoesNotContain("review_context_packet:", yaml, StringComparison.Ordinal);
+        Assert.Contains("implementation_issue_packet:", yaml, StringComparison.Ordinal);
+        // Also missing most of the strict contract's required implementation
+        // fields — so "make review_context_packet optional" alone would not
+        // have been enough.
+        Assert.DoesNotContain("landing_policy:", yaml, StringComparison.Ordinal);
+
+        var reviewContext = File.ReadAllText(ReviewContextPath());
+        Assert.DoesNotContain("# Deterministic Review Checks", reviewContext, StringComparison.Ordinal);
+        Assert.DoesNotContain("# Execution Unit", reviewContext, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ClarifyOpen_OnAFreshlyScaffoldedPacket_RecordsTheClarification_G561()
+    {
+        var context = CreateContext();
+        Assert.Equal(0, RunPacketDraft(context));
+        WriteQueueState(QueueItemState.Queued);
+        ClarifyOpenCommand.TimestampFactory = () => FixedNow;
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyOpenCommand.Execute(
+            context,
+            [Unit, "--question", "Should the pre-publish exit be a flag or its own command?"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains($"Clarification opened for {Unit}", writer.ToString(), StringComparison.Ordinal);
+
+        // The durable artifact — the thing detection and design actually read.
+        var artifactPath = Path.Combine(rootPath, ".intent-cli", "clarifications", Unit, "request.json");
+        Assert.True(File.Exists(artifactPath), writer.ToString());
+        var artifact = ClarificationSerializer.Deserialize(File.ReadAllText(artifactPath));
+        Assert.Equal(Unit, artifact.ExecutionUnit);
+        Assert.Equal(ClarificationStatus.Open, artifact.Status);
+        Assert.Equal("blocking", artifact.BlockingOrNonblocking);
+        Assert.Equal(
+            "Should the pre-publish exit be a flag or its own command?",
+            artifact.QuestionText);
+        // The return path comes from the queue item, which is authoritative for
+        // it; the scaffold has no review-context packet to carry a copy.
+        Assert.Equal(ReturnPath, artifact.ClarificationReturnPath);
+
+        // And the queue side moved, exactly as it does for a complete packet.
+        var item = ReadQueueItem();
+        Assert.Equal(QueueItemState.ClarifyBlocked, item.State);
+        Assert.NotEmpty(item.BlockedBy);
+    }
+
+    [Fact]
+    public void ClarifyOpen_OnAScaffold_WithoutAnExplicitQuestion_StillRecordsSomethingReadable_G561()
+    {
+        var context = CreateContext();
+        Assert.Equal(0, RunPacketDraft(context));
+        WriteQueueState(QueueItemState.Queued);
+        ClarifyOpenCommand.TimestampFactory = () => FixedNow;
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, ClarifyOpenCommand.Execute(context, [Unit], writer));
+
+        var artifact = ClarificationSerializer.Deserialize(
+            File.ReadAllText(Path.Combine(rootPath, ".intent-cli", "clarifications", Unit, "request.json")));
+
+        // A scaffold has not filled in a goal yet. The derived text makes that
+        // gap explicit rather than asserting detail the packet does not
+        // contain, and the reason still names the unit being held.
+        Assert.Contains("not yet recorded in the packet", artifact.QuestionText, StringComparison.Ordinal);
+        Assert.Contains(Unit, artifact.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheResultingArtifact_IsReadByDesignDecisionPendingDetection_G561()
+    {
+        // Recording the clarification is only useful if the detector that
+        // surfaces held design decisions can read what was written.
+        var context = CreateContext();
+        Assert.Equal(0, RunPacketDraft(context));
+        WriteQueueState(QueueItemState.Queued);
+        ClarifyOpenCommand.TimestampFactory = () => FixedNow.AddMinutes(-120);
+
+        using var openWriter = new StringWriter();
+        Assert.Equal(0, ClarifyOpenCommand.Execute(
+            context, [Unit, "--question", "Flag or command?"], openWriter));
+
+        AutomationStalledWorkCommand.UtcNowFactory = () => FixedNow;
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            context,
+            ["--domain", Domain, "--repo", "J-Tech-Japan/intent-system", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var item = document.RootElement.GetProperty("items").EnumerateArray()
+            .Single(entry => entry.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindDesignDecisionPending);
+
+        Assert.Equal(Unit, item.GetProperty("execution_unit").GetString());
+        Assert.Equal(120, item.GetProperty("age_minutes").GetInt32());
+        Assert.Contains("Flag or command?", item.GetProperty("recommended_action").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void APacketWhoseExecutionUnitDisagreesWithTheQueueItem_IsStillRefused_G561()
+    {
+        // The one guard that must NOT relax: identity. A clarification filed
+        // against the wrong unit is worse than none.
+        var context = CreateContext();
+        Assert.Equal(0, RunPacketDraft(context));
+        WriteQueueState(QueueItemState.Queued);
+
+        var yaml = File.ReadAllText(PacketYamlPath())
+            .Replace($"source_execution_unit: {Unit}", "source_execution_unit: G999", StringComparison.Ordinal);
+        File.WriteAllText(PacketYamlPath(), yaml);
+
+        var queueBefore = File.ReadAllText(QueueStatePath());
+        using var writer = new StringWriter();
+        var exitCode = ClarifyOpenCommand.Execute(context, [Unit], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must match queue item execution unit", writer.ToString(), StringComparison.Ordinal);
+        Assert.Equal(queueBefore, File.ReadAllText(QueueStatePath()));
+        Assert.False(Directory.Exists(Path.Combine(rootPath, ".intent-cli", "clarifications", Unit)));
+    }
+
+    [Fact]
+    public void APacketMissingItsExecutionUnitEntirely_IsRefused_G561()
+    {
+        var context = CreateContext();
+        Assert.Equal(0, RunPacketDraft(context));
+        WriteQueueState(QueueItemState.Queued);
+
+        var yaml = File.ReadAllText(PacketYamlPath())
+            .Replace($"source_execution_unit: {Unit}", "# the identity line, removed", StringComparison.Ordinal);
+        File.WriteAllText(PacketYamlPath(), yaml);
+
+        using var writer = new StringWriter();
+        Assert.Equal(1, ClarifyOpenCommand.Execute(context, [Unit], writer));
+        Assert.Contains("source_execution_unit", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    private static int RunPacketDraft(CliContext context)
+    {
+        using var writer = new StringWriter();
+        return PacketDraftCommand.Execute(
+            context,
+            ["--execution-unit", Unit, "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+    }
+
+    private CliContext CreateContext() => new()
+    {
+        RepoRoot = rootPath,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = Domain,
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private string PacketYamlPath() => Path.Combine(rootPath, ".intent-cli", "issues", Unit, "packet.yaml");
+
+    private string ReviewContextPath() => Path.Combine(rootPath, ".intent-cli", "issues", Unit, "review-context.md");
+
+    private string QueueStatePath() => Path.Combine(rootPath, ".intent-cli", "queue-state.json");
+
+    private QueueItem ReadQueueItem() =>
+        QueueStateSerializer.Deserialize(File.ReadAllText(QueueStatePath()))
+            .Items.Single(item => item.ExecutionUnit == Unit);
+
+    private void WriteQueueState(QueueItemState state)
+    {
+        Directory.CreateDirectory(Path.Combine(rootPath, ".intent-cli"));
+        File.WriteAllText(QueueStatePath(), QueueStateSerializer.Serialize(new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = FixedNow,
+            Items =
+            [
+                new QueueItem
+                {
+                    ExecutionUnit = Unit,
+                    Title = $"[{Unit}] Scaffolded slice",
+                    State = state,
+                    Dependencies = [],
+                    BlockedBy = [],
+                    ClarificationReturnPath = ReturnPath,
+                    PacketPaths = new PacketPaths
+                    {
+                        Implementation = $".intent-cli/issues/{Unit}/implementation.md",
+                        ReviewContext = $".intent-cli/issues/{Unit}/review-context.md",
+                        Yaml = $".intent-cli/issues/{Unit}/packet.yaml",
+                    },
+                    WorkerRole = "coder",
+                    ReviewRole = "reviewer",
+                    Priority = "normal",
+                },
+            ],
+        }));
+    }
+}


### PR DESCRIPTION
Closes #1225

Both gaps surfaced in the same field incident (2026-07-31, G559 wake), and each forced a design one-off ruling to move a single unit.

## Gap 1 — no canonical exit from a pre-publish block

Publish-priority ordering works by blocking a not-yet-published unit so the selector skips it. But `issue-block --clear` requires a **complete** `linked_issue` before touching anything — rightly, since it also converges the GitHub label and issue #818 exists in almost every repo — and an unpublished unit has none. A bare `queue transition` would move the state and strand `blocked_by` populated: exactly the half-converged shape the selector excludes. There was no exit at all.

```bash
intent-cli automation issue-block <execution-unit> --clear --pre-publish --write
```

- Converges the queue side **only**, through the same `ConvergeQueueSide` the two-sided path uses — run-log event first, queue-state second, guarded write, idempotent retry reuse.
- Performs **no GitHub interaction whatsoever**: it does not even construct a mutator, because an unpublished unit has no issue to read. A test asserts `ReadCount == 0`, not merely "no mutation".
- The durable event **names the wait reason it cleared** — a log recording only `queued` would leave the priority decision unauditable.

Fails closed twice, both deliberate:

| Case | Why |
| --- | --- |
| the unit HAS a `linked_issue` (even a partial one) | the two-sided path owns it and also converges the label; the queue-only shortcut would leave the label behind — the exact drift that command exists to prevent. Half a linkage is evidence of a publish attempt, not of its absence. |
| `--repo` / `--issue` supplied | refused, not ignored: accepting identifiers this path cannot act on would let a caller believe a GitHub side converged when none was touched. |

`--pre-publish` also requires `--clear`: it is an *exit*, not a way to block. `QueueManager` is untouched — the event's reason is supplied by this command.

## Gap 2 — `clarify open` rejected every scaffolded packet

**Scope note worth flagging:** the issue named the missing `review_context_packet` section, but that was only the *first* failure. A `packet draft` scaffold also lacks ~10 required `implementation_issue_packet` fields **and** both required `review-context.md` sections — so making that one section optional would not have been sufficient to meet the acceptance criterion. The fix addresses all of them.

`clarify open` now reads only the facts a clarification record contains, asymmetrically on purpose:

- `source_execution_unit` is **required** and must match the queue item — identity never degrades, because a clarification filed against the wrong unit is worse than none;
- every other field is optional; derived question/reason text degrades field by field and makes the gap explicit rather than asserting detail the packet lacks;
- a packet that **does** carry `review_context_packet` is validated exactly as before — same checks, same order, same messages;
- `review-context.md` is still read by the canonical parser, so its execution-unit rules (including the malformed-section throw) are unchanged; only the absent `# Deterministic Review Checks` section is accommodated, and that costs solely the derived question text.

The strict `ProjectionPacketSerializer` is deliberately **not** weakened — publish-flow and review legitimately require a complete contract, and the issue's target paths scope this slice to `src/IntentSystem.Cli`. The tolerance lives in the CLI.

## Verification

- `dotnet test IntentSystem.sln` — all green (Cli 3976 passed + 1 skipped).
- Pre-publish: happy path (both queue fields read back from disk, durable event with the cleared reason, zero GitHub reads), dry-run writes nothing, idempotency, both fail-closed cases plus partial linkage and `--pre-publish` without `--clear`, and the block → clear → selector-eligible lifecycle.
- Clarify: the scaffold is produced by the **real** `PacketDraftCommand`, not a fixture copy, so it cannot drift out of sync — that is how this gap survived, since every existing clarify fixture was a complete packet. The suite asserts the scaffold's incompleteness as its own premise, records the clarification, keeps refusing an identity mismatch, and proves `design-decision-pending` detection reads the resulting artifact. **Verified to fail 5/6 against the pre-fix implementation.**
- ja/en developer reference: publish-priority ordering documented as a first-class lifecycle, plus the clarify-open compatibility contract.
- `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPT7cFrCzT6ehACFez8dpE