### PR TITLE
G564: Intent-tree co-evolution enforcement — declared write-backs become recorded evidence, unrecorded ones become aging stalled work

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -637,6 +637,23 @@ host commit as evidence. It is the clearing half of
   than overwritten (replacing evidence silently is how an audit trail stops
   being one); an existing record that cannot be read is refused rather than
   clobbered.
+- **The execution unit is a canonical identifier, validated before any
+  filesystem access.** ASCII letters, digits, `-`, `_` and `.`, never leading
+  with `.` and never containing `..` — which structurally excludes path
+  separators, rooted paths, drive/ADS colons, dot-segments, whitespace, and
+  control characters. Both derived paths (the packet and the record) are then
+  re-checked for containment beneath `.intent-cli/issues` and
+  `.intent-cli/knowledge-writebacks`. The same validation is applied to
+  execution units read out of `runs.jsonl` by the detector, since a runs log is
+  data rather than a trusted identifier; a non-canonical unit there is reported
+  in `excluded[]` and no path is derived from it.
+- **A record is evidence only for the unit it names.** On every consumption —
+  the detector's clearing path and the recorder's idempotency/refusal path
+  alike — the record's embedded `execution_unit` must equal the unit it is
+  stored under, and `host_commit` must be SHA-shaped. A record under
+  `…/G564/record.json` declaring `execution_unit: G999`, or carrying evidence
+  that is not a commit, is reported as unreadable-with-path rather than
+  clearing `knowledge-writeback-pending`.
 - **`--dry-run` is the default.** `--write` is required to persist.
 - Recording against a unit that declared nothing required still succeeds, but
   the result carries a warning: if the tree genuinely owed something there,

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -353,6 +353,30 @@ is always a runnable `intent-cli` command):
   guide's clarification-backed hold rule is what puts the artifact on disk
   for this kind to read — an agmsg-only hold is a contract violation, and if
   the hold is real but this kind is absent, the artifact was never recorded.
+- `knowledge-writeback-pending` (G564) — a **closed-out** unit (a
+  `closeout-recorded` event in `runs.jsonl`) whose packet **declared** a
+  knowledge write-back — any `knowledge_updates.*.required: true`
+  (`intent_tree` / `adr` / `diagram` / `docs`) or
+  `closeout_learning.write_back_required: true` — with **no write-back
+  record** at `.intent-cli/knowledge-writebacks/<unit>/record.json`. The item
+  carries the age from closeout (the EARLIEST `closeout-recorded` event, so a
+  retried closeout cannot reset it), the declared facets, and
+  `declared_write_back_targets`; `recommended_action` names
+  `intent-cli automation knowledge-writeback-record`. A unit that declared
+  nothing required never appears — declining is a legitimate answer, and this
+  kind detects broken promises, not missing enthusiasm. Fails closed in both
+  directions: an unreadable packet declaration, an unreadable `runs.jsonl`, and
+  an unreadable existing record all go to `excluded[]` **with their path**
+  (`knowledge-metadata-unreadable`) rather than being read as "nothing
+  pending". Units closed out before this shipped are out of scope by default
+  (floor: `2026-08-01T00:00:00Z`); `--knowledge-writeback-since <iso-8601>`
+  opts into scanning further back. Nothing here writes intent content — the
+  tree is written by design (G300); this kind only makes an unrecorded
+  obligation visible and aging. Field evidence: the pre-v0.7.0 audit
+  (2026-07-31), where node 09 still described a pre-implementation design,
+  node 02 recorded none of the seven release-flow rules the docs implement,
+  and node 08 lagged the wake contract by releases — weeks of drift with no
+  structural signal.
 
 **Informational categories (G533)** — `is_informational: true`,
 `recommended_action` is descriptive prose (never a transition command), age
@@ -588,6 +612,43 @@ wake procedure and from an external heartbeat are separate follow-up slices.
 ` command `` for an actionable kind or `— FYI: ` prose `` for an
 informational one, so a reader (human or orchestrator) can never mistake
 "no transition needed" for an actionable next command.
+
+### Intent-tree co-evolution: recording a performed knowledge write-back (G564)
+
+`intent-cli automation knowledge-writeback-record --execution-unit <u> --commit <host-commit-sha> [--target <path>]... [--note <text>] [--dry-run|--write] [--format json|markdown]`
+
+records that the write-backs a packet **declared** were performed, with the
+host commit as evidence. It is the clearing half of
+`knowledge-writeback-pending` above.
+
+- **Records only.** The write-back itself is design's host-side act — this
+  command never writes intent content and never mutates the intent tree
+  (G300). Hand-editing the artifact is not the path.
+- **Artifact.** `.intent-cli/knowledge-writebacks/<unit>/record.json`, one per
+  execution unit: `artifact_kind`, `execution_unit`, `host_commit`,
+  `recorded_at`, `targets`, `note`.
+- **Idempotent.** Re-recording the SAME commit (case-insensitively) is a
+  no-op success — `already_recorded: true`, `applied: false`, and the file is
+  left byte-identical, so a retried closeout wake cannot move `recorded_at`
+  off the real event.
+- **Fails closed.** An execution unit with no `.intent-cli/issues/<u>/packet.yaml`
+  is UNKNOWN and refused; evidence that is not a 7–40 character hexadecimal
+  SHA is refused; an existing record with a DIFFERENT commit is refused rather
+  than overwritten (replacing evidence silently is how an audit trail stops
+  being one); an existing record that cannot be read is refused rather than
+  clobbered.
+- **`--dry-run` is the default.** `--write` is required to persist.
+- Recording against a unit that declared nothing required still succeeds, but
+  the result carries a warning: if the tree genuinely owed something there,
+  the packet's declaration was dishonest, and that is the defect to fix.
+
+The duty this enforces is stated in the guides rather than only here: the
+design-thread playbook (`guide orchestrator-thread`), the packet-authoring
+prompts (`guide workflow task packet-draft`), and the closeout prompt
+(`guide closeout run`, Stage 5b) all carry it, single-sourced so they cannot
+drift apart. The orchestrator's closeout report to the design thread
+enumerates the packet's declared write-backs and whether each is recorded or
+pending — read-only propagation of packet metadata, no host mutation.
 
 ### Retiring a stuck published issue (G525)
 

--- a/docs/en/release-notes-v0.7.0.md
+++ b/docs/en/release-notes-v0.7.0.md
@@ -263,7 +263,7 @@ This gate fails closed — if any item is unmet, do not publish the Release yet.
 
 - [ ] Every release-bound packet is **complete and its PR merged to `main`**:
       G559 (PR #1224), G560 (PR #1222), G561 (PR #1226), G563
-      (PR #1230), and G564 (PR #<G564-PR>), plus the G562 release-prep
+      (PR #1230), and G564 (PR #1232), plus the G562 release-prep
       (PR #1228). Confirm on the
       host/review side via the host queue-state /
       GitHub PR state — the child implementation loop must not read parent

--- a/docs/en/release-notes-v0.7.0.md
+++ b/docs/en/release-notes-v0.7.0.md
@@ -11,21 +11,22 @@
 
 ## What's in v0.7.0
 
-v0.7.0 covers exactly the four slices merged after `v0.6.2`: **G559**,
-**G560**, **G561**, and **G563**.
+v0.7.0 covers exactly the five slices merged after `v0.6.2`: **G559**,
+**G560**, **G561**, **G563**, and **G564**.
 
 **Why minor, not patch.** The documented policy reserves a minor bump for a new
 command surface. G559 adds one: `intent-cli skill list | install | diff` is a
 new top-level command group, not an extension of an existing one. That alone
-decides it — G560, G561, and G563 would each have been a patch on their own. Nothing
+decides it — G560, G561, G563, and G564 would each have been a patch on their own. Nothing
 is removed or renamed, so the bump is minor rather than major: every v0.6.x
 command, argument, and flag keeps its shape. The package id remains
 `JTechJapan.IntentSystem.Cli`; there are no package id, license, or workflow-
 semantics changes.
 
-The headline is the skill surface. The other three close release-flow and
-publish-priority machinery gaps that each cost a real incident, and reconcile
-the guide corpus with the skill this release ships.
+The headline is the skill surface. The other four close release-flow and
+publish-priority machinery gaps that each cost a real incident, reconcile the
+guide corpus with the skill this release ships, and make intent-tree
+co-evolution enforceable instead of aspirational.
 
 ### Cross-platform agent skill, installed by one command (G559)
 
@@ -166,6 +167,53 @@ per-receiver delegation cap instead of the superseded "at most one message"
 rule; and the provisioning Authority-boundary sentence enumerates the same four
 MAY-answer classes the supervision section grants.
 
+### A stale intent tree is now visible work, not a silent fault (G564)
+
+The same pre-release audit that produced G563 is the evidence for this one: G559
+shipped while intent-tree node 09 still described a pre-implementation design,
+node 02 recorded none of the seven release-flow rules the docs implement, and
+node 08 lagged the wake contract by releases. Development moved for weeks with
+**no structural signal** that the tree was stale — a manual, operator-ordered
+audit was the only detector, and it cost a full review cycle immediately before
+a release.
+
+The ingredients already existed and nothing connected them: packets declare
+`knowledge_updates.*.required` and `closeout_learning.write_back_required`, and
+the write-back itself happens as a host commit the child repo never sees. No
+record said "done", so nothing could say "not done".
+
+**Recording.** A new subcommand states that a declared write-back was performed,
+with the host commit as evidence:
+
+```bash
+intent-cli automation knowledge-writeback-record \
+  --execution-unit G564 --commit <host-commit-sha> \
+  --target intents/<domain>/intent-tree/means/03-state-and-audit-strategy.md --write
+```
+
+It is idempotent for the same commit, refuses a *different* commit rather than
+overwriting evidence, and fails closed on an unknown execution unit or
+non-SHA evidence. `--dry-run` is the default. It records only — the tree is
+written by design, never by tooling.
+
+**Detection.** `automation stalled-work` gains a `knowledge-writeback-pending`
+kind, carried by `automation heartbeat`: a closed-out unit whose packet declared
+a write-back with no record becomes an actionable, aging item that names the
+declared facets and target paths and recommends the recording command. A unit
+that declared nothing required never appears; unreadable packet metadata or an
+unreadable record is reported in `excluded` **with its path**, never silently
+read as "nothing pending". Units closed out before this shipped are out of scope
+by default (`--knowledge-writeback-since <iso-8601>` opts into scanning further
+back).
+
+**Duty.** The guides now state the operator's 2026-07-31 ruling directly: the
+intent tree moves *with* development, and leaving it unupdated while
+implementation advances is a serious fault in its own right. Packet-authoring
+guidance requires honest declarations for slices that add a surface or change
+behavior; closeout guidance performs and records the write-back in the **same**
+wake; and the orchestrator's closeout report to the design thread enumerates the
+packet's declared write-backs and whether each is recorded or pending.
+
 ## Install
 
 ```bash
@@ -196,6 +244,12 @@ and release flows**. No command, argument, or flag was removed or renamed.
   `--clear --pre-publish`; the existing two-sided block/unblock path is
   unchanged. `clarify open` now succeeds on packets it previously rejected;
   packets it previously accepted are validated exactly as before.
+- **Additive — write-back recording and detection (G564).** `automation
+  knowledge-writeback-record` is a new subcommand, and `automation stalled-work`
+  / `automation heartbeat` gain the `knowledge-writeback-pending` kind. Existing
+  kinds, thresholds, and output fields are unchanged. Nothing is reported
+  retroactively: only units closed out after this release can produce the new
+  item, so an upgrade does not light up historical units.
 - **Corrective — release flow only.** G560 changes how the repository's own
   documentation guards are asserted and completes the post-release roll rule. It
   affects maintainers cutting a release, not consumers of the CLI.
@@ -208,8 +262,9 @@ These items must hold **before the GitHub Release for `v0.7.0` is published**.
 This gate fails closed — if any item is unmet, do not publish the Release yet.
 
 - [ ] Every release-bound packet is **complete and its PR merged to `main`**:
-      G559 (PR #1224), G560 (PR #1222), G561 (PR #1226), and G563
-      (PR #1230), plus the G562 release-prep (PR #1228). Confirm on the
+      G559 (PR #1224), G560 (PR #1222), G561 (PR #1226), G563
+      (PR #1230), and G564 (PR #<G564-PR>), plus the G562 release-prep
+      (PR #1228). Confirm on the
       host/review side via the host queue-state /
       GitHub PR state — the child implementation loop must not read parent
       queue-state, so this is a host-owned precondition.
@@ -261,6 +316,10 @@ Post-release verification (after the GitHub Release is published and
 - [ ] **Skill smoke** (G559): `intent-cli skill list` names the `intent-cli`
       skill and every target/scope, and `intent-cli skill install --target all`
       places `SKILL.md` in each platform's own location.
+- [ ] **Write-back surface smoke** (G564): `intent-cli automation
+      knowledge-writeback-record --help` prints its usage, and
+      `intent-cli automation stalled-work --help` lists
+      `--knowledge-writeback-since`.
 - [ ] **ROLL `eng/version.json` NOW**, per the G554 rule as amended by G557 and
       completed by G560: `stableVersion → 0.7.0`, `nextVersion → 0.7.1`, **in
       the same commit as new DRAFT `release-notes-v0.7.1.md` stubs (EN/JA)**,

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -654,6 +654,21 @@ orchestrator でも）が「transition は不要」を actionable な次コマ�
   UNKNOWN として拒否。7〜40 文字の 16 進 SHA でない証跡は拒否。**異なる** commit を
   持つ既存レコードは上書きせず拒否(証跡を黙って差し替えることは、監査証跡を監査
   証跡でなくすことです)。読めない既存レコードも上書きせず拒否します。
+- **execution unit は canonical な識別子であり、ファイルシステムに触れる前に検証
+  します。** 使えるのは ASCII 英数字 / `-` / `_` / `.` のみで、先頭 `.` と `..` を
+  含むものは禁止です。これにより path separator、絶対パス、ドライブ文字や ADS の
+  コロン、dot-segment、空白、制御文字が構造的に排除されます。導出した 2 つのパス
+  (packet と record)は、その後さらに `.intent-cli/issues` と
+  `.intent-cli/knowledge-writebacks` の配下にあることを検査します。同じ検証は検出側が
+  `runs.jsonl` から読む execution unit にも適用されます — runs log は信頼済みの識別子
+  ではなくデータだからです。そこに canonical でない unit があれば `excluded[]` に
+  報告し、そこからパスを導出しません。
+- **レコードは、それが名指しする unit に対してのみ証跡です。** 消費のたびに(検出側の
+  クリア経路でも、記録側の冪等/拒否判定でも)、レコードに埋め込まれた
+  `execution_unit` が保存先の unit と一致し、`host_commit` が SHA 形状であることを
+  要求します。`…/G564/record.json` にありながら `execution_unit: G999` を宣言する
+  レコードや、commit でない証跡を持つレコードは、`knowledge-writeback-pending` を
+  消さず、パス付きで「読めない」として報告されます。
 - **既定は `--dry-run`。** 永続化には `--write` が必要です。
 - 何も required と宣言していない unit への記録も成功しますが、結果に警告が付きます。
   そこで tree が本当に何かを負っていたなら、packet の宣言が不誠実だったということで、

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -353,6 +353,28 @@ queue-state、`runs.jsonl` を変更することは一切ありません — inf
   ディスク上に置くのは guide の clarification-backed hold ルールです — agmsg
   だけの hold は contract violation であり、hold が実在するのにこの kind が
   出ないなら、それは artifact が記録されなかったということです。
+- `knowledge-writeback-pending` (G564) — **closeout 済み**の unit
+  (`runs.jsonl` に `closeout-recorded` イベントがある)で、packet が knowledge
+  write-back を**宣言**しているのに(`knowledge_updates.*.required: true` —
+  `intent_tree` / `adr` / `diagram` / `docs` — または
+  `closeout_learning.write_back_required: true`)、
+  `.intent-cli/knowledge-writebacks/<unit>/record.json` に**記録が無い**もの。
+  item は closeout からの age(最も**早い** `closeout-recorded` を基準にするため、
+  closeout のリトライで age がリセットされることはありません)、宣言された facet、
+  `declared_write_back_targets` を持ち、`recommended_action` は
+  `intent-cli automation knowledge-writeback-record` を名指しします。何も required
+  と宣言していない unit は決して現れません — 辞退は正当な回答であり、この kind は
+  「破られた約束」を検出するものであって「熱意の不足」を検出するものではありません。
+  両方向に fail closed です: 読めない packet 宣言、読めない `runs.jsonl`、読めない
+  既存レコードはいずれも「保留なし」と解釈せず、**パス付き**で `excluded[]`
+  (`knowledge-metadata-unreadable`)に出ます。本機能の出荷前に closeout された
+  unit は既定で対象外です(floor: `2026-08-01T00:00:00Z`)。
+  `--knowledge-writeback-since <iso-8601>` で明示的に遡れます。ここでは intent の
+  content を書きません — tree を書くのは design です(G300)。この kind は記録されて
+  いない義務を可視化し、経過時間を刻むだけです。field evidence はリリース前監査
+  (2026-07-31): node 09 は実装前の設計を記述したまま、node 02 は docs が実装する 7 つの
+  リリースフロー規則を 1 つも記録しておらず、node 08 は wake contract に対して数
+  リリース分遅れていました — 構造的シグナルの無いまま数週間の drift です。
 
 **informational なカテゴリ (G533)** — `is_informational: true`、
 `recommended_action` は（transition コマンドではなく）説明的な prose、
@@ -611,6 +633,39 @@ actionable な kind では `— recommended:` コマンド ``、informational �
 kind では `— FYI:` prose `` で終わります — そのため読み手（人間でも
 orchestrator でも）が「transition は不要」を actionable な次コマンドと
 取り違えることはありません。
+
+### intent-tree の共進化: 実施した knowledge write-back を記録する (G564)
+
+`intent-cli automation knowledge-writeback-record --execution-unit <u> --commit <host-commit-sha> [--target <path>]... [--note <text>] [--dry-run|--write] [--format json|markdown]`
+
+は、packet が**宣言した** write-back を実施したことを、host commit を証跡として
+記録します。上記 `knowledge-writeback-pending` を消す側の半分です。
+
+- **記録するだけ。** write-back 自体は design の host 側の行為です。このコマンドは
+  intent の content を書かず、intent tree を変更しません(G300)。artifact の手編集は
+  正規の経路ではありません。
+- **artifact。** `.intent-cli/knowledge-writebacks/<unit>/record.json`(execution
+  unit ごとに 1 つ): `artifact_kind` / `execution_unit` / `host_commit` /
+  `recorded_at` / `targets` / `note`。
+- **冪等。** 同一 commit(大文字小文字は区別しない)の再記録は no-op success —
+  `already_recorded: true`、`applied: false`、ファイルはバイト単位で不変です。
+  closeout をリトライしても `recorded_at` が実際のイベントからずれることはありません。
+- **fail closed。** `.intent-cli/issues/<u>/packet.yaml` を持たない execution unit は
+  UNKNOWN として拒否。7〜40 文字の 16 進 SHA でない証跡は拒否。**異なる** commit を
+  持つ既存レコードは上書きせず拒否(証跡を黙って差し替えることは、監査証跡を監査
+  証跡でなくすことです)。読めない既存レコードも上書きせず拒否します。
+- **既定は `--dry-run`。** 永続化には `--write` が必要です。
+- 何も required と宣言していない unit への記録も成功しますが、結果に警告が付きます。
+  そこで tree が本当に何かを負っていたなら、packet の宣言が不誠実だったということで、
+  直すべき欠陥はそちらです。
+
+この責務は本リファレンスだけでなく guide 側にも書かれています: design thread の
+playbook(`guide orchestrator-thread`)、packet 作成時のプロンプト
+(`guide workflow task packet-draft`)、closeout プロンプト(`guide closeout run` の
+Stage 5b)がいずれも同じ文言を単一ソースから共有しており、互いに drift できません。
+orchestrator の closeout レポートは、packet が宣言した write-back と、その各々が
+recorded か pending かを列挙します — packet metadata の read-only な伝播であり、
+host の変更は行いません。
 
 ### 行き詰まった published issue を retire する (G525)
 

--- a/docs/ja/release-notes-v0.7.0.md
+++ b/docs/ja/release-notes-v0.7.0.md
@@ -257,7 +257,7 @@ dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.7.0
 
 - [ ] リリース対象のパケットがすべて**完了し、その PR が `main` にマージ済み**である:
       G559(PR #1224)、G560(PR #1222)、G561(PR #1226)、G563(PR #1230)、
-      G564(PR #<G564-PR>)、および G562 release-prep(PR #1228)。
+      G564(PR #1232)、および G562 release-prep(PR #1228)。
       確認は host/review 側で host queue-state / GitHub PR state から行ってください —
       child implementation loop は parent queue-state を読んではならないため、これは
       host 側の前提条件です。

--- a/docs/ja/release-notes-v0.7.0.md
+++ b/docs/ja/release-notes-v0.7.0.md
@@ -11,21 +11,22 @@
 
 ## v0.7.0 の内容
 
-v0.7.0 は `v0.6.2` 以降にマージされた 4 スライス — **G559**、**G560**、**G561**、
-**G563** — を正確にカバーします。
+v0.7.0 は `v0.6.2` 以降にマージされた 5 スライス — **G559**、**G560**、**G561**、
+**G563**、**G564** — を正確にカバーします。
 
 **なぜ patch ではなく minor か。** 文書化されたポリシーは、新しいコマンドサーフェスに
 対して minor バンプを予約しています。G559 がまさにそれです。
 `intent-cli skill list | install | diff` は既存グループの拡張ではなく、新しい
-トップレベルのコマンドグループです。これだけで決まります — G560 / G561 / G563 は
-単独ならそれぞれ patch でした。削除も改名も無いため major ではなく minor です。v0.6.x の
+トップレベルのコマンドグループです。これだけで決まります — G560 / G561 / G563 /
+G564 は単独ならそれぞれ patch でした。削除も改名も無いため major ではなく minor です。v0.6.x の
 コマンド・引数・フラグはすべて形を保ちます。パッケージ ID は
 `JTechJapan.IntentSystem.Cli` のままで、パッケージ ID / ライセンス / workflow
 セマンティクスの変更はありません。
 
-見出しは skill サーフェスです。残る 3 つは、それぞれ実際のインシデントを 1 件ずつ
-生んだリリースフローと publish 優先順位の機構の穴を塞ぎ、さらに guide 群を本リリースが
-同梱する skill と整合させます。
+見出しは skill サーフェスです。残る 4 つは、それぞれ実際のインシデントを 1 件ずつ
+生んだリリースフローと publish 優先順位の機構の穴を塞ぎ、guide 群を本リリースが
+同梱する skill と整合させ、さらに intent-tree の共進化を「心がけ」ではなく
+強制可能なものにします。
 
 ### クロスプラットフォーム agent skill を 1 コマンドで install(G559)
 
@@ -161,6 +162,51 @@ packet だけです。
 Authority-boundary の一文が、supervision セクションが認める 4 つの MAY-answer クラスを
 同じ内容で列挙するようにしました。
 
+### 古びた intent-tree を「見える仕掛かり」にする(G564)
+
+G563 を生んだのと同じリリース前監査が、このスライスの根拠です。G559 が出荷された
+時点で intent-tree の node 09 はまだ実装前の設計を記述しており、node 02 は docs が
+実装している 7 つのリリースフロー規則を 1 つも記録しておらず、node 08 は wake
+contract に対して数リリース分遅れていました。開発は数週間動き続けたのに、tree が
+古びていることを示す**構造的なシグナルが一切ありませんでした**。検出手段は
+オペレーター指示による手作業監査だけで、しかもそれはリリース直前に review 1 サイクル
+分のコストを払わせました。
+
+材料はすでに揃っていて、繋がっていなかっただけです。packet は
+`knowledge_updates.*.required` と `closeout_learning.write_back_required` を宣言でき、
+write-back 自体は child repo からは見えない host commit として起こります。「やった」と
+言う記録が無いので、「やっていない」と言うこともできませんでした。
+
+**記録。** 宣言された write-back を実施したことを、host commit を証跡として記録する
+サブコマンドを追加しました。
+
+```bash
+intent-cli automation knowledge-writeback-record \
+  --execution-unit G564 --commit <host-commit-sha> \
+  --target intents/<domain>/intent-tree/means/03-state-and-audit-strategy.md --write
+```
+
+同一 commit に対しては冪等で、**異なる** commit での上書きは拒否し(証跡を黙って
+差し替えない)、未知の execution unit や SHA でない証跡には fail closed で応じます。
+既定は `--dry-run` です。記録するだけであり、tree を書くのは常に design であって
+ツールではありません。
+
+**検出。** `automation stalled-work` に `knowledge-writeback-pending` kind を追加し、
+`automation heartbeat` がそれを運びます。closeout 済みなのに packet が宣言した
+write-back の記録が無い unit は、宣言された facet と対象パスを挙げ、記録コマンドを
+recommended_action に持つ、経過時間つきの actionable な item になります。何も required
+と宣言していない unit は決して現れません。読めない packet metadata や読めない記録は
+**パスつきで `excluded`** に出て、「保留なし」と黙って解釈されることはありません。
+本機能の出荷前に closeout された unit は既定で対象外です
+(`--knowledge-writeback-since <iso-8601>` で明示的に遡れます)。
+
+**責務。** guide 群はオペレーターの 2026-07-31 の裁定をそのまま述べます。intent-tree
+は開発**と同時に**動くものであり、実装だけ進めて tree を更新しないことはそれ自体が
+重要な過失です。packet 作成時の guidance は、サーフェスを追加する / 挙動を変える
+スライスに対して正直な宣言を要求します。closeout の guidance は**同じ wake の中で**
+write-back を実施し記録することを求めます。そして orchestrator の closeout レポートは、
+packet が宣言した write-back と、その各々が recorded か pending かを列挙します。
+
 ## インストール
 
 ```bash
@@ -190,6 +236,13 @@ dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.7.0
   `--clear --pre-publish` が加わります。既存の two-sided な block/unblock 経路は
   不変です。`clarify open` は従来拒否していた packet で成功するようになりました。
   従来受け入れていた packet の検証は以前とまったく同じです。
+- **追加のみ — write-back の記録と検出(G564)。** `automation
+  knowledge-writeback-record` が新しいサブコマンドとして加わり、
+  `automation stalled-work` / `automation heartbeat` に
+  `knowledge-writeback-pending` kind が加わります。既存の kind / しきい値 / 出力
+  フィールドは不変です。遡及的な報告は行いません — 新しい item を生み得るのは本
+  リリース以降に closeout された unit だけなので、アップグレードが過去の unit を
+  一斉に点灯させることはありません。
 - **是正的 — リリースフローのみ。** G560 はリポジトリ自身のドキュメントガードの
   検査方法を変更し、リリース後の roll ルールを完成させます。影響するのはリリースを
   カットするメンテナであり、CLI の利用者ではありません。
@@ -204,7 +257,7 @@ dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.7.0
 
 - [ ] リリース対象のパケットがすべて**完了し、その PR が `main` にマージ済み**である:
       G559(PR #1224)、G560(PR #1222)、G561(PR #1226)、G563(PR #1230)、
-      および G562 release-prep(PR #1228)。
+      G564(PR #<G564-PR>)、および G562 release-prep(PR #1228)。
       確認は host/review 側で host queue-state / GitHub PR state から行ってください —
       child implementation loop は parent queue-state を読んではならないため、これは
       host 側の前提条件です。
@@ -254,6 +307,10 @@ dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.7.0
 - [ ] **skill スモーク**(G559): `intent-cli skill list` が `intent-cli` skill と全
       target/scope を表示し、`intent-cli skill install --target all` が各プラット
       フォーム固有の場所に `SKILL.md` を配置する。
+- [ ] **write-back サーフェスのスモーク**(G564):
+      `intent-cli automation knowledge-writeback-record --help` が usage を表示し、
+      `intent-cli automation stalled-work --help` が
+      `--knowledge-writeback-since` を含む。
 - [ ] **今すぐ `eng/version.json` を ROLL する**。G554 のルール(G557 による改訂、
       G560 による完成)に従い、`stableVersion → 0.7.0`、`nextVersion → 0.7.1` を、
       **新しい DRAFT `release-notes-v0.7.1.md` スタブ(EN/JA)と同じ commit で**行い、

--- a/src/IntentSystem.Cli/Commands/AutomationKnowledgeWriteBackRecordCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationKnowledgeWriteBackRecordCommand.cs
@@ -1,0 +1,440 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G564: <c>intent-cli automation knowledge-writeback-record --execution-unit
+/// &lt;u&gt; --commit &lt;sha&gt; [--target &lt;path&gt;]... [--note &lt;text&gt;]
+/// [--dry-run|--write] [--format json|markdown]</c> — records that the
+/// write-backs a packet DECLARED were performed, with the host commit as
+/// evidence.
+///
+/// This command records; it never writes intent content and never mutates the
+/// intent tree (G300). The write-back is design's host-side act — this is the
+/// statement that it happened, which is what makes the absence of one
+/// detectable (<see cref="AutomationStalledWorkCommand.KindKnowledgeWritebackPending"/>).
+///
+/// Fail-closed, by design:
+/// <list type="bullet">
+///   <item>an execution unit with no packet is UNKNOWN — recording against it
+///         would create evidence for an obligation nobody declared;</item>
+///   <item>evidence that is not a commit-shaped SHA is malformed — "recorded"
+///         must mean a reader can go look at the commit;</item>
+///   <item>a second record with DIFFERENT evidence is refused, never
+///         overwritten: replacing evidence silently is how an audit trail
+///         stops being one. Re-recording the SAME commit is a no-op success,
+///         so the command is safe to re-run in a retried closeout wake.</item>
+/// </list>
+/// </summary>
+internal static class AutomationKnowledgeWriteBackRecordCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const int MinimumCommitLength = 7;
+    private const int MaximumCommitLength = 40;
+
+    /// <summary>Test seam: deterministic <c>recorded_at</c>.</summary>
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    private const string UsageLine =
+        "Usage: intent-cli automation knowledge-writeback-record --execution-unit <unit> --commit <host-commit-sha> "
+        + "[--target <path>]... [--note <text>] [--dry-run|--write] [--format json|markdown]";
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var executionUnit, out var commit, out var targets, out var note, out var write, out var format, out var parseError))
+        {
+            writer.WriteLine(parseError);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var packetPath = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit!, "packet.yaml");
+        if (!File.Exists(packetPath))
+        {
+            return Fail(
+                writer,
+                format,
+                executionUnit!,
+                $"unknown execution unit '{executionUnit}': no packet at `{packetPath}`. A write-back record is "
+                + "evidence for a DECLARED obligation, so it is never recorded against a unit this host cannot "
+                + "resolve. Check the unit id, or run this from the host repo root that owns `.intent-cli/`.");
+        }
+
+        KnowledgeWriteBackDeclaration declaration;
+        try
+        {
+            declaration = KnowledgeWriteBackDeclaration.Read(File.ReadAllText(packetPath));
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException)
+        {
+            return Fail(
+                writer,
+                format,
+                executionUnit!,
+                $"packet `{packetPath}` could not be read for its knowledge write-back declaration: {exception.Message}");
+        }
+
+        var recordPath = KnowledgeWriteBackRecord.ResolveFullPath(context.RepoRoot, executionUnit!);
+        KnowledgeWriteBackRecord? existing = null;
+        if (File.Exists(recordPath))
+        {
+            try
+            {
+                existing = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(recordPath));
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                return Fail(
+                    writer,
+                    format,
+                    executionUnit!,
+                    $"an existing record at `{recordPath}` could not be read: {exception.Message}. Refusing to "
+                    + "overwrite unreadable evidence — repair or remove the artifact deliberately, then re-run.");
+            }
+        }
+
+        if (existing is not null
+            && !string.Equals(existing.HostCommit, commit, StringComparison.OrdinalIgnoreCase))
+        {
+            return Fail(
+                writer,
+                format,
+                executionUnit!,
+                $"`{executionUnit}` already carries a write-back record for commit `{existing.HostCommit}` "
+                + $"(recorded {existing.RecordedAt:O}); refusing to replace it with `{commit}`. Evidence is "
+                + "append-only in spirit: record a LATER write-back as its own unit's record, or remove the "
+                + "existing artifact deliberately if it was wrong.");
+        }
+
+        var warnings = new List<string>();
+        if (!declaration.IsRequired)
+        {
+            warnings.Add(
+                $"`{executionUnit}` declared no required knowledge write-back (`knowledge_updates.*.required` and "
+                + "`closeout_learning.write_back_required` are all false or absent), so nothing was pending for it. "
+                + "The record is still written — recording a write-back nobody demanded is harmless — but if the "
+                + "tree genuinely owed something here, the packet's declaration was dishonest and that is the "
+                + "defect to fix.");
+        }
+
+        var alreadyRecorded = existing is not null;
+        var record = existing ?? new KnowledgeWriteBackRecord
+        {
+            ArtifactKind = KnowledgeWriteBackRecord.ArtifactKindValue,
+            ExecutionUnit = executionUnit!,
+            HostCommit = commit!,
+            RecordedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
+            Targets = targets,
+            Note = note,
+        };
+
+        var applied = false;
+        if (write && !alreadyRecorded)
+        {
+            var directory = Path.GetDirectoryName(recordPath)
+                ?? throw new InvalidOperationException("Knowledge write-back record path did not contain a directory.");
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(recordPath, KnowledgeWriteBackRecord.Serialize(record));
+            applied = true;
+        }
+
+        var result = new KnowledgeWriteBackRecordResult
+        {
+            ExecutionUnit = executionUnit!,
+            Mode = write ? "write" : "dry-run",
+            Applied = applied,
+            AlreadyRecorded = alreadyRecorded,
+            HostCommit = record.HostCommit,
+            RecordedAt = record.RecordedAt,
+            RecordPath = KnowledgeWriteBackRecord.ResolveRelativePath(executionUnit!),
+            Targets = record.Targets,
+            DeclaredTargets = declaration.DeclaredTargets,
+            DeclaredFacets = declaration.RequiredFacets,
+            DeclarationRequired = declaration.IsRequired,
+            Note = record.Note,
+            Warnings = warnings,
+            Error = null,
+        };
+
+        Emit(writer, format, result);
+        return 0;
+    }
+
+    private static int Fail(TextWriter writer, string format, string executionUnit, string error)
+    {
+        var result = new KnowledgeWriteBackRecordResult
+        {
+            ExecutionUnit = executionUnit,
+            Mode = "refused",
+            Applied = false,
+            AlreadyRecorded = false,
+            HostCommit = null,
+            RecordedAt = null,
+            RecordPath = KnowledgeWriteBackRecord.ResolveRelativePath(executionUnit),
+            Targets = Array.Empty<string>(),
+            DeclaredTargets = Array.Empty<string>(),
+            DeclaredFacets = Array.Empty<string>(),
+            DeclarationRequired = false,
+            Note = null,
+            Warnings = Array.Empty<string>(),
+            Error = error,
+        };
+
+        Emit(writer, format, result);
+        return 1;
+    }
+
+    private static void Emit(TextWriter writer, string format, KnowledgeWriteBackRecordResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        writer.WriteLine($"# automation knowledge-writeback-record — `{result.ExecutionUnit}`");
+        writer.WriteLine();
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- applied: {(result.Applied ? "true" : "false")}");
+        writer.WriteLine($"- already_recorded: {(result.AlreadyRecorded ? "true" : "false")}");
+        writer.WriteLine($"- record_path: `{result.RecordPath}`");
+        if (!string.IsNullOrWhiteSpace(result.HostCommit))
+        {
+            writer.WriteLine($"- host_commit: `{result.HostCommit}`");
+        }
+        if (result.Targets.Count > 0)
+        {
+            writer.WriteLine($"- targets: {string.Join(", ", result.Targets)}");
+        }
+        if (result.DeclaredTargets.Count > 0)
+        {
+            writer.WriteLine($"- declared_targets: {string.Join(", ", result.DeclaredTargets)}");
+        }
+        if (result.DeclaredFacets.Count > 0)
+        {
+            writer.WriteLine($"- declared_facets: {string.Join(", ", result.DeclaredFacets)}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(result.Error))
+        {
+            writer.WriteLine();
+            writer.WriteLine($"## Error");
+            writer.WriteLine($"- {result.Error}");
+        }
+
+        if (result.Warnings.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Warnings");
+            foreach (var warning in result.Warnings)
+            {
+                writer.WriteLine($"- {warning}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? executionUnit,
+        out string? commit,
+        out IReadOnlyList<string> targets,
+        out string? note,
+        out bool write,
+        out string format,
+        out string error)
+    {
+        executionUnit = null;
+        commit = null;
+        note = null;
+        write = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        var collectedTargets = new List<string>();
+        targets = collectedTargets;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--execution-unit":
+                case "--unit":
+                    if (index + 1 >= args.Length)
+                    {
+                        error = $"{argument} requires a value.";
+                        return false;
+                    }
+                    executionUnit = args[++index];
+                    break;
+
+                case "--commit":
+                    if (index + 1 >= args.Length)
+                    {
+                        error = "--commit requires a value.";
+                        return false;
+                    }
+                    commit = args[++index];
+                    break;
+
+                case "--target":
+                    if (index + 1 >= args.Length)
+                    {
+                        error = "--target requires a value.";
+                        return false;
+                    }
+                    collectedTargets.Add(args[++index]);
+                    break;
+
+                case "--note":
+                    if (index + 1 >= args.Length)
+                    {
+                        error = "--note requires a value.";
+                        return false;
+                    }
+                    note = args[++index];
+                    break;
+
+                case "--write":
+                    write = true;
+                    break;
+
+                case "--dry-run":
+                    write = false;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length)
+                    {
+                        error = "--format requires a value.";
+                        return false;
+                    }
+                    format = args[++index];
+                    if (!string.Equals(format, FormatJson, StringComparison.Ordinal)
+                        && !string.Equals(format, FormatMarkdown, StringComparison.Ordinal))
+                    {
+                        error = $"Unsupported --format '{format}'. Use json or markdown.";
+                        return false;
+                    }
+                    break;
+
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            error = "--execution-unit is required.";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(commit))
+        {
+            error =
+                "--commit is required: a write-back record without host-commit evidence is not evidence. Use the "
+                + "commit the write-back landed in (`git rev-parse HEAD` in the host repo).";
+            return false;
+        }
+
+        if (!IsCommitShaped(commit!))
+        {
+            error =
+                $"--commit '{commit}' is not a commit SHA ({MinimumCommitLength}-{MaximumCommitLength} hexadecimal "
+                + "characters). Malformed evidence is refused rather than recorded — a reader must be able to go "
+                + "look at the commit.";
+            return false;
+        }
+
+        // Normalize so `--commit ABC123…` and `--commit abc123…` are the same
+        // evidence for the idempotency check as well as on disk.
+        commit = commit!.ToLowerInvariant();
+        return true;
+    }
+
+    private static bool IsCommitShaped(string value) =>
+        value.Length >= MinimumCommitLength
+        && value.Length <= MaximumCommitLength
+        && value.All(Uri.IsHexDigit);
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("automation knowledge-writeback-record");
+        writer.WriteLine();
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine(IntentTreeCoEvolutionDuty.CloseoutCheck);
+        writer.WriteLine();
+        writer.WriteLine("Records that a packet-declared knowledge write-back was performed, with the host commit as evidence.");
+        writer.WriteLine("  --dry-run (default) plans only; --write persists `.intent-cli/knowledge-writebacks/<unit>/record.json`.");
+        writer.WriteLine("  Idempotent: re-recording the SAME commit is a no-op success; a DIFFERENT commit is refused, never overwritten.");
+        writer.WriteLine("  Fail-closed: an unknown execution unit (no packet) and non-SHA evidence are both refused.");
+        writer.WriteLine("  Never writes intent content — the tree is written by design; this command only records that it was.");
+    }
+}
+
+internal sealed record KnowledgeWriteBackRecordResult
+{
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("already_recorded")]
+    public required bool AlreadyRecorded { get; init; }
+
+    [JsonPropertyName("host_commit")]
+    public required string? HostCommit { get; init; }
+
+    [JsonPropertyName("recorded_at")]
+    public required DateTimeOffset? RecordedAt { get; init; }
+
+    [JsonPropertyName("record_path")]
+    public required string RecordPath { get; init; }
+
+    [JsonPropertyName("targets")]
+    public required IReadOnlyList<string> Targets { get; init; }
+
+    [JsonPropertyName("declared_targets")]
+    public required IReadOnlyList<string> DeclaredTargets { get; init; }
+
+    [JsonPropertyName("declared_facets")]
+    public required IReadOnlyList<string> DeclaredFacets { get; init; }
+
+    [JsonPropertyName("declaration_required")]
+    public required bool DeclarationRequired { get; init; }
+
+    [JsonPropertyName("note")]
+    public required string? Note { get; init; }
+
+    [JsonPropertyName("warnings")]
+    public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("error")]
+    public required string? Error { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/AutomationKnowledgeWriteBackRecordCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationKnowledgeWriteBackRecordCommand.cs
@@ -32,9 +32,6 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
     private const string FormatJson = "json";
     private const string FormatMarkdown = "markdown";
 
-    private const int MinimumCommitLength = 7;
-    private const int MaximumCommitLength = 40;
-
     /// <summary>Test seam: deterministic <c>recorded_at</c>.</summary>
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
 
@@ -67,7 +64,23 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
             return 1;
         }
 
-        var packetPath = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit!, "packet.yaml");
+        // G564 review repair: both paths are resolved through the containment
+        // helpers, so a unit that somehow got past the argument-boundary
+        // identifier gate still cannot reach outside the artifact roots.
+        string packetPath;
+        string recordPath;
+        try
+        {
+            packetPath = KnowledgeWriteBackRecord.ResolvePacketPath(context.RepoRoot, executionUnit!);
+            recordPath = KnowledgeWriteBackRecord.ResolveFullPath(context.RepoRoot, executionUnit!);
+        }
+        catch (InvalidOperationException exception)
+        {
+            writer.WriteLine($"--execution-unit '{executionUnit}' is not usable: {exception.Message}");
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
         if (!File.Exists(packetPath))
         {
             return Fail(
@@ -93,13 +106,16 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
                 $"packet `{packetPath}` could not be read for its knowledge write-back declaration: {exception.Message}");
         }
 
-        var recordPath = KnowledgeWriteBackRecord.ResolveFullPath(context.RepoRoot, executionUnit!);
         KnowledgeWriteBackRecord? existing = null;
         if (File.Exists(recordPath))
         {
             try
             {
-                existing = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(recordPath));
+                // G564 review repair: the existing record is validated against
+                // THIS unit and against SHA-shaped evidence before it is allowed
+                // to short-circuit anything — an unreadable or mis-attributed
+                // record must never be silently accepted as prior evidence.
+                existing = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(recordPath), executionUnit!);
             }
             catch (Exception exception) when (exception is IOException or InvalidOperationException)
             {
@@ -344,9 +360,12 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
             }
         }
 
-        if (string.IsNullOrWhiteSpace(executionUnit))
+        // G564 review repair: the identifier is validated HERE — before the
+        // command touches the filesystem at all — so a traversal/rooted/
+        // malformed unit is refused rather than resolved and inspected.
+        if (!KnowledgeWriteBackRecord.TryValidateExecutionUnit(executionUnit, out var unitError))
         {
-            error = "--execution-unit is required.";
+            error = $"--execution-unit is invalid: {unitError}";
             return false;
         }
 
@@ -358,12 +377,15 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
             return false;
         }
 
-        if (!IsCommitShaped(commit!))
+        // G564 review repair: single-sourced with the shape the record reader
+        // enforces on consumption, so what this command accepts and what a
+        // consumer trusts can never drift apart.
+        if (!KnowledgeWriteBackRecord.IsCommitShaped(commit))
         {
             error =
-                $"--commit '{commit}' is not a commit SHA ({MinimumCommitLength}-{MaximumCommitLength} hexadecimal "
-                + "characters). Malformed evidence is refused rather than recorded — a reader must be able to go "
-                + "look at the commit.";
+                $"--commit '{commit}' is not a commit SHA ({KnowledgeWriteBackRecord.MinimumCommitLength}-"
+                + $"{KnowledgeWriteBackRecord.MaximumCommitLength} hexadecimal characters). Malformed evidence is "
+                + "refused rather than recorded — a reader must be able to go look at the commit.";
             return false;
         }
 
@@ -372,11 +394,6 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
         commit = commit!.ToLowerInvariant();
         return true;
     }
-
-    private static bool IsCommitShaped(string value) =>
-        value.Length >= MinimumCommitLength
-        && value.Length <= MaximumCommitLength
-        && value.All(Uri.IsHexDigit);
 
     private static void WriteHelp(TextWriter writer)
     {

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -1778,7 +1778,28 @@ internal static class AutomationStalledWorkCommand
                 continue;
             }
 
-            var packetYamlPath = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit, "packet.yaml");
+            // G564 review repair: the unit here comes from the runs log, which
+            // is data, not a trusted identifier. Validate BEFORE any path is
+            // built from it — a traversal/rooted/malformed unit is reported
+            // with its own diagnostic rather than resolved and stat'ed.
+            if (!KnowledgeWriteBackRecord.TryValidateExecutionUnit(executionUnit, out var unitError))
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindKnowledgeWritebackPending,
+                    ExecutionUnit = executionUnit,
+                    Issue = null,
+                    Pr = null,
+                    Reason = ReasonKnowledgeMetadataUnreadable,
+                    Detail =
+                        $"a `{CloseoutRecordedEvent}` event in `{runLogPath}` names a non-canonical execution unit: "
+                        + $"{unitError} No packet or record path is derived from it — repair the runs log rather "
+                        + "than resolving an identifier that is not one.",
+                });
+                continue;
+            }
+
+            var packetYamlPath = KnowledgeWriteBackRecord.ResolvePacketPath(context.RepoRoot, executionUnit);
             var resolution = new ExecutionUnitResolution(
                 executionUnit,
                 Corroborated: File.Exists(packetYamlPath),
@@ -1835,7 +1856,12 @@ internal static class AutomationStalledWorkCommand
             {
                 try
                 {
-                    _ = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(recordPath));
+                    // G564 review repair: the record must NAME this unit and
+                    // carry SHA-shaped evidence. Clearing on any deserializable
+                    // file let a record carrying a different unit's id — or a
+                    // host_commit that is not a commit — discharge this unit's
+                    // obligation.
+                    _ = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(recordPath), executionUnit);
                     // Recorded: the obligation is discharged. This is the
                     // clearing path — no item, no exclusion.
                     continue;

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -311,6 +311,55 @@ internal static class AutomationStalledWorkCommand
     /// </summary>
     public const string KindDesignDecisionPending = "design-decision-pending";
 
+    /// <summary>
+    /// G564: a CLOSED-OUT unit whose packet DECLARED a knowledge write-back
+    /// (<c>knowledge_updates.*.required</c> or
+    /// <c>closeout_learning.write_back_required</c>) with no
+    /// <see cref="KnowledgeWriteBackRecord"/> on disk — the promised intent-tree
+    /// / ADR / diagram / docs update either did not happen or was never
+    /// recorded, and until it is recorded the two are indistinguishable.
+    /// ACTIONABLE: <c>recommended_action</c> names the recording command and
+    /// the declared target paths. Nothing here writes intent content — the
+    /// write-back is design's host-side act (G300); this kind only makes its
+    /// absence visible and aging.
+    ///
+    /// Field evidence (pre-v0.7.0 audit, 2026-07-31): G559 shipped while node
+    /// 09 still described a pre-implementation design; node 02 recorded none of
+    /// the seven release-flow rules the docs implement; node 08 lagged the wake
+    /// contract by releases. Weeks of drift with NO structural signal — a
+    /// manual, operator-ordered audit was the only detector, and it cost a full
+    /// review cycle immediately before a release. The ingredients already
+    /// existed (packets declare the obligation; write-backs happen as host
+    /// commits) but nothing said "done", so nothing could say "not done".
+    /// </summary>
+    public const string KindKnowledgeWritebackPending = "knowledge-writeback-pending";
+
+    /// <summary>
+    /// G564: a closed-out unit's write-back metadata — its packet's G461
+    /// declaration, the runs log the closeout is read from, or an existing
+    /// write-back record — is present but unreadable. Reported here WITH the
+    /// path rather than skipped: unreadable evidence is not evidence of a
+    /// cleared obligation, and silently downgrading it to "nothing pending" is
+    /// exactly the false all-clear this kind exists to prevent.
+    /// </summary>
+    public const string ReasonKnowledgeMetadataUnreadable = "knowledge-metadata-unreadable";
+
+    /// <summary>
+    /// G564: units closed out BEFORE this detection shipped are out of scope
+    /// (the pre-v0.7.0 backlog was cleared by the 2026-07-31 operator audit),
+    /// so the scan has a floor: a closeout recorded before this instant never
+    /// produces an item. Override with
+    /// <c>--knowledge-writeback-since &lt;iso-8601&gt;</c> to scan further back
+    /// deliberately — retroactive detection is a choice the operator makes, not
+    /// a default that lights up every historical unit on the first wake after
+    /// an upgrade.
+    /// </summary>
+    public static readonly DateTimeOffset KnowledgeWriteBackActivationUtc =
+        new(2026, 8, 1, 0, 0, 0, TimeSpan.Zero);
+
+    /// <summary>G564: the closeout event this detection reads as "the unit is closed out".</summary>
+    private const string CloseoutRecordedEvent = "closeout-recorded";
+
     public static Func<IGitHubAutomationCandidateLister>? CandidateListerFactory { get; set; }
 
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
@@ -322,7 +371,7 @@ internal static class AutomationStalledWorkCommand
     };
 
     private const string UsageLine =
-        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--stale-minutes <m>] [--claimed-silent-minutes <m>] [--backlog-idle-minutes <m>] [--repair-silent-minutes <m>] [--format json|markdown]";
+        "Usage: intent-cli automation stalled-work --domain <name> --repo <owner/repo> [--stale-minutes <m>] [--claimed-silent-minutes <m>] [--backlog-idle-minutes <m>] [--repair-silent-minutes <m>] [--knowledge-writeback-since <iso-8601>] [--format json|markdown]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -336,7 +385,7 @@ internal static class AutomationStalledWorkCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var domain, out var repo, out var staleMinutes, out var claimedSilentMinutes, out var backlogIdleMinutes, out var repairSilentMinutes, out var format, out var error))
+        if (!TryParseArguments(args, out var domain, out var repo, out var staleMinutes, out var claimedSilentMinutes, out var backlogIdleMinutes, out var repairSilentMinutes, out var knowledgeWriteBackSince, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -346,7 +395,7 @@ internal static class AutomationStalledWorkCommand
         AutomationStalledWorkResult result;
         try
         {
-            result = Analyze(context, domain!, repo!, staleMinutes, claimedSilentMinutes, backlogIdleMinutes, repairSilentMinutes);
+            result = Analyze(context, domain!, repo!, staleMinutes, claimedSilentMinutes, backlogIdleMinutes, repairSilentMinutes, knowledgeWriteBackSince);
         }
         catch (Exception exception) when (exception is IOException or InvalidOperationException)
         {
@@ -389,7 +438,8 @@ internal static class AutomationStalledWorkCommand
         int staleMinutes,
         int claimedSilentMinutes = DefaultClaimedSilentMinutes,
         int backlogIdleMinutes = DefaultBacklogIdleMinutes,
-        int repairSilentMinutes = DefaultRepairSilentMinutes)
+        int repairSilentMinutes = DefaultRepairSilentMinutes,
+        DateTimeOffset? knowledgeWriteBackSince = null)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentException.ThrowIfNullOrWhiteSpace(domain);
@@ -413,6 +463,15 @@ internal static class AutomationStalledWorkCommand
         CollectClaimedButSilent(context, domain, candidateDomains, openIssues, openPrs, repo, now, claimedSilentMinutes, items, excluded, warnings);
         CollectBacklogReadyIdle(context, domain, candidateDomains, openIssues, openPrs, repo, now, backlogIdleMinutes, items, excluded);
         CollectDesignDecisionPending(context, domain, candidateDomains, repo, now, items, excluded);
+        CollectKnowledgeWritebackPending(
+            context,
+            domain,
+            candidateDomains,
+            repo,
+            now,
+            knowledgeWriteBackSince ?? KnowledgeWriteBackActivationUtc,
+            items,
+            excluded);
 
         var filtered = items
             .Where(item => item.AgeMinutes >= staleMinutes)
@@ -1651,6 +1710,192 @@ internal static class AutomationStalledWorkCommand
     }
 
     /// <summary>
+    /// G564: closed-out units whose DECLARED knowledge write-back has no
+    /// record. The closeout fact comes from the runs log
+    /// (<c>closeout-recorded</c>, written by <c>closeout pr --write</c>), the
+    /// obligation from the packet's own G461 declaration, and the clearance
+    /// from <see cref="KnowledgeWriteBackRecord"/>. A unit that declared
+    /// nothing required is silent — declining is a legitimate answer, and this
+    /// detects broken promises, not missing enthusiasm.
+    /// </summary>
+    private static void CollectKnowledgeWritebackPending(
+        CliContext context,
+        string domain,
+        IReadOnlyList<string> candidateDomains,
+        string repo,
+        DateTimeOffset now,
+        DateTimeOffset since,
+        List<StalledWorkItem> items,
+        List<StalledWorkExcluded> excluded)
+    {
+        var runLogPath = context.GetRunLogPath();
+        if (!File.Exists(runLogPath))
+        {
+            // No runs log in this checkout — no closeout has been recorded
+            // here, so there is no obligation to have broken.
+            return;
+        }
+
+        IReadOnlyList<RunEvent> events;
+        try
+        {
+            events = RunLogSerializer.DeserializeAll(File.ReadAllText(runLogPath));
+        }
+        catch (Exception exception) when (exception is IOException or JsonException or InvalidOperationException or NotSupportedException)
+        {
+            excluded.Add(new StalledWorkExcluded
+            {
+                Kind = KindKnowledgeWritebackPending,
+                ExecutionUnit = string.Empty,
+                Issue = null,
+                Pr = null,
+                Reason = ReasonKnowledgeMetadataUnreadable,
+                Detail =
+                    $"the runs log `{runLogPath}` could not be read: {exception.Message}. Closed-out units cannot be "
+                    + "enumerated, so a pending knowledge write-back may exist and be invisible — repair the log "
+                    + "rather than reading this as a clean pipeline.",
+            });
+            return;
+        }
+
+        var closeouts = events
+            .Where(runEvent =>
+                string.Equals(runEvent.Event, CloseoutRecordedEvent, StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(runEvent.ExecutionUnit))
+            .GroupBy(runEvent => runEvent.ExecutionUnit, StringComparer.Ordinal)
+            // The EARLIEST closeout is when the obligation started; a repeated
+            // closeout (retry, re-application) must not reset the item's age.
+            .Select(group => (Unit: group.Key, ClosedAt: group.Min(runEvent => runEvent.Ts)))
+            .OrderBy(entry => entry.Unit, StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var (executionUnit, closedAt) in closeouts)
+        {
+            if (closedAt < since)
+            {
+                // Closed out before this detection shipped: out of scope by
+                // contract (see KnowledgeWriteBackActivationUtc).
+                continue;
+            }
+
+            var packetYamlPath = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit, "packet.yaml");
+            var resolution = new ExecutionUnitResolution(
+                executionUnit,
+                Corroborated: File.Exists(packetYamlPath),
+                IsAmbiguous: false,
+                CandidatePacketPaths: Array.Empty<string>());
+            if (!TryConfirmDomain(domain, resolution, ReadPacketDeclaredDomain(context, executionUnit), candidateDomains, repo,
+                    out var reason, out var detail))
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindKnowledgeWritebackPending,
+                    ExecutionUnit = executionUnit,
+                    Issue = null,
+                    Pr = null,
+                    Reason = reason,
+                    Detail = detail,
+                });
+                continue;
+            }
+
+            KnowledgeWriteBackDeclaration declaration;
+            try
+            {
+                declaration = KnowledgeWriteBackDeclaration.Read(File.ReadAllText(packetYamlPath));
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException)
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindKnowledgeWritebackPending,
+                    ExecutionUnit = executionUnit,
+                    Issue = null,
+                    Pr = null,
+                    Reason = ReasonKnowledgeMetadataUnreadable,
+                    Detail =
+                        $"`{executionUnit}`: packet `{packetYamlPath}` could not be read for its knowledge write-back "
+                        + $"declaration: {exception.Message}. Excluded with its path rather than assumed to declare "
+                        + "nothing — an unreadable declaration establishes neither that a write-back is owed nor "
+                        + "that it is not.",
+                });
+                continue;
+            }
+
+            if (!declaration.IsRequired)
+            {
+                // Declared nothing (or declined every facet): no obligation,
+                // no item, no noise. This is the `required=false` silence the
+                // acceptance criteria require.
+                continue;
+            }
+
+            var recordPath = KnowledgeWriteBackRecord.ResolveFullPath(context.RepoRoot, executionUnit);
+            if (File.Exists(recordPath))
+            {
+                try
+                {
+                    _ = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(recordPath));
+                    // Recorded: the obligation is discharged. This is the
+                    // clearing path — no item, no exclusion.
+                    continue;
+                }
+                catch (Exception exception) when (exception is IOException or InvalidOperationException)
+                {
+                    excluded.Add(new StalledWorkExcluded
+                    {
+                        Kind = KindKnowledgeWritebackPending,
+                        ExecutionUnit = executionUnit,
+                        Issue = null,
+                        Pr = null,
+                        Reason = ReasonKnowledgeMetadataUnreadable,
+                        Detail =
+                            $"`{executionUnit}`: write-back record `{recordPath}` could not be read: "
+                            + $"{exception.Message}. Excluded with its path rather than counted as cleared — an "
+                            + "unreadable record is not evidence that the write-back happened.",
+                    });
+                    continue;
+                }
+            }
+
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindKnowledgeWritebackPending,
+                ExecutionUnit = executionUnit,
+                Issue = null,
+                Pr = null,
+                AgeMinutes = ComputeAgeMinutesFromInstant(ClampToNow(closedAt, now), now),
+                IsInformational = false,
+                DeclaredWriteBackTargets = declaration.DeclaredTargets,
+                RecommendedAction = BuildKnowledgeWritebackPendingAction(executionUnit, declaration),
+            });
+        }
+    }
+
+    /// <summary>
+    /// G564: names the recording command and what the packet promised. The
+    /// write-back itself is design's act; the recommendation is to perform it
+    /// and then record it — never a state transition this command could run,
+    /// and never an auto-write of intent content.
+    /// </summary>
+    private static string BuildKnowledgeWritebackPendingAction(
+        string executionUnit,
+        KnowledgeWriteBackDeclaration declaration)
+    {
+        var facets = string.Join(", ", declaration.RequiredFacets);
+        var targets = declaration.DeclaredTargets.Count > 0
+            ? string.Join(", ", declaration.DeclaredTargets)
+            : "(no target paths named in the packet)";
+
+        return
+            $"perform and record the declared knowledge write-back for `{executionUnit}` "
+            + $"(declared: {facets}; targets: {targets}) — design writes the tree/ADR/diagram/docs in the host repo, "
+            + $"then: `{IntentTreeCoEvolutionDuty.RecordCommand(executionUnit)}`. "
+            + "This item stays visible until a record exists; closing the PR does not clear it, and nothing here "
+            + "writes intent content on design's behalf.";
+    }
+
+    /// <summary>
     /// G552: names the exact clarification to answer (design) and the
     /// escalation path (operator). Never an auto-answer: the answer is human
     /// content, and this command only ever emits text.
@@ -2144,6 +2389,7 @@ internal static class AutomationStalledWorkCommand
         out int claimedSilentMinutes,
         out int backlogIdleMinutes,
         out int repairSilentMinutes,
+        out DateTimeOffset? knowledgeWriteBackSince,
         out string format,
         out string error)
     {
@@ -2153,6 +2399,7 @@ internal static class AutomationStalledWorkCommand
         claimedSilentMinutes = DefaultClaimedSilentMinutes;
         backlogIdleMinutes = DefaultBacklogIdleMinutes;
         repairSilentMinutes = DefaultRepairSilentMinutes;
+        knowledgeWriteBackSince = null;
         format = FormatMarkdown;
         error = string.Empty;
 
@@ -2224,6 +2471,20 @@ internal static class AutomationStalledWorkCommand
                     repairSilentMinutes = parsedRepairSilentMinutes;
                     index++;
                     break;
+                // G564: deliberate opt-in to scanning closeouts older than the
+                // activation floor. Retroactive detection is never a default.
+                case "--knowledge-writeback-since":
+                    if (index + 1 >= args.Length
+                        || !DateTimeOffset.TryParse(args[index + 1], System.Globalization.CultureInfo.InvariantCulture,
+                            System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                            out var parsedSince))
+                    {
+                        error = "--knowledge-writeback-since requires an ISO-8601 instant (e.g. 2026-08-01T00:00:00Z).";
+                        return false;
+                    }
+                    knowledgeWriteBackSince = parsedSince;
+                    index++;
+                    break;
                 case "--format":
                     if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
                     {
@@ -2286,6 +2547,12 @@ internal static class AutomationStalledWorkCommand
                 if (item.Pr is { } pr)
                 {
                     writer.WriteLine($"- pr: #{pr.Number} — {pr.Url}");
+                }
+                // G564: the declared targets belong in the item itself, so a
+                // reader knows WHAT the packet promised without opening it.
+                if (item.DeclaredWriteBackTargets is { Count: > 0 } declaredTargets)
+                {
+                    writer.WriteLine($"- declared_write_back_targets: {string.Join(", ", declaredTargets)}");
                 }
                 // G533: informational kinds never recommend a transition —
                 // rendered as `status` (descriptive prose) rather than
@@ -2409,6 +2676,15 @@ internal sealed record StalledWorkItem
 
     [JsonPropertyName("recommended_action")]
     public required string RecommendedAction { get; init; }
+
+    /// <summary>
+    /// G564: for <see cref="AutomationStalledWorkCommand.KindKnowledgeWritebackPending"/>,
+    /// the target paths the packet DECLARED — so the report says what was
+    /// promised and where, not merely that something is outstanding. Null for
+    /// every other kind.
+    /// </summary>
+    [JsonPropertyName("declared_write_back_targets")]
+    public IReadOnlyList<string>? DeclaredWriteBackTargets { get; init; }
 }
 
 internal sealed record StalledWorkExcluded

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -67,6 +67,7 @@ internal static class CommandRouter
         "automation host-sync-preflight",
         "automation intent-target-gap-recovery --repo <r> [--write]",
         "automation issue-publish --issue <n> --write",
+        "automation knowledge-writeback-record --execution-unit <u> --commit <host-sha> [--target <path>]... [--dry-run|--write]",
         "automation pr-transition --transition review-start --write",
         "automation pr-transition --transition request-update --write",
         "automation pr-transition --transition approved --write",
@@ -192,6 +193,8 @@ internal static class CommandRouter
                 ["issue-publish"] = AutomationIssuePublishCommand.Execute,
                 ["issue-release"] = AutomationIssueReleaseCommand.Execute,
                 ["issue-retire"] = AutomationIssueRetireCommand.Execute,
+                // G564: records a performed intent-tree/ADR/diagram/docs write-back.
+                ["knowledge-writeback-record"] = AutomationKnowledgeWriteBackRecordCommand.Execute,
                 ["label-palette-audit"] = AutomationLabelPaletteAuditCommand.Execute,
                 ["label-palette-sync"] = AutomationLabelPaletteSyncCommand.Execute,
                 ["pr-transition"] = AutomationPrTransitionCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/GuideCloseoutRunCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCloseoutRunCommand.cs
@@ -105,16 +105,21 @@ Stage 5 — apply queue/runs state (write):
    - If the result has an `error` field, stop and report the error.
    - Confirm: mode is `write`, queue_state_after is `completed`.
 
-Stage 5b — knowledge writeback check (G461; read-only):
-1. If the packet carried optional `closeout_learning` metadata with `write_back_required: true`, confirm the expected intent-tree / ADR / diagram / docs writeback either landed in the merged PR or was captured as a follow-up packet.
-2. If the writeback was expected but neither landed nor captured, report `knowledge-writeback-pending` with the named `write_back_targets` so the design thread can open a follow-up packet. Do not block the closeout queue write on this.
-3. If the packet declined knowledge maintenance (or carried no such metadata — legacy packets), this stage is a no-op. Packet-time intent maintenance is the normal path; `improve` (G456 / G460) remains the later safety net.
+Stage 5b — knowledge writeback check (G461 / G564; SAME CADENCE as the closeout):
+{IntentTreeCoEvolutionDuty.Duty}
+1. Read the packet's declarations: any `knowledge_updates.*.required: true` (intent_tree / adr / diagram / docs) or `closeout_learning.write_back_required: true`. If every one is false or absent, this stage is a no-op — declining is a legitimate answer, and legacy packets carry no such block.
+2. If anything was declared, DESIGN performs the write-back in the host repo now — in this same closeout wake, not ""later"". intent-cli never writes intent content; the tree is written by design.
+3. Then RECORD it, with the host commit as evidence: `intent-cli automation knowledge-writeback-record --execution-unit <execution-unit> --commit <host-commit-sha> [--target <path>]... --write`. The command is idempotent for the same commit and fails closed on an unknown unit or non-SHA evidence.
+4. Until a record exists, the unit stays visible as a `knowledge-writeback-pending` item in `intent-cli automation stalled-work` / `automation heartbeat`, with its age measured from closeout and its declared target paths named. Merging and closing the PR do NOT clear it.
+5. Do not block the closeout queue write on this — but do not report the closeout as complete while the declared write-back is unrecorded either; a still-pending item is part of the closeout report (below).
+6. {IntentTreeCoEvolutionDuty.AuthoringRule}
 
 Stage 6 — parent commit/push checklist (required last step):
 1. Stage parent durable state: `git add .intent-cli/queue-state.json .intent-cli/runs.jsonl submodules/<child-repo-name>`.
 2. Commit: `git commit -m ""closeout: PR #{targetRepoPlaceholder}#<n> — <execution-unit>""`.
 3. Push: `git push`.
 4. Report continuation hint from the closeout result (`next-slice-ready`, `no-actionable-item`, or `clarification-required`).
+5. G564: the closeout report to the design thread NAMES the packet's declared write-backs — each declared facet and target path, and whether it is `recorded` (with the host commit) or `pending`. Design cannot act on an obligation it is never told about, so a closeout report that omits a declared-but-unrecorded write-back is incomplete.
 
 Hard rules:
 - Do not use the `intent-closeout` skill file or any local skill file.

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -962,6 +962,11 @@ internal static class GuideOrchestratorThreadCommand
                     "Send the orchestrator a state update or a nudge (start/resume); do not drive implementation/review yourself.",
                     "Do NOT directly mutate implementation/review work, labels, or host metadata — that is the orchestrator/receivers' job through intent-cli.",
                     "Summarize ONLY human-needed items to the human; keep routine progress internal.",
+                    // G564: the one design duty that is NOT delegable to the
+                    // orchestrator — the tree is written by design, and only
+                    // design can discharge it.
+                    IntentTreeCoEvolutionDuty.Duty,
+                    IntentTreeCoEvolutionDuty.CloseoutCheck,
                 },
                 IdleDiagnostic = new[]
                 {
@@ -1347,6 +1352,16 @@ internal static class GuideOrchestratorThreadCommand
                     + "\"design_alignment_checked\":true,\"design_alignment_sources_checked\":[\"packet\","
                     + "\"review-context\",\"intent-tree\",\"adr-decision-notes\",\"relevant-docs\"],"
                     + "\"managed_worktree_policy\":\"compliant — .intent-cli/worktrees/review-<unit>, removed after review\"}",
+                CloseoutKnowledgeWriteBackRule =
+                    "G564 — closeout reports NAME the packet's declared knowledge write-backs: for every "
+                    + "`knowledge_updates.*.required: true` facet and `closeout_learning.write_back_required: true`, "
+                    + "the report to the design thread lists the facet, its declared target paths, and whether it is "
+                    + "`recorded` (with the host commit) or `pending`. A closed-out unit whose declared write-back has "
+                    + "no record is an aging `knowledge-writeback-pending` item in `automation stalled-work` / "
+                    + "`automation heartbeat`, cleared only by `intent-cli automation knowledge-writeback-record "
+                    + "--execution-unit <unit> --commit <host-sha> --write`. This is read-only propagation of packet "
+                    + "metadata: the orchestrator reports the obligation, design performs the write-back, and no thread "
+                    + "here mutates host intent content.",
                 ReviewIncompleteRule =
                     "A review `completed` reply that omits `design_alignment_checked: true` and the checked-source list "
                     + "is INCOMPLETE — the orchestrator does not route merge/closeout on that reply alone. The only "
@@ -5191,4 +5206,14 @@ internal sealed record OrchestratorReplyContract
 
     [JsonPropertyName("review_incomplete_rule")]
     public required string ReviewIncompleteRule { get; init; }
+
+    /// <summary>
+    /// G564: the closeout report is the only place design reliably learns
+    /// that a packet promised a write-back, so it must NAME the declared
+    /// facets/targets and their recorded-or-pending state. Read-only
+    /// propagation of packet metadata — the orchestrator never mutates host
+    /// intent content.
+    /// </summary>
+    [JsonPropertyName("closeout_knowledge_write_back_rule")]
+    public required string CloseoutKnowledgeWriteBackRule { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskPacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskPacketDraftCommand.cs
@@ -97,7 +97,11 @@ internal static class GuideWorkflowTaskPacketDraftCommand
         new IntentMaintenancePrompt { Id = "adr-candidate", Prompt = "Does this slice make an ADR-worthy decision (a hard-to-reverse choice, a rejected alternative, a new constraint)? If so, name the decision title and target ADR path; otherwise explicitly decline (`adr.required: false`). ADRs are not required for every packet." },
         new IntentMaintenancePrompt { Id = "diagram-candidate", Prompt = "Does a concept / workflow / topology / state diagram need to change because of this slice? Name the diagram type and target path, or decline (`diagram.required: false`)." },
         new IntentMaintenancePrompt { Id = "docs-update", Prompt = "Which user-facing docs must change so the documented behavior matches this slice once it lands? List target doc paths, or decline (`docs.required: false`)." },
-        new IntentMaintenancePrompt { Id = "closeout-learning", Prompt = "What knowledge should be written back AFTER this slice lands (intent tree, ADR, diagram, docs)? Set `closeout_learning.write_back_required` and name the write-back targets so review / closeout can verify it happened or open a follow-up packet." }
+        new IntentMaintenancePrompt { Id = "closeout-learning", Prompt = "What knowledge should be written back AFTER this slice lands (intent tree, ADR, diagram, docs)? Set `closeout_learning.write_back_required` and name the write-back targets so review / closeout can verify it happened or open a follow-up packet." },
+        // G564: the declarations above are only worth reading if they are
+        // honest — an undeclared obligation is invisible to closeout, to
+        // review, and to `automation stalled-work`.
+        new IntentMaintenancePrompt { Id = "co-evolution-duty", Prompt = IntentTreeCoEvolutionDuty.Duty + " " + IntentTreeCoEvolutionDuty.AuthoringRule + " Whatever you declare here is enforced after the slice lands: a closed-out unit with a declared-but-unrecorded write-back becomes an aging `knowledge-writeback-pending` item, cleared only by `intent-cli automation knowledge-writeback-record --execution-unit <unit> --commit <host-sha> --write`." }
     };
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/IntentTreeCoEvolutionDuty.cs
+++ b/src/IntentSystem.Cli/Commands/IntentTreeCoEvolutionDuty.cs
@@ -1,0 +1,53 @@
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G564: the operator's 2026-07-31 ruling, single-sourced so every guide
+/// surface that states it states the SAME thing — the duty, the packet-time
+/// authoring rule, and the closeout-cadence check.
+///
+/// The ruling: intent-cli is developed with intent-cli, and the intent tree
+/// falling behind development is itself a serious fault
+/// (「開発だけ進め、intent-tree を更新しないことは重要な過失」). Reinforcing the
+/// tree CONCURRENTLY with development is a primary design responsibility, not
+/// a nice-to-have that a busy release can defer.
+///
+/// The field evidence is the pre-v0.7.0 audit: G559 shipped while node 09
+/// still described a pre-implementation design, node 02 recorded none of the
+/// seven release-flow rules the docs implement, and node 08 lagged the wake
+/// contract by releases — weeks of drift with no structural signal, found only
+/// by a manual operator-ordered audit right before a release.
+///
+/// These strings are guidance TEXT. They never write intent content: the tree
+/// is written by design, and this CLI only declares, records, and detects.
+/// </summary>
+internal static class IntentTreeCoEvolutionDuty
+{
+    /// <summary>The duty itself, for design-thread guidance.</summary>
+    public const string Duty =
+        "PRIMARY DESIGN DUTY — intent-tree co-evolution: the intent tree moves WITH development, not after it. "
+        + "Leaving the tree unupdated while implementation advances is a serious fault in its own right, not a "
+        + "deferred chore: a tree that describes a design the code no longer has is worse than no tree, because "
+        + "every downstream packet, review, and audit is written against it. Reinforce the tree in the same wake "
+        + "that changes the surface it describes.";
+
+    /// <summary>The packet-authoring rule this duty implies.</summary>
+    public const string AuthoringRule =
+        "Declare knowledge write-backs HONESTLY at packet-authoring time: a slice that adds a surface or changes "
+        + "behavior almost always owes the tree something, so `knowledge_updates.*.required` and "
+        + "`closeout_learning.write_back_required` must reflect what is actually owed. Defaulting them to `false` "
+        + "to keep the packet quiet is the failure mode this rule exists to stop — an undeclared obligation is "
+        + "invisible to closeout, to review, and to `automation stalled-work`.";
+
+    /// <summary>The closeout-cadence check the duty implies (G524 same-cadence rule).</summary>
+    public const string CloseoutCheck =
+        "Same-cadence write-back check: perform the packet's declared write-backs and RECORD them in the same "
+        + "closeout wake, with `intent-cli automation knowledge-writeback-record --execution-unit <unit> --commit "
+        + "<host-sha> --write`. Until it is recorded, the unit stays visible as a `knowledge-writeback-pending` "
+        + "item in `automation stalled-work` / `automation heartbeat` — closing the PR does not clear it, and "
+        + "nothing here writes intent content on design's behalf.";
+
+    /// <summary>The canonical recording command for <paramref name="executionUnit"/>.</summary>
+    public static string RecordCommand(string executionUnit) =>
+        $"intent-cli automation knowledge-writeback-record --execution-unit {executionUnit} "
+        + "--commit <host-commit-sha> [--target <path>]... --write";
+}

--- a/src/IntentSystem.Cli/Commands/KnowledgeWriteBackDeclaration.cs
+++ b/src/IntentSystem.Cli/Commands/KnowledgeWriteBackDeclaration.cs
@@ -1,0 +1,178 @@
+using YamlDotNet.RepresentationModel;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G564: the write-back OBLIGATION a packet declared, read from the packet's
+/// own G461 metadata (<c>knowledge_updates.*.required</c> +
+/// <c>closeout_learning.write_back_required</c>).
+///
+/// This is the declaration half of intent-tree co-evolution: the packet says
+/// which knowledge has to be written back after the slice lands, and
+/// <see cref="KnowledgeWriteBackRecord"/> says whether it was. Neither half
+/// writes intent content — the tree is written by design, never by tooling.
+///
+/// Read tolerantly on ABSENCE and loudly on MALFORMEDNESS, for the same
+/// reason <see cref="ClarifyPacketFacts"/> splits those cases: a packet that
+/// never filled the optional G461 block in is a legacy/declined packet and
+/// declares no obligation (<see cref="IsRequired"/> false); a packet whose
+/// block is present but unparseable is evidence that cannot be trusted either
+/// way, so it throws and the caller reports it with its path rather than
+/// treating it as "nothing required".
+/// </summary>
+internal sealed record KnowledgeWriteBackDeclaration
+{
+    /// <summary>The four G461 <c>knowledge_updates</c> facets, in declaration order.</summary>
+    private static readonly (string Facet, string PathsKey)[] KnowledgeUpdateFacets =
+    [
+        ("intent_tree", "target_paths"),
+        ("adr", "target_paths"),
+        ("diagram", "target_paths"),
+        ("docs", "target_paths"),
+    ];
+
+    /// <summary>
+    /// True when the packet declared at least one <c>required: true</c> facet
+    /// or <c>closeout_learning.write_back_required: true</c>. A packet that
+    /// declared nothing required never produces a pending item — declining is
+    /// a legitimate answer, and this surface exists to detect broken promises,
+    /// not to force every slice to touch the tree.
+    /// </summary>
+    public required bool IsRequired { get; init; }
+
+    /// <summary>
+    /// The facets that carry the obligation (<c>intent_tree</c>, <c>adr</c>,
+    /// <c>diagram</c>, <c>docs</c>, <c>closeout_learning</c>) — named so a
+    /// report can say WHAT was promised, not merely that something was.
+    /// </summary>
+    public required IReadOnlyList<string> RequiredFacets { get; init; }
+
+    /// <summary>
+    /// Declared target paths, de-duplicated across the required facets and
+    /// <c>closeout_learning.write_back_targets</c>, in declaration order.
+    /// Empty when the packet promised a write-back without naming where.
+    /// </summary>
+    public required IReadOnlyList<string> DeclaredTargets { get; init; }
+
+    public static readonly KnowledgeWriteBackDeclaration None = new()
+    {
+        IsRequired = false,
+        RequiredFacets = Array.Empty<string>(),
+        DeclaredTargets = Array.Empty<string>(),
+    };
+
+    /// <summary>
+    /// Reads the declaration from raw packet YAML. Throws
+    /// <see cref="InvalidOperationException"/> when the YAML does not parse,
+    /// when the root is not a mapping, or when a declared <c>required</c> /
+    /// <c>write_back_required</c> value is present but is not a boolean — the
+    /// three cases where the metadata exists but cannot be believed.
+    /// </summary>
+    public static KnowledgeWriteBackDeclaration Read(string yaml)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+
+        if (string.IsNullOrWhiteSpace(yaml))
+        {
+            throw new InvalidOperationException("Packet YAML is empty, so its knowledge write-back declaration cannot be read.");
+        }
+
+        YamlMappingNode? root;
+        try
+        {
+            var stream = new YamlStream();
+            using var reader = new StringReader(yaml);
+            stream.Load(reader);
+            root = stream.Documents.Count == 0 ? null : stream.Documents[0].RootNode as YamlMappingNode;
+        }
+        catch (YamlDotNet.Core.YamlException exception)
+        {
+            throw new InvalidOperationException($"Packet YAML could not be parsed: {exception.Message}");
+        }
+
+        if (root is null)
+        {
+            throw new InvalidOperationException("Packet YAML is empty or is not a mapping.");
+        }
+
+        var requiredFacets = new List<string>();
+        var declaredTargets = new List<string>();
+
+        var knowledgeUpdates = GetMapping(root, "knowledge_updates");
+        if (knowledgeUpdates is not null)
+        {
+            foreach (var (facet, pathsKey) in KnowledgeUpdateFacets)
+            {
+                var facetNode = GetMapping(knowledgeUpdates, facet);
+                if (facetNode is null)
+                {
+                    continue;
+                }
+
+                if (!ReadBoolean(facetNode, "required", $"knowledge_updates.{facet}.required"))
+                {
+                    continue;
+                }
+
+                requiredFacets.Add(facet);
+                declaredTargets.AddRange(GetList(facetNode, pathsKey));
+            }
+        }
+
+        var closeoutLearning = GetMapping(root, "closeout_learning");
+        if (closeoutLearning is not null
+            && ReadBoolean(closeoutLearning, "write_back_required", "closeout_learning.write_back_required"))
+        {
+            requiredFacets.Add("closeout_learning");
+            declaredTargets.AddRange(GetList(closeoutLearning, "write_back_targets"));
+        }
+
+        return new KnowledgeWriteBackDeclaration
+        {
+            IsRequired = requiredFacets.Count > 0,
+            RequiredFacets = requiredFacets,
+            DeclaredTargets = declaredTargets.Distinct(StringComparer.Ordinal).ToArray(),
+        };
+    }
+
+    /// <summary>
+    /// An absent flag means "not declared" (false). A PRESENT flag that is not
+    /// a boolean is malformed metadata and throws: silently reading
+    /// <c>required: yes-please</c> as false would turn a broken declaration
+    /// into a clean bill of health, which is the exact failure this slice
+    /// exists to stop.
+    /// </summary>
+    private static bool ReadBoolean(YamlMappingNode parent, string key, string path)
+    {
+        var raw = GetScalar(parent, key);
+        if (raw is null || raw.Length == 0)
+        {
+            return false;
+        }
+
+        if (bool.TryParse(raw, out var value))
+        {
+            return value;
+        }
+
+        throw new InvalidOperationException(
+            $"Packet field '{path}' is '{raw}', which is not a boolean. A write-back obligation cannot be "
+            + "established or ruled out from an unreadable declaration.");
+    }
+
+    private static YamlMappingNode? GetMapping(YamlMappingNode parent, string key) =>
+        parent.Children.TryGetValue(new YamlScalarNode(key), out var node) ? node as YamlMappingNode : null;
+
+    private static string? GetScalar(YamlMappingNode parent, string key) =>
+        parent.Children.TryGetValue(new YamlScalarNode(key), out var node) && node is YamlScalarNode scalar
+            ? scalar.Value
+            : null;
+
+    private static IReadOnlyList<string> GetList(YamlMappingNode parent, string key) =>
+        parent.Children.TryGetValue(new YamlScalarNode(key), out var node) && node is YamlSequenceNode sequence
+            ? sequence.Children.OfType<YamlScalarNode>()
+                .Select(scalar => (scalar.Value ?? string.Empty).Trim())
+                .Where(value => value.Length > 0)
+                .ToArray()
+            : Array.Empty<string>();
+}

--- a/src/IntentSystem.Cli/Commands/KnowledgeWriteBackRecord.cs
+++ b/src/IntentSystem.Cli/Commands/KnowledgeWriteBackRecord.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G564: the canonical, machine-readable record that a packet-declared
+/// knowledge write-back was PERFORMED, carrying the host commit as evidence.
+///
+/// The write-back itself is design's host-side act (G300 stands — nothing here
+/// writes intent content). What was missing was any durable statement that it
+/// happened: the evidence lived only in host commits the detection layer
+/// cannot see, so nothing could say "not done" and the tree fell weeks behind
+/// development with no structural signal.
+///
+/// One record per execution unit at
+/// <c>.intent-cli/knowledge-writebacks/&lt;unit&gt;/record.json</c>, written
+/// only by <see cref="AutomationKnowledgeWriteBackRecordCommand"/> — hand
+/// editing is not the path, and a record whose evidence conflicts with an
+/// existing one is refused rather than overwritten.
+/// </summary>
+internal sealed record KnowledgeWriteBackRecord
+{
+    public const string ArtifactKindValue = "knowledge-writeback-record";
+
+    private static readonly JsonSerializerOptions SerializeOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    [JsonPropertyName("artifact_kind")]
+    public required string ArtifactKind { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    /// <summary>The host commit the write-back landed in — the evidence.</summary>
+    [JsonPropertyName("host_commit")]
+    public required string HostCommit { get; init; }
+
+    [JsonPropertyName("recorded_at")]
+    public required DateTimeOffset RecordedAt { get; init; }
+
+    /// <summary>
+    /// Paths actually written, as reported by the recorder. Optional: the
+    /// packet's declared targets remain the contract, and a recorder that
+    /// names nothing still produces a valid record.
+    /// </summary>
+    [JsonPropertyName("targets")]
+    public required IReadOnlyList<string> Targets { get; init; }
+
+    [JsonPropertyName("note")]
+    public string? Note { get; init; }
+
+    /// <summary>
+    /// Repo-relative artifact path for <paramref name="executionUnit"/>,
+    /// always in forward-slash form so it reads identically on every platform
+    /// and in every report.
+    /// </summary>
+    public static string ResolveRelativePath(string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
+        return $".intent-cli/knowledge-writebacks/{executionUnit}/record.json";
+    }
+
+    public static string ResolveFullPath(string repoRoot, string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        return Path.GetFullPath(Path.Combine(
+            repoRoot,
+            ResolveRelativePath(executionUnit).Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    public static string Serialize(KnowledgeWriteBackRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        return JsonSerializer.Serialize(record, SerializeOptions);
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> on a payload that is not
+    /// a well-formed record of this kind. A record on disk that cannot be read
+    /// is never treated as absent: absence means "not written back yet", and
+    /// silently downgrading unreadable evidence to that would re-open the
+    /// false-clearance path this artifact closes.
+    /// </summary>
+    public static KnowledgeWriteBackRecord Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        KnowledgeWriteBackRecord? record;
+        try
+        {
+            record = JsonSerializer.Deserialize<KnowledgeWriteBackRecord>(json, SerializeOptions);
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException($"Knowledge write-back record is not valid JSON: {exception.Message}");
+        }
+
+        if (record is null)
+        {
+            throw new InvalidOperationException("Knowledge write-back record payload deserialized to null.");
+        }
+
+        if (!string.Equals(record.ArtifactKind, ArtifactKindValue, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Knowledge write-back record declares artifact_kind '{record.ArtifactKind}', expected '{ArtifactKindValue}'.");
+        }
+
+        if (string.IsNullOrWhiteSpace(record.ExecutionUnit) || string.IsNullOrWhiteSpace(record.HostCommit))
+        {
+            throw new InvalidOperationException(
+                "Knowledge write-back record is missing 'execution_unit' or 'host_commit' — a record without "
+                + "evidence is not a record.");
+        }
+
+        // `targets: null` satisfies the required-member check but would hand
+        // callers a null list; an unnamed target set is empty, not absent.
+        return record.Targets is null
+            ? record with { Targets = Array.Empty<string>() }
+            : record;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/KnowledgeWriteBackRecord.cs
+++ b/src/IntentSystem.Cli/Commands/KnowledgeWriteBackRecord.cs
@@ -53,6 +53,86 @@ internal sealed record KnowledgeWriteBackRecord
     [JsonPropertyName("note")]
     public string? Note { get; init; }
 
+    /// <summary>G564 review repair: the artifact root every record lives beneath.</summary>
+    public const string RecordRootRelativePath = ".intent-cli/knowledge-writebacks";
+
+    /// <summary>G564 review repair: the packet root every declaration is read from.</summary>
+    public const string PacketRootRelativePath = ".intent-cli/issues";
+
+    /// <summary>Shortest / longest evidence a commit SHA may be.</summary>
+    public const int MinimumCommitLength = 7;
+
+    public const int MaximumCommitLength = 40;
+
+    /// <summary>
+    /// G564 review repair: an execution unit is a canonical IDENTIFIER, and this
+    /// feature interpolates it into two filesystem paths. Without this gate,
+    /// <c>--execution-unit ../../.intent-cli/issues/G564</c> resolved a record
+    /// path OUTSIDE the artifact root, and a write would have escaped it.
+    ///
+    /// The rule is an allow-list rather than a blocklist of dangerous sequences:
+    /// letters, digits, <c>-</c>, <c>_</c> and <c>.</c>, never starting with
+    /// <c>.</c> and never containing <c>..</c>. That admits every real unit id
+    /// (<c>G564</c>, <c>SKS-G818</c>, <c>v1.2</c>) and structurally excludes
+    /// separators, rooted paths, drive/ADS colons, dot-segments, whitespace, and
+    /// control characters — so the classes of input the reviewer found cannot be
+    /// enumerated wrongly.
+    /// </summary>
+    public static bool TryValidateExecutionUnit(string? executionUnit, out string error)
+    {
+        const int MaximumLength = 128;
+
+        if (string.IsNullOrWhiteSpace(executionUnit))
+        {
+            error = "execution unit is required and must not be blank.";
+            return false;
+        }
+
+        if (executionUnit.Length > MaximumLength)
+        {
+            error = $"execution unit '{executionUnit}' exceeds {MaximumLength} characters.";
+            return false;
+        }
+
+        if (executionUnit[0] == '.')
+        {
+            error =
+                $"execution unit '{executionUnit}' starts with '.', which is not a canonical identifier "
+                + "(a leading dot introduces a relative path segment).";
+            return false;
+        }
+
+        if (executionUnit.Contains("..", StringComparison.Ordinal))
+        {
+            error =
+                $"execution unit '{executionUnit}' contains '..' — a dot-segment is a path traversal, never part "
+                + "of an execution unit id.";
+            return false;
+        }
+
+        foreach (var character in executionUnit)
+        {
+            if (!char.IsAsciiLetterOrDigit(character) && character is not ('-' or '_' or '.'))
+            {
+                error =
+                    $"execution unit '{executionUnit}' contains '{character}', which is not allowed. Canonical "
+                    + "execution unit ids use ASCII letters, digits, '-', '_' and '.' only — never path separators, "
+                    + "drive letters, or whitespace.";
+                return false;
+            }
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    /// <summary>True when <paramref name="value"/> is a 7–40 character hexadecimal SHA.</summary>
+    public static bool IsCommitShaped(string? value) =>
+        value is not null
+        && value.Length >= MinimumCommitLength
+        && value.Length <= MaximumCommitLength
+        && value.All(Uri.IsHexDigit);
+
     /// <summary>
     /// Repo-relative artifact path for <paramref name="executionUnit"/>,
     /// always in forward-slash form so it reads identically on every platform
@@ -60,16 +140,66 @@ internal sealed record KnowledgeWriteBackRecord
     /// </summary>
     public static string ResolveRelativePath(string executionUnit)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
-        return $".intent-cli/knowledge-writebacks/{executionUnit}/record.json";
+        if (!TryValidateExecutionUnit(executionUnit, out var error))
+        {
+            throw new InvalidOperationException(error);
+        }
+
+        return $"{RecordRootRelativePath}/{executionUnit}/record.json";
     }
 
     public static string ResolveFullPath(string repoRoot, string executionUnit)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
-        return Path.GetFullPath(Path.Combine(
+        var resolved = Path.GetFullPath(Path.Combine(
             repoRoot,
             ResolveRelativePath(executionUnit).Replace('/', Path.DirectorySeparatorChar)));
+
+        // Defense in depth: the identifier gate above already makes escape
+        // impossible, so a failure here means that gate regressed — refuse
+        // rather than touch a path outside the artifact root.
+        return EnsureContained(repoRoot, RecordRootRelativePath, resolved, executionUnit);
+    }
+
+    /// <summary>
+    /// G564 review repair: the packet a declaration is read from is resolved and
+    /// contained by the same rules as the record — both paths interpolate the
+    /// execution unit, so both need the same guarantee.
+    /// </summary>
+    public static string ResolvePacketPath(string repoRoot, string executionUnit)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        if (!TryValidateExecutionUnit(executionUnit, out var error))
+        {
+            throw new InvalidOperationException(error);
+        }
+
+        var resolved = Path.GetFullPath(Path.Combine(
+            repoRoot,
+            PacketRootRelativePath.Replace('/', Path.DirectorySeparatorChar),
+            executionUnit,
+            "packet.yaml"));
+
+        return EnsureContained(repoRoot, PacketRootRelativePath, resolved, executionUnit);
+    }
+
+    private static string EnsureContained(string repoRoot, string rootRelativePath, string resolved, string executionUnit)
+    {
+        var root = Path.GetFullPath(Path.Combine(
+            repoRoot,
+            rootRelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        var rootPrefix = root.EndsWith(Path.DirectorySeparatorChar)
+            ? root
+            : root + Path.DirectorySeparatorChar;
+
+        if (!resolved.StartsWith(rootPrefix, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"resolved path for execution unit '{executionUnit}' escapes `{rootRelativePath}` "
+                + $"({resolved}); refusing to read or write outside the artifact root.");
+        }
+
+        return resolved;
     }
 
     public static string Serialize(KnowledgeWriteBackRecord record)
@@ -84,10 +214,20 @@ internal sealed record KnowledgeWriteBackRecord
     /// is never treated as absent: absence means "not written back yet", and
     /// silently downgrading unreadable evidence to that would re-open the
     /// false-clearance path this artifact closes.
+    ///
+    /// G564 review repair: <paramref name="expectedExecutionUnit"/> is REQUIRED
+    /// by every consumer. A record is only evidence for the unit it is stored
+    /// under, and validation used to stop at "non-blank" — so a file at
+    /// <c>…/G564/record.json</c> carrying <c>execution_unit: G999</c>, or a
+    /// <c>host_commit</c> that is not a SHA at all, cleared
+    /// <c>knowledge-writeback-pending</c> for G564 anyway. Both are now
+    /// rejected, which surfaces them as unreadable-with-path rather than as a
+    /// discharged obligation.
     /// </summary>
-    public static KnowledgeWriteBackRecord Deserialize(string json)
+    public static KnowledgeWriteBackRecord Deserialize(string json, string expectedExecutionUnit)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(json);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedExecutionUnit);
 
         KnowledgeWriteBackRecord? record;
         try
@@ -115,6 +255,22 @@ internal sealed record KnowledgeWriteBackRecord
             throw new InvalidOperationException(
                 "Knowledge write-back record is missing 'execution_unit' or 'host_commit' — a record without "
                 + "evidence is not a record.");
+        }
+
+        if (!string.Equals(record.ExecutionUnit, expectedExecutionUnit, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Knowledge write-back record declares execution_unit '{record.ExecutionUnit}' but is stored for "
+                + $"'{expectedExecutionUnit}'. A record is evidence only for the unit it names; a mismatched record "
+                + "never discharges this unit's obligation.");
+        }
+
+        if (!IsCommitShaped(record.HostCommit))
+        {
+            throw new InvalidOperationException(
+                $"Knowledge write-back record for '{expectedExecutionUnit}' carries host_commit "
+                + $"'{record.HostCommit}', which is not a {MinimumCommitLength}-{MaximumCommitLength} character "
+                + "hexadecimal SHA. Evidence a reader cannot follow to a commit is not evidence.");
         }
 
         // `targets: null` satisfies the required-member check but would hand

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
@@ -112,8 +112,13 @@ public sealed class GuideWorkflowTaskPacketDraftCommandTests
         var root = document.RootElement;
         Assert.True(root.TryGetProperty("intent_maintenance_prompts", out var prompts));
         var ids = prompts.EnumerateArray().Select(p => p.GetProperty("id").GetString()).ToArray();
+        // G564 extends the G461 five with the co-evolution duty: the four
+        // declarations above are only worth reading if they are honest, so the
+        // duty and the authoring rule are asked at the same moment, in the same
+        // list, rather than living only in a separate guide an author may not
+        // open. The G461 five keep their ids and their order.
         Assert.Equal(
-            new[] { "intent-placement", "adr-candidate", "diagram-candidate", "docs-update", "closeout-learning" },
+            new[] { "intent-placement", "adr-candidate", "diagram-candidate", "docs-update", "closeout-learning", "co-evolution-duty" },
             ids);
         // Each prompt carries actionable text.
         foreach (var p in prompts.EnumerateArray())

--- a/tests/IntentSystem.Cli.Tests/KnowledgeWriteBackG564Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/KnowledgeWriteBackG564Tests.cs
@@ -1,0 +1,711 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G564: intent-tree co-evolution enforcement. A packet-declared knowledge
+/// write-back that never happens used to be invisible — the declaration lived
+/// in the packet, the write-back (when it happened) lived in a host commit the
+/// detection layer cannot see, and nothing said "done", so nothing could say
+/// "not done". These fixtures pin the three halves that close it: a recording
+/// surface with evidence, a stalled-work kind that ages the absence, and the
+/// guide text that binds the duty into design's cadence.
+///
+/// Shares <see cref="AutomationStalledWorkSharedStateCollection"/> because it
+/// mutates <see cref="AutomationStalledWorkCommand"/>'s process-global
+/// <c>CandidateListerFactory</c> / <c>UtcNowFactory</c> seams.
+/// </summary>
+[Collection(AutomationStalledWorkSharedStateCollection.Name)]
+public sealed class KnowledgeWriteBackG564Tests : IDisposable
+{
+    /// <summary>
+    /// After <see cref="AutomationStalledWorkCommand.KnowledgeWriteBackActivationUtc"/>,
+    /// so the fixtures below exercise the in-scope path; the pre-activation
+    /// floor has its own fixture.
+    /// </summary>
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private const string Repo = "J-Tech-Japan/intent-system";
+    private const string HostCommit = "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678";
+
+    public KnowledgeWriteBackG564Tests()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new EmptyCandidateLister();
+        AutomationStalledWorkCommand.UtcNowFactory = () => FixedNow;
+        AutomationKnowledgeWriteBackRecordCommand.UtcNowFactory = () => FixedNow;
+    }
+
+    public void Dispose()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = null;
+        AutomationKnowledgeWriteBackRecordCommand.UtcNowFactory = null;
+    }
+
+    // ---------------------------------------------------------------- detection
+
+    [Fact]
+    public void AClosedUnitWithDeclaredWriteBacks_ProducesAVisibleAgingItem_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md"]);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-180));
+
+        var items = workspace.RunStalledWork();
+        var item = Assert.Single(items.EnumerateArray());
+
+        Assert.Equal(AutomationStalledWorkCommand.KindKnowledgeWritebackPending, item.GetProperty("kind").GetString());
+        Assert.Equal("G564", item.GetProperty("execution_unit").GetString());
+        Assert.Equal(180, item.GetProperty("age_minutes").GetInt32());
+        Assert.False(item.GetProperty("is_informational").GetBoolean());
+
+        // The declared target paths belong in the item — a report that only
+        // says "something is pending" cannot be acted on.
+        var declared = item.GetProperty("declared_write_back_targets").EnumerateArray().Select(t => t.GetString()).ToArray();
+        Assert.Contains("intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md", declared);
+
+        var action = item.GetProperty("recommended_action").GetString()!;
+        Assert.Contains("intent-cli automation knowledge-writeback-record", action, StringComparison.Ordinal);
+        Assert.Contains("--execution-unit G564", action, StringComparison.Ordinal);
+        Assert.Contains("intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md", action, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RecordingTheWriteBack_ClearsThePendingItem_G564()
+    {
+        // The acceptance walk-through, driven through the REAL surfaces:
+        // declare → close out → observe pending → record → observe clearance.
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/intent-cli/intent-tree/means/08-agent-message-orchestration.md"]);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-180));
+
+        Assert.Equal(1, workspace.RunStalledWork().GetArrayLength());
+
+        var record = workspace.RunRecord(["--execution-unit", "G564", "--commit", HostCommit, "--write", "--format", "json"]);
+        Assert.Equal(0, record.ExitCode);
+        Assert.True(record.Json.GetProperty("applied").GetBoolean());
+        Assert.False(record.Json.GetProperty("already_recorded").GetBoolean());
+        Assert.True(File.Exists(workspace.RecordPath("G564")));
+
+        Assert.Equal(0, workspace.RunStalledWork().GetArrayLength());
+    }
+
+    [Fact]
+    public void AUnitThatDeclaredNothingRequired_NeverAppears_G564()
+    {
+        // Declining is a legitimate answer. This kind detects broken promises,
+        // not slices that legitimately owe the tree nothing.
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: false, targets: []);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-4000));
+
+        Assert.Equal(0, workspace.RunStalledWork().GetArrayLength());
+    }
+
+    [Fact]
+    public void ClosedOutLearningAlone_IsEnoughToRaiseTheObligation_G564()
+    {
+        // `closeout_learning.write_back_required` is the second declaration
+        // source; a packet using only it must be detected exactly the same.
+        using var workspace = new WriteBackWorkspace();
+        workspace.WritePacket("G564", """
+            implementation_issue_packet:
+              source_execution_unit: G564
+              domain: intent-cli
+            closeout_learning:
+              expected: "node 03 gains the audit-state machinery section"
+              write_back_required: true
+              write_back_targets:
+                - intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md
+            """);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-90));
+
+        var item = Assert.Single(workspace.RunStalledWork().EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindKnowledgeWritebackPending, item.GetProperty("kind").GetString());
+        Assert.Contains(
+            "closeout_learning",
+            item.GetProperty("recommended_action").GetString()!,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnreadableDeclarationMetadata_IsExcludedWithItsPath_NotSilentlyCleared_G564()
+    {
+        // A present-but-unparseable declaration establishes NEITHER that a
+        // write-back is owed nor that it is not. Reading it as `false` would
+        // manufacture the exact false all-clear this slice exists to stop.
+        using var workspace = new WriteBackWorkspace();
+        workspace.WritePacket("G564", """
+            implementation_issue_packet:
+              source_execution_unit: G564
+              domain: intent-cli
+            knowledge_updates:
+              intent_tree:
+                required: yes-please
+                target_paths: []
+            """);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-120));
+
+        var result = workspace.RunStalledWorkResult();
+        Assert.Equal(0, result.GetProperty("items").GetArrayLength());
+
+        var excluded = Assert.Single(result.GetProperty("excluded").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindKnowledgeWritebackPending, excluded.GetProperty("kind").GetString());
+        Assert.Equal(AutomationStalledWorkCommand.ReasonKnowledgeMetadataUnreadable, excluded.GetProperty("reason").GetString());
+
+        var detail = excluded.GetProperty("detail").GetString()!;
+        Assert.Contains("packet.yaml", detail, StringComparison.Ordinal);
+        Assert.Contains("knowledge_updates.intent_tree.required", detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnUnreadableRecord_IsExcludedWithItsPath_NotCountedAsCleared_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/x.md"]);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-120));
+        Directory.CreateDirectory(Path.GetDirectoryName(workspace.RecordPath("G564"))!);
+        File.WriteAllText(workspace.RecordPath("G564"), "{ not json");
+
+        var result = workspace.RunStalledWorkResult();
+        Assert.Equal(0, result.GetProperty("items").GetArrayLength());
+
+        var excluded = Assert.Single(result.GetProperty("excluded").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.ReasonKnowledgeMetadataUnreadable, excluded.GetProperty("reason").GetString());
+        Assert.Contains("record.json", excluded.GetProperty("detail").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void UnitsClosedBeforeActivation_AreOutOfScope_UnlessTheOperatorAsksForThem_G564()
+    {
+        // Retroactive detection is out of scope by contract: an upgrade must
+        // not light up every historical unit on its first wake. Asking for it
+        // explicitly still works.
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G520", requiredIntentTree: true, targets: ["intents/legacy.md"]);
+        workspace.WriteCloseout("G520", AutomationStalledWorkCommand.KnowledgeWriteBackActivationUtc.AddDays(-10));
+
+        Assert.Equal(0, workspace.RunStalledWork().GetArrayLength());
+
+        var retroactive = workspace.RunStalledWork(extraArgs: ["--knowledge-writeback-since", "2026-01-01T00:00:00Z"]);
+        var item = Assert.Single(retroactive.EnumerateArray());
+        Assert.Equal("G520", item.GetProperty("execution_unit").GetString());
+    }
+
+    [Fact]
+    public void ARepeatedCloseout_DoesNotResetTheItemAge_G564()
+    {
+        // Age is measured from when the obligation STARTED. A retried closeout
+        // must not make a three-day-old pending write-back look fresh.
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/x.md"]);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-4320));
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-10));
+
+        var item = Assert.Single(workspace.RunStalledWork().EnumerateArray());
+        Assert.Equal(4320, item.GetProperty("age_minutes").GetInt32());
+    }
+
+    [Fact]
+    public void Heartbeat_CarriesTheKind_AndNamesItInTheMessageBody_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md"]);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-180));
+
+        using var writer = new StringWriter();
+        var exit = AutomationHeartbeatCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", Repo, "--format", "json"],
+            writer);
+        Assert.Equal(0, exit);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.True(document.RootElement.GetProperty("stale").GetBoolean());
+        var item = Assert.Single(document.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindKnowledgeWritebackPending, item.GetProperty("kind").GetString());
+
+        var body = document.RootElement.GetProperty("message_body").GetString()!;
+        Assert.Contains("knowledge-writeback-record", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownReport_NamesTheDeclaredTargets_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md"]);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-180));
+
+        using var writer = new StringWriter();
+        var exit = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", Repo],
+            writer);
+        Assert.Equal(0, exit);
+
+        var output = writer.ToString();
+        Assert.Contains("knowledge-writeback-pending", output, StringComparison.Ordinal);
+        Assert.Contains(
+            "declared_write_back_targets: intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md",
+            output,
+            StringComparison.Ordinal);
+    }
+
+    // ---------------------------------------------------------------- recording
+
+    [Fact]
+    public void Record_IsIdempotentForTheSameCommit_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/x.md"]);
+
+        var first = workspace.RunRecord(["--execution-unit", "G564", "--commit", HostCommit, "--write", "--format", "json"]);
+        Assert.Equal(0, first.ExitCode);
+        var firstBytes = File.ReadAllBytes(workspace.RecordPath("G564"));
+
+        var second = workspace.RunRecord(["--execution-unit", "G564", "--commit", HostCommit.ToUpperInvariant(), "--write", "--format", "json"]);
+        Assert.Equal(0, second.ExitCode);
+        Assert.True(second.Json.GetProperty("already_recorded").GetBoolean());
+        Assert.False(second.Json.GetProperty("applied").GetBoolean());
+
+        // Byte-identical: a re-run in a retried closeout wake must not rewrite
+        // the evidence (it would move `recorded_at` off the real event).
+        Assert.Equal(firstBytes, File.ReadAllBytes(workspace.RecordPath("G564")));
+    }
+
+    [Fact]
+    public void Record_RefusesConflictingEvidence_RatherThanOverwritingIt_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/x.md"]);
+        Assert.Equal(0, workspace.RunRecord(["--execution-unit", "G564", "--commit", HostCommit, "--write", "--format", "json"]).ExitCode);
+        var before = File.ReadAllBytes(workspace.RecordPath("G564"));
+
+        var conflict = workspace.RunRecord(["--execution-unit", "G564", "--commit", "0f0f0f0f0f0f0f0f", "--write", "--format", "json"]);
+        Assert.Equal(1, conflict.ExitCode);
+        Assert.Contains("refusing to replace", conflict.Json.GetProperty("error").GetString()!, StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllBytes(workspace.RecordPath("G564")));
+    }
+
+    [Fact]
+    public void Record_FailsClosedOnAnUnknownExecutionUnit_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+
+        var result = workspace.RunRecord(["--execution-unit", "G999", "--commit", HostCommit, "--write", "--format", "json"]);
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("unknown execution unit", result.Json.GetProperty("error").GetString()!, StringComparison.Ordinal);
+        Assert.False(File.Exists(workspace.RecordPath("G999")));
+        Assert.False(Directory.Exists(Path.GetDirectoryName(workspace.RecordPath("G999"))));
+    }
+
+    [Theory]
+    [InlineData("not-a-sha")]
+    [InlineData("abc")]
+    [InlineData("zzzzzzzzzz")]
+    public void Record_FailsClosedOnMalformedEvidence_G564(string commit)
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/x.md"]);
+
+        // Malformed evidence is rejected at the ARGUMENT boundary, before the
+        // command touches the packet or the artifact directory at all.
+        using var writer = new StringWriter();
+        var exit = AutomationKnowledgeWriteBackRecordCommand.Execute(
+            workspace.Context, ["--execution-unit", "G564", "--commit", commit, "--write"], writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("is not a commit SHA", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(workspace.RecordPath("G564")));
+    }
+
+    [Fact]
+    public void Record_WithoutEvidence_IsRefused_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/x.md"]);
+
+        using var writer = new StringWriter();
+        var exit = AutomationKnowledgeWriteBackRecordCommand.Execute(
+            workspace.Context, ["--execution-unit", "G564", "--write"], writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--commit is required", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(workspace.RecordPath("G564")));
+    }
+
+    [Fact]
+    public void Record_DryRunIsTheDefault_AndWritesNothing_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/x.md"]);
+
+        var result = workspace.RunRecord(["--execution-unit", "G564", "--commit", HostCommit, "--format", "json"]);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("dry-run", result.Json.GetProperty("mode").GetString());
+        Assert.False(result.Json.GetProperty("applied").GetBoolean());
+        Assert.False(File.Exists(workspace.RecordPath("G564")));
+    }
+
+    [Fact]
+    public void Record_OnAUnitThatDeclaredNothing_SucceedsButSaysSo_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: false, targets: []);
+
+        var result = workspace.RunRecord(["--execution-unit", "G564", "--commit", HostCommit, "--write", "--format", "json"]);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.False(result.Json.GetProperty("declaration_required").GetBoolean());
+        var warning = Assert.Single(result.Json.GetProperty("warnings").EnumerateArray());
+        Assert.Contains("declared no required knowledge write-back", warning.GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Record_CarriesTheEvidenceAndDeclaredTargetsIntoTheArtifact_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/declared.md"]);
+
+        var result = workspace.RunRecord([
+            "--execution-unit", "G564",
+            "--commit", HostCommit,
+            "--target", "intents/declared.md",
+            "--note", "node 03 gains the audit-state machinery section",
+            "--write", "--format", "json"
+        ]);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("intents/declared.md", result.Json.GetProperty("declared_targets").EnumerateArray().Select(t => t.GetString()));
+
+        var record = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(workspace.RecordPath("G564")));
+        Assert.Equal(KnowledgeWriteBackRecord.ArtifactKindValue, record.ArtifactKind);
+        Assert.Equal("G564", record.ExecutionUnit);
+        Assert.Equal(HostCommit, record.HostCommit);
+        Assert.Equal(FixedNow, record.RecordedAt);
+        Assert.Contains("intents/declared.md", record.Targets);
+        Assert.Equal("node 03 gains the audit-state machinery section", record.Note);
+    }
+
+    // ---------------------------------------------------------------- router
+
+    [Fact]
+    public void CommandRouter_DispatchesAndAdvertisesTheRecordingCommand_G564()
+    {
+        var router = typeof(CommandRouter);
+
+        var helpField = router.GetField("AutomationCommandHelp",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var lines = (IReadOnlyList<string>?)helpField!.GetValue(null);
+        Assert.Contains(lines!, line => line.Contains("knowledge-writeback-record", StringComparison.Ordinal));
+
+        var commandsField = router.GetField("ImplementedCommands",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var outer = (System.Collections.IDictionary)commandsField!.GetValue(null)!;
+        var automation = (System.Collections.IDictionary)outer["automation"]!;
+        Assert.True(automation.Contains("knowledge-writeback-record"));
+        var handler = (Delegate)automation["knowledge-writeback-record"]!;
+        Assert.Equal(
+            typeof(AutomationKnowledgeWriteBackRecordCommand).GetMethod(
+                "Execute",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)!,
+            handler.Method);
+    }
+
+    // ---------------------------------------------------------------- guides
+
+    [Fact]
+    public void CloseoutGuide_BindsTheWriteBackToTheSameCadence_AndNamesTheRecordCommand_G564()
+    {
+        var output = Render(["guide", "closeout", "run", "--domain", "intent-cli", "--repo", Repo]);
+
+        Assert.Contains(IntentTreeCoEvolutionDuty.Duty, output, StringComparison.Ordinal);
+        Assert.Contains(IntentTreeCoEvolutionDuty.AuthoringRule, output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli automation knowledge-writeback-record", output, StringComparison.Ordinal);
+        // The item is not cleared by merging — that is the whole point of a
+        // record separate from the PR lifecycle.
+        Assert.Contains("Merging and closing the PR do NOT clear it", output, StringComparison.Ordinal);
+        // And the closeout report is what tells design about it.
+        Assert.Contains("closeout report to the design thread NAMES the packet's declared write-backs", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PacketAuthoringGuide_RequiresHonestDeclarations_G564()
+    {
+        var output = Render(["guide", "workflow", "task", "packet-draft"]);
+
+        Assert.Contains(IntentTreeCoEvolutionDuty.AuthoringRule, output, StringComparison.Ordinal);
+        Assert.Contains("knowledge-writeback-pending", output, StringComparison.Ordinal);
+        Assert.Contains(
+            "co-evolution-duty",
+            GuideWorkflowTaskPacketDraftCommand.IntentMaintenancePrompts.Select(p => p.Id));
+    }
+
+    [Fact]
+    public void DesignThreadGuidance_StatesTheDutyInTheOperatorsTerms_G564()
+    {
+        var output = Render(["guide", "orchestrator-thread", "--domain", "intent-cli", "--target-repo", Repo, "--agent", "claude"]);
+
+        Assert.Contains(IntentTreeCoEvolutionDuty.Duty, output, StringComparison.Ordinal);
+        Assert.Contains(IntentTreeCoEvolutionDuty.CloseoutCheck, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OrchestratorCloseoutReport_EnumeratesDeclaredWriteBacks_WithoutMutatingHostIntent_G564()
+    {
+        using var writer = new StringWriter();
+        var exit = CommandRouter.Execute(
+            ["guide", "orchestrator-thread", "--domain", "intent-cli", "--target-repo", Repo, "--agent", "claude", "--format", "json"],
+            CreateGuideContext(),
+            writer);
+        Assert.Equal(0, exit);
+
+        using var document = JsonDocument.Parse(writer.ToString());
+        var rule = FindStringProperty(document.RootElement, "closeout_knowledge_write_back_rule");
+        Assert.False(string.IsNullOrWhiteSpace(rule), "the closeout report rule is missing from the orchestrator-thread contract");
+        Assert.Contains("knowledge_updates", rule!, StringComparison.Ordinal);
+        Assert.Contains("closeout_learning.write_back_required", rule!, StringComparison.Ordinal);
+        Assert.Contains("knowledge-writeback-record", rule!, StringComparison.Ordinal);
+        // Read-only propagation: reporting an obligation is not writing the tree.
+        Assert.Contains("mutates host intent content", rule!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReleaseNotes_CoverG564_InBothLanguages_G564()
+    {
+        var repoRoot = FindRepoRoot();
+        foreach (var language in new[] { "en", "ja" })
+        {
+            var notes = File.ReadAllText(Path.Combine(repoRoot, "docs", language, "release-notes-v0.7.0.md"));
+            Assert.Contains("G564", notes, StringComparison.Ordinal);
+            Assert.Contains("knowledge-writeback-record", notes, StringComparison.Ordinal);
+            Assert.Contains("knowledge-writeback-pending", notes, StringComparison.Ordinal);
+        }
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private static string Render(string[] args)
+    {
+        using var writer = new StringWriter();
+        var exit = CommandRouter.Execute(args, CreateGuideContext(), writer);
+        Assert.True(exit == 0, $"`intent-cli {string.Join(' ', args)}` exited {exit}: {writer}");
+        return writer.ToString();
+    }
+
+    private static CliContext CreateGuideContext() => new()
+    {
+        RepoRoot = Path.GetTempPath(),
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private static string FindRepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir is not null && !Directory.Exists(Path.Combine(dir, "src")))
+        {
+            dir = Path.GetDirectoryName(dir);
+        }
+
+        Assert.NotNull(dir);
+        return dir!;
+    }
+
+    private static string? FindStringProperty(JsonElement element, string name)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (string.Equals(property.Name, name, StringComparison.Ordinal)
+                        && property.Value.ValueKind == JsonValueKind.String)
+                    {
+                        return property.Value.GetString();
+                    }
+
+                    var nested = FindStringProperty(property.Value, name);
+                    if (nested is not null)
+                    {
+                        return nested;
+                    }
+                }
+
+                return null;
+
+            case JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    var nested = FindStringProperty(item, name);
+                    if (nested is not null)
+                    {
+                        return nested;
+                    }
+                }
+
+                return null;
+
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Keeps <c>automation stalled-work</c> off the network: without an
+    /// injected lister it shells out to `gh`, which passes on a developer
+    /// machine with credentials and fails on a CI runner.
+    /// </summary>
+    private sealed class EmptyCandidateLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) =>
+            Array.Empty<GitHubAutomationIssueCandidate>();
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) =>
+            Array.Empty<GitHubAutomationPrCandidate>();
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) =>
+            Array.Empty<GitHubAutomationPrCandidate>();
+    }
+
+    private sealed record RecordRun(int ExitCode, JsonElement Json);
+
+    private sealed class WriteBackWorkspace : IDisposable
+    {
+        private readonly List<JsonDocument> _documents = new();
+
+        public WriteBackWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("knowledge-writeback-g564-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public string RecordPath(string executionUnit) =>
+            KnowledgeWriteBackRecord.ResolveFullPath(RootPath, executionUnit);
+
+        public void WritePacket(string executionUnit, string yaml)
+        {
+            var directory = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, "packet.yaml"), yaml);
+        }
+
+        public void WriteDeclaringPacket(string executionUnit, bool requiredIntentTree, IReadOnlyList<string> targets)
+        {
+            var targetLines = targets.Count == 0
+                ? "    target_paths: []"
+                : "    target_paths:\n" + string.Join('\n', targets.Select(target => $"      - {target}"));
+
+            WritePacket(executionUnit, $"""
+                implementation_issue_packet:
+                  source_execution_unit: {executionUnit}
+                  domain: intent-cli
+                knowledge_updates:
+                  intent_tree:
+                    required: {(requiredIntentTree ? "true" : "false")}
+                {targetLines}
+                    summary: ""
+                  adr:
+                    required: false
+                    target_paths: []
+                  diagram:
+                    required: false
+                    target_paths: []
+                  docs:
+                    required: false
+                    target_paths: []
+                closeout_learning:
+                  expected: ""
+                  write_back_required: false
+                  write_back_targets: []
+                """);
+        }
+
+        /// <summary>Appends the canonical `closeout-recorded` runs event `closeout pr --write` emits.</summary>
+        public void WriteCloseout(string executionUnit, DateTimeOffset at)
+        {
+            var runLogPath = Context.GetRunLogPath();
+            Directory.CreateDirectory(Path.GetDirectoryName(runLogPath)!);
+            var line = IntentSystem.Supervisor.Serialization.RunLogSerializer.SerializeLine(
+                new IntentSystem.Supervisor.Models.RunEvent
+                {
+                    Ts = at,
+                    ExecutionUnit = executionUnit,
+                    Event = "closeout-recorded",
+                    By = "intent-cli closeout pr",
+                });
+            File.AppendAllText(runLogPath, line + Environment.NewLine);
+        }
+
+        public JsonElement RunStalledWorkResult(string[]? extraArgs = null)
+        {
+            using var writer = new StringWriter();
+            var args = new List<string> { "--domain", "intent-cli", "--repo", Repo, "--format", "json" };
+            args.AddRange(extraArgs ?? Array.Empty<string>());
+            var exit = AutomationStalledWorkCommand.Execute(Context, args.ToArray(), writer);
+            Assert.True(exit == 0, $"automation stalled-work exited {exit}: {writer}");
+
+            var document = JsonDocument.Parse(writer.ToString());
+            _documents.Add(document);
+            return document.RootElement;
+        }
+
+        public JsonElement RunStalledWork(string[]? extraArgs = null) =>
+            RunStalledWorkResult(extraArgs).GetProperty("items");
+
+        public RecordRun RunRecord(string[] args)
+        {
+            using var writer = new StringWriter();
+            var exit = AutomationKnowledgeWriteBackRecordCommand.Execute(Context, args, writer);
+            var document = JsonDocument.Parse(writer.ToString());
+            _documents.Add(document);
+            return new RecordRun(exit, document.RootElement);
+        }
+
+        public void Dispose()
+        {
+            foreach (var document in _documents)
+            {
+                document.Dispose();
+            }
+
+            try
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+            catch (IOException)
+            {
+                // Best effort: a leftover temp directory never fails a test.
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/KnowledgeWriteBackG564Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/KnowledgeWriteBackG564Tests.cs
@@ -383,13 +383,148 @@ public sealed class KnowledgeWriteBackG564Tests : IDisposable
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("intents/declared.md", result.Json.GetProperty("declared_targets").EnumerateArray().Select(t => t.GetString()));
 
-        var record = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(workspace.RecordPath("G564")));
+        var record = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(workspace.RecordPath("G564")), "G564");
         Assert.Equal(KnowledgeWriteBackRecord.ArtifactKindValue, record.ArtifactKind);
         Assert.Equal("G564", record.ExecutionUnit);
         Assert.Equal(HostCommit, record.HostCommit);
         Assert.Equal(FixedNow, record.RecordedAt);
         Assert.Contains("intents/declared.md", record.Targets);
         Assert.Equal("node 03 gains the audit-state machinery section", record.Note);
+    }
+
+    // ------------------------------------------- G564 review repair: identity
+
+    /// <summary>
+    /// Review finding 1: the execution unit was interpolated into the packet
+    /// and record paths with no canonical-identifier check. A dry run accepted
+    /// `../../.intent-cli/issues/G564` and resolved a record path OUTSIDE
+    /// `.intent-cli/knowledge-writebacks`; write mode could have escaped the
+    /// artifact root entirely.
+    /// </summary>
+    [Theory]
+    [InlineData("../../.intent-cli/issues/G564")]      // the reported traversal
+    [InlineData("..")]
+    [InlineData("../G564")]
+    [InlineData("G564/../../escape")]
+    [InlineData("/etc/passwd")]                         // rooted (POSIX)
+    [InlineData("C:\\Windows\\system32")]               // rooted (Windows) + separators + colon
+    [InlineData("\\\\server\\share")]                   // UNC
+    [InlineData("sub/dir")]                             // any separator at all
+    [InlineData(".hidden")]                             // leading dot segment
+    [InlineData("G564 with space")]
+    [InlineData("G564\nG999")]
+    public void Record_RejectsNoncanonicalExecutionUnits_BeforeTouchingTheFilesystem_G564(string executionUnit)
+    {
+        using var workspace = new WriteBackWorkspace();
+
+        using var writer = new StringWriter();
+        var exit = AutomationKnowledgeWriteBackRecordCommand.Execute(
+            workspace.Context, ["--execution-unit", executionUnit, "--commit", HostCommit, "--write"], writer);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--execution-unit is invalid", writer.ToString(), StringComparison.Ordinal);
+
+        // Nothing anywhere under the workspace was created — not inside the
+        // artifact root, and (the actual defect) not outside it either.
+        Assert.False(Directory.Exists(Path.Combine(workspace.RootPath, ".intent-cli", "knowledge-writebacks")));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(Path.Combine(workspace.RootPath, ".intent-cli")));
+    }
+
+    [Fact]
+    public void RecordPathResolution_ContainsEveryPathBeneathItsArtifactRoot_G564()
+    {
+        var repoRoot = Path.Combine(Path.GetTempPath(), "g564-containment");
+
+        // Canonical unit: contained, as expected.
+        var recordRoot = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "knowledge-writebacks"));
+        var packetRoot = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "issues"));
+        Assert.StartsWith(recordRoot + Path.DirectorySeparatorChar, KnowledgeWriteBackRecord.ResolveFullPath(repoRoot, "G564"), StringComparison.Ordinal);
+        Assert.StartsWith(packetRoot + Path.DirectorySeparatorChar, KnowledgeWriteBackRecord.ResolvePacketPath(repoRoot, "G564"), StringComparison.Ordinal);
+
+        // Non-canonical unit: refused at resolution, so no caller can be handed
+        // an escaping path even if it skipped the argument-boundary gate.
+        Assert.Throws<InvalidOperationException>(() => KnowledgeWriteBackRecord.ResolveFullPath(repoRoot, "../escape"));
+        Assert.Throws<InvalidOperationException>(() => KnowledgeWriteBackRecord.ResolvePacketPath(repoRoot, "../escape"));
+        Assert.Throws<InvalidOperationException>(() => KnowledgeWriteBackRecord.ResolveRelativePath("../escape"));
+    }
+
+    [Fact]
+    public void StalledWork_ExcludesANoncanonicalUnitFromTheRunsLog_WithoutDerivingAPathFromIt_G564()
+    {
+        // The runs log is DATA. A `closeout-recorded` event naming
+        // `../../etc` must not become a filesystem probe.
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteCloseout("../../etc", FixedNow.AddMinutes(-120));
+
+        var result = workspace.RunStalledWorkResult();
+
+        Assert.Equal(0, result.GetProperty("items").GetArrayLength());
+        var excluded = Assert.Single(result.GetProperty("excluded").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindKnowledgeWritebackPending, excluded.GetProperty("kind").GetString());
+        Assert.Equal(AutomationStalledWorkCommand.ReasonKnowledgeMetadataUnreadable, excluded.GetProperty("reason").GetString());
+        Assert.Contains("non-canonical execution unit", excluded.GetProperty("detail").GetString()!, StringComparison.Ordinal);
+    }
+
+    // ------------------------------------------- G564 review repair: evidence
+
+    /// <summary>
+    /// Review finding 2: `Deserialize` checked only that `execution_unit` and
+    /// `host_commit` were non-blank, while stalled-work cleared the item for
+    /// ANY deserializable record. A record stored under `G564` naming `G999`
+    /// therefore discharged G564's obligation.
+    /// </summary>
+    [Fact]
+    public void ARecordNamingADifferentUnit_DoesNotClearThisUnit_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/x.md"]);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-120));
+        workspace.WriteRawRecord("G564", executionUnit: "G999", hostCommit: HostCommit);
+
+        var result = workspace.RunStalledWorkResult();
+
+        Assert.Equal(0, result.GetProperty("items").GetArrayLength());
+        var excluded = Assert.Single(result.GetProperty("excluded").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.ReasonKnowledgeMetadataUnreadable, excluded.GetProperty("reason").GetString());
+        Assert.Contains("record.json", excluded.GetProperty("detail").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("G999", excluded.GetProperty("detail").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ARecordWithNonShaEvidence_DoesNotClearTheItem_G564()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/x.md"]);
+        workspace.WriteCloseout("G564", FixedNow.AddMinutes(-120));
+        workspace.WriteRawRecord("G564", executionUnit: "G564", hostCommit: "written-it-honest");
+
+        var result = workspace.RunStalledWorkResult();
+
+        Assert.Equal(0, result.GetProperty("items").GetArrayLength());
+        var excluded = Assert.Single(result.GetProperty("excluded").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.ReasonKnowledgeMetadataUnreadable, excluded.GetProperty("reason").GetString());
+        Assert.Contains("hexadecimal SHA", excluded.GetProperty("detail").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Record_RefusesToActOnAMisattributedExistingRecord_RatherThanTreatingItAsPriorEvidence_G564()
+    {
+        // The same validation on the WRITE side: a mis-attributed record must
+        // not silently satisfy the idempotency check, and must not be
+        // overwritten either — it is unreadable evidence, and repairing it is
+        // a deliberate act.
+        using var workspace = new WriteBackWorkspace();
+        workspace.WriteDeclaringPacket("G564", requiredIntentTree: true, targets: ["intents/x.md"]);
+        workspace.WriteRawRecord("G564", executionUnit: "G999", hostCommit: HostCommit);
+        var before = File.ReadAllBytes(workspace.RecordPath("G564"));
+
+        var result = workspace.RunRecord(["--execution-unit", "G564", "--commit", HostCommit, "--write", "--format", "json"]);
+
+        Assert.Equal(1, result.ExitCode);
+        var error = result.Json.GetProperty("error").GetString()!;
+        Assert.Contains("could not be read", error, StringComparison.Ordinal);
+        Assert.Contains("G999", error, StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllBytes(workspace.RecordPath("G564")));
     }
 
     // ---------------------------------------------------------------- router
@@ -647,6 +782,28 @@ public sealed class KnowledgeWriteBackG564Tests : IDisposable
                   expected: ""
                   write_back_required: false
                   write_back_targets: []
+                """);
+        }
+
+        /// <summary>
+        /// G564 review repair: writes a record artifact with hand-chosen
+        /// contents under <paramref name="storedUnder"/>, so a consumer can be
+        /// shown a record whose embedded identity or evidence does not match
+        /// the unit it is stored for.
+        /// </summary>
+        public void WriteRawRecord(string storedUnder, string executionUnit, string hostCommit)
+        {
+            var path = RecordPath(storedUnder);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, $$"""
+                {
+                  "artifact_kind": "knowledge-writeback-record",
+                  "execution_unit": "{{executionUnit}}",
+                  "host_commit": "{{hostCommit}}",
+                  "recorded_at": "2026-08-15T12:00:00+00:00",
+                  "targets": [],
+                  "note": null
+                }
                 """);
         }
 


### PR DESCRIPTION
Closes #1231

## What this does

Makes "the intent tree moves with development" enforceable instead of aspirational, in three connected halves.

### 1. Recording (`automation knowledge-writeback-record`)

```bash
intent-cli automation knowledge-writeback-record \
  --execution-unit G564 --commit <host-commit-sha> \
  --target intents/<domain>/intent-tree/means/03-state-and-audit-strategy.md --write
```

Writes `.intent-cli/knowledge-writebacks/<unit>/record.json` (`artifact_kind`, `execution_unit`, `host_commit`, `recorded_at`, `targets`, `note`).

- **Idempotent** for the same commit (case-insensitive): `already_recorded: true`, `applied: false`, artifact left **byte-identical** — a retried closeout wake cannot move `recorded_at` off the real event.
- **Refuses a DIFFERENT commit** rather than overwriting it. Replacing evidence silently is how an audit trail stops being one.
- **Fails closed** on an unknown execution unit (no `packet.yaml`), on evidence that is not a 7–40 char hex SHA, and on an existing record that cannot be read.
- `--dry-run` is the default.
- Records only — it never writes intent content and never mutates the tree (G300).

### 2. Detection (`knowledge-writeback-pending`)

New actionable kind in `automation stalled-work`, carried by `automation heartbeat` (it wraps the same analyzer, so carriage is structural — pinned by a test).

- Closed-out unit = a `closeout-recorded` event in `runs.jsonl`; age is measured from the **earliest** such event, so a retried closeout cannot reset it.
- Fires when the packet declared any `knowledge_updates.*.required: true` or `closeout_learning.write_back_required: true` and no record exists.
- Item carries `declared_write_back_targets`; `recommended_action` names the facets, the targets, and the recording command.
- `required=false` units never appear — declining is a legitimate answer.
- **Never silently dropped**: an unreadable packet declaration, an unreadable `runs.jsonl`, and an unreadable record each go to `excluded[]` **with their path** (`knowledge-metadata-unreadable`), never read as "nothing pending".
- **No retroactive detection** (explicitly out of scope in the packet): closeouts before `2026-08-01T00:00:00Z` are ignored by default, so an upgrade does not light up every historical unit. `--knowledge-writeback-since <iso-8601>` opts in deliberately.

### 3. Duty binding

`IntentTreeCoEvolutionDuty` single-sources the operator's 2026-07-31 ruling into:

- the **design-thread** playbook (`guide orchestrator-thread`) — the duty and the same-cadence check;
- **packet authoring** (`guide workflow task packet-draft`) — a new `co-evolution-duty` prompt requiring honest declarations for surface-adding / behavior-changing slices;
- **closeout** (`guide closeout run`, Stage 5b) — perform *and record* in the same wake; merging and closing the PR do **not** clear the item;
- the **closeout report** (`closeout_knowledge_write_back_rule` in the orchestrator reply contract) — enumerates declared write-backs and whether each is recorded or pending. Read-only propagation of packet metadata; no host mutation.

Docs: `docs/{en,ja}/release-notes-v0.7.0.md` add G564 (now five slices, PR row in the readiness gate, upgrade note, post-release smoke) and `docs/{en,ja}/09-developer-reference.md` document the kind and the command.

## Design decisions worth reviewing

- **Recording surface placement.** Put under `automation` (sibling of the detector) rather than a new top-level group, so no new `guide commands list` row is needed and the recommended action names a command in the family that reports it.
- **Where the record lives.** A dedicated artifact (mirroring the G552 clarification pattern the detector already reads) rather than a `runs.jsonl` event — `RunEvent` has no commit field, and adding one would change a shared schema this packet says not to touch.
- **Activation floor as a constant.** The packet puts retroactive detection out of scope; a hardcoded floor with an explicit opt-in flag is the most literal implementation of that. If you would rather derive it (e.g. from the first record ever written), say so and I will change it.

## Verification

- `dotnet build IntentSystem.sln` — clean, 0 errors.
- `dotnet test IntentSystem.sln` — **4014 passed, 0 failed, 1 skipped** (plus every other test project green).
- Re-run of the **full** suite with a `gh` shim exiting 1 and `GH_TOKEN`/`GITHUB_TOKEN=invalid` — same result, so green here does not depend on ambient credentials.
- `git diff --check` — clean.

**Regression-proof.** Each new guard was verified to FAIL against a deliberately broken implementation, then reverted byte-for-byte:

| Mutation | Fixture that caught it |
| --- | --- |
| drop the activation floor | `UnitsClosedBeforeActivation_AreOutOfScope_UnlessTheOperatorAsksForThem_G564` |
| read malformed `required:` as `false` | `UnreadableDeclarationMetadata_IsExcludedWithItsPath_NotSilentlyCleared_G564` |
| re-write the artifact on a repeat record | `Record_IsIdempotentForTheSameCommit_G564` |

Fixture walk-through (declare → close out → observe pending → record → observe clearance) is driven through the real surfaces in `RecordingTheWriteBack_ClearsThePendingItem_G564`.

## Scope notes

- One pre-existing test was updated, not weakened: `Execute_EmitsPacketTimeIntentMaintenancePrompts` pins the packet-authoring prompt ids, and G564 legitimately adds a sixth. The G461 five keep their ids and order.
- No packet-schema changes, no auto-written intent content, no retroactive detection, **no release/tag/publish/roll actions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
