### PR TITLE
G566: Fix the G560 roll-simulation helper — the readiness heading is now unreachable from every substitution

### DIFF
--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
@@ -238,26 +238,77 @@ public sealed class ReleaseNotesV061DocsTests
         // temporary bumped eng/version.json, and checked with the SAME helper
         // the current-state theory uses. A guard that regains a literal fails
         // here even while it still passes against today's docs.
+        AssertRollSimulationHolds(ReadDeveloperReference(language), language, RepoVersionPolicySource.Read());
+    }
+
+    /// <summary>
+    /// G566: the same simulation, run from the POST-ROLL reality — the live
+    /// policy one roll ahead (0.6.2/0.7.0 → 0.7.0/0.7.1 as this lands) with the
+    /// readiness sections refreshed to match.
+    ///
+    /// This is the shape the roller's pre-push verification hit: with
+    /// <c>from.StableVersion</c> equal to the hardcoded <c>(0.6.9, 0.7.0)</c>
+    /// fixture's <c>nextVersion</c>, the helper's final plain-stable
+    /// substitution rewrote the freshly-updated readiness heading back down —
+    /// "Expected 0.7.0 / Actual 0.6.9" at the exactly-one-heading assertion.
+    /// The repository's own <c>eng/version.json</c> is NOT mutated: the
+    /// post-roll policy is derived from the live one and read through the real
+    /// reader, so this keeps proving itself after the roll actually lands.
+    /// </summary>
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void RollSimulation_HoldsFromThePostRollReality_G566(string language)
+    {
         var reference = ReadDeveloperReference(language);
         var policy = RepoVersionPolicySource.Read();
 
-        foreach (var (stable, next) in new[]
-                 {
-                     (policy.NextVersion, NextPatch(policy.NextVersion)),
-                     ("0.6.9", "0.7.0"),
-                     ("0.9.9", "1.0.0"),
-                 })
+        using var postRollRepo = new TemporaryVersionPolicyRoot(policy.NextVersion, NextPatch(policy.NextVersion));
+        var postRollPolicy = RepoVersionPolicySource.ReadFrom(postRollRepo.RootPath);
+        var postRollReference = RefreshReadinessForRoll(reference, language, policy, postRollPolicy);
+
+        // The docs as they will read once the roll lands still satisfy the
+        // current-state invariant...
+        AssertCurrentStateInvariant(postRollReference, language, postRollPolicy);
+
+        // ...and the simulation still holds when run FROM there, which is the
+        // theory that failed before this fix.
+        AssertRollSimulationHolds(postRollReference, language, postRollPolicy);
+    }
+
+    private static void AssertRollSimulationHolds(
+        string reference, string language, IntentSystem.Cli.Infrastructure.VersionPolicy from)
+    {
+        foreach (var (stable, next) in RollFixturePairs(from))
         {
             using var rolledRepo = new TemporaryVersionPolicyRoot(stable, next);
             var rolledPolicy = RepoVersionPolicySource.ReadFrom(rolledRepo.RootPath);
             Assert.Equal(stable, rolledPolicy.StableVersion);
             Assert.Equal(next, rolledPolicy.NextVersion);
 
-            var refreshed = RefreshReadinessForRoll(reference, language, policy, rolledPolicy);
+            var refreshed = RefreshReadinessForRoll(reference, language, from, rolledPolicy);
 
             AssertCurrentStateInvariant(refreshed, language, rolledPolicy);
         }
     }
+
+    /// <summary>
+    /// G560's pairs, plus the G566 collision pair. The collision is the one the
+    /// live policy walks into on a roll: a target whose <c>nextVersion</c>
+    /// EQUALS the live <c>stableVersion</c>, so a substitution keyed on
+    /// <c>v{from.StableVersion}</c> and one keyed on <c>v{to.NextVersion}</c>
+    /// address the same text. It is derived from <paramref name="from"/> rather
+    /// than hardcoded, so it keeps reproducing the collision after every future
+    /// roll instead of aging into an unrelated pair.
+    /// </summary>
+    private static IReadOnlyList<(string Stable, string Next)> RollFixturePairs(
+        IntentSystem.Cli.Infrastructure.VersionPolicy from) =>
+    [
+        (from.NextVersion, NextPatch(from.NextVersion)),
+        ("0.6.9", "0.7.0"),
+        ("0.9.9", "1.0.0"),
+        (PreviousVersion(from.StableVersion), from.StableVersion),
+    ];
 
     /// <summary>
     /// G560: the single current-state invariant. Everything it asserts is
@@ -302,6 +353,20 @@ public sealed class ReleaseNotesV061DocsTests
     /// 4-5 — the readiness heading and every current-state mention of the cycle
     /// move to the new line. Deliberately blunt: anything this does not touch
     /// is not current state, and must not be asserting a version.
+    ///
+    /// G566: the heading is now written LAST, into a slot no substitution can
+    /// reach. Previously it was rewritten first and the plain
+    /// <c>v{from.StableVersion}</c> substitution ran last, so whenever the live
+    /// <c>stableVersion</c> equalled a fixture's <c>nextVersion</c> that final
+    /// pass rewrote the fresh heading back down (the live 0.7.0/0.7.1 roll
+    /// against the hardcoded <c>(0.6.9, 0.7.0)</c> pair: "Expected 0.7.0 /
+    /// Actual 0.6.9"). Reordering alone would fix that one collision; removing
+    /// the heading from the string entirely fixes the CLASS, because a
+    /// substitution added later cannot reach text that is not there.
+    ///
+    /// The plain-stable substitution also moves ahead of the ones that
+    /// INTRODUCE <c>v{to.NextVersion}</c> text, so it can never re-rewrite a
+    /// value this same call just produced.
     /// </summary>
     private static string RefreshReadinessForRoll(
         string reference,
@@ -309,6 +374,10 @@ public sealed class ReleaseNotesV061DocsTests
         IntentSystem.Cli.Infrastructure.VersionPolicy from,
         IntentSystem.Cli.Infrastructure.VersionPolicy to)
     {
+        // Contains no digit, no '.', no 'v' — so it matches none of the
+        // substitutions below, whatever versions they are keyed on.
+        const string HeadingSlot = "￿_G566_READINESS_HEADING_SLOT_￿";
+
         var oldHeading = language == "en"
             ? $"### Next release readiness (v{from.NextVersion})"
             : $"### 次リリース準備(v{from.NextVersion})";
@@ -316,19 +385,48 @@ public sealed class ReleaseNotesV061DocsTests
             ? $"### Next release readiness (v{to.NextVersion})"
             : $"### 次リリース準備(v{to.NextVersion})";
 
+        Assert.Contains(oldHeading, reference, StringComparison.Ordinal);
+
         return reference
-            .Replace(oldHeading, newHeading, StringComparison.Ordinal)
+            .Replace(oldHeading, HeadingSlot, StringComparison.Ordinal)
+            // First: the shipped line moves up. Doing this BEFORE the pair
+            // substitutions means it cannot clobber a `v{to.NextVersion}`
+            // string that one of them is about to write.
+            .Replace($"v{from.StableVersion}", $"v{to.StableVersion}", StringComparison.Ordinal)
             .Replace($"stableVersion {from.StableVersion}", $"stableVersion {to.StableVersion}", StringComparison.Ordinal)
             .Replace($"nextVersion {from.NextVersion}", $"nextVersion {to.NextVersion}", StringComparison.Ordinal)
             .Replace($"JTechJapan.IntentSystem.Cli.{from.NextVersion}.nupkg", $"JTechJapan.IntentSystem.Cli.{to.NextVersion}.nupkg", StringComparison.Ordinal)
             .Replace($"release-notes-v{from.NextVersion}.md", $"release-notes-v{to.NextVersion}.md", StringComparison.Ordinal)
-            .Replace($"v{from.StableVersion}", $"v{to.StableVersion}", StringComparison.Ordinal);
+            // Last, and by construction unreachable from every line above.
+            .Replace(HeadingSlot, newHeading, StringComparison.Ordinal);
     }
 
     private static string NextPatch(string version)
     {
         var parts = version.Split('.');
         return $"{parts[0]}.{parts[1]}.{int.Parse(parts[2]) + 1}";
+    }
+
+    /// <summary>
+    /// G566: the strictly-lower version used to build the collision pair. Only
+    /// ever called on a real published <c>stableVersion</c>, which is never
+    /// 0.0.0, so the walk down always terminates on a valid version.
+    /// </summary>
+    private static string PreviousVersion(string version)
+    {
+        var parts = version.Split('.').Select(int.Parse).ToArray();
+        Assert.True(
+            parts[0] > 0 || parts[1] > 0 || parts[2] > 0,
+            $"cannot derive a lower version than '{version}'.");
+
+        if (parts[2] > 0)
+        {
+            return $"{parts[0]}.{parts[1]}.{parts[2] - 1}";
+        }
+
+        return parts[1] > 0
+            ? $"{parts[0]}.{parts[1] - 1}.9"
+            : $"{parts[0] - 1}.9.9";
     }
 
     /// <summary>G560: a temporary repo root holding only a bumped eng/version.json, read through the real policy reader.</summary>


### PR DESCRIPTION
Closes #1233

Test-only. Single file changed: `tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs` (+107 / −9).

## Root cause

`RefreshReadinessForRoll` rewrote the readiness heading **first** and applied the plain `v{from.StableVersion}` substitution **last**:

```csharp
.Replace(oldHeading, newHeading, …)          // heading becomes (v0.7.0) for the (0.6.9, 0.7.0) fixture
…
.Replace($"v{from.StableVersion}", …)         // live stable 0.7.0 → rewrites that fresh heading to (v0.6.9)
```

So whenever the live `stableVersion` equals a fixture's `nextVersion`, the last pass clobbers the heading the first pass just wrote — "Expected 0.7.0 / Actual 0.6.9" at the exactly-one-heading assertion. Latent since G560; the 0.7.0/0.7.1 roll is the first policy to collide with the hardcoded `(0.6.9, 0.7.0)` pair.

## Fix

1. **The heading is removed from the string while substitutions run.** It is swapped for a slot containing no digit, no `.` and no `v` — so it matches none of the substitutions, whatever versions they are keyed on — and written back last.

   Reordering alone would fix *this* collision. Removing the heading fixes the **class**: a substitution added to this helper later cannot reach text that is not there. That is the difference between fixing the incident and fixing the defect, and this is the third incident in the roll-breaks-tests lineage (G557 → G560 → G566).

2. **The plain-stable substitution moves ahead of the ones that introduce `v{to.NextVersion}` text**, so it can never re-rewrite a value the same call just produced (e.g. turning a freshly written `release-notes-v0.6.2.md` back into `…v0.6.1.md` on the collision pair).

3. **Collision pair added to the fixture matrix**: `(PreviousVersion(from.StableVersion), from.StableVersion)` — i.e. `to.NextVersion == from.StableVersion`. Derived from the live policy rather than hardcoded, so it keeps reproducing the collision after every future roll instead of aging into an unrelated pair. The existing three pairs are kept and the G560 invariant assertions are untouched.

4. **New theory `RollSimulation_HoldsFromThePostRollReality_G566`** runs the entire simulation *from* the post-roll line — the live policy one roll ahead (0.6.2/0.7.0 → 0.7.0/0.7.1 as this lands), with the readiness sections refreshed to match — and asserts the current-state invariant there as well. The post-roll policy is **derived** from the live one and read through the real policy reader, and the repository's `eng/version.json` is **not** mutated, so this keeps proving itself after the roll actually lands.

## Verification

- `dotnet test IntentSystem.sln` — **4032 passed, 0 failed, 1 skipped** (all other test projects green).
- Full suite re-run with a `gh` shim exiting 1 and `GH_TOKEN`/`GITHUB_TOKEN=invalid` — same result, so green does not depend on ambient credentials.
- `git diff --check` clean; diff limited to `tests/`.

**Regression-proof.** With the pre-fix ordering temporarily restored, the suite fails exactly as the roller reported — and more:

| Theory | Pre-fix |
| --- | --- |
| `RollSimulation_HoldsFromThePostRollReality_G566` (en, ja) | FAIL |
| `RollSimulation_BumpedPolicyPlusRefreshedReadiness_SatisfiesTheSameInvariant_G560` (en, ja) | FAIL |

The existing G560 theory failing too is the point of item 3: the collision pair reproduces the defect **under today's live policy**, not only after the roll — so the regression is pinned locally rather than only in a future state. The mutation was then reverted byte-for-byte and the suite re-run green.

## Scope

No product code, docs, guide, or notes change. The roll commit itself is the roller's post-merge step; G565 and the rest of the backlog are untouched. No release/tag/publish/roll action taken here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
