### PR TITLE
G565: Unify packet YAML parsing — projection parses YAML with a YAML parser

### DIFF
--- a/src/IntentSystem.Projection/IntentSystem.Projection.csproj
+++ b/src/IntentSystem.Projection/IntentSystem.Projection.csproj
@@ -6,4 +6,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- G565: packet.yaml is parsed by the same YAML implementation the packet
+         schema surfaces use, so projection cannot accept a different language
+         than the surfaces that author and validate the file. -->
+    <PackageReference Include="YamlDotNet" Version="18.1.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/IntentSystem.Projection/Serialization/ProjectionPacketSerializer.cs
+++ b/src/IntentSystem.Projection/Serialization/ProjectionPacketSerializer.cs
@@ -1,4 +1,5 @@
 using IntentSystem.Projection.Models;
+using YamlDotNet.RepresentationModel;
 
 namespace IntentSystem.Projection.Serialization;
 
@@ -101,107 +102,119 @@ public static class ProjectionPacketSerializer
         };
     }
 
+    /// <summary>
+    /// G565: reads the packet through YamlDotNet — the SAME YAML
+    /// implementation the packet schema surfaces (<c>packet draft</c>,
+    /// <c>queue-seed-from-packet</c>, <c>clarify open</c>, the facet checks) use
+    /// to read the same file.
+    ///
+    /// This replaces a hand-rolled line reader whose acceptance was an
+    /// approximation of YAML, so every legal construct it failed to anticipate
+    /// became a projection-only failure. The field report is the shape of the
+    /// whole class: a packet whose title contained an em-dash and a quoted
+    /// <c>": "</c> was authored and validated happily by the packet surfaces,
+    /// then rejected by projection with "contains invalid section header"
+    /// (<c>clarify open SKS-G837</c>, 2026-07-31, v0.6.2). G534 had already
+    /// patched one such gap (block-sequence indentation) and G561 another
+    /// (required-section rejection); parsing YAML with a YAML parser removes
+    /// the source rather than the next symptom.
+    ///
+    /// The projection CONTRACT is unchanged — the section/field requirements,
+    /// their validation order, and their messages all still come from the code
+    /// below this method. Only the question "what is valid YAML" moves, and it
+    /// moves to the same answer the rest of the toolchain already gives.
+    /// </summary>
     private static Dictionary<string, Dictionary<string, object>> ParseSections(string yaml)
     {
-        var sections = new Dictionary<string, Dictionary<string, object>>(StringComparer.Ordinal);
-        Dictionary<string, object>? currentSection = null;
-        string? currentListKey = null;
-
-        using var reader = new StringReader(yaml);
-        string? line;
-        while ((line = reader.ReadLine()) is not null)
+        YamlMappingNode? root;
+        try
         {
-            if (string.IsNullOrWhiteSpace(line))
+            var stream = new YamlStream();
+            using var reader = new StringReader(yaml);
+            stream.Load(reader);
+            root = stream.Documents.Count == 0 ? null : stream.Documents[0].RootNode as YamlMappingNode;
+        }
+        // YamlDotNet reports most malformed documents as a YamlException, but
+        // some — a flow sequence left unterminated across following lines, for
+        // one — surface as a bare InvalidOperationException from the node
+        // builder. Both are "this file is not YAML", and a caller must not have
+        // to tell a parse failure apart from a contract violation by exception
+        // type, so both are wrapped with the same diagnostic.
+        catch (Exception exception) when (exception is YamlDotNet.Core.YamlException or InvalidOperationException)
+        {
+            throw new InvalidOperationException(
+                $"Projection packet YAML could not be parsed: {exception.Message}");
+        }
+
+        if (root is null)
+        {
+            throw new InvalidOperationException("Projection packet YAML is empty or is not a mapping.");
+        }
+
+        var sections = new Dictionary<string, Dictionary<string, object>>(StringComparer.Ordinal);
+        foreach (var (keyNode, valueNode) in root.Children)
+        {
+            if (keyNode is not YamlScalarNode { Value: { } sectionName })
             {
                 continue;
             }
 
-            if (!char.IsWhiteSpace(line[0]))
+            // A top-level entry that is not a mapping is not a section. It is
+            // not an error either — the packet carries optional non-section
+            // metadata, and only the sections this contract REQUIRES are
+            // enforced, by GetRequiredSection below.
+            if (valueNode is YamlMappingNode sectionNode)
             {
-                if (!line.EndsWith(':'))
-                {
-                    throw new InvalidOperationException(
-                        $"Projection packet YAML contains invalid section header '{line}'.");
-                }
-
-                var sectionName = line[..^1];
-                currentSection = new Dictionary<string, object>(StringComparer.Ordinal);
-                sections[sectionName] = currentSection;
-                currentListKey = null;
-                continue;
+                sections[sectionName] = ReadSection(sectionNode);
             }
-
-            if (currentSection is null)
-            {
-                throw new InvalidOperationException(
-                    "Projection packet YAML must declare a section before its fields.");
-            }
-
-            // G534 review repair: a YAML block-sequence item may be
-            // indented at the SAME column as its parent key (the common
-            // convention, e.g. "  intent_references:\n  - foo") or nested
-            // one level deeper (this project's own renderer convention,
-            // "    - foo") — both are valid YAML. Detect a list item by
-            // its CONTENT ("- " once leading spaces are stripped), not by
-            // a fixed column count, so either convention — and any mix of
-            // the two across different fields in the same file — parses
-            // identically. Previously only the 4-space form was accepted;
-            // a 2-space list item fell through to the generic field-line
-            // branch below and failed with "field line is missing ':'"
-            // (no colon in "- foo"), rejecting every hand-authored packet
-            // using the more common convention.
-            var listItemCandidate = line.TrimStart(' ');
-            if (listItemCandidate.StartsWith("- ", StringComparison.Ordinal) || listItemCandidate == "-")
-            {
-                if (currentListKey is null
-                    || !currentSection.TryGetValue(currentListKey, out var listValue)
-                    || listValue is not List<string> list)
-                {
-                    throw new InvalidOperationException(
-                        $"Projection packet YAML contains list item without a list field: '{line.Trim()}'.");
-                }
-
-                var itemText = listItemCandidate.Length > 1 ? listItemCandidate[2..] : string.Empty;
-                list.Add(ParseScalar(itemText));
-                continue;
-            }
-
-            if (!line.StartsWith("  ", StringComparison.Ordinal))
-            {
-                throw new InvalidOperationException(
-                    $"Projection packet YAML contains invalid indentation: '{line}'.");
-            }
-
-            var trimmed = line[2..];
-            var separatorIndex = trimmed.IndexOf(':');
-            if (separatorIndex < 0)
-            {
-                throw new InvalidOperationException(
-                    $"Projection packet YAML field line is missing ':': '{trimmed}'.");
-            }
-
-            var key = trimmed[..separatorIndex];
-            var value = trimmed[(separatorIndex + 1)..].TrimStart();
-
-            if (value.Length == 0)
-            {
-                currentSection[key] = new List<string>();
-                currentListKey = key;
-                continue;
-            }
-
-            currentListKey = null;
-
-            if (value == "[]")
-            {
-                currentSection[key] = Array.Empty<string>();
-                continue;
-            }
-
-            currentSection[key] = ParseScalar(value);
         }
 
         return sections;
+    }
+
+    /// <summary>
+    /// G565: maps one section's entries onto the value shapes the rest of this
+    /// contract already expects — a scalar becomes <see cref="string"/>, a
+    /// sequence becomes <c>List&lt;string&gt;</c>, and everything else (an
+    /// empty value, a nested mapping) becomes an empty list.
+    ///
+    /// That last case preserves the previous reader's behaviour exactly: it
+    /// turned a valueless <c>key:</c> into an empty list, so a REQUIRED SCALAR
+    /// left empty failed with "must be a scalar string" rather than passing as
+    /// an empty string. Keeping the mapping means the same packet produces the
+    /// same diagnostic it did before.
+    /// </summary>
+    private static Dictionary<string, object> ReadSection(YamlMappingNode section)
+    {
+        var values = new Dictionary<string, object>(StringComparer.Ordinal);
+
+        foreach (var (keyNode, valueNode) in section.Children)
+        {
+            if (keyNode is not YamlScalarNode { Value: { } key })
+            {
+                continue;
+            }
+
+            values[key] = valueNode switch
+            {
+                // A valueless `key:` is an empty PLAIN scalar. The previous
+                // reader turned it into an empty list, so a required scalar
+                // left blank failed with "must be a scalar string" — keep that,
+                // or a packet with a blank title would start passing. An
+                // explicitly quoted `key: ""` is a real empty string and stays
+                // a scalar, exactly as before.
+                YamlScalarNode { Style: YamlDotNet.Core.ScalarStyle.Plain } plain
+                    when string.IsNullOrEmpty(plain.Value) => new List<string>(),
+                YamlScalarNode scalar => scalar.Value!,
+                YamlSequenceNode sequence => sequence.Children
+                    .OfType<YamlScalarNode>()
+                    .Select(item => item.Value ?? string.Empty)
+                    .ToList(),
+                _ => new List<string>(),
+            };
+        }
+
+        return values;
     }
 
     private static Dictionary<string, object> GetRequiredSection(
@@ -259,51 +272,6 @@ public static class ProjectionPacketSerializer
             _ => throw new InvalidOperationException(
                 $"Projection packet YAML field '{key}' must be a list.")
         };
-    }
-
-    private static string ParseScalar(string value)
-    {
-        if (value.Length >= 2
-            && value[0] == '"'
-            && value[^1] == '"')
-        {
-            return Unescape(value[1..^1]);
-        }
-
-        return value;
-    }
-
-    private static string Unescape(string value)
-    {
-        var chars = new List<char>(value.Length);
-
-        for (var index = 0; index < value.Length; index++)
-        {
-            var current = value[index];
-            if (current != '\\')
-            {
-                chars.Add(current);
-                continue;
-            }
-
-            if (index == value.Length - 1)
-            {
-                throw new InvalidOperationException("Projection packet YAML contains an invalid escape sequence.");
-            }
-
-            index++;
-            chars.Add(value[index] switch
-            {
-                '\\' => '\\',
-                '"' => '"',
-                'n' => '\n',
-                'r' => '\r',
-                _ => throw new InvalidOperationException(
-                    "Projection packet YAML contains an unsupported escape sequence.")
-            });
-        }
-
-        return new string(chars.ToArray());
     }
 
     private static IssueKind ParseIssueKind(string issueKind)

--- a/tests/IntentSystem.Cli.Tests/ClarifyOpenScaffoldedPacketTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClarifyOpenScaffoldedPacketTests.cs
@@ -239,13 +239,18 @@ public sealed class ClarifyOpenScaffoldedPacketTests : IDisposable
               clarification_return_path: "intents/intent-cli/clarifications/open.md"
             """);
 
-        // It fails inside the strict serializer, which is the whole point. The
-        // exact stop is the scaffold's own top-level comment lines — the strict
-        // parser treats any column-0 line as a section header — which is a
-        // second, independent reason the scaffold could never have travelled
-        // this route. Either way: refused, before any mutation.
+        // It fails inside the strict serializer, which is the whole point.
+        //
+        // G565 changed WHERE it stops, and the new stop is the one this test
+        // always meant. The scaffold used to trip the hand-rolled reader on its
+        // own top-level comment lines ("invalid section header") — an accident
+        // of the parser, not a statement about the packet. Now that projection
+        // parses YAML with a YAML parser, comments are comments, and the
+        // scaffold is refused for the real reason: declaring the section is a
+        // claim of completeness, and the packet does not carry the required
+        // implementation fields. Either way: refused, before any mutation.
         workspace.AssertRefusedBeforeMutation(
-            [ScaffoldWorkspace.Unit], "Projection packet YAML contains invalid section header");
+            [ScaffoldWorkspace.Unit], "Implementation issue packet must contain required field");
     }
 }
 

--- a/tests/IntentSystem.Cli.Tests/PacketYamlParityG565Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketYamlParityG565Tests.cs
@@ -1,0 +1,297 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Projection.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G565 parity matrix: <em>valid to the packet surfaces ⇔ valid to
+/// projection</em>.
+///
+/// The field defect was a DISAGREEMENT, not a bug in either half: the packet
+/// surfaces (<c>packet draft</c>, <c>queue-seed-from-packet</c>,
+/// <c>clarify open</c>) read real YAML, projection read an approximation of it,
+/// and a packet that lived happily on the authoring side was rejected on the
+/// projection side. Fixing the parser is only half the answer — without a test
+/// that exercises BOTH sides on the SAME bytes, the two can drift apart again
+/// the next time either changes.
+///
+/// So every fixture below is written to disk once and then run through the
+/// packet surface AND through projection, and the two must agree.
+/// </summary>
+public sealed class PacketYamlParityG565Tests : IDisposable
+{
+    private readonly ParityWorkspace workspace = new();
+
+    public void Dispose() => workspace.Dispose();
+
+    /// <summary>
+    /// YAML constructs the packet surfaces accept. Each was a projection-only
+    /// failure before this slice, or would have become one.
+    ///
+    /// The set is deliberately what the surfaces ACTUALLY accept, not what they
+    /// ought to: writing these fixtures turned up two cases that do not belong
+    /// here and are documented on the rejection side instead — a plain
+    /// (unquoted) scalar containing <c>": "</c>, which is not legal YAML at
+    /// all, and a title with escaped quotes, which the queue-seed lane's own
+    /// legacy scalar reader refuses (<c>unsafe-prepared-packet</c>) even though
+    /// projection now reads it fine.
+    /// </summary>
+    public static TheoryData<string, string> AcceptedByBothSurfaces() => new()
+    {
+        { "em-dash and a quoted colon-space title", "\"G565: parsing — one pathway, two readers: no more\"" },
+        { "single-quoted title", "'G565 — single quoted'" },
+        { "japanese title with a colon", "\"G565: 日本語 — コロン付き\"" },
+    };
+
+    [Theory]
+    [MemberData(nameof(AcceptedByBothSurfaces))]
+    public void APacketTheSurfacesAccept_IsAcceptedByProjection_G565(string description, string issueTitleYaml)
+    {
+        var yaml = ParityWorkspace.BuildPacket(issueTitleYaml);
+        workspace.WritePacket(yaml);
+
+        var seedClassification = workspace.RunQueueSeedDryRun();
+        var projection = Record.Exception(() => ProjectionPacketSerializer.Deserialize(yaml));
+
+        Assert.Equal(AutomationQueueSeedFromPacketCommand.ClassificationReady, seedClassification);
+        Assert.True(
+            projection is null,
+            $"the packet surfaces accept this packet ({description}) but projection rejected it: {projection?.Message}");
+    }
+
+    [Theory]
+    [MemberData(nameof(AcceptedByBothSurfaces))]
+    public void APacketTheSurfacesAccept_IsAlsoUsableByClarifyOpen_G565(string description, string issueTitleYaml)
+    {
+        // `clarify open` is the surface the field report came through: it reads
+        // the packet through projection, so a projection-only rejection made
+        // recording a blocking design question impossible for a packet the rest
+        // of the toolchain considered fine.
+        _ = description;
+        var yaml = ParityWorkspace.BuildPacket(issueTitleYaml);
+        workspace.WritePacket(yaml);
+        workspace.WriteReviewContextMarkdown();
+        workspace.WriteQueueState();
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyOpenCommand.Execute(
+            workspace.Context, [ParityWorkspace.Unit, "--question", "Which pathway parses this?"], writer);
+
+        Assert.True(exitCode == 0, $"clarify open refused a packet the surfaces accept: {writer}");
+    }
+
+    /// <summary>
+    /// The other direction. Parity is two-way — a parser that accepts
+    /// everything agrees with nothing — so malformed YAML must still be refused,
+    /// and refused as a PARSE failure rather than as a guess about section
+    /// headers.
+    ///
+    /// Note what is NOT asserted here: <c>queue-seed-from-packet</c> still
+    /// classifies both of these <c>queue-seed-ready</c>, because its own field
+    /// lookup is a regex scalar reader (G361) that never parses the document. So
+    /// the surfaces are not yet parsing-equivalent in this direction. That is a
+    /// pre-existing leniency in a different lane, outside this unit's scope
+    /// (which is projection conforming to the schema surfaces, not the reverse)
+    /// — recorded here rather than papered over, and worth its own packet.
+    /// </summary>
+    [Theory]
+    [InlineData("unterminated flow sequence", "  dependencies: [G1, G2")]
+    [InlineData("plain scalar containing a colon-space", "  dependencies: G565 — plain, unquoted: no")]
+    public void MalformedYaml_IsRejectedByProjectionAndByClarifyOpen_G565(string description, string replacement)
+    {
+        var yaml = ParityWorkspace.BuildPacket("\"G565\"").Replace(
+            "  dependencies: []", replacement, StringComparison.Ordinal);
+        workspace.WritePacket(yaml);
+        workspace.WriteQueueState();
+
+        var projection = Record.Exception(() => ProjectionPacketSerializer.Deserialize(yaml));
+        Assert.NotNull(projection);
+        Assert.Contains("could not be parsed", projection!.Message, StringComparison.Ordinal);
+
+        using var writer = new StringWriter();
+        var exitCode = ClarifyOpenCommand.Execute(
+            workspace.Context, [ParityWorkspace.Unit, "--question", "Which pathway parses this?"], writer);
+        Assert.True(exitCode != 0, $"clarify open accepted malformed YAML ({description}): {writer}");
+    }
+
+    [Fact]
+    public void AlreadyParseablePackets_ProduceByteIdenticalProjectionOutput_G565()
+    {
+        // Byte-compatibility: the packets that parsed BEFORE this slice must
+        // project to exactly the same artifacts after it. The canonical
+        // renderers are the observable output, so compare their bytes rather
+        // than field-by-field.
+        var yaml = ParityWorkspace.BuildPacket("\"G565 packet\"");
+        var contract = ProjectionPacketSerializer.Deserialize(yaml);
+
+        var implementation = IntentSystem.Projection.Rendering.ImplementationMarkdownRenderer.Render(
+            contract.ImplementationIssuePacket);
+        var reviewContext = IntentSystem.Projection.Rendering.ReviewContextMarkdownRenderer.Render(
+            contract.ReviewContextPacket);
+
+        // Field-level identity is what byte identity rests on: the renderers are
+        // pure functions of the contract, so an unchanged contract is an
+        // unchanged artifact.
+        Assert.Equal("G565 packet", contract.ImplementationIssuePacket.IssueTitle);
+        Assert.Equal(["one"], contract.ImplementationIssuePacket.InScope);
+        Assert.Equal(["two"], contract.ImplementationIssuePacket.OutOfScope);
+        Assert.Contains("G565 packet", implementation, StringComparison.Ordinal);
+        Assert.Contains(ParityWorkspace.Unit, reviewContext, StringComparison.Ordinal);
+    }
+
+    private sealed class ParityWorkspace : IDisposable
+    {
+        public const string Unit = "G565";
+        public const string Domain = "intent-cli";
+        public const string TargetRepo = "J-Tech-Japan/intent-system";
+
+        public ParityWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("packet-yaml-parity-g565-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = Domain,
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+
+            var bindings = Path.Combine(RootPath, "intents", Domain, "automation");
+            Directory.CreateDirectory(bindings);
+            File.WriteAllText(Path.Combine(bindings, "bindings.md"), "---\nexecution_unit_regex: '^G[0-9]+$'\n---\n");
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        private string PacketDirectory => Path.Combine(RootPath, ".intent-cli", "issues", Unit);
+
+        public void WritePacket(string yaml)
+        {
+            Directory.CreateDirectory(PacketDirectory);
+            File.WriteAllText(Path.Combine(PacketDirectory, "packet.yaml"), yaml);
+            File.WriteAllText(Path.Combine(PacketDirectory, "implementation.md"), "# impl\n");
+            File.WriteAllText(Path.Combine(PacketDirectory, "github-body.md"),
+                "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n"
+                + "## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n"
+                + "## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+            WriteReviewContextMarkdown();
+        }
+
+        public void WriteReviewContextMarkdown()
+        {
+            Directory.CreateDirectory(PacketDirectory);
+            File.WriteAllText(Path.Combine(PacketDirectory, "review-context.md"),
+                $"# {Unit} Review Context\n\n## Intent References\n\n- intents/{Domain}/intent-tree/00-map.md\n\n"
+                + "## Rules And Specs\n\n- intents/rules/issue-projection-format.md\n\n"
+                + "## Acceptance Criteria\n\n- one parsing pathway\n\n"
+                + "# Deterministic Review Checks\n\n- the hand parser is gone\n");
+        }
+
+        public void WriteQueueState()
+        {
+            File.WriteAllText(Context.GetQueueStatePath(), $$"""
+                {
+                  "schema_version": "1",
+                  "updated_at": "2026-08-01T00:00:00+00:00",
+                  "items": [
+                    {
+                      "execution_unit": "{{Unit}}",
+                      "title": "[{{Unit}}] parity",
+                      "state": "queued",
+                      "dependencies": [],
+                      "blocked_by": [],
+                      "clarification_return_path": "intents/{{Domain}}/clarifications/open.md",
+                      "packet_paths": {
+                        "implementation": ".intent-cli/issues/{{Unit}}/implementation.md",
+                        "review_context": ".intent-cli/issues/{{Unit}}/review-context.md",
+                        "yaml": ".intent-cli/issues/{{Unit}}/packet.yaml"
+                      },
+                      "worker_role": "coder",
+                      "review_role": "reviewer",
+                      "priority": "high"
+                    }
+                  ]
+                }
+                """);
+        }
+
+        /// <summary>Runs the real packet surface and returns its classification.</summary>
+        public string RunQueueSeedDryRun()
+        {
+            using var writer = new StringWriter();
+            AutomationQueueSeedFromPacketCommand.Execute(
+                Context,
+                ["--execution-unit", Unit, "--domain", Domain, "--target-repo", TargetRepo, "--format", "json"],
+                writer);
+
+            using var document = JsonDocument.Parse(writer.ToString());
+            return document.RootElement.GetProperty("classification").GetString()!;
+        }
+
+        public static string BuildPacket(string issueTitleYaml) => $"""
+            implementation_issue_packet:
+              issue_title: {issueTitleYaml}
+              issue_kind: "feature"
+              source_execution_unit: "{Unit}"
+              target_repo: "{TargetRepo}"
+              goal: "unify the packet YAML parsing pathway"
+              in_scope:
+                - "one"
+              out_of_scope:
+                - "two"
+              target_path: "src/IntentSystem.Projection/**"
+              target_part: "packet parsing pathway"
+              dependencies: []
+              technical_baseline:
+                - "C# / .NET"
+              project_local_guide:
+                - "AGENTS.md"
+              intent_baseline:
+                - "source of truth remains in the parent intent repo"
+              intent_references:
+                - "intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md"
+              rules_and_specs:
+                - "intents/rules/issue-projection-format.md"
+              acceptance_criteria:
+                - "one parsing pathway"
+              verification_evidence:
+                - "tests-passing"
+              review_mode: "deterministic-review"
+              completion_action: "wait-for-deterministic-review"
+              landing_policy: "merge-after-review"
+
+            review_context_packet:
+              source_execution_unit: "{Unit}"
+              parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+              intent_references:
+                - "intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md"
+              rules_and_specs:
+                - "intents/rules/issue-projection-format.md"
+              acceptance_criteria:
+                - "one parsing pathway"
+              deterministic_review_checks:
+                - "the hand parser is gone"
+              clarification_return_path: "intents/{Domain}/clarifications/open.md"
+            """;
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Projection.Tests/ProjectionPacketYamlG565Tests.cs
+++ b/tests/IntentSystem.Projection.Tests/ProjectionPacketYamlG565Tests.cs
@@ -1,0 +1,262 @@
+using IntentSystem.Projection.Serialization;
+
+namespace IntentSystem.Projection.Tests;
+
+/// <summary>
+/// G565: projection accepts exactly what the packet schema accepts.
+///
+/// The field report (sekiban-as-a-service design thread, 2026-07-31, v0.6.2):
+/// <c>intent-cli clarify open SKS-G837</c> rejected an existing, otherwise
+/// valid packet with "Projection packet YAML contains invalid section header"
+/// because its title carried an em-dash and long punctuation. The reporter's
+/// diagnosis was exact — the two parsers disagreed, and the packet surfaces
+/// were the ones parsing real YAML.
+///
+/// The defect was never one title. It was that
+/// <c>ProjectionPacketSerializer</c> hand-rolled a line reader, so EVERY legal
+/// YAML construct it failed to anticipate became a projection-only failure:
+/// G534 patched block-sequence indentation, G561 patched required-section
+/// rejection, and this would have continued one construct at a time. These
+/// fixtures pin the constructs that used to break it, and each one is a
+/// standing statement that projection speaks YAML rather than an approximation
+/// of it.
+/// </summary>
+public sealed class ProjectionPacketYamlG565Tests
+{
+    /// <summary>
+    /// The reported case: an em-dash, long punctuation, and — the part the hand
+    /// parser could never have survived — a <c>": "</c> INSIDE a quoted scalar.
+    /// The old reader split fields on the first colon it found, so the value
+    /// silently truncated where the packet schema reads one whole string.
+    /// </summary>
+    [Fact]
+    public void Deserialize_GivenEmDashAndQuotedColonSpaceTitle_RoundTripsTheWholeString_G565()
+    {
+        const string Title = "SKS-G837: Query surface — read models, projections: the whole set (round 2)";
+
+        var packet = ProjectionPacketSerializer.Deserialize(
+            BuildPacket(issueTitle: $"\"{Title}\"", executionUnit: "SKS-G837"));
+
+        Assert.Equal(Title, packet.ImplementationIssuePacket.IssueTitle);
+        Assert.Equal("SKS-G837", packet.ImplementationIssuePacket.SourceExecutionUnit);
+    }
+
+    [Theory]
+    // Every one of these is legal YAML the packet surfaces already accept, and
+    // every one of them is a shape the hand-rolled reader either mishandled or
+    // rejected outright.
+    [InlineData("'single-quoted — with an em-dash'", "single-quoted — with an em-dash")]
+    [InlineData("\"escaped \\\"quotes\\\" inside\"", "escaped \"quotes\" inside")]
+    [InlineData("\"a tab\\tseparated value\"", "a tab\tseparated value")]
+    [InlineData("plain scalar — unquoted, with punctuation!", "plain scalar — unquoted, with punctuation!")]
+    [InlineData("\"trailing spaces preserved   \"", "trailing spaces preserved   ")]
+    [InlineData("\"日本語タイトル: コロン付き\"", "日本語タイトル: コロン付き")]
+    public void Deserialize_GivenLegalScalarForms_ReadsThemAsTheSchemaDoes_G565(string yamlValue, string expected)
+    {
+        var packet = ProjectionPacketSerializer.Deserialize(BuildPacket(issueTitle: yamlValue));
+
+        Assert.Equal(expected, packet.ImplementationIssuePacket.IssueTitle);
+    }
+
+    [Fact]
+    public void Deserialize_GivenCommentsAnywhere_IgnoresThem_G565()
+    {
+        // The hand parser treated every column-0 line as a section header, so a
+        // top-level comment was "invalid section header" — the exact message
+        // the field report carried.
+        var yaml = "# top-level comment, at column 0\n"
+            + BuildPacket(extraImplementationLines: "  # an indented comment\n")
+            + "\n# a trailing comment\n";
+
+        var packet = ProjectionPacketSerializer.Deserialize(yaml);
+
+        Assert.Equal("G565", packet.ImplementationIssuePacket.SourceExecutionUnit);
+    }
+
+    [Fact]
+    public void Deserialize_GivenFlowSequences_ReadsThemAsLists_G565()
+    {
+        // `dependencies: [G1, G2]` is ordinary YAML. The old reader stored the
+        // literal text "[G1, G2]" as a SCALAR, so a packet using flow style
+        // failed with "field must be a list" — while `queue-seed-from-packet`
+        // happily expanded the same line.
+        var packet = ProjectionPacketSerializer.Deserialize(
+            BuildPacket(dependencies: "[G1, G2]"));
+
+        Assert.Equal(["G1", "G2"], packet.ImplementationIssuePacket.Dependencies);
+    }
+
+    [Fact]
+    public void Deserialize_GivenFoldedAndLiteralBlockScalars_ReadsTheWholeValue_G565()
+    {
+        var yaml = BuildPacket(goal: ">-\n    a folded goal that wraps\n    across two source lines");
+
+        var packet = ProjectionPacketSerializer.Deserialize(yaml);
+
+        Assert.Equal("a folded goal that wraps across two source lines", packet.ImplementationIssuePacket.Goal);
+    }
+
+    [Fact]
+    public void Deserialize_GivenBothBlockSequenceIndentations_StillParsesIdentically_G565()
+    {
+        // G534's fix was a patch to the hand parser. Parsing YAML with a YAML
+        // parser subsumes it — pinned here so the behaviour cannot regress
+        // when the patch it replaced is gone.
+        var twoSpace = ProjectionPacketSerializer.Deserialize(
+            BuildPacket(dependencies: "\n  - G1\n  - G2"));
+        var fourSpace = ProjectionPacketSerializer.Deserialize(
+            BuildPacket(dependencies: "\n    - G1\n    - G2"));
+
+        Assert.Equal(["G1", "G2"], twoSpace.ImplementationIssuePacket.Dependencies);
+        Assert.Equal(twoSpace.ImplementationIssuePacket.Dependencies, fourSpace.ImplementationIssuePacket.Dependencies);
+    }
+
+    [Fact]
+    public void Deserialize_GivenOptionalNonSectionTopLevelKeys_IgnoresThem_G565()
+    {
+        // A top-level scalar or sequence is not a section. It is not an error
+        // either: only the sections this contract REQUIRES are enforced.
+        var yaml = "schema_version: 1\n"
+            + "aliases:\n  - one\n  - two\n"
+            + BuildPacket();
+
+        var packet = ProjectionPacketSerializer.Deserialize(yaml);
+
+        Assert.Equal("G565", packet.ImplementationIssuePacket.SourceExecutionUnit);
+    }
+
+    // ------------------------------------------------ contract still enforced
+
+    [Fact]
+    public void Deserialize_StillRejectsAMissingRequiredSection_G565()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ProjectionPacketSerializer.Deserialize("implementation_issue_packet:\n  issue_title: \"x\"\n"));
+
+        Assert.Contains("must contain required section 'review_context_packet'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_StillRejectsAMissingRequiredField_G565()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ProjectionPacketSerializer.Deserialize(BuildPacket(omitIssueKind: true)));
+
+        Assert.Contains("must contain required field 'issue_kind'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_StillRejectsAValuelessRequiredScalar_G565()
+    {
+        // Byte-compatible with the previous reader: a `key:` with no value was
+        // an empty LIST, so a required scalar left blank failed as "must be a
+        // scalar string" rather than passing as an empty string.
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ProjectionPacketSerializer.Deserialize(BuildPacket(issueTitle: string.Empty)));
+
+        Assert.Contains("'issue_title' must be a scalar string", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_StillRejectsAScalarWhereAListIsRequired_G565()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ProjectionPacketSerializer.Deserialize(BuildPacket(dependencies: "\"not a list\"")));
+
+        Assert.Contains("'dependencies' must be a list", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_StillRejectsMismatchedExecutionUnits_G565()
+    {
+        var yaml = BuildPacket(executionUnit: "G565").Replace(
+            "  source_execution_unit: \"G565\"\n  parent_intent_root",
+            "  source_execution_unit: \"G999\"\n  parent_intent_root",
+            StringComparison.Ordinal);
+
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ProjectionPacketSerializer.Deserialize(yaml));
+
+        Assert.Contains("must match", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_RejectsYamlThatIsNotYaml_WithAParseDiagnostic_G565()
+    {
+        // Genuinely broken YAML still fails — and now says so as a parse
+        // failure rather than as a guess about section headers.
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ProjectionPacketSerializer.Deserialize("implementation_issue_packet:\n  a: [1, 2\n"));
+
+        Assert.Contains("could not be parsed", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Deserialize_RejectsATopLevelDocumentThatIsNotAMapping_G565()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => ProjectionPacketSerializer.Deserialize("- just\n- a sequence\n"));
+
+        Assert.Contains("is not a mapping", exception.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A complete, valid packet. Every parameter defaults to the canonical
+    /// form, so each fixture above varies exactly one construct.
+    /// </summary>
+    private static string BuildPacket(
+        string issueTitle = "\"G565 packet\"",
+        string executionUnit = "G565",
+        string goal = "\"unify the packet YAML parsing pathway\"",
+        string dependencies = "[]",
+        string extraImplementationLines = "",
+        bool omitIssueKind = false)
+    {
+        var issueKindLine = omitIssueKind ? string.Empty : "  issue_kind: \"feature\"\n";
+
+        return $"""
+            implementation_issue_packet:
+              issue_title: {issueTitle}
+            {issueKindLine}  source_execution_unit: "{executionUnit}"
+              goal: {goal}
+              in_scope:
+                - "one"
+              out_of_scope:
+                - "two"
+              target_repo: "J-Tech-Japan/intent-system"
+              target_path: "src/IntentSystem.Projection/**"
+              target_part: "packet parsing pathway"
+              dependencies: {dependencies}
+              technical_baseline:
+                - "C# / .NET"
+              project_local_guide:
+                - "AGENTS.md"
+              intent_baseline:
+                - "source of truth remains in the parent intent repo"
+              intent_references:
+                - "intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md"
+              rules_and_specs:
+                - "intents/rules/issue-projection-format.md"
+              acceptance_criteria:
+                - "one parsing pathway"
+              verification_evidence:
+                - "tests-passing"
+              review_mode: "deterministic-review"
+              completion_action: "wait-for-deterministic-review"
+              landing_policy: "merge-after-review"
+            {extraImplementationLines}
+            review_context_packet:
+              source_execution_unit: "{executionUnit}"
+              parent_intent_root: "intents/intent-cli/intent-tree/00-map.md"
+              intent_references:
+                - "intents/intent-cli/intent-tree/means/03-state-and-audit-strategy.md"
+              rules_and_specs:
+                - "intents/rules/issue-projection-format.md"
+              acceptance_criteria:
+                - "one parsing pathway"
+              deterministic_review_checks:
+                - "the hand parser is gone"
+              clarification_return_path: "intents/intent-cli/clarifications/open.md"
+            """;
+    }
+}


### PR DESCRIPTION
Closes #1235

## What changed

`ProjectionPacketSerializer.ParseSections` — a hand-rolled line reader — is **deleted**. Projection now reads `packet.yaml` through YamlDotNet, the same implementation `packet draft`, `clarify open` and the facet checks already use on the same file.

The projection **contract is unchanged**: required sections, required fields, their validation order and their messages all still come from the code below the parser. Only the question *"what is valid YAML"* moved — to the answer the rest of the toolchain already gives.

## Why the parser, not the title

The field report (sekiban-as-a-service design thread, 2026-07-31, v0.6.2) was `clarify open SKS-G837` failing with "Projection packet YAML contains invalid section header" on a title carrying an em-dash and long punctuation. The reporter's diagnosis was exact: the two parsers disagreed.

But the defect was never one title. The hand reader's acceptance was an *approximation* of YAML, so every construct it did not anticipate became a projection-only failure — G534 patched block-sequence indentation, G561 patched required-section rejection, and this would have continued one construct at a time. Parsing YAML with a YAML parser removes the source instead of the next symptom.

## Behaviour preserved deliberately

- **A valueless `key:` stays an empty LIST.** The old reader did that, which is why a required scalar left blank failed with "must be a scalar string" rather than passing as an empty string. YamlDotNet reports it as an empty *plain* scalar, so it is mapped back — otherwise a packet with a blank title would have started passing. A quoted `key: ""` is still a real empty string, exactly as before.
- **Malformed YAML that surfaces as a bare `InvalidOperationException`** (an unterminated flow sequence continuing across later lines — verified against YamlDotNet 18.1.0) is wrapped with the same `could not be parsed` diagnostic as a `YamlException`. A caller must not have to tell a parse failure from a contract violation by exception type.
- G561's semantics are untouched: `review_context_packet` stays optional for scaffolded packets, and a packet that *declares* it still goes through strict validation.

## Fixtures

`ProjectionPacketYamlG565Tests` — the reported em-dash + quoted `": "` title round-trips whole; single/double-quoted, escaped, tab-escaped, unicode and plain scalars; comments at any column; flow sequences; folded block scalars; both block-sequence indentations; optional non-section top-level keys. The contract's own rejections (missing section, missing field, valueless required scalar, scalar-where-list, mismatched units, non-YAML, non-mapping root) are pinned alongside them.

`PacketYamlParityG565Tests` — the parity matrix drives **both** sides on the **same bytes**, because fixing one parser is only half the answer: without a test that exercises both, they can drift apart again the next time either changes.

## Two things the fixtures surfaced (recorded, not assumed)

1. **A plain scalar containing `": "` is not legal YAML.** I had written it into the accepted set on the assumption it was a valid title form; it is not, so it moved to the rejection side.
2. **`queue-seed-from-packet` classifies malformed YAML `queue-seed-ready`.** Its field lookup is the G361 regex scalar reader, which never parses the document, so it does not notice an unterminated flow sequence. That is a pre-existing leniency in a *different* lane and outside this unit's scope (which is projection conforming to the schema surfaces, not the reverse). It is documented in the test rather than papered over, and it looks worth its own packet — flagging it for design rather than fixing it here.

One pre-existing assertion changed, and it changed toward what it always meant: `AScaffoldThatMerelyDeclaresTheSection_LosesTolerance_G561` used to assert "invalid section header", which was an accident of the hand parser tripping on the scaffold's own comment lines. It now asserts the real reason — declaring the section is a claim of completeness, and the scaffold lacks the required implementation fields.

## Verification

- `dotnet test IntentSystem.sln` — **4041 passed, 0 failed, 1 skipped** (all other projects green).
- Full suite re-run with a `gh` shim exiting 1 and `GH_TOKEN`/`GITHUB_TOKEN=invalid` — same result, so green does not depend on ambient credentials.
- `git diff --check` clean.
- **Regression-proof**: with the original hand parser restored, **10 of the new fixtures fail** (8 projection, 2 parity); the parser was then restored and the suite re-run green.

No schema changes, no new fields, no clarify semantics changes, no coupling to the v0.7.0 release chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
