### PR TITLE
G567: Queue-seed validates through the unified packet parser — malformed YAML can no longer classify as queue-seed-ready

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
@@ -91,7 +91,36 @@ internal static class AutomationQueueSeedFromPacketCommand
         // the underlying domain-binding regex check MUST ALWAYS RUN —
         // otherwise a wrong-domain packet could be seeded as long as
         // `target_repo` matches (fail-open).
-        var packetFields = ReadPacketFields(packetDirectoryAbsolute);
+        // G567: the WHOLE document is parsed before anything reads a field from
+        // it, and a packet that is not valid YAML fails closed here — in
+        // dry-run and in write alike, with the parse error named and before any
+        // queue-state or runs.jsonl mutation is even planned.
+        //
+        // Until now this lane read fields with the G361 regex scalar reader,
+        // which never parses the document, so a packet that the schema and
+        // projection surfaces both reject could still classify
+        // `queue-seed-ready` and seed the queue. That is the same
+        // acceptance-surface disagreement G565 closed for projection, one
+        // surface upstream and on a mutation path — where the cost is a
+        // malformed unit sitting in the queue and failing later at publish or
+        // preflight, far from its cause.
+        if (!TryReadPacketFields(packetDirectoryAbsolute, out var packetFields, out var packetParseError))
+        {
+            var unparseable = new QueueSeedFromPacketResult
+            {
+                Classification = ClassificationUnsafe,
+                ExecutionUnit = executionUnit,
+                PacketDirectory = packetDirectoryRelative,
+                Write = write,
+                UnsafeReason = PreparedPacketCommitReadyAnalyzer.ReasonPacketYamlUnparseable,
+                Summary = $"refusing to seed queue-state from `{packetDirectoryRelative}`: {packetParseError} "
+                    + "No queue-state or runs.jsonl mutation was planned or applied. Repair the packet and re-run — "
+                    + "this is the same acceptance the packet schema and projection surfaces apply.",
+            };
+            EmitResult(writer, format, unparseable);
+            return 1;
+        }
+
         var packetDeclaredDomain = LookupScalar(packetFields, "domain");
         var domainResolution = PacketDomainResolution.Resolve(
             domain,
@@ -437,25 +466,41 @@ internal static class AutomationQueueSeedFromPacketCommand
             .ToArray();
     }
 
-    private static IReadOnlyDictionary<string, string> ReadPacketFields(string packetDirectoryAbsolute)
+    /// <summary>
+    /// G567: reads the packet's fields THROUGH a whole-document YAML parse
+    /// (<see cref="PacketYamlDocument"/>), the same acceptance G565 gave
+    /// projection. Returns <see langword="false"/> with a named error when the
+    /// file is present but is not valid YAML — the caller fails closed on that
+    /// rather than seeding from a partial read.
+    ///
+    /// A MISSING or empty packet.yaml is not this method's failure to report:
+    /// it stays an empty map so
+    /// <see cref="PreparedPacketCommitReadyAnalyzer"/> produces its own
+    /// missing-file diagnostic downstream, exactly as before.
+    /// </summary>
+    private static bool TryReadPacketFields(
+        string packetDirectoryAbsolute,
+        out IReadOnlyDictionary<string, string> fields,
+        out string error)
     {
+        error = string.Empty;
         var packetYamlPath = Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNamePacketYaml);
         var content = TryReadFile(packetYamlPath);
         if (string.IsNullOrEmpty(content))
         {
-            return new Dictionary<string, string>(StringComparer.Ordinal);
+            fields = new Dictionary<string, string>(StringComparer.Ordinal);
+            return true;
         }
-        try
+
+        if (!PacketYamlDocument.TryParse(content!, out var document, out var parseError))
         {
-            return PreparedPacketYamlScalarParser.Parse(content);
+            fields = new Dictionary<string, string>(StringComparer.Ordinal);
+            error = parseError;
+            return false;
         }
-        catch (FormatException)
-        {
-            // Validation upstream already enforced parseable YAML;
-            // defensive fallback returns empty map so the seed uses
-            // the deterministic defaults.
-            return new Dictionary<string, string>(StringComparer.Ordinal);
-        }
+
+        fields = document!.Fields;
+        return true;
     }
 
     private static string? LookupScalar(IReadOnlyDictionary<string, string> fields, params string[] keys)

--- a/src/IntentSystem.Cli/Commands/PacketYamlDocument.cs
+++ b/src/IntentSystem.Cli/Commands/PacketYamlDocument.cs
@@ -1,0 +1,143 @@
+using YamlDotNet.RepresentationModel;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G567: a whole-document parse of <c>packet.yaml</c>, flattened to the dotted
+/// scalar map the seeding path already consumes.
+///
+/// G565 unified projection onto a real YAML parser. This is the same move one
+/// surface further upstream, and on a MUTATION path: the queue-seed lane read
+/// packet fields with <see cref="PreparedPacketYamlScalarParser"/>, a
+/// line-and-regex reader that never parses the document, so a packet the schema
+/// and projection surfaces both reject could still classify
+/// <c>queue-seed-ready</c> and put a malformed unit into the queue. The failure
+/// then surfaces at publish or preflight time, far from its cause.
+///
+/// The flattening reproduces the previous reader's OUTPUT shape exactly, so
+/// well-formed packets seed byte-identically:
+/// <list type="bullet">
+///   <item>each scalar is recorded under its dotted path
+///         (<c>implementation_issue_packet.target_repo</c>) AND, first-wins,
+///         under its bare key (<c>target_repo</c>);</item>
+///   <item>quoted scalars lose their quotes and plain scalars lose a trailing
+///         <c>#</c> comment — the YAML parser does both natively;</item>
+///   <item>a key with no inline value records nothing, exactly as before;</item>
+///   <item>a FLOW sequence (<c>dependencies: [G1, G2]</c>) records its
+///         bracketed text, which is what the previous reader captured and what
+///         <c>ParsePacketArrayField</c> expects. A BLOCK sequence records
+///         nothing — also as before. That second case is a pre-existing
+///         data-loss bug (block-style <c>dependencies</c> are silently dropped
+///         from the seed), deliberately preserved here because this unit is
+///         about WHERE parsing happens, not about changing what a packet
+///         means; it is listed for follow-up rather than fixed in passing.</item>
+/// </list>
+/// </summary>
+internal sealed class PacketYamlDocument
+{
+    private PacketYamlDocument(IReadOnlyDictionary<string, string> fields)
+    {
+        Fields = fields;
+    }
+
+    /// <summary>Dotted-path scalar map, with bare-key aliases.</summary>
+    public IReadOnlyDictionary<string, string> Fields { get; }
+
+    /// <summary>
+    /// Parses <paramref name="yaml"/> as a whole document. Returns
+    /// <see langword="false"/> with a named <paramref name="error"/> when the
+    /// text is not a YAML mapping — the caller is expected to fail closed on
+    /// that, never to fall back to a partial read.
+    /// </summary>
+    public static bool TryParse(string yaml, out PacketYamlDocument? document, out string error)
+    {
+        document = null;
+        error = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(yaml))
+        {
+            error = "packet.yaml is empty.";
+            return false;
+        }
+
+        YamlMappingNode? root;
+        try
+        {
+            var stream = new YamlStream();
+            using var reader = new StringReader(yaml);
+            stream.Load(reader);
+            root = stream.Documents.Count == 0 ? null : stream.Documents[0].RootNode as YamlMappingNode;
+        }
+        // Same two-exception catch as the projection reader: YamlDotNet reports
+        // most malformed documents as a YamlException, but some — an
+        // unterminated flow sequence continuing across later lines — surface as
+        // a bare InvalidOperationException from the node builder.
+        catch (Exception exception) when (exception is YamlDotNet.Core.YamlException or InvalidOperationException)
+        {
+            error = $"packet.yaml is not valid YAML: {exception.Message}";
+            return false;
+        }
+
+        if (root is null)
+        {
+            error = "packet.yaml is empty or its top-level document is not a mapping.";
+            return false;
+        }
+
+        var fields = new Dictionary<string, string>(StringComparer.Ordinal);
+        Flatten(root, prefix: null, fields);
+        document = new PacketYamlDocument(fields);
+        return true;
+    }
+
+    private static void Flatten(YamlMappingNode mapping, string? prefix, Dictionary<string, string> fields)
+    {
+        foreach (var (keyNode, valueNode) in mapping.Children)
+        {
+            if (keyNode is not YamlScalarNode { Value: { } key } || key.Length == 0)
+            {
+                continue;
+            }
+
+            var dottedPath = prefix is null ? key : $"{prefix}.{key}";
+
+            switch (valueNode)
+            {
+                case YamlMappingNode nested:
+                    Flatten(nested, dottedPath, fields);
+                    break;
+
+                case YamlSequenceNode { Style: YamlDotNet.Core.Events.SequenceStyle.Flow } flow:
+                    Record(fields, dottedPath, key, RenderFlowSequence(flow));
+                    break;
+
+                case YamlScalarNode scalar when !string.IsNullOrEmpty(scalar.Value):
+                    Record(fields, dottedPath, key, scalar.Value!);
+                    break;
+
+                // A block sequence, an empty scalar, or anything else: the
+                // previous reader recorded nothing for these, and neither does
+                // this one.
+                default:
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Dotted path always wins; the bare-key alias is FIRST-WINS, matching the
+    /// previous reader (<c>if (!fields.ContainsKey(key))</c>) so a nested key
+    /// cannot shadow a top-level one that appeared earlier in the file.
+    /// </summary>
+    private static void Record(Dictionary<string, string> fields, string dottedPath, string key, string value)
+    {
+        fields[dottedPath] = value;
+        if (!fields.ContainsKey(key))
+        {
+            fields[key] = value;
+        }
+    }
+
+    private static string RenderFlowSequence(YamlSequenceNode sequence) =>
+        "[" + string.Join(", ", sequence.Children.OfType<YamlScalarNode>().Select(item => item.Value ?? string.Empty)) + "]";
+}

--- a/src/IntentSystem.Cli/Commands/PreparedPacketCommitReadyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PreparedPacketCommitReadyAnalyzer.cs
@@ -237,12 +237,16 @@ internal static class PreparedPacketCommitReadyAnalyzer
         }
 
         // 3. packet.yaml parses -----------------------------------------
-        IReadOnlyDictionary<string, string> packetFields;
-        try
-        {
-            packetFields = PreparedPacketYamlScalarParser.Parse(input.PacketYaml!);
-        }
-        catch (FormatException exception)
+        // G567: this gate is on a MUTATION path (queue-seed seeds the queue
+        // from a packet this analyzer classified), so "parses" now means the
+        // whole document parses as YAML — the same acceptance G565 gave
+        // projection — rather than every line matching a scalar regex. The
+        // regex reader never parsed the document, so a packet the schema and
+        // projection surfaces both reject could reach `queue-seed-ready`.
+        //
+        // The fields used below come from that same parse, so the parsed
+        // document is authoritative for both the gate and the lookups.
+        if (!PacketYamlDocument.TryParse(input.PacketYaml!, out var packetDocument, out var packetParseError))
         {
             return new PreparedPacketCommitReadyResult
             {
@@ -251,9 +255,11 @@ internal static class PreparedPacketCommitReadyAnalyzer
                 ExecutionUnit = input.ExecutionUnit,
                 PacketDirectory = packetDirectory,
                 Summary = $"prepared packet `{packetDirectory}` packet.yaml does not parse "
-                    + $"as a scalar YAML map: {exception.Message}. Operator review required before auto-commit.",
+                    + $"as YAML: {packetParseError} Operator review required before auto-commit.",
             };
         }
+
+        IReadOnlyDictionary<string, string> packetFields = packetDocument!.Fields;
 
         // 4. Target repo check ------------------------------------------
         // PR #824 review repair #7: the prepared-packet lane MUST NOT

--- a/tests/IntentSystem.Cli.Tests/PacketYamlParityG565Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketYamlParityG565Tests.cs
@@ -29,21 +29,25 @@ public sealed class PacketYamlParityG565Tests : IDisposable
 
     /// <summary>
     /// YAML constructs the packet surfaces accept. Each was a projection-only
-    /// failure before this slice, or would have become one.
+    /// failure before G565, or would have become one.
     ///
-    /// The set is deliberately what the surfaces ACTUALLY accept, not what they
-    /// ought to: writing these fixtures turned up two cases that do not belong
-    /// here and are documented on the rejection side instead — a plain
-    /// (unquoted) scalar containing <c>": "</c>, which is not legal YAML at
-    /// all, and a title with escaped quotes, which the queue-seed lane's own
-    /// legacy scalar reader refuses (<c>unsafe-prepared-packet</c>) even though
-    /// projection now reads it fine.
+    /// The set is what the surfaces ACTUALLY accept, not what they ought to. One
+    /// case documented here as an exception when these fixtures were written —
+    /// a plain (unquoted) scalar containing <c>": "</c> — stays out, because it
+    /// is not legal YAML at all and belongs on the rejection side.
+    ///
+    /// G567 moved the other one IN: a title with escaped quotes was refused by
+    /// the queue-seed lane's legacy scalar reader (its heuristic could not tell
+    /// an escaped quote from an unbalanced one) even though projection read it
+    /// fine. Now that queue-seed validates through the same whole-document
+    /// parse, all three surfaces agree on it.
     /// </summary>
     public static TheoryData<string, string> AcceptedByBothSurfaces() => new()
     {
         { "em-dash and a quoted colon-space title", "\"G565: parsing — one pathway, two readers: no more\"" },
         { "single-quoted title", "'G565 — single quoted'" },
         { "japanese title with a colon", "\"G565: 日本語 — コロン付き\"" },
+        { "escaped quotes (accepted by all three since G567)", "\"G565 \\\"quoted\\\" inside\"" },
     };
 
     [Theory]
@@ -85,22 +89,23 @@ public sealed class PacketYamlParityG565Tests : IDisposable
 
     /// <summary>
     /// The other direction. Parity is two-way — a parser that accepts
-    /// everything agrees with nothing — so malformed YAML must still be refused,
-    /// and refused as a PARSE failure rather than as a guess about section
-    /// headers.
+    /// everything agrees with nothing — so malformed YAML must be refused by
+    /// ALL THREE surfaces, and refused as a PARSE failure rather than as a
+    /// guess about section headers.
     ///
-    /// Note what is NOT asserted here: <c>queue-seed-from-packet</c> still
-    /// classifies both of these <c>queue-seed-ready</c>, because its own field
-    /// lookup is a regex scalar reader (G361) that never parses the document. So
-    /// the surfaces are not yet parsing-equivalent in this direction. That is a
-    /// pre-existing leniency in a different lane, outside this unit's scope
-    /// (which is projection conforming to the schema surfaces, not the reverse)
-    /// — recorded here rather than papered over, and worth its own packet.
+    /// G567 added the third column. When these fixtures were written for G565,
+    /// <c>queue-seed-from-packet</c> classified both of these
+    /// <c>queue-seed-ready</c> — its field lookup was a regex scalar reader
+    /// (G361) that never parsed the document, so a packet the other two
+    /// surfaces rejected could still seed the queue. That gap was recorded here
+    /// as out-of-scope, adjudicated to its own unit, and is now closed: the
+    /// assertion below is the proof, and it is deliberately in the SAME fixture
+    /// so the three surfaces can never again be checked one at a time.
     /// </summary>
     [Theory]
     [InlineData("unterminated flow sequence", "  dependencies: [G1, G2")]
     [InlineData("plain scalar containing a colon-space", "  dependencies: G565 — plain, unquoted: no")]
-    public void MalformedYaml_IsRejectedByProjectionAndByClarifyOpen_G565(string description, string replacement)
+    public void MalformedYaml_IsRejectedByAllThreeSurfaces_G565(string description, string replacement)
     {
         var yaml = ParityWorkspace.BuildPacket("\"G565\"").Replace(
             "  dependencies: []", replacement, StringComparison.Ordinal);
@@ -115,6 +120,8 @@ public sealed class PacketYamlParityG565Tests : IDisposable
         var exitCode = ClarifyOpenCommand.Execute(
             workspace.Context, [ParityWorkspace.Unit, "--question", "Which pathway parses this?"], writer);
         Assert.True(exitCode != 0, $"clarify open accepted malformed YAML ({description}): {writer}");
+
+        Assert.NotEqual(AutomationQueueSeedFromPacketCommand.ClassificationReady, workspace.RunQueueSeedDryRun());
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/QueueSeedPacketParsingG567Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueSeedPacketParsingG567Tests.cs
@@ -1,0 +1,291 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G567: the queue-seed lane validates through the unified packet parser, so
+/// malformed YAML can no longer classify <c>queue-seed-ready</c>.
+///
+/// This is G565's move one surface upstream and — the part that matters — on a
+/// MUTATION path. The seeding lane read packet fields with a regex scalar
+/// reader that never parsed the document, so a packet the schema and projection
+/// surfaces both reject could seed the queue. The malformed unit then failed at
+/// publish or preflight time, far from its cause.
+///
+/// Fail-closed here means all of: named parse error, no queue-state file, no
+/// runs.jsonl entry, non-zero exit — in dry-run AND in <c>--write</c>.
+/// </summary>
+public sealed class QueueSeedPacketParsingG567Tests : IDisposable
+{
+    private readonly SeedWorkspace workspace = new();
+
+    public void Dispose() => workspace.Dispose();
+
+    public static TheoryData<string, string> MalformedPackets() => new()
+    {
+        { "unterminated flow sequence", "  dependencies: [G1, G2" },
+        { "plain scalar containing a colon-space", "  dependencies: G567 — plain, unquoted: no" },
+        { "tab indentation", "\tdependencies: []" },
+        { "a block sequence item with no parent key", "- orphan" },
+    };
+
+    [Theory]
+    [MemberData(nameof(MalformedPackets))]
+    public void MalformedPacket_FailsClosedInDryRun_G567(string description, string replacement)
+    {
+        workspace.WritePacket(SeedWorkspace.BuildPacket(replacement));
+
+        var (exitCode, result) = workspace.RunSeed(write: false);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(
+            AutomationQueueSeedFromPacketCommand.ClassificationUnsafe,
+            result.GetProperty("classification").GetString());
+        Assert.Equal(
+            PreparedPacketCommitReadyAnalyzer.ReasonPacketYamlUnparseable,
+            result.GetProperty("unsafe_reason").GetString());
+        Assert.False(File.Exists(workspace.QueueStatePath), $"dry-run created queue-state.json for {description}");
+        Assert.False(File.Exists(workspace.RunsPath), $"dry-run appended runs.jsonl for {description}");
+    }
+
+    [Theory]
+    [MemberData(nameof(MalformedPackets))]
+    public void MalformedPacket_FailsClosedInWriteMode_G567(string description, string replacement)
+    {
+        // The write path is the one that matters: this is the difference
+        // between a diagnostic and a malformed unit living in the queue.
+        workspace.WritePacket(SeedWorkspace.BuildPacket(replacement));
+
+        var (exitCode, result) = workspace.RunSeed(write: true);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(
+            AutomationQueueSeedFromPacketCommand.ClassificationUnsafe,
+            result.GetProperty("classification").GetString());
+        Assert.False(File.Exists(workspace.QueueStatePath), $"--write seeded the queue for {description}");
+        Assert.False(File.Exists(workspace.RunsPath), $"--write appended runs.jsonl for {description}");
+    }
+
+    [Fact]
+    public void MalformedPacket_LeavesAnExistingQueueStateByteIdentical_G567()
+    {
+        // "No mutation" has to mean the file on disk, not just "no new item".
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies: [G1, G2"));
+        workspace.WriteExistingQueueState();
+        var before = File.ReadAllBytes(workspace.QueueStatePath);
+
+        var (exitCode, _) = workspace.RunSeed(write: true);
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(before, File.ReadAllBytes(workspace.QueueStatePath));
+        Assert.False(File.Exists(workspace.RunsPath));
+    }
+
+    [Fact]
+    public void TheParseFailure_IsNamedInTheSummary_G567()
+    {
+        // A fail-closed stop the operator cannot diagnose just moves the cost.
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies: [G1, G2"));
+
+        var (_, result) = workspace.RunSeed(write: true);
+
+        var summary = result.GetProperty("summary").GetString()!;
+        Assert.Contains("packet.yaml", summary, StringComparison.Ordinal);
+        Assert.Contains("not valid YAML", summary, StringComparison.Ordinal);
+    }
+
+    // ------------------------------------------------------ byte-compatibility
+
+    [Fact]
+    public void AWellFormedPacket_SeedsExactlyAsBefore_G567()
+    {
+        // The seeded fields come from the parsed document now, so this pins that
+        // the values did not shift: same classification, same title, same
+        // dependencies expanded from the same flow sequence.
+        workspace.WritePacket(SeedWorkspace.BuildPacket(
+            "  dependencies: [G565, G566]",
+            issueTitle: "Queue seed parity"));
+
+        var (exitCode, result) = workspace.RunSeed(write: false);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(
+            AutomationQueueSeedFromPacketCommand.ClassificationReady,
+            result.GetProperty("classification").GetString());
+
+        var seeded = result.GetProperty("seeded_item");
+        Assert.Equal("Queue seed parity", seeded.GetProperty("title").GetString());
+        Assert.Equal(
+            ["G565", "G566"],
+            seeded.GetProperty("dependencies").EnumerateArray().Select(d => d.GetString()).ToArray());
+    }
+
+    [Fact]
+    public void AQuotedTitleLosesItsQuotes_AsEveryOtherSurfaceAlreadyReadsIt_G567()
+    {
+        // The regex reader stripped quotes with a hand-rolled rule; the YAML
+        // parser does it natively. Pinned because the seeded TITLE is what an
+        // operator sees in the queue.
+        workspace.WritePacket(SeedWorkspace.BuildPacket(
+            "  dependencies: []",
+            issueTitle: "G567: quoted — with a colon"));
+
+        var (exitCode, result) = workspace.RunSeed(write: false);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(
+            "G567: quoted — with a colon",
+            result.GetProperty("seeded_item").GetProperty("title").GetString());
+    }
+
+    // --------------------------------------------------------- parser contract
+
+    [Fact]
+    public void PacketYamlDocument_FlattensDottedPathsWithBareKeyAliases_G567()
+    {
+        Assert.True(PacketYamlDocument.TryParse(
+            """
+            domain: intent-cli
+            implementation_issue_packet:
+              issue_title: "titled"
+              target_repo: owner/repo
+              dependencies: [A, B]
+              blocked_by:
+                - C
+              empty_value:
+            """,
+            out var document,
+            out var error));
+        Assert.Equal(string.Empty, error);
+
+        var fields = document!.Fields;
+        Assert.Equal("intent-cli", fields["domain"]);
+        Assert.Equal("titled", fields["implementation_issue_packet.issue_title"]);
+        // Bare-key alias, exactly as the previous reader produced.
+        Assert.Equal("titled", fields["issue_title"]);
+        Assert.Equal("[A, B]", fields["implementation_issue_packet.dependencies"]);
+
+        // Deliberately unchanged from the previous reader: a BLOCK sequence and
+        // a valueless key record nothing. The block-sequence case is a
+        // pre-existing data-loss bug (block-style `dependencies` never reach the
+        // seed); this unit moves WHERE parsing happens, not what a packet means,
+        // so it is pinned as-is and listed for follow-up rather than changed in
+        // passing.
+        Assert.False(fields.ContainsKey("implementation_issue_packet.blocked_by"));
+        Assert.False(fields.ContainsKey("implementation_issue_packet.empty_value"));
+    }
+
+    [Fact]
+    public void PacketYamlDocument_BareKeyAliasIsFirstWins_G567()
+    {
+        // The previous reader wrote the bare alias only when absent, so a nested
+        // key could not shadow a top-level one seen earlier.
+        Assert.True(PacketYamlDocument.TryParse(
+            """
+            target_repo: top/level
+            implementation_issue_packet:
+              target_repo: nested/one
+            """,
+            out var document,
+            out _));
+
+        Assert.Equal("top/level", document!.Fields["target_repo"]);
+        Assert.Equal("nested/one", document.Fields["implementation_issue_packet.target_repo"]);
+    }
+
+    private sealed class SeedWorkspace : IDisposable
+    {
+        public const string Unit = "G567";
+        public const string Domain = "intent-cli";
+        public const string TargetRepo = "J-Tech-Japan/intent-system";
+
+        public SeedWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("queue-seed-parsing-g567-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = Domain,
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+
+            var bindings = Path.Combine(RootPath, "intents", Domain, "automation");
+            Directory.CreateDirectory(bindings);
+            File.WriteAllText(Path.Combine(bindings, "bindings.md"), "---\nexecution_unit_regex: '^G[0-9]+$'\n---\n");
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public string QueueStatePath => Context.GetQueueStatePath();
+
+        public string RunsPath => Context.GetRunLogPath();
+
+        public void WritePacket(string yaml)
+        {
+            var directory = Path.Combine(RootPath, ".intent-cli", "issues", Unit);
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, "packet.yaml"), yaml);
+            File.WriteAllText(Path.Combine(directory, "implementation.md"), "# impl\n");
+            File.WriteAllText(Path.Combine(directory, "review-context.md"), "# review\n");
+            File.WriteAllText(Path.Combine(directory, "github-body.md"),
+                "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n"
+                + "## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n"
+                + "## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+        }
+
+        public void WriteExistingQueueState() => File.WriteAllText(QueueStatePath, """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-08-01T00:00:00+00:00",
+              "items": []
+            }
+            """);
+
+        public (int ExitCode, JsonElement Result) RunSeed(bool write)
+        {
+            using var writer = new StringWriter();
+            var args = new List<string>
+            {
+                "--execution-unit", Unit, "--domain", Domain, "--target-repo", TargetRepo, "--format", "json",
+            };
+            if (write)
+            {
+                args.Add("--write");
+            }
+
+            var exitCode = AutomationQueueSeedFromPacketCommand.Execute(Context, args.ToArray(), writer);
+            var document = JsonDocument.Parse(writer.ToString());
+            return (exitCode, document.RootElement.Clone());
+        }
+
+        public static string BuildPacket(string dependenciesLine, string issueTitle = "Demo") => $"""
+            domain: {Domain}
+            implementation_issue_packet:
+              source_execution_unit: {Unit}
+              issue_title: "{issueTitle}"
+              target_repo: {TargetRepo}
+            {dependenciesLine}
+            """;
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1237

## What changed

The queue-seed lane no longer reads `packet.yaml` with a parser that never parses it.

- **`PacketYamlDocument`** (new) parses the packet as a whole YAML document — the same acceptance G565 gave projection — and flattens it to the dotted scalar map the seeding path already consumes.
- **`queue-seed-from-packet`** reads its fields through that parse and **fails closed** when the file is present but is not YAML: named parse error, non-zero exit, and **no** queue-state or `runs.jsonl` mutation, in **dry-run and `--write` alike**.
- **`PreparedPacketCommitReadyAnalyzer` step 3** (the gate queue-seed validates through) parses the same way. That is what actually removes the regex reader from the seeding path rather than leaving it behind the new gate as a second, differently-strict acceptance — and its `target_repo` lookup now comes from that same parse, so the parsed document is authoritative for both the gate and the lookups.

## Byte-compatibility is the delicate part, so it is pinned

The flattening reproduces the previous reader's **output shape**, not just its intent:

| Construct | Previous reader | `PacketYamlDocument` |
| --- | --- | --- |
| scalar | dotted path + first-wins bare-key alias | same |
| quoted scalar | quotes stripped by hand | quotes stripped by the parser |
| trailing `# comment` | stripped | stripped |
| `key:` with no value | records nothing | records nothing |
| flow seq `[A, B]` | records `[A, B]` | records `[A, B]` |
| block seq | records nothing | records nothing |

The entire existing suite passes unchanged, including the queue-seed tests that pin seeded titles, dependencies, roles and priority.

**The block-sequence row is a pre-existing data-loss bug** — block-style `dependencies:` never reach the seed. I preserved it deliberately and pinned it in a test rather than fixing it in passing: this unit moves *where* parsing happens, not *what a packet means*, and the packet says no new acceptance semantics. **Listed for follow-up.**

## Three-way parity

The G565 parity fixtures gain queue-seed as a third column **in the same fixture**, so the three surfaces can never again be checked one at a time. The escaped-quotes title also moves into the accepted set: queue-seed's old unbalanced-quote heuristic could not tell an escaped quote from an unbalanced one and was the only surface rejecting it.

## Regex audit (required by the packet)

`PreparedPacketYamlScalarParser` call sites remaining after this PR — **none on a mutation path**:

| Call site | Lane | Verdict |
| --- | --- | --- |
| `PreparedPacketCommitReadyAnalyzer:243` | queue-seed gate | **migrated** in this PR |
| `AutomationQueueSeedFromPacketCommand` (`ReadPacketFields`) | seeding | **migrated** in this PR (removed) |
| `AutomationStalledWorkCommand:2059, 2283` | read-only detection | display-only — reads `domain` to attribute a candidate; emits text, mutates nothing |
| `IntentNextSliceCommand:956` | read-only planning | display-only — next-slice candidate metadata; no mutation |
| `ReviewCloseoutPlanCommand:349` | read-only planning | display-only — resolves the packet-declared domain for the plan |
| `RunsLogRowInspector:175` | read-only diagnostics | display-only — domain attribution for a runs row |
| `AutomationIssueRetireCommand:602` | mutation command, **read-only use** | reads `domain` only for the domain-resolution diagnostic; the retire mutation is gated by GitHub/queue state, not by this read |
| `AutomationPublishRecoveryCommand:270` | mutation command, **read-only use** | same shape: `domain` lookup feeding `PacketDomainResolution`, not a readiness gate |

The two mutation *commands* in that list use the reader only to resolve a declared domain for `PacketDomainResolution`, which fails loud on ambiguity — no readiness classification depends on it. Migrating them is safe follow-up work, not a gap this packet leaves open.

## Verification

- `dotnet test IntentSystem.sln` — **4057 passed, 0 failed, 1 skipped** (all other projects green).
- Full suite re-run with a `gh` shim exiting 1 and `GH_TOKEN`/`GITHUB_TOKEN=invalid` — same result.
- `git diff --check` clean.
- **Regression-proof**: with both sources reverted to their pre-fix state, **9 of the new/updated fixtures fail** (fail-closed in dry-run ×3, in write ×3, existing-queue-state untouched, named parse error, and the escaped-quotes parity case); both files were then restored byte-for-byte and the suite re-run green.

## One unrelated flake found while verifying — reporting, not fixing

`IssuePrepareCommandTests.Execute_GivenValidBody_PacketJsonRoundTripsStably` failed **once** in a full-suite run and passed on two subsequent full runs and in isolation. Cause: `IssuePrepareCommand.TimestampFactory` is a process-global static mutated by **two** test classes (`IssuePrepareCommandTests` and `IssuePublishReviewedCommandTests`) that share **no** xUnit collection, so they run in parallel and reset each other's clock mid-run. It is the same shape as the shared-static races this repo already solves with `[CollectionDefinition(DisableParallelization = true)]`.

It is unrelated to packet YAML parsing and outside this packet's scope, so I have not touched it — but it can turn required CI red at random on any PR, so it is worth its own unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
