### PR TITLE
G568: Queue-seed preserves dependencies faithfully — block sequences no longer drop, with a reconcile path for seeded items

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationQueueDependencyReconcileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationQueueDependencyReconcileCommand.cs
@@ -1,0 +1,429 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G568: <c>intent-cli automation queue-dependency-reconcile
+/// [--execution-unit &lt;u&gt;] [--write] [--format json|markdown]</c> —
+/// diagnoses and repairs queue items whose <c>dependencies</c> drifted from
+/// what their packet declares.
+///
+/// G568 fixes the seed path going forward, but items already in the queue were
+/// seeded by the lossy one: a block-style <c>dependencies:</c> was dropped
+/// entirely, so a dependent unit sits in the queue looking like it has no
+/// prerequisites. Dependency-aware selection reads exactly that field, so those
+/// units can be picked while their root is still open — and hand-editing
+/// <c>queue-state.json</c> to fix it is forbidden (G548). Hence a canonical
+/// surface.
+///
+/// Contract:
+/// <list type="bullet">
+///   <item>read-only by default: reports the per-unit delta between what the
+///         packet declares and what the queue holds, and mutates nothing;</item>
+///   <item><c>--write</c> re-derives <c>dependencies</c> FROM THE PACKET — it
+///         never merges, never guesses, and touches no other field of the
+///         item;</item>
+///   <item>idempotent: a second run reports <c>in-sync</c> and applies
+///         nothing;</item>
+///   <item>fail-closed: an unknown unit, a missing packet, or a packet that
+///         does not parse is REPORTED and SKIPPED, never repaired from a
+///         partial read — and with <c>--execution-unit</c> naming such a unit,
+///         the command exits non-zero without writing at all;</item>
+///   <item>the write goes through <see cref="QueueStatePersistence.Persist"/>,
+///         so G548's no-item-loss and stale-base invariants hold.</item>
+/// </list>
+///
+/// It is never run automatically. The operator or orchestrator invokes it.
+/// </summary>
+internal static class AutomationQueueDependencyReconcileCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    public const string StatusInSync = "in-sync";
+    public const string StatusDrifted = "dependencies-drifted";
+    public const string StatusRepaired = "dependencies-repaired";
+    public const string StatusPacketMissing = "packet-missing";
+    public const string StatusPacketUnparseable = "packet-unparseable";
+
+    public const string ReconcileEventName = "queue_dependencies_reconciled";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    private const string UsageLine =
+        "Usage: intent-cli automation queue-dependency-reconcile [--execution-unit <unit>] [--dry-run|--write] [--format json|markdown]";
+
+    /// <summary>Test seam: deterministic runs-log timestamps.</summary>
+    public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(UsageLine);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var executionUnit, out var write, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var queueStatePath = context.GetQueueStatePath();
+        if (!File.Exists(queueStatePath))
+        {
+            writer.WriteLine($"queue-state.json not found at `{queueStatePath}`; nothing to reconcile.");
+            return 1;
+        }
+
+        QueueState baseState;
+        try
+        {
+            baseState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+        }
+        catch (Exception exception) when (exception is IOException or JsonException or InvalidOperationException)
+        {
+            writer.WriteLine($"queue-state.json at `{queueStatePath}` is unparseable; refusing to reconcile. {exception.Message}");
+            return 1;
+        }
+
+        var targets = executionUnit is null
+            ? baseState.Items
+            : baseState.Items.Where(item => string.Equals(item.ExecutionUnit, executionUnit, StringComparison.Ordinal)).ToArray();
+
+        if (executionUnit is not null && targets.Count == 0)
+        {
+            writer.WriteLine(
+                $"execution unit '{executionUnit}' is not in queue-state; refusing to reconcile a unit this queue does not hold.");
+            return 1;
+        }
+
+        var findings = new List<QueueDependencyFinding>();
+        var repairs = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+
+        foreach (var item in targets.OrderBy(item => item.ExecutionUnit, StringComparer.Ordinal))
+        {
+            findings.Add(Inspect(context, item, repairs));
+        }
+
+        // Fail closed on an explicitly named unit whose packet cannot be read:
+        // the caller asked about THAT unit, and "I could not tell" is an error
+        // for a single-unit question even though it is a skip in a sweep.
+        var namedFailure = executionUnit is not null
+            && findings.Any(finding => finding.Status is StatusPacketMissing or StatusPacketUnparseable);
+
+        var applied = false;
+        if (write && repairs.Count > 0 && !namedFailure)
+        {
+            applied = Apply(context, queueStatePath, baseState, repairs);
+        }
+
+        var result = new QueueDependencyReconcileResult
+        {
+            Mode = write ? "write" : "dry-run",
+            Applied = applied,
+            ExecutionUnit = executionUnit,
+            Inspected = findings.Count,
+            Drifted = findings.Count(finding => finding.Status is StatusDrifted),
+            Skipped = findings.Count(finding => finding.Status is StatusPacketMissing or StatusPacketUnparseable),
+            Items = applied
+                ? findings.Select(finding => finding.Status == StatusDrifted ? finding with { Status = StatusRepaired } : finding).ToArray()
+                : findings,
+            Summary = BuildSummary(write, applied, findings, executionUnit),
+        };
+
+        Emit(writer, format, result);
+        return namedFailure ? 1 : 0;
+    }
+
+    private static QueueDependencyFinding Inspect(
+        CliContext context,
+        QueueItem item,
+        Dictionary<string, IReadOnlyList<string>> repairs)
+    {
+        var packetPath = Path.Combine(context.RepoRoot, ".intent-cli", "issues", item.ExecutionUnit, "packet.yaml");
+        if (!File.Exists(packetPath))
+        {
+            return new QueueDependencyFinding
+            {
+                ExecutionUnit = item.ExecutionUnit,
+                Status = StatusPacketMissing,
+                QueueDependencies = item.Dependencies,
+                PacketDependencies = Array.Empty<string>(),
+                Detail = $"no packet at `.intent-cli/issues/{item.ExecutionUnit}/packet.yaml`; the queue's dependencies "
+                    + "cannot be checked against a declaration that is not there, so this item is reported and skipped.",
+            };
+        }
+
+        string content;
+        try
+        {
+            content = File.ReadAllText(packetPath);
+        }
+        catch (IOException exception)
+        {
+            return new QueueDependencyFinding
+            {
+                ExecutionUnit = item.ExecutionUnit,
+                Status = StatusPacketUnparseable,
+                QueueDependencies = item.Dependencies,
+                PacketDependencies = Array.Empty<string>(),
+                Detail = $"packet `.intent-cli/issues/{item.ExecutionUnit}/packet.yaml` could not be read: {exception.Message}",
+            };
+        }
+
+        if (!PacketYamlDocument.TryParse(content, out var document, out var parseError))
+        {
+            return new QueueDependencyFinding
+            {
+                ExecutionUnit = item.ExecutionUnit,
+                Status = StatusPacketUnparseable,
+                QueueDependencies = item.Dependencies,
+                PacketDependencies = Array.Empty<string>(),
+                Detail = $"packet `.intent-cli/issues/{item.ExecutionUnit}/packet.yaml` does not parse: {parseError} "
+                    + "Repairing from a partial read would replace one wrong answer with another, so this item is skipped.",
+            };
+        }
+
+        var declared = document!.LookupSequence(
+            "implementation_issue_packet.dependencies",
+            "implementation_issue.dependencies",
+            "dependencies");
+
+        if (declared.SequenceEqual(item.Dependencies, StringComparer.Ordinal))
+        {
+            return new QueueDependencyFinding
+            {
+                ExecutionUnit = item.ExecutionUnit,
+                Status = StatusInSync,
+                QueueDependencies = item.Dependencies,
+                PacketDependencies = declared,
+                Detail = "queue dependencies match the packet declaration.",
+            };
+        }
+
+        repairs[item.ExecutionUnit] = declared;
+        return new QueueDependencyFinding
+        {
+            ExecutionUnit = item.ExecutionUnit,
+            Status = StatusDrifted,
+            QueueDependencies = item.Dependencies,
+            PacketDependencies = declared,
+            Detail = $"packet declares [{string.Join(", ", declared)}]; queue holds [{string.Join(", ", item.Dependencies)}]. "
+                + "`--write` re-derives the queue's dependencies FROM the packet — it never merges the two.",
+        };
+    }
+
+    /// <summary>
+    /// Rewrites ONLY <c>dependencies</c>, on only the drifted items, through
+    /// the guarded persistence path so G548's no-item-loss and stale-base
+    /// re-application invariants hold.
+    /// </summary>
+    private static bool Apply(
+        CliContext context,
+        string queueStatePath,
+        QueueState baseState,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> repairs)
+    {
+        var updated = baseState with
+        {
+            UpdatedAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
+            Items = baseState.Items
+                .Select(item => repairs.TryGetValue(item.ExecutionUnit, out var dependencies)
+                    ? item with { Dependencies = dependencies }
+                    : item)
+                .ToArray(),
+        };
+
+        QueueStatePersistence.Persist(queueStatePath, baseState, updated);
+
+        var runLogPath = context.GetRunLogPath();
+        Directory.CreateDirectory(Path.GetDirectoryName(runLogPath)!);
+        foreach (var (unit, dependencies) in repairs.OrderBy(entry => entry.Key, StringComparer.Ordinal))
+        {
+            File.AppendAllText(
+                runLogPath,
+                RunLogSerializer.SerializeLine(new RunEvent
+                {
+                    Ts = updated.UpdatedAt,
+                    ExecutionUnit = unit,
+                    Event = ReconcileEventName,
+                    By = "intent-cli automation queue-dependency-reconcile",
+                    Reason = $"dependencies re-derived from packet: [{string.Join(", ", dependencies)}]",
+                }) + Environment.NewLine);
+        }
+
+        return true;
+    }
+
+    private static string BuildSummary(
+        bool write,
+        bool applied,
+        IReadOnlyList<QueueDependencyFinding> findings,
+        string? executionUnit)
+    {
+        var scope = executionUnit is null ? "every queue item" : $"`{executionUnit}`";
+        var drifted = findings.Count(finding => finding.Status == StatusDrifted);
+        var skipped = findings.Count(finding => finding.Status is StatusPacketMissing or StatusPacketUnparseable);
+
+        if (drifted == 0 && skipped == 0)
+        {
+            return $"{scope}: dependencies match the packet declarations; nothing to reconcile.";
+        }
+
+        var applyNote = applied
+            ? "Re-derived them from the packets and persisted the queue through the guarded write."
+            : write
+                ? "No write was applied — resolve the skipped item(s) first."
+                : $"Re-run with `--write` to re-derive them from the packets{(executionUnit is null ? string.Empty : $" for `{executionUnit}`")}.";
+
+        return $"{scope}: {drifted} item(s) with dependencies drifted from their packet, {skipped} skipped. {applyNote}";
+    }
+
+    private static void Emit(TextWriter writer, string format, QueueDependencyReconcileResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        writer.WriteLine("# automation queue-dependency-reconcile");
+        writer.WriteLine();
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- applied: {(result.Applied ? "true" : "false")}");
+        writer.WriteLine($"- inspected: {result.Inspected}");
+        writer.WriteLine($"- drifted: {result.Drifted}");
+        writer.WriteLine($"- skipped: {result.Skipped}");
+        writer.WriteLine();
+        foreach (var finding in result.Items.Where(finding => finding.Status != StatusInSync))
+        {
+            writer.WriteLine($"## `{finding.ExecutionUnit}` — {finding.Status}");
+            writer.WriteLine($"- packet: [{string.Join(", ", finding.PacketDependencies)}]");
+            writer.WriteLine($"- queue: [{string.Join(", ", finding.QueueDependencies)}]");
+            writer.WriteLine($"- detail: {finding.Detail}");
+            writer.WriteLine();
+        }
+
+        writer.WriteLine(result.Summary);
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out string? executionUnit,
+        out bool write,
+        out string format,
+        out string error)
+    {
+        executionUnit = null;
+        write = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--execution-unit":
+                case "--unit":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = $"{args[index]} requires a value.";
+                        return false;
+                    }
+                    executionUnit = args[++index].Trim();
+                    break;
+
+                case "--write":
+                    write = true;
+                    break;
+
+                case "--dry-run":
+                    write = false;
+                    break;
+
+                case "--format":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+                    format = args[++index].Trim();
+                    if (!string.Equals(format, FormatJson, StringComparison.Ordinal)
+                        && !string.Equals(format, FormatMarkdown, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{format}').";
+                        return false;
+                    }
+                    break;
+
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+internal sealed record QueueDependencyFinding
+{
+    [JsonPropertyName("execution_unit")]
+    public required string ExecutionUnit { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("packet_dependencies")]
+    public required IReadOnlyList<string> PacketDependencies { get; init; }
+
+    [JsonPropertyName("queue_dependencies")]
+    public required IReadOnlyList<string> QueueDependencies { get; init; }
+
+    [JsonPropertyName("detail")]
+    public required string Detail { get; init; }
+}
+
+internal sealed record QueueDependencyReconcileResult
+{
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public required string? ExecutionUnit { get; init; }
+
+    [JsonPropertyName("inspected")]
+    public required int Inspected { get; init; }
+
+    [JsonPropertyName("drifted")]
+    public required int Drifted { get; init; }
+
+    [JsonPropertyName("skipped")]
+    public required int Skipped { get; init; }
+
+    [JsonPropertyName("items")]
+    public required IReadOnlyList<QueueDependencyFinding> Items { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
@@ -104,7 +104,7 @@ internal static class AutomationQueueSeedFromPacketCommand
         // surface upstream and on a mutation path — where the cost is a
         // malformed unit sitting in the queue and failing later at publish or
         // preflight, far from its cause.
-        if (!TryReadPacketFields(packetDirectoryAbsolute, out var packetFields, out var packetParseError))
+        if (!TryReadPacketDocument(packetDirectoryAbsolute, out var packetDocument, out var packetParseError))
         {
             var unparseable = new QueueSeedFromPacketResult
             {
@@ -121,6 +121,7 @@ internal static class AutomationQueueSeedFromPacketCommand
             return 1;
         }
 
+        var packetFields = packetDocument.Fields;
         var packetDeclaredDomain = LookupScalar(packetFields, "domain");
         var domainResolution = PacketDomainResolution.Resolve(
             domain,
@@ -217,7 +218,7 @@ internal static class AutomationQueueSeedFromPacketCommand
 
         var seed = BuildSeedItem(
             executionUnit,
-            packetFields,
+            packetDocument,
             defaultClarificationReturnPath,
             defaultWorkerRole,
             defaultReviewRole,
@@ -334,14 +335,15 @@ internal static class AutomationQueueSeedFromPacketCommand
     /// </summary>
     internal static QueueItem BuildSeedItem(
         string executionUnit,
-        IReadOnlyDictionary<string, string> packetFields,
+        PacketYamlDocument packet,
         string defaultClarificationReturnPath,
         string defaultWorkerRole,
         string defaultReviewRole,
         string defaultPriority)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(executionUnit);
-        ArgumentNullException.ThrowIfNull(packetFields);
+        ArgumentNullException.ThrowIfNull(packet);
+        var packetFields = packet.Fields;
         ArgumentException.ThrowIfNullOrWhiteSpace(defaultClarificationReturnPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(defaultWorkerRole);
         ArgumentException.ThrowIfNullOrWhiteSpace(defaultReviewRole);
@@ -395,17 +397,22 @@ internal static class AutomationQueueSeedFromPacketCommand
         // blocked_by data when the packet declares them. Previously
         // these fields were hardcoded empty, which silently dropped
         // dependency metadata the operator already authored into
-        // the prepared packet. The G361 scalar parser stores
-        // bracketed inline-list values as raw strings (e.g.
-        // `dependencies: [G1, G2]` ends up keyed by
-        // `dependencies` with value `[G1, G2]`); we expand them
-        // here. Empty arrays remain the safe default when the
-        // packet truly carries no dependencies — never guess.
-        var dependencies = ParsePacketArrayField(packetFields,
+        // the prepared packet.
+        //
+        // G568: both come off the parsed document's structured
+        // sequences, so a FLOW (`[G1, G2]`) and a BLOCK (`- G1`)
+        // declaration seed identically. Until now a flow sequence
+        // survived as bracket text that had to be re-split here, and
+        // a block sequence was dropped entirely — which silently
+        // un-gated dependency-aware selection for exactly the units
+        // that declared their dependencies in the more common style.
+        // Empty stays the safe default when the packet truly carries
+        // none — absence is never guessed into content.
+        var dependencies = packet.LookupSequence(
             "implementation_issue_packet.dependencies",
             "implementation_issue.dependencies",
             "dependencies");
-        var blockedBy = ParsePacketArrayField(packetFields,
+        var blockedBy = packet.LookupSequence(
             "implementation_issue_packet.blocked_by",
             "implementation_issue.blocked_by",
             "blocked_by");
@@ -432,41 +439,6 @@ internal static class AutomationQueueSeedFromPacketCommand
     }
 
     /// <summary>
-    /// PR #830 review repair: parse a packet.yaml field whose value
-    /// is an inline list (<c>[G1, G2]</c>) or a comma-separated
-    /// scalar. The G361 PreparedPacketYamlScalarParser stores
-    /// list-shaped values as the raw bracketed text; this helper
-    /// strips brackets, splits on commas, and trims surrounding
-    /// whitespace / quotes. Returns an empty list when no key
-    /// resolves — packets carrying no dependencies legitimately
-    /// produce queue items with empty arrays (no guessing).
-    /// </summary>
-    internal static IReadOnlyList<string> ParsePacketArrayField(
-        IReadOnlyDictionary<string, string> packetFields,
-        params string[] keys)
-    {
-        var raw = LookupScalar(packetFields, keys);
-        if (string.IsNullOrWhiteSpace(raw))
-        {
-            return Array.Empty<string>();
-        }
-        var trimmed = raw.Trim();
-        if (trimmed.StartsWith('[') && trimmed.EndsWith(']'))
-        {
-            trimmed = trimmed[1..^1];
-        }
-        if (string.IsNullOrWhiteSpace(trimmed))
-        {
-            return Array.Empty<string>();
-        }
-        return trimmed
-            .Split(',', StringSplitOptions.RemoveEmptyEntries)
-            .Select(token => token.Trim().Trim('"', '\''))
-            .Where(token => token.Length > 0)
-            .ToArray();
-    }
-
-    /// <summary>
     /// G567: reads the packet's fields THROUGH a whole-document YAML parse
     /// (<see cref="PacketYamlDocument"/>), the same acceptance G565 gave
     /// projection. Returns <see langword="false"/> with a named error when the
@@ -478,9 +450,9 @@ internal static class AutomationQueueSeedFromPacketCommand
     /// <see cref="PreparedPacketCommitReadyAnalyzer"/> produces its own
     /// missing-file diagnostic downstream, exactly as before.
     /// </summary>
-    private static bool TryReadPacketFields(
+    private static bool TryReadPacketDocument(
         string packetDirectoryAbsolute,
-        out IReadOnlyDictionary<string, string> fields,
+        out PacketYamlDocument document,
         out string error)
     {
         error = string.Empty;
@@ -488,18 +460,18 @@ internal static class AutomationQueueSeedFromPacketCommand
         var content = TryReadFile(packetYamlPath);
         if (string.IsNullOrEmpty(content))
         {
-            fields = new Dictionary<string, string>(StringComparer.Ordinal);
+            document = PacketYamlDocument.Empty;
             return true;
         }
 
-        if (!PacketYamlDocument.TryParse(content!, out var document, out var parseError))
+        if (!PacketYamlDocument.TryParse(content!, out var parsed, out var parseError))
         {
-            fields = new Dictionary<string, string>(StringComparer.Ordinal);
+            document = PacketYamlDocument.Empty;
             error = parseError;
             return false;
         }
 
-        fields = document!.Fields;
+        document = parsed!;
         return true;
     }
 

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -67,6 +67,7 @@ internal static class CommandRouter
         "automation host-sync-preflight",
         "automation intent-target-gap-recovery --repo <r> [--write]",
         "automation issue-publish --issue <n> --write",
+        "automation queue-dependency-reconcile [--execution-unit <u>] [--dry-run|--write]",
         "automation knowledge-writeback-record --execution-unit <u> --commit <host-sha> [--target <path>]... [--dry-run|--write]",
         "automation pr-transition --transition review-start --write",
         "automation pr-transition --transition request-update --write",
@@ -200,6 +201,8 @@ internal static class CommandRouter
                 ["pr-transition"] = AutomationPrTransitionCommand.Execute,
                 ["publish-lifecycle-repair"] = AutomationPublishLifecycleRepairCommand.Execute,
                 ["publish-recovery"] = AutomationPublishRecoveryCommand.Execute,
+                // G568: diagnose/repair packet-vs-queue dependency drift.
+                ["queue-dependency-reconcile"] = AutomationQueueDependencyReconcileCommand.Execute,
                 ["queue-seed-from-packet"] = AutomationQueueSeedFromPacketCommand.Execute,
                 ["reconcile"] = AutomationReconcileCommand.Execute,
                 ["runs-audit"] = AutomationRunsAuditCommand.Execute,

--- a/src/IntentSystem.Cli/Commands/PacketYamlDocument.cs
+++ b/src/IntentSystem.Cli/Commands/PacketYamlDocument.cs
@@ -35,13 +35,59 @@ namespace IntentSystem.Cli.Commands;
 /// </summary>
 internal sealed class PacketYamlDocument
 {
-    private PacketYamlDocument(IReadOnlyDictionary<string, string> fields)
+    private PacketYamlDocument(
+        IReadOnlyDictionary<string, string> fields,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> sequences)
     {
         Fields = fields;
+        Sequences = sequences;
     }
+
+    /// <summary>A packet that is absent or empty: no fields, no sequences.</summary>
+    public static readonly PacketYamlDocument Empty = new(
+        new Dictionary<string, string>(StringComparer.Ordinal),
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal));
 
     /// <summary>Dotted-path scalar map, with bare-key aliases.</summary>
     public IReadOnlyDictionary<string, string> Fields { get; }
+
+    /// <summary>
+    /// G568: dotted-path SEQUENCE map, with bare-key aliases — the same keying
+    /// as <see cref="Fields"/>, and the reason a sequence no longer appears
+    /// there at all.
+    ///
+    /// G567 kept a flow sequence as its bracketed TEXT and a block sequence as
+    /// nothing, faithfully reproducing the reader it replaced. That was correct
+    /// for a slice about where parsing happens, and it left real data loss in
+    /// place: <c>dependencies:</c> written in block style never reached the
+    /// queue at all. A dropped dependency is not cosmetic — dependency-aware
+    /// selection reads the seeded list, so a dependent unit looks publish-ready
+    /// while its root is still open, which is exactly what the ordering
+    /// taxonomy exists to prevent.
+    ///
+    /// Both YAML styles now produce the SAME structured list, so how an author
+    /// happened to write the sequence stops being a semantic difference.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> Sequences { get; }
+
+    /// <summary>
+    /// First non-empty sequence among <paramref name="keys"/>, in caller order.
+    /// Returns an empty list when none resolve — a packet that declares no
+    /// dependencies legitimately produces an empty list, and absence is never
+    /// guessed into content.
+    /// </summary>
+    public IReadOnlyList<string> LookupSequence(params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (Sequences.TryGetValue(key, out var value) && value.Count > 0)
+            {
+                return value;
+            }
+        }
+
+        return Array.Empty<string>();
+    }
 
     /// <summary>
     /// Parses <paramref name="yaml"/> as a whole document. Returns
@@ -85,12 +131,17 @@ internal sealed class PacketYamlDocument
         }
 
         var fields = new Dictionary<string, string>(StringComparer.Ordinal);
-        Flatten(root, prefix: null, fields);
-        document = new PacketYamlDocument(fields);
+        var sequences = new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal);
+        Flatten(root, prefix: null, fields, sequences);
+        document = new PacketYamlDocument(fields, sequences);
         return true;
     }
 
-    private static void Flatten(YamlMappingNode mapping, string? prefix, Dictionary<string, string> fields)
+    private static void Flatten(
+        YamlMappingNode mapping,
+        string? prefix,
+        Dictionary<string, string> fields,
+        Dictionary<string, IReadOnlyList<string>> sequences)
     {
         foreach (var (keyNode, valueNode) in mapping.Children)
         {
@@ -104,20 +155,22 @@ internal sealed class PacketYamlDocument
             switch (valueNode)
             {
                 case YamlMappingNode nested:
-                    Flatten(nested, dottedPath, fields);
+                    Flatten(nested, dottedPath, fields, sequences);
                     break;
 
-                case YamlSequenceNode { Style: YamlDotNet.Core.Events.SequenceStyle.Flow } flow:
-                    Record(fields, dottedPath, key, RenderFlowSequence(flow));
+                // G568: EVERY sequence — flow or block — becomes a structured
+                // list under the same key. Style is a formatting choice, not a
+                // semantic one, so the two must be indistinguishable downstream.
+                case YamlSequenceNode sequence:
+                    RecordSequence(sequences, dottedPath, key, ReadSequence(sequence));
                     break;
 
                 case YamlScalarNode scalar when !string.IsNullOrEmpty(scalar.Value):
                     Record(fields, dottedPath, key, scalar.Value!);
                     break;
 
-                // A block sequence, an empty scalar, or anything else: the
-                // previous reader recorded nothing for these, and neither does
-                // this one.
+                // An empty scalar, or anything else: recorded as nothing, as
+                // the previous reader did.
                 default:
                     break;
             }
@@ -138,6 +191,24 @@ internal sealed class PacketYamlDocument
         }
     }
 
-    private static string RenderFlowSequence(YamlSequenceNode sequence) =>
-        "[" + string.Join(", ", sequence.Children.OfType<YamlScalarNode>().Select(item => item.Value ?? string.Empty)) + "]";
+    /// <summary>Same first-wins alias rule as <see cref="Record"/>.</summary>
+    private static void RecordSequence(
+        Dictionary<string, IReadOnlyList<string>> sequences,
+        string dottedPath,
+        string key,
+        IReadOnlyList<string> value)
+    {
+        sequences[dottedPath] = value;
+        if (!sequences.ContainsKey(key))
+        {
+            sequences[key] = value;
+        }
+    }
+
+    private static IReadOnlyList<string> ReadSequence(YamlSequenceNode sequence) =>
+        sequence.Children
+            .OfType<YamlScalarNode>()
+            .Select(item => (item.Value ?? string.Empty).Trim())
+            .Where(item => item.Length > 0)
+            .ToArray();
 }

--- a/tests/IntentSystem.Cli.Tests/QueueSeedDependenciesG568Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueSeedDependenciesG568Tests.cs
@@ -1,0 +1,477 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G568: queue seeding preserves <c>dependencies</c> faithfully, and already
+/// seeded items can be reconciled.
+///
+/// G567 pinned the loss it inherited: a FLOW sequence survived as bracket text
+/// and a BLOCK sequence was dropped entirely. The severity is not cosmetic —
+/// dependency-aware selection reads the seeded list, so a dropped dependency
+/// makes a dependent unit look publish-ready while its root is still open.
+/// That is precisely the failure the ordering taxonomy exists to prevent,
+/// happening silently at the surface furthest upstream.
+///
+/// So the fixtures below assert the property that matters — how an author
+/// happened to write the sequence is not a semantic difference — and then
+/// follow it through to the selection gate that consumes it.
+/// </summary>
+public sealed class QueueSeedDependenciesG568Tests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly SeedWorkspace workspace = new();
+
+    public QueueSeedDependenciesG568Tests()
+    {
+        AutomationQueueDependencyReconcileCommand.UtcNowFactory = () => FixedNow;
+    }
+
+    public void Dispose()
+    {
+        AutomationQueueDependencyReconcileCommand.UtcNowFactory = null;
+        workspace.Dispose();
+    }
+
+    /// <summary>
+    /// The equivalence classes. Each pair is the SAME declaration written two
+    /// ways; the seeded item must not be able to tell them apart.
+    /// </summary>
+    public static TheoryData<string, string, string[]> EquivalentDeclarations() => new()
+    {
+        { "empty", "  dependencies: []", Array.Empty<string>() },
+        { "single", "  dependencies: [G565]", ["G565"] },
+        { "multiple", "  dependencies: [G565, G566]", ["G565", "G566"] },
+        { "block single", "  dependencies:\n    - G565", ["G565"] },
+        { "block multiple", "  dependencies:\n    - G565\n    - G566", ["G565", "G566"] },
+        { "block at parent indent", "  dependencies:\n  - G565\n  - G566", ["G565", "G566"] },
+        { "quoted block items", "  dependencies:\n    - \"G565\"\n    - 'G566'", ["G565", "G566"] },
+        { "absent key", "  target_part: no dependencies declared", Array.Empty<string>() },
+    };
+
+    [Theory]
+    [MemberData(nameof(EquivalentDeclarations))]
+    public void SeededDependencies_AreTheSameStructuredList_ForEveryDeclarationStyle_G568(
+        string description,
+        string dependenciesYaml,
+        string[] expected)
+    {
+        workspace.WritePacket(SeedWorkspace.BuildPacket(dependenciesYaml));
+
+        var (exitCode, result) = workspace.RunSeed(write: false);
+
+        Assert.Equal(0, exitCode);
+        var seeded = result.GetProperty("seeded_item").GetProperty("dependencies")
+            .EnumerateArray().Select(entry => entry.GetString()).ToArray();
+        Assert.Equal(expected, seeded);
+
+        // And no bracket text anywhere in the seeded state — the representation
+        // is a list, not a string that happens to look like one.
+        Assert.DoesNotContain("[G565", result.GetRawText(), StringComparison.Ordinal);
+        _ = description;
+    }
+
+    [Fact]
+    public void BlockDeclaredDependencies_SurviveTheWritePath_G568()
+    {
+        // Dry-run planning and the persisted item must agree; the queue file is
+        // what selection actually reads.
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies:\n    - G565\n    - G566"));
+
+        var (exitCode, _) = workspace.RunSeed(write: true);
+        Assert.Equal(0, exitCode);
+
+        var state = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        var item = Assert.Single(state.Items);
+        Assert.Equal(["G565", "G566"], item.Dependencies);
+    }
+
+    [Fact]
+    public void BlockDeclaredBlockedBy_IsAlsoPreserved_G568()
+    {
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  blocked_by:\n    - G999"));
+
+        var (exitCode, result) = workspace.RunSeed(write: false);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(
+            ["G999"],
+            result.GetProperty("seeded_item").GetProperty("blocked_by")
+                .EnumerateArray().Select(entry => entry.GetString()).ToArray());
+    }
+
+    // ------------------------------------------------------- selection gating
+
+    [Fact]
+    public void ABlockDeclaredDependency_ActuallyGatesSelection_G568()
+    {
+        // The point of the fix, end to end: seed a unit whose dependency is
+        // declared in block style, and the shared selector must NOT hand it out
+        // while that root is unfinished. Before G568 the dependency never
+        // reached the queue, so this returned the dependent immediately.
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies:\n    - G565"));
+        Assert.Equal(0, workspace.RunSeed(write: true).ExitCode);
+
+        var seeded = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        var withOpenRoot = seeded with
+        {
+            Items = seeded.Items.Append(SeedWorkspace.BuildQueueItem("G565", QueueItemState.Queued)).ToArray(),
+        };
+
+        // Root is queued (not completed) → the dependent is not selectable.
+        var selected = QueueSelection.SelectNext(withOpenRoot);
+        Assert.NotNull(selected);
+        Assert.Equal("G565", selected!.ExecutionUnit);
+
+        // Complete the root → the dependent becomes selectable.
+        var withCompletedRoot = seeded with
+        {
+            Items = seeded.Items.Append(SeedWorkspace.BuildQueueItem("G565", QueueItemState.Completed)).ToArray(),
+        };
+        Assert.Equal(SeedWorkspace.Unit, QueueSelection.SelectNext(withCompletedRoot)!.ExecutionUnit);
+    }
+
+    // ------------------------------------------------------------- reconcile
+
+    [Fact]
+    public void Reconcile_DiagnosesALegacyItemWhoseDependenciesWereDropped_G568()
+    {
+        // The historical shape: the packet declared a block dependency, the
+        // lossy seed recorded none.
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies:\n    - G565"));
+        workspace.WriteQueueStateWithDependencies([]);
+
+        var (exitCode, result) = workspace.RunReconcile(write: false);
+
+        Assert.Equal(0, exitCode);
+        var finding = Assert.Single(result.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationQueueDependencyReconcileCommand.StatusDrifted, finding.GetProperty("status").GetString());
+        Assert.Equal(
+            ["G565"],
+            finding.GetProperty("packet_dependencies").EnumerateArray().Select(e => e.GetString()).ToArray());
+        Assert.Empty(finding.GetProperty("queue_dependencies").EnumerateArray());
+
+        // Read-only really means read-only.
+        Assert.False(result.GetProperty("applied").GetBoolean());
+        var state = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Empty(Assert.Single(state.Items).Dependencies);
+    }
+
+    [Fact]
+    public void Reconcile_Write_RederivesFromThePacket_AndIsIdempotent_G568()
+    {
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies:\n    - G565\n    - G566"));
+        workspace.WriteQueueStateWithDependencies([]);
+
+        var (exitCode, result) = workspace.RunReconcile(write: true);
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("applied").GetBoolean());
+        Assert.Equal(
+            ["G565", "G566"],
+            QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath))
+                .Items.Single().Dependencies);
+
+        // Second run: nothing left to do, and nothing done.
+        var (secondExit, second) = workspace.RunReconcile(write: true);
+        Assert.Equal(0, secondExit);
+        Assert.False(second.GetProperty("applied").GetBoolean());
+        Assert.Equal(0, second.GetProperty("drifted").GetInt32());
+        Assert.Equal(
+            AutomationQueueDependencyReconcileCommand.StatusInSync,
+            Assert.Single(second.GetProperty("items").EnumerateArray()).GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void Reconcile_RederivesRatherThanMerges_G568()
+    {
+        // A queue entry that has dependencies the packet no longer declares is
+        // corrected DOWN. Merging would make the queue a second source of truth
+        // that no packet can ever contradict.
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies:\n    - G565"));
+        workspace.WriteQueueStateWithDependencies(["G001", "G002"]);
+
+        Assert.Equal(0, workspace.RunReconcile(write: true).ExitCode);
+
+        Assert.Equal(
+            ["G565"],
+            QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath))
+                .Items.Single().Dependencies);
+    }
+
+    [Fact]
+    public void Reconcile_TouchesOnlyTheDependenciesField_G568()
+    {
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies:\n    - G565"));
+        workspace.WriteQueueStateWithDependencies([]);
+        var before = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath)).Items.Single();
+
+        Assert.Equal(0, workspace.RunReconcile(write: true).ExitCode);
+
+        var after = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath)).Items.Single();
+        Assert.Equal(["G565"], after.Dependencies);
+
+        // Everything else is unchanged: the repair is not a re-seed. Compared
+        // field by field rather than with record equality, because QueueItem's
+        // list members compare by reference and a JSON round-trip always yields
+        // fresh instances — record equality would pass or fail for reasons that
+        // have nothing to do with what this test is asserting.
+        Assert.Equal(before.ExecutionUnit, after.ExecutionUnit);
+        Assert.Equal(before.Title, after.Title);
+        Assert.Equal(before.State, after.State);
+        Assert.Equal(before.BlockedBy, after.BlockedBy);
+        Assert.Equal(before.ClarificationReturnPath, after.ClarificationReturnPath);
+        Assert.Equal(before.PacketPaths, after.PacketPaths);
+        Assert.Equal(before.LinkedIssue, after.LinkedIssue);
+        Assert.Equal(before.LinkedPr, after.LinkedPr);
+        Assert.Equal(before.WorkerRole, after.WorkerRole);
+        Assert.Equal(before.ReviewRole, after.ReviewRole);
+        Assert.Equal(before.Priority, after.Priority);
+        Assert.Equal(before.RetirementReason, after.RetirementReason);
+        Assert.Equal(before.PriorityRevision, after.PriorityRevision);
+    }
+
+    [Fact]
+    public void Reconcile_PreservesUnrelatedItems_G548_G568()
+    {
+        // G548's no-item-loss invariant: a targeted repair must not drop the
+        // rest of the queue.
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies:\n    - G565"));
+        workspace.WriteQueueStateWithDependencies([], extraUnits: ["G900", "G901"]);
+
+        Assert.Equal(0, workspace.RunReconcile(write: true).ExitCode);
+
+        var state = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal(3, state.Items.Count);
+        Assert.Contains(state.Items, item => item.ExecutionUnit == "G900");
+        Assert.Contains(state.Items, item => item.ExecutionUnit == "G901");
+    }
+
+    [Fact]
+    public void Reconcile_FailsClosedOnAnUnknownUnit_G568()
+    {
+        workspace.WriteQueueStateWithDependencies([]);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationQueueDependencyReconcileCommand.Execute(
+            workspace.Context, ["--execution-unit", "G999", "--write"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("is not in queue-state", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Reconcile_FailsClosedOnAnUnparseablePacket_AndWritesNothing_G568()
+    {
+        // "I cannot read the declaration" must never become "the declaration is
+        // empty" — that would repair a dropped dependency into a confirmed
+        // absence.
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies: [G565, G566"));
+        workspace.WriteQueueStateWithDependencies([]);
+        var before = File.ReadAllBytes(workspace.QueueStatePath);
+
+        var (exitCode, result) = workspace.RunReconcile(write: true, unit: SeedWorkspace.Unit);
+
+        Assert.Equal(1, exitCode);
+        Assert.False(result.GetProperty("applied").GetBoolean());
+        Assert.Equal(
+            AutomationQueueDependencyReconcileCommand.StatusPacketUnparseable,
+            Assert.Single(result.GetProperty("items").EnumerateArray()).GetProperty("status").GetString());
+        Assert.Equal(before, File.ReadAllBytes(workspace.QueueStatePath));
+    }
+
+    [Fact]
+    public void Reconcile_SkipsAnItemWithNoPacket_WithoutFailingASweep_G568()
+    {
+        // A sweep across the whole queue meets items whose packet is not in
+        // this checkout. That is a skip with a reason, not a failure — but it
+        // is never silent.
+        workspace.WriteQueueStateWithDependencies([], extraUnits: ["G900"]);
+
+        var (exitCode, result) = workspace.RunReconcile(write: false);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(2, result.GetProperty("skipped").GetInt32());
+        Assert.All(
+            result.GetProperty("items").EnumerateArray(),
+            finding => Assert.Equal(
+                AutomationQueueDependencyReconcileCommand.StatusPacketMissing,
+                finding.GetProperty("status").GetString()));
+    }
+
+    [Fact]
+    public void Reconcile_RecordsAnAuditEventForEachRepair_G568()
+    {
+        workspace.WritePacket(SeedWorkspace.BuildPacket("  dependencies:\n    - G565"));
+        workspace.WriteQueueStateWithDependencies([]);
+
+        Assert.Equal(0, workspace.RunReconcile(write: true).ExitCode);
+
+        var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsPath));
+        var reconciled = Assert.Single(events.Where(e =>
+            e.Event == AutomationQueueDependencyReconcileCommand.ReconcileEventName));
+        Assert.Equal(SeedWorkspace.Unit, reconciled.ExecutionUnit);
+        Assert.Contains("G565", reconciled.Reason!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CommandRouter_DispatchesTheReconcileCommand_G568()
+    {
+        var router = typeof(CommandRouter);
+        var commandsField = router.GetField("ImplementedCommands",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var outer = (System.Collections.IDictionary)commandsField!.GetValue(null)!;
+        var automation = (System.Collections.IDictionary)outer["automation"]!;
+        Assert.True(automation.Contains("queue-dependency-reconcile"));
+
+        var helpField = router.GetField("AutomationCommandHelp",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        var lines = (IReadOnlyList<string>?)helpField!.GetValue(null);
+        Assert.Contains(lines!, line => line.Contains("queue-dependency-reconcile", StringComparison.Ordinal));
+    }
+
+    private sealed class SeedWorkspace : IDisposable
+    {
+        public const string Unit = "G568";
+        public const string Domain = "intent-cli";
+        public const string TargetRepo = "J-Tech-Japan/intent-system";
+
+        public SeedWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("queue-seed-dependencies-g568-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = Domain,
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+
+            var bindings = Path.Combine(RootPath, "intents", Domain, "automation");
+            Directory.CreateDirectory(bindings);
+            File.WriteAllText(Path.Combine(bindings, "bindings.md"), "---\nexecution_unit_regex: '^G[0-9]+$'\n---\n");
+        }
+
+        public string RootPath { get; }
+
+        public CliContext Context { get; }
+
+        public string QueueStatePath => Context.GetQueueStatePath();
+
+        public string RunsPath => Context.GetRunLogPath();
+
+        public void WritePacket(string yaml)
+        {
+            var directory = Path.Combine(RootPath, ".intent-cli", "issues", Unit);
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, "packet.yaml"), yaml);
+            File.WriteAllText(Path.Combine(directory, "implementation.md"), "# impl\n");
+            File.WriteAllText(Path.Combine(directory, "review-context.md"), "# review\n");
+            File.WriteAllText(Path.Combine(directory, "github-body.md"),
+                "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n"
+                + "## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n"
+                + "## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+        }
+
+        public void WriteQueueStateWithDependencies(string[] dependencies, string[]? extraUnits = null)
+        {
+            var items = new List<QueueItem> { BuildQueueItem(Unit, QueueItemState.Queued, dependencies) };
+            foreach (var extra in extraUnits ?? Array.Empty<string>())
+            {
+                items.Add(BuildQueueItem(extra, QueueItemState.Queued));
+            }
+
+            File.WriteAllText(QueueStatePath, QueueStateSerializer.Serialize(new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero),
+                Items = items,
+            }));
+        }
+
+        public static QueueItem BuildQueueItem(
+            string executionUnit,
+            QueueItemState state,
+            string[]? dependencies = null) => new()
+            {
+                ExecutionUnit = executionUnit,
+                Title = $"[{executionUnit}] fixture",
+                State = state,
+                Dependencies = dependencies ?? Array.Empty<string>(),
+                BlockedBy = Array.Empty<string>(),
+                ClarificationReturnPath = $"intents/{Domain}/clarifications/open.md",
+                PacketPaths = new PacketPaths
+                {
+                    Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+                    ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+                    Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                },
+                WorkerRole = "coder",
+                ReviewRole = "reviewer",
+                Priority = "high",
+            };
+
+        public (int ExitCode, JsonElement Result) RunSeed(bool write)
+        {
+            using var writer = new StringWriter();
+            var args = new List<string>
+            {
+                "--execution-unit", Unit, "--domain", Domain, "--target-repo", TargetRepo, "--format", "json",
+            };
+            if (write)
+            {
+                args.Add("--write");
+            }
+
+            var exitCode = AutomationQueueSeedFromPacketCommand.Execute(Context, args.ToArray(), writer);
+            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+        }
+
+        public (int ExitCode, JsonElement Result) RunReconcile(bool write, string? unit = null)
+        {
+            using var writer = new StringWriter();
+            var args = new List<string> { "--format", "json" };
+            if (unit is not null)
+            {
+                args.AddRange(["--execution-unit", unit]);
+            }
+            if (write)
+            {
+                args.Add("--write");
+            }
+
+            var exitCode = AutomationQueueDependencyReconcileCommand.Execute(Context, args.ToArray(), writer);
+            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+        }
+
+        public static string BuildPacket(string listYaml) => $"""
+            domain: {Domain}
+            implementation_issue_packet:
+              source_execution_unit: {Unit}
+              issue_title: "Dependency fixture"
+              target_repo: {TargetRepo}
+            {listYaml}
+            """;
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/QueueSeedPacketParsingG567Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueSeedPacketParsingG567Tests.cs
@@ -166,16 +166,22 @@ public sealed class QueueSeedPacketParsingG567Tests : IDisposable
         Assert.Equal("titled", fields["implementation_issue_packet.issue_title"]);
         // Bare-key alias, exactly as the previous reader produced.
         Assert.Equal("titled", fields["issue_title"]);
-        Assert.Equal("[A, B]", fields["implementation_issue_packet.dependencies"]);
 
-        // Deliberately unchanged from the previous reader: a BLOCK sequence and
-        // a valueless key record nothing. The block-sequence case is a
-        // pre-existing data-loss bug (block-style `dependencies` never reach the
-        // seed); this unit moves WHERE parsing happens, not what a packet means,
-        // so it is pinned as-is and listed for follow-up rather than changed in
-        // passing.
-        Assert.False(fields.ContainsKey("implementation_issue_packet.blocked_by"));
+        // G568 MOVED this pin rather than deleting it. G567 pinned the lossy
+        // behaviour it faithfully preserved: a FLOW sequence survived as the
+        // bracket TEXT `"[A, B]"` in Fields, and a BLOCK sequence recorded
+        // nothing at all. The follow-up this pin was flagging is now done, so it
+        // pins the faithful behaviour instead — sequences are structured, both
+        // styles are indistinguishable, and no bracket text remains.
+        Assert.False(fields.ContainsKey("implementation_issue_packet.dependencies"));
+        Assert.Equal(["A", "B"], document.Sequences["implementation_issue_packet.dependencies"]);
+        Assert.Equal(["C"], document.Sequences["implementation_issue_packet.blocked_by"]);
+        Assert.Equal(["A", "B"], document.LookupSequence("implementation_issue_packet.dependencies"));
+
+        // A valueless key still records nothing — unchanged, and still correct:
+        // an absent value is not an empty list, it is an absent declaration.
         Assert.False(fields.ContainsKey("implementation_issue_packet.empty_value"));
+        Assert.False(document.Sequences.ContainsKey("implementation_issue_packet.empty_value"));
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1239

Fixes the data loss G567 pinned and flagged.

## The defect, and why it is not cosmetic

The seed path kept a **flow** sequence only as raw bracket text and recorded **nothing** for a **block** sequence — so `dependencies:` written in the more common style never reached the queue.

Dependency-aware selection reads exactly that seeded list. A dropped dependency therefore makes a dependent unit look publish-ready while its root is still open: the failure the ordering taxonomy exists to prevent, happening silently at the surface furthest upstream.

## Faithful persistence

- **`PacketYamlDocument` gains a structured `Sequences` map** (dotted path + the same first-wins bare-key alias as `Fields`). **Every** sequence lands there, flow or block, so how an author happened to write it stops being a semantic difference.
- **Sequences no longer appear in `Fields` at all.** No bracket text remains in seeded state, and `ParsePacketArrayField` — which existed only to re-split that text — is deleted.
- `queue-seed-from-packet` reads `dependencies` / `blocked_by` from those sequences.

Eight declaration styles must produce the same list:

| | seeded |
| --- | --- |
| `[]` / absent key | `[]` |
| `[G565]` / block single | `["G565"]` |
| `[G565, G566]` / block multiple / block at parent indent / quoted block items | `["G565", "G566"]` |

## The gate it actually restores

`ABlockDeclaredDependency_ActuallyGatesSelection_G568` drives it end to end through the **shared** selector: seed a block-declared dependency, and the dependent is withheld while its root is queued — then becomes selectable the moment the root completes. Before this PR the dependency never reached the queue, so the dependent came back immediately.

## Reconcile surface for already-seeded items

Items already in the queue were seeded by the lossy path, and hand-editing `queue-state.json` is forbidden (G548). So:

```bash
intent-cli automation queue-dependency-reconcile                        # diagnose everything, read-only
intent-cli automation queue-dependency-reconcile --execution-unit G540  # diagnose one
intent-cli automation queue-dependency-reconcile --write                # repair
```

- **Re-derives, never merges.** A merge would make the queue a second source of truth that no packet could contradict; the packet is authoritative, so a queue entry carrying dependencies the packet no longer declares is corrected *down*.
- **Idempotent** — a second run reports `in-sync` and applies nothing.
- **Touches only `dependencies`** (asserted field by field against the whole item).
- **G548-safe** — persists through `QueueStatePersistence.Persist`; unrelated items survive.
- **Audit trail** — one `queue_dependencies_reconciled` run event per repair, naming the re-derived list.
- **Fail-closed where it matters**: an unknown unit exits non-zero; a missing or unparseable packet is reported and **skipped**, never repaired from a partial read. *"I cannot read the declaration"* must not become *"the declaration is empty"* — that would repair a dropped dependency into a confirmed absence. A named unit in that state exits non-zero **without writing**.
- **Never auto-run.** The operator or orchestrator invokes it.

## G567 pins moved, not deleted

`PacketYamlDocument_FlattensDottedPathsWithBareKeyAliases_G567` pinned the lossy shape G567 faithfully preserved. It now pins the faithful shape, with the history in the comment — so the fixed behaviour stays documented at the point it was fixed rather than quietly disappearing.

## Verification

- `dotnet test IntentSystem.sln` — **4078 passed, 0 failed, 1 skipped** (all other projects green).
- Full suite re-run with a `gh` shim exiting 1 and `GH_TOKEN`/`GITHUB_TOKEN=invalid` — same result.
- `git diff --check` clean.
- **Regression-proof**: with block sequences dropped again (the pre-fix behaviour), **12 of the new fixtures fail** — every block style, the write path, the selection gate, and all four reconcile behaviours. Reverted byte-for-byte, suite re-run green.

No dependency-semantics or selection-algorithm changes, no auto-run of the repair, no other queue fields touched, no guide/docs content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
