### PR TITLE
G569: Remove the TimestampFactory test race — no process-global mutable statics across parallel test classes

### DIFF
--- a/src/IntentSystem.Cli/Commands/IssuePrepareCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePrepareCommand.cs
@@ -21,13 +21,42 @@ internal static class IssuePrepareCommand
         DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.Never
     };
 
-    public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
+    /// <summary>
+    /// G569: the router entry point. Supplies the real clock; every caller that
+    /// needs a different one passes it explicitly to <see cref="Execute(CliContext, string[], TextWriter, Func{DateTimeOffset})"/>
+    /// rather than reaching into shared state.
+    ///
+    /// This replaced a <c>public static Func&lt;DateTimeOffset&gt;
+    /// TimestampFactory { get; set; }</c>. That property was process-global and
+    /// mutable, and TWO test classes assigned it while sharing no
+    /// non-parallel xUnit collection — so xUnit's default parallelism could
+    /// interleave their assignments and one test would read the other's clock.
+    /// It did: one full-suite run went red on 2026-08-01 with two clean reruns
+    /// and an isolated pass, the signature of an interleaving race rather than
+    /// a flaky assertion.
+    ///
+    /// Random red on unrelated PRs is the most corrosive CI failure class —
+    /// it teaches operators to rerun instead of read, and it degrades the
+    /// exact-head "CI SUCCESS" evidence the review and merge gates treat as
+    /// canonical. A parameter cannot be raced: there is no shared cell left to
+    /// interleave, so the fix is structural rather than a scheduling
+    /// constraint that a future test class can forget to join.
+    /// </summary>
+    public static int Execute(CliContext context, string[] args, TextWriter writer) =>
+        Execute(context, args, writer, static () => DateTimeOffset.UtcNow);
 
-    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    /// <summary>
+    /// G569: <paramref name="utcNow"/> is the only time source. Runtime
+    /// behaviour is unchanged — the router's overload passes
+    /// <see cref="DateTimeOffset.UtcNow"/>, exactly what the removed static
+    /// defaulted to.
+    /// </summary>
+    public static int Execute(CliContext context, string[] args, TextWriter writer, Func<DateTimeOffset> utcNow)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(utcNow);
 
         if (!TryParseArguments(args, out var fromFile, out var executionUnit, out var title, out var outPath, out var error))
         {
@@ -76,7 +105,7 @@ internal static class IssuePrepareCommand
             Published = false,
             IssueNumber = null,
             IssueUrl = null,
-            PreparedAtUtc = FormatUtcTimestamp(TimestampFactory()),
+            PreparedAtUtc = FormatUtcTimestamp(utcNow()),
             PublishedAtUtc = null
         };
 

--- a/src/IntentSystem.Cli/Commands/TaskingPublishReviewedBridgeCommand.cs
+++ b/src/IntentSystem.Cli/Commands/TaskingPublishReviewedBridgeCommand.cs
@@ -50,10 +50,18 @@ internal static class TaskingPublishReviewedBridgeCommand
     };
 
     /// <summary>
-    /// Test seam mirroring the timestamp pattern used by
-    /// <see cref="IssuePrepareCommand.TimestampFactory"/>. Defaults to
+    /// Test seam for the prepared-at timestamp. Defaults to
     /// <see cref="DateTimeOffset.UtcNow"/>; tests can pin a deterministic
     /// timestamp for round-trip and stability assertions.
+    ///
+    /// G569 review repair: this used to describe itself as mirroring
+    /// <c>IssuePrepareCommand.TimestampFactory</c>, which no longer exists —
+    /// that command now takes its clock per call
+    /// (<see cref="IssuePrepareCommand.Execute(CliContext, string[], TextWriter, Func{DateTimeOffset})"/>)
+    /// because a process-global mutable clock raced across parallel test
+    /// classes. This one is assigned by a single test class today, so it is not
+    /// that race; the per-call seam above is simply the shape that cannot
+    /// become one.
     /// </summary>
     public static Func<DateTimeOffset> TimestampFactory { get; set; } = () => DateTimeOffset.UtcNow;
 

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
@@ -17,6 +17,10 @@ namespace IntentSystem.Cli.Tests;
 /// prefix alone must never create/mutate a queue entry), and a fail-closed
 /// refusal for already-Completed work.
 /// </summary>
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection("WorkerNextActionSharedState")]
 public sealed class AutomationIssueRetireCommandTests : IDisposable
 {
     private static readonly DateTimeOffset FixedNow = new(2026, 7, 14, 16, 0, 0, TimeSpan.Zero);

--- a/tests/IntentSystem.Cli.Tests/BugImplementationIssueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/BugImplementationIssueCommandTests.cs
@@ -4,6 +4,10 @@ using IntentSystem.Supervisor.Models;
 
 namespace IntentSystem.Cli.Tests;
 
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class BugImplementationIssueCommandTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IssueCreateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueCreateCommandTests.cs
@@ -5,6 +5,10 @@ using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class IssueCreateCommandTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IssueDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueDraftCommandTests.cs
@@ -4,6 +4,10 @@ using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class IssueDraftCommandTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IssuePrepareCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePrepareCommandTests.cs
@@ -5,19 +5,16 @@ using IntentSystem.Cli.Models;
 
 namespace IntentSystem.Cli.Tests;
 
-public sealed class IssuePrepareCommandTests : IDisposable
+/// <summary>
+/// G569: this class no longer saves and restores a process-global clock. It
+/// passes one to the call it is testing, so nothing it does is observable by
+/// another test class — and it needs no <c>IDisposable</c> to stay that way.
+/// </summary>
+public sealed class IssuePrepareCommandTests
 {
-    private readonly Func<DateTimeOffset> originalTimestampFactory;
-
-    public IssuePrepareCommandTests()
-    {
-        originalTimestampFactory = IssuePrepareCommand.TimestampFactory;
-    }
-
-    public void Dispose()
-    {
-        IssuePrepareCommand.TimestampFactory = originalTimestampFactory;
-    }
+    /// <summary>The clock these fixtures pin their expected timestamps to.</summary>
+    private static Func<DateTimeOffset> ClockAt(int hour, int minute, int second) =>
+        () => new DateTimeOffset(2026, 4, 28, hour, minute, second, TimeSpan.Zero);
 
     [Fact]
     public void Execute_GivenValidBody_WritesReviewedPacketAndReturnsZero()
@@ -26,13 +23,12 @@ public sealed class IssuePrepareCommandTests : IDisposable
         workspace.WriteFile("body.md", CompleteValidBody);
         var bodyPath = workspace.GetPath("body.md");
         var outPath = workspace.GetPath("packet.json");
-        IssuePrepareCommand.TimestampFactory = () => new DateTimeOffset(2026, 4, 28, 12, 34, 56, TimeSpan.Zero);
-
         using var writer = new StringWriter();
         var exitCode = IssuePrepareCommand.Execute(
             workspace.Context,
             ["--from-file", bodyPath, "--execution-unit", "G184", "--title", "G184 sample title", "--out", outPath],
-            writer);
+            writer,
+            ClockAt(12, 34, 56));
 
         Assert.Equal(0, exitCode);
         Assert.True(File.Exists(outPath));
@@ -117,13 +113,12 @@ public sealed class IssuePrepareCommandTests : IDisposable
         using var workspace = new IssuePrepareWorkspace();
         workspace.WriteFile("body.md", CompleteValidBody);
         var outPath = workspace.GetPath("packet.json");
-        IssuePrepareCommand.TimestampFactory = () => new DateTimeOffset(2026, 4, 28, 9, 0, 0, TimeSpan.Zero);
-
         using var writer = new StringWriter();
         var exitCode = IssuePrepareCommand.Execute(
             workspace.Context,
             ["--from-file", workspace.GetPath("body.md"), "--execution-unit", "G184", "--title", "G184 RT", "--out", outPath],
-            writer);
+            writer,
+            ClockAt(9, 0, 0));
 
         Assert.Equal(0, exitCode);
 
@@ -205,6 +200,53 @@ public sealed class IssuePrepareCommandTests : IDisposable
         Expected PR base branch: `main`
         Open all child PRs against `main` directly.
         """;
+
+    /// <summary>
+    /// G569: the direct proof. Many callers run <c>issue prepare</c>
+    /// CONCURRENTLY with DIFFERENT clocks, and every one must observe its own —
+    /// which is possible only because there is no shared cell left to observe.
+    ///
+    /// Against the removed static this fails deterministically rather than
+    /// occasionally: the last writer wins, so the recorded timestamps collapse
+    /// onto whichever clock was assigned last. That is the same interleaving
+    /// that turned one full-suite run red on 2026-08-01, reproduced on demand
+    /// instead of waited for.
+    /// </summary>
+    [Fact]
+    public void Execute_ConcurrentCallsWithDifferentClocks_EachObservesItsOwn_G569()
+    {
+        const int Callers = 32;
+        using var workspace = new IssuePrepareWorkspace();
+        workspace.WriteFile("body.md", CompleteValidBody);
+        var bodyPath = workspace.GetPath("body.md");
+
+        var recorded = new string?[Callers];
+        Parallel.For(0, Callers, index =>
+        {
+            var outPath = workspace.GetPath($"packet-{index}.json");
+            using var writer = new StringWriter();
+            var exitCode = IssuePrepareCommand.Execute(
+                workspace.Context,
+                ["--from-file", bodyPath, "--execution-unit", $"G{index}", "--title", $"title {index}", "--out", outPath],
+                writer,
+                // A distinct second per caller: any leakage between callers
+                // shows up as a duplicated or wrong timestamp.
+                () => new DateTimeOffset(2026, 4, 28, 0, 0, index, TimeSpan.Zero));
+
+            Assert.Equal(0, exitCode);
+            using var document = JsonDocument.Parse(File.ReadAllText(outPath));
+            recorded[index] = document.RootElement.GetProperty("prepared_at_utc").GetString();
+        });
+
+        for (var index = 0; index < Callers; index++)
+        {
+            Assert.Equal($"2026-04-28T00:00:{index:D2}.000Z", recorded[index]);
+        }
+
+        // And no two callers share a timestamp — the assertion above already
+        // implies it, but stating it separately is what a leak would trip first.
+        Assert.Equal(Callers, recorded.Distinct(StringComparer.Ordinal).Count());
+    }
 
     internal sealed class IssuePrepareWorkspace : IDisposable
     {

--- a/tests/IntentSystem.Cli.Tests/IssuePublishCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishCommandTests.cs
@@ -5,6 +5,10 @@ using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class IssuePublishCommandTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IssuePublishReviewedCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssuePublishReviewedCommandTests.cs
@@ -10,20 +10,17 @@ public sealed class IssuePublishReviewedCommandTests : IDisposable
 {
     private readonly Func<IGhIssueCreator> originalCreatorFactory;
     private readonly Func<DateTimeOffset> originalTimestampFactory;
-    private readonly Func<DateTimeOffset> originalPrepareTimestampFactory;
 
     public IssuePublishReviewedCommandTests()
     {
         originalCreatorFactory = IssuePublishReviewedCommand.GhIssueCreatorFactory;
         originalTimestampFactory = IssuePublishReviewedCommand.TimestampFactory;
-        originalPrepareTimestampFactory = IssuePrepareCommand.TimestampFactory;
     }
 
     public void Dispose()
     {
         IssuePublishReviewedCommand.GhIssueCreatorFactory = originalCreatorFactory;
         IssuePublishReviewedCommand.TimestampFactory = originalTimestampFactory;
-        IssuePrepareCommand.TimestampFactory = originalPrepareTimestampFactory;
     }
 
     [Fact]
@@ -304,14 +301,15 @@ public sealed class IssuePublishReviewedCommandTests : IDisposable
             File.WriteAllText(bodyPath, IssuePrepareCommandTests.CompleteValidBody);
             var packetPath = GetPath("packet.json");
 
-            IssuePrepareCommand.TimestampFactory =
-                () => new DateTimeOffset(2026, 4, 28, 12, 0, 0, TimeSpan.Zero);
-
+            // G569: the prepare clock is an argument now, so this helper no
+            // longer reaches into a static that IssuePrepareCommandTests also
+            // writes — the two classes ran in parallel and reset each other.
             using var writer = new StringWriter();
             var exit = IssuePrepareCommand.Execute(
                 Context,
                 ["--from-file", bodyPath, "--execution-unit", "G184", "--title", "G184 sample title", "--out", packetPath],
-                writer);
+                writer,
+                static () => new DateTimeOffset(2026, 4, 28, 12, 0, 0, TimeSpan.Zero));
             if (exit != 0)
             {
                 throw new InvalidOperationException(

--- a/tests/IntentSystem.Cli.Tests/IssueStatusCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueStatusCommandTests.cs
@@ -4,6 +4,10 @@ using IntentSystem.Supervisor.Models;
 
 namespace IntentSystem.Cli.Tests;
 
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class IssueStatusCommandTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueDispatchCommandTests.cs
@@ -5,6 +5,10 @@ using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class QueueDispatchCommandTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/QueueEnqueueCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueEnqueueCommandTests.cs
@@ -5,6 +5,10 @@ using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Tests;
 
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class QueueEnqueueCommandTests
 {
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/TaskingHandoffCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingHandoffCommandTests.cs
@@ -11,6 +11,10 @@ namespace IntentSystem.Cli.Tests;
 /// <c>Tasking</c> and <c>Handoff</c> so reviewers can match the issue's
 /// recommended <c>~Tasking|~Handoff</c> filter.
 /// </summary>
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class TaskingHandoffCommandTests : IDisposable
 {
     private readonly Func<DateTimeOffset> originalTimestampFactory;

--- a/tests/IntentSystem.Cli.Tests/TaskingTaskPacketCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/TaskingTaskPacketCommandTests.cs
@@ -12,6 +12,10 @@ namespace IntentSystem.Cli.Tests;
 /// contains <c>Tasking</c> and <c>TaskPacket</c> so reviewers can match the
 /// issue's recommended <c>~Tasking|~Handoff|~TaskPacket</c> filter.
 /// </summary>
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection(RunSubmitCommandCollection.Name)]
 public sealed class TaskingTaskPacketCommandTests : IDisposable
 {
     private readonly Func<DateTimeOffset> originalTimestampFactory;

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -15,6 +15,10 @@ namespace IntentSystem.Cli.Tests;
 /// the issue" defensive guard, the dry-run vs write split, and the
 /// no-mutation invariants.
 /// </summary>
+// G569 audit: joins the non-parallel collection that already owns the
+// process-global statics this class assigns, so it can no longer interleave
+// with the other class that assigns them.
+[Collection("WorkerNextActionSharedState")]
 public sealed class WorkerCompleteCommandTests : IDisposable
 {
     public WorkerCompleteCommandTests()


### PR DESCRIPTION
Closes #1241

## Chosen shape and rationale

**Removed the mutable static** (the packet's preferred option) rather than serializing its mutators.

`IssuePrepareCommand.TimestampFactory` is gone. The clock is a parameter on an `Execute` overload; the router overload passes `DateTimeOffset.UtcNow` — exactly what the static defaulted to — so **runtime behaviour is byte-for-byte unchanged**.

Why this shape over a shared non-parallel collection:

- **A parameter cannot be raced.** There is no shared cell left to interleave, so the race is structurally impossible rather than merely scheduled away.
- **A collection is a constraint a future class can forget.** The next test class that assigns the static would silently reintroduce the race; removing the static means there is nothing to assign.
- **The compiler enumerated the mutators for me.** Deleting the property turned "which classes touch this?" from a question into a build error list — which is how the second class was confirmed rather than remembered.

## Stress verification

A single green run is not evidence, so three kinds:

| Method | Result |
| --- | --- |
| New fixture: 32 concurrent `Execute` calls with 32 distinct clocks, each must observe its own | pass |
| **The same fixture against the old shape** (clock routed through a process-global cell, reproducing the removed static's sharing semantics) | **fails deterministically** |
| Previously-racing classes (`IssuePrepareCommandTests` + `IssuePublishReviewedCommandTests`), 20 consecutive runs | 0 failures |
| Full suite, 5 consecutive runs | 0 failures |

The second row is the important one: the race is now reproducible **on demand** instead of waited for, so this is a proof rather than an absence of evidence.

## Suite audit

**Criterion (corrected in review).** The first version of this audit called a static "unguarded" when its mutators sat in two *different* non-parallel collections. That was wrong: under xUnit 2.9.3 a collection with `DisableParallelization = true` runs serially and **never concurrently with any other collection**, so mutators spread across two disabled collections cannot interleave. All three collections in this suite — `RunSubmitCommandCollection`, `AutomationStalledWorkSharedStateCollection`, `WorkerNextActionSharedState` — declare it.

The criterion actually used is therefore:

> A static assigned by two or more test classes is a **current race** iff at least one assigning class is *parallelizable* — i.e. it has no `[Collection]` at all (xUnit gives it its own parallelizable collection), or its collection does not disable parallelization.

Nested helper types (`FakeMutator`, `FailingPrMutator`) resolve to their outer test class; those are same-class assignments, not multi-class ones.

**Races found and fixed.** `IssuePrepareCommand.TimestampFactory` (both mutators had no collection — the reported failure), plus 11 classes with no collection assigning statics that a `RunSubmitCommandCollection` / `WorkerNextActionSharedState` class also assigns:

| Collection joined | Classes | Statics thereby guarded |
| --- | --- | --- |
| `RunSubmitCommandCollection` | `IssueCreateCommandTests`, `IssueDraftCommandTests`, `IssuePublishCommandTests`, `IssueStatusCommandTests`, `QueueDispatchCommandTests`, `QueueEnqueueCommandTests`, `BugImplementationIssueCommandTests`, `TaskingHandoffCommandTests`, `TaskingTaskPacketCommandTests` | `IssueCreateCommand.{GitCommandRunner,Publisher,Timestamp}Factory`, `IssueDraftCommand.TimestampFactory`, `IssuePublishCommand.{GitCommandRunner,Publisher,Timestamp}Factory`, `IssueStatusCommand.{GitCommandRunner,Publisher}Factory`, `QueueDispatchCommand.{GitCommandRunner,Publisher,Timestamp}Factory`, `QueueEnqueueCommand.TimestampFactory`, `BugImplementationIssueCommand.{GitCommandRunner,Publisher}Factory`, `TaskingHandoffCommand.TimestampFactory` |
| `WorkerNextActionSharedState` | `AutomationIssueRetireCommandTests`, `WorkerCompleteCommandTests` | `AutomationHostReviewPreflightCommand.CandidateListerFactory`, `WorkerCompleteCommand.MutatorFactory` |

**Already guarded — dispositioned, not merely omitted.** Every other multi-class-mutated static has all its mutators inside a disabled collection, so none is a current race:

| Static | Mutating classes (all in disabled collections) |
| --- | --- |
| `AutomationStalledWorkCommand.CandidateListerFactory` | `AutomationHeartbeatCommandTests`, `AutomationStalledWorkCommandTests`, `ClarifyOpenScaffoldedPacketDetectionTests`, `KnowledgeWriteBackG564Tests` — all `AutomationStalledWorkSharedStateCollection` |
| `AutomationStalledWorkCommand.UtcNowFactory` | same four classes, same collection |
| `ClarifyOpenCommand.TimestampFactory` | `AutomationStalledWorkCommandTests` (`AutomationStalledWorkSharedState`); `ClarifyOpenCommandTests`, `ClarifyOpenScaffoldedPacketTests`, `CommandRouterTests` (`RunSubmitCommand`) — **two different disabled collections, which do not overlap, so this is NOT a current race** |
| `AutomationHostReviewDiagnosticsCommand.{CandidateLister,NextSliceDryRunProbe,PublishRecoveryProbe}Factory` | `AutomationCloseoutDriftCheckCommandTests`, `AutomationHostReviewDiagnosticsCommandTests` — `WorkerNextActionSharedState` |
| `AutomationIssueBlockCommand.{Mutator,UtcNow}Factory` | `AutomationHostReviewPreflightCommandTests`, `AutomationIssueBlockCommandTests` — `WorkerNextActionSharedState` |
| `ClarifyAnswerCommand.{InputReader,Timestamp}Factory`, `InterviewAnswerCommand.{InputReader,Timestamp}Factory` | with `CommandRouterTests` — `RunSubmitCommand` |
| `WorkerNextActionCommand.CandidateListerFactory` | `AutomationCheckCommandTests`, `ProgramTests`, `WorkerNextActionCommandTests` — `WorkerNextActionSharedState` |

**Optional follow-up, not a defect.** `ClarifyOpenCommand.TimestampFactory` is the widest of these — four classes across two collections — and its safety is invisible at the assignment site: it holds only because every one of those classes happens to be in *some* disabled collection, which a future class need not be. Converting it to the same per-call clock seam would remove that dependency. That is a design-owned cleanup, **not** a currently unguarded race, and it is out of this packet's scope.

## Verification

- `dotnet test IntentSystem.sln` — **4079 passed, 0 failed, 1 skipped** (all other projects green).
- Full suite re-run with a `gh` shim exiting 1 and `GH_TOKEN`/`GITHUB_TOKEN=invalid` — same result.
- `git diff --check` clean.

No product behaviour changes and no CI pipeline configuration changes. The diff is the time-control seam, its two test classes, the new proof fixture, and 11 one-line collection attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
