### PR TITLE
G571: add herdr-only operating guide

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -224,12 +224,16 @@ herdr agent start <logical-role> --kind <agent-kind> --pane <pane-id> -- <operat
 ```
 
 Permission flags belong to the launch, not injected modifier chords. Approvals
-are never auto-answered; G550's MAY/escalate boundary still governs. A role is
-READY only after G556 verified liveness: expected cwd/repo and agent kind,
-same-pane detection, then a bounded probe whose response is observed. Workspace
-existence, a shell prompt, or agent state alone is not READY. In herdr-only the
-verified logical-role→pane mapping is the role identity; there is no separate
-agmsg identity step.
+are never auto-answered; G550's MAY/escalate boundary still governs. Approvals
+are pane-visible and handled at the supervision boundary, explicitly unlike the
+agmsg Codex bridge's headless auto-decline. A role is READY only after the
+self-contained G556 verified-liveness gate: after the startup report, wait a
+settle delay, then re-check the expected cwd/repo and agent kind, same-pane
+detection, and a bounded probe whose response is observed. Repeat the entire
+settle-and-re-check sequence after re-provisioning. Workspace existence, a shell
+prompt, or agent state alone is not READY. In herdr-only the verified
+logical-role→pane mapping is the role identity; there is no separate agmsg
+identity step.
 
 ### Dispatch, wait, and verify the artifact
 
@@ -299,7 +303,7 @@ intent-cli workflow state.
   typed `agent start ... -- <permission-flags>` surface.
 - Post-reboot dead pty wiring: an undetected agent or shell-only pane requires
   preserving artifacts, re-provisioning, rebuilding the mapping, and repeating
-  the complete G556 gate.
+  the self-contained settle-and-re-check READY gate above.
 - Long-wait turn death: use bounded waits, re-entry, and deterministic persisted
   loops.
 

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -200,6 +200,121 @@ provided the same rules hold: one dedicated folder per role as the pane cwd,
 shim-safe typed launch, attended first-run prompts, actas + readiness before the
 ping test, and one holder per role with a graceful drop on handover.
 
+## Herdr-only (PREVIEW) operating procedure
+
+This section is operative only when the team has recorded `herdr-only`. It is
+the concrete counterpart to the agmsg provisioning/receiver sections. PREVIEW
+qualifies the transport, not the four-thread model. Exactly one transport runs
+per team; mixed agmsg and herdr delivery is a contract violation.
+
+### Provision and prove READY
+
+Create the team workspace and role tabs/panes with the role cwd (`<host-repo>`
+for design/orchestrator, the child checkout for implementation, and an isolated
+review cwd/worktree). Use `herdr workspace create`, `herdr tab create`, or
+`herdr pane split` as shown by the installed `herdr ... --help`. Record an
+operator-visible logical-role→pane-id/cwd mapping and resolve it before every
+operation; workflows never hard-code pane ids. An external design frontend is
+recorded as a reader type rather than fabricated as a pane.
+
+Launch with the typed surface:
+
+```text
+herdr agent start <logical-role> --kind <agent-kind> --pane <pane-id> -- <operator-approved-permission-flags>
+```
+
+Permission flags belong to the launch, not injected modifier chords. Approvals
+are never auto-answered; G550's MAY/escalate boundary still governs. A role is
+READY only after G556 verified liveness: expected cwd/repo and agent kind,
+same-pane detection, then a bounded probe whose response is observed. Workspace
+existence, a shell prompt, or agent state alone is not READY. In herdr-only the
+verified logical-role→pane mapping is the role identity; there is no separate
+agmsg identity step.
+
+### Dispatch, wait, and verify the artifact
+
+Send one structured block with `herdr agent prompt <logical-role> <task-block>`:
+
+```text
+TASK <task-id>
+role: <logical-role>
+objective: <one bounded outcome>
+inputs:
+  - <canonical issue/PR/path/reference>
+expected-artifacts:
+  - <file, commit, PR, report, or other inspectable artifact>
+completion-marker: Print exactly `ORCH_RESULT <task-id> <status> <artifact>` when ready; status is completed, blocked, or question.
+```
+
+Files, commits, PRs, and verification logs are the handoff; screen prose only
+points to them. Repairs return to the same logical role with the task id and
+concrete delta after resolving its current pane.
+
+Every wait is bounded:
+
+```text
+herdr agent wait <logical-role> --until done --until blocked --timeout <milliseconds>
+herdr pane wait-output --match "ORCH_RESULT <task-id>" --source recent-unwrapped --timeout <milliseconds> <pane-id>
+```
+
+A timeout is a re-entry point: inspect and persist progress, return control,
+then resume on a later wake. Deterministic scripts with persisted cursors are
+preferred for long flows. Composite success requires settled state + the exact
+task marker + an existing verified artifact. herdr `done`/`idle` alone never
+means success.
+
+### Normative `events.jsonl` design boundary
+
+Resolve the host root at runtime and use
+`<host-repo>/.intent-cli/events/<team>.jsonl`. `<team>` is the agmsg/herdr team
+name verbatim in one flat filename (`intent-cli-dev.jsonl`, for example); no
+team subdirectories and no hard-coded absolute paths. Before constructing the
+path, fail closed on an empty name, a leading dot, `/` or `\`, or any `..`
+sequence. Never sanitize an invalid name.
+
+The orchestrator is the only writer. Open with `O_APPEND`, append one complete
+JSON object per line, permit no embedded newline, and normalize `summary` to one
+line. The required schema is:
+
+```json
+{"timestamp":"<RFC3339>","team":"<team>","kind":"completion|blocked|question|escalation","unit":"<execution-unit-or-task-id>","summary":"<one-line-summary>","artifact":"<repo-relative-path-or-URL>"}
+```
+
+Write only design-relevant completion, blocked, question, and escalation
+events. This mode-independent channel is the design boundary only—never an
+inter-agent bus and never a replacement for herdr dispatch, GitHub, or
+intent-cli workflow state.
+
+- Claude app watcher: tail complete unseen lines from the resolved path and
+  retain its offset across restarts.
+- Codex CLI in a herdr pane: prompt the role directly; do not poll this file for
+  ordinary coordination.
+- Codex Desktop: poll at a one-minute-class cadence, consume only complete lines
+  after a durable byte-offset watermark, and advance after successful handling.
+  Truncation or malformed JSON fails closed and requires operator recovery.
+
+### Recovery and mode switches
+
+- Modifier-chord launch corruption: return to a shell/re-provision and use the
+  typed `agent start ... -- <permission-flags>` surface.
+- Post-reboot dead pty wiring: an undetected agent or shell-only pane requires
+  preserving artifacts, re-provisioning, rebuilding the mapping, and repeating
+  the complete G556 gate.
+- Long-wait turn death: use bounded waits, re-entry, and deterministic persisted
+  loops.
+
+For **agmsg → herdr-only**: drain/park work; gracefully drop roles and stop
+watchers/bridges; provision herdr, its mapping, and the validated events path;
+pass G556 and marker/artifact detection; finally run `intent-cli session-layer
+set --domain <domain> --team <team> --mode herdr-only --write`.
+
+For **herdr-only → agmsg**: drain/park work and append any final design event;
+stop or retain/close the workspace according to operator policy so it cannot
+keep delivering; provision agmsg roles and approved watcher/bridge; pass G556
+and end-to-end delivery; finally run `intent-cli session-layer set --domain
+<domain> --team <team> --mode agmsg --write`. The mode flip is the final
+canonical step in both directions.
+
 ## Design-thread workspace supervision (keeping the team moving)
 
 Provisioning builds the team; **supervision keeps it moving** — and that half is

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -215,11 +215,14 @@ herdr agent start <logical-role> --kind <agent-kind> --pane <pane-id> -- <operat
 ```
 
 permission flag は launch に渡し、modifier chord を注入しません。approval は自動回答せず、
-G550 の MAY/escalate 境界がそのまま支配します。READY は G556 verified liveness（期待する
-cwd/repo と agent kind、同一 pane での detection、bounded probe の応答観測）をすべて
-通った後だけです。workspace の存在、shell prompt、agent state だけでは READY では
-ありません。herdr-only の role identity は検証済み logical-role→pane mapping であり、
-別の agmsg identity step はありません。
+G550 の MAY/escalate 境界がそのまま支配します。approval は pane-visible で supervision boundary
+において処理し、agmsg Codex bridge の headless auto-decline とは明確に異なります。
+READY は自己完結した G556 verified-liveness gate、すなわち startup report 後に settle delay を
+置き、その後で期待する cwd/repo と agent kind、同一 pane での detection、bounded probe の
+応答観測を再確認して、すべて通った後だけです。re-provision 後は settle-and-re-check sequence
+全体を繰り返します。workspace の存在、shell prompt、agent state だけでは READY では
+ありません。herdr-only の role identity は検証済み logical-role→pane mapping であり、別の
+agmsg identity step はありません。
 
 ### Dispatch、wait、artifact 検証
 
@@ -283,7 +286,7 @@ dispatch、GitHub、intent-cli workflow state の代替でもありません。
 - modifier-chord launch corruption: shell へ戻すか再 provision し、typed な
   `agent start ... -- <permission-flags>` を使います。
 - reboot 後の dead pty wiring: undetected agent / shell-only pane では artifact を保全して
-  re-provision、mapping 再構築、完全な G556 gate 再実行を行います。
+  re-provision、mapping 再構築、上記の自己完結した settle-and-re-check READY gate 再実行を行います。
 - long-wait turn death: bounded wait、re-entry、persist された deterministic loop を使います。
 
 **agmsg → herdr-only**: work を drain/park、role を graceful drop して watcher/bridge を停止、

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -191,6 +191,111 @@ agmsg internals と同じくリンクアウトし、herdr 自身のドキュメ�
 立ち会う、ping テスト前の actas + readiness、1 ロール 1 保持者と handover 時の graceful
 drop）が満たされるなら、**任意の** 同等なワークスペースマネージャーで置き換えられます。
 
+## herdr-only（PREVIEW）の運用手順
+
+この節はチームが `herdr-only` を記録している場合だけ operative です。agmsg の
+provisioning / receiver 節に対する具体的な counterpart です。PREVIEW が限定するのは
+transport であり、4 スレッドモデルではありません。1 チームでは transport を 1 つだけ
+動かし、agmsg と herdr の mixed delivery は contract violation です。
+
+### Provisioning と READY の証明
+
+チーム workspace と role ごとの tab/pane を role cwd 付きで作成します（design /
+orchestrator は `<host-repo>`、implementation は child checkout、review は隔離した review
+cwd/worktree）。インストール済みの `herdr ... --help` に従い、`herdr workspace create`、
+`herdr tab create`、`herdr pane split` を使います。operator-visible な
+logical-role→pane-id/cwd mapping を記録し、毎操作前に解決します。workflow が pane id を
+hard-code してはいけません。herdr 外の design frontend は架空 pane ではなく reader type
+として記録します。
+
+typed launch は次の surface です。
+
+```text
+herdr agent start <logical-role> --kind <agent-kind> --pane <pane-id> -- <operator-approved-permission-flags>
+```
+
+permission flag は launch に渡し、modifier chord を注入しません。approval は自動回答せず、
+G550 の MAY/escalate 境界がそのまま支配します。READY は G556 verified liveness（期待する
+cwd/repo と agent kind、同一 pane での detection、bounded probe の応答観測）をすべて
+通った後だけです。workspace の存在、shell prompt、agent state だけでは READY では
+ありません。herdr-only の role identity は検証済み logical-role→pane mapping であり、
+別の agmsg identity step はありません。
+
+### Dispatch、wait、artifact 検証
+
+`herdr agent prompt <logical-role> <task-block>` で次の structured block を 1 つ送ります。
+
+```text
+TASK <task-id>
+role: <logical-role>
+objective: <one bounded outcome>
+inputs:
+  - <canonical issue/PR/path/reference>
+expected-artifacts:
+  - <file, commit, PR, report, or other inspectable artifact>
+completion-marker: Ready になったら `ORCH_RESULT <task-id> <status> <artifact>` を正確に出力する。status は completed、blocked、question。
+```
+
+handoff は file、commit、PR、verification log などの inspectable artifact です。screen prose
+はそれを指す signal にすぎません。repair は現在の pane mapping を解決した後、同じ logical
+role に task id と具体的 delta を添えて戻します。
+
+wait は必ず bounded にします。
+
+```text
+herdr agent wait <logical-role> --until done --until blocked --timeout <milliseconds>
+herdr pane wait-output --match "ORCH_RESULT <task-id>" --source recent-unwrapped --timeout <milliseconds> <pane-id>
+```
+
+timeout は re-entry point です。状態を inspect/persist して制御を返し、後続 wake で再開します。
+長い flow には cursor を永続化する deterministic script を推奨します。success は settled
+state + 正確な task marker + 存在して検証済みの artifact の合成判定です。herdr の
+`done` / `idle` だけで成功と結論してはいけません。
+
+### Normative な `events.jsonl` design boundary
+
+host root を実行時に解決し、`<host-repo>/.intent-cli/events/<team>.jsonl` を使います。
+`<team>` は agmsg/herdr team name を verbatim にした flat filename（例:
+`intent-cli-dev.jsonl`）で、team subdirectory と absolute path の hard-code は禁止です。
+path 構築前に、空文字、先頭 dot、`/` または `\`、任意の `..` sequence を fail closed で
+拒否します。不正名を sanitize してはいけません。
+
+writer は orchestrator だけです。`O_APPEND` で開き、1 行に完全な JSON object を 1 つ
+append し、embedded newline を許さず、`summary` を 1 行へ normalize します。必須 schema:
+
+```json
+{"timestamp":"<RFC3339>","team":"<team>","kind":"completion|blocked|question|escalation","unit":"<execution-unit-or-task-id>","summary":"<one-line-summary>","artifact":"<repo-relative-path-or-URL>"}
+```
+
+design-relevant な completion / blocked / question / escalation だけを書きます。この
+mode-independent channel は design boundary のみで、inter-agent bus ではなく、herdr
+dispatch、GitHub、intent-cli workflow state の代替でもありません。
+
+- Claude app watcher: 解決済み path の完全な未読行だけを tail し、restart をまたいで offset
+  を保持します。
+- herdr pane の Codex CLI: role を直接 prompt し、通常 coordination で file poll しません。
+- Codex Desktop: one-minute-class（約 1 分）cadence で poll し、durable byte-offset watermark より後の
+  完全な行だけを処理し、成功後に watermark を進めます。truncate または malformed JSON は
+  fail closed とし operator recovery を要求します。
+
+### Recovery と mode switch
+
+- modifier-chord launch corruption: shell へ戻すか再 provision し、typed な
+  `agent start ... -- <permission-flags>` を使います。
+- reboot 後の dead pty wiring: undetected agent / shell-only pane では artifact を保全して
+  re-provision、mapping 再構築、完全な G556 gate 再実行を行います。
+- long-wait turn death: bounded wait、re-entry、persist された deterministic loop を使います。
+
+**agmsg → herdr-only**: work を drain/park、role を graceful drop して watcher/bridge を停止、
+herdr・mapping・検証済み events path を provision、G556 と marker/artifact 検出を通し、最後に
+`intent-cli session-layer set --domain <domain> --team <team> --mode herdr-only --write`。
+
+**herdr-only → agmsg**: work を drain/park して必要な final design event を append、operator
+policy に従って workspace を停止または retain/close し delivery を止め、agmsg role と承認済み
+watcher/bridge を provision、G556 と end-to-end delivery を通し、最後に `intent-cli
+session-layer set --domain <domain> --team <team> --mode agmsg --write`。両方向とも mode flip が
+final canonical step です。
+
 ## 設計スレッドによるワークスペース監督（チームを動かし続ける）
 
 provisioning はチームを作りますが、**チームを動かし続けるのは監督（supervision）** であり、

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -159,8 +159,9 @@ internal static class GuideOrchestratorThreadCommand
                 + "reversibly, in both directions.",
             ResidualAgmsgMechanics = sessionLayer.IsHerdrOnly
                 ? "HERDR-ONLY: the agmsg-only sections of this guide are REPLACED, whole, by the concrete herdr-only "
-                    + "operating sections below. Retained sections are mode-independent; any agmsg mechanics they "
-                    + "mention are explicitly scoped descriptive examples or pointed to their herdr counterpart."
+                    + "operating sections below. Retained sections carry mode-independent duties, but transport-specific "
+                    + "examples in them govern only their named transport; the concrete herdr-only counterparts below "
+                    + "govern this mode."
                 : null,
         };
 

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -158,9 +158,9 @@ internal static class GuideOrchestratorThreadCommand
                 + $"`intent-cli session-layer set --domain {values["<domain>"]} --mode agmsg|herdr-only --write` changes it, "
                 + "reversibly, in both directions.",
             ResidualAgmsgMechanics = sessionLayer.IsHerdrOnly
-                ? "HERDR-ONLY: the agmsg-only sections of this guide are REPLACED, whole, by the switch-checklist "
-                    + "section below — they are not rendered and not annotated. Every section that remains is "
-                    + "mode-independent and applies unchanged."
+                ? "HERDR-ONLY: the agmsg-only sections of this guide are REPLACED, whole, by the concrete herdr-only "
+                    + "operating sections below. Retained sections are mode-independent; any agmsg mechanics they "
+                    + "mention are explicitly scoped descriptive examples or pointed to their herdr counterpart."
                 : null,
         };
 
@@ -527,7 +527,9 @@ internal static class GuideOrchestratorThreadCommand
             replaced.Select(name => (System.Text.Json.Nodes.JsonNode?)System.Text.Json.Nodes.JsonValue.Create(name)).ToArray());
         node[SessionLayerSections.ReplacementNoteProperty] =
             "Removed because this team runs the herdr-only session layer: these sections operate agmsg. Their "
-            + "herdr-only counterparts ship in G571. Every remaining field is mode-independent and applies unchanged.";
+            + "concrete counterparts are in the herdr_only_operations object. Every remaining field is "
+            + "mode-independent and applies unchanged.";
+        node[HerdrOnlyOperatingGuide.JsonProperty] = HerdrOnlyOperatingGuide.CreateJson(replaced);
 
         return node.ToJsonString(JsonOptions);
     }
@@ -682,7 +684,8 @@ internal static class GuideOrchestratorThreadCommand
                     + "signals between threads; it is NOT workflow state. intent-cli and GitHub remain authoritative "
                     + "for domain status, queue-state, issue/PR facts, labels, CI, and closeout. Timer-loop mode "
                     + "remains fully supported as the simpler ALTERNATIVE for setups without an orchestrator thread "
-                    + "(see Mode separation). The herdr-only operating steps ship in G571."
+                    + "(see Mode separation). The concrete herdr-only operating sections below cover provisioning, "
+                    + "dispatch, bounded completion detection, the events boundary, recovery, and both switches."
                 : "PRIMARY agmsg-backed four-thread orchestrator model (ADR-012 / spec-26): design / orchestrator / "
                     + "implementation / review coordinate over agmsg. agmsg carries natural-language delegation / "
                     + "progress / completion / blocker signals between threads; it is NOT workflow state. intent-cli "
@@ -3026,8 +3029,8 @@ internal static class GuideOrchestratorThreadCommand
             {
                 Status = IntakeSetupReady,
                 Headline =
-                    "setup-ready (herdr-only) — the registration, delivery-configuration and role-prompt steps of "
-                    + "this intake are agmsg-only and do not apply. Their herdr-only counterparts ship in G571.",
+                    "setup-ready (herdr-only) — concrete provisioning, logical-role→pane mapping, typed launch, and "
+                    + "G556 READY procedures are present in the herdr-only operating sections.",
                 MissingFields = Array.Empty<string>(),
                 Inputs = inputs,
                 AgmsgCommands = null,

--- a/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
+++ b/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
@@ -44,7 +44,7 @@ internal static class HerdrOnlyOperatingGuide
         2. Create a team workspace with `herdr workspace create --cwd <host-repo> --label <team> --no-focus`. Create role tabs/panes with the role cwd: design and orchestrator use `<host-repo>`, implementation uses `<implementation-repo>`, and review uses its isolated review cwd/worktree. `herdr tab create --workspace <workspace-id> --cwd <role-cwd> --label <logical-role> --no-focus` is the typed tab surface; `herdr pane split --pane <pane-id> --direction right|down --cwd <role-cwd> --no-focus` is available when a split is preferred.
         3. Record a durable operator-visible mapping of each herdr-resident logical role (`design`, `orchestrator`, `implementation`, `review`) to its current workspace/tab/pane id and cwd. Workflows address the logical role and resolve this mapping at dispatch time; they NEVER hard-code a pane id. A design frontend outside herdr is recorded as the design reader type, not fabricated as a pane.
         4. Launch the typed agent in the mapped pane with `herdr agent start <logical-role> --kind <claude|codex|...> --pane <pane-id> -- <operator-approved-permission-flags>`. Pass launch and permission flags after `--`; do not inject modifier chords into an interactive prompt. Approvals are NEVER auto-answered: only the G550 MAY-answer classes may be handled, and every other approval is escalated to the operator.
-        5. READY is a G556 verified-liveness result, not workspace existence. Check `herdr agent list`, inspect the mapped pane/agent, verify the expected cwd/repository and detected agent kind, then send a bounded ping and observe its ack in that same pane. An undetected agent, a shell prompt where the agent should be, a mismatched cwd, or no ack is NOT READY.
+        5. READY is a G556 verified-liveness result, not workspace existence. Approvals surface visibly in the pane and are handled at the supervision boundary, explicitly unlike the agmsg Codex bridge's headless auto-decline. After the startup report, wait a settle delay, then re-check `herdr agent list`, inspect the mapped pane/agent, verify the expected cwd/repository and detected agent kind, and send a bounded ping whose ack is observed in that same pane. An undetected agent, a shell prompt where the agent should be, a mismatched cwd, or no ack is NOT READY; after re-provisioning, repeat this entire settle-and-re-check sequence before declaring READY.
 
         Role identity in herdr-only is this verified logical-role→pane mapping. There is no agmsg identity or separate role-switching step.
 
@@ -78,7 +78,7 @@ internal static class HerdrOnlyOperatingGuide
         This is a normative, mode-independent design-boundary channel documented here because herdr-only has no separate message bridge. It is NEVER an inter-agent bus and never replaces direct herdr dispatch, GitHub, or intent-cli workflow state.
 
         - **Location:** resolve the host repository root at runtime, then use `<host-repo>/.intent-cli/events/<team>.jsonl`. The team name is the agmsg/herdr team name verbatim in one flat filename (example: `intent-cli-dev.jsonl`); there are no team subdirectories and readers never hard-code an absolute path.
-        - **Fail closed before path construction:** reject an empty team name, a leading dot, `/` or `\\`, and any `..` sequence. Do not sanitize or silently rewrite an invalid name.
+        - **Fail closed before path construction:** reject an empty team name, a leading dot, `/` or `\`, and any `..` sequence. Do not sanitize or silently rewrite an invalid name.
         - **Append contract:** the orchestrator is the only writer. Open with append semantics (`O_APPEND`), append exactly one complete JSON object per line, include no embedded newline, and normalize `summary` to one line.
         - **Schema:** `{"timestamp":"<RFC3339>","team":"<team>","kind":"completion|blocked|question|escalation","unit":"<execution-unit-or-task-id>","summary":"<one-line-summary>","artifact":"<repo-relative-path-or-URL>"}`. These six fields are required; `artifact` identifies the inspectable handoff or the decision input.
         - **Writer boundary:** append only design-relevant completion, blocked, question, and escalation events. Routine progress, dispatch traffic, pane output, acknowledgements, and workflow label changes do not belong here.
@@ -92,7 +92,7 @@ internal static class HerdrOnlyOperatingGuide
         ## Herdr-only failure modes and recovery
 
         - **Modifier-chord injection / launch corruption:** do not type launch control chords into a live prompt. Re-provision or return the pane to a shell, then use `herdr agent start ... -- <permission-flags>` so flags are part of the typed launch.
-        - **Post-reboot dead pty wiring:** a pane may still exist while `herdr agent list` cannot detect the agent or the pane is sitting at a shell. Treat it as `agent-undetected`, preserve artifacts, close/re-provision the affected workspace/panes, rebuild the logical-role mapping, and repeat the complete G556 verified-liveness gate before READY.
+        - **Post-reboot dead pty wiring:** a pane may still exist while `herdr agent list` cannot detect the agent or the pane is sitting at a shell. Treat it as `agent-undetected`, preserve artifacts, close/re-provision the affected workspace/panes, rebuild the logical-role mapping, and repeat the self-contained settle-and-re-check READY gate above before READY.
         - **Long-wait turn death:** replace unbounded `agent wait`/`pane wait-output` calls with bounded timeouts and re-entry. Use deterministic scripts with persisted task id, pane resolution, and watermark for long loops.
 
         ## Session-layer switch checklists
@@ -104,7 +104,7 @@ internal static class HerdrOnlyOperatingGuide
         1. Drain or explicitly park every in-flight delegation; record artifacts and unresolved blockers.
         2. Gracefully drop outgoing agmsg roles and stop their watchers/bridges. Verify no agmsg receiver can still deliver for this team.
         3. Provision the herdr workspace, role cwds, typed agents, and logical-role→pane mapping above; validate approvals and the events path.
-        4. Pass the complete G556 verified-liveness READY gate for every incoming role and verify bounded dispatch/marker/artifact detection.
+        4. Pass the self-contained settle-and-re-check READY gate above for every incoming role and verify bounded dispatch/marker/artifact detection.
         5. As the FINAL canonical step, run `intent-cli session-layer set --domain <domain> --team <team> --mode herdr-only --write`.
 
         **herdr-only → agmsg**
@@ -112,7 +112,7 @@ internal static class HerdrOnlyOperatingGuide
         1. Drain or explicitly park every in-flight delegation; append any final design-relevant event and record artifacts/blockers.
         2. Gracefully stop agents or retain/close the outgoing herdr workspace according to the operator's workspace policy; ensure it cannot keep delivering tasks for this team.
         3. Provision agmsg roles, transport configuration, and any approved watcher/bridge; do not reuse a stale role hold. Keep `events.jsonl` as the mode-independent design boundary, not as an agmsg bus.
-        4. Pass the complete G556 verified-liveness READY gate and end-to-end delivery ack for every incoming role.
+        4. Pass the applicable self-contained G556 settle-and-re-check READY gate and end-to-end delivery ack for every incoming role.
         5. As the FINAL canonical step, run `intent-cli session-layer set --domain <domain> --team <team> --mode agmsg --write`.
         """;
     }
@@ -126,8 +126,8 @@ internal static class HerdrOnlyOperatingGuide
             ["workspace"] = "Create the team workspace and role tabs/panes with role-specific cwds; consult installed herdr help for version-specific options.",
             ["mapping"] = "Record an operator-visible logical-role-to-current-pane-id-and-cwd mapping; resolve it at dispatch time and never hard-code pane ids.",
             ["typed_launch"] = "herdr agent start <logical-role> --kind <agent-kind> --pane <pane-id> -- <operator-approved-permission-flags>",
-            ["approval_boundary"] = "Approvals are never auto-answered; the G550 MAY/escalate boundary governs.",
-            ["ready_gate"] = "READY only after G556 verified liveness: expected agent/cwd/repo, detected same-pane process, and bounded probe response.",
+            ["approval_boundary"] = "Approvals surface visibly in the pane and are handled at the supervision boundary, unlike the agmsg Codex bridge's headless auto-decline; the G550 MAY/escalate boundary governs.",
+            ["ready_gate"] = "READY only after G556 verified liveness: after the startup report, wait a settle delay, then re-check the expected agent/cwd/repo and detected same-pane process before observing a bounded probe response; repeat after re-provisioning.",
         },
         ["dispatch"] = new JsonObject
         {

--- a/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
+++ b/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
@@ -1,0 +1,174 @@
+using System.Text.Json.Nodes;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G571: the concrete operating procedure selected by the G570 session-layer
+/// router. This content is synthetic rather than part of the agmsg-backed
+/// guide model so the practiced agmsg rendering remains byte-for-byte on its
+/// existing path.
+/// </summary>
+internal static class HerdrOnlyOperatingGuide
+{
+    public const string JsonProperty = "herdr_only_operations";
+
+    public static readonly IReadOnlyList<string> Headings =
+    [
+        "## Herdr-only provisioning and READY gate",
+        "## Herdr-only dispatch and artifact handoff",
+        "## Herdr-only bounded waiting and success detection",
+        "## events.jsonl design boundary",
+        "## Herdr-only failure modes and recovery",
+        "## Session-layer switch checklists",
+    ];
+
+    public static string RenderMarkdown(IReadOnlyList<string> replacedHeadings)
+    {
+        var replaced = string.Join('\n', replacedHeadings.Select(heading => $"- `{heading.TrimStart('#', ' ')}`"));
+        return $$"""
+        {{SessionLayerSections.ReplacementHeading}}
+
+        This team runs the **herdr-only** session layer. The agmsg-only sections listed below do not apply and are not rendered; the concrete **G571** herdr-only procedures follow immediately after the list.
+
+        Replaced here (agmsg-only):
+
+        {{replaced}}
+
+        Everything else in this document is mode-independent and applies unchanged: G550 supervision and approval boundaries, G555 isolation, G556 liveness, the wake contract, publish authority, the design↔orchestrator double-check rule, dependency planning, and escalation are properties of the four-thread model, not of its transport.
+
+        ## Herdr-only provisioning and READY gate
+
+        herdr is the only session transport in this mode; do not join agmsg identities, run an agmsg bridge, or mix delivery mechanisms inside the team.
+
+        1. Confirm the installed surface with `herdr workspace --help`, `herdr tab --help`, `herdr pane --help`, and `herdr agent --help`. Use the installed help when a version-specific option is needed.
+        2. Create a team workspace with `herdr workspace create --cwd <host-repo> --label <team> --no-focus`. Create role tabs/panes with the role cwd: design and orchestrator use `<host-repo>`, implementation uses `<implementation-repo>`, and review uses its isolated review cwd/worktree. `herdr tab create --workspace <workspace-id> --cwd <role-cwd> --label <logical-role> --no-focus` is the typed tab surface; `herdr pane split --pane <pane-id> --direction right|down --cwd <role-cwd> --no-focus` is available when a split is preferred.
+        3. Record a durable operator-visible mapping of each herdr-resident logical role (`design`, `orchestrator`, `implementation`, `review`) to its current workspace/tab/pane id and cwd. Workflows address the logical role and resolve this mapping at dispatch time; they NEVER hard-code a pane id. A design frontend outside herdr is recorded as the design reader type, not fabricated as a pane.
+        4. Launch the typed agent in the mapped pane with `herdr agent start <logical-role> --kind <claude|codex|...> --pane <pane-id> -- <operator-approved-permission-flags>`. Pass launch and permission flags after `--`; do not inject modifier chords into an interactive prompt. Approvals are NEVER auto-answered: only the G550 MAY-answer classes may be handled, and every other approval is escalated to the operator.
+        5. READY is a G556 verified-liveness result, not workspace existence. Check `herdr agent list`, inspect the mapped pane/agent, verify the expected cwd/repository and detected agent kind, then send a bounded ping and observe its ack in that same pane. An undetected agent, a shell prompt where the agent should be, a mismatched cwd, or no ack is NOT READY.
+
+        Role identity in herdr-only is this verified logical-role→pane mapping. There is no agmsg identity or separate role-switching step.
+
+        ## Herdr-only dispatch and artifact handoff
+
+        Submit one structured task block with `herdr agent prompt <logical-role> <task-block>`. Every block has this shape:
+
+        ```text
+        TASK <task-id>
+        role: <logical-role>
+        objective: <one bounded outcome>
+        inputs:
+          - <canonical issue/PR/path/reference>
+        expected-artifacts:
+          - <file, commit, PR, report, or other inspectable artifact>
+        completion-marker: Print exactly `ORCH_RESULT <task-id> <status> <artifact>` when the artifact is ready; use status completed, blocked, or question.
+        ```
+
+        Files, commits, PRs, test logs, and other inspectable artifacts are the handoff; terminal prose is only a signal pointing at them. A repair or re-dispatch goes to the same logical role after resolving its current pane mapping and carries the same task id plus the concrete delta. Never infer completion from screen text that lacks the task-specific marker and artifact.
+
+        ## Herdr-only bounded waiting and success detection
+
+        Use bounded waits only. For agent state, use `herdr agent wait <logical-role> --until done --until blocked --timeout <milliseconds>`. For the task signal, use `herdr pane wait-output --match "ORCH_RESULT <task-id>" --source recent-unwrapped --timeout <milliseconds> <pane-id>`. Both commands wait indefinitely when `--timeout` is omitted, so omission is forbidden in an orchestrator wake.
+
+        A timeout is a re-entry point: inspect state and pane output, persist progress, return control to the orchestrator, and wait again on the next bounded wake. Prefer a deterministic script that persists its cursor for long multi-wait flows; do not hold one chat turn open indefinitely, because turn death loses the continuation.
+
+        **Composite success is mandatory:** (1) herdr reports a settled state, (2) the exact `ORCH_RESULT` marker matches the task id and status, and (3) the named artifact exists and passes the task's verification. State alone NEVER means task success; in particular, herdr `done` or `idle` alone is insufficient. `blocked` and `question` markers route back to the orchestrator/design decision boundary; they are not failures to hide or successes to assume.
+
+        ## events.jsonl design boundary
+
+        This is a normative, mode-independent design-boundary channel documented here because herdr-only has no separate message bridge. It is NEVER an inter-agent bus and never replaces direct herdr dispatch, GitHub, or intent-cli workflow state.
+
+        - **Location:** resolve the host repository root at runtime, then use `<host-repo>/.intent-cli/events/<team>.jsonl`. The team name is the agmsg/herdr team name verbatim in one flat filename (example: `intent-cli-dev.jsonl`); there are no team subdirectories and readers never hard-code an absolute path.
+        - **Fail closed before path construction:** reject an empty team name, a leading dot, `/` or `\\`, and any `..` sequence. Do not sanitize or silently rewrite an invalid name.
+        - **Append contract:** the orchestrator is the only writer. Open with append semantics (`O_APPEND`), append exactly one complete JSON object per line, include no embedded newline, and normalize `summary` to one line.
+        - **Schema:** `{"timestamp":"<RFC3339>","team":"<team>","kind":"completion|blocked|question|escalation","unit":"<execution-unit-or-task-id>","summary":"<one-line-summary>","artifact":"<repo-relative-path-or-URL>"}`. These six fields are required; `artifact` identifies the inspectable handoff or the decision input.
+        - **Writer boundary:** append only design-relevant completion, blocked, question, and escalation events. Routine progress, dispatch traffic, pane output, acknowledgements, and workflow label changes do not belong here.
+
+        Reader recipes:
+
+        1. **Claude app watcher:** resolve the host root and validated team path, then tail complete lines from `<host-repo>/.intent-cli/events/<team>.jsonl`; surface only unseen design-relevant records and retain the read offset across watcher restarts.
+        2. **Codex CLI:** when Codex is a herdr pane, prompt that logical role directly with `herdr agent prompt`; it does not poll the file for ordinary coordination. The events file remains available only when that Codex role is acting as a design-boundary reader.
+        3. **Codex Desktop:** run a one-minute-class timer poll. Resolve the host root plus validated team filename on every resumed session, read only complete lines after a durable byte-offset watermark, surface the unseen records, then advance the watermark after successful handling. Rotation/truncation or malformed JSON fails closed and requires operator recovery; it never resets silently and replays decisions.
+
+        ## Herdr-only failure modes and recovery
+
+        - **Modifier-chord injection / launch corruption:** do not type launch control chords into a live prompt. Re-provision or return the pane to a shell, then use `herdr agent start ... -- <permission-flags>` so flags are part of the typed launch.
+        - **Post-reboot dead pty wiring:** a pane may still exist while `herdr agent list` cannot detect the agent or the pane is sitting at a shell. Treat it as `agent-undetected`, preserve artifacts, close/re-provision the affected workspace/panes, rebuild the logical-role mapping, and repeat the complete G556 verified-liveness gate before READY.
+        - **Long-wait turn death:** replace unbounded `agent wait`/`pane wait-output` calls with bounded timeouts and re-entry. Use deterministic scripts with persisted task id, pane resolution, and watermark for long loops.
+
+        ## Session-layer switch checklists
+
+        One team runs exactly one session-layer mode at a time. Simultaneous agmsg and herdr-only delivery is a mixed-delivery CONTRACT VIOLATION.
+
+        **agmsg → herdr-only**
+
+        1. Drain or explicitly park every in-flight delegation; record artifacts and unresolved blockers.
+        2. Gracefully drop outgoing agmsg roles and stop their watchers/bridges. Verify no agmsg receiver can still deliver for this team.
+        3. Provision the herdr workspace, role cwds, typed agents, and logical-role→pane mapping above; validate approvals and the events path.
+        4. Pass the complete G556 verified-liveness READY gate for every incoming role and verify bounded dispatch/marker/artifact detection.
+        5. As the FINAL canonical step, run `intent-cli session-layer set --domain <domain> --team <team> --mode herdr-only --write`.
+
+        **herdr-only → agmsg**
+
+        1. Drain or explicitly park every in-flight delegation; append any final design-relevant event and record artifacts/blockers.
+        2. Gracefully stop agents or retain/close the outgoing herdr workspace according to the operator's workspace policy; ensure it cannot keep delivering tasks for this team.
+        3. Provision agmsg roles, transport configuration, and any approved watcher/bridge; do not reuse a stale role hold. Keep `events.jsonl` as the mode-independent design boundary, not as an agmsg bus.
+        4. Pass the complete G556 verified-liveness READY gate and end-to-end delivery ack for every incoming role.
+        5. As the FINAL canonical step, run `intent-cli session-layer set --domain <domain> --team <team> --mode agmsg --write`.
+        """;
+    }
+
+    public static JsonObject CreateJson(IReadOnlyList<string> replacedProperties) => new()
+    {
+        ["replaces_agmsg_properties"] = new JsonArray(
+            replacedProperties.Select(value => (JsonNode?)JsonValue.Create(value)).ToArray()),
+        ["provisioning"] = new JsonObject
+        {
+            ["workspace"] = "Create the team workspace and role tabs/panes with role-specific cwds; consult installed herdr help for version-specific options.",
+            ["mapping"] = "Record an operator-visible logical-role-to-current-pane-id-and-cwd mapping; resolve it at dispatch time and never hard-code pane ids.",
+            ["typed_launch"] = "herdr agent start <logical-role> --kind <agent-kind> --pane <pane-id> -- <operator-approved-permission-flags>",
+            ["approval_boundary"] = "Approvals are never auto-answered; the G550 MAY/escalate boundary governs.",
+            ["ready_gate"] = "READY only after G556 verified liveness: expected agent/cwd/repo, detected same-pane process, and bounded probe response.",
+        },
+        ["dispatch"] = new JsonObject
+        {
+            ["command"] = "herdr agent prompt <logical-role> <task-block>",
+            ["required_fields"] = new JsonArray("task-id", "role", "objective", "inputs", "expected-artifacts", "completion-marker"),
+            ["marker"] = "ORCH_RESULT <task-id> <status> <artifact>",
+            ["artifact_first"] = "Files, commits, PRs, and verification logs are the handoff; terminal text points to them.",
+            ["redispatch"] = "Resolve the same logical role's current pane and send the task id plus concrete repair delta.",
+        },
+        ["waiting"] = new JsonObject
+        {
+            ["agent"] = "herdr agent wait <logical-role> --until done --until blocked --timeout <milliseconds>",
+            ["marker"] = "herdr pane wait-output --match \"ORCH_RESULT <task-id>\" --source recent-unwrapped --timeout <milliseconds> <pane-id>",
+            ["bounded_rule"] = "Timeouts are re-entry points; never leave a wait unbounded. Persist cursors in deterministic scripts for long loops.",
+            ["success"] = "Composite success requires settled state + matching task marker + existing verified artifact; state alone never concludes success.",
+        },
+        ["events_jsonl"] = new JsonObject
+        {
+            ["scope"] = "Mode-independent design boundary only; never an inter-agent bus.",
+            ["path"] = "<host-repo>/.intent-cli/events/<team>.jsonl",
+            ["team_encoding"] = "Team name verbatim as one flat filename; no subdirectories.",
+            ["validation"] = "Reject empty, leading-dot, path separators, and any '..' sequence before path construction.",
+            ["append"] = "Orchestrator-only O_APPEND writer; one object per line, no embedded newline, summary normalized to one line.",
+            ["schema"] = "timestamp, team, kind, unit, summary, artifact",
+            ["kinds"] = new JsonArray("completion", "blocked", "question", "escalation"),
+            ["readers"] = new JsonObject
+            {
+                ["claude_app"] = "Tail complete unseen lines from the resolved host path and retain the read offset.",
+                ["codex_cli"] = "Prompt a herdr-resident Codex pane directly; no file poll for ordinary coordination.",
+                ["codex_desktop"] = "One-minute-class timer poll using a durable byte-offset watermark; fail closed on truncation or malformed JSON.",
+            },
+        },
+        ["failure_recovery"] = new JsonArray(
+            "Modifier-chord injection: relaunch with typed agent-start permission flags.",
+            "Post-reboot dead pty: detect agent-undetected panes, re-provision, rebuild mapping, repeat G556.",
+            "Long-wait turn death: bounded waits, re-entry, and deterministic persisted loops."),
+        ["switches"] = new JsonObject
+        {
+            ["exclusivity"] = "Exactly one mode per team; mixed delivery is a contract violation.",
+            ["agmsg_to_herdr_only"] = "Drain; gracefully drop roles/bridges; provision herdr; G556 verify; set herdr-only as the final canonical step.",
+            ["herdr_only_to_agmsg"] = "Drain; handle workspace; provision roles/bridge; G556 verify; set agmsg as the final canonical step.",
+        },
+    };
+}

--- a/src/IntentSystem.Cli/Commands/SessionLayerFragments.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerFragments.cs
@@ -176,9 +176,7 @@ internal static class SessionLayerFragments
             Descriptive("A herdr-only request made at first setup is honoured from then on; the choice is reversible in both directions.")),
         Fragment(
             S0,
-            Descriptive("- setup-ready (herdr-only) — the registration, delivery-configuration and role-prompt steps of this intake are agmsg-only and do not apply."),
-            Scaffold(" "),
-            Descriptive("Their herdr-only counterparts ship in G571.")),
+            Descriptive("- setup-ready (herdr-only) — concrete provisioning, logical-role→pane mapping, typed launch, and G556 READY procedures are present in the herdr-only operating sections.")),
         Fragment(
             S0,
             Descriptive("PRIMARY four-thread orchestrator model (ADR-012 / spec-26): design / orchestrator / implementation / review coordinate over the session layer this team runs — herdr-only here."),
@@ -187,7 +185,7 @@ internal static class SessionLayerFragments
             Scaffold(" "),
             Descriptive("Timer-loop mode remains fully supported as the simpler ALTERNATIVE for setups without an orchestrator thread (see Mode separation)."),
             Scaffold(" "),
-            Descriptive("The herdr-only operating steps ship in G571.")),
+            Descriptive("The concrete herdr-only operating sections below cover provisioning, dispatch, bounded completion detection, the events boundary, recovery, and both switches.")),
         Fragment(S0, Operative("- missing-inputs — supply the 4 missing field(s) below to get a setup-ready plan.")),
         Fragment(S0, Descriptive("- **status: `missing-inputs`**")),
         Fragment(S0, Operative("- missing-inputs — supply the 6 missing field(s) below to get a setup-ready plan.")),
@@ -1040,12 +1038,10 @@ internal static class SessionLayerFragments
             Scaffold(" "),
             Descriptive("Timer-loop mode remains fully supported as the simpler ALTERNATIVE for setups without an orchestrator thread (see Mode separation)."),
             Scaffold(" "),
-            Descriptive("The herdr-only operating steps ship in G571.")),
+            Descriptive("The concrete herdr-only operating sections below cover provisioning, dispatch, bounded completion detection, the events boundary, recovery, and both switches.")),
         Fragment(
             "setup_intake",
-            Descriptive("setup-ready (herdr-only) — the registration, delivery-configuration and role-prompt steps of this intake are agmsg-only and do not apply."),
-            Scaffold(" "),
-            Descriptive("Their herdr-only counterparts ship in G571.")),
+            Descriptive("setup-ready (herdr-only) — concrete provisioning, logical-role→pane mapping, typed launch, and G556 READY procedures are present in the herdr-only operating sections.")),
         Fragment("setup_intake", Operative("missing-inputs — supply the 4 missing field(s) below to get a setup-ready plan.")),
         Fragment(
             "summary",

--- a/src/IntentSystem.Cli/Commands/SessionLayerSections.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerSections.cs
@@ -37,9 +37,9 @@ internal static class SessionLayerSections
 
         /// <summary>
         /// G570 fourth repair: the ruling's fourth value, previously missing.
-        /// Content that exists only under herdr-only — today the synthetic
-        /// switch-checklist section and its JSON replacement metadata, which
-        /// have no agmsg counterpart and are produced by the routing itself.
+        /// Content that exists only under herdr-only — the synthetic G571
+        /// operating sections and their JSON representation, which have no
+        /// agmsg counterpart and are produced by the routing itself.
         /// </summary>
         HerdrOnly,
     }
@@ -124,6 +124,9 @@ internal static class SessionLayerSections
         new(ReplacementHeadingValue, "herdr_only_replaced_sections", Applicability.HerdrOnly),
         new("(json) herdr-only replacement note", "herdr_only_replacement_note", Applicability.HerdrOnly),
         new("(json) herdr-only descriptive context", "herdr_only_descriptive_agmsg_context", Applicability.HerdrOnly),
+        new("(json) herdr-only operations", HerdrOnlyOperatingGuide.JsonProperty, Applicability.HerdrOnly),
+        ..HerdrOnlyOperatingGuide.Headings.Select(heading =>
+            new SectionDeclaration(heading, null, Applicability.HerdrOnly)),
 
         // mode-independent — unchanged in both.
         new("## Session layer", "session_layer", Applicability.ModeIndependent),
@@ -275,8 +278,8 @@ internal static class SessionLayerSections
 
     public const string DescriptiveAgmsgContextSuffix =
         " — which explains the model using the agmsg transport because that is the practiced one. In herdr-only the "
-        + "rule it states still binds; the agmsg mechanics it names are illustration, and the herdr-only operating "
-        + "steps ship in G571. Every other sentence here is an instruction that applies unchanged.";
+        + "rule it states still binds; the agmsg mechanics it names are illustration. Follow the concrete herdr-only "
+        + "operating sections in this guide. Every other sentence here is an instruction that applies unchanged.";
 
     /// <summary>
     /// Names the table a deferred label's sentence lives in, so a reader who
@@ -331,7 +334,7 @@ internal static class SessionLayerSections
 
     public const string MechanicPointer =
         "(herdr-only: the session-layer step described here is agmsg-specific and does not apply; its herdr-only "
-        + "counterpart ships in G571. The rule stated by this section still binds.)";
+        + "counterpart is in the herdr-only operating sections above. The rule stated by this section still binds.)";
 
     private const string ReplacementHeadingValue = "## Session-layer switch checklist (herdr-only)";
 
@@ -353,32 +356,5 @@ internal static class SessionLayerSections
         Declarations.Single(d => d.Heading == "(json) herdr-only descriptive context").JsonProperty!;
 
     public static string ReplacementSection(IReadOnlyList<string> replacedHeadings)
-    {
-        var lines = new List<string>
-        {
-            ReplacementHeading,
-            string.Empty,
-            "This team runs the **herdr-only** session layer, so the agmsg-only sections of this guide do not apply "
-            + "and are not rendered. Their herdr-only counterparts — provisioning, dispatch and task format, the "
-            + "events channel, and the switch checklists — ship in **G571**.",
-            string.Empty,
-            "Replaced here (agmsg-only):",
-            string.Empty,
-        };
-
-        foreach (var heading in replacedHeadings)
-        {
-            lines.Add($"- `{heading.TrimStart('#', ' ')}`");
-        }
-
-        lines.Add(string.Empty);
-        lines.Add(
-            "Everything else in this document is mode-independent and applies unchanged: supervision, isolation, "
-            + "liveness, the wake contract, publish authority, the design↔orchestrator double-check rule, dependency "
-            + "planning, and escalation are properties of the four-thread model, and the model does not change with "
-            + "the transport.");
-        lines.Add(string.Empty);
-
-        return string.Join('\n', lines);
-    }
+        => HerdrOnlyOperatingGuide.RenderMarkdown(replacedHeadings);
 }

--- a/tests/IntentSystem.Cli.Tests/HerdrOnlyOperatingGuideG571Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrOnlyOperatingGuideG571Tests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class HerdrOnlyOperatingGuideG571Tests : IDisposable
+{
+    private readonly string root = Directory.CreateTempSubdirectory("herdr-guide-g571-").FullName;
+
+    [Fact]
+    public void HerdrOnlyMarkdown_RendersTheCompleteOperatingContract_G571()
+    {
+        var output = Render(herdrOnly: true, format: "markdown");
+
+        foreach (var heading in HerdrOnlyOperatingGuide.Headings)
+        {
+            Assert.Contains(heading, output, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("herdr agent start <logical-role>", output, StringComparison.Ordinal);
+        Assert.Contains("logical-role→pane", output, StringComparison.Ordinal);
+        Assert.Contains("G556 verified-liveness", output, StringComparison.Ordinal);
+        Assert.Contains("ORCH_RESULT <task-id> <status> <artifact>", output, StringComparison.Ordinal);
+        Assert.Contains("herdr agent wait <logical-role> --until done --until blocked --timeout", output, StringComparison.Ordinal);
+        Assert.Contains("Composite success is mandatory", output, StringComparison.Ordinal);
+        Assert.Contains("state alone NEVER means task success", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Approvals are NEVER auto-answered", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("ship in G571", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void EventsJsonl_UsesTheClarifiedNormativeBoundary_G571()
+    {
+        var output = Render(herdrOnly: true, format: "markdown");
+        var json = JsonDocument.Parse(Render(herdrOnly: true, format: "json")).RootElement;
+        var events = json.GetProperty(HerdrOnlyOperatingGuide.JsonProperty).GetProperty("events_jsonl");
+
+        Assert.Contains("<host-repo>/.intent-cli/events/<team>.jsonl", output, StringComparison.Ordinal);
+        Assert.Contains("O_APPEND", output, StringComparison.Ordinal);
+        Assert.Contains("no embedded newline", output, StringComparison.Ordinal);
+        Assert.Contains("leading dot", output, StringComparison.Ordinal);
+        Assert.Contains("any `..` sequence", output, StringComparison.Ordinal);
+        Assert.Contains("Claude app watcher", output, StringComparison.Ordinal);
+        Assert.Contains("Codex CLI", output, StringComparison.Ordinal);
+        Assert.Contains("Codex Desktop", output, StringComparison.Ordinal);
+        Assert.Contains("one-minute-class", output, StringComparison.Ordinal);
+        Assert.Contains("watermark", output, StringComparison.Ordinal);
+        Assert.Contains("NEVER an inter-agent bus", output, StringComparison.Ordinal);
+
+        Assert.Equal("<host-repo>/.intent-cli/events/<team>.jsonl", events.GetProperty("path").GetString());
+        Assert.Equal("timestamp, team, kind, unit, summary, artifact", events.GetProperty("schema").GetString());
+        Assert.Equal(4, events.GetProperty("kinds").GetArrayLength());
+        Assert.True(events.GetProperty("readers").TryGetProperty("claude_app", out _));
+        Assert.True(events.GetProperty("readers").TryGetProperty("codex_cli", out _));
+        Assert.True(events.GetProperty("readers").TryGetProperty("codex_desktop", out _));
+    }
+
+    [Fact]
+    public void SwitchesAndRecoveries_ArePresentInBothDirections_G571()
+    {
+        var output = Render(herdrOnly: true, format: "markdown");
+
+        Assert.Contains("Modifier-chord injection", output, StringComparison.Ordinal);
+        Assert.Contains("Post-reboot dead pty wiring", output, StringComparison.Ordinal);
+        Assert.Contains("Long-wait turn death", output, StringComparison.Ordinal);
+        Assert.Contains("**agmsg → herdr-only**", output, StringComparison.Ordinal);
+        Assert.Contains("**herdr-only → agmsg**", output, StringComparison.Ordinal);
+        Assert.Equal(2, Count(output, "As the FINAL canonical step"));
+        Assert.Contains("mixed-delivery CONTRACT VIOLATION", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AgmsgMode_DoesNotRenderAnyHerdrOnlyOperatingSurface_G571()
+    {
+        var markdown = Render(herdrOnly: false, format: "markdown");
+        var json = JsonDocument.Parse(Render(herdrOnly: false, format: "json")).RootElement;
+
+        foreach (var heading in HerdrOnlyOperatingGuide.Headings)
+        {
+            Assert.DoesNotContain(heading, markdown, StringComparison.Ordinal);
+        }
+
+        Assert.False(json.TryGetProperty(HerdrOnlyOperatingGuide.JsonProperty, out _));
+        Assert.Contains("## Terminal-workspace provisioning (G549)", markdown, StringComparison.Ordinal);
+        Assert.Contains("## agmsg reply contract", markdown, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void OrchestrationDocs_MirrorTheNormativeContract_G571(string language)
+    {
+        var path = Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, "12-agent-message-orchestration.md");
+        var content = File.ReadAllText(path);
+
+        foreach (var token in new[]
+                 {
+                     "<host-repo>/.intent-cli/events/<team>.jsonl",
+                     "O_APPEND",
+                     "timestamp",
+                     "completion|blocked|question|escalation",
+                     "ORCH_RESULT <task-id> <status> <artifact>",
+                     "one-minute-class",
+                     "byte-offset watermark",
+                     "agmsg → herdr-only",
+                     "herdr-only → agmsg",
+                 })
+        {
+            Assert.Contains(token, content, StringComparison.Ordinal);
+        }
+    }
+
+    private string Render(bool herdrOnly, string format)
+    {
+        Directory.CreateDirectory(Path.Combine(root, ".intent-cli"));
+        var record = SessionLayerModeStore.ResolvePath(root);
+        if (herdrOnly)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(record)!);
+            File.WriteAllText(
+                record,
+                """
+                {
+                  "schema_version": "1",
+                  "entries": [
+                    {
+                      "domain": "intent-cli",
+                      "mode": "herdr-only",
+                      "updated_at": "2026-08-01T12:00:00+00:00",
+                      "transitions": [
+                        { "from": "agmsg", "to": "herdr-only", "at": "2026-08-01T12:00:00+00:00" }
+                      ]
+                    }
+                  ]
+                }
+                """);
+        }
+        else if (File.Exists(record))
+        {
+            File.Delete(record);
+        }
+
+        var context = new CliContext
+        {
+            RepoRoot = root,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                },
+            },
+        };
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "orchestrator-thread", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude", "--format", format],
+            context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        return writer.ToString();
+    }
+
+    private static int Count(string value, string needle) =>
+        (value.Length - value.Replace(needle, string.Empty, StringComparison.Ordinal).Length) / needle.Length;
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/HerdrOnlyOperatingGuideG571Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrOnlyOperatingGuideG571Tests.cs
@@ -41,6 +41,8 @@ public sealed class HerdrOnlyOperatingGuideG571Tests : IDisposable
         Assert.Contains("O_APPEND", output, StringComparison.Ordinal);
         Assert.Contains("no embedded newline", output, StringComparison.Ordinal);
         Assert.Contains("leading dot", output, StringComparison.Ordinal);
+        Assert.Contains("`/` or `\\`, and any", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("`/` or `\\\\`, and any", output, StringComparison.Ordinal);
         Assert.Contains("any `..` sequence", output, StringComparison.Ordinal);
         Assert.Contains("Claude app watcher", output, StringComparison.Ordinal);
         Assert.Contains("Codex CLI", output, StringComparison.Ordinal);
@@ -55,6 +57,40 @@ public sealed class HerdrOnlyOperatingGuideG571Tests : IDisposable
         Assert.True(events.GetProperty("readers").TryGetProperty("claude_app", out _));
         Assert.True(events.GetProperty("readers").TryGetProperty("codex_cli", out _));
         Assert.True(events.GetProperty("readers").TryGetProperty("codex_desktop", out _));
+    }
+
+    [Fact]
+    public void ApprovalBoundary_IsPaneVisibleAndContrastsHeadlessAutoDecline_G571()
+    {
+        var output = Render(herdrOnly: true, format: "markdown");
+        var provisioning = JsonDocument.Parse(Render(herdrOnly: true, format: "json"))
+            .RootElement
+            .GetProperty(HerdrOnlyOperatingGuide.JsonProperty)
+            .GetProperty("provisioning");
+
+        Assert.Contains("Approvals surface visibly in the pane", output, StringComparison.Ordinal);
+        Assert.Contains("supervision boundary", output, StringComparison.Ordinal);
+        Assert.Contains("agmsg Codex bridge's headless auto-decline", output, StringComparison.Ordinal);
+        Assert.Contains("surface visibly in the pane", provisioning.GetProperty("approval_boundary").GetString());
+        Assert.Contains("headless auto-decline", provisioning.GetProperty("approval_boundary").GetString());
+    }
+
+    [Fact]
+    public void ReadyGate_IsSelfContainedAndResidualScopeIsTruthful_G571()
+    {
+        var section = HerdrOnlyOperatingGuide.RenderMarkdown([]);
+        var output = Render(herdrOnly: true, format: "markdown");
+        var provisioning = JsonDocument.Parse(Render(herdrOnly: true, format: "json"))
+            .RootElement
+            .GetProperty(HerdrOnlyOperatingGuide.JsonProperty)
+            .GetProperty("provisioning");
+
+        Assert.Contains("After the startup report, wait a settle delay, then re-check", section, StringComparison.Ordinal);
+        Assert.Contains("repeat this entire settle-and-re-check sequence", section, StringComparison.Ordinal);
+        Assert.DoesNotContain("complete G556", section, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("wait a settle delay, then re-check", provisioning.GetProperty("ready_gate").GetString());
+        Assert.Contains("transport-specific examples in them govern only their named transport", output, StringComparison.Ordinal);
+        Assert.Contains("the concrete herdr-only counterparts below govern this mode", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -106,6 +142,11 @@ public sealed class HerdrOnlyOperatingGuideG571Tests : IDisposable
                      "byte-offset watermark",
                      "agmsg → herdr-only",
                      "herdr-only → agmsg",
+                     "pane-visible",
+                     "supervision boundary",
+                     "headless auto-decline",
+                     "settle delay",
+                     "settle-and-re-check",
                  })
         {
             Assert.Contains(token, content, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/SessionLayerModeG570Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerModeG570Tests.cs
@@ -245,6 +245,15 @@ public sealed class SessionLayerModeG570Tests : IDisposable
         // session-layer metadata, and fragment typing is what keeps descriptive
         // identities from being flagged.
         var body = WithoutSessionLayerExemptions(workspace.RenderOrchestratorGuide());
+        if (instruction.Equals("Codex bridge", StringComparison.OrdinalIgnoreCase))
+        {
+            // G571 requires this one non-operative contrast while preserving
+            // the G570 ban on every actual bridge instruction.
+            body = body.Replace(
+                "agmsg Codex bridge's headless auto-decline",
+                string.Empty,
+                StringComparison.OrdinalIgnoreCase);
+        }
 
         Assert.DoesNotContain(instruction, body, StringComparison.OrdinalIgnoreCase);
     }
@@ -268,7 +277,16 @@ public sealed class SessionLayerModeG570Tests : IDisposable
             CollectStringValues(property.Value, path: property.Name, values);
         }
 
-        Assert.DoesNotContain(instruction, string.Join("\n", values), StringComparison.OrdinalIgnoreCase);
+        var body = string.Join("\n", values);
+        if (instruction.Equals("Codex bridge", StringComparison.OrdinalIgnoreCase))
+        {
+            body = body.Replace(
+                "agmsg Codex bridge's headless auto-decline",
+                string.Empty,
+                StringComparison.OrdinalIgnoreCase);
+        }
+
+        Assert.DoesNotContain(instruction, body, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- replace G570 herdr-only pointers with concrete provisioning, dispatch, bounded wait, composite-success, recovery, and two-way switch procedures
- define the clarified normative events.jsonl design boundary and its Claude app, Codex CLI, and Codex Desktop reader recipes
- mirror the operating contract in English/Japanese orchestration docs and preserve the agmsg rendering path

## Verification
- focused G570/G571 tests: 145 passed, 0 failed
- full suite: 4,553 tests, 0 failed (1 pre-existing skip)
- clean detached-worktree restore/build/full test at 980c871bfbfb88846662324252a5525600378288
- touched-file dotnet format verification passed
- git diff --check passed

Closes #1247