### PR TITLE
G573: add shipped skill version lineage

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2238,28 +2238,50 @@ intent-cli skill diff --target claude              # what an edited copy changed
 `--target claude|codex|copilot|all`, `--scope user|repo`, `--skill <name>`,
 `--force`, and `--format`.
 
-Four properties are the contract:
+The installed copy has four observable states: `not-installed`, `current`,
+`stale-shipped`, and `locally-modified`. `stale-shipped` means its normalized
+content hash matches an earlier entry in the package's shipped-version lineage;
+`skill list` marks it `update_available`, and `skill diff` labels the comparison
+as previous-shipped → current. `skill install` updates that state without
+`--force` and reports `updated-stale`. Content outside the lineage is
+`locally-modified` and retains the refusal described below.
+
+Every change to `skills/<name>/SKILL.md` must append the old and new normalized
+SHA-256 identities to the embedded lineage. A guard fails when the current
+embedded content is missing, so a skill-content change cannot ship without its
+lineage duty. Guide-group commands perform only a bounded local-filesystem check
+of known install locations. If a stale-shipped copy exists, Markdown receives
+one footer and JSON one `skill_update_nudge` field naming an exact `skill install`
+command. Not-installed and locally-modified copies are never nudged;
+probe failures are silently ignored and never block or alter guide output.
+
+Modifying the installed official skill is unsupported. `locally-modified` is a
+data-safety state, not a customization feature: the installed-guide-wins rule
+makes such edits semantically inert. Create a separate, own-named skill for
+local behavior or send upstream feedback instead.
+
+Four installation properties remain the contract:
 
 1. **A scope the platform does not define is refused, not written.** `--scope
    repo` for `codex` fails with the supported scopes named. Writing to a
    plausible-looking directory the platform never reads would look like a
    successful install and behave like no install at all.
 2. **An edited copy is never replaced silently.** Install compares the
-   installed file against the embedded source; on a difference it reports
-   `refused-drifted`, leaves the file byte-identical, and **exits non-zero** so
-   a script notices. `--force` is the explicit opt-in to replace it. Line-ending
-   differences are not drift, so a Windows checkout does not report every
-   install as edited.
+   normalized installed hash with the shipped lineage. Content outside that
+   lineage is locally modified: it reports `refused-drifted`, leaves the file
+   byte-identical, and **exits non-zero** so a script notices. `--force` is the
+   explicit opt-in to replace it. Line-ending differences are not drift, so a
+   Windows checkout does not report every install as edited.
 3. **The whole plan is resolved and inspected before the first write.**
    Install runs in two phases: it validates every target/scope pair, resolves
    every destination path, and inspects every destination's state — and only
-   then writes. An unsupported target/scope pair *or* a drifted destination
-   **anywhere** in the plan aborts the entire run with nothing created and
-   nothing changed; the writable destinations are reported
+   then writes. An unsupported target/scope pair *or* a locally-modified
+   destination **anywhere** in the plan aborts the entire run with nothing
+   created and nothing changed; the other destinations are reported
    `skipped-plan-aborted` so it is clear they were part of the plan and were
    deliberately not written. Inspecting and writing in one pass is not
    "validated before any write" — under `--target all` an earlier missing
-   target would already be on disk by the time a later drifted one was found,
+   target would already be on disk by the time a later local edit was found,
    leaving a partial install behind an exit code that claims nothing happened.
    `--force` is what makes that same plan succeed end to end.
 4. **Nothing is written that is already current.** A matching copy reports

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2343,25 +2343,44 @@ intent-cli skill diff --target claude              # 編集済みコピーの差
 `--target claude|codex|copilot|all`、`--scope user|repo`、`--skill <name>`、
 `--force`、`--format` を受け取ります。
 
-契約は次の 4 点です:
+installed copy には `not-installed`、`current`、`stale-shipped`、
+`locally-modified` の 4 状態があります。`stale-shipped` は正規化 content hash が package の
+shipped-version lineage にある以前の entry と一致する状態です。`skill list` は
+`update_available` を示し、`skill diff` は previous-shipped → current の比較だと明示します。
+`skill install` は `--force` なしで更新し、`updated-stale` を報告します。lineage 外の content は
+`locally-modified` で、後述する拒否保護を維持します。
+
+`skills/<name>/SKILL.md` を変更するたびに、旧版と新版の正規化 SHA-256 identity を embedded
+lineage へ追記しなければなりません。current embedded content が lineage に無いと guard が失敗する
+ため、lineage duty を伴わない skill-content change は出荷できません。guide group の各 command は
+known install location だけを bounded な local-filesystem check で確認します。stale-shipped copy が
+あれば Markdown へ footer を 1 行、JSON へ exact な `skill install` command を含む
+`skill_update_nudge` field を 1 つ追加します。not-installed / locally-modified は nudge せず、probe
+failure は黙って無視され、guide output を block・変更しません。
+
+installed official skill の変更は unsupported です。`locally-modified` は data-safety state であり
+customization feature ではありません。installed-guide-wins rule により編集は意味的に inert です。
+local behavior には別の own-named skill を作るか、upstream feedback を送ってください。
+
+install 契約は引き続き次の 4 点です:
 
 1. **プラットフォームが定義していない scope は、書かずに拒否する。** `codex` に対する
    `--scope repo` は、サポートされる scope を明示して失敗します。そのプラットフォームが
    決して読まない、それらしいディレクトリへ書くことは、install 成功に見えて
    install していないのと同じ挙動になります。
-2. **編集済みコピーを黙って置き換えない。** install は installed ファイルを埋め込み
-   ソースと比較し、差分があれば `refused-drifted` を報告し、ファイルを 1 バイトも
-   変えずに残し、**非ゼロで終了**します(script が検知できるように)。置き換えは
+2. **編集済みコピーを黙って置き換えない。** install は正規化した installed hash を shipped
+   lineage と比較します。lineage 外の content は locally-modified として `refused-drifted` を
+   報告し、ファイルを 1 バイトも変えずに残し、**非ゼロで終了**します(script が検知できるように)。置き換えは
    `--force` による明示的な opt-in です。改行コードの違いは drift 扱いしないため、
    Windows checkout ですべての install が編集済みと報告されることはありません。
 3. **最初の書き込み前に plan 全体を解決・検査する。** install は 2 フェーズで動きます。
    まず全 target/scope の組み合わせを検証し、全 destination のパスを解決し、全
    destination の状態を検査します。書き込みはその後です。不正な target/scope の
-   組み合わせ**または** drift した destination が plan の**どこかに**1 つでもあれば、
+   組み合わせ**または** locally-modified destination が plan の**どこかに**1 つでもあれば、
    何も作らず何も変更せずに実行全体を中止します。書き込み可能だった destination は
    `skipped-plan-aborted` として報告され、plan に含まれていたが意図的に書かれなかった
    ことが分かるようになっています。検査と書き込みを 1 パスで行うのは「書き込み前の
-   検証」ではありません。`--target all` の下では、後続の drift が見つかった時点で
+   検証」ではありません。`--target all` の下では、後続の local edit が見つかった時点で
    先行する未 install の target はすでにディスク上にあり、「何も起きていない」と主張する
    exit code の裏で部分 install が残ります。同じ plan を最後まで成功させるのが
    `--force` です。

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -341,6 +341,20 @@ internal static class CommandRouter
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(writer);
 
+        if (args.Length > 0 && string.Equals(args[0], "guide", StringComparison.Ordinal))
+        {
+            return GuideSkillUpdateNudge.Execute(
+                context,
+                args,
+                writer,
+                guideWriter => ExecuteCore(args, context, guideWriter));
+        }
+
+        return ExecuteCore(args, context, writer);
+    }
+
+    private static int ExecuteCore(string[] args, CliContext context, TextWriter writer)
+    {
         // G379: `intent-cli --help --all` (and the `--help-all` synonym) shows
         // every command group, including the advanced/legacy/provider-runtime
         // surfaces hidden from the chat-first default. Checked before the

--- a/src/IntentSystem.Cli/Commands/GuideSkillUpdateNudge.cs
+++ b/src/IntentSystem.Cli/Commands/GuideSkillUpdateNudge.cs
@@ -1,0 +1,77 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G573: common guide-group output boundary for a best-effort, local-only
+/// shipped-skill update nudge. The guide command runs first and its exit code
+/// remains authoritative; probe or JSON-shaping failures leave its bytes alone.
+/// </summary>
+internal static class GuideSkillUpdateNudge
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    public static int Execute(
+        CliContext context,
+        string[] args,
+        TextWriter writer,
+        Func<TextWriter, int> executeGuide)
+    {
+        using var buffer = new StringWriter();
+        var exitCode = executeGuide(buffer);
+        var output = buffer.ToString();
+        var location = SkillCommand.FindStaleShippedInstall(context);
+        if (location is null)
+        {
+            writer.Write(output);
+            return exitCode;
+        }
+
+        var command = $"intent-cli skill install --target {location.Target} --scope {location.Scope} --skill {location.Skill}";
+        var nudge = $"Skill update available: run `{command}`.";
+
+        if (RequestsJson(args))
+        {
+            try
+            {
+                if (JsonNode.Parse(output) is JsonObject root)
+                {
+                    root["skill_update_nudge"] = nudge;
+                    writer.WriteLine(root.ToJsonString(JsonOptions));
+                    return exitCode;
+                }
+            }
+            catch (JsonException)
+            {
+                // Preserve the guide command's original error/output shape.
+            }
+
+            writer.Write(output);
+            return exitCode;
+        }
+
+        writer.Write(output);
+        if (output.Length > 0 && !output.EndsWith('\n'))
+        {
+            writer.WriteLine();
+        }
+        writer.WriteLine();
+        writer.WriteLine($"> {nudge}");
+        return exitCode;
+    }
+
+    private static bool RequestsJson(string[] args)
+    {
+        for (var index = 0; index < args.Length - 1; index++)
+        {
+            if (string.Equals(args[index], "--format", StringComparison.Ordinal)
+                && string.Equals(args[index + 1], "json", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/SkillAssets.cs
+++ b/src/IntentSystem.Cli/Commands/SkillAssets.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -15,6 +17,15 @@ namespace IntentSystem.Cli.Commands;
 /// </summary>
 internal static class SkillAssets
 {
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> ShippedContentHashes =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.Ordinal)
+        {
+            // G573: append the normalized SHA-256 before changing the shipped
+            // content. Never replace older entries: they are what lets a
+            // forceless install distinguish stale shipped content from edits.
+            ["intent-cli"] = ["af071a2882b65d17955e690f7936d1b7d4895e1bce02d4a3cabe03f838ffaaff"],
+        };
+
     /// <summary>The single embedded skill. A list rather than a constant so a second skill needs no structural change.</summary>
     public static IReadOnlyList<EmbeddedSkill> All { get; } =
     [
@@ -25,6 +36,11 @@ internal static class SkillAssets
 
     public static EmbeddedSkill? Find(string name) =>
         All.FirstOrDefault(skill => string.Equals(skill.Name, name, StringComparison.Ordinal));
+
+    /// <summary>G573 test seams for walking a future embedded version without changing the shipped skill.</summary>
+    internal static Func<EmbeddedSkill, string>? BodyReader { get; set; }
+
+    internal static Func<EmbeddedSkill, IReadOnlyList<string>>? LineageReader { get; set; }
 
     /// <summary>
     /// Reads the embedded SKILL.md body. Throws
@@ -42,6 +58,44 @@ internal static class SkillAssets
     {
         ArgumentNullException.ThrowIfNull(skill);
 
+        var body = BodyReader?.Invoke(skill) ?? ReadEmbeddedBody(skill);
+        EnsureCurrentBodyIsInLineage(skill, body);
+        return body;
+    }
+
+    public static IReadOnlyList<string> ReadLineage(EmbeddedSkill skill)
+    {
+        ArgumentNullException.ThrowIfNull(skill);
+        if (LineageReader is not null)
+        {
+            return LineageReader(skill);
+        }
+
+        return ShippedContentHashes.TryGetValue(skill.Name, out var hashes) ? hashes : [];
+    }
+
+    internal static void EnsureCurrentBodyIsInLineage(EmbeddedSkill skill, string body)
+    {
+        var currentHash = ComputeNormalizedHash(body);
+        if (!ReadLineage(skill).Contains(currentHash, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"embedded skill '{skill.Name}' is absent from its shipped-version lineage; "
+                + $"add normalized SHA-256 {currentHash} before shipping the content change.");
+        }
+    }
+
+    internal static string ComputeNormalizedHash(string content)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(Normalize(content)));
+        return Convert.ToHexStringLower(bytes);
+    }
+
+    internal static string Normalize(string content) =>
+        content.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd('\n');
+
+    private static string ReadEmbeddedBody(EmbeddedSkill skill)
+    {
         var assembly = typeof(SkillAssets).Assembly;
         var resourceName = ResolveResourceName(assembly, skill.Name)
             ?? throw new InvalidOperationException(

--- a/src/IntentSystem.Cli/Commands/SkillCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SkillCommand.cs
@@ -138,16 +138,17 @@ internal static class SkillCommand
             {
                 var path = SkillTargets.ResolveSkillFilePath(entry.Target, entry.Scope, entry.Skill.Name, repoRoot, userHome);
                 var embedded = SkillAssets.ReadBody(entry.Skill);
-                return (entry.Target, entry.Scope, entry.Skill, Path: path, Embedded: embedded, State: InspectState(path, embedded));
+                return (entry.Target, entry.Scope, entry.Skill, Path: path, Embedded: embedded, State: InspectState(path, embedded, entry.Skill));
             })
             .ToList();
 
         var results = new List<SkillInstallResult>();
 
-        // PHASE 2: a drifted destination anywhere in the plan aborts the WHOLE
-        // run without touching the filesystem. --force is the opt-in that turns
-        // every drifted destination into an overwrite instead.
-        if (!force && inspected.Any(entry => entry.State == SkillState.Drifted))
+        // PHASE 2: a locally-modified destination anywhere in the plan aborts
+        // the WHOLE run without touching the filesystem. A known stale shipped
+        // version is safe to update without --force; only content outside the
+        // lineage retains the edited-copy protection.
+        if (!force && inspected.Any(entry => entry.State == SkillState.LocallyModified))
         {
             foreach (var entry in inspected)
             {
@@ -157,9 +158,9 @@ internal static class SkillCommand
                     Target = entry.Target,
                     Scope = entry.Scope,
                     Path = entry.Path,
-                    Outcome = entry.State == SkillState.Drifted ? "refused-drifted" : "skipped-plan-aborted",
-                    Detail = entry.State == SkillState.Drifted
-                        ? "the installed copy differs from the embedded skill and was NOT overwritten. "
+                    Outcome = entry.State == SkillState.LocallyModified ? "refused-drifted" : "skipped-plan-aborted",
+                    Detail = entry.State == SkillState.LocallyModified
+                        ? "the installed copy is locally modified and was NOT overwritten. "
                           + "Re-run with --force to replace it, or run `intent-cli skill diff` to see what differs."
                         : "not written: another destination in this plan has an edited copy, so the whole "
                           + "install was abandoned before any file was created or changed.",
@@ -196,9 +197,16 @@ internal static class SkillCommand
                 Target = entry.Target,
                 Scope = entry.Scope,
                 Path = entry.Path,
-                Outcome = entry.State == SkillState.NotInstalled ? "installed" : "overwritten",
+                Outcome = entry.State switch
+                {
+                    SkillState.NotInstalled => "installed",
+                    SkillState.StaleShipped => "updated-stale",
+                    _ => "overwritten",
+                },
                 Detail = entry.State == SkillState.NotInstalled
                     ? "written for the first time."
+                    : entry.State == SkillState.StaleShipped
+                        ? "a previous shipped version was updated to the current embedded skill without requiring --force."
                     : "an edited copy was replaced because --force was given.",
             });
         }
@@ -261,6 +269,8 @@ internal static class SkillCommand
             {
                 writer.WriteLine($"## {skill.Name} → {installation.Target} ({installation.Scope}) — {installation.State}");
                 writer.WriteLine($"- path: {installation.Path}");
+                writer.WriteLine($"- comparison: {installation.Comparison}");
+                writer.WriteLine($"- update available: {(installation.UpdateAvailable ? "yes" : "no")}");
                 if (installation.Diff is { Count: > 0 })
                 {
                     foreach (var line in installation.Diff)
@@ -318,14 +328,18 @@ internal static class SkillCommand
                 foreach (var candidateScope in scopes)
                 {
                     var path = SkillTargets.ResolveSkillFilePath(candidate, candidateScope, skill.Name, repoRoot, userHome);
-                    var state = InspectState(path, embedded);
+                    var state = InspectState(path, embedded, skill);
                     installations.Add(new SkillInstallationState
                     {
                         Target = candidate,
                         Scope = candidateScope,
                         Path = path,
                         State = Describe(state),
-                        Diff = state == SkillState.Drifted ? BuildDiff(embedded, File.ReadAllText(path)) : null,
+                        UpdateAvailable = state == SkillState.StaleShipped,
+                        Comparison = DescribeComparison(state),
+                        Diff = state is SkillState.StaleShipped or SkillState.LocallyModified
+                            ? BuildDiff(embedded, File.ReadAllText(path))
+                            : null,
                     });
                 }
             }
@@ -360,7 +374,7 @@ internal static class SkillCommand
         return [skill];
     }
 
-    private static SkillState InspectState(string path, string embedded)
+    private static SkillState InspectState(string path, string embedded, EmbeddedSkill skill)
     {
         if (!File.Exists(path))
         {
@@ -368,21 +382,32 @@ internal static class SkillCommand
         }
 
         var installed = File.ReadAllText(path);
-        return Normalize(installed) == Normalize(embedded) ? SkillState.Current : SkillState.Drifted;
-    }
+        if (SkillAssets.Normalize(installed) == SkillAssets.Normalize(embedded))
+        {
+            return SkillState.Current;
+        }
 
-    /// <summary>
-    /// Line-ending differences are not drift — a checkout on Windows would
-    /// otherwise report every install as edited.
-    /// </summary>
-    private static string Normalize(string content) =>
-        content.Replace("\r\n", "\n", StringComparison.Ordinal).TrimEnd('\n');
+        var installedHash = SkillAssets.ComputeNormalizedHash(installed);
+        return SkillAssets.ReadLineage(skill)
+            .Contains(installedHash, StringComparer.Ordinal)
+            ? SkillState.StaleShipped
+            : SkillState.LocallyModified;
+    }
 
     private static string Describe(SkillState state) => state switch
     {
         SkillState.NotInstalled => "not-installed",
-        SkillState.Current => "installed",
-        _ => "drifted",
+        SkillState.Current => "current",
+        SkillState.StaleShipped => "stale-shipped",
+        _ => "locally-modified",
+    };
+
+    private static string DescribeComparison(SkillState state) => state switch
+    {
+        SkillState.NotInstalled => "not installed; no comparison",
+        SkillState.Current => "installed copy matches the current embedded version",
+        SkillState.StaleShipped => "previous shipped version → current embedded version",
+        _ => "locally modified copy → current embedded version",
     };
 
     /// <summary>
@@ -391,8 +416,8 @@ internal static class SkillCommand
     /// </summary>
     private static IReadOnlyList<string> BuildDiff(string embedded, string installed)
     {
-        var embeddedLines = Normalize(embedded).Split('\n');
-        var installedLines = Normalize(installed).Split('\n');
+        var embeddedLines = SkillAssets.Normalize(embedded).Split('\n');
+        var installedLines = SkillAssets.Normalize(installed).Split('\n');
         var lines = new List<string>();
 
         for (var index = 0; index < Math.Max(embeddedLines.Length, installedLines.Length); index++)
@@ -428,6 +453,10 @@ internal static class SkillCommand
             foreach (var installation in skill.Installations)
             {
                 writer.WriteLine($"- {installation.Target} ({installation.Scope}): {installation.State} — {installation.Path}");
+                if (installation.UpdateAvailable)
+                {
+                    writer.WriteLine("  update available: yes (previous shipped version)");
+                }
             }
 
             writer.WriteLine();
@@ -553,9 +582,55 @@ internal static class SkillCommand
     {
         NotInstalled,
         Current,
-        Drifted,
+        StaleShipped,
+        LocallyModified,
+    }
+
+    internal static SkillUpdateLocation? FindStaleShippedInstall(CliContext context)
+    {
+        try
+        {
+            var userHome = SkillTargets.ResolveUserHome();
+            foreach (var skill in SkillAssets.All)
+            {
+                var embedded = SkillAssets.ReadBody(skill);
+                foreach (var target in SkillTargets.Installable)
+                {
+                    foreach (var scope in SkillTargets.SupportedScopes(target))
+                    {
+                        var path = SkillTargets.ResolveSkillFilePath(
+                            target, scope, skill.Name, context.RepoRoot, userHome);
+                        try
+                        {
+                            if (InspectState(path, embedded, skill) == SkillState.StaleShipped)
+                            {
+                                return new SkillUpdateLocation(skill.Name, target, scope, path);
+                            }
+                        }
+                        catch (Exception exception) when (
+                            exception is IOException or UnauthorizedAccessException)
+                        {
+                            // One unreadable known location does not prevent
+                            // checking the remaining local locations.
+                        }
+                    }
+                }
+            }
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or UnauthorizedAccessException
+            or InvalidOperationException)
+        {
+            // Guide output is authoritative and must never fail or block on
+            // this best-effort local-only check.
+        }
+
+        return null;
     }
 }
+
+internal sealed record SkillUpdateLocation(string Skill, string Target, string Scope, string Path);
 
 internal sealed record SkillReport
 {
@@ -586,9 +661,15 @@ internal sealed record SkillInstallationState
     [JsonPropertyName("path")]
     public required string Path { get; init; }
 
-    /// <summary>One of <c>not-installed</c>, <c>installed</c>, <c>drifted</c>.</summary>
+    /// <summary>One of <c>not-installed</c>, <c>current</c>, <c>stale-shipped</c>, <c>locally-modified</c>.</summary>
     [JsonPropertyName("state")]
     public required string State { get; init; }
+
+    [JsonPropertyName("update_available")]
+    public required bool UpdateAvailable { get; init; }
+
+    [JsonPropertyName("comparison")]
+    public required string Comparison { get; init; }
 
     [JsonPropertyName("diff")]
     public IReadOnlyList<string>? Diff { get; init; }
@@ -615,7 +696,7 @@ internal sealed record SkillInstallResult
     public required string Path { get; init; }
 
     /// <summary>
-    /// One of <c>installed</c>, <c>overwritten</c>, <c>already-current</c>,
+    /// One of <c>installed</c>, <c>updated-stale</c>, <c>overwritten</c>, <c>already-current</c>,
     /// <c>refused-drifted</c>, or <c>skipped-plan-aborted</c> — the last one
     /// meaning this destination was writable but a sibling in the same plan was
     /// drifted, so nothing at all was written.

--- a/tests/IntentSystem.Cli.Tests/SkillCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/SkillCommandTests.cs
@@ -304,7 +304,7 @@ public sealed class SkillCommandTests
         Assert.Contains(("claude", "repo", "not-installed"), installations);
         Assert.Contains(("claude", "user", "not-installed"), installations);
         Assert.Contains(("codex", "user", "not-installed"), installations);
-        Assert.Contains(("copilot", "repo", "installed"), installations);
+        Assert.Contains(("copilot", "repo", "current"), installations);
     }
 
     [Fact]
@@ -319,7 +319,8 @@ public sealed class SkillCommandTests
         var exit = workspace.Run(SkillCommand.ExecuteDiff, ["--target", "copilot"], out var output);
 
         Assert.Equal(0, exit);
-        Assert.Contains("drifted", output, StringComparison.Ordinal);
+        Assert.Contains("locally-modified", output, StringComparison.Ordinal);
+        Assert.Contains("locally modified copy → current embedded version", output, StringComparison.Ordinal);
         Assert.Contains("Operator addition worth seeing.", output, StringComparison.Ordinal);
     }
 

--- a/tests/IntentSystem.Cli.Tests/SkillVersionLineageG573Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SkillVersionLineageG573Tests.cs
@@ -1,0 +1,229 @@
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class SkillVersionLineageG573Collection
+{
+    public const string Name = "Skill version lineage G573";
+}
+
+[Collection(SkillVersionLineageG573Collection.Name)]
+public sealed class SkillVersionLineageG573Tests : IDisposable
+{
+    private readonly string root = Path.Combine(
+        Path.GetTempPath(), "intent-cli-skill-lineage-tests", Guid.NewGuid().ToString("n"));
+    private readonly Func<string>? previousUserHome = SkillTargets.UserHomeFactory;
+    private readonly Func<EmbeddedSkill, string>? previousBodyReader = SkillAssets.BodyReader;
+    private readonly Func<EmbeddedSkill, IReadOnlyList<string>>? previousLineageReader = SkillAssets.LineageReader;
+
+    public SkillVersionLineageG573Tests()
+    {
+        Directory.CreateDirectory(RepoRoot);
+        Directory.CreateDirectory(UserHome);
+        SkillTargets.UserHomeFactory = () => UserHome;
+    }
+
+    private string RepoRoot => Path.Combine(root, "repo");
+
+    private string UserHome => Path.Combine(root, "home");
+
+    [Fact]
+    public void CurrentEmbeddedSkill_IsPresentInShippedLineage_G573()
+    {
+        var skill = SkillAssets.Find("intent-cli")!;
+        var body = SkillAssets.ReadBody(skill);
+
+        Assert.Contains(SkillAssets.ComputeNormalizedHash(body), SkillAssets.ReadLineage(skill));
+    }
+
+    [Fact]
+    public void UnlistedEmbeddedSkillContent_FailsClosed_G573()
+    {
+        var skill = SkillAssets.Find("intent-cli")!;
+        var shipped = SkillAssets.ReadBody(skill);
+        SkillAssets.BodyReader = _ => shipped + "\nfuture unlisted content\n";
+
+        var exception = Assert.Throws<InvalidOperationException>(() => SkillAssets.ReadBody(skill));
+
+        Assert.Contains("absent from its shipped-version lineage", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("add normalized SHA-256", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FixtureWalk_ClassifiesNudgesUpdatesAndProtectsLocalEdits_G573()
+    {
+        var path = Path.Combine(RepoRoot, ".github", "skills", "intent-cli", "SKILL.md");
+
+        Assert.Equal(0, Run(["skill", "list", "--format", "json"], out var absentReport));
+        Assert.Equal("not-installed", StateFor(absentReport, "copilot", "repo"));
+        Assert.DoesNotContain("Skill update available", RenderGuide(["guide", "model"]), StringComparison.Ordinal);
+
+        Assert.Equal(0, Run(["skill", "install", "--target", "copilot"], out _));
+        Assert.Equal("current", StateFor(ListJson(), "copilot", "repo"));
+
+        var previous = File.ReadAllText(path);
+        var current = previous + "\nFuture shipped dispatcher content.\n";
+        UseFutureVersion(previous, current);
+
+        var staleReport = ListJson();
+        Assert.Equal("stale-shipped", StateFor(staleReport, "copilot", "repo"));
+        Assert.True(UpdateAvailableFor(staleReport, "copilot", "repo"));
+
+        Assert.Equal(0, Run(["skill", "diff", "--target", "copilot"], out var staleDiff));
+        Assert.Contains("stale-shipped", staleDiff, StringComparison.Ordinal);
+        Assert.Contains("previous shipped version → current embedded version", staleDiff, StringComparison.Ordinal);
+
+        var markdown = RenderGuide(["guide", "model"]);
+        const string exactCommand = "intent-cli skill install --target copilot --scope repo --skill intent-cli";
+        Assert.Equal(1, Count(markdown, "Skill update available"));
+        Assert.Contains(exactCommand, markdown, StringComparison.Ordinal);
+
+        var guideHelp = RenderGuide(["guide", "--help"]);
+        Assert.Equal(1, Count(guideHelp, "Skill update available"));
+        Assert.Contains(exactCommand, guideHelp, StringComparison.Ordinal);
+
+        using (var json = JsonDocument.Parse(RenderGuide(["guide", "model", "--format", "json"])))
+        {
+            Assert.Contains(exactCommand, json.RootElement.GetProperty("skill_update_nudge").GetString());
+        }
+
+        Assert.Equal(0, Run(["skill", "install", "--target", "copilot"], out var updateOutput));
+        Assert.Contains("updated-stale", updateOutput, StringComparison.Ordinal);
+        Assert.Equal(SkillAssets.Normalize(current), SkillAssets.Normalize(File.ReadAllText(path)));
+        Assert.DoesNotContain("Skill update available", RenderGuide(["guide", "model"]), StringComparison.Ordinal);
+
+        var edited = File.ReadAllText(path) + "\nOperator edit.\n";
+        File.WriteAllText(path, edited);
+        var modifiedReport = ListJson();
+        Assert.Equal("locally-modified", StateFor(modifiedReport, "copilot", "repo"));
+        Assert.False(UpdateAvailableFor(modifiedReport, "copilot", "repo"));
+        Assert.DoesNotContain("Skill update available", RenderGuide(["guide", "model"]), StringComparison.Ordinal);
+
+        Assert.Equal(1, Run(["skill", "install", "--target", "copilot"], out var refusal));
+        Assert.Contains("refused-drifted", refusal, StringComparison.Ordinal);
+        Assert.Equal(edited, File.ReadAllText(path));
+    }
+
+    [Fact]
+    public void GuideOutput_IsByteIdenticalWhenLocalProbeFails_G573()
+    {
+        var expected = RenderGuide(["guide", "model"]);
+        SkillAssets.BodyReader = _ => throw new IOException("simulated unreadable skill asset");
+
+        var actual = RenderGuide(["guide", "model"]);
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ThreePhasePlan_DoesNotUpdateStaleSiblingWhenLocalEditAborts_G573()
+    {
+        Assert.Equal(0, Run(["skill", "install", "--target", "all"], out _));
+        var skill = SkillAssets.Find("intent-cli")!;
+        var previous = SkillAssets.ReadBody(skill);
+        var current = previous + "\nFuture shipped dispatcher content.\n";
+        UseFutureVersion(previous, current);
+
+        var claude = Path.Combine(RepoRoot, ".claude", "skills", "intent-cli", "SKILL.md");
+        var codex = Path.Combine(UserHome, ".codex", "skills", "intent-cli", "SKILL.md");
+        var copilot = Path.Combine(RepoRoot, ".github", "skills", "intent-cli", "SKILL.md");
+        var edited = File.ReadAllText(codex) + "\nOperator edit.\n";
+        File.WriteAllText(codex, edited);
+
+        Assert.Equal(1, Run(["skill", "install", "--target", "all"], out var output));
+
+        Assert.Contains("refused-drifted", output, StringComparison.Ordinal);
+        Assert.Contains("skipped-plan-aborted", output, StringComparison.Ordinal);
+        Assert.Equal(SkillAssets.Normalize(previous), SkillAssets.Normalize(File.ReadAllText(claude)));
+        Assert.Equal(edited, File.ReadAllText(codex));
+        Assert.Equal(SkillAssets.Normalize(previous), SkillAssets.Normalize(File.ReadAllText(copilot)));
+    }
+
+    private void UseFutureVersion(string previous, string current)
+    {
+        SkillAssets.BodyReader = _ => current;
+        SkillAssets.LineageReader = _ =>
+        [
+            SkillAssets.ComputeNormalizedHash(previous),
+            SkillAssets.ComputeNormalizedHash(current),
+        ];
+    }
+
+    private string ListJson()
+    {
+        Assert.Equal(0, Run(["skill", "list", "--format", "json"], out var output));
+        return output;
+    }
+
+    private string RenderGuide(string[] args)
+    {
+        Assert.Equal(0, Run(args, out var output));
+        return output;
+    }
+
+    private int Run(string[] args, out string output)
+    {
+        var builder = new StringBuilder();
+        using var writer = new StringWriter(builder);
+        var exitCode = CommandRouter.Execute(args, BuildContext(), writer);
+        output = builder.ToString();
+        return exitCode;
+    }
+
+    private static string? StateFor(string report, string target, string scope) =>
+        InstallationFor(report, target, scope).GetProperty("state").GetString();
+
+    private static bool UpdateAvailableFor(string report, string target, string scope) =>
+        InstallationFor(report, target, scope).GetProperty("update_available").GetBoolean();
+
+    private static JsonElement InstallationFor(string report, string target, string scope)
+    {
+        using var document = JsonDocument.Parse(report);
+        return document.RootElement
+            .GetProperty("skills")[0]
+            .GetProperty("installations")
+            .EnumerateArray()
+            .Single(element =>
+                element.GetProperty("target").GetString() == target
+                && element.GetProperty("scope").GetString() == scope)
+            .Clone();
+    }
+
+    private CliContext BuildContext() => new()
+    {
+        RepoRoot = RepoRoot,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private static int Count(string value, string needle) =>
+        (value.Length - value.Replace(needle, string.Empty, StringComparison.Ordinal).Length) / needle.Length;
+
+    public void Dispose()
+    {
+        SkillTargets.UserHomeFactory = previousUserHome;
+        SkillAssets.BodyReader = previousBodyReader;
+        SkillAssets.LineageReader = previousLineageReader;
+
+        try
+        {
+            Directory.Delete(root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not worth failing a test over.
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- embed normalized hashes for current and prior shipped skill versions
- classify installs as current, stale-shipped, locally-modified, or not-installed and safely update stale shipped copies
- add local-only guide nudges plus EN/JA lifecycle documentation and focused regressions

## Verification
- focused tests: 111 passed
- full suite: 4,560 total, 0 failed, 1 skipped
- hermetic restore/build/full suite: passed
- dotnet format touched files: passed
- git diff --check: passed

Closes #1249