### PR TITLE
fix: harden herdr completion detection

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -212,7 +212,10 @@ per team; mixed agmsg and herdr delivery is a contract violation.
 Create the team workspace and role tabs/panes with the role cwd (`<host-repo>`
 for design/orchestrator, the child checkout for implementation, and an isolated
 review cwd/worktree). Use `herdr workspace create`, `herdr tab create`, or
-`herdr pane split` as shown by the installed `herdr ... --help`. Record an
+`herdr pane split` as shown by the installed `herdr ... --help`. In herdr 0.7.5,
+the `workspace_created` result has top-level `workspace`, `tab`, and
+`root_pane`; seed the mapping from `workspace.workspace_id`, `tab.tab_id`, and
+`root_pane.pane_id`, and verify `root_pane.cwd`. Record an
 operator-visible logical-role→pane-id/cwd mapping and resolve it before every
 operation; workflows never hard-code pane ids. An external design frontend is
 recorded as a reader type rather than fabricated as a pane.
@@ -247,25 +250,38 @@ inputs:
   - <canonical issue/PR/path/reference>
 expected-artifacts:
   - <file, commit, PR, report, or other inspectable artifact>
-completion-marker: Print exactly `ORCH_RESULT <task-id> <status> <artifact>` when ready; status is completed, blocked, or question.
+result-prefix: ORCH_RESULT
+result-nonce: <fresh-per-dispatch-nonce>
+completion-marker: When ready, print one line by concatenating result-prefix, one space, result-nonce, one space, status, one space, and artifact; status is completed, blocked, or question. Do not copy a precomposed marker into this task block.
 ```
 
+Generate a fresh unpredictable nonce for each dispatch; never reuse one or use
+the task id alone. `pane wait-output` searches existing output immediately, so
+a precomposed wait needle in the task block can be echoed and falsely match
+before work starts. The split fields keep that literal out of the dispatch.
 Files, commits, PRs, and verification logs are the handoff; screen prose only
 points to them. Repairs return to the same logical role with the task id and
-concrete delta after resolving its current pane.
+concrete delta after resolving its current pane. A marker match from any buffer
+is never sufficient; the named artifact must exist and pass verification.
 
 Every wait is bounded:
 
 ```text
-herdr agent wait <logical-role> --until done --until blocked --timeout <milliseconds>
-herdr pane wait-output --match "ORCH_RESULT <task-id>" --source recent-unwrapped --timeout <milliseconds> <pane-id>
+herdr agent wait <logical-role> --until idle --until done --until blocked --timeout <milliseconds>
+herdr pane wait-output --match "ORCH_RESULT <fresh-per-dispatch-nonce>" --source recent-unwrapped --timeout <milliseconds> <pane-id>
 ```
 
-A timeout is a re-entry point: inspect and persist progress, return control,
-then resume on a later wake. Deterministic scripts with persisted cursors are
-preferred for long flows. Composite success requires settled state + the exact
-task marker + an existing verified artifact. herdr `done`/`idle` alone never
-means success.
+After every wait return—including `idle`, `done`, `blocked`, marker match, and
+timeout—run `herdr pane read --source recent-unwrapped <pane-id>` and inspect
+for a pending approval or question. `idle` can mean approval-paused. Classify
+the outcome as settled, approval/question-paused, or timeout. For a pause,
+answer only a pane-read G550 MAY class; escalate everything else, then re-enter
+the wake and wait again. A timeout is likewise a re-entry point: persist
+progress, return control, then resume on a later wake. Deterministic scripts
+with persisted cursors are preferred for long flows. Composite success requires
+dialog-free settled state + the exact fresh-nonce marker + an existing verified
+artifact. Artifact verification is the final gate; neither state nor marker
+alone means success.
 
 ### Normative `events.jsonl` design boundary
 
@@ -306,6 +322,11 @@ intent-cli workflow state.
   the self-contained settle-and-re-check READY gate above.
 - Long-wait turn death: use bounded waits, re-entry, and deterministic persisted
   loops.
+- Dispatch-echo false match: keep the composed wait needle out of the task
+  block, inspect the pane after the return, and independently verify the named
+  artifact.
+- Approval/question pause reported as idle: inspect the pane after every wait,
+  apply the G550 MAY/escalate boundary, and re-enter the wake.
 
 For **agmsg → herdr-only**: drain/park work; gracefully drop roles and stop
 watchers/bridges; provision herdr, its mapping, and the validated events path;

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -203,7 +203,10 @@ transport であり、4 スレッドモデルではありません。1 チーム
 チーム workspace と role ごとの tab/pane を role cwd 付きで作成します（design /
 orchestrator は `<host-repo>`、implementation は child checkout、review は隔離した review
 cwd/worktree）。インストール済みの `herdr ... --help` に従い、`herdr workspace create`、
-`herdr tab create`、`herdr pane split` を使います。operator-visible な
+`herdr tab create`、`herdr pane split` を使います。herdr 0.7.5 の
+`workspace_created` result は top-level の `workspace`、`tab`、`root_pane` を返すため、
+`workspace.workspace_id`、`tab.tab_id`、`root_pane.pane_id` から mapping を seed し、
+`root_pane.cwd` を検証します。operator-visible な
 logical-role→pane-id/cwd mapping を記録し、毎操作前に解決します。workflow が pane id を
 hard-code してはいけません。herdr 外の design frontend は架空 pane ではなく reader type
 として記録します。
@@ -236,24 +239,35 @@ inputs:
   - <canonical issue/PR/path/reference>
 expected-artifacts:
   - <file, commit, PR, report, or other inspectable artifact>
-completion-marker: Ready になったら `ORCH_RESULT <task-id> <status> <artifact>` を正確に出力する。status は completed、blocked、question。
+result-prefix: ORCH_RESULT
+result-nonce: <fresh-per-dispatch-nonce>
+completion-marker: Ready になったら result-prefix、1 space、result-nonce、1 space、status、1 space、artifact を連結した 1 行を出力する。status は completed、blocked、question。precomposed marker をこの task block にコピーしない。
 ```
 
-handoff は file、commit、PR、verification log などの inspectable artifact です。screen prose
-はそれを指す signal にすぎません。repair は現在の pane mapping を解決した後、同じ logical
-role に task id と具体的 delta を添えて戻します。
+dispatch ごとに fresh で予測不能な nonce を生成し、再利用や task id 単独での代用をしません。
+`pane wait-output` は既存 output を即座に検索するため、task block 内の precomposed wait needle
+が echo され、作業開始前に false match することがあります。split field により、その literal を
+dispatch から除外します。handoff は file、commit、PR、verification log などの inspectable
+artifact です。screen prose はそれを指す signal にすぎません。repair は現在の pane mapping を
+解決した後、同じ logical role に task id と具体的 delta を添えて戻します。どの buffer 由来でも
+marker match だけでは不十分で、named artifact の存在と verification が必要です。
 
 wait は必ず bounded にします。
 
 ```text
-herdr agent wait <logical-role> --until done --until blocked --timeout <milliseconds>
-herdr pane wait-output --match "ORCH_RESULT <task-id>" --source recent-unwrapped --timeout <milliseconds> <pane-id>
+herdr agent wait <logical-role> --until idle --until done --until blocked --timeout <milliseconds>
+herdr pane wait-output --match "ORCH_RESULT <fresh-per-dispatch-nonce>" --source recent-unwrapped --timeout <milliseconds> <pane-id>
 ```
 
-timeout は re-entry point です。状態を inspect/persist して制御を返し、後続 wake で再開します。
-長い flow には cursor を永続化する deterministic script を推奨します。success は settled
-state + 正確な task marker + 存在して検証済みの artifact の合成判定です。herdr の
-`done` / `idle` だけで成功と結論してはいけません。
+`idle`、`done`、`blocked`、marker match、timeout を含む EVERY wait return 後に
+`herdr pane read --source recent-unwrapped <pane-id>` を実行し、pending approval / question を
+inspect します。`idle` は approval-paused の場合があります。結果を settled、
+approval/question-paused、timeout に分類します。pause では pane から読んだ G550 MAY class
+だけを回答し、それ以外は escalate してから wake に re-enter し、再度 wait します。timeout も
+re-entry point です。進捗を persist して制御を返し、後続 wake で再開します。長い flow には
+cursor を永続化する deterministic script を推奨します。success は dialog-free settled state +
+正確な fresh-nonce marker + 存在して検証済みの artifact の合成判定です。artifact verification
+が final gate であり、state 単独も marker 単独も success ではありません。
 
 ### Normative な `events.jsonl` design boundary
 
@@ -288,6 +302,10 @@ dispatch、GitHub、intent-cli workflow state の代替でもありません。
 - reboot 後の dead pty wiring: undetected agent / shell-only pane では artifact を保全して
   re-provision、mapping 再構築、上記の自己完結した settle-and-re-check READY gate 再実行を行います。
 - long-wait turn death: bounded wait、re-entry、persist された deterministic loop を使います。
+- dispatch-echo false match: composed wait needle を task block に入れず、return 後に pane を
+  inspect し、named artifact を独立に検証します。
+- idle と報告された approval/question pause: every wait 後に pane を inspect し、G550 の
+  MAY/escalate 境界を適用して wake に re-enter します。
 
 **agmsg → herdr-only**: work を drain/park、role を graceful drop して watcher/bridge を停止、
 herdr・mapping・検証済み events path を provision、G556 と marker/artifact 検出を通し、最後に

--- a/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
+++ b/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
@@ -41,7 +41,7 @@ internal static class HerdrOnlyOperatingGuide
         herdr is the only session transport in this mode; do not join agmsg identities, run an agmsg bridge, or mix delivery mechanisms inside the team.
 
         1. Confirm the installed surface with `herdr workspace --help`, `herdr tab --help`, `herdr pane --help`, and `herdr agent --help`. Use the installed help when a version-specific option is needed.
-        2. Create a team workspace with `herdr workspace create --cwd <host-repo> --label <team> --no-focus`. Create role tabs/panes with the role cwd: design and orchestrator use `<host-repo>`, implementation uses `<implementation-repo>`, and review uses its isolated review cwd/worktree. `herdr tab create --workspace <workspace-id> --cwd <role-cwd> --label <logical-role> --no-focus` is the typed tab surface; `herdr pane split --pane <pane-id> --direction right|down --cwd <role-cwd> --no-focus` is available when a split is preferred.
+        2. Create a team workspace with `herdr workspace create --cwd <host-repo> --label <team> --no-focus`. In herdr 0.7.5 its `workspace_created` result has top-level `workspace`, `tab`, and `root_pane`; seed the mapping from `workspace.workspace_id`, `tab.tab_id`, and `root_pane.pane_id`, and verify `root_pane.cwd`. Create role tabs/panes with the role cwd: design and orchestrator use `<host-repo>`, implementation uses `<implementation-repo>`, and review uses its isolated review cwd/worktree. `herdr tab create --workspace <workspace-id> --cwd <role-cwd> --label <logical-role> --no-focus` is the typed tab surface; `herdr pane split --pane <pane-id> --direction right|down --cwd <role-cwd> --no-focus` is available when a split is preferred. Update the mapping from each later tab/pane creation result.
         3. Record a durable operator-visible mapping of each herdr-resident logical role (`design`, `orchestrator`, `implementation`, `review`) to its current workspace/tab/pane id and cwd. Workflows address the logical role and resolve this mapping at dispatch time; they NEVER hard-code a pane id. A design frontend outside herdr is recorded as the design reader type, not fabricated as a pane.
         4. Launch the typed agent in the mapped pane with `herdr agent start <logical-role> --kind <claude|codex|...> --pane <pane-id> -- <operator-approved-permission-flags>`. Pass launch and permission flags after `--`; do not inject modifier chords into an interactive prompt. Approvals are NEVER auto-answered: only the G550 MAY-answer classes may be handled, and every other approval is escalated to the operator.
         5. READY is a G556 verified-liveness result, not workspace existence. Approvals surface visibly in the pane and are handled at the supervision boundary, explicitly unlike the agmsg Codex bridge's headless auto-decline. After the startup report, wait a settle delay, then re-check `herdr agent list`, inspect the mapped pane/agent, verify the expected cwd/repository and detected agent kind, and send a bounded ping whose ack is observed in that same pane. An undetected agent, a shell prompt where the agent should be, a mismatched cwd, or no ack is NOT READY; after re-provisioning, repeat this entire settle-and-re-check sequence before declaring READY.
@@ -60,18 +60,22 @@ internal static class HerdrOnlyOperatingGuide
           - <canonical issue/PR/path/reference>
         expected-artifacts:
           - <file, commit, PR, report, or other inspectable artifact>
-        completion-marker: Print exactly `ORCH_RESULT <task-id> <status> <artifact>` when the artifact is ready; use status completed, blocked, or question.
+        result-prefix: ORCH_RESULT
+        result-nonce: <fresh-per-dispatch-nonce>
+        completion-marker: When the artifact is ready, print one line by concatenating result-prefix, one space, result-nonce, one space, status, one space, and artifact; use status completed, blocked, or question. Do not copy a precomposed marker into this task block.
         ```
 
-        Files, commits, PRs, test logs, and other inspectable artifacts are the handoff; terminal prose is only a signal pointing at them. A repair or re-dispatch goes to the same logical role after resolving its current pane mapping and carries the same task id plus the concrete delta. Never infer completion from screen text that lacks the task-specific marker and artifact.
+        Generate a fresh, unpredictable nonce for every dispatch; never reuse one or substitute the task id alone. `pane wait-output` searches existing pane output immediately, so a precomposed wait needle in the dispatched task can be echoed and falsely match before the agent does any work. Splitting the prefix and nonce above keeps the literal needle out of the task block. Files, commits, PRs, test logs, and other inspectable artifacts are the handoff; terminal prose is only a signal pointing at them. A repair or re-dispatch goes to the same logical role after resolving its current pane mapping and carries the same task id plus the concrete delta. A marker match from any pane buffer is NEVER sufficient: the named artifact must exist and pass its verification.
 
         ## Herdr-only bounded waiting and success detection
 
-        Use bounded waits only. For agent state, use `herdr agent wait <logical-role> --until done --until blocked --timeout <milliseconds>`. For the task signal, use `herdr pane wait-output --match "ORCH_RESULT <task-id>" --source recent-unwrapped --timeout <milliseconds> <pane-id>`. Both commands wait indefinitely when `--timeout` is omitted, so omission is forbidden in an orchestrator wake.
+        Use bounded waits only. For agent state, use `herdr agent wait <logical-role> --until idle --until done --until blocked --timeout <milliseconds>`. For the task signal, use `herdr pane wait-output --match "ORCH_RESULT <fresh-per-dispatch-nonce>" --source recent-unwrapped --timeout <milliseconds> <pane-id>`. Both commands wait indefinitely when `--timeout` is omitted, so omission is forbidden in an orchestrator wake.
 
-        A timeout is a re-entry point: inspect state and pane output, persist progress, return control to the orchestrator, and wait again on the next bounded wake. Prefer a deterministic script that persists its cursor for long multi-wait flows; do not hold one chat turn open indefinitely, because turn death loses the continuation.
+        After EVERY wait return—including `idle`, `done`, `blocked`, marker match, and timeout—run `herdr pane read --source recent-unwrapped <pane-id>` and inspect the pane for a pending approval or question before interpreting the result. `idle` can mean approval-paused, not settled. Classify the return as settled, approval/question-paused, or timeout. For an approval/question pause, answer only a G550 MAY class after reading it; escalate every other case, then re-enter the wake and wait again. Never conclude the task while the pane is paused.
 
-        **Composite success is mandatory:** (1) herdr reports a settled state, (2) the exact `ORCH_RESULT` marker matches the task id and status, and (3) the named artifact exists and passes the task's verification. State alone NEVER means task success; in particular, herdr `done` or `idle` alone is insufficient. `blocked` and `question` markers route back to the orchestrator/design decision boundary; they are not failures to hide or successes to assume.
+        A timeout is a re-entry point: persist progress, return control to the orchestrator, and wait again on the next bounded wake. Prefer a deterministic script that persists its cursor for long multi-wait flows; do not hold one chat turn open indefinitely, because turn death loses the continuation.
+
+        **Composite success is mandatory:** (1) herdr reports a settled state and pane inspection finds no pending dialog, (2) the exact `ORCH_RESULT` marker matches the fresh dispatch nonce and status, and (3) the named artifact exists and passes the task's verification. The named artifact verification is the final gate. State alone and marker alone NEVER mean task success; in particular, herdr `done` or `idle` alone is insufficient, and a marker found anywhere in the pane buffer is only a signal. `blocked` and `question` markers route back to the orchestrator/design decision boundary; they are not failures to hide or successes to assume.
 
         ## events.jsonl design boundary
 
@@ -94,6 +98,8 @@ internal static class HerdrOnlyOperatingGuide
         - **Modifier-chord injection / launch corruption:** do not type launch control chords into a live prompt. Re-provision or return the pane to a shell, then use `herdr agent start ... -- <permission-flags>` so flags are part of the typed launch.
         - **Post-reboot dead pty wiring:** a pane may still exist while `herdr agent list` cannot detect the agent or the pane is sitting at a shell. Treat it as `agent-undetected`, preserve artifacts, close/re-provision the affected workspace/panes, rebuild the logical-role mapping, and repeat the self-contained settle-and-re-check READY gate above before READY.
         - **Long-wait turn death:** replace unbounded `agent wait`/`pane wait-output` calls with bounded timeouts and re-entry. Use deterministic scripts with persisted task id, pane resolution, and watermark for long loops.
+        - **Dispatch-echo false match:** never place the composed `ORCH_RESULT <fresh-per-dispatch-nonce>` wait needle in the task block. Use the split prefix/nonce fields, then require pane inspection and independently verified artifact evidence after a match.
+        - **Approval/question pause reported as idle:** read the pane after every wait return. Apply the G550 MAY/escalate boundary to the visible dialog and re-enter the wake; `idle` is not completion evidence.
 
         ## Session-layer switch checklists
 
@@ -123,7 +129,8 @@ internal static class HerdrOnlyOperatingGuide
             replacedProperties.Select(value => (JsonNode?)JsonValue.Create(value)).ToArray()),
         ["provisioning"] = new JsonObject
         {
-            ["workspace"] = "Create the team workspace and role tabs/panes with role-specific cwds; consult installed herdr help for version-specific options.",
+            ["workspace"] = "Create the team workspace and role tabs/panes with role-specific cwds; in herdr 0.7.5 workspace_created returns top-level workspace, tab, and root_pane.",
+            ["workspace_result_mapping"] = "Seed from workspace.workspace_id, tab.tab_id, and root_pane.pane_id; verify root_pane.cwd and update from later tab/pane creation results.",
             ["mapping"] = "Record an operator-visible logical-role-to-current-pane-id-and-cwd mapping; resolve it at dispatch time and never hard-code pane ids.",
             ["typed_launch"] = "herdr agent start <logical-role> --kind <agent-kind> --pane <pane-id> -- <operator-approved-permission-flags>",
             ["approval_boundary"] = "Approvals surface visibly in the pane and are handled at the supervision boundary, unlike the agmsg Codex bridge's headless auto-decline; the G550 MAY/escalate boundary governs.",
@@ -132,17 +139,20 @@ internal static class HerdrOnlyOperatingGuide
         ["dispatch"] = new JsonObject
         {
             ["command"] = "herdr agent prompt <logical-role> <task-block>",
-            ["required_fields"] = new JsonArray("task-id", "role", "objective", "inputs", "expected-artifacts", "completion-marker"),
-            ["marker"] = "ORCH_RESULT <task-id> <status> <artifact>",
+            ["required_fields"] = new JsonArray("task-id", "role", "objective", "inputs", "expected-artifacts", "result-prefix", "result-nonce", "completion-marker"),
+            ["marker_construction"] = "Concatenate result-prefix, space, fresh-per-dispatch result-nonce, space, status, space, artifact; never embed the composed wait needle in the task block.",
+            ["echo_hazard"] = "pane wait-output searches existing output immediately, so an echoed precomposed marker can falsely match before work begins.",
             ["artifact_first"] = "Files, commits, PRs, and verification logs are the handoff; terminal text points to them.",
             ["redispatch"] = "Resolve the same logical role's current pane and send the task id plus concrete repair delta.",
         },
         ["waiting"] = new JsonObject
         {
-            ["agent"] = "herdr agent wait <logical-role> --until done --until blocked --timeout <milliseconds>",
-            ["marker"] = "herdr pane wait-output --match \"ORCH_RESULT <task-id>\" --source recent-unwrapped --timeout <milliseconds> <pane-id>",
+            ["agent"] = "herdr agent wait <logical-role> --until idle --until done --until blocked --timeout <milliseconds>",
+            ["marker"] = "herdr pane wait-output --match \"ORCH_RESULT <fresh-per-dispatch-nonce>\" --source recent-unwrapped --timeout <milliseconds> <pane-id>",
+            ["post_wait_inspection"] = "After every wait return, run herdr pane read --source recent-unwrapped <pane-id> and classify settled, approval/question-paused, or timeout; idle can be approval-paused.",
+            ["paused_reentry"] = "For a visible approval/question, apply the G550 MAY/escalate boundary, then re-enter the wake and wait again.",
             ["bounded_rule"] = "Timeouts are re-entry points; never leave a wait unbounded. Persist cursors in deterministic scripts for long loops.",
-            ["success"] = "Composite success requires settled state + matching task marker + existing verified artifact; state alone never concludes success.",
+            ["success"] = "Composite success requires dialog-free settled state + matching fresh-nonce marker + existing verified artifact; artifact verification is the final gate, and neither state nor marker alone concludes success.",
         },
         ["events_jsonl"] = new JsonObject
         {
@@ -163,7 +173,9 @@ internal static class HerdrOnlyOperatingGuide
         ["failure_recovery"] = new JsonArray(
             "Modifier-chord injection: relaunch with typed agent-start permission flags.",
             "Post-reboot dead pty: detect agent-undetected panes, re-provision, rebuild mapping, repeat G556.",
-            "Long-wait turn death: bounded waits, re-entry, and deterministic persisted loops."),
+            "Long-wait turn death: bounded waits, re-entry, and deterministic persisted loops.",
+            "Dispatch-echo false match: keep the composed wait needle out of the task block and require independently verified artifact evidence.",
+            "Approval/question pause: inspect the pane after every wait return, apply G550 MAY/escalate, and re-enter the wake."),
         ["switches"] = new JsonObject
         {
             ["exclusivity"] = "Exactly one mode per team; mixed delivery is a contract violation.",

--- a/tests/IntentSystem.Cli.Tests/HerdrOnlyOperatingGuideG571Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrOnlyOperatingGuideG571Tests.cs
@@ -22,10 +22,10 @@ public sealed class HerdrOnlyOperatingGuideG571Tests : IDisposable
         Assert.Contains("herdr agent start <logical-role>", output, StringComparison.Ordinal);
         Assert.Contains("logical-role→pane", output, StringComparison.Ordinal);
         Assert.Contains("G556 verified-liveness", output, StringComparison.Ordinal);
-        Assert.Contains("ORCH_RESULT <task-id> <status> <artifact>", output, StringComparison.Ordinal);
-        Assert.Contains("herdr agent wait <logical-role> --until done --until blocked --timeout", output, StringComparison.Ordinal);
+        Assert.Contains("result-nonce: <fresh-per-dispatch-nonce>", output, StringComparison.Ordinal);
+        Assert.Contains("herdr agent wait <logical-role> --until idle --until done --until blocked --timeout", output, StringComparison.Ordinal);
         Assert.Contains("Composite success is mandatory", output, StringComparison.Ordinal);
-        Assert.Contains("state alone NEVER means task success", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("State alone and marker alone NEVER mean task success", output, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Approvals are NEVER auto-answered", output, StringComparison.Ordinal);
         Assert.DoesNotContain("ship in G571", output, StringComparison.OrdinalIgnoreCase);
     }
@@ -137,7 +137,15 @@ public sealed class HerdrOnlyOperatingGuideG571Tests : IDisposable
                      "O_APPEND",
                      "timestamp",
                      "completion|blocked|question|escalation",
-                     "ORCH_RESULT <task-id> <status> <artifact>",
+                     "fresh-per-dispatch-nonce",
+                     "workspace.workspace_id",
+                     "tab.tab_id",
+                     "root_pane.pane_id",
+                     "root_pane.cwd",
+                     "--until idle --until done --until blocked",
+                     "pane read --source recent-unwrapped",
+                     "approval/question-paused",
+                     "final gate",
                      "one-minute-class",
                      "byte-offset watermark",
                      "agmsg → herdr-only",
@@ -151,6 +159,76 @@ public sealed class HerdrOnlyOperatingGuideG571Tests : IDisposable
         {
             Assert.Contains(token, content, StringComparison.Ordinal);
         }
+
+        Assert.Contains(
+            language == "en" ? "neither state nor marker" : "state 単独も marker 単独も",
+            content,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DispatchMarker_CannotMatchItsOwnPromptEcho_G575()
+    {
+        var output = Render(herdrOnly: true, format: "markdown");
+        var taskBlockStart = output.IndexOf("```text\nTASK <task-id>", StringComparison.Ordinal);
+        Assert.True(taskBlockStart >= 0);
+        var taskBlockEnd = output.IndexOf("```", taskBlockStart + "```text".Length, StringComparison.Ordinal);
+        Assert.True(taskBlockEnd > taskBlockStart);
+        var taskBlock = output[taskBlockStart..taskBlockEnd];
+        var dispatch = JsonDocument.Parse(Render(herdrOnly: true, format: "json"))
+            .RootElement.GetProperty(HerdrOnlyOperatingGuide.JsonProperty).GetProperty("dispatch");
+
+        Assert.Contains("result-prefix: ORCH_RESULT", taskBlock, StringComparison.Ordinal);
+        Assert.Contains("result-nonce: <fresh-per-dispatch-nonce>", taskBlock, StringComparison.Ordinal);
+        Assert.DoesNotContain("ORCH_RESULT <fresh-per-dispatch-nonce>", taskBlock, StringComparison.Ordinal);
+        Assert.Contains("searches existing pane output immediately", output, StringComparison.Ordinal);
+        Assert.Contains("falsely match before the agent does any work", output, StringComparison.Ordinal);
+        Assert.Contains("never embed the composed wait needle", dispatch.GetProperty("marker_construction").GetString());
+        Assert.Contains("falsely match", dispatch.GetProperty("echo_hazard").GetString());
+    }
+
+    [Fact]
+    public void Completion_RequiresArtifactAndPostWaitPaneInspection_G575()
+    {
+        var output = Render(herdrOnly: true, format: "markdown");
+        var json = JsonDocument.Parse(Render(herdrOnly: true, format: "json"))
+            .RootElement.GetProperty(HerdrOnlyOperatingGuide.JsonProperty);
+        var waiting = json.GetProperty("waiting");
+
+        Assert.Contains("--until idle --until done --until blocked", output, StringComparison.Ordinal);
+        Assert.Contains("After EVERY wait return", output, StringComparison.Ordinal);
+        Assert.Contains("herdr pane read --source recent-unwrapped <pane-id>", output, StringComparison.Ordinal);
+        Assert.Contains("`idle` can mean approval-paused", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("G550 MAY", output, StringComparison.Ordinal);
+        Assert.Contains("re-enter the wake and wait again", output, StringComparison.Ordinal);
+        Assert.Contains("marker alone NEVER mean task success", output, StringComparison.Ordinal);
+        Assert.Contains("named artifact verification is the final gate", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("idle can be approval-paused", waiting.GetProperty("post_wait_inspection").GetString());
+        Assert.Contains("G550 MAY/escalate", waiting.GetProperty("paused_reentry").GetString());
+        Assert.Contains("neither state nor marker alone", waiting.GetProperty("success").GetString());
+    }
+
+    [Fact]
+    public void WorkspaceCreate_UsesInstalledHerdr075ResultFields_G575()
+    {
+        var output = Render(herdrOnly: true, format: "markdown");
+        var provisioning = JsonDocument.Parse(Render(herdrOnly: true, format: "json"))
+            .RootElement.GetProperty(HerdrOnlyOperatingGuide.JsonProperty).GetProperty("provisioning");
+
+        foreach (var field in new[]
+                 {
+                     "workspace_created",
+                     "workspace.workspace_id",
+                     "tab.tab_id",
+                     "root_pane.pane_id",
+                     "root_pane.cwd",
+                 })
+        {
+            Assert.Contains(field, output, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("workspace.workspace_id", provisioning.GetProperty("workspace_result_mapping").GetString());
+        Assert.Contains("root_pane.cwd", provisioning.GetProperty("workspace_result_mapping").GetString());
     }
 
     private string Render(bool herdrOnly, string format)


### PR DESCRIPTION
Closes #1253

## Summary
- prevent pane wait-output from matching a marker echoed by the dispatched task
- require post-wait pane inspection and verified artifacts, including approval-paused idle handling
- align workspace-created fields and agent-wait examples with installed herdr 0.7.5
- mirror the bounded procedure in EN/JA docs and add focused regressions

## Verification
- dotnet format IntentSystem.sln --no-restore --include src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs tests/IntentSystem.Cli.Tests/HerdrOnlyOperatingGuideG571Tests.cs
- focused herdr/session/docs tests: 166 passed
- full solution: 4567 passed, 1 skipped
- clean detached exact-head locked restore + full solution: 4567 passed, 1 skipped
- git diff --check

No dogfood or runtime/manual end-to-end claim is made.