### PR TITLE
G577: Unify --workdir resolution across automation commands

### DIFF
--- a/src/IntentSystem.Cli/Commands/AutomationCheckCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationCheckCommand.cs
@@ -24,7 +24,7 @@ internal static class AutomationCheckCommand
             return 1;
         }
 
-        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
         var repo = repoOverride;
         if (string.IsNullOrWhiteSpace(repo)
             && !TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
@@ -109,16 +109,6 @@ internal static class AutomationCheckCommand
         }
 
         return true;
-    }
-
-    private static string ResolveWorkdir(CliContext context, string? workdir)
-    {
-        if (string.IsNullOrWhiteSpace(workdir))
-        {
-            return context.RepoRoot;
-        }
-
-        return Path.GetFullPath(workdir);
     }
 
     internal static bool TryInferGitHubRepo(string workdir, out string? repo, out string error)

--- a/src/IntentSystem.Cli/Commands/AutomationClarificationStopCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationClarificationStopCommand.cs
@@ -48,7 +48,7 @@ internal static class AutomationClarificationStopCommand
         var repo = repoOverride;
         if (string.IsNullOrWhiteSpace(targetUrl) && string.IsNullOrWhiteSpace(repo))
         {
-            var resolvedWorkdir = ResolveWorkdir(context, workdir);
+            var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
             if (!AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
             {
                 writer.WriteLine(error);
@@ -258,16 +258,6 @@ internal static class AutomationClarificationStopCommand
             return false;
         }
         return true;
-    }
-
-    private static string ResolveWorkdir(CliContext context, string? workdir)
-    {
-        if (string.IsNullOrWhiteSpace(workdir))
-        {
-            return context.RepoRoot;
-        }
-
-        return Path.GetFullPath(workdir);
     }
 
     private static string BuildTargetUrl(string repo, string kind, int number)

--- a/src/IntentSystem.Cli/Commands/AutomationCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationCompleteCommand.cs
@@ -48,7 +48,7 @@ internal static class AutomationCompleteCommand
             return 1;
         }
 
-        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
         var repo = repoOverride;
         if (string.IsNullOrWhiteSpace(repo)
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
@@ -371,16 +371,6 @@ internal static class AutomationCompleteCommand
             return false;
         }
         return true;
-    }
-
-    private static string ResolveWorkdir(CliContext context, string? workdir)
-    {
-        if (string.IsNullOrWhiteSpace(workdir))
-        {
-            return context.RepoRoot;
-        }
-
-        return Path.GetFullPath(workdir);
     }
 
     private static bool TryMapCompletionTarget(

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewDiagnosticsCommand.cs
@@ -108,7 +108,7 @@ internal static class AutomationHostReviewDiagnosticsCommand
             return 1;
         }
 
-        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
         if (string.IsNullOrWhiteSpace(repo)
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
         {
@@ -645,18 +645,6 @@ internal static class AutomationHostReviewDiagnosticsCommand
         }
 
         return false;
-    }
-
-    private static string ResolveWorkdir(CliContext context, string? workdir)
-    {
-        if (string.IsNullOrWhiteSpace(workdir))
-        {
-            return context.RepoRoot;
-        }
-
-        return Path.IsPathRooted(workdir)
-            ? workdir
-            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
     }
 
     private static void Emit(TextWriter writer, AutomationHostReviewDiagnosticsResult result, string format)

--- a/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostReviewPreflightCommand.cs
@@ -56,7 +56,7 @@ internal static class AutomationHostReviewPreflightCommand
             return 1;
         }
 
-        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
         if (string.IsNullOrWhiteSpace(repo)
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
         {
@@ -712,18 +712,6 @@ internal static class AutomationHostReviewPreflightCommand
         }
 
         return true;
-    }
-
-    private static string ResolveWorkdir(CliContext context, string? workdir)
-    {
-        if (string.IsNullOrWhiteSpace(workdir))
-        {
-            return context.RepoRoot;
-        }
-
-        return Path.IsPathRooted(workdir)
-            ? workdir
-            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
     }
 
     private static void WriteText(TextWriter writer, AutomationHostReviewPreflightResult result)

--- a/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
@@ -61,7 +61,7 @@ internal static class AutomationIssuePublishCommand
             return 1;
         }
 
-        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
         if (string.IsNullOrWhiteSpace(repo)
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
         {
@@ -324,18 +324,6 @@ internal static class AutomationIssuePublishCommand
             return false;
         }
         return true;
-    }
-
-    private static string ResolveWorkdir(CliContext context, string? workdir)
-    {
-        if (string.IsNullOrWhiteSpace(workdir))
-        {
-            return context.RepoRoot;
-        }
-
-        return Path.IsPathRooted(workdir)
-            ? workdir
-            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
     }
 
     private static string BuildIssueUrl(string repo, int issue) =>

--- a/src/IntentSystem.Cli/Commands/AutomationIssueReleaseCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueReleaseCommand.cs
@@ -55,7 +55,7 @@ internal static class AutomationIssueReleaseCommand
             return 1;
         }
 
-        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
         if (string.IsNullOrWhiteSpace(repo)
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
         {
@@ -224,17 +224,6 @@ internal static class AutomationIssueReleaseCommand
         }
 
         return true;
-    }
-
-    private static string ResolveWorkdir(CliContext context, string? workdir)
-    {
-        if (string.IsNullOrWhiteSpace(workdir))
-        {
-            return context.RepoRoot;
-        }
-        return Path.IsPathRooted(workdir)
-            ? workdir
-            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
     }
 
     private static string BuildIssueUrl(string repo, int issue) =>

--- a/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPrTransitionCommand.cs
@@ -61,7 +61,7 @@ internal static class AutomationPrTransitionCommand
             return 1;
         }
 
-        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
         if (string.IsNullOrWhiteSpace(repo)
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
         {
@@ -495,18 +495,6 @@ internal static class AutomationPrTransitionCommand
             return false;
         }
         return true;
-    }
-
-    private static string ResolveWorkdir(CliContext context, string? workdir)
-    {
-        if (string.IsNullOrWhiteSpace(workdir))
-        {
-            return context.RepoRoot;
-        }
-
-        return Path.IsPathRooted(workdir)
-            ? workdir
-            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
     }
 
     private static string BuildSummary(

--- a/src/IntentSystem.Cli/Commands/AutomationReconcileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationReconcileCommand.cs
@@ -106,7 +106,7 @@ internal static class AutomationReconcileCommand
             return 2;
         }
 
-        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
         if (string.IsNullOrWhiteSpace(repo)
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
         {
@@ -526,18 +526,6 @@ internal static class AutomationReconcileCommand
         }
 
         return true;
-    }
-
-    private static string ResolveWorkdir(CliContext context, string? workdir)
-    {
-        if (string.IsNullOrWhiteSpace(workdir))
-        {
-            return context.RepoRoot;
-        }
-
-        return Path.IsPathRooted(workdir)
-            ? workdir
-            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
     }
 
     private static void Emit(TextWriter writer, AutomationReconcileResult result, string format)

--- a/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
@@ -75,7 +75,7 @@ internal static class AutomationStateDoctorCommand
             return 2;
         }
 
-        var resolvedWorkdir = ResolveWorkdir(context, workdir);
+        var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
 
         // G448 (review fix): --workdir must consistently drive the HOST context
         // used for every read/write — queue-state, publish artifacts, and the
@@ -561,18 +561,6 @@ internal static class AutomationStateDoctorCommand
         }
 
         return true;
-    }
-
-    private static string ResolveWorkdir(CliContext context, string? workdir)
-    {
-        if (string.IsNullOrWhiteSpace(workdir))
-        {
-            return context.RepoRoot;
-        }
-
-        return Path.IsPathRooted(workdir)
-            ? workdir
-            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
     }
 
     private static void Emit(TextWriter writer, AutomationStateDoctorResult result, string format)

--- a/src/IntentSystem.Cli/Commands/WorkdirResolver.cs
+++ b/src/IntentSystem.Cli/Commands/WorkdirResolver.cs
@@ -1,0 +1,18 @@
+namespace IntentSystem.Cli.Commands;
+
+internal static class WorkdirResolver
+{
+    public static string Resolve(CliContext context, string? workdir)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        if (string.IsNullOrWhiteSpace(workdir))
+        {
+            return context.RepoRoot;
+        }
+
+        return Path.IsPathRooted(workdir)
+            ? workdir
+            : Path.GetFullPath(Path.Combine(context.RepoRoot, workdir));
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkdirResolverTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkdirResolverTests.cs
@@ -1,0 +1,192 @@
+using System.Collections;
+using System.Reflection;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class WorkdirResolverTests
+{
+    [Fact]
+    public void Resolve_RelativePathUsesRepoRoot_AndRootedPathIsUnchanged()
+    {
+        using var workspace = new WorkdirResolutionWorkspace();
+        var context = CreateContext(workspace.RepoRoot);
+        var rootedWithTraversal = Path.Combine(workspace.Root, "absolute", "..", "target");
+
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(workspace.RepoRoot, "relative", "target")),
+            WorkdirResolver.Resolve(context, Path.Combine("relative", "target")));
+        Assert.Equal(rootedWithTraversal, WorkdirResolver.Resolve(context, rootedWithTraversal));
+        Assert.Equal(workspace.RepoRoot, WorkdirResolver.Resolve(context, null));
+        Assert.Equal(workspace.RepoRoot, WorkdirResolver.Resolve(context, "   "));
+    }
+
+    [Fact]
+    public void RegisteredAutomationWorkdirCommands_ResolveTheSameRelativePathFromNonRootCwd()
+    {
+        using var workspace = new WorkdirResolutionWorkspace();
+        var context = CreateContext(workspace.RepoRoot);
+        var relativeWorkdir = "missing-relative-workdir";
+        var expectedWorkdir = Path.GetFullPath(Path.Combine(workspace.RepoRoot, relativeWorkdir));
+        var cwdRelativeWorkdir = Path.GetFullPath(Path.Combine(workspace.CallerRoot, relativeWorkdir));
+        var commands = DiscoverAutomationCommandsAcceptingWorkdir(context);
+        var originalDirectory = Directory.GetCurrentDirectory();
+
+        Assert.Equal(10, commands.Count);
+
+        try
+        {
+            Directory.SetCurrentDirectory(workspace.CallerRoot);
+
+            foreach (var command in commands)
+            {
+                using var writer = new StringWriter();
+                var exitCode = CommandRouter.Execute(
+                    ["automation", command, .. BuildArguments(command, relativeWorkdir)],
+                    context,
+                    writer);
+
+                Assert.Equal(1, exitCode);
+                Assert.Contains(expectedWorkdir, writer.ToString(), StringComparison.Ordinal);
+                Assert.DoesNotContain(cwdRelativeWorkdir, writer.ToString(), StringComparison.Ordinal);
+            }
+        }
+        finally
+        {
+            Directory.SetCurrentDirectory(originalDirectory);
+        }
+    }
+
+    [Fact]
+    public void RegisteredAutomationWorkdirCommands_HaveNoPrivateResolverCopies()
+    {
+        using var workspace = new WorkdirResolutionWorkspace();
+        var context = CreateContext(workspace.RepoRoot);
+        var commands = DiscoverAutomationCommandsAcceptingWorkdir(context);
+        var handlers = GetAutomationHandlers();
+
+        Assert.Equal(10, commands.Count);
+
+        foreach (var command in commands)
+        {
+            var commandType = ((Delegate)handlers[command]!).Method.DeclaringType;
+            Assert.NotNull(commandType);
+            Assert.Null(commandType!.GetMethod(
+                "ResolveWorkdir",
+                BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly));
+        }
+    }
+
+    private static IReadOnlyList<string> DiscoverAutomationCommandsAcceptingWorkdir(CliContext context)
+    {
+        var commands = new List<string>();
+
+        foreach (var key in GetAutomationHandlers().Keys)
+        {
+            var command = (string)key!;
+            using var writer = new StringWriter();
+
+            CommandRouter.Execute(["automation", command, "--discover-options"], context, writer);
+            if (writer.ToString().Contains("--workdir", StringComparison.Ordinal))
+            {
+                commands.Add(command);
+            }
+        }
+
+        return commands.OrderBy(command => command, StringComparer.Ordinal).ToArray();
+    }
+
+    private static IDictionary GetAutomationHandlers()
+    {
+        var commandsField = typeof(CommandRouter).GetField(
+            "ImplementedCommands",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(commandsField);
+
+        var groups = commandsField!.GetValue(null) as IDictionary;
+        Assert.NotNull(groups);
+
+        var automation = groups!["automation"] as IDictionary;
+        Assert.NotNull(automation);
+        return automation!;
+    }
+
+    private static string[] BuildArguments(string command, string relativeWorkdir) => command switch
+    {
+        "check" => ["--workdir", relativeWorkdir, "--format", "json"],
+        "clarification-stop" =>
+        [
+            "--kind", "issue-to-pr",
+            "--issue", "1",
+            "--reason", "reason",
+            "--recommended-owner-action", "action",
+            "--workdir", relativeWorkdir,
+            "--format", "json"
+        ],
+        "complete" =>
+        [
+            "--kind", "issue-to-pr",
+            "--issue", "1",
+            "--outcome", "failed",
+            "--workdir", relativeWorkdir,
+            "--format", "json"
+        ],
+        "host-review-diagnostics" => ["--workdir", relativeWorkdir, "--format", "json"],
+        "host-review-preflight" => ["--workdir", relativeWorkdir, "--format", "json"],
+        "issue-publish" => ["--issue", "1", "--workdir", relativeWorkdir, "--format", "json"],
+        "issue-release" => ["--issue", "1", "--workdir", relativeWorkdir, "--format", "json"],
+        "pr-transition" =>
+        [
+            "--pr", "1",
+            "--transition", "review-start",
+            "--workdir", relativeWorkdir,
+            "--format", "json"
+        ],
+        "reconcile" => ["--workdir", relativeWorkdir, "--format", "json"],
+        "state-doctor" => ["--workdir", relativeWorkdir, "--format", "json"],
+        _ => throw new InvalidOperationException(
+            $"Registered automation command '{command}' accepts --workdir but has no drive arguments.")
+    };
+
+    private static CliContext CreateContext(string repoRoot) => new()
+    {
+        RepoRoot = repoRoot,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli"
+            }
+        }
+    };
+
+    private sealed class WorkdirResolutionWorkspace : IDisposable
+    {
+        public WorkdirResolutionWorkspace()
+        {
+            Root = Path.Combine(Path.GetTempPath(), $"intent-cli-workdir-tests-{Guid.NewGuid():N}");
+            RepoRoot = Path.Combine(Root, "repo-root");
+            CallerRoot = Path.Combine(Root, "caller-root");
+            Directory.CreateDirectory(RepoRoot);
+            Directory.CreateDirectory(CallerRoot);
+        }
+
+        public string Root { get; }
+
+        public string RepoRoot { get; }
+
+        public string CallerRoot { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add one shared `WorkdirResolver` that preserves rooted paths and resolves relative paths against `CliContext.RepoRoot`
- remove all ten private `ResolveWorkdir` copies and route the ten automation command call sites through the shared resolver
- add command-surface-derived tests that discover every registered automation command accepting `--workdir`, drive all ten from a non-root cwd, and fail if the surface count or private-resolver invariant drifts

## Behavior change

Relative `--workdir` values for `automation check`, `automation complete`, and `automation clarification-stop` are now resolved against the host repo root. They were previously resolved against the process cwd. The other seven commands retain their existing repo-root-relative behavior, and rooted paths remain unchanged.

## Verification

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~WorkdirResolverTests --no-restore` — passed: 3, failed: 0
- `dotnet test IntentSystem.sln --configuration Release` — passed across the full solution; CLI tests passed: 4,243, skipped: 1, failed: 0
- `git diff --check` — clean

Closes #1257