### PR TITLE
G578: add transport-neutral notify workflow

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -13,6 +13,45 @@ current prompts with:
 intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --mode single-domain|multi-domain --format markdown
 ```
 
+## Canonical notify workflow
+
+All role-to-role workflow messages use `intent-cli notify`; agents never choose
+or invoke agmsg/herdr delivery themselves. The CLI resolves the team's recorded
+session-layer mode internally (`agmsg` when unrecorded), validates the logical
+roles before delivery, and keeps the command shape unchanged when a team
+switches transport.
+
+```bash
+# Delegate one bounded task. Repeat --input and --expected-artifact as needed.
+intent-cli notify delegate --domain <domain> --team <team> --from <sender-role> \
+  --to <receiver-role> --report-to <orchestrator-role> --task-id <task-id> \
+  --objective <one-bounded-outcome> --input <canonical-reference> \
+  --expected-artifact <inspectable-artifact> --result-nonce <fresh-nonce> \
+  --write --format json
+
+# The receiver's final step (the delegate payload supplies this command).
+intent-cli notify report --domain <domain> --team <team> --from <receiver-role> \
+  --to <orchestrator-role> --task-id <task-id> \
+  --status completed|blocked|question --artifact <artifact> \
+  --summary <one-line-summary> --write --format json
+
+# Route a design decision to the existing events.jsonl boundary.
+intent-cli notify escalate --domain <domain> --team <team> --from <sender-role> \
+  --task-id <task-id> --artifact <decision-input> \
+  --summary <one-line-summary> --write --format json
+```
+
+`notify delegate` embeds the task id, expected artifacts, fresh marker nonce,
+and complete canonical report command (including the transport-neutral
+`--routing-root` needed from an isolated child checkout) in the delivered task. Running that
+report command is the receiver's required final step after all other work, so a
+herdr-only completion actively wakes the orchestration role instead of merely
+printing into the receiver pane. Unknown roles and delivery failures fail
+closed with a named cause. `notify escalate` appends the unchanged six-field
+event schema; none of these commands merges, labels, publishes, or mutates queue
+state. Direct transport commands remain provisioning/readiness diagnostics,
+not workflow send instructions.
+
 ## Starting orchestrator mode (design-thread setup)
 
 A design thread that wants to run orchestration can ask intent-cli directly —
@@ -68,9 +107,10 @@ The full reference checklist follows the intake:
 8. **Cleanup** — on teardown, leave/despawn the roles through the agmsg scripts
    (`leave.sh` / `despawn.sh`) and stop any inbox watchers.
 
-> **Warning:** never edit the agmsg database or team files directly — register,
-> message, and clean up only through the agmsg scripts. Hand-editing agmsg state
-> corrupts delivery.
+> **Warning:** never edit the agmsg database or team files directly — provision,
+> diagnose, and clean up only through the agmsg scripts; send workflow
+> notifications through `intent-cli notify`, which invokes the adapter. Hand-editing
+> agmsg state corrupts delivery.
 
 ## Terminal-workspace provisioning (building the team)
 
@@ -240,28 +280,18 @@ identity step.
 
 ### Dispatch, wait, and verify the artifact
 
-Send one structured block with `herdr agent prompt <logical-role> <task-block>`:
-
-```text
-TASK <task-id>
-role: <logical-role>
-objective: <one bounded outcome>
-inputs:
-  - <canonical issue/PR/path/reference>
-expected-artifacts:
-  - <file, commit, PR, report, or other inspectable artifact>
-result-prefix: ORCH_RESULT
-result-nonce: <fresh-per-dispatch-nonce>
-completion-marker: When ready, print one line by concatenating result-prefix, one space, result-nonce, one space, status, one space, and artifact; status is completed, blocked, or question. Do not copy a precomposed marker into this task block.
-```
+Use the [canonical notify workflow](#canonical-notify-workflow): run
+`intent-cli notify delegate ...` with the target logical role. The CLI resolves
+herdr-only internally, validates the role mapping, and generates the structured
+task block; do not hand-write `herdr agent prompt`.
 
 Generate a fresh unpredictable nonce for each dispatch; never reuse one or use
 the task id alone. `pane wait-output` searches existing output immediately, so
 a precomposed wait needle in the task block can be echoed and falsely match
-before work starts. The split fields keep that literal out of the dispatch.
+before work starts. The generated split fields keep that literal out of the dispatch.
 Files, commits, PRs, and verification logs are the handoff; screen prose only
 points to them. Repairs return to the same logical role with the task id and
-concrete delta after resolving its current pane. A marker match from any buffer
+concrete delta through `intent-cli notify delegate`. A marker match from any buffer
 is never sufficient; the named artifact must exist and pass verification.
 
 Every wait is bounded:
@@ -302,12 +332,12 @@ line. The required schema is:
 
 Write only design-relevant completion, blocked, question, and escalation
 events. This mode-independent channel is the design boundary only—never an
-inter-agent bus and never a replacement for herdr dispatch, GitHub, or
+inter-agent bus and never a replacement for `intent-cli notify`, GitHub, or
 intent-cli workflow state.
 
 - Claude app watcher: tail complete unseen lines from the resolved path and
   retain its offset across restarts.
-- Codex CLI in a herdr pane: prompt the role directly; do not poll this file for
+- Codex CLI in a herdr pane: use `intent-cli notify delegate` / `report`; do not poll this file for
   ordinary coordination.
 - Codex Desktop: poll at a one-minute-class cadence, consume only complete lines
   after a durable byte-offset watermark, and advance after successful handling.
@@ -716,10 +746,10 @@ either trigger runs exactly one pass:
   operator escalation, and handling of any pending receiver reports — all
   together.
 - **Verify the recipient roster before dispatch (G524).** Before sending any
-  agmsg message, confirm the recipient id is on the team roster
-  (`agmsg team.sh`); agmsg accepts an unknown recipient silently, so treat an
-  off-roster id as an error, never a guess (a legacy `review` vs the
-  registered `reviewer` has silently lost messages in the field).
+  notification, use `intent-cli notify`; it validates the recipient against the
+  active transport's role source before delivery and fails closed with
+  `unknown-role` rather than guessing (a legacy `review` vs the registered
+  `reviewer` silently lost messages before this surface existed).
 - **End the wake with a stalled-work check (G523/G524).** Run
   `intent-cli automation stalled-work --domain <domain> --repo <owner/repo>
   --format json` and process every actionable item it reports before
@@ -787,9 +817,9 @@ and `intent-cli automation issue-publish` — never raw `gh issue create` or
 `gh ... --add-label`. After publishing, verify via intent-cli / GitHub (not
 chat) that the issue exists with the expected body and the `intent-target`
 label and that durable state reflects it, then, **in this same wake**,
-delegate implementation over agmsg (G524) — do not stop after publishing to
+delegate implementation through `intent-cli notify delegate` (G524) — do not stop after publishing to
 wait for a future wake. The implementation receiver still derives its target
-from `intent-cli worker next-action`, not the agmsg text.
+from `intent-cli worker next-action`, not the notification text.
 
 ## End-of-wake check (G523/G524)
 
@@ -815,11 +845,13 @@ intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --forma
 
 ## Dispatch verification (G524)
 
-Before sending ANY agmsg message, verify the recipient id is present in the
-team roster (agmsg `team.sh`). agmsg accepts an unknown recipient silently —
-there is no delivery error to notice. Treat a recipient id that is not on
-the roster as an error: fix the id or the roster registration before
-sending; never guess or approximate a role name.
+Send workflow messages only with `intent-cli notify`. It validates every
+recipient before delivery: the agmsg adapter checks the team roster and the
+herdr-only adapter resolves the logical-role mapping plus running agent/pane.
+An unknown role or unavailable receiver returns non-zero with a named cause and
+never claims delivery. Fix the role registration/mapping before retrying; never
+guess or approximate a role name, and never bypass this check with a handwritten
+transport invocation.
 
 Field-observed loss: 8 dispatches addressed to `review` were silently lost
 when the registered role was `reviewer` — agmsg neither delivered nor
@@ -1189,22 +1221,24 @@ visible on the operator's screen the moment it breaks.
   (Claude same-thread) or a Codex automation firing every 30 minutes, with a
   prompt that on each wake runs
   `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --format json`;
-  when the result's `stale` field is `true`, send its `message_body` verbatim
-  to the orchestrator via the agmsg send script (exactly **one** message);
+  when the result's `stale` field is `true`, send its `message_body` to the
+  orchestrator with exactly **one** `intent-cli notify report` call (`--from
+  design --to orchestrator --status question`, a fresh heartbeat task id, and
+  the heartbeat evidence artifact);
   when `stale` is `false`, send nothing and exit quietly — silence is
   reserved for this healthy case **only**. A heartbeat command execution
   failure or malformed/non-object output is **never** silent: state the
   failure explicitly in this wake's own turn output, visible to the operator
   watching this live session — the exact advantage an in-session watchdog
   has over the retired invisible external scheduler (see Retired below) —
-  while still never fabricating or sending an agmsg nudge from broken input;
+  while still never fabricating or sending a notify nudge from broken input;
   only a genuine `stale=true` result ever produces a sent message.
 - **Failure visibility** — silence is reserved for a healthy `stale=false`
   heartbeat result ONLY. A heartbeat command execution failure or
   malformed/non-object output must be surfaced **visibly** in the watchdog's
   own turn output this wake — never silently swallowed or silently retried,
   since silent failure is exactly the defect this slice retires the external
-  OS scheduler for — while still never fabricating or sending an agmsg nudge
+  OS scheduler for — while still never fabricating or sending a notify nudge
   from broken input; only a genuine `stale=true` result ever produces a sent
   message.
 - **Checks** — the design/HITL inbox for unread human-facing escalations
@@ -1579,8 +1613,9 @@ carries `design_alignment_checked` and the checked-source list:
   messages, an escalation, and receiver-report handling may all happen in one
   wake (G524); never defer a publish's delegation to an unscheduled future
   wake.
-- Verify the recipient id against the team roster (`agmsg team.sh`) before
-  every send; an id not on the roster is an error, not a guess (G524).
+- Use `intent-cli notify` for every workflow send; it validates the active
+  transport's role source and fails closed on unknown or unavailable recipients
+  (G524/G578).
 - End every wake with a stalled-work check (`automation stalled-work`, G523)
   and process any actionable item before sleeping; escalate explicitly
   rather than deferring silently.

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -13,6 +13,43 @@ host リポジトリが **複数の intent ドメイン** を保持する場合�
 intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --mode single-domain|multi-domain --format markdown
 ```
 
+## canonical notify workflow
+
+role 間の workflow message はすべて `intent-cli notify` を使い、agent 自身は
+agmsg/herdr の配信方法を選択・直接実行しません。CLI が team に記録された session-layer
+mode（未記録時は `agmsg`）を内部で解決し、送信前に logical role を検証するため、team が
+transport を切り替えても command shape は変わりません。
+
+```bash
+# 1 件の bounded task を委譲。--input / --expected-artifact は必要に応じて反復する。
+intent-cli notify delegate --domain <domain> --team <team> --from <sender-role> \
+  --to <receiver-role> --report-to <orchestrator-role> --task-id <task-id> \
+  --objective <one-bounded-outcome> --input <canonical-reference> \
+  --expected-artifact <inspectable-artifact> --result-nonce <fresh-nonce> \
+  --write --format json
+
+# receiver の final step（delegate payload がこの command を供給する）。
+intent-cli notify report --domain <domain> --team <team> --from <receiver-role> \
+  --to <orchestrator-role> --task-id <task-id> \
+  --status completed|blocked|question --artifact <artifact> \
+  --summary <one-line-summary> --write --format json
+
+# design decision を既存 events.jsonl boundary へ送る。
+intent-cli notify escalate --domain <domain> --team <team> --from <sender-role> \
+  --task-id <task-id> --artifact <decision-input> \
+  --summary <one-line-summary> --write --format json
+```
+
+`notify delegate` は task id、expected artifact、fresh marker nonce、isolated child
+checkout から必要な transport-neutral `--routing-root` を含む完全な canonical report
+command を配信 task に埋め込みます。receiver は他のすべての作業後、その report
+command を final step として実行するため、herdr-only の完了が receiver pane に表示される
+だけで終わらず orchestration role を能動的に wake します。unknown role と delivery failure
+は named cause と non-zero で fail closed します。`notify escalate` は変更していない 6-field
+event schema を append します。いずれも merge / label / publish / queue mutation を行いません。
+direct transport command は provisioning/readiness diagnostics に限り、workflow send instruction
+には使いません。
+
 ## orchestrator モードの開始（設計スレッドのセットアップ）
 
 オーケストレーションを動かしたい設計スレッドは intent-cli に直接尋ねられます —
@@ -64,9 +101,9 @@ intake の後に、完全なリファレンスチェックリストが続きま�
 8. **クリーンアップ** — 終了時は agmsg スクリプト（`leave.sh` / `despawn.sh`）でロールを
    leave/despawn し、inbox watcher を停止する。
 
-> **警告:** agmsg のデータベースや team ファイルを直接編集しないでください — 登録・送信・
-> クリーンアップはすべて agmsg スクリプト経由で行います。agmsg state の手編集は delivery を
-> 壊します。
+> **警告:** agmsg のデータベースや team ファイルを直接編集しないでください — provision・
+> diagnose・cleanup は agmsg script を使い、workflow notification は adapter を呼ぶ
+> `intent-cli notify` で送ります。agmsg state の手編集は delivery を壊します。
 
 ## ターミナルワークスペースの provisioning（チームを構築する）
 
@@ -229,28 +266,19 @@ agmsg identity step はありません。
 
 ### Dispatch、wait、artifact 検証
 
-`herdr agent prompt <logical-role> <task-block>` で次の structured block を 1 つ送ります。
-
-```text
-TASK <task-id>
-role: <logical-role>
-objective: <one bounded outcome>
-inputs:
-  - <canonical issue/PR/path/reference>
-expected-artifacts:
-  - <file, commit, PR, report, or other inspectable artifact>
-result-prefix: ORCH_RESULT
-result-nonce: <fresh-per-dispatch-nonce>
-completion-marker: Ready になったら result-prefix、1 space、result-nonce、1 space、status、1 space、artifact を連結した 1 行を出力する。status は completed、blocked、question。precomposed marker をこの task block にコピーしない。
-```
+[canonical notify workflow](#canonical-notify-workflow) の
+`intent-cli notify delegate ...` を target logical role に対して実行します。CLI が
+herdr-only を内部解決し、role mapping を検証して structured task block を生成します。
+`herdr agent prompt` を手書きしてはいけません。
 
 dispatch ごとに fresh で予測不能な nonce を生成し、再利用や task id 単独での代用をしません。
 `pane wait-output` は既存 output を即座に検索するため、task block 内の precomposed wait needle
 が echo され、作業開始前に false match することがあります。split field により、その literal を
-dispatch から除外します。handoff は file、commit、PR、verification log などの inspectable
+生成された split field により、その literal を dispatch から除外します。handoff は file、commit、PR、verification log などの inspectable
 artifact です。screen prose はそれを指す signal にすぎません。repair は現在の pane mapping を
 解決した後、同じ logical role に task id と具体的 delta を添えて戻します。どの buffer 由来でも
-marker match だけでは不十分で、named artifact の存在と verification が必要です。
+marker match だけでは不十分で、named artifact の存在と verification が必要です。repair も
+`intent-cli notify delegate` で同じ logical role に戻します。
 
 wait は必ず bounded にします。
 
@@ -285,12 +313,12 @@ append し、embedded newline を許さず、`summary` を 1 行へ normalize �
 ```
 
 design-relevant な completion / blocked / question / escalation だけを書きます。この
-mode-independent channel は design boundary のみで、inter-agent bus ではなく、herdr
-dispatch、GitHub、intent-cli workflow state の代替でもありません。
+mode-independent channel は design boundary のみで、inter-agent bus ではなく、
+`intent-cli notify`、GitHub、intent-cli workflow state の代替でもありません。
 
 - Claude app watcher: 解決済み path の完全な未読行だけを tail し、restart をまたいで offset
   を保持します。
-- herdr pane の Codex CLI: role を直接 prompt し、通常 coordination で file poll しません。
+- herdr pane の Codex CLI: `intent-cli notify delegate` / `report` を使い、通常 coordination で file poll しません。
 - Codex Desktop: one-minute-class（約 1 分）cadence で poll し、durable byte-offset watermark より後の
   完全な行だけを処理し、成功後に watermark を進めます。truncate または malformed JSON は
   fail closed とし operator recovery を要求します。
@@ -668,11 +696,11 @@ orchestrator がメッセージ駆動で動作する場合でも fallback/legacy
   同一 wake 内 delegation、停滞している receiver ごとに 1 通の repair メッセージ、
   1 件のオペレーターエスカレーション、保留中の receiver report への対応が
   すべて含まれてよい。
-- **送信前に受信者ロースターを検証する（G524）。** どの agmsg メッセージを送る前にも、
-  受信者 id が team roster（`agmsg team.sh`）に存在することを確認する — agmsg は
-  未知の受信者を黙って受け付けてしまうため、roster に無い id は推測せず、
-  エラーとして扱う（フィールドでは、登録済みロール `reviewer` に対して `review` と
-  誤指定し、メッセージが静かに失われた例があります）。
+- **notify が受信者を検証する（G524/G578）。** workflow message は
+  `intent-cli notify` だけで送り、active transport の role source に無い id や
+  unavailable receiver は named cause と non-zero で fail closed にする。role 名を
+  推測したり、handwritten transport call で検証を迂回したりしない（旧経路では、登録済み
+  `reviewer` に対して `review` と誤指定したメッセージが静かに失われました）。
 - **stalled-work チェックで wake を終える（G523/G524）。**
   `intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json`
   を実行し、報告されたすべての actionable item を眠りにつく前に処理する — wake が
@@ -764,11 +792,11 @@ intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --forma
 
 ## dispatch 検証（G524）
 
-どの agmsg メッセージを送る前にも、受信者 id が team roster（agmsg `team.sh`）に
-存在することを確認してください。agmsg は未知の受信者を黙って受け付けてしまいます —
-配信エラーとして気づく手段がありません。roster に無い受信者 id はエラーとして扱い、
-送信前に id か roster 登録を修正してください。ロール名を推測したり近似したり
-しないでください。
+workflow message は `intent-cli notify` だけで送ります。agmsg adapter は team roster を、
+herdr-only adapter は logical-role mapping と running agent/pane を検証してから配信します。
+unknown role / unavailable receiver は named cause と non-zero を返し、配信済みとは決して
+報告しません。再試行前に role registration/mapping を直し、role 名を推測・近似したり、
+handwritten transport invocation で検証を迂回したりしてはいけません。
 
 フィールドで観測された損失: 登録済みロールが `reviewer` であったにもかかわらず
 `review` 宛に送られた 8 件の dispatch が、静かに失われました — agmsg は配信もせず、
@@ -1102,13 +1130,14 @@ authenticate します)、壊れた瞬間にオペレーターの画面上で可
   実行します。プロンプトは各 wake で
   `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --format json`
   を実行し、結果の `stale` フィールドが `true` であれば `message_body` をそのまま
-  agmsg send スクリプト経由で orchestrator に送ります(正確に **1 通**)。`stale` が
+  `intent-cli notify report`（`--from design --to orchestrator --status question`、fresh な
+  heartbeat task id、heartbeat evidence artifact）で orchestrator に送ります（正確に **1 通**）。`stale` が
   `false` であれば何も送らず静かに終了します — 沈黙は **この健全なケースにのみ**
   許されます。heartbeat コマンドの実行失敗や不正な/オブジェクトでない出力は
   **決して沈黙しません**: この wake 自身の turn 出力で、生きたこのセッションを
   監視しているオペレーターに見える形で、失敗を明示的に述べます — これこそが、
   retire された見えない外部スケジューラに対して in-session の watchdog が持つ
-  正確な優位性です(下記 Retired を参照)— その一方で、壊れた入力から agmsg の
+  正確な優位性です(下記 Retired を参照)— その一方で、壊れた入力から notify の
   nudge を捏造・送信することは決してありません。実際に送信されるメッセージは、
   本物の `stale=true` 結果の場合だけです。
 - **failure visibility** — 沈黙は健全な `stale=false` の heartbeat 結果にのみ
@@ -1116,7 +1145,7 @@ authenticate します)、壊れた瞬間にオペレーターの画面上で可
   この wake の watchdog 自身の turn 出力で **可視的に** 表面化させなければ
   なりません — 決して黙って飲み込んだり、黙ってリトライしたりしません。沈黙した
   失敗こそが、このスライスが外部 OS スケジューラを retire する理由そのものだから
-  です — その一方で、壊れた入力から agmsg の nudge を捏造・送信することは決して
+  です — その一方で、壊れた入力から notify の nudge を捏造・送信することは決して
   ありません。実際に送信されるメッセージは、本物の `stale=true` 結果の場合だけです。
 - **チェック内容** — design/HITL inbox で未読の人間向けエスカレーションを確認
   (design ロールの `inbox.sh`)、read-only な intent-cli/GitHub の事実
@@ -1464,8 +1493,8 @@ required-final-step のルールは review スレッドにも適用され、そ�
   メッセージ、1 件のエスカレーション、receiver report への対応は 1 回の wake に
   すべて含まれてよい（G524）。publish の delegation をスケジュールされていない
   将来の wake に先送りしない。
-- 送信の前に必ず受信者 id を team roster（`agmsg team.sh`）と照合する。roster に
-  無い id は推測ではなくエラーとして扱う（G524）。
+- workflow send は必ず `intent-cli notify` を使う。active transport の role source を
+  検証し、unknown / unavailable recipient は fail closed にする（G524/G578）。
 - すべての wake を stalled-work チェック（`automation stalled-work`、G523）で終え、
   眠りにつく前に actionable な item を処理する。黙って先送りせず、明示的に
   エスカレーションする。

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -31,7 +31,9 @@ internal static class CommandRouter
         "migrate",
         "skill",
         // G570: session-layer transport selection (agmsg | herdr-only).
-        "session-layer"
+        "session-layer",
+        // G578: transport-neutral role notification surface.
+        "notify"
     ];
 
     /// <summary>
@@ -44,6 +46,7 @@ internal static class CommandRouter
     {
         "guide",
         "automation",
+        "notify",
         "worker",
         "review",
         "issue",
@@ -116,6 +119,13 @@ internal static class CommandRouter
             {
                 ["show"] = SessionLayerCommand.ExecuteShow,
                 ["set"] = SessionLayerCommand.ExecuteSet
+            },
+            // G578: one workflow contract over agmsg and herdr-only transports.
+            ["notify"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["delegate"] = NotifyCommand.ExecuteDelegate,
+                ["report"] = NotifyCommand.ExecuteReport,
+                ["escalate"] = NotifyCommand.ExecuteEscalate
             },
             // G559: cross-platform agent skill install surface.
             ["skill"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
@@ -571,6 +581,7 @@ internal static class CommandRouter
             ["issue"] = "`intent-cli issue publish-flow <id> --repo <r> --write --format json` then `intent-cli automation issue-publish --write`.",
             ["automation"] = "`intent-cli automation summary --domain <d> --format json` (capability JSON), `intent-cli automation doctor --format json` (CLI freshness).",
             ["session-layer"] = "`intent-cli session-layer show --domain <d> [--team <t>]` (which transport is in force), then `intent-cli session-layer set --domain <d> --mode agmsg|herdr-only --write` to change it.",
+            ["notify"] = "`intent-cli notify delegate|report|escalate --domain <d> --team <t> ...` (canonical role workflow; transport follows the recorded session-layer mode).",
             ["bug"] = "`intent-cli guide worker pr-comment-fix --format json` (repair guidance), `intent-cli bug report`/`triage` for new-bug intake.",
             ["worker"] = "`intent-cli worker next-action --repo <r> --workdir <child> --format json` then claim / result-summary / complete.",
             ["metadata"] = "`intent-cli metadata validate --format json` (read-only); use `intent-cli metadata update --mode completed-closeout --write` for the bounded controlled writer instead of hand-editing.",

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -153,6 +153,15 @@ internal static class GuideCommandsListCommand
         },
         new CommandGroupEntry
         {
+            Name = "notify",
+            Role = RoleDesign,
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "Transport-neutral role workflow (G578): `intent-cli notify delegate|report|escalate`. The CLI resolves the recorded session-layer mode internally, validates logical roles before delivery, embeds the canonical report command in delegated work, and appends escalation events to the existing design-boundary JSONL channel. Dry-run is read-only; delivery and event append require `--write`."
+        },
+        new CommandGroupEntry
+        {
             Name = "automation",
             Role = RoleHostReview,
             Classification = ClassificationSupport,

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -857,7 +857,7 @@ internal static class GuideOrchestratorThreadCommand
                     "If intent-cli reports an `issue-cut-ready` candidate and all gates pass (same-domain or routed, complete contract, no open clarification, dependencies satisfied, under WIP, clean host-sync/preflight), publish ONE issue this wake via canonical publish-flow / issue-publish, verify it, THEN delegate that same issue to implementation in THIS SAME WAKE (G524) — do not ask the operator to create it, and do not stop after publishing to wait for a future wake to send the delegation.",
                     "If the candidate has unmet dependencies, plan the chain instead of pausing: act on the EARLIEST unmet resolvable dependency (publish or route it), keep the dependent held, and escalate only ambiguous/cycle/cross-domain-unrouted cases.",
                     "The per-wake cap is AT MOST ONE DELEGATION PER RECEIVER (implementation, review) — NOT at-most-one-message overall (G524): this wake's actions may include a publish plus its same-wake delegation, one repair message per stalled receiver, one operator escalation, and handling any pending receiver reports, all together.",
-                    "Before sending any agmsg message this wake, verify the recipient id against the team roster (`agmsg team.sh`) — treat an id not on the roster as an error, never a guess (G524).",
+                    "Send workflow notifications only through `intent-cli notify`; it resolves the recorded session-layer mode and validates the recipient before delivery, failing closed on an unknown role (G524/G578).",
                     "Apply the design-thread escalation filter: keep routine progress / CI-wait / success / closeout / idle internal; surface to the design thread ONLY human-needed decisions, with structured evidence and the exact decision needed. Never hide a failure that needs a human.",
                     Apply("End this wake with the stalled-work check (G523): `intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json`, and process every actionable item it reports before sleeping — never leave one for an unscheduled next wake; escalate explicitly if it is genuinely blocked on an operator decision. This includes a `backlog-ready-idle` item (G544, empty WIP + a ready packet + no activity past the idle threshold) — publish and delegate it in THIS wake, the same as any other issue-cut-ready candidate; only announce a following wake will handle it when that wake is actually scheduled."),
                 },
@@ -992,10 +992,10 @@ internal static class GuideOrchestratorThreadCommand
             DispatchVerification = new OrchestratorDispatchVerification
             {
                 Rule =
-                    "G524: before sending ANY agmsg message, verify the recipient id is present in the team roster "
-                    + "(agmsg `team.sh`). agmsg accepts an unknown recipient silently — there is no delivery error to "
-                    + "notice. Treat a recipient id that is not on the roster as an error: fix the id or the roster "
-                    + "registration before sending; never guess or approximate a role name.",
+                    "G524/G578: send workflow notifications only through `intent-cli notify`. It validates the agmsg "
+                    + "roster or herdr logical-role mapping before delivery and returns a named failure instead of a "
+                    + "silent no-op. Fix the active transport's role registration or mapping before retrying; never "
+                    + "guess a role name or bypass notify with a handwritten transport call.",
                 DeadAddressExample =
                     "Field-observed loss: 8 dispatches addressed to `review` were silently lost when the registered "
                     + "role was `reviewer` — agmsg neither delivered nor reported the mismatch.",
@@ -1235,20 +1235,21 @@ internal static class GuideOrchestratorThreadCommand
                     + "the DESIGN thread, run `/loop 30m` (Claude same-thread) or a Codex automation firing every "
                     + "30 minutes, with a prompt that on each wake runs `intent-cli automation heartbeat --domain "
                     + "<domain> --repo <owner/repo> --format json`; when the result's `stale` field is `true`, send "
-                    + "its `message_body` verbatim to the orchestrator via the agmsg send script (exactly ONE "
-                    + "message); when `stale` is `false`, send nothing and exit quietly — silence is reserved for "
+                    + "its `message_body` to the orchestrator with exactly ONE canonical `intent-cli notify report` "
+                    + "call (`--from design --to orchestrator --status question`, plus a fresh heartbeat task id and "
+                    + "the heartbeat evidence artifact); when `stale` is `false`, send nothing and exit quietly — silence is reserved for "
                     + "this healthy case ONLY. A heartbeat command execution failure or malformed/non-object output "
                     + "is NEVER silent: state the failure explicitly in this wake's own turn output, visible to the "
                     + "operator watching this live session — the exact advantage an in-session watchdog has over "
                     + "the retired invisible external scheduler (see the fallback timer / retired-cron notes) — "
-                    + "while still never fabricating or sending an agmsg nudge from broken input; only a genuine "
+                    + "while still never fabricating or sending a notify nudge from broken input; only a genuine "
                     + "`stale=true` heartbeat result ever produces a sent message."),
                 FailureVisibilityRule =
                     "Silence is reserved for a healthy `stale=false` heartbeat result ONLY. A heartbeat command "
                     + "execution failure or malformed/non-object output must be surfaced VISIBLY in the watchdog's "
                     + "own turn output this wake — never silently swallowed or silently retried, since silent "
                     + "failure is exactly the defect this slice retires the external OS scheduler for — while "
-                    + "still never fabricating or sending an agmsg nudge from broken input; only a genuine "
+                    + "still never fabricating or sending a notify nudge from broken input; only a genuine "
                     + "`stale=true` result ever produces a sent message.",
                 HeartbeatCommandExample =
                     "intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --format json",
@@ -1803,10 +1804,9 @@ internal static class GuideOrchestratorThreadCommand
                         + "(implementation, review), NOT at-most-one-message overall: alongside a publish+delegation you "
                         + "may also send one repair request per stalled receiver (pointing it back to the official "
                         + "intent-cli workflow), escalate one operator decision, and handle any pending receiver "
-                        + "reports. Before sending ANY agmsg message, verify the recipient id is present in the team "
-                        + "roster (agmsg `team.sh`) — agmsg accepts an unknown recipient silently, so treat an "
-                        + "off-roster id as an error, never a guess (a legacy `review` vs the registered `reviewer` has "
-                        + "silently lost messages in the field). Unmet dependencies are normal work, not a stop: if the "
+                        + "reports. Send every workflow notification through `intent-cli notify`; it resolves the "
+                        + "recorded transport and validates recipients before delivery, so an unknown role fails "
+                        + "closed instead of becoming a silent no-op (G578). Unmet dependencies are normal work, not a stop: if the "
                         + "next candidate depends on incomplete work, act on the EARLIEST unmet resolvable dependency "
                         + "(publish or route it) and keep the dependent held, rather than pausing for the operator. For a "
                         + "no-reply receiver past the threshold (default 30m), run the SAFE stale-thread health check — "
@@ -1835,14 +1835,14 @@ internal static class GuideOrchestratorThreadCommand
                 {
                     Role = "implementation",
                     Purpose =
-                        "Implement exactly one delegated item, then report a structured agmsg reply.",
+                        "Implement exactly one delegated item, then run the canonical notify report command embedded in it.",
                     Prompt = Apply(
                         "You are the IMPLEMENTATION thread for domain `<domain>` against `<owner/repo>` using `<agent>`, "
-                        + "driven by orchestrator agmsg delegations. You are a LOOPLESS receiver: do NOT start your own "
+                        + "driven by canonical `intent-cli notify delegate` calls. You are a LOOPLESS receiver: do NOT start your own "
                         + "recurring timer/loop for this domain/repo — wait for a delegation, act once, reply once, then "
                         + "wait again (receivers are never scheduled; the orchestrator is message-driven by default, with an explicit fallback/legacy timer as the only case where it is scheduled). When delegated an item, run "
                         + "the normal child implementation workflow: the issue/PR number comes from `intent-cli worker "
-                        + "next-action --repo <owner/repo> --github-only`, NOT from the agmsg text. Before claiming, "
+                        + "next-action --repo <owner/repo> --github-only`, NOT from the notification text. Before claiming, "
                         + "verify your local checkout context matches the delegation: your cwd/worktree, the git remote "
                         + "repo, and the delegated domain must line up with the routing you were handed. If the checkout "
                         + "does not match the delegated repo/domain, STOP and reply blocked instead of claiming. An "
@@ -1850,31 +1850,30 @@ internal static class GuideOrchestratorThreadCommand
                         + "signal — confirm via packet/domain metadata and the routing context, not the prefix. Then "
                         + "claim, implement, open the PR with a `Closes #<issue>` reference, and `worker complete` — all "
                         + "label transitions through intent-cli worker/automation only. intent-cli and GitHub remain "
-                        + "authoritative; agmsg is only how you receive the delegation and send back your reply. "
+                        + "authoritative; notify is only how you receive the delegation and send back your report. "
                         + "Reporting completion or blocked status to the orchestrator is a REQUIRED FINAL STEP of "
                         + "EVERY delegation (G524) — it is not optional and the orchestrator cannot discover a silent "
                         + "completion on its own (a PR opened with no report reaching the orchestrator is LOST WORK "
                         + "from the orchestrator's perspective, observed in the field for 88 minutes before a manual "
-                        + "check found it). When done or blocked, send ONE structured agmsg reply (accepted / progress "
-                        + "/ completed / blocked) in the exact shape "
-                        + "`{\"status\":\"completed\",\"thread\":\"implementation\",\"ref\":\"pr#<n>\",\"note\":\"PR "
-                        + "opened, Closes #<n>, CI green\"}` (or the `blocked` shape naming one operator action), "
-                        + "citing the GitHub facts (PR number, CI) — do not consider the delegation finished until this "
-                        + "reply is sent. Do NOT read host metadata (`.intent-cli/**`, "
+                        + "check found it). After ALL other work, run the complete canonical `intent-cli notify report` "
+                        + "command embedded in the delegation, supplying `completed`, `blocked`, or `question`, the "
+                        + "inspectable artifact, and a one-line summary citing GitHub facts (PR number, CI). Never "
+                        + "hand-write an agmsg/herdr transport call, and do not consider the delegation finished until "
+                        + "the canonical report command succeeds. Do NOT read host metadata (`.intent-cli/**`, "
                         + "`intents/**`)."),
                 },
                 new OrchestratorThreadPrompt
                 {
                     Role = "review",
                     Purpose =
-                        "Review/closeout exactly one delegated PR through intent-cli, then report a structured agmsg reply.",
+                        "Review/closeout exactly one delegated PR through intent-cli, then run the embedded canonical notify report command.",
                     Prompt = Apply(
                         "You are the REVIEW thread for domain `<domain>` against `<owner/repo>` using `<agent>`, driven "
-                        + "by orchestrator agmsg delegations. You are a LOOPLESS receiver: do NOT start your own "
+                        + "by canonical `intent-cli notify delegate` calls. You are a LOOPLESS receiver: do NOT start your own "
                         + "recurring timer/loop for this domain/repo — wait for a delegation, act once, reply once, then "
                         + "wait again (receivers are never scheduled; the orchestrator is message-driven by default, with an explicit fallback/legacy timer as the only case where it is scheduled). When delegated a PR, run the "
                         + "official host review/closeout through intent-cli surfaces (`review closeout-plan`, `guide "
-                        + "review`, `automation pr-transition`, `closeout pr`) — agmsg never replaces semantic review or "
+                        + "review`, `automation pr-transition`, `closeout pr`) — notify never replaces semantic review or "
                         + "authorizes a merge. Perform semantic review only when you are the packet `review_role` or "
                         + "explicitly assigned (G480); otherwise orchestrate the merge/closeout of an already-approved "
                         + "PR. If you need a review worktree, allocate it under the MANAGED root "
@@ -1888,20 +1887,19 @@ internal static class GuideOrchestratorThreadCommand
                         + "of those sources you checked — the orchestrator treats a reply missing that evidence as an "
                         + "INCOMPLETE review unless an authoritative prior approval state already proves equivalent "
                         + "review. Reporting completion or blocked status to the orchestrator is a REQUIRED FINAL STEP "
-                        + "of EVERY delegation (G524) — report ONE structured agmsg reply (accepted / progress / "
-                        + "completed / blocked) in the exact shape "
-                        + "`{\"status\":\"completed\",\"thread\":\"review\",\"ref\":\"pr#<n>\",\"note\":\"approved; "
-                        + "closeout done\",\"design_alignment_checked\":true,\"design_alignment_sources_checked\":"
-                        + "[\"packet\",\"review-context\",\"intent-tree\",\"adr-decision-notes\",\"relevant-docs\"]}` "
-                        + "(or the `blocked` shape naming one operator action), citing the intent-cli/GitHub facts — do "
-                        + "not consider the delegation finished until this reply is sent. intent-cli and GitHub stay "
+                        + "of EVERY delegation (G524) — after ALL other work, run the complete canonical "
+                        + "`intent-cli notify report` command embedded in the delegation with `completed`, `blocked`, "
+                        + "or `question`, the inspectable artifact, and a one-line summary citing intent-cli/GitHub "
+                        + "facts and the design-alignment sources checked. Never hand-write an agmsg/herdr transport "
+                        + "call, and do not consider the delegation finished until the canonical report command "
+                        + "succeeds. intent-cli and GitHub stay "
                         + "authoritative."),
                 },
             },
             AgmsgReplyContract = new OrchestratorReplyContract
             {
                 Description =
-                    "Implementation/review threads reply to a delegation with exactly one structured agmsg message. "
+                    "Implementation/review threads finish a delegation with exactly one canonical `intent-cli notify report` call using the command embedded by `notify delegate`. "
                     + "The reply is a SIGNAL; the orchestrator re-verifies every claim against intent-cli / GitHub "
                     + "before acting on it.",
                 Accepted = "{\"status\":\"accepted\",\"thread\":\"implementation\",\"ref\":\"issue#<n>\",\"note\":\"claimed; starting\"}",
@@ -1937,7 +1935,7 @@ internal static class GuideOrchestratorThreadCommand
                 Apply("Ask intent-cli for the real state: `intent-cli intent status --domain <domain> --format json` and `intent-cli worker next-action --repo <owner/repo> --github-only --format json`."),
                 "Verify every GitHub fact an agmsg reply claims (PR merged, CI concluded, labels) before acting on it.",
                 "The per-wake cap is AT MOST ONE DELEGATION PER RECEIVER, not at-most-one-message overall (G524): a publish this wake must be delegated to implementation in this SAME wake — never defer that delegation to an unscheduled next wake — alongside any repair requests (one per stalled receiver) or one operator escalation.",
-                "Before sending any agmsg message, verify the recipient id against the team roster (`agmsg team.sh`); treat an id not on the roster as an error, never a guess (G524).",
+                "Send workflow notifications only through `intent-cli notify`; it resolves the recorded transport and validates the recipient before delivery, failing closed on an unknown role (G524/G578).",
                 "Do not launch implement/review recurring timers for this domain/repo while orchestrating.",
                 Apply("End this wake with the stalled-work check (G523): `intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json`, and process every actionable item before sleeping — never leave one for an unscheduled next wake; escalate explicitly if it is genuinely blocked on an operator decision."),
             },
@@ -1948,7 +1946,7 @@ internal static class GuideOrchestratorThreadCommand
                 "No hand-editing queue-state, runs.jsonl, packets, or any host metadata (`.intent-cli/**`, `intents/**`).",
                 "agmsg never replaces semantic review or authorizes a merge; review/closeout decisions run through intent-cli review surfaces (G480).",
                 "Per-wake cap is AT MOST ONE DELEGATION PER RECEIVER (implementation, review) — NOT at-most-one-message: a publish's same-wake delegation, repair messages, an escalation, and receiver-report handling may all happen in one wake (G524); never defer a publish's delegation to an unscheduled future wake.",
-                "Verify the recipient id against the team roster (`agmsg team.sh`) before every send; an id not on the roster is an error, not a guess (G524).",
+                "Use `intent-cli notify` for every workflow send; it validates the active transport's role source and fails closed on unknown or unavailable recipients (G524/G578).",
                 "End every wake with a stalled-work check (`automation stalled-work`, G523) and process any actionable item before sleeping; escalate explicitly rather than deferring silently.",
                 "Domain isolation: a host repo can hold several domains and one repo can serve several domains, so visibility is not authorization. Single-domain orchestrators ignore/escalate other-domain items; multi-domain orchestrators require explicit per-delegation routing. An execution-unit prefix mismatch alone is not a wrong-repo signal.",
                 "Fail closed on duplicate orchestrators for the same domain/repo, or when an agmsg reply conflicts with intent-cli/GitHub facts — STOP and escalate, never guess.",

--- a/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
+++ b/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
@@ -50,22 +50,26 @@ internal static class HerdrOnlyOperatingGuide
 
         ## Herdr-only dispatch and artifact handoff
 
-        Submit one structured task block with `herdr agent prompt <logical-role> <task-block>`. Every block has this shape:
+        Submit through the transport-neutral notify surface. The CLI resolves the recorded `herdr-only` mode, validates the logical-role mapping, and invokes the herdr adapter internally; workflow prompts never hand-write `herdr agent prompt`:
+
+        ```bash
+        intent-cli notify delegate --domain <domain> --team <team> --from <sender-role> \
+          --to <logical-role> --report-to <orchestrator-role> --task-id <task-id> \
+          --objective <one-bounded-outcome> --input <canonical-issue-or-reference> \
+          --expected-artifact <inspectable-artifact> --result-nonce <fresh-per-dispatch-nonce> \
+          --write --format json
+        ```
+
+        The command generates and delivers a task block containing these echo-safe marker fields (they are output data, not a hand-written transport invocation):
 
         ```text
         TASK <task-id>
-        role: <logical-role>
-        objective: <one bounded outcome>
-        inputs:
-          - <canonical issue/PR/path/reference>
-        expected-artifacts:
-          - <file, commit, PR, report, or other inspectable artifact>
         result-prefix: ORCH_RESULT
         result-nonce: <fresh-per-dispatch-nonce>
-        completion-marker: When the artifact is ready, print one line by concatenating result-prefix, one space, result-nonce, one space, status, one space, and artifact; use status completed, blocked, or question. Do not copy a precomposed marker into this task block.
+        completion-marker: Concatenate result-prefix, one space, result-nonce, one space, status, one space, and artifact; use completed, blocked, or question. Never include the precomposed wait needle.
         ```
 
-        Generate a fresh, unpredictable nonce for every dispatch; never reuse one or substitute the task id alone. `pane wait-output` searches existing pane output immediately, so a precomposed wait needle in the dispatched task can be echoed and falsely match before the agent does any work. Splitting the prefix and nonce above keeps the literal needle out of the task block. Files, commits, PRs, test logs, and other inspectable artifacts are the handoff; terminal prose is only a signal pointing at them. A repair or re-dispatch goes to the same logical role after resolving its current pane mapping and carries the same task id plus the concrete delta. A marker match from any pane buffer is NEVER sufficient: the named artifact must exist and pass its verification.
+        `notify delegate` generates the structured task block, keeps the result prefix and fresh unpredictable nonce separate, and embeds task id, expected artifact, plus the complete canonical `intent-cli notify report` command as the receiver's required final step. That command carries the transport-neutral `--routing-root`, so an isolated child checkout still resolves the recorded mode internally without learning a transport-specific send instruction. The receiver reports `completed`, `blocked`, or `question` only through that embedded command; it never hand-writes a transport call. Never reuse a nonce or substitute the task id alone. `pane wait-output` searches existing pane output immediately, so a precomposed wait needle in the dispatched task can be echoed and falsely match before the agent does any work. Files, commits, PRs, test logs, and other inspectable artifacts are the handoff; terminal prose is only a signal pointing at them. A repair or re-dispatch goes to the same logical role through `intent-cli notify delegate` and carries the same task id plus the concrete delta. A marker match from any pane buffer is NEVER sufficient: the named artifact must exist and pass its verification.
 
         ## Herdr-only bounded waiting and success detection
 
@@ -79,7 +83,7 @@ internal static class HerdrOnlyOperatingGuide
 
         ## events.jsonl design boundary
 
-        This is a normative, mode-independent design-boundary channel documented here because herdr-only has no separate message bridge. It is NEVER an inter-agent bus and never replaces direct herdr dispatch, GitHub, or intent-cli workflow state.
+        This is a normative, mode-independent design-boundary channel documented here because herdr-only has no separate message bridge. It is NEVER an inter-agent bus and never replaces `intent-cli notify delegate` / `report`, GitHub, or intent-cli workflow state.
 
         - **Location:** resolve the host repository root at runtime, then use `<host-repo>/.intent-cli/events/<team>.jsonl`. The team name is the agmsg/herdr team name verbatim in one flat filename (example: `intent-cli-dev.jsonl`); there are no team subdirectories and readers never hard-code an absolute path.
         - **Fail closed before path construction:** reject an empty team name, a leading dot, `/` or `\`, and any `..` sequence. Do not sanitize or silently rewrite an invalid name.
@@ -90,7 +94,7 @@ internal static class HerdrOnlyOperatingGuide
         Reader recipes:
 
         1. **Claude app watcher:** resolve the host root and validated team path, then tail complete lines from `<host-repo>/.intent-cli/events/<team>.jsonl`; surface only unseen design-relevant records and retain the read offset across watcher restarts.
-        2. **Codex CLI:** when Codex is a herdr pane, prompt that logical role directly with `herdr agent prompt`; it does not poll the file for ordinary coordination. The events file remains available only when that Codex role is acting as a design-boundary reader.
+        2. **Codex CLI:** when Codex is a herdr pane, address that logical role through `intent-cli notify delegate` / `report`; it does not poll the file for ordinary coordination. The events file remains available only when that Codex role is acting as a design-boundary reader.
         3. **Codex Desktop:** run a one-minute-class timer poll. Resolve the host root plus validated team filename on every resumed session, read only complete lines after a durable byte-offset watermark, surface the unseen records, then advance the watermark after successful handling. Rotation/truncation or malformed JSON fails closed and requires operator recovery; it never resets silently and replays decisions.
 
         ## Herdr-only failure modes and recovery
@@ -138,12 +142,13 @@ internal static class HerdrOnlyOperatingGuide
         },
         ["dispatch"] = new JsonObject
         {
-            ["command"] = "herdr agent prompt <logical-role> <task-block>",
-            ["required_fields"] = new JsonArray("task-id", "role", "objective", "inputs", "expected-artifacts", "result-prefix", "result-nonce", "completion-marker"),
+            ["command"] = "intent-cli notify delegate --domain <domain> --team <team> --from <sender-role> --to <logical-role> --report-to <orchestrator-role> --task-id <task-id> --objective <outcome> --input <reference> --expected-artifact <artifact> --result-nonce <nonce> --write --format json",
+            ["required_fields"] = new JsonArray("domain", "team", "from", "to", "report-to", "task-id", "objective", "inputs", "expected-artifacts", "result-prefix", "result-nonce", "completion-marker"),
+            ["reporting_contract"] = "The generated payload embeds task id, expected artifact, and the complete intent-cli notify report command (including transport-neutral --routing-root for isolated child checkouts) as the receiver's required final step; never hand-write a transport call.",
             ["marker_construction"] = "Concatenate result-prefix, space, fresh-per-dispatch result-nonce, space, status, space, artifact; never embed the composed wait needle in the task block.",
             ["echo_hazard"] = "pane wait-output searches existing output immediately, so an echoed precomposed marker can falsely match before work begins.",
             ["artifact_first"] = "Files, commits, PRs, and verification logs are the handoff; terminal text points to them.",
-            ["redispatch"] = "Resolve the same logical role's current pane and send the task id plus concrete repair delta.",
+            ["redispatch"] = "Use intent-cli notify delegate for the same logical role with the task id plus concrete repair delta.",
         },
         ["waiting"] = new JsonObject
         {
@@ -166,7 +171,7 @@ internal static class HerdrOnlyOperatingGuide
             ["readers"] = new JsonObject
             {
                 ["claude_app"] = "Tail complete unseen lines from the resolved host path and retain the read offset.",
-                ["codex_cli"] = "Prompt a herdr-resident Codex pane directly; no file poll for ordinary coordination.",
+                ["codex_cli"] = "Use intent-cli notify delegate/report for a herdr-resident Codex role; no file poll for ordinary coordination.",
                 ["codex_desktop"] = "One-minute-class timer poll using a durable byte-offset watermark; fail closed on truncation or malformed JSON.",
             },
         },

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -1,0 +1,655 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal static class NotifyCommand
+{
+    private const string OperationDelegate = "delegate";
+    private const string OperationReport = "report";
+    private const string OperationEscalate = "escalate";
+    private const string EscalationEventKind = "escalation";
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private const string DelegateUsage =
+        "Usage: intent-cli notify delegate --domain <d> --team <t> --from <role> --to <role> --report-to <role> "
+        + "--task-id <id> --objective <text> [--input <value>]... --expected-artifact <value> "
+        + "[--expected-artifact <value>]... --result-nonce <nonce> [--routing-root <host-root>] "
+        + "[--dry-run|--write] [--format markdown|json]";
+
+    private const string ReportUsage =
+        "Usage: intent-cli notify report --domain <d> --team <t> --from <role> --to <role> --task-id <id> "
+        + "--status completed|blocked|question --artifact <value> --summary <text> "
+        + "[--routing-root <host-root>] [--dry-run|--write] [--format markdown|json]";
+
+    private const string EscalateUsage =
+        "Usage: intent-cli notify escalate --domain <d> --team <t> --from <role> --task-id <id> "
+        + "--artifact <value> --summary <text> [--routing-root <host-root>] "
+        + "[--dry-run|--write] [--format markdown|json]";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    internal static Func<INotifyProcessRunner>? ProcessRunnerFactory { get; set; }
+
+    internal static Func<string>? AgmsgScriptsDirectoryFactory { get; set; }
+
+    internal static Func<string>? HerdrExecutableFactory { get; set; }
+
+    internal static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    public static int ExecuteDelegate(CliContext context, string[] args, TextWriter writer) =>
+        Execute(context, args, writer, OperationDelegate);
+
+    public static int ExecuteReport(CliContext context, string[] args, TextWriter writer) =>
+        Execute(context, args, writer, OperationReport);
+
+    public static int ExecuteEscalate(CliContext context, string[] args, TextWriter writer) =>
+        Execute(context, args, writer, OperationEscalate);
+
+    private static int Execute(CliContext context, string[] args, TextWriter writer, string operation)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(Usage(operation));
+            return 0;
+        }
+
+        if (!TryParse(args, operation, out var options, out var error))
+        {
+            writer.WriteLine($"invalid-notification: {error}");
+            writer.WriteLine(Usage(operation));
+            return 1;
+        }
+
+        string routingRoot;
+        try
+        {
+            routingRoot = Path.GetFullPath(options.RoutingRoot ?? context.RepoRoot);
+            options = options with { RoutingRoot = routingRoot };
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            Emit(writer, options.Format, FailureResult(
+                operation,
+                options,
+                SessionLayerMode.Default,
+                "invalid-routing-root",
+                $"Could not resolve --routing-root: {exception.Message}"));
+            return 1;
+        }
+
+        SessionLayerModeResolution resolution;
+        try
+        {
+            resolution = SessionLayerModeStore.Resolve(routingRoot, options.Domain!, options.Team);
+        }
+        catch (InvalidOperationException exception)
+        {
+            Emit(writer, options.Format, FailureResult(
+                operation,
+                options,
+                SessionLayerMode.Default,
+                "session-layer-mode-unreadable",
+                exception.Message));
+            return 1;
+        }
+
+        return string.Equals(operation, OperationEscalate, StringComparison.Ordinal)
+            ? ExecuteEscalation(writer, options, resolution)
+            : ExecuteDelivery(writer, operation, options, resolution);
+    }
+
+    private static int ExecuteDelivery(
+        TextWriter writer,
+        string operation,
+        NotifyOptions options,
+        SessionLayerModeResolution resolution)
+    {
+        var reportCommand = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+            ? BuildReportCommand(options)
+            : null;
+        var payload = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+            ? BuildDelegatePayload(options, reportCommand!)
+            : BuildReportPayload(options);
+
+        if (!options.Write)
+        {
+            Emit(writer, options.Format, SuccessResult(
+                operation,
+                options,
+                resolution,
+                delivered: false,
+                eventAppended: false,
+                payload,
+                reportCommand,
+                $"Dry-run: would deliver {operation} through {resolution.Mode}."));
+            return 0;
+        }
+
+        var runner = ProcessRunnerFactory?.Invoke() ?? new NotifyProcessRunner();
+        var transport = string.Equals(resolution.Mode, SessionLayerMode.HerdrOnly, StringComparison.Ordinal)
+            ? (INotifyTransport)new HerdrNotifyTransport(
+                runner,
+                HerdrExecutableFactory?.Invoke() ?? NotifyTransportPaths.ResolveHerdrExecutable())
+            : new AgmsgNotifyTransport(
+                runner,
+                AgmsgScriptsDirectoryFactory?.Invoke() ?? NotifyTransportPaths.ResolveAgmsgScriptsDirectory());
+        var roles = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+            ? new[] { options.FromRole!, options.ToRole!, options.ReportToRole! }
+            : new[] { options.FromRole!, options.ToRole! };
+        var delivery = transport.Deliver(
+            options.Team!,
+            options.FromRole!,
+            options.ToRole!,
+            roles,
+            payload);
+
+        if (!delivery.Delivered)
+        {
+            Emit(writer, options.Format, FailureResult(
+                operation,
+                options,
+                resolution.Mode,
+                delivery.Cause!,
+                delivery.Summary,
+                payload,
+                reportCommand));
+            return 1;
+        }
+
+        Emit(writer, options.Format, SuccessResult(
+            operation,
+            options,
+            resolution,
+            delivered: true,
+            eventAppended: false,
+            payload,
+            reportCommand,
+            delivery.Summary));
+        return 0;
+    }
+
+    private static int ExecuteEscalation(
+        TextWriter writer,
+        NotifyOptions options,
+        SessionLayerModeResolution resolution)
+    {
+        if (!NotifyEventWriter.TryResolvePath(options.RoutingRoot!, options.Team!, out var path, out var error))
+        {
+            Emit(writer, options.Format, FailureResult(
+                OperationEscalate,
+                options,
+                resolution.Mode,
+                "invalid-team",
+                error));
+            return 1;
+        }
+
+        if (!options.Write)
+        {
+            Emit(writer, options.Format, SuccessResult(
+                OperationEscalate,
+                options,
+                resolution,
+                delivered: false,
+                eventAppended: false,
+                payload: null,
+                reportCommand: null,
+                $"Dry-run: would append escalation to '{path}'.",
+                eventPath: path));
+            return 0;
+        }
+
+        try
+        {
+            NotifyEventWriter.Append(path, new NotifyDesignEvent
+            {
+                Timestamp = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
+                Team = options.Team!,
+                Kind = EscalationEventKind,
+                Unit = options.TaskId!,
+                Summary = NotifyEventWriter.NormalizeSummary(options.Summary!),
+                Artifact = options.Artifact!,
+            });
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            Emit(writer, options.Format, FailureResult(
+                OperationEscalate,
+                options,
+                resolution.Mode,
+                "event-append-failed",
+                $"Could not append the design-boundary event: {exception.Message}"));
+            return 1;
+        }
+
+        Emit(writer, options.Format, SuccessResult(
+            OperationEscalate,
+            options,
+            resolution,
+            delivered: false,
+            eventAppended: true,
+            payload: null,
+            reportCommand: null,
+            $"Appended escalation for task '{options.TaskId}' to the design-boundary event channel.",
+            eventPath: path));
+        return 0;
+    }
+
+    private static string BuildDelegatePayload(NotifyOptions options, string reportCommand)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"TASK {options.TaskId}");
+        builder.AppendLine($"role: {options.ToRole}");
+        builder.AppendLine($"objective: {options.Objective}");
+        builder.AppendLine("inputs:");
+        foreach (var input in options.Inputs)
+        {
+            builder.AppendLine($"  - {input}");
+        }
+        builder.AppendLine("expected-artifacts:");
+        foreach (var artifact in options.ExpectedArtifacts)
+        {
+            builder.AppendLine($"  - {artifact}");
+        }
+        builder.AppendLine("reporting-contract:");
+        builder.AppendLine($"  task-id: {options.TaskId}");
+        builder.AppendLine($"  expected-artifact: {string.Join("; ", options.ExpectedArtifacts)}");
+        builder.AppendLine($"  canonical-report-command: {reportCommand}");
+        builder.AppendLine("  required-final-step: Run canonical-report-command after all other work; never hand-write a transport invocation.");
+        builder.AppendLine("result-prefix: ORCH_RESULT");
+        builder.AppendLine($"result-nonce: {options.ResultNonce}");
+        builder.Append("completion-marker: When the artifact is ready, concatenate result-prefix, one space, result-nonce, one space, status, one space, and artifact; use completed, blocked, or question. Do not precompose the marker in this task block.");
+        return builder.ToString();
+    }
+
+    private static string BuildReportCommand(NotifyOptions options) =>
+        $"intent-cli notify report --domain {options.Domain} --team {options.Team} --from {options.ToRole} "
+        + $"--to {options.ReportToRole} --task-id {options.TaskId} --status <completed|blocked|question> "
+        + $"--artifact <artifact> --summary <one-line-summary> --routing-root {ShellQuote(options.RoutingRoot!)} "
+        + "--write --format json";
+
+    private static string ShellQuote(string value) => $"'{value.Replace("'", "'\\''", StringComparison.Ordinal)}'";
+
+    private static string BuildReportPayload(NotifyOptions options) => JsonSerializer.Serialize(new
+    {
+        notification = OperationReport,
+        task_id = options.TaskId,
+        status = options.Status,
+        from_role = options.FromRole,
+        artifact = options.Artifact,
+        summary = NotifyEventWriter.NormalizeSummary(options.Summary!),
+    });
+
+    private static NotifyResult SuccessResult(
+        string operation,
+        NotifyOptions options,
+        SessionLayerModeResolution resolution,
+        bool delivered,
+        bool eventAppended,
+        string? payload,
+        string? reportCommand,
+        string summary,
+        string? eventPath = null) => new()
+        {
+            Operation = operation,
+            RoutingRoot = options.RoutingRoot!,
+            Domain = options.Domain!,
+            Team = options.Team!,
+            Mode = resolution.Mode,
+            ModeSource = resolution.Source == SessionLayerModeSource.Recorded ? "recorded" : "default",
+            CommandMode = options.Write ? "write" : "dry-run",
+            FromRole = options.FromRole!,
+            ToRole = options.ToRole,
+            TaskId = options.TaskId!,
+            Status = options.Status,
+            Artifact = options.Artifact,
+            Delivered = delivered,
+            EventAppended = eventAppended,
+            EventPath = eventPath,
+            Cause = null,
+            Payload = payload,
+            ReportCommand = reportCommand,
+            Summary = summary,
+        };
+
+    private static NotifyResult FailureResult(
+        string operation,
+        NotifyOptions options,
+        string mode,
+        string cause,
+        string summary,
+        string? payload = null,
+        string? reportCommand = null) => new()
+        {
+            Operation = operation,
+            RoutingRoot = options.RoutingRoot ?? string.Empty,
+            Domain = options.Domain!,
+            Team = options.Team!,
+            Mode = mode,
+            ModeSource = null,
+            CommandMode = options.Write ? "write" : "dry-run",
+            FromRole = options.FromRole!,
+            ToRole = options.ToRole,
+            TaskId = options.TaskId!,
+            Status = options.Status,
+            Artifact = options.Artifact,
+            Delivered = false,
+            EventAppended = false,
+            EventPath = null,
+            Cause = cause,
+            Payload = payload,
+            ReportCommand = reportCommand,
+            Summary = summary,
+        };
+
+    private static void Emit(TextWriter writer, string format, NotifyResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+            return;
+        }
+
+        writer.WriteLine($"# notify {result.Operation} — {result.TaskId}");
+        writer.WriteLine();
+        writer.WriteLine($"- mode: {result.Mode} ({result.ModeSource ?? "unresolved"})");
+        writer.WriteLine($"- command mode: {result.CommandMode}");
+        writer.WriteLine($"- delivered: {result.Delivered.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"- event appended: {result.EventAppended.ToString().ToLowerInvariant()}");
+        if (result.Cause is not null)
+        {
+            writer.WriteLine($"- cause: {result.Cause}");
+        }
+        if (result.ReportCommand is not null)
+        {
+            writer.WriteLine($"- report command: `{result.ReportCommand}`");
+        }
+        if (result.EventPath is not null)
+        {
+            writer.WriteLine($"- event path: `{result.EventPath}`");
+        }
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+    }
+
+    private static bool TryParse(string[] args, string operation, out NotifyOptions options, out string error)
+    {
+        options = null!;
+        string? domain = null;
+        string? team = null;
+        string? fromRole = null;
+        string? toRole = null;
+        string? reportToRole = null;
+        string? taskId = null;
+        string? objective = null;
+        string? resultNonce = null;
+        string? status = null;
+        string? artifact = null;
+        string? summary = null;
+        string? routingRoot = null;
+        var inputs = new List<string>();
+        var expectedArtifacts = new List<string>();
+        var write = false;
+        var format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain": if (!ReadValue(args, ref index, argument, out domain, out error)) return false; break;
+                case "--team": if (!ReadValue(args, ref index, argument, out team, out error)) return false; break;
+                case "--from": if (!ReadValue(args, ref index, argument, out fromRole, out error)) return false; break;
+                case "--to": if (!ReadValue(args, ref index, argument, out toRole, out error)) return false; break;
+                case "--report-to": if (!ReadValue(args, ref index, argument, out reportToRole, out error)) return false; break;
+                case "--task-id": if (!ReadValue(args, ref index, argument, out taskId, out error)) return false; break;
+                case "--objective": if (!ReadValue(args, ref index, argument, out objective, out error)) return false; break;
+                case "--result-nonce": if (!ReadValue(args, ref index, argument, out resultNonce, out error)) return false; break;
+                case "--status": if (!ReadValue(args, ref index, argument, out status, out error)) return false; break;
+                case "--artifact": if (!ReadValue(args, ref index, argument, out artifact, out error)) return false; break;
+                case "--summary": if (!ReadValue(args, ref index, argument, out summary, out error)) return false; break;
+                case "--routing-root": if (!ReadValue(args, ref index, argument, out routingRoot, out error)) return false; break;
+                case "--input":
+                    if (!ReadValue(args, ref index, argument, out var input, out error)) return false;
+                    inputs.Add(input!);
+                    break;
+                case "--expected-artifact":
+                    if (!ReadValue(args, ref index, argument, out var expectedArtifact, out error)) return false;
+                    expectedArtifacts.Add(expectedArtifact!);
+                    break;
+                case "--write": write = true; break;
+                case "--dry-run": write = false; break;
+                case "--format":
+                    if (!ReadValue(args, ref index, argument, out format, out error)) return false;
+                    if (format is not FormatJson and not FormatMarkdown)
+                    {
+                        error = "--format must be markdown or json.";
+                        return false;
+                    }
+                    break;
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        options = new NotifyOptions
+        {
+            Domain = domain,
+            Team = team,
+            FromRole = fromRole,
+            ToRole = toRole,
+            ReportToRole = reportToRole,
+            TaskId = taskId,
+            Objective = objective,
+            Inputs = inputs,
+            ExpectedArtifacts = expectedArtifacts,
+            ResultNonce = resultNonce,
+            Status = status,
+            Artifact = artifact,
+            Summary = summary,
+            RoutingRoot = routingRoot,
+            Write = write,
+            Format = format,
+        };
+
+        return Validate(operation, options, out error);
+    }
+
+    private static bool Validate(string operation, NotifyOptions options, out string error)
+    {
+        error = string.Empty;
+        foreach (var (name, value) in new[]
+        {
+            ("--domain", options.Domain),
+            ("--team", options.Team),
+            ("--from", options.FromRole),
+            ("--task-id", options.TaskId),
+        })
+        {
+            if (!IsSafeIdentity(value))
+            {
+                error = $"{name} is required and must contain only letters, digits, '.', '_', ':', or '-' without path syntax.";
+                return false;
+            }
+        }
+
+        if (!NotifyEventWriter.TryValidateTeam(options.Team!, out error))
+        {
+            return false;
+        }
+
+        if (string.Equals(operation, OperationDelegate, StringComparison.Ordinal))
+        {
+            if (!IsSafeIdentity(options.ToRole) || !IsSafeIdentity(options.ReportToRole))
+            {
+                error = "--to and --report-to are required safe logical-role names for delegate.";
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(options.Objective)
+                || options.ExpectedArtifacts.Count == 0
+                || !IsSafeIdentity(options.ResultNonce))
+            {
+                error = "delegate requires --objective, at least one --expected-artifact, and a safe --result-nonce.";
+                return false;
+            }
+        }
+        else if (string.Equals(operation, OperationReport, StringComparison.Ordinal))
+        {
+            if (!IsSafeIdentity(options.ToRole)
+                || options.Status is not ("completed" or "blocked" or "question")
+                || string.IsNullOrWhiteSpace(options.Artifact)
+                || string.IsNullOrWhiteSpace(options.Summary))
+            {
+                error = "report requires --to, --status completed|blocked|question, --artifact, and --summary.";
+                return false;
+            }
+        }
+        else if (string.IsNullOrWhiteSpace(options.Artifact) || string.IsNullOrWhiteSpace(options.Summary))
+        {
+            error = "escalate requires --artifact and --summary.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool IsSafeIdentity(string? value) =>
+        !string.IsNullOrWhiteSpace(value)
+        && value.All(character => char.IsAsciiLetterOrDigit(character) || character is '.' or '_' or ':' or '-');
+
+    private static bool ReadValue(
+        string[] args,
+        ref int index,
+        string option,
+        out string? value,
+        out string error)
+    {
+        if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+        {
+            value = null;
+            error = $"{option} requires a value.";
+            return false;
+        }
+
+        value = args[++index];
+        error = string.Empty;
+        return true;
+    }
+
+    private static string Usage(string operation) => operation switch
+    {
+        OperationDelegate => DelegateUsage,
+        OperationReport => ReportUsage,
+        _ => EscalateUsage,
+    };
+}
+
+internal sealed record NotifyOptions
+{
+    public string? Domain { get; init; }
+    public string? Team { get; init; }
+    public string? FromRole { get; init; }
+    public string? ToRole { get; init; }
+    public string? ReportToRole { get; init; }
+    public string? TaskId { get; init; }
+    public string? Objective { get; init; }
+    public required IReadOnlyList<string> Inputs { get; init; }
+    public required IReadOnlyList<string> ExpectedArtifacts { get; init; }
+    public string? ResultNonce { get; init; }
+    public string? Status { get; init; }
+    public string? Artifact { get; init; }
+    public string? Summary { get; init; }
+    public string? RoutingRoot { get; init; }
+    public bool Write { get; init; }
+    public required string Format { get; init; }
+}
+
+internal sealed record NotifyResult
+{
+    [JsonPropertyName("operation")] public required string Operation { get; init; }
+    [JsonPropertyName("routing_root")] public required string RoutingRoot { get; init; }
+    [JsonPropertyName("domain")] public required string Domain { get; init; }
+    [JsonPropertyName("team")] public required string Team { get; init; }
+    [JsonPropertyName("mode")] public required string Mode { get; init; }
+    [JsonPropertyName("mode_source")] public string? ModeSource { get; init; }
+    [JsonPropertyName("command_mode")] public required string CommandMode { get; init; }
+    [JsonPropertyName("from_role")] public required string FromRole { get; init; }
+    [JsonPropertyName("to_role")] public string? ToRole { get; init; }
+    [JsonPropertyName("task_id")] public required string TaskId { get; init; }
+    [JsonPropertyName("status")] public string? Status { get; init; }
+    [JsonPropertyName("artifact")] public string? Artifact { get; init; }
+    [JsonPropertyName("delivered")] public required bool Delivered { get; init; }
+    [JsonPropertyName("event_appended")] public required bool EventAppended { get; init; }
+    [JsonPropertyName("event_path")] public string? EventPath { get; init; }
+    [JsonPropertyName("cause")] public string? Cause { get; init; }
+    [JsonPropertyName("payload")] public string? Payload { get; init; }
+    [JsonPropertyName("report_command")] public string? ReportCommand { get; init; }
+    [JsonPropertyName("summary")] public required string Summary { get; init; }
+}
+
+internal static class NotifyEventWriter
+{
+    public static bool TryValidateTeam(string team, out string error)
+    {
+        if (string.IsNullOrWhiteSpace(team)
+            || team.StartsWith(".", StringComparison.Ordinal)
+            || team.Contains('/')
+            || team.Contains('\\')
+            || team.Contains("..", StringComparison.Ordinal))
+        {
+            error = "Team name must be non-empty and must not start with '.', contain path separators, or contain '..'.";
+            return false;
+        }
+
+        error = string.Empty;
+        return true;
+    }
+
+    public static bool TryResolvePath(string repoRoot, string team, out string path, out string error)
+    {
+        if (!TryValidateTeam(team, out error))
+        {
+            path = string.Empty;
+            return false;
+        }
+
+        path = Path.GetFullPath(Path.Combine(repoRoot, ".intent-cli", "events", $"{team}.jsonl"));
+        return true;
+    }
+
+    public static void Append(string path, NotifyDesignEvent designEvent)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var line = JsonSerializer.Serialize(designEvent);
+        using var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+        using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        writer.Write(line);
+        writer.Write('\n');
+    }
+
+    public static string NormalizeSummary(string summary) =>
+        string.Join(' ', summary.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+}
+
+internal sealed record NotifyDesignEvent
+{
+    [JsonPropertyName("timestamp")] public required DateTimeOffset Timestamp { get; init; }
+    [JsonPropertyName("team")] public required string Team { get; init; }
+    [JsonPropertyName("kind")] public required string Kind { get; init; }
+    [JsonPropertyName("unit")] public required string Unit { get; init; }
+    [JsonPropertyName("summary")] public required string Summary { get; init; }
+    [JsonPropertyName("artifact")] public required string Artifact { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/NotifyTransport.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyTransport.cs
@@ -1,0 +1,387 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record NotifyProcessResult(int ExitCode, string StandardOutput, string StandardError);
+
+internal interface INotifyProcessRunner
+{
+    NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments);
+}
+
+internal sealed class NotifyProcessRunner : INotifyProcessRunner
+{
+    public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        try
+        {
+            using var process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException($"Failed to start notification transport '{fileName}'.");
+            var standardOutput = process.StandardOutput.ReadToEndAsync();
+            var standardError = process.StandardError.ReadToEndAsync();
+            process.WaitForExit();
+            return new NotifyProcessResult(
+                process.ExitCode,
+                standardOutput.GetAwaiter().GetResult(),
+                standardError.GetAwaiter().GetResult());
+        }
+        catch (Exception exception) when (exception is Win32Exception or IOException)
+        {
+            throw new InvalidOperationException(
+                $"Notification transport '{fileName}' could not start: {exception.Message}",
+                exception);
+        }
+    }
+}
+
+internal sealed record NotifyDeliveryResult
+{
+    public required bool Delivered { get; init; }
+
+    public string? Cause { get; init; }
+
+    public required string Summary { get; init; }
+}
+
+internal interface INotifyTransport
+{
+    NotifyDeliveryResult Deliver(
+        string team,
+        string fromRole,
+        string toRole,
+        IReadOnlyList<string> rolesToValidate,
+        string payload);
+}
+
+internal sealed class AgmsgNotifyTransport : INotifyTransport
+{
+    private readonly INotifyProcessRunner runner;
+    private readonly string scriptsDirectory;
+
+    public AgmsgNotifyTransport(INotifyProcessRunner runner, string scriptsDirectory)
+    {
+        this.runner = runner;
+        this.scriptsDirectory = scriptsDirectory;
+    }
+
+    public NotifyDeliveryResult Deliver(
+        string team,
+        string fromRole,
+        string toRole,
+        IReadOnlyList<string> rolesToValidate,
+        string payload)
+    {
+        var teamScript = Path.Combine(scriptsDirectory, "team.sh");
+        var sendScript = Path.Combine(scriptsDirectory, "send.sh");
+        if (!File.Exists(teamScript) || !File.Exists(sendScript))
+        {
+            return Failure(
+                "transport-unavailable",
+                $"agmsg scripts were not found at '{scriptsDirectory}' (expected team.sh and send.sh).");
+        }
+
+        NotifyProcessResult roster;
+        try
+        {
+            roster = runner.Run("bash", [teamScript, team]);
+        }
+        catch (InvalidOperationException exception)
+        {
+            return Failure("transport-unavailable", exception.Message);
+        }
+
+        if (roster.ExitCode != 0)
+        {
+            return Failure(
+                "receiver-missing",
+                $"agmsg roster lookup failed for team '{team}': {OneLine(roster.StandardError, roster.StandardOutput)}");
+        }
+
+        var rosterRoles = ParseRoster(roster.StandardOutput);
+        foreach (var role in rolesToValidate.Distinct(StringComparer.Ordinal))
+        {
+            if (!rosterRoles.Contains(role))
+            {
+                return Failure(
+                    "unknown-role",
+                    $"agmsg role '{role}' is not registered in team '{team}' (registered: "
+                    + $"{(rosterRoles.Count == 0 ? "none" : string.Join(", ", rosterRoles.OrderBy(value => value, StringComparer.Ordinal)))}).");
+            }
+        }
+
+        NotifyProcessResult delivery;
+        try
+        {
+            delivery = runner.Run("bash", [sendScript, team, fromRole, toRole, payload]);
+        }
+        catch (InvalidOperationException exception)
+        {
+            return Failure("transport-unavailable", exception.Message);
+        }
+
+        return delivery.ExitCode == 0
+            ? new NotifyDeliveryResult
+            {
+                Delivered = true,
+                Summary = $"Delivered notification to agmsg role '{toRole}' in team '{team}'.",
+            }
+            : Failure(
+                "transport-failure",
+                $"agmsg delivery to role '{toRole}' in team '{team}' failed: "
+                + OneLine(delivery.StandardError, delivery.StandardOutput));
+    }
+
+    internal static IReadOnlySet<string> ParseRoster(string output)
+    {
+        var roles = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var rawLine in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var line = rawLine.Trim();
+            var typeStart = line.IndexOf(" (", StringComparison.Ordinal);
+            if (typeStart > 0 && !line.StartsWith("Team:", StringComparison.Ordinal))
+            {
+                roles.Add(line[..typeStart]);
+            }
+        }
+
+        return roles;
+    }
+
+    private static NotifyDeliveryResult Failure(string cause, string summary) => new()
+    {
+        Delivered = false,
+        Cause = cause,
+        Summary = summary,
+    };
+
+    private static string OneLine(params string[] values)
+    {
+        var value = values.FirstOrDefault(item => !string.IsNullOrWhiteSpace(item)) ?? "no detail";
+        return string.Join(' ', value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
+}
+
+internal sealed class HerdrNotifyTransport : INotifyTransport
+{
+    private readonly INotifyProcessRunner runner;
+    private readonly string executable;
+
+    public HerdrNotifyTransport(INotifyProcessRunner runner, string executable)
+    {
+        this.runner = runner;
+        this.executable = executable;
+    }
+
+    public NotifyDeliveryResult Deliver(
+        string team,
+        string fromRole,
+        string toRole,
+        IReadOnlyList<string> rolesToValidate,
+        string payload)
+    {
+        NotifyProcessResult agentList;
+        try
+        {
+            agentList = runner.Run(executable, ["agent", "list"]);
+        }
+        catch (InvalidOperationException exception)
+        {
+            return Failure("transport-unavailable", exception.Message);
+        }
+
+        if (agentList.ExitCode != 0)
+        {
+            return Failure(
+                "transport-failure",
+                $"herdr logical-role lookup failed: {OneLine(agentList.StandardError, agentList.StandardOutput)}");
+        }
+
+        IReadOnlyDictionary<string, HerdrRoleState> roles;
+        try
+        {
+            roles = ParseRoles(agentList.StandardOutput);
+        }
+        catch (InvalidOperationException exception)
+        {
+            return Failure("transport-invalid-response", exception.Message);
+        }
+
+        foreach (var role in rolesToValidate.Distinct(StringComparer.Ordinal))
+        {
+            if (!roles.TryGetValue(role, out var state))
+            {
+                return Failure(
+                    "unknown-role",
+                    $"herdr logical role '{role}' is not present in the recorded agent mapping.");
+            }
+
+            if (string.IsNullOrWhiteSpace(state.PaneId))
+            {
+                return Failure("pane-absent", $"herdr logical role '{role}' has no mapped pane.");
+            }
+
+            if (!state.AgentRunning)
+            {
+                return Failure("agent-not-running", $"herdr logical role '{role}' has no running agent.");
+            }
+        }
+
+        NotifyProcessResult delivery;
+        try
+        {
+            delivery = runner.Run(executable, ["agent", "prompt", toRole, payload]);
+        }
+        catch (InvalidOperationException exception)
+        {
+            return Failure("transport-unavailable", exception.Message);
+        }
+
+        if (delivery.ExitCode == 0)
+        {
+            return new NotifyDeliveryResult
+            {
+                Delivered = true,
+                Summary = $"Delivered notification to herdr logical role '{toRole}' in team '{team}'.",
+            };
+        }
+
+        var detail = OneLine(delivery.StandardError, delivery.StandardOutput);
+        var cause = ClassifyPromptFailure(detail);
+        return Failure(cause, $"herdr delivery to logical role '{toRole}' failed: {detail}");
+    }
+
+    internal static IReadOnlyDictionary<string, HerdrRoleState> ParseRoles(string output)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(output);
+            if (!document.RootElement.TryGetProperty("result", out var result)
+                || !result.TryGetProperty("agents", out var agents)
+                || agents.ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidOperationException("herdr agent list response did not contain result.agents.");
+            }
+
+            var roles = new Dictionary<string, HerdrRoleState>(StringComparer.Ordinal);
+            foreach (var agent in agents.EnumerateArray())
+            {
+                var name = ReadString(agent, "name");
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    continue;
+                }
+
+                var paneId = ReadString(agent, "pane_id");
+                var agentKind = ReadString(agent, "agent");
+                var status = ReadString(agent, "agent_status");
+                var explicitlyNotReady = agent.TryGetProperty("interactive_ready", out var ready)
+                    && ready.ValueKind == JsonValueKind.False;
+                var hasSession = agent.TryGetProperty("agent_session", out var session)
+                    && session.ValueKind == JsonValueKind.Object;
+                var running = !string.IsNullOrWhiteSpace(agentKind)
+                    && hasSession
+                    && !explicitlyNotReady
+                    && !string.Equals(status, "unknown", StringComparison.Ordinal);
+
+                if (!roles.TryAdd(name, new HerdrRoleState(paneId, running)))
+                {
+                    throw new InvalidOperationException(
+                        $"herdr agent list returned duplicate logical-role mapping '{name}'.");
+                }
+            }
+
+            return roles;
+        }
+        catch (JsonException exception)
+        {
+            throw new InvalidOperationException(
+                $"herdr agent list returned invalid JSON: {exception.Message}",
+                exception);
+        }
+    }
+
+    private static string? ReadString(JsonElement element, string property) =>
+        element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static string ClassifyPromptFailure(string detail)
+    {
+        if (detail.Contains("pane", StringComparison.OrdinalIgnoreCase)
+            && (detail.Contains("absent", StringComparison.OrdinalIgnoreCase)
+                || detail.Contains("not found", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "pane-absent";
+        }
+
+        if (detail.Contains("agent", StringComparison.OrdinalIgnoreCase)
+            && (detail.Contains("not running", StringComparison.OrdinalIgnoreCase)
+                || detail.Contains("undetected", StringComparison.OrdinalIgnoreCase)))
+        {
+            return "agent-not-running";
+        }
+
+        if (detail.Contains("receiver", StringComparison.OrdinalIgnoreCase)
+            && detail.Contains("missing", StringComparison.OrdinalIgnoreCase))
+        {
+            return "receiver-missing";
+        }
+
+        return "transport-failure";
+    }
+
+    private static NotifyDeliveryResult Failure(string cause, string summary) => new()
+    {
+        Delivered = false,
+        Cause = cause,
+        Summary = summary,
+    };
+
+    private static string OneLine(params string[] values)
+    {
+        var value = values.FirstOrDefault(item => !string.IsNullOrWhiteSpace(item)) ?? "no detail";
+        return string.Join(' ', value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
+}
+
+internal sealed record HerdrRoleState(string? PaneId, bool AgentRunning);
+
+internal static class NotifyTransportPaths
+{
+    public const string AgmsgScriptsEnvironmentVariable = "INTENT_CLI_AGMSG_SCRIPTS";
+    public const string HerdrExecutableEnvironmentVariable = "INTENT_CLI_HERDR_EXECUTABLE";
+
+    public static string ResolveAgmsgScriptsDirectory()
+    {
+        var configured = Environment.GetEnvironmentVariable(AgmsgScriptsEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            return Path.GetFullPath(configured);
+        }
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        return Path.Combine(home, ".agents", "skills", "agmsg", "scripts");
+    }
+
+    public static string ResolveHerdrExecutable()
+    {
+        var configured = Environment.GetEnvironmentVariable(HerdrExecutableEnvironmentVariable);
+        return string.IsNullOrWhiteSpace(configured) ? "herdr" : configured;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/SessionLayerFragments.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerFragments.cs
@@ -644,7 +644,7 @@ internal static class SessionLayerFragments
         Fragment(S4, Operative("- If intent-cli reports an `issue-cut-ready` candidate and all gates pass (same-domain or routed, complete contract, no open clarification, dependencies satisfied, under WIP, clean host-sync/preflight), publish ONE issue this wake via canonical publish-flow / issue-publish, verify it, THEN delegate that same issue to implementation in THIS SAME WAKE (G524) — do not ask the operator to create it, and do not stop after publishing to wait for a future wake to send the delegation.")),
         Fragment(S4, Operative("- If the candidate has unmet dependencies, plan the chain instead of pausing: act on the EARLIEST unmet resolvable dependency (publish or route it), keep the dependent held, and escalate only ambiguous/cycle/cross-domain-unrouted cases.")),
         Fragment(S4, Operative("- The per-wake cap is AT MOST ONE DELEGATION PER RECEIVER (implementation, review) — NOT at-most-one-message overall (G524): this wake's actions may include a publish plus its same-wake delegation, one repair message per stalled receiver, one operator escalation, and handling any pending receiver reports, all together.")),
-        Fragment(S4, Transport("- Before sending any agmsg message this wake, verify the recipient id against the team roster (`agmsg team.sh`) — treat an id not on the roster as an error, never a guess (G524).")),
+        Fragment(S4, Operative("- Send workflow notifications only through `intent-cli notify`; it resolves the recorded session-layer mode and validates the recipient before delivery, failing closed on an unknown role (G524/G578).")),
         Fragment(
             S4,
             Operative("- Apply the design-thread escalation filter: keep routine progress / CI-wait / success / closeout / idle internal; surface to the design thread ONLY human-needed decisions, with structured evidence and the exact decision needed."),
@@ -697,9 +697,11 @@ internal static class SessionLayerFragments
             Transport("The implementation receiver still derives its target from `intent-cli worker next-action`, not the agmsg text.")),
         Fragment(
             S6,
-            Transport("G524: before sending ANY agmsg message, verify the recipient id is present in the team roster (agmsg `team.sh`). agmsg accepts an unknown recipient silently — there is no delivery error to notice."),
+            Operative("G524/G578: send workflow notifications only through `intent-cli notify`."),
             Scaffold(" "),
-            Transport("Treat a recipient id that is not on the roster as an error: fix the id or the roster registration before sending; never guess or approximate a role name.")),
+            Operative("It validates the agmsg roster or herdr logical-role mapping before delivery and returns a named failure instead of a silent no-op."),
+            Scaffold(" "),
+            Operative("Fix the active transport's role registration or mapping before retrying; never guess a role name or bypass notify with a handwritten transport call.")),
         Fragment(S6, Descriptive("- Field-observed loss: 8 dispatches addressed to `review` were silently lost when the registered role was `reviewer` — agmsg neither delivered nor reported the mismatch.")),
         Fragment(
             S7,
@@ -888,7 +890,7 @@ internal static class SessionLayerFragments
             S11,
             Descriptive("1."),
             Scaffold(" "),
-            Transport("Before sending any agmsg message, verify the recipient id against the team roster (`agmsg team.sh`); treat an id not on the roster as an error, never a guess (G524).")),
+            Operative("Send workflow notifications only through `intent-cli notify`; it resolves the recorded transport and validates the recipient before delivery, failing closed on an unknown role (G524/G578).")),
         Fragment(
             S11,
             Descriptive("1."),
@@ -904,7 +906,7 @@ internal static class SessionLayerFragments
         Fragment(S12, Operative("- No hand-editing queue-state, runs.jsonl, packets, or any host metadata (`.intent-cli/**`, `intents/**`).")),
         Fragment(S12, Operative("- agmsg never replaces semantic review or authorizes a merge; review/closeout decisions run through intent-cli review surfaces (G480).")),
         Fragment(S12, Operative("- Per-wake cap is AT MOST ONE DELEGATION PER RECEIVER (implementation, review) — NOT at-most-one-message: a publish's same-wake delegation, repair messages, an escalation, and receiver-report handling may all happen in one wake (G524); never defer a publish's delegation to an unscheduled future wake.")),
-        Fragment(S12, Transport("- Verify the recipient id against the team roster (`agmsg team.sh`) before every send; an id not on the roster is an error, not a guess (G524).")),
+        Fragment(S12, Operative("- Use `intent-cli notify` for every workflow send; it validates the active transport's role source and fails closed on unknown or unavailable recipients (G524/G578).")),
         Fragment(S12, Operative("- End every wake with a stalled-work check (`automation stalled-work`, G523) and process any actionable item before sleeping; escalate explicitly rather than deferring silently.")),
         Fragment(
             S12,
@@ -1538,7 +1540,7 @@ internal static class SessionLayerFragments
         Fragment("scheduling", Operative("If intent-cli reports an `issue-cut-ready` candidate and all gates pass (same-domain or routed, complete contract, no open clarification, dependencies satisfied, under WIP, clean host-sync/preflight), publish ONE issue this wake via canonical publish-flow / issue-publish, verify it, THEN delegate that same issue to implementation in THIS SAME WAKE (G524) — do not ask the operator to create it, and do not stop after publishing to wait for a future wake to send the delegation.")),
         Fragment("scheduling", Operative("If the candidate has unmet dependencies, plan the chain instead of pausing: act on the EARLIEST unmet resolvable dependency (publish or route it), keep the dependent held, and escalate only ambiguous/cycle/cross-domain-unrouted cases.")),
         Fragment("scheduling", Operative("The per-wake cap is AT MOST ONE DELEGATION PER RECEIVER (implementation, review) — NOT at-most-one-message overall (G524): this wake's actions may include a publish plus its same-wake delegation, one repair message per stalled receiver, one operator escalation, and handling any pending receiver reports, all together.")),
-        Fragment("scheduling", Transport("Before sending any agmsg message this wake, verify the recipient id against the team roster (`agmsg team.sh`) — treat an id not on the roster as an error, never a guess (G524).")),
+        Fragment("scheduling", Operative("Send workflow notifications only through `intent-cli notify`; it resolves the recorded session-layer mode and validates the recipient before delivery, failing closed on an unknown role (G524/G578).")),
         Fragment(
             "scheduling",
             Operative("Apply the design-thread escalation filter: keep routine progress / CI-wait / success / closeout / idle internal; surface to the design thread ONLY human-needed decisions, with structured evidence and the exact decision needed."),
@@ -1561,9 +1563,11 @@ internal static class SessionLayerFragments
             Operative("Do not escalate states you can repair by message.")),
         Fragment(
             "dispatch_verification",
-            Transport("G524: before sending ANY agmsg message, verify the recipient id is present in the team roster (agmsg `team.sh`). agmsg accepts an unknown recipient silently — there is no delivery error to notice."),
+            Operative("G524/G578: send workflow notifications only through `intent-cli notify`."),
             Scaffold(" "),
-            Transport("Treat a recipient id that is not on the roster as an error: fix the id or the roster registration before sending; never guess or approximate a role name.")),
+            Operative("It validates the agmsg roster or herdr logical-role mapping before delivery and returns a named failure instead of a silent no-op."),
+            Scaffold(" "),
+            Operative("Fix the active transport's role registration or mapping before retrying; never guess a role name or bypass notify with a handwritten transport call.")),
         Fragment("dispatch_verification", Descriptive("Field-observed loss: 8 dispatches addressed to `review` were silently lost when the registered role was `reviewer` — agmsg neither delivered nor reported the mismatch.")),
         Fragment(
             "design_handoff",
@@ -1683,7 +1687,7 @@ internal static class SessionLayerFragments
         Fragment("orchestrator_first_wake", Operative("Ask intent-cli for the real state: `intent-cli intent status --domain __DOMAIN__ --format json` and `intent-cli worker next-action --repo __OWNER__/__REPO__ --github-only --format json`.")),
         Fragment("orchestrator_first_wake", Transport("Verify every GitHub fact an agmsg reply claims (PR merged, CI concluded, labels) before acting on it.")),
         Fragment("orchestrator_first_wake", Operative("The per-wake cap is AT MOST ONE DELEGATION PER RECEIVER, not at-most-one-message overall (G524): a publish this wake must be delegated to implementation in this SAME wake — never defer that delegation to an unscheduled next wake — alongside any repair requests (one per stalled receiver) or one operator escalation.")),
-        Fragment("orchestrator_first_wake", Transport("Before sending any agmsg message, verify the recipient id against the team roster (`agmsg team.sh`); treat an id not on the roster as an error, never a guess (G524).")),
+        Fragment("orchestrator_first_wake", Operative("Send workflow notifications only through `intent-cli notify`; it resolves the recorded transport and validates the recipient before delivery, failing closed on an unknown role (G524/G578).")),
         Fragment("orchestrator_first_wake", Operative("Do not launch implement/review recurring timers for this domain/repo while orchestrating.")),
         Fragment("orchestrator_first_wake", Operative("End this wake with the stalled-work check (G523): `intent-cli automation stalled-work --domain __DOMAIN__ --repo __OWNER__/__REPO__ --format json`, and process every actionable item before sleeping — never leave one for an unscheduled next wake; escalate explicitly if it is genuinely blocked on an operator decision.")),
         Fragment("safety_boundaries", Descriptive("agmsg is a message/progress/completion signal layer only; intent-cli and GitHub are authoritative for all workflow state.")),
@@ -1691,7 +1695,7 @@ internal static class SessionLayerFragments
         Fragment("safety_boundaries", Operative("No hand-editing queue-state, runs.jsonl, packets, or any host metadata (`.intent-cli/**`, `intents/**`).")),
         Fragment("safety_boundaries", Operative("agmsg never replaces semantic review or authorizes a merge; review/closeout decisions run through intent-cli review surfaces (G480).")),
         Fragment("safety_boundaries", Operative("Per-wake cap is AT MOST ONE DELEGATION PER RECEIVER (implementation, review) — NOT at-most-one-message: a publish's same-wake delegation, repair messages, an escalation, and receiver-report handling may all happen in one wake (G524); never defer a publish's delegation to an unscheduled future wake.")),
-        Fragment("safety_boundaries", Transport("Verify the recipient id against the team roster (`agmsg team.sh`) before every send; an id not on the roster is an error, not a guess (G524).")),
+        Fragment("safety_boundaries", Operative("Use `intent-cli notify` for every workflow send; it validates the active transport's role source and fails closed on unknown or unavailable recipients (G524/G578).")),
         Fragment("safety_boundaries", Operative("End every wake with a stalled-work check (`automation stalled-work`, G523) and process any actionable item before sleeping; escalate explicitly rather than deferring silently.")),
         Fragment(
             "safety_boundaries",

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -48,6 +48,7 @@ internal static class Program
                 || IsInspectCommand(args)
                 || IsWorkerCommand(args)
                 || IsSkillCommand(args)
+                || IsNotifyCommand(args)
                 || IsHelpCommand(args))
             {
                 return CommandRouter.Execute(args, CreateBootstrapContext(currentDirectory, args), Console.Out);
@@ -134,6 +135,17 @@ internal static class Program
     private static bool IsSkillCommand(string[] args)
     {
         return args.Length >= 1 && string.Equals(args[0], "skill", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// G578: a receiver runs the canonical report command from its isolated
+    /// child checkout. The delegate payload supplies the host routing root as
+    /// data, so notify must reach its bounded resolver without requiring the
+    /// child cwd itself to contain host metadata.
+    /// </summary>
+    private static bool IsNotifyCommand(string[] args)
+    {
+        return args.Length >= 1 && string.Equals(args[0], "notify", StringComparison.Ordinal);
     }
 
     private static bool IsGuideOneshotCommand(string[] args)

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -393,7 +393,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("is NEVER silent", output, StringComparison.Ordinal);
         Assert.Contains("state the failure explicitly in this wake's own turn output", output, StringComparison.Ordinal);
         Assert.Contains("visible to the operator watching this live session", output, StringComparison.Ordinal);
-        Assert.Contains("never fabricating or sending an agmsg nudge from broken input", output, StringComparison.Ordinal);
+        Assert.Contains("never fabricating or sending a notify nudge from broken input", output, StringComparison.Ordinal);
         Assert.DoesNotContain("stay silent this wake and retry next", output, StringComparison.Ordinal);
         Assert.Contains("### Watchdog checks", output, StringComparison.Ordinal);
         Assert.Contains("HITL", output, StringComparison.Ordinal);
@@ -530,7 +530,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("healthy `stale=false`", failureVisibility, StringComparison.Ordinal);
         Assert.Contains("surfaced VISIBLY", failureVisibility, StringComparison.Ordinal);
         Assert.Contains("never silently swallowed or silently retried", failureVisibility, StringComparison.Ordinal);
-        Assert.Contains("never fabricating or sending an agmsg nudge from broken input", failureVisibility, StringComparison.Ordinal);
+        Assert.Contains("never fabricating or sending a notify nudge from broken input", failureVisibility, StringComparison.Ordinal);
 
         Assert.Equal(
             "intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --format json",
@@ -1792,15 +1792,16 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
-    public void Execute_Markdown_DispatchVerification_RequiresRosterCheckBeforeSend()
+    public void Execute_Markdown_DispatchVerification_UsesCanonicalNotifyValidation()
     {
         var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
 
-        // AC: dispatch guidance requires team-roster verification of the
-        // recipient id before sending.
+        // G578 moves role verification inside the canonical notify surface.
         Assert.Contains("## Dispatch verification (G524)", output, StringComparison.Ordinal);
-        Assert.Contains("team roster", output, StringComparison.Ordinal);
-        Assert.Contains("team.sh", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli notify", output, StringComparison.Ordinal);
+        Assert.Contains("herdr logical-role mapping", output, StringComparison.Ordinal);
+        Assert.Contains("named failure", output, StringComparison.Ordinal);
+        Assert.Contains("handwritten transport call", output, StringComparison.Ordinal);
         Assert.Contains("`review`", output, StringComparison.Ordinal);
         Assert.Contains("`reviewer`", output, StringComparison.Ordinal);
     }
@@ -1817,7 +1818,9 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Equal(0, exitCode);
         using var doc = JsonDocument.Parse(writer.ToString());
         var verification = doc.RootElement.GetProperty("dispatch_verification");
-        Assert.Contains("team.sh", verification.GetProperty("rule").GetString(), StringComparison.Ordinal);
+        Assert.Contains("intent-cli notify", verification.GetProperty("rule").GetString(), StringComparison.Ordinal);
+        Assert.Contains("herdr logical-role mapping", verification.GetProperty("rule").GetString(), StringComparison.Ordinal);
+        Assert.Contains("named failure", verification.GetProperty("rule").GetString(), StringComparison.Ordinal);
         Assert.True(verification.GetProperty("dead_address_example").GetString()!.Length > 0);
     }
 

--- a/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
@@ -1,0 +1,456 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifyCommandG578Tests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 2, 12, 34, 56, TimeSpan.Zero);
+    private readonly NotifyWorkspace workspace = new();
+
+    public NotifyCommandG578Tests()
+    {
+        NotifyCommand.AgmsgScriptsDirectoryFactory = () => workspace.AgmsgScriptsPath;
+        NotifyCommand.HerdrExecutableFactory = () => "fake-herdr";
+        NotifyCommand.UtcNowFactory = () => FixedNow;
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifyCommand.AgmsgScriptsDirectoryFactory = null;
+        NotifyCommand.HerdrExecutableFactory = null;
+        NotifyCommand.UtcNowFactory = null;
+        workspace.Dispose();
+    }
+
+    [Theory]
+    [InlineData(SessionLayerMode.Agmsg)]
+    [InlineData(SessionLayerMode.HerdrOnly)]
+    public void Delegate_UsesTheSameSurface_AndEmbedsTheCanonicalReportingContract_G578(string mode)
+    {
+        workspace.SetMode(mode);
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(mode, result.GetProperty("mode").GetString());
+        Assert.Equal("recorded", result.GetProperty("mode_source").GetString());
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        var payload = result.GetProperty("payload").GetString()!;
+        Assert.Contains("TASK G578-demo", payload, StringComparison.Ordinal);
+        Assert.Contains("expected-artifact: draft PR URL", payload, StringComparison.Ordinal);
+        Assert.Contains("result-prefix: ORCH_RESULT", payload, StringComparison.Ordinal);
+        Assert.Contains("result-nonce: demo-nonce", payload, StringComparison.Ordinal);
+        Assert.Contains("canonical-report-command: intent-cli notify report", payload, StringComparison.Ordinal);
+        Assert.Contains("--from implementation --to orchestration", payload, StringComparison.Ordinal);
+        Assert.Contains($"--routing-root '{workspace.RootPath}'", payload, StringComparison.Ordinal);
+        Assert.Contains("required-final-step", payload, StringComparison.Ordinal);
+        Assert.DoesNotContain("agmsg send", payload, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("herdr agent prompt", payload, StringComparison.OrdinalIgnoreCase);
+
+        var delivery = Assert.Single(runner.Calls, call =>
+            mode == SessionLayerMode.Agmsg
+                ? call.Arguments.Any(argument => argument.EndsWith("send.sh", StringComparison.Ordinal))
+                : call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "implementation"]));
+        Assert.Equal(payload, delivery.Arguments[^1]);
+    }
+
+    [Fact]
+    public void UnrecordedMode_DefaultsToAgmsg_G578()
+    {
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(SessionLayerMode.Agmsg, result.GetProperty("mode").GetString());
+        Assert.Equal("default", result.GetProperty("mode_source").GetString());
+        Assert.Contains(runner.Calls, call => call.Arguments.Any(argument =>
+            argument.EndsWith("send.sh", StringComparison.Ordinal)));
+    }
+
+    [Theory]
+    [InlineData(SessionLayerMode.Agmsg)]
+    [InlineData(SessionLayerMode.HerdrOnly)]
+    public void UnknownRole_FailsBeforeDelivery_InBothModes_G578(string mode)
+    {
+        workspace.SetMode(mode);
+        var runner = mode == SessionLayerMode.Agmsg
+            ? Runner((_, arguments) => arguments[0].EndsWith("team.sh", StringComparison.Ordinal)
+                ? Success(AgmsgRoster(withImplementation: false))
+                : Success())
+            : Runner((_, arguments) => arguments.SequenceEqual(["agent", "list"])
+                ? Success(HerdrRoster(withImplementation: false))
+                : Success());
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("unknown-role", result.GetProperty("cause").GetString());
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+        Assert.DoesNotContain(runner.Calls, call =>
+            call.Arguments.Any(argument => argument.EndsWith("send.sh", StringComparison.Ordinal))
+            || call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+    }
+
+    [Theory]
+    [InlineData(SessionLayerMode.Agmsg)]
+    [InlineData(SessionLayerMode.HerdrOnly)]
+    public void TransportFailure_IsNamedAndFailsClosed_InBothModes_G578(string mode)
+    {
+        workspace.SetMode(mode);
+        var runner = mode == SessionLayerMode.Agmsg
+            ? Runner((_, arguments) => arguments[0].EndsWith("team.sh", StringComparison.Ordinal)
+                ? Success(AgmsgRoster())
+                : Failure("receiver unavailable"))
+            : Runner((_, arguments) => arguments.SequenceEqual(["agent", "list"])
+                ? Success(HerdrRoster())
+                : Failure("prompt transport broke"));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("transport-failure", result.GetProperty("cause").GetString());
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+    }
+
+    [Fact]
+    public void AgmsgRosterLookupFailure_IsReceiverMissing_G578()
+    {
+        var runner = Runner((_, _) => Failure("team receiver missing"));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("receiver-missing", result.GetProperty("cause").GetString());
+    }
+
+    [Theory]
+    [InlineData("pane-absent")]
+    [InlineData("agent-not-running")]
+    public void HerdrRoleStateFailures_AreNamedBeforePrompt_G578(string expectedCause)
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var roster = expectedCause == "pane-absent"
+            ? HerdrRoster(implementationPane: null)
+            : HerdrRoster(implementationRunning: false);
+        var runner = Runner((_, arguments) => arguments.SequenceEqual(["agent", "list"])
+            ? Success(roster)
+            : Success());
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal(expectedCause, result.GetProperty("cause").GetString());
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+    }
+
+    [Theory]
+    [InlineData(SessionLayerMode.Agmsg)]
+    [InlineData(SessionLayerMode.HerdrOnly)]
+    public void Report_UsesTheRecordedTransport_WithStructuredOutcome_G578(string mode)
+    {
+        workspace.SetMode(mode);
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run([
+            "notify", "report", "--domain", NotifyWorkspace.Domain, "--team", NotifyWorkspace.Team,
+            "--from", "implementation", "--to", "orchestration", "--task-id", "G578-demo",
+            "--status", "completed", "--artifact", "https://example.test/pr/1",
+            "--summary", "notify surface implemented", "--write", "--format", "json",
+        ]);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(mode, result.GetProperty("mode").GetString());
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        using var payload = JsonDocument.Parse(result.GetProperty("payload").GetString()!);
+        Assert.Equal("completed", payload.RootElement.GetProperty("status").GetString());
+        Assert.Equal("https://example.test/pr/1", payload.RootElement.GetProperty("artifact").GetString());
+    }
+
+    [Fact]
+    public void Report_ResolvesTheRecordedModeFromDelegationRoutingData_OutsideTheHostCwd_G578()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var childRoot = Directory.CreateTempSubdirectory("notify-child-g578-").FullName;
+        try
+        {
+            var childContext = workspace.CreateContext(childRoot);
+            using var writer = new StringWriter();
+
+            var exitCode = CommandRouter.Execute([
+                "notify", "report", "--domain", NotifyWorkspace.Domain, "--team", NotifyWorkspace.Team,
+                "--from", "implementation", "--to", "orchestration", "--task-id", "G578-demo",
+                "--status", "completed", "--artifact", "https://example.test/pr/1",
+                "--summary", "reported from child cwd", "--routing-root", workspace.RootPath,
+                "--write", "--format", "json",
+            ], childContext, writer);
+
+            using var result = JsonDocument.Parse(writer.ToString());
+            Assert.Equal(0, exitCode);
+            Assert.Equal(SessionLayerMode.HerdrOnly, result.RootElement.GetProperty("mode").GetString());
+            Assert.Equal(workspace.RootPath, result.RootElement.GetProperty("routing_root").GetString());
+            Assert.Contains(runner.Calls, call =>
+                call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "orchestration"]));
+        }
+        finally
+        {
+            Directory.Delete(childRoot, recursive: true);
+        }
+    }
+
+    [Theory]
+    [InlineData(SessionLayerMode.Agmsg)]
+    [InlineData(SessionLayerMode.HerdrOnly)]
+    public void Escalate_AppendsTheExistingSixFieldEventSchema_InEitherMode_G578(string mode)
+    {
+        workspace.SetMode(mode);
+        NotifyCommand.ProcessRunnerFactory = () => throw new InvalidOperationException("escalate must not start a transport");
+
+        var (exitCode, result) = workspace.Run([
+            "notify", "escalate", "--domain", NotifyWorkspace.Domain, "--team", NotifyWorkspace.Team,
+            "--from", "implementation", "--task-id", "G578-demo", "--artifact", "notes/blocker.md",
+            "--summary", "needs   a\n design decision", "--write", "--format", "json",
+        ]);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("event_appended").GetBoolean());
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+        var lines = File.ReadAllLines(workspace.EventPath);
+        Assert.Single(lines);
+        using var document = JsonDocument.Parse(lines[0]);
+        var root = document.RootElement;
+        Assert.Equal(
+            ["timestamp", "team", "kind", "unit", "summary", "artifact"],
+            root.EnumerateObject().Select(property => property.Name));
+        Assert.Equal(FixedNow, root.GetProperty("timestamp").GetDateTimeOffset());
+        Assert.Equal(NotifyWorkspace.Team, root.GetProperty("team").GetString());
+        Assert.Equal("escalation", root.GetProperty("kind").GetString());
+        Assert.Equal("G578-demo", root.GetProperty("unit").GetString());
+        Assert.Equal("needs a design decision", root.GetProperty("summary").GetString());
+        Assert.Equal("notes/blocker.md", root.GetProperty("artifact").GetString());
+    }
+
+    [Fact]
+    public void Escalate_RejectsPathLikeTeam_WithoutWriting_G578()
+    {
+        var args = new[]
+        {
+            "notify", "escalate", "--domain", NotifyWorkspace.Domain, "--team", "../escape",
+            "--from", "implementation", "--task-id", "G578-demo", "--artifact", "notes/blocker.md",
+            "--summary", "needs design", "--write", "--format", "json",
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(args, workspace.Context, writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("must contain only", writer.ToString(), StringComparison.Ordinal);
+        Assert.False(Directory.Exists(Path.Combine(workspace.RootPath, ".intent-cli", "events")));
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void OrchestrationDocs_TeachOneCanonicalNotifyVocabulary_G578(string language)
+    {
+        var path = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "docs",
+            language,
+            "12-agent-message-orchestration.md");
+        var content = File.ReadAllText(path);
+
+        Assert.Contains("intent-cli notify delegate", content, StringComparison.Ordinal);
+        Assert.Contains("intent-cli notify report", content, StringComparison.Ordinal);
+        Assert.Contains("intent-cli notify escalate", content, StringComparison.Ordinal);
+        Assert.Contains("--routing-root", content, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Send one structured block with `herdr agent prompt",
+            content,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "`herdr agent prompt <logical-role> <task-block>` で",
+            content,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RuntimeGuides_RequireCanonicalNotifyAndEmbeddedWakeBack_G578()
+    {
+        var herdrGuide = HerdrOnlyOperatingGuide.RenderMarkdown([]);
+        Assert.Contains("intent-cli notify delegate", herdrGuide, StringComparison.Ordinal);
+        Assert.Contains("intent-cli notify report", herdrGuide, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Submit one structured task block with `herdr agent prompt",
+            herdrGuide,
+            StringComparison.Ordinal);
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideOrchestratorThreadCommand.Execute(
+            workspace.Context,
+            ["--domain", NotifyWorkspace.Domain, "--target-repo", "J-Tech-Japan/intent-system", "--agent", "codex", "--format", "json"],
+            writer));
+        using var document = JsonDocument.Parse(writer.ToString());
+        var prompts = document.RootElement.GetProperty("threads").EnumerateArray()
+            .ToDictionary(item => item.GetProperty("role").GetString()!, item => item.GetProperty("prompt").GetString()!);
+        foreach (var role in new[] { "implementation", "review" })
+        {
+            Assert.Contains("intent-cli notify report", prompts[role], StringComparison.Ordinal);
+            Assert.Contains("REQUIRED FINAL STEP", prompts[role], StringComparison.Ordinal);
+            Assert.Contains("Never hand-write", prompts[role], StringComparison.Ordinal);
+            Assert.DoesNotContain("structured agmsg reply", prompts[role], StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private FakeNotifyProcessRunner SuccessfulRunner() => Runner((_, arguments) =>
+    {
+        if (arguments.SequenceEqual(["agent", "list"]))
+        {
+            return Success(HerdrRoster());
+        }
+
+        if (arguments.Count > 0 && arguments[0].EndsWith("team.sh", StringComparison.Ordinal))
+        {
+            return Success(AgmsgRoster());
+        }
+
+        return Success();
+    });
+
+    private static FakeNotifyProcessRunner Runner(
+        Func<string, IReadOnlyList<string>, NotifyProcessResult> handler) => new(handler);
+
+    private static NotifyProcessResult Success(string output = "") => new(0, output, "");
+
+    private static NotifyProcessResult Failure(string error) => new(1, "", error);
+
+    private static string AgmsgRoster(bool withImplementation = true) =>
+        "Team: intent-cli-dev\n"
+        + "  orchestration (claude) — /work/orchestration\n"
+        + (withImplementation ? "  implementation (codex) — /work/implementation\n" : string.Empty)
+        + "  review (codex) — /work/review\n";
+
+    private static string HerdrRoster(
+        bool withImplementation = true,
+        string? implementationPane = "wH:p2",
+        bool implementationRunning = true)
+    {
+        var agents = new List<object>
+        {
+            HerdrAgent("orchestration", "wH:p1", running: true),
+            HerdrAgent("review", "wH:p3", running: true),
+        };
+        if (withImplementation)
+        {
+            agents.Add(HerdrAgent("implementation", implementationPane, implementationRunning));
+        }
+
+        return JsonSerializer.Serialize(new { result = new { agents } });
+    }
+
+    private static object HerdrAgent(string name, string? paneId, bool running) => new
+    {
+        name,
+        pane_id = paneId,
+        agent = running ? "codex" : null,
+        agent_session = running ? new { id = name } : null,
+        agent_status = running ? "idle" : "unknown",
+        interactive_ready = running,
+    };
+
+    private static string[] DelegateArgs() =>
+    [
+        "notify", "delegate", "--domain", NotifyWorkspace.Domain, "--team", NotifyWorkspace.Team,
+        "--from", "orchestration", "--to", "implementation", "--report-to", "orchestration",
+        "--task-id", "G578-demo", "--objective", "Implement the notification contract",
+        "--input", "issue #1259", "--expected-artifact", "draft PR URL", "--result-nonce", "demo-nonce",
+        "--write", "--format", "json",
+    ];
+
+    private sealed class FakeNotifyProcessRunner(
+        Func<string, IReadOnlyList<string>, NotifyProcessResult> handler) : INotifyProcessRunner
+    {
+        public List<(string FileName, IReadOnlyList<string> Arguments)> Calls { get; } = [];
+
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            Calls.Add((fileName, arguments.ToArray()));
+            return handler(fileName, arguments);
+        }
+    }
+
+    private sealed class NotifyWorkspace : IDisposable
+    {
+        public const string Domain = "intent-cli";
+        public const string Team = "intent-cli-dev";
+
+        public NotifyWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("notify-g578-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            AgmsgScriptsPath = Path.Combine(RootPath, "agmsg-scripts");
+            Directory.CreateDirectory(AgmsgScriptsPath);
+            File.WriteAllText(Path.Combine(AgmsgScriptsPath, "team.sh"), "fixture");
+            File.WriteAllText(Path.Combine(AgmsgScriptsPath, "send.sh"), "fixture");
+            Context = CreateContext(RootPath);
+        }
+
+        public CliContext CreateContext(string repoRoot) => new()
+        {
+            RepoRoot = repoRoot,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = Domain,
+                    ArtifactRoot = ".intent-cli",
+                },
+            },
+        };
+
+        public string RootPath { get; }
+        public string AgmsgScriptsPath { get; }
+        public string EventPath => Path.Combine(RootPath, ".intent-cli", "events", $"{Team}.jsonl");
+        public CliContext Context { get; }
+
+        public void SetMode(string mode)
+        {
+            using var writer = new StringWriter();
+            var exitCode = SessionLayerCommand.ExecuteSet(
+                Context,
+                ["--domain", Domain, "--team", Team, "--mode", mode, "--write", "--format", "json"],
+                writer);
+            Assert.True(exitCode == 0, writer.ToString());
+        }
+
+        public (int ExitCode, JsonElement Result) Run(string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = CommandRouter.Execute(args, Context, writer);
+            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1259

## Summary

- add canonical intent-cli notify delegate, report, and escalate commands
- resolve agmsg versus herdr-only from the recorded session-layer mode, defaulting to agmsg
- validate roles and fail closed with named delivery causes
- embed the canonical wake-back report command, including child-safe routing data, in every delegation
- append escalations to the unchanged events JSONL design-boundary schema
- update English/Japanese orchestration docs and runtime guides to use the canonical surface

## Verification

- Focused: dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --filter FullyQualifiedName~NotifyCommandG578Tests — 19 passed
- Full: dotnet test IntentSystem.sln --configuration Release — all project suites green; CLI suite 4262 passed, 1 existing skip
- git diff --cached --check — clean

## Scratch demos

Using one scratch team and the same notify delegate arguments:

- recorded agmsg mode: delivered=true and the fake agmsg send adapter received the task payload
- recorded herdr-only mode: delivered=true and the fake herdr prompt adapter received the same task payload
- canonical report from an isolated child cwd: routing-root resolved herdr-only and prompted orchestration
- unknown logical role: exit 1, cause=unknown-role, delivered=false
- escalation: event_appended=true and the existing six-field JSONL record was appended with kind=escalation

The notify surface performs no merge, label, publish, or queue transition.