### PR TITLE
G579: Write canonical queue state atomically

### DIFF
--- a/src/IntentSystem.Supervisor/AtomicFileWriter.cs
+++ b/src/IntentSystem.Supervisor/AtomicFileWriter.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+using System.Text;
+
+namespace IntentSystem.Supervisor;
+
+/// <summary>
+/// Writes complete text files without exposing a truncated or partially
+/// written target: bytes are flushed to a uniquely named temporary sibling,
+/// then published with one overwrite-move.
+/// </summary>
+public static class AtomicFileWriter
+{
+    private static readonly ConcurrentDictionary<string, Action<string>> BeforeMoveHooks =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Registers a path-scoped fault seam that runs after the temporary file
+    /// has been flushed and before it is moved over the target. The callback
+    /// receives the temporary file path.
+    /// </summary>
+    public static IDisposable RegisterBeforeMoveHook(string targetPath, Action<string> hook)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
+        ArgumentNullException.ThrowIfNull(hook);
+
+        var key = Path.GetFullPath(targetPath);
+        if (!BeforeMoveHooks.TryAdd(key, hook))
+        {
+            throw new InvalidOperationException($"a before-move hook is already registered for '{key}'.");
+        }
+
+        return new BeforeMoveHookRegistration(key);
+    }
+
+    /// <summary>
+    /// Writes <paramref name="contents"/> to a temporary sibling, flushes
+    /// the file to disk, and atomically publishes it with one overwrite-move.
+    /// </summary>
+    public static void WriteAllText(string targetPath, string contents)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
+        ArgumentNullException.ThrowIfNull(contents);
+
+        var fullTargetPath = Path.GetFullPath(targetPath);
+        var directory = Path.GetDirectoryName(fullTargetPath)!;
+        Directory.CreateDirectory(directory);
+
+        var tempPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(fullTargetPath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            using (var stream = new FileStream(
+                tempPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 4096,
+                FileOptions.WriteThrough))
+            using (var writer = new StreamWriter(
+                stream,
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
+                bufferSize: 1024,
+                leaveOpen: true))
+            {
+                writer.Write(contents);
+                writer.Flush();
+                stream.Flush(flushToDisk: true);
+            }
+
+            InvokeBeforeMoveHook(fullTargetPath, tempPath);
+            File.Move(tempPath, fullTargetPath, overwrite: true);
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+    }
+
+    private static void InvokeBeforeMoveHook(string targetPath, string tempPath)
+    {
+        if (!BeforeMoveHooks.IsEmpty && BeforeMoveHooks.TryGetValue(targetPath, out var hook))
+        {
+            hook(tempPath);
+        }
+    }
+
+    private sealed class BeforeMoveHookRegistration : IDisposable
+    {
+        private readonly string key;
+
+        public BeforeMoveHookRegistration(string key) => this.key = key;
+
+        public void Dispose() => BeforeMoveHooks.TryRemove(key, out _);
+    }
+}

--- a/src/IntentSystem.Supervisor/QueueStatePersistence.cs
+++ b/src/IntentSystem.Supervisor/QueueStatePersistence.cs
@@ -32,7 +32,7 @@ namespace IntentSystem.Supervisor;
 /// recovery gate into a circular deadlock. Restoration took three canonical
 /// surfaces plus an operator (host commit <c>c0897649</c>).
 ///
-/// Three guarantees, all enforced here rather than re-implemented per
+/// Four guarantees, all enforced here rather than re-implemented per
 /// command:
 /// <list type="number">
 /// <item><b>Stale-base detection and re-application.</b> The state the caller
@@ -51,6 +51,10 @@ namespace IntentSystem.Supervisor;
 ///   only the units its delta actually covers, plus <c>updated_at</c>. Every
 ///   unrelated item is carried through byte-identically from the fresh
 ///   on-disk state.</item>
+/// <item><b>Atomic publication.</b> The complete serialized document is
+///   flushed to a uniquely named sibling in the target directory, then
+///   published with one overwrite-move. An interruption before that move
+///   leaves the previous canonical document intact and parseable.</item>
 /// </list>
 ///
 /// Deliberately NOT in this layer (out of scope, and recorded as such): a
@@ -375,15 +379,7 @@ public static class QueueStatePersistence
     }
 
     private static void WriteText(string queueStatePath, string text)
-    {
-        var directory = Path.GetDirectoryName(queueStatePath);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
-
-        File.WriteAllText(queueStatePath, text);
-    }
+        => AtomicFileWriter.WriteAllText(queueStatePath, text);
 
     /// <summary>
     /// Persists <paramref name="outgoingState"/>, enforcing every guarantee
@@ -573,15 +569,7 @@ public static class QueueStatePersistence
     };
 
     private static void Write(string queueStatePath, QueueState state)
-    {
-        var directory = Path.GetDirectoryName(queueStatePath);
-        if (!string.IsNullOrEmpty(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
-
-        File.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(state));
-    }
+        => AtomicFileWriter.WriteAllText(queueStatePath, QueueStateSerializer.Serialize(state));
 }
 
 /// <summary>

--- a/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssueRetireCommandTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
 using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -677,8 +678,9 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
     public void Execute_Write_QueueStateWriteFails_RecoversOnRetryWithoutReClosing()
     {
         // Fault injected AFTER close + label removal succeed, around queue
-        // persistence: make the pre-existing queue-state.json read-only so
-        // the overwrite throws, then retry after restoring write access.
+        // persistence: interrupt the atomic writer after its temporary file
+        // is flushed but before the overwrite-move, then retry without the
+        // fault.
         using var workspace = new RetireWorkspace();
         workspace.WriteQueueState(BuildQueueStateJson("G600", QueueItemState.Queued, Repo, linkedIssueNumber: 2001));
         var queueStatePath = workspace.Context.GetQueueStatePath();
@@ -688,32 +690,24 @@ public sealed class AutomationIssueRetireCommandTests : IDisposable
         retirementMutator.Snapshots[2001] = OpenSnapshot(2001, "G600: Some slice", "intent-target");
         AutomationIssueRetireCommand.RetirementMutatorFactory = () => retirementMutator;
 
-        if (!OperatingSystem.IsWindows())
+        int firstExitCode;
+        using (AtomicFileWriter.RegisterBeforeMoveHook(
+            queueStatePath,
+            _ => throw new IOException("simulated queue-state publication failure")))
         {
-            File.SetUnixFileMode(queueStatePath, UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
-        }
+            using var firstWriter = new StringWriter();
+            firstExitCode = AutomationIssueRetireCommand.Execute(
+                workspace.Context,
+                ["--repo", Repo, "--issue", "2001", "--reason", "superseded", "--domain", "intent-cli", "--write", "--format", "json"],
+                firstWriter);
 
-        using var firstWriter = new StringWriter();
-        var firstExitCode = AutomationIssueRetireCommand.Execute(
-            workspace.Context,
-            ["--repo", Repo, "--issue", "2001", "--reason", "superseded", "--domain", "intent-cli", "--write", "--format", "json"],
-            firstWriter);
-
-        if (OperatingSystem.IsWindows())
-        {
-            // Read-only fault injection is unix-permission-specific; skip
-            // the assertions that depend on the write actually failing.
-            return;
+            Assert.Contains("queue-state update failed", firstWriter.ToString(), StringComparison.Ordinal);
         }
 
         Assert.Equal(1, firstExitCode);
-        Assert.Contains("queue-state update failed", firstWriter.ToString(), StringComparison.Ordinal);
         Assert.Single(retirementMutator.Closed);
         Assert.Single(labelMutator.Transitions);
 
-        File.SetUnixFileMode(
-            queueStatePath,
-            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.GroupRead | UnixFileMode.OtherRead);
         retirementMutator.Snapshots[2001] = ClosedNotPlannedSnapshot(
             2001, "G600: Some slice", Array.Empty<string>(), new[] { retirementMutator.Closed[0].Comment });
 

--- a/tests/IntentSystem.Supervisor.Tests/AtomicFileWriterTests.cs
+++ b/tests/IntentSystem.Supervisor.Tests/AtomicFileWriterTests.cs
@@ -1,0 +1,121 @@
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Supervisor.Tests;
+
+public sealed class AtomicFileWriterTests : IDisposable
+{
+    private static readonly DateTimeOffset BaseTime = new(2026, 8, 2, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly string root = Directory.CreateTempSubdirectory("atomic-file-writer-tests-").FullName;
+
+    private string QueueStatePath => Path.Combine(root, ".intent-cli", "queue-state.json");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void QueueStatePersist_InterruptedAfterTempFlush_PreservesPriorParseableContent_G579()
+    {
+        var priorState = State(BaseTime, QueueItemState.Queued);
+        Directory.CreateDirectory(Path.GetDirectoryName(QueueStatePath)!);
+        File.WriteAllText(QueueStatePath, QueueStateSerializer.Serialize(priorState));
+        var priorText = File.ReadAllText(QueueStatePath);
+
+        var outgoingState = State(BaseTime.AddMinutes(1), QueueItemState.Active);
+        using var hook = AtomicFileWriter.RegisterBeforeMoveHook(QueueStatePath, tempPath =>
+        {
+            Assert.Equal(Path.GetDirectoryName(QueueStatePath), Path.GetDirectoryName(tempPath));
+            Assert.StartsWith(".queue-state.json.", Path.GetFileName(tempPath), StringComparison.Ordinal);
+            Assert.EndsWith(".tmp", tempPath, StringComparison.Ordinal);
+
+            var flushedState = QueueStateSerializer.Deserialize(File.ReadAllText(tempPath));
+            Assert.Equal(QueueItemState.Active, Assert.Single(flushedState.Items).State);
+
+            throw new SimulatedWriteInterruptionException();
+        });
+
+        Assert.Throws<SimulatedWriteInterruptionException>(
+            () => QueueStatePersistence.Persist(QueueStatePath, priorState, outgoingState));
+
+        Assert.Equal(priorText, File.ReadAllText(QueueStatePath));
+        var survivingState = QueueStateSerializer.Deserialize(File.ReadAllText(QueueStatePath));
+        Assert.Equal(QueueItemState.Queued, Assert.Single(survivingState.Items).State);
+        Assert.Empty(TemporarySiblings());
+    }
+
+    [Fact]
+    public void PersistRawJson_InterruptedAfterTempFlush_PreservesPriorContent_G579()
+    {
+        var priorState = State(BaseTime, QueueItemState.Queued);
+        Directory.CreateDirectory(Path.GetDirectoryName(QueueStatePath)!);
+        var priorText = QueueStateSerializer.Serialize(priorState);
+        File.WriteAllText(QueueStatePath, priorText);
+        var outgoingText = QueueStateSerializer.Serialize(State(BaseTime.AddMinutes(1), QueueItemState.Review));
+
+        using var hook = AtomicFileWriter.RegisterBeforeMoveHook(
+            QueueStatePath,
+            _ => throw new SimulatedWriteInterruptionException());
+
+        Assert.Throws<SimulatedWriteInterruptionException>(
+            () => QueueStatePersistence.PersistRawJson(QueueStatePath, priorText, outgoingText));
+
+        Assert.Equal(priorText, File.ReadAllText(QueueStatePath));
+        Assert.Equal(
+            QueueItemState.Queued,
+            Assert.Single(QueueStateSerializer.Deserialize(File.ReadAllText(QueueStatePath)).Items).State);
+        Assert.Empty(TemporarySiblings());
+    }
+
+    [Fact]
+    public void WriteAllText_SuccessfullyReplacesTarget_WithoutTempLitter_G579()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(QueueStatePath)!);
+        File.WriteAllText(QueueStatePath, "prior");
+
+        AtomicFileWriter.WriteAllText(QueueStatePath, "replacement");
+
+        Assert.Equal("replacement", File.ReadAllText(QueueStatePath));
+        Assert.Empty(TemporarySiblings());
+    }
+
+    private string[] TemporarySiblings() =>
+        Directory.GetFiles(Path.GetDirectoryName(QueueStatePath)!, ".queue-state.json.*.tmp");
+
+    private static QueueState State(DateTimeOffset updatedAt, QueueItemState state) => new()
+    {
+        SchemaVersion = "1",
+        UpdatedAt = updatedAt,
+        Items =
+        [
+            new QueueItem
+            {
+                ExecutionUnit = "G579",
+                Title = "Atomic canonical state writes",
+                State = state,
+                Dependencies = [],
+                BlockedBy = [],
+                ClarificationReturnPath = string.Empty,
+                PacketPaths = new PacketPaths
+                {
+                    Yaml = ".intent-cli/issues/G579/packet.yaml",
+                    Implementation = ".intent-cli/issues/G579/implementation.md",
+                    ReviewContext = ".intent-cli/issues/G579/review-context.md",
+                },
+                WorkerRole = "implementation",
+                ReviewRole = "review",
+                Priority = "normal",
+            },
+        ],
+    };
+
+    private sealed class SimulatedWriteInterruptionException : Exception
+    {
+    }
+}


### PR DESCRIPTION
## Summary

- add a shared `AtomicFileWriter` that writes a uniquely named `.tmp` sibling in the target directory, flushes it with `Flush(true)`, and publishes it with one overwrite-move
- route both model and raw canonical `QueueStatePersistence` writes through the helper
- add path-scoped post-flush/pre-move fault injection plus success/failure temp-file hygiene coverage
- update issue-retire recovery coverage to inject failure at the canonical atomic publication seam

## Interruption demonstration

The durability test registers `AtomicFileWriter.RegisterBeforeMoveHook` at the point after the temporary file has been flushed and before `File.Move(..., overwrite: true)`. At that seam, the temporary JSON parses as the outgoing `active` state. Throwing a simulated interruption leaves the canonical target byte-for-byte equal to its prior content; that target still deserializes as the prior `queued` state, and no `.queue-state.json.*.tmp` sibling remains. The raw-JSON persistence path has the same preservation assertion.

## Verification

- `dotnet test tests/IntentSystem.Supervisor.Tests/IntentSystem.Supervisor.Tests.csproj --configuration Release --filter FullyQualifiedName~AtomicFileWriterTests` — passed: 3, failed: 0
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --filter "FullyQualifiedName~AutomationIssueRetireCommandTests.Execute_Write_QueueStateWriteFails_RecoversOnRetryWithoutReClosing|FullyQualifiedName~QueueStatePersistenceTests|FullyQualifiedName~QueueStateWriterCoverageTests"` — passed: 29, failed: 0
- `dotnet test IntentSystem.sln --configuration Release --no-restore` — passed: 4592, skipped: 1, failed: 0
- `git diff --cached --check` — clean

Closes #1261