### PR TITLE
G581: Add herdr state-change wake source contract

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -294,6 +294,49 @@ points to them. Repairs return to the same logical role with the task id and
 concrete delta through `intent-cli notify delegate`. A marker match from any buffer
 is never sufficient; the named artifact must exist and pass verification.
 
+### Two normative wake sources
+
+Herdr-only orchestration has two normative wake sources. The canonical
+`intent-cli notify report` is primary and most informative: it carries the task
+id, status, artifact, and summary, but depends on the worker cooperating and
+running its required final command. The normative **SECOND wake source** is
+herdr's observed `pane.agent_status_changed`: it depends only on herdr observing
+the process, so it still wakes orchestration when the worker omits its report,
+but it carries no task outcome.
+
+The measured herdr 0.7.5 socket API uses `events.subscribe`. Include one
+subscription entry per watched pane because `pane.agent_status_changed`
+requires `pane_id`:
+
+```json
+{"method":"events.subscribe","params":{"subscriptions":[{"type":"pane.agent_status_changed","pane_id":"<resolved-pane-id>"}]}}
+```
+
+Resolve every `<resolved-pane-id>` from the recorded logical-role→pane mapping
+when subscribing and after re-provisioning; never hard-code pane ids. The event
+frame carries `agent`, `agent_status`, `pane_id`, and `workspace_id`:
+
+```json
+{"event":"pane.agent_status_changed","data":{"agent":"<agent>","agent_status":"<working|idle|done|blocked|unknown>","pane_id":"<resolved-pane-id>","workspace_id":"<workspace-id>"}}
+```
+
+Track the prior status independently for each logical role. Wake only on that
+role's `working`→settled transition, where settled is `idle`, `done`, or
+`blocked`; an initial settled sample, `unknown`, or settled→settled change does
+not wake orchestration. Apply a settle delay before waking and per-role dedupe
+so a burst produces one wake for that observed transition. A new `working`
+observation re-arms that role.
+
+**A state change means only that something happened, never that a task
+succeeded.** After every wake from either source, orchestration checks current
+herdr state and any approval/question pause, the exact fresh completion marker
+and status, the named verified artifact, and fresh canonical intent-cli/GitHub
+facts. The two sources cover complementary failures: notify report is richest
+but depends on worker cooperation; state change needs only herdr observation but
+carries no outcome. The periodic `intent-cli automation stalled-work ...` check
+is the last net. This measured shape does not replace the standing rule to
+consult installed herdr help/schema for version-specific details.
+
 Every wait is bounded:
 
 ```text
@@ -309,9 +352,10 @@ answer only a pane-read G550 MAY class; escalate everything else, then re-enter
 the wake and wait again. A timeout is likewise a re-entry point: persist
 progress, return control, then resume on a later wake. Deterministic scripts
 with persisted cursors are preferred for long flows. Composite success requires
-dialog-free settled state + the exact fresh-nonce marker + an existing verified
-artifact. Artifact verification is the final gate; neither state nor marker
-alone means success.
+approval/question-free settled state + the exact fresh-nonce marker and status +
+an existing verified artifact + fresh canonical intent-cli/GitHub facts.
+Artifact verification plus canonical facts is the final gate;
+neither state nor marker alone means success.
 
 ### Normative `events.jsonl` design boundary
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -280,6 +280,47 @@ artifact です。screen prose はそれを指す signal にすぎません。re
 marker match だけでは不十分で、named artifact の存在と verification が必要です。repair も
 `intent-cli notify delegate` で同じ logical role に戻します。
 
+### 2 つの normative wake source
+
+herdr-only orchestration には 2 つの normative wake source があります。canonical な
+`intent-cli notify report` は primary かつ最も情報量が多く、task id、status、artifact、
+summary を運びますが、worker が協力して必須の final command を実行することに依存します。
+normative な **SECOND wake source** は herdr が観測する
+`pane.agent_status_changed` です。worker が report を省略しても、herdr による process 観測
+だけで orchestration を wake できますが、task outcome は運びません。
+
+実測した herdr 0.7.5 socket API は `events.subscribe` を使います。
+`pane.agent_status_changed` は `pane_id` を必須とするため、watched pane ごとに 1 つの
+subscription entry を含めます。
+
+```json
+{"method":"events.subscribe","params":{"subscriptions":[{"type":"pane.agent_status_changed","pane_id":"<resolved-pane-id>"}]}}
+```
+
+各 `<resolved-pane-id>` は subscribe 時と re-provision 後に、記録済み
+logical-role→pane mapping から解決し、pane id を hard-code してはいけません。event frame は
+`agent`、`agent_status`、`pane_id`、`workspace_id` を運びます。
+
+```json
+{"event":"pane.agent_status_changed","data":{"agent":"<agent>","agent_status":"<working|idle|done|blocked|unknown>","pane_id":"<resolved-pane-id>","workspace_id":"<workspace-id>"}}
+```
+
+直前の status は logical role ごとに独立して追跡します。その role が `working` から
+settled (`idle`、`done`、`blocked`) へ遷移した場合だけ wake します。最初から settled の
+sample、`unknown`、settled→settled の変化では wake しません。wake 前に settle delay を置き、
+per-role dedupe により burst から生じる wake を、その観測済み transition につき 1 回にします。
+新しい `working` の観測で、その role を re-arm します。
+
+**state change は何かが起きたことだけを意味し、task が成功したことを決して意味しません。**
+どちらの source から wake した後も毎回、orchestration は現在の herdr state と pending
+approval/question pause、正確で fresh な completion marker と status、検証済み named
+artifact、fresh な canonical intent-cli/GitHub facts を確認します。2 つの source は相補的です:
+notify report は最も情報量が多い一方で worker の協力に依存し、state change は herdr の観測
+だけに依存する一方で outcome を運びません。periodic な
+`intent-cli automation stalled-work ...` check が last net です。この実測 shape は、
+version-specific details について installed herdr help/schema を確認するという standing rule を
+置き換えません。
+
 wait は必ず bounded にします。
 
 ```text
@@ -293,9 +334,10 @@ inspect します。`idle` は approval-paused の場合があります。結果
 approval/question-paused、timeout に分類します。pause では pane から読んだ G550 MAY class
 だけを回答し、それ以外は escalate してから wake に re-enter し、再度 wait します。timeout も
 re-entry point です。進捗を persist して制御を返し、後続 wake で再開します。長い flow には
-cursor を永続化する deterministic script を推奨します。success は dialog-free settled state +
-正確な fresh-nonce marker + 存在して検証済みの artifact の合成判定です。artifact verification
-が final gate であり、state 単独も marker 単独も success ではありません。
+cursor を永続化する deterministic script を推奨します。success は pending
+approval/question のない settled state + 正確な fresh-nonce marker と status + 存在して検証済みの
+artifact + fresh な canonical intent-cli/GitHub facts の合成判定です。artifact verification と
+canonical facts が final gate であり、state 単独も marker 単独も success ではありません。
 
 ### Normative な `events.jsonl` design boundary
 

--- a/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
+++ b/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
@@ -3,10 +3,10 @@ using System.Text.Json.Nodes;
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
-/// G571: the concrete operating procedure selected by the G570 session-layer
-/// router. This content is synthetic rather than part of the agmsg-backed
-/// guide model so the practiced agmsg rendering remains byte-for-byte on its
-/// existing path.
+/// G571/G581: the concrete operating procedure selected by the G570
+/// session-layer router. This content is synthetic rather than part of the
+/// agmsg-backed guide model so the practiced agmsg rendering remains
+/// byte-for-byte on its existing path.
 /// </summary>
 internal static class HerdrOnlyOperatingGuide
 {
@@ -16,6 +16,7 @@ internal static class HerdrOnlyOperatingGuide
     [
         "## Herdr-only provisioning and READY gate",
         "## Herdr-only dispatch and artifact handoff",
+        "## Herdr-only wake sources",
         "## Herdr-only bounded waiting and success detection",
         "## events.jsonl design boundary",
         "## Herdr-only failure modes and recovery",
@@ -71,6 +72,31 @@ internal static class HerdrOnlyOperatingGuide
 
         `notify delegate` generates the structured task block, keeps the result prefix and fresh unpredictable nonce separate, and embeds task id, expected artifact, plus the complete canonical `intent-cli notify report` command as the receiver's required final step. That command carries the transport-neutral `--routing-root`, so an isolated child checkout still resolves the recorded mode internally without learning a transport-specific send instruction. The receiver reports `completed`, `blocked`, or `question` only through that embedded command; it never hand-writes a transport call. Never reuse a nonce or substitute the task id alone. `pane wait-output` searches existing pane output immediately, so a precomposed wait needle in the dispatched task can be echoed and falsely match before the agent does any work. Files, commits, PRs, test logs, and other inspectable artifacts are the handoff; terminal prose is only a signal pointing at them. A repair or re-dispatch goes to the same logical role through `intent-cli notify delegate` and carries the same task id plus the concrete delta. A marker match from any pane buffer is NEVER sufficient: the named artifact must exist and pass its verification.
 
+        ## Herdr-only wake sources
+
+        Herdr-only has two normative wake sources. Neither replaces the composite success gate below:
+
+        1. **Canonical notify report (primary and most informative):** the receiver's embedded `intent-cli notify report` carries task id, status, artifact, and summary directly to orchestration, but it depends on the worker cooperating and running its required final command.
+        2. **Observed agent state change (normative SECOND wake source):** independently subscribe to herdr `pane.agent_status_changed` for every watched role. This depends only on herdr observing the agent process, so it still wakes orchestration when a worker omits its report; the event carries no task outcome.
+
+        For the measured herdr 0.7.5 socket API, call `events.subscribe` with one subscription entry per watched pane because `pane.agent_status_changed` requires `pane_id`:
+
+        ```json
+        {"method":"events.subscribe","params":{"subscriptions":[{"type":"pane.agent_status_changed","pane_id":"<resolved-pane-id>"}]} }
+        ```
+
+        Resolve each `<resolved-pane-id>` from the recorded logical-role→pane mapping at subscription time and after any re-provisioning; NEVER hard-code pane ids. The subscription event frame carries the observed `agent`, `agent_status`, `pane_id`, and `workspace_id`:
+
+        ```json
+        {"event":"pane.agent_status_changed","data":{"agent":"<agent>","agent_status":"<working|idle|done|blocked|unknown>","pane_id":"<resolved-pane-id>","workspace_id":"<workspace-id>"} }
+        ```
+
+        Track the previous status independently for each logical role. Schedule a wake only when that role transitions from `working` to a settled state (`idle`, `done`, or `blocked`); an initial settled observation, `unknown`, or a settled→settled change does not wake orchestration. Apply a settle delay before the wake, and keep per-role dedupe state so a burst produces only one wake for that role's observed working→settled transition. A newly observed `working` state re-arms that role.
+
+        **A state change means only that something happened, never that a task succeeded.** After EVERY wake from either source, orchestration checks current herdr state and pending approval/question, the exact fresh-nonce completion marker and status, the named verified artifact, and fresh canonical intent-cli/GitHub facts before advancing or concluding the task. A settled pane may still be paused for approval or a question.
+
+        The failure modes are complementary: notify report is the richest signal but depends on worker cooperation; state change depends only on herdr observation but carries no outcome. The periodic `intent-cli automation stalled-work ...` check remains the last net when neither immediate source produces a usable wake. This herdr 0.7.5 shape does not replace the standing rule: consult the installed herdr help/schema for version-specific details before operating it.
+
         ## Herdr-only bounded waiting and success detection
 
         Use bounded waits only. For agent state, use `herdr agent wait <logical-role> --until idle --until done --until blocked --timeout <milliseconds>`. For the task signal, use `herdr pane wait-output --match "ORCH_RESULT <fresh-per-dispatch-nonce>" --source recent-unwrapped --timeout <milliseconds> <pane-id>`. Both commands wait indefinitely when `--timeout` is omitted, so omission is forbidden in an orchestrator wake.
@@ -79,7 +105,7 @@ internal static class HerdrOnlyOperatingGuide
 
         A timeout is a re-entry point: persist progress, return control to the orchestrator, and wait again on the next bounded wake. Prefer a deterministic script that persists its cursor for long multi-wait flows; do not hold one chat turn open indefinitely, because turn death loses the continuation.
 
-        **Composite success is mandatory:** (1) herdr reports a settled state and pane inspection finds no pending dialog, (2) the exact `ORCH_RESULT` marker matches the fresh dispatch nonce and status, and (3) the named artifact exists and passes the task's verification. The named artifact verification is the final gate. State alone and marker alone NEVER mean task success; in particular, herdr `done` or `idle` alone is insufficient, and a marker found anywhere in the pane buffer is only a signal. `blocked` and `question` markers route back to the orchestrator/design decision boundary; they are not failures to hide or successes to assume.
+        **Composite success is mandatory:** (1) herdr reports a settled state and pane inspection finds no pending approval/question, (2) the exact `ORCH_RESULT` marker matches the fresh dispatch nonce and status, (3) the named artifact exists and passes the task's verification, and (4) fresh canonical intent-cli/GitHub facts confirm the workflow state. The named artifact verification is the final gate only together with fresh canonical facts. State alone and marker alone NEVER mean task success; in particular, herdr `done` or `idle` alone is insufficient, and a marker found anywhere in the pane buffer is only a signal. `blocked` and `question` markers route back to the orchestrator/design decision boundary; they are not failures to hide or successes to assume.
 
         ## events.jsonl design boundary
 
@@ -150,6 +176,25 @@ internal static class HerdrOnlyOperatingGuide
             ["artifact_first"] = "Files, commits, PRs, and verification logs are the handoff; terminal text points to them.",
             ["redispatch"] = "Use intent-cli notify delegate for the same logical role with the task id plus concrete repair delta.",
         },
+        ["wake_sources"] = new JsonObject
+        {
+            ["notify_report"] = "Primary and most informative: carries task id, status, artifact, and summary, but depends on the worker running the embedded final intent-cli notify report command.",
+            ["state_change"] = new JsonObject
+            {
+                ["role"] = "Normative SECOND wake source; depends only on herdr observation and carries no outcome.",
+                ["measured_version"] = "herdr 0.7.5",
+                ["method"] = "events.subscribe",
+                ["subscription"] = "{\"type\":\"pane.agent_status_changed\",\"pane_id\":\"<resolved-pane-id>\"}",
+                ["cardinality"] = "One subscription entry per watched pane; resolve pane_id from the recorded logical-role mapping and never hard-code it.",
+                ["event"] = "{\"event\":\"pane.agent_status_changed\",\"data\":{\"agent\":\"<agent>\",\"agent_status\":\"<working|idle|done|blocked|unknown>\",\"pane_id\":\"<resolved-pane-id>\",\"workspace_id\":\"<workspace-id>\"}}",
+                ["transition"] = "Wake only on a per-role working-to-settled transition: idle, done, or blocked; initial settled, unknown, and settled-to-settled observations do not wake.",
+                ["settle_and_dedupe"] = "Apply a settle delay and per-role dedupe so one observed working-to-settled transition produces one wake; a new working observation re-arms the role.",
+            },
+            ["semantic_boundary"] = "A state change means only that something happened, never that a task succeeded.",
+            ["composite_check"] = "After every wake from either source, check current herdr state and approval/question pauses + exact fresh-nonce completion marker/status + verified artifact + fresh canonical intent-cli/GitHub facts.",
+            ["last_net"] = "The periodic intent-cli automation stalled-work check remains the last net when neither immediate source produces a usable wake.",
+            ["version_rule"] = "Consult installed herdr help/schema for version-specific details before operating the measured 0.7.5 shape.",
+        },
         ["waiting"] = new JsonObject
         {
             ["agent"] = "herdr agent wait <logical-role> --until idle --until done --until blocked --timeout <milliseconds>",
@@ -157,7 +202,7 @@ internal static class HerdrOnlyOperatingGuide
             ["post_wait_inspection"] = "After every wait return, run herdr pane read --source recent-unwrapped <pane-id> and classify settled, approval/question-paused, or timeout; idle can be approval-paused.",
             ["paused_reentry"] = "For a visible approval/question, apply the G550 MAY/escalate boundary, then re-enter the wake and wait again.",
             ["bounded_rule"] = "Timeouts are re-entry points; never leave a wait unbounded. Persist cursors in deterministic scripts for long loops.",
-            ["success"] = "Composite success requires dialog-free settled state + matching fresh-nonce marker + existing verified artifact; artifact verification is the final gate, and neither state nor marker alone concludes success.",
+            ["success"] = "Composite success requires approval/question-free settled state + matching fresh-nonce marker/status + existing verified artifact + fresh canonical intent-cli/GitHub facts; artifact verification plus canonical facts are the final gate, and neither state nor marker alone concludes success.",
         },
         ["events_jsonl"] = new JsonObject
         {

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -1,0 +1,200 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class HerdrWakeSourcesG581Tests : IDisposable
+{
+    private const string PreG581AgmsgGuideSha256 =
+        "F1ED7A4DE358012BC19B197359DB5163CBC4FF04A8CE744E3A2DA4AD34248406";
+
+    private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
+
+    [Fact]
+    public void HerdrOnlyGuide_PublishesTheNormativeSecondWakeSource_G581()
+    {
+        var markdown = Render(herdrOnly: true, format: "markdown");
+        var operations = JsonDocument.Parse(Render(herdrOnly: true, format: "json"))
+            .RootElement.GetProperty(HerdrOnlyOperatingGuide.JsonProperty);
+        var wakeSources = operations.GetProperty("wake_sources");
+        var stateChange = wakeSources.GetProperty("state_change");
+
+        Assert.Contains("## Herdr-only wake sources", markdown, StringComparison.Ordinal);
+        Assert.Contains("normative SECOND wake source", markdown, StringComparison.Ordinal);
+        Assert.Contains("events.subscribe", markdown, StringComparison.Ordinal);
+        Assert.Contains(
+            "{\"method\":\"events.subscribe\",\"params\":{\"subscriptions\":[{\"type\":\"pane.agent_status_changed\",\"pane_id\":\"<resolved-pane-id>\"}]} }",
+            markdown,
+            StringComparison.Ordinal);
+        Assert.Contains("one subscription entry per watched pane", markdown, StringComparison.Ordinal);
+        Assert.Contains("logical-role→pane mapping", markdown, StringComparison.Ordinal);
+        Assert.Contains("NEVER hard-code pane ids", markdown, StringComparison.Ordinal);
+        Assert.Equal("herdr 0.7.5", stateChange.GetProperty("measured_version").GetString());
+        Assert.Equal("events.subscribe", stateChange.GetProperty("method").GetString());
+        Assert.Contains("One subscription entry per watched pane", stateChange.GetProperty("cardinality").GetString());
+    }
+
+    [Fact]
+    public void StateChangeWake_IsSettledDedupedAndOutcomeNeutral_G581()
+    {
+        var markdown = Render(herdrOnly: true, format: "markdown");
+        var wakeSources = JsonDocument.Parse(Render(herdrOnly: true, format: "json"))
+            .RootElement.GetProperty(HerdrOnlyOperatingGuide.JsonProperty).GetProperty("wake_sources");
+
+        Assert.Contains(
+            "{\"event\":\"pane.agent_status_changed\",\"data\":{\"agent\":\"<agent>\",\"agent_status\":\"<working|idle|done|blocked|unknown>\",\"pane_id\":\"<resolved-pane-id>\",\"workspace_id\":\"<workspace-id>\"} }",
+            markdown,
+            StringComparison.Ordinal);
+        Assert.Contains("transitions from `working` to a settled state (`idle`, `done`, or `blocked`)", markdown, StringComparison.Ordinal);
+        Assert.Contains("Apply a settle delay", markdown, StringComparison.Ordinal);
+        Assert.Contains("per-role dedupe", markdown, StringComparison.Ordinal);
+        Assert.Contains("A newly observed `working` state re-arms that role", markdown, StringComparison.Ordinal);
+        Assert.Contains("means only that something happened, never that a task succeeded", markdown, StringComparison.Ordinal);
+
+        Assert.Contains("working-to-settled", wakeSources.GetProperty("state_change").GetProperty("transition").GetString());
+        Assert.Contains("settle delay and per-role dedupe", wakeSources.GetProperty("state_change").GetProperty("settle_and_dedupe").GetString());
+        Assert.Equal(
+            "A state change means only that something happened, never that a task succeeded.",
+            wakeSources.GetProperty("semantic_boundary").GetString());
+    }
+
+    [Fact]
+    public void EveryWake_RequiresTheCompositeCheckAndKeepsThePeriodicLastNet_G581()
+    {
+        var markdown = Render(herdrOnly: true, format: "markdown");
+        var wakeSources = JsonDocument.Parse(Render(herdrOnly: true, format: "json"))
+            .RootElement.GetProperty(HerdrOnlyOperatingGuide.JsonProperty).GetProperty("wake_sources");
+
+        Assert.Contains("After EVERY wake from either source", markdown, StringComparison.Ordinal);
+        Assert.Contains("current herdr state and pending approval/question", markdown, StringComparison.Ordinal);
+        Assert.Contains("exact fresh-nonce completion marker and status", markdown, StringComparison.Ordinal);
+        Assert.Contains("named verified artifact", markdown, StringComparison.Ordinal);
+        Assert.Contains("fresh canonical intent-cli/GitHub facts", markdown, StringComparison.Ordinal);
+        Assert.Contains("notify report is the richest signal but depends on worker cooperation", markdown, StringComparison.Ordinal);
+        Assert.Contains("state change depends only on herdr observation but carries no outcome", markdown, StringComparison.Ordinal);
+        Assert.Contains("stalled-work ...` check remains the last net", markdown, StringComparison.Ordinal);
+        Assert.Contains("Consult installed herdr help/schema", wakeSources.GetProperty("version_rule").GetString());
+        Assert.Contains("approval/question pauses", wakeSources.GetProperty("composite_check").GetString());
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void OrchestrationDocs_MirrorTheExactWakeContract_G581(string language)
+    {
+        var path = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "docs",
+            language,
+            "12-agent-message-orchestration.md");
+        var content = File.ReadAllText(path);
+
+        foreach (var token in new[]
+                 {
+                     "SECOND wake source",
+                     "events.subscribe",
+                     "pane.agent_status_changed",
+                     "subscription entry",
+                     "<resolved-pane-id>",
+                     "\"agent\"",
+                     "\"agent_status\"",
+                     "\"pane_id\"",
+                     "\"workspace_id\"",
+                     "working",
+                     "idle",
+                     "done",
+                     "blocked",
+                     "settle delay",
+                     "per-role dedupe",
+                     "completion marker",
+                     "artifact",
+                     "canonical intent-cli/GitHub facts",
+                     "approval/question",
+                     "stalled-work",
+                     "herdr 0.7.5",
+                     "installed herdr help/schema",
+                 })
+        {
+            Assert.Contains(token, content, StringComparison.Ordinal);
+        }
+
+        Assert.Contains(
+            "{\"method\":\"events.subscribe\",\"params\":{\"subscriptions\":[{\"type\":\"pane.agent_status_changed\",\"pane_id\":\"<resolved-pane-id>\"}]}}",
+            content,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "{\"event\":\"pane.agent_status_changed\",\"data\":{\"agent\":\"<agent>\",\"agent_status\":\"<working|idle|done|blocked|unknown>\",\"pane_id\":\"<resolved-pane-id>\",\"workspace_id\":\"<workspace-id>\"}}",
+            content,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AgmsgGuide_RemainsByteIdenticalToPreG581Baseline_G581()
+    {
+        var markdown = Render(herdrOnly: false, format: "markdown");
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(markdown)));
+
+        Assert.Equal(PreG581AgmsgGuideSha256, hash);
+        Assert.DoesNotContain("## Herdr-only wake sources", markdown, StringComparison.Ordinal);
+        Assert.DoesNotContain("pane.agent_status_changed", markdown, StringComparison.Ordinal);
+    }
+
+    private string Render(bool herdrOnly, string format)
+    {
+        Directory.CreateDirectory(Path.Combine(root, ".intent-cli"));
+        if (herdrOnly)
+        {
+            File.WriteAllText(
+                SessionLayerModeStore.ResolvePath(root),
+                """
+                {
+                  "schema_version": "1",
+                  "entries": [
+                    {
+                      "domain": "intent-cli",
+                      "mode": "herdr-only",
+                      "updated_at": "2026-08-02T12:00:00+00:00",
+                      "transitions": [
+                        { "from": "agmsg", "to": "herdr-only", "at": "2026-08-02T12:00:00+00:00" }
+                      ]
+                    }
+                  ]
+                }
+                """);
+        }
+
+        var context = new CliContext
+        {
+            RepoRoot = root,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                },
+            },
+        };
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(
+            ["guide", "orchestrator-thread", "--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude", "--format", format],
+            context,
+            writer);
+
+        Assert.Equal(0, exitCode);
+        return writer.ToString();
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make `pane.agent_status_changed` the normative second herdr-only wake source beside `intent-cli notify report`
- pin the measured herdr 0.7.5 `events.subscribe` request and event frame, logical-role pane resolution, working-to-settled gate, settle delay, and per-role dedupe
- require the state + fresh marker/status + verified artifact + fresh canonical intent-cli/GitHub composite check after every wake
- mirror the contract in EN/JA docs while keeping agmsg guide output byte-identical

## Verification
- focused guide/docs/session tests: 191 passed, 0 failed
- full Release suite: 4,602 passed, 1 intentional skip, 0 failed (4,603 total)
- `git diff --check`: clean
- installed surface checked with herdr 0.7.5 help and bundled API schema

## Scope
Contract and documentation only. No subscriber, daemon, new CLI command, notify behavior change, or product runtime behavior is introduced.

Closes #1265