### PR TITLE
G582: close herdr-only trial findings F1-F5

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -256,8 +256,15 @@ review cwd/worktree). Use `herdr workspace create`, `herdr tab create`, or
 the `workspace_created` result has top-level `workspace`, `tab`, and
 `root_pane`; seed the mapping from `workspace.workspace_id`, `tab.tab_id`, and
 `root_pane.pane_id`, and verify `root_pane.cwd`. Record an
-operator-visible logical-role→pane-id/cwd mapping and resolve it before every
-operation; workflows never hard-code pane ids. An external design frontend is
+operator-visible logical-role→pane-id/cwd mapping; workflows never hard-code
+pane/workspace ids. After initial workspace creation returns the first ids,
+every provisioning or mutation command must resolve its explicit non-empty
+pane/workspace target id from that recorded mapping immediately before it runs
+and carry the id on the command. If resolution is missing or empty, fail closed
+and do not run the command: herdr can otherwise focus-default to the currently
+focused pane, including a pane in another team. The existing G555 cross-project
+attribution rules remain authoritative and unchanged; reference them rather
+than inventing another attribution policy. An external design frontend is
 recorded as a reader type rather than fabricated as a pane.
 
 Launch with the typed surface:
@@ -334,8 +341,12 @@ and status, the named verified artifact, and fresh canonical intent-cli/GitHub
 facts. The two sources cover complementary failures: notify report is richest
 but depends on worker cooperation; state change needs only herdr observation but
 carries no outcome. The periodic `intent-cli automation stalled-work ...` check
-is the last net. This measured shape does not replace the standing rule to
-consult installed herdr help/schema for version-specific details.
+is the last net. Its non-informational `approved-not-merged` kind makes an open,
+non-blocked PR carrying `intent-pr-approved` past the configured stale threshold
+actionable even if every immediate wake source failed; it reports age and points
+to the canonical merge-then-`closeout pr` path. This measured shape does not
+replace the standing rule to consult installed herdr help/schema for
+version-specific details.
 
 Every wait is bounded:
 
@@ -379,13 +390,30 @@ events. This mode-independent channel is the design boundary only—never an
 inter-agent bus and never a replacement for `intent-cli notify`, GitHub, or
 intent-cli workflow state.
 
-- Claude app watcher: tail complete unseen lines from the resolved path and
-  retain its offset across restarts.
-- Codex CLI in a herdr pane: use `intent-cli notify delegate` / `report`; do not poll this file for
-  ordinary coordination.
+Every reader persists a durable watermark across watcher restarts containing
+the file identity, byte offset, and complete-line count. Before each read it
+verifies the same identity and that neither byte nor line count moved backwards.
+The durable byte-offset watermark is always paired with that file identity and
+complete-line count; none of the three values is restart-local.
+Rotation, truncation, a backwards count, or file replacement fails closed for
+operator recovery; readers never silently reset to the beginning because replay
+can duplicate a design decision.
+
+- Claude app watcher: tail complete unseen lines after its durable
+  file-identity/byte-offset/complete-line-count watermark, advance only after
+  successful handling, and preserve it across watcher restarts. Rotation,
+  truncation, backwards byte/line count, or file replacement fails closed and
+  never resumes at the beginning.
+- Codex CLI in a herdr pane: use `intent-cli notify delegate` / `report` and do
+  not poll this file for ordinary coordination. When acting as a design-boundary
+  reader, use the same durable restart-surviving watermark and fail closed on
+  rotation, truncation, backwards count, or file replacement—never reset to the
+  beginning.
 - Codex Desktop: poll at a one-minute-class cadence, consume only complete lines
-  after a durable byte-offset watermark, and advance after successful handling.
-  Truncation or malformed JSON fails closed and requires operator recovery.
+  after its durable restart-surviving file-identity/byte-offset/complete-line-count
+  watermark, and advance after successful handling. Rotation, truncation,
+  backwards byte/line count, file replacement, or malformed JSON fails closed
+  and never resets to the beginning.
 
 ### Recovery and mode switches
 
@@ -394,6 +422,12 @@ intent-cli workflow state.
 - Post-reboot dead pty wiring: an undetected agent or shell-only pane requires
   preserving artifacts, re-provisioning, rebuilding the mapping, and repeating
   the self-contained settle-and-re-check READY gate above.
+- Focus-default cross-team mutation: a missing or empty explicit pane/workspace
+  id can mutate the currently focused pane in another team. For every
+  provisioning/mutation command after initial workspace creation, resolve a
+  non-empty id from the recorded logical-role mapping, carry it explicitly, and
+  do not run when resolution fails. Apply the existing G555 attribution rules
+  unchanged.
 - Long-wait turn death: use bounded waits, re-entry, and deterministic persisted
   loops.
 - Dispatch-echo false match: keep the composed wait needle out of the task
@@ -402,10 +436,16 @@ intent-cli workflow state.
 - Approval/question pause reported as idle: inspect the pane after every wait,
   apply the G550 MAY/escalate boundary, and re-enter the wake.
 
+### Session-layer switch checklist
+
 For **agmsg → herdr-only**: drain/park work; gracefully drop roles and stop
-watchers/bridges; provision herdr, its mapping, and the validated events path;
-pass G556 and marker/artifact detection; finally run `intent-cli session-layer
-set --domain <domain> --team <team> --mode herdr-only --write`.
+watchers/bridges. Turn off or remove the outgoing transport's
+per-project agmsg hook configuration and delivery mode, then verify it cannot
+deliver. This is not cosmetic: the observed leftover hook caused the next-launch hook-trust screen
+to block the next Codex launch. Provision herdr, its mapping, and the validated
+events path; pass G556 and marker/artifact detection; finally run
+`intent-cli session-layer set --domain <domain> --team <team> --mode herdr-only
+--write`.
 
 For **herdr-only → agmsg**: drain/park work and append any final design event;
 stop or retain/close the workspace according to operator policy so it cannot

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -244,8 +244,14 @@ cwd/worktree）。インストール済みの `herdr ... --help` に従い、`he
 `workspace_created` result は top-level の `workspace`、`tab`、`root_pane` を返すため、
 `workspace.workspace_id`、`tab.tab_id`、`root_pane.pane_id` から mapping を seed し、
 `root_pane.cwd` を検証します。operator-visible な
-logical-role→pane-id/cwd mapping を記録し、毎操作前に解決します。workflow が pane id を
-hard-code してはいけません。herdr 外の design frontend は架空 pane ではなく reader type
+logical-role→pane-id/cwd mapping を記録し、workflow は pane/workspace id を hard-code
+しません。initial workspace creation が最初の id を返した後、すべての provisioning /
+mutation command は実行直前に記録済み mapping から明示的で空でない pane/workspace
+target id を解決し、command にその id を必ず指定します。解決結果が missing または
+empty なら fail closed とし、command を実行しません。そうしないと herdr が focus-default で
+他チームの currently focused pane を mutate する可能性があります。既存 G555 cross-project
+attribution rules が変わらず authoritative であり、別の attribution policy を再定義せず
+それを reference します。herdr 外の design frontend は架空 pane ではなく reader type
 として記録します。
 
 typed launch は次の surface です。
@@ -318,6 +324,9 @@ artifact、fresh な canonical intent-cli/GitHub facts を確認します。2 �
 notify report は最も情報量が多い一方で worker の協力に依存し、state change は herdr の観測
 だけに依存する一方で outcome を運びません。periodic な
 `intent-cli automation stalled-work ...` check が last net です。この実測 shape は、
+non-informational な `approved-not-merged` kind により、`intent-pr-approved` を持つ
+open かつ non-blocked な PR が configured stale threshold を超えたら、すべての immediate wake
+source が失敗しても age と canonical な merge → `closeout pr` path 付きで actionable にします。
 version-specific details について installed herdr help/schema を確認するという standing rule を
 置き換えません。
 
@@ -358,12 +367,25 @@ design-relevant な completion / blocked / question / escalation だけを書き
 mode-independent channel は design boundary のみで、inter-agent bus ではなく、
 `intent-cli notify`、GitHub、intent-cli workflow state の代替でもありません。
 
-- Claude app watcher: 解決済み path の完全な未読行だけを tail し、restart をまたいで offset
-  を保持します。
-- herdr pane の Codex CLI: `intent-cli notify delegate` / `report` を使い、通常 coordination で file poll しません。
-- Codex Desktop: one-minute-class（約 1 分）cadence で poll し、durable byte-offset watermark より後の
-  完全な行だけを処理し、成功後に watermark を進めます。truncate または malformed JSON は
-  fail closed とし operator recovery を要求します。
+すべての reader は watcher restart をまたいで durable watermark を永続化し、file identity、
+byte offset、complete-line count を保持します。各 read 前に同じ file identity であることと、
+byte / line count が backwards になっていないことを検証します。
+durable byte-offset watermark は必ず file identity と complete-line count と組にし、3 値のどれも
+restart-local にしません。
+rotation、truncation、backwards count、file replacement は operator recovery まで fail closed とします。replay が design
+decision を重複させるため、先頭から silent reset してはいけません。
+
+- Claude app watcher: durable な file-identity/byte-offset/complete-line-count watermark より後の
+  完全な未読行だけを tail し、成功後にのみ進め、watcher restart をまたいで保持します。
+  rotation、truncation、backwards byte/line count、file replacement で fail closed とし、先頭から再開しません。
+- herdr pane の Codex CLI: 通常 coordination では `intent-cli notify delegate` / `report` を使い
+  file poll しません。design-boundary reader として動く場合は同じ durable で restart-surviving
+  watermark を使い、rotation、truncation、backwards count、file replacement で fail closed とし、
+  先頭へ reset しません。
+- Codex Desktop: one-minute-class（約 1 分）cadence で poll し、durable で restart-surviving な
+  file-identity/byte-offset/complete-line-count watermark より後の完全な行だけを処理します。
+  rotation、truncation、backwards byte/line count、file replacement、malformed JSON で fail closed とし、
+  先頭から reset しません。
 
 ### Recovery と mode switch
 
@@ -371,15 +393,24 @@ mode-independent channel は design boundary のみで、inter-agent bus では�
   `agent start ... -- <permission-flags>` を使います。
 - reboot 後の dead pty wiring: undetected agent / shell-only pane では artifact を保全して
   re-provision、mapping 再構築、上記の自己完結した settle-and-re-check READY gate 再実行を行います。
+- focus-default cross-team mutation: 明示的な pane/workspace id が missing / empty だと、他チームの
+  currently focused pane を mutate する可能性があります。initial workspace creation 後の every
+  provisioning/mutation command で記録済み logical-role mapping から non-empty id を解決・明示し、
+  解決失敗時は実行しません。既存 G555 attribution rules を変更せず適用します。
 - long-wait turn death: bounded wait、re-entry、persist された deterministic loop を使います。
 - dispatch-echo false match: composed wait needle を task block に入れず、return 後に pane を
   inspect し、named artifact を独立に検証します。
 - idle と報告された approval/question pause: every wait 後に pane を inspect し、G550 の
   MAY/escalate 境界を適用して wake に re-enter します。
 
-**agmsg → herdr-only**: work を drain/park、role を graceful drop して watcher/bridge を停止、
-herdr・mapping・検証済み events path を provision、G556 と marker/artifact 検出を通し、最後に
-`intent-cli session-layer set --domain <domain> --team <team> --mode herdr-only --write`。
+### Session-layer switch checklist
+
+**agmsg → herdr-only**: work を drain/park、role を graceful drop して watcher/bridge を停止、outgoing
+transport の per-project agmsg hook configuration と delivery mode を turn off または remove し、delivery
+不可を検証します。これは cosmetic ではありません。残存 hook が next-launch hook-trust screen を
+発生させ、次の Codex launch を block した実測事象があります。herdr・mapping・検証済み events
+path を provision、G556 と marker/artifact 検出を通し、最後に `intent-cli session-layer set
+--domain <domain> --team <team> --mode herdr-only --write`。
 
 **herdr-only → agmsg**: work を drain/park して必要な final design event を append、operator
 policy に従って workspace を停止または retain/close し delivery を止め、agmsg role と承認済み

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -33,6 +33,10 @@ namespace IntentSystem.Cli.Commands;
 ///   recommendation mid-repair).</item>
 /// <item><c>merged-not-closed-out</c> — a MERGED PR's linked queue item is
 ///   not <see cref="QueueItemState.Completed"/>.</item>
+/// <item><c>approved-not-merged</c> — an OPEN PR carries
+///   <c>intent-pr-approved</c> past the scan's stale threshold. Reports the
+///   age and canonical merge-then-closeout continuation so the last-net
+///   heartbeat still detects it when every immediate wake source fails.</item>
 /// <item><c>backlog-ready-idle</c> — WIP is empty for the domain (no open PR
 ///   or <c>intent-target</c> issue confirmed for it, each resolved through
 ///   its own closing-issue/packet linkage — a confirmed OTHER-domain PR or
@@ -141,6 +145,14 @@ internal static class AutomationStalledWorkCommand
     public const string KindPublishedNotDelegated = "published-not-delegated";
     public const string KindPrCreatedNotReviewing = "pr-created-not-reviewing";
     public const string KindMergedNotClosedOut = "merged-not-closed-out";
+
+    /// <summary>
+    /// G582: an approved PR is an intermediate workflow state, not completion.
+    /// This actionable kind closes the last-net gap when an open approved PR
+    /// sits past <c>--stale-minutes</c> without any wake source advancing the
+    /// canonical merge and closeout continuation.
+    /// </summary>
+    public const string KindApprovedNotMerged = "approved-not-merged";
 
     /// <summary>
     /// G533: a PR whose source issue carries <c>intent-pr-created</c> but
@@ -473,6 +485,7 @@ internal static class AutomationStalledWorkCommand
         var warnings = new List<string>();
 
         CollectPublishedNotDelegated(context, domain, candidateDomains, openIssues, openPrs, repo, now, items, excluded);
+        CollectApprovedNotMerged(context, domain, candidateDomains, openIssues, openPrs, repo, now, items, excluded, warnings);
         CollectPrCreatedNotReviewing(context, domain, candidateDomains, openIssues, openPrs, repo, now, repairSilentMinutes, items, excluded);
         CollectDraftRepairStalled(context, domain, candidateDomains, openIssues, openPrs, repo, now, repairSilentMinutes, items, excluded);
         CollectMergedNotClosedOut(context, domain, candidateDomains, repo, mergedPrs, now, items, excluded, warnings);
@@ -505,6 +518,129 @@ internal static class AutomationStalledWorkCommand
             Excluded = excluded,
             Warnings = warnings,
         };
+    }
+
+    /// <summary>
+    /// G582 F5: detects the intermediate approved-but-unmerged state using the
+    /// existing global stale threshold. The collector is deliberately silent
+    /// for non-open PRs, a draft that is simultaneously back in request-update,
+    /// and a source unit blocked either on GitHub or in canonical queue-state.
+    /// </summary>
+    private static void CollectApprovedNotMerged(
+        CliContext context,
+        string domain,
+        IReadOnlyList<string> candidateDomains,
+        IReadOnlyList<GitHubAutomationIssueCandidate> openIssues,
+        IReadOnlyList<GitHubAutomationPrCandidate> openPrs,
+        string repo,
+        DateTimeOffset now,
+        List<StalledWorkItem> items,
+        List<StalledWorkExcluded> excluded,
+        List<string> warnings)
+    {
+        var queueState = TryLoadQueueStateForApprovedNotMerged(context, domain, repo, warnings);
+
+        foreach (var pr in openPrs)
+        {
+            if (!IsOpen(pr.State))
+            {
+                continue;
+            }
+
+            var prLabels = LabelSet(pr.Labels);
+            if (!prLabels.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrApproved))
+            {
+                continue;
+            }
+
+            // A draft handed back for updates is a repair wait, not a merge
+            // continuation, even if a stale approved label is still present.
+            if (pr.IsDraft
+                && prLabels.Contains(WorkerPrReviewPreflightConstants.Labels.IntentPrRequestUpdate))
+            {
+                continue;
+            }
+
+            var matchedIssue = pr.ClosingIssuesReferences
+                .Where(reference => reference.Number > 0 && ReferenceMatchesRepo(reference, repo))
+                .Select(reference => openIssues.FirstOrDefault(issue =>
+                    issue.Number == reference.Number && IsOpen(issue.State)))
+                .FirstOrDefault(issue => issue is not null);
+            if (matchedIssue is null)
+            {
+                continue;
+            }
+
+            var issueLabels = LabelSet(matchedIssue.Labels);
+            if (issueLabels.Contains(WorkerNextActionConstants.Labels.IntentIssueBlocked))
+            {
+                continue;
+            }
+
+            var resolution = ResolveExecutionUnit(context, matchedIssue.Title);
+            if (queueState?.Items.FirstOrDefault(candidate =>
+                    string.Equals(candidate.ExecutionUnit, resolution.ExecutionUnit, StringComparison.Ordinal))
+                is { State: QueueItemState.Blocked })
+            {
+                continue;
+            }
+
+            var packetDeclaredDomain = resolution.Corroborated
+                ? ReadPacketDeclaredDomain(context, resolution.ExecutionUnit)
+                : null;
+            if (!TryConfirmDomain(domain, resolution, packetDeclaredDomain, candidateDomains, repo,
+                    out var reason, out var detail))
+            {
+                excluded.Add(new StalledWorkExcluded
+                {
+                    Kind = KindApprovedNotMerged,
+                    ExecutionUnit = resolution.ExecutionUnit,
+                    Issue = new StalledWorkRef { Number = matchedIssue.Number, Url = matchedIssue.Url },
+                    Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
+                    Reason = reason,
+                    Detail = detail,
+                });
+                continue;
+            }
+
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindApprovedNotMerged,
+                ExecutionUnit = resolution.ExecutionUnit,
+                Issue = new StalledWorkRef { Number = matchedIssue.Number, Url = matchedIssue.Url },
+                Pr = new StalledWorkRef { Number = pr.Number, Url = pr.Url },
+                // GitHub updates the PR when the approved label is applied;
+                // this is the same conservative label-age proxy used by the
+                // other post-creation lifecycle kinds.
+                AgeMinutes = ComputeAgeMinutes(pr.UpdatedAt, now),
+                IsInformational = false,
+                RecommendedAction =
+                    $"canonical merge/closeout: merge PR #{pr.Number} through the repository-approved merge "
+                    + "operation, verify merged == true, then run "
+                    + $"intent-cli closeout pr --pr {pr.Number} --repo {repo} --domain {domain} "
+                    + "--pr-merged true --write --format json",
+            });
+        }
+    }
+
+    private static QueueState? TryLoadQueueStateForApprovedNotMerged(
+        CliContext context, string domain, string repo, List<string> warnings)
+    {
+        var queueStateLocation = RuntimeScopedStateResolver.ResolveQueueStatePathForRead(context.RepoRoot, domain, repo);
+        if (!File.Exists(queueStateLocation.Path))
+        {
+            return null;
+        }
+
+        try
+        {
+            return QueueStateSerializer.Deserialize(File.ReadAllText(queueStateLocation.Path));
+        }
+        catch (Exception exception) when (exception is IOException or JsonException or InvalidOperationException)
+        {
+            warnings.Add($"queue-state at '{queueStateLocation.Path}' could not be parsed: {exception.Message}; skipped the approved-not-merged blocked exemption.");
+            return null;
+        }
     }
 
     private static void CollectPublishedNotDelegated(
@@ -2905,8 +3041,8 @@ internal sealed record StalledWorkItem
     /// these kinds carry age for visibility but never recommend a state
     /// transition (<see cref="RecommendedAction"/> is descriptive prose, not
     /// an executable command). <see langword="false"/> for the original
-    /// three actionable kinds, where <see cref="RecommendedAction"/> is
-    /// always a runnable <c>intent-cli</c> command.
+    /// actionable kinds, where <see cref="RecommendedAction"/> names the
+    /// canonical action or runnable <c>intent-cli</c> command.
     /// </summary>
     [JsonPropertyName("is_informational")]
     public required bool IsInformational { get; init; }

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -672,6 +672,7 @@ internal static class GuideOrchestratorThreadCommand
 
         return new OrchestratorThreadGuide
         {
+            SessionLayerSwitchChecklist = SessionLayerSwitchChecklist.Create(),
             SetupIntake = BuildSetupIntake(values, herdrOnly),
             // G570 third repair: the summary is CANON about authority, and it
             // must survive in both modes — but its agmsg phrasing is an
@@ -3682,6 +3683,8 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine(guide.Summary);
         writer.WriteLine();
 
+        SessionLayerSwitchChecklist.WriteMarkdown(writer, guide.SessionLayerSwitchChecklist);
+
         writer.WriteLine("## Mode separation");
         writer.WriteLine();
         writer.WriteLine($"- **timer-loop mode** — {guide.ModeSeparation.TimerLoopMode}");
@@ -4487,6 +4490,9 @@ internal sealed record OrchestratorThreadGuide
     /// <summary>G570: which session-layer transport this guide is rendering for, and how that was decided.</summary>
     [JsonPropertyName("session_layer")]
     public OrchestratorSessionLayer? SessionLayer { get; init; }
+
+    [JsonPropertyName("session_layer_switch_checklist")]
+    public required OrchestratorSessionLayerSwitchChecklist SessionLayerSwitchChecklist { get; init; }
 
     [JsonPropertyName("setup_intake")]
     public required OrchestratorSetupIntake SetupIntake { get; init; }

--- a/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
+++ b/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
@@ -20,7 +20,6 @@ internal static class HerdrOnlyOperatingGuide
         "## Herdr-only bounded waiting and success detection",
         "## events.jsonl design boundary",
         "## Herdr-only failure modes and recovery",
-        "## Session-layer switch checklists",
     ];
 
     public static string RenderMarkdown(IReadOnlyList<string> replacedHeadings)
@@ -43,7 +42,7 @@ internal static class HerdrOnlyOperatingGuide
 
         1. Confirm the installed surface with `herdr workspace --help`, `herdr tab --help`, `herdr pane --help`, and `herdr agent --help`. Use the installed help when a version-specific option is needed.
         2. Create a team workspace with `herdr workspace create --cwd <host-repo> --label <team> --no-focus`. In herdr 0.7.5 its `workspace_created` result has top-level `workspace`, `tab`, and `root_pane`; seed the mapping from `workspace.workspace_id`, `tab.tab_id`, and `root_pane.pane_id`, and verify `root_pane.cwd`. Create role tabs/panes with the role cwd: design and orchestrator use `<host-repo>`, implementation uses `<implementation-repo>`, and review uses its isolated review cwd/worktree. `herdr tab create --workspace <workspace-id> --cwd <role-cwd> --label <logical-role> --no-focus` is the typed tab surface; `herdr pane split --pane <pane-id> --direction right|down --cwd <role-cwd> --no-focus` is available when a split is preferred. Update the mapping from each later tab/pane creation result.
-        3. Record a durable operator-visible mapping of each herdr-resident logical role (`design`, `orchestrator`, `implementation`, `review`) to its current workspace/tab/pane id and cwd. Workflows address the logical role and resolve this mapping at dispatch time; they NEVER hard-code a pane id. A design frontend outside herdr is recorded as the design reader type, not fabricated as a pane.
+        3. Record a durable operator-visible mapping of each herdr-resident logical role (`design`, `orchestrator`, `implementation`, `review`) to its current workspace/tab/pane id and cwd. Workflows address the logical role and NEVER hard-code pane/workspace ids. After the initial workspace creation returns the first ids, every provisioning or mutation command MUST resolve its explicit non-empty pane/workspace target id from this recorded mapping immediately before execution and carry that id on the command. If resolution is missing or empty, fail closed and DO NOT run the command: herdr can otherwise apply a focus-default and mutate the currently focused pane in another team. The existing G555 cross-project attribution rules remain authoritative and unchanged; reference them rather than inventing a second attribution policy. A design frontend outside herdr is recorded as the design reader type, not fabricated as a pane.
         4. Launch the typed agent in the mapped pane with `herdr agent start <logical-role> --kind <claude|codex|...> --pane <pane-id> -- <operator-approved-permission-flags>`. Pass launch and permission flags after `--`; do not inject modifier chords into an interactive prompt. Approvals are NEVER auto-answered: only the G550 MAY-answer classes may be handled, and every other approval is escalated to the operator.
         5. READY is a G556 verified-liveness result, not workspace existence. Approvals surface visibly in the pane and are handled at the supervision boundary, explicitly unlike the agmsg Codex bridge's headless auto-decline. After the startup report, wait a settle delay, then re-check `herdr agent list`, inspect the mapped pane/agent, verify the expected cwd/repository and detected agent kind, and send a bounded ping whose ack is observed in that same pane. An undetected agent, a shell prompt where the agent should be, a mismatched cwd, or no ack is NOT READY; after re-provisioning, repeat this entire settle-and-re-check sequence before declaring READY.
 
@@ -119,37 +118,21 @@ internal static class HerdrOnlyOperatingGuide
 
         Reader recipes:
 
-        1. **Claude app watcher:** resolve the host root and validated team path, then tail complete lines from `<host-repo>/.intent-cli/events/<team>.jsonl`; surface only unseen design-relevant records and retain the read offset across watcher restarts.
-        2. **Codex CLI:** when Codex is a herdr pane, address that logical role through `intent-cli notify delegate` / `report`; it does not poll the file for ordinary coordination. The events file remains available only when that Codex role is acting as a design-boundary reader.
-        3. **Codex Desktop:** run a one-minute-class timer poll. Resolve the host root plus validated team filename on every resumed session, read only complete lines after a durable byte-offset watermark, surface the unseen records, then advance the watermark after successful handling. Rotation/truncation or malformed JSON fails closed and requires operator recovery; it never resets silently and replays decisions.
+        Every reader persists a durable watermark across watcher restarts containing the file identity, byte offset, and complete-line count. Before each read it verifies the same file identity and that neither the byte nor line count moved backwards. Rotation, truncation, a backwards count, or file replacement fails closed for operator recovery; a reader NEVER silently resets to the beginning because replay can duplicate a design decision.
+
+        1. **Claude app watcher:** resolve the host root and validated team path, then tail complete lines after its durable file-identity/byte-offset/complete-line-count watermark; surface only unseen design-relevant records and advance the watermark only after successful handling. The watermark survives watcher restarts; rotation, truncation, a backwards byte/line count, or file replacement fails closed and never resumes at the beginning.
+        2. **Codex CLI:** when Codex is a herdr pane, address that logical role through `intent-cli notify delegate` / `report`; it does not poll the file for ordinary coordination. If that Codex role acts as a design-boundary reader, it uses the same durable file-identity/byte-offset/complete-line-count watermark across restarts and fails closed on rotation, truncation, a backwards count, or file replacement—never a reset to the beginning.
+        3. **Codex Desktop:** run a one-minute-class timer poll. Resolve the host root plus validated team filename on every resumed session, read only complete lines after its durable file-identity/byte-offset/complete-line-count watermark, surface the unseen records, then advance the watermark after successful handling. The watermark survives watcher restarts; rotation, truncation, a backwards byte/line count, file replacement, or malformed JSON fails closed and requires operator recovery; it never resets silently to the beginning and replays decisions.
 
         ## Herdr-only failure modes and recovery
 
         - **Modifier-chord injection / launch corruption:** do not type launch control chords into a live prompt. Re-provision or return the pane to a shell, then use `herdr agent start ... -- <permission-flags>` so flags are part of the typed launch.
         - **Post-reboot dead pty wiring:** a pane may still exist while `herdr agent list` cannot detect the agent or the pane is sitting at a shell. Treat it as `agent-undetected`, preserve artifacts, close/re-provision the affected workspace/panes, rebuild the logical-role mapping, and repeat the self-contained settle-and-re-check READY gate above before READY.
+        - **Focus-default cross-team mutation:** a missing or empty explicit pane/workspace id can make herdr target the currently focused pane, including a pane in another team. For every provisioning/mutation command after initial workspace creation, resolve a non-empty id from the recorded logical-role mapping, include it explicitly, and do not run when resolution fails. Apply the existing G555 attribution rules unchanged.
         - **Long-wait turn death:** replace unbounded `agent wait`/`pane wait-output` calls with bounded timeouts and re-entry. Use deterministic scripts with persisted task id, pane resolution, and watermark for long loops.
         - **Dispatch-echo false match:** never place the composed `ORCH_RESULT <fresh-per-dispatch-nonce>` wait needle in the task block. Use the split prefix/nonce fields, then require pane inspection and independently verified artifact evidence after a match.
         - **Approval/question pause reported as idle:** read the pane after every wait return. Apply the G550 MAY/escalate boundary to the visible dialog and re-enter the wake; `idle` is not completion evidence.
 
-        ## Session-layer switch checklists
-
-        One team runs exactly one session-layer mode at a time. Simultaneous agmsg and herdr-only delivery is a mixed-delivery CONTRACT VIOLATION.
-
-        **agmsg → herdr-only**
-
-        1. Drain or explicitly park every in-flight delegation; record artifacts and unresolved blockers.
-        2. Gracefully drop outgoing agmsg roles and stop their watchers/bridges. Verify no agmsg receiver can still deliver for this team.
-        3. Provision the herdr workspace, role cwds, typed agents, and logical-role→pane mapping above; validate approvals and the events path.
-        4. Pass the self-contained settle-and-re-check READY gate above for every incoming role and verify bounded dispatch/marker/artifact detection.
-        5. As the FINAL canonical step, run `intent-cli session-layer set --domain <domain> --team <team> --mode herdr-only --write`.
-
-        **herdr-only → agmsg**
-
-        1. Drain or explicitly park every in-flight delegation; append any final design-relevant event and record artifacts/blockers.
-        2. Gracefully stop agents or retain/close the outgoing herdr workspace according to the operator's workspace policy; ensure it cannot keep delivering tasks for this team.
-        3. Provision agmsg roles, transport configuration, and any approved watcher/bridge; do not reuse a stale role hold. Keep `events.jsonl` as the mode-independent design boundary, not as an agmsg bus.
-        4. Pass the applicable self-contained G556 settle-and-re-check READY gate and end-to-end delivery ack for every incoming role.
-        5. As the FINAL canonical step, run `intent-cli session-layer set --domain <domain> --team <team> --mode agmsg --write`.
         """;
     }
 
@@ -161,7 +144,8 @@ internal static class HerdrOnlyOperatingGuide
         {
             ["workspace"] = "Create the team workspace and role tabs/panes with role-specific cwds; in herdr 0.7.5 workspace_created returns top-level workspace, tab, and root_pane.",
             ["workspace_result_mapping"] = "Seed from workspace.workspace_id, tab.tab_id, and root_pane.pane_id; verify root_pane.cwd and update from later tab/pane creation results.",
-            ["mapping"] = "Record an operator-visible logical-role-to-current-pane-id-and-cwd mapping; resolve it at dispatch time and never hard-code pane ids.",
+            ["mapping"] = "Record an operator-visible logical-role-to-current-pane-id-and-cwd mapping; never hard-code pane/workspace ids.",
+            ["target_id_rule"] = "After initial workspace creation returns the first ids, every provisioning/mutation command resolves an explicit non-empty pane/workspace target id from the recorded logical-role mapping immediately before execution and carries it on the command; empty or missing resolution fails closed and the command does not run. This prevents herdr focus-default mutation of the currently focused pane in another team and references the unchanged G555 attribution rules.",
             ["typed_launch"] = "herdr agent start <logical-role> --kind <agent-kind> --pane <pane-id> -- <operator-approved-permission-flags>",
             ["approval_boundary"] = "Approvals surface visibly in the pane and are handled at the supervision boundary, unlike the agmsg Codex bridge's headless auto-decline; the G550 MAY/escalate boundary governs.",
             ["ready_gate"] = "READY only after G556 verified liveness: after the startup report, wait a settle delay, then re-check the expected agent/cwd/repo and detected same-pane process before observing a bounded probe response; repeat after re-provisioning.",
@@ -213,24 +197,20 @@ internal static class HerdrOnlyOperatingGuide
             ["append"] = "Orchestrator-only O_APPEND writer; one object per line, no embedded newline, summary normalized to one line.",
             ["schema"] = "timestamp, team, kind, unit, summary, artifact",
             ["kinds"] = new JsonArray("completion", "blocked", "question", "escalation"),
+            ["watermark_invariant"] = "Every reader persists file identity, byte offset, and complete-line count durably across watcher restarts; rotation, truncation, backwards byte/line count, or file replacement fails closed and never resets to the beginning because replay can duplicate a design decision.",
             ["readers"] = new JsonObject
             {
-                ["claude_app"] = "Tail complete unseen lines from the resolved host path and retain the read offset.",
-                ["codex_cli"] = "Use intent-cli notify delegate/report for a herdr-resident Codex role; no file poll for ordinary coordination.",
-                ["codex_desktop"] = "One-minute-class timer poll using a durable byte-offset watermark; fail closed on truncation or malformed JSON.",
+                ["claude_app"] = "Tail complete unseen lines after a durable file-identity/byte-offset/complete-line-count watermark that survives watcher restarts; fail closed on rotation, truncation, backwards count, or file replacement, never reset to the beginning.",
+                ["codex_cli"] = "Use intent-cli notify delegate/report for ordinary coordination; when acting as a design-boundary reader, use the same durable restart-surviving file-identity/byte-offset/complete-line-count watermark and fail closed on rotation, truncation, backwards count, or file replacement, never reset to the beginning.",
+                ["codex_desktop"] = "One-minute-class timer poll using a durable restart-surviving file-identity/byte-offset/complete-line-count watermark; fail closed on rotation, truncation, backwards count, file replacement, or malformed JSON, never reset to the beginning.",
             },
         },
         ["failure_recovery"] = new JsonArray(
             "Modifier-chord injection: relaunch with typed agent-start permission flags.",
             "Post-reboot dead pty: detect agent-undetected panes, re-provision, rebuild mapping, repeat G556.",
+            "Focus-default cross-team mutation: every provisioning/mutation command after initial workspace creation resolves and carries a non-empty explicit pane/workspace id from the recorded mapping; empty resolution fails closed and the command does not run; G555 attribution remains unchanged.",
             "Long-wait turn death: bounded waits, re-entry, and deterministic persisted loops.",
             "Dispatch-echo false match: keep the composed wait needle out of the task block and require independently verified artifact evidence.",
             "Approval/question pause: inspect the pane after every wait return, apply G550 MAY/escalate, and re-enter the wake."),
-        ["switches"] = new JsonObject
-        {
-            ["exclusivity"] = "Exactly one mode per team; mixed delivery is a contract violation.",
-            ["agmsg_to_herdr_only"] = "Drain; gracefully drop roles/bridges; provision herdr; G556 verify; set herdr-only as the final canonical step.",
-            ["herdr_only_to_agmsg"] = "Drain; handle workspace; provision roles/bridge; G556 verify; set agmsg as the final canonical step.",
-        },
     };
 }

--- a/src/IntentSystem.Cli/Commands/SessionLayerCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerCommand.cs
@@ -24,13 +24,13 @@ internal static class SessionLayerCommand
     private const string FormatMarkdown = "markdown";
 
     /// <summary>
-    /// G570: the guide section a switch must be followed by. Its CONTENT ships
-    /// in G571 — this slice makes the mode exist, persist, and route — so the
-    /// pointer names the section without claiming the content is already there.
+    /// G570/G582: the guide section a switch must be followed by. The heading
+    /// is shared with the renderer so the pointer cannot drift from the section
+    /// that is present in both modes.
     /// </summary>
     public const string SwitchChecklistSection =
         "`intent-cli guide orchestrator-thread --domain <domain> --target-repo <owner/repo> --agent <agent>` → "
-        + "\"Session-layer switch checklist\" (herdr-only operating content ships in G571)";
+        + "`" + SessionLayerSwitchChecklist.Heading + "`";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {

--- a/src/IntentSystem.Cli/Commands/SessionLayerSections.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerSections.cs
@@ -130,6 +130,7 @@ internal static class SessionLayerSections
 
         // mode-independent — unchanged in both.
         new("## Session layer", "session_layer", Applicability.ModeIndependent),
+        new(SessionLayerSwitchChecklist.Heading, SessionLayerSwitchChecklist.JsonProperty, Applicability.ModeIndependent),
         new("## Mode separation", "mode_separation", Applicability.ModeIndependent, Descriptive: true),
         new("## Role boundary (design authors; orchestrator coordinates)", "role_boundary", Applicability.ModeIndependent),
         new("## Domain routing — single-domain vs multi-domain", "domain_routing", Applicability.ModeIndependent),
@@ -336,7 +337,7 @@ internal static class SessionLayerSections
         "(herdr-only: the session-layer step described here is agmsg-specific and does not apply; its herdr-only "
         + "counterpart is in the herdr-only operating sections above. The rule stated by this section still binds.)";
 
-    private const string ReplacementHeadingValue = "## Session-layer switch checklist (herdr-only)";
+    private const string ReplacementHeadingValue = "## Herdr-only operating procedures";
 
     public const string ReplacementHeading = ReplacementHeadingValue;
 

--- a/src/IntentSystem.Cli/Commands/SessionLayerSwitchChecklist.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerSwitchChecklist.cs
@@ -1,0 +1,83 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G582: the mode-independent handover checklist. It is deliberately one
+/// model rendered into both markdown and JSON so <c>session-layer show</c>
+/// always points at a section present in the current mode.
+/// </summary>
+internal static class SessionLayerSwitchChecklist
+{
+    public const string Heading = "## Session-layer switch checklist";
+    public const string JsonProperty = "session_layer_switch_checklist";
+
+    public static OrchestratorSessionLayerSwitchChecklist Create() => new()
+    {
+        Exclusivity =
+            "One team runs exactly one session-layer mode at a time. Simultaneous agmsg and herdr-only delivery "
+            + "is a mixed-delivery CONTRACT VIOLATION.",
+        AgmsgToHerdrOnly =
+        [
+            "Drain or explicitly park every in-flight delegation; record artifacts and unresolved blockers.",
+            "Gracefully drop outgoing agmsg roles and stop their watchers/bridges. Turn off or remove the outgoing "
+            + "transport's per-project agmsg hook configuration AND delivery mode, then verify no agmsg receiver can "
+            + "still deliver for this team. This teardown is operationally required: leftover hook configuration "
+            + "caused the observed next-launch hook-trust screen to block the next Codex launch.",
+            "Provision the herdr workspace, role cwds, typed agents, and logical-role-to-pane mapping from the "
+            + "herdr-only operating procedures; validate approvals and the events path.",
+            "Pass the self-contained G556 settle-and-re-check READY gate for every incoming role and verify bounded "
+            + "dispatch/marker/artifact detection.",
+            "As the FINAL canonical step, run `intent-cli session-layer set --domain <domain> --team <team> "
+            + "--mode herdr-only --write`.",
+        ],
+        HerdrOnlyToAgmsg =
+        [
+            "Drain or explicitly park every in-flight delegation; append any final design-relevant event and record "
+            + "artifacts/blockers.",
+            "Gracefully stop agents or retain/close the outgoing herdr workspace according to the operator's "
+            + "workspace policy; ensure it cannot keep delivering tasks for this team.",
+            "Provision agmsg roles, transport configuration, and any approved watcher/bridge; do not reuse a stale "
+            + "role hold. Keep `events.jsonl` as the mode-independent design boundary, not as an agmsg bus.",
+            "Pass the applicable self-contained G556 settle-and-re-check READY gate and end-to-end delivery ack for "
+            + "every incoming role.",
+            "As the FINAL canonical step, run `intent-cli session-layer set --domain <domain> --team <team> "
+            + "--mode agmsg --write`.",
+        ],
+    };
+
+    public static void WriteMarkdown(TextWriter writer, OrchestratorSessionLayerSwitchChecklist checklist)
+    {
+        writer.WriteLine(Heading);
+        writer.WriteLine();
+        writer.WriteLine(checklist.Exclusivity);
+        writer.WriteLine();
+        writer.WriteLine("**agmsg → herdr-only**");
+        writer.WriteLine();
+        WriteSteps(writer, checklist.AgmsgToHerdrOnly);
+        writer.WriteLine("**herdr-only → agmsg**");
+        writer.WriteLine();
+        WriteSteps(writer, checklist.HerdrOnlyToAgmsg);
+    }
+
+    private static void WriteSteps(TextWriter writer, IReadOnlyList<string> steps)
+    {
+        for (var index = 0; index < steps.Count; index++)
+        {
+            writer.WriteLine($"{index + 1}. {steps[index]}");
+        }
+        writer.WriteLine();
+    }
+}
+
+internal sealed record OrchestratorSessionLayerSwitchChecklist
+{
+    [JsonPropertyName("exclusivity")]
+    public required string Exclusivity { get; init; }
+
+    [JsonPropertyName("agmsg_to_herdr_only")]
+    public required IReadOnlyList<string> AgmsgToHerdrOnly { get; init; }
+
+    [JsonPropertyName("herdr_only_to_agmsg")]
+    public required IReadOnlyList<string> HerdrOnlyToAgmsg { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/HerdrOnlyOperatingGuideG571Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrOnlyOperatingGuideG571Tests.cs
@@ -119,6 +119,8 @@ public sealed class HerdrOnlyOperatingGuideG571Tests : IDisposable
         }
 
         Assert.False(json.TryGetProperty(HerdrOnlyOperatingGuide.JsonProperty, out _));
+        Assert.Contains(SessionLayerSwitchChecklist.Heading, markdown, StringComparison.Ordinal);
+        Assert.True(json.TryGetProperty(SessionLayerSwitchChecklist.JsonProperty, out _));
         Assert.Contains("## Terminal-workspace provisioning (G549)", markdown, StringComparison.Ordinal);
         Assert.Contains("## agmsg reply contract", markdown, StringComparison.Ordinal);
     }

--- a/tests/IntentSystem.Cli.Tests/HerdrTrialFindingsG582Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrTrialFindingsG582Tests.cs
@@ -1,0 +1,430 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(AutomationStalledWorkSharedStateCollection.Name)]
+public sealed class HerdrTrialFindingsG582Tests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 2, 18, 0, 0, TimeSpan.Zero);
+    private readonly string root = Directory.CreateTempSubdirectory("herdr-trial-g582-").FullName;
+
+    public HerdrTrialFindingsG582Tests()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = () => FixedNow;
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void F1_SwitchChecklistAndPointerResolveInBothSessionModes(bool herdrOnly)
+    {
+        var (context, markdown, json) = RenderGuide(herdrOnly);
+
+        Assert.Equal(1, Count(markdown, SessionLayerSwitchChecklist.Heading));
+        Assert.True(json.TryGetProperty(SessionLayerSwitchChecklist.JsonProperty, out var checklist));
+        Assert.Equal(5, checklist.GetProperty("agmsg_to_herdr_only").GetArrayLength());
+        Assert.Equal(5, checklist.GetProperty("herdr_only_to_agmsg").GetArrayLength());
+
+        using var writer = new StringWriter();
+        var exitCode = SessionLayerCommand.ExecuteShow(
+            context,
+            ["--domain", "intent-cli", "--team", "intent-cli-dev", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var show = JsonDocument.Parse(writer.ToString());
+        var pointer = show.RootElement.GetProperty("switch_checklist").GetString();
+        Assert.Contains($"`{SessionLayerSwitchChecklist.Heading}`", pointer, StringComparison.Ordinal);
+        Assert.DoesNotContain("ships in G571", pointer, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void F2_AgmsgTeardownRemovesProjectHookAndDeliveryModeAndNamesObservedBlock(bool herdrOnly)
+    {
+        var (_, markdown, json) = RenderGuide(herdrOnly);
+        var checklist = json.GetProperty(SessionLayerSwitchChecklist.JsonProperty);
+        var teardown = checklist.GetProperty("agmsg_to_herdr_only")[1].GetString();
+
+        Assert.Contains("per-project agmsg hook configuration", teardown, StringComparison.Ordinal);
+        Assert.Contains("delivery mode", teardown, StringComparison.Ordinal);
+        Assert.Contains("Turn off or remove", teardown, StringComparison.Ordinal);
+        Assert.Contains("next-launch hook-trust screen", teardown, StringComparison.Ordinal);
+        Assert.Contains("block the next Codex launch", teardown, StringComparison.Ordinal);
+        Assert.Contains(teardown!, markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void F3_HerdrFocusDefaultHazardFailsClosedOnEmptyMappedIdAndReferencesG555()
+    {
+        var (_, markdown, json) = RenderGuide(herdrOnly: true);
+        var operations = json.GetProperty(HerdrOnlyOperatingGuide.JsonProperty);
+        var targetRule = operations.GetProperty("provisioning").GetProperty("target_id_rule").GetString();
+        var recovery = string.Join('\n', operations.GetProperty("failure_recovery")
+            .EnumerateArray().Select(value => value.GetString()));
+
+        foreach (var token in new[]
+                 {
+                     "every provisioning or mutation command MUST resolve",
+                     "explicit non-empty pane/workspace target id",
+                     "recorded mapping",
+                     "fail closed and DO NOT run the command",
+                     "focus-default",
+                     "currently focused pane in another team",
+                     "G555",
+                     "authoritative and unchanged",
+                 })
+        {
+            Assert.Contains(token, markdown, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("every provisioning/mutation command", targetRule, StringComparison.Ordinal);
+        Assert.Contains("command does not run", targetRule, StringComparison.Ordinal);
+        Assert.Contains("G555 attribution rules", targetRule, StringComparison.Ordinal);
+        Assert.Contains("Focus-default cross-team mutation", recovery, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void F4_EveryEventsReaderUsesRestartDurableWatermarkAndFailsClosedWithoutReplay()
+    {
+        var (_, markdown, json) = RenderGuide(herdrOnly: true);
+        var eventsJson = json.GetProperty(HerdrOnlyOperatingGuide.JsonProperty).GetProperty("events_jsonl");
+        var invariant = eventsJson.GetProperty("watermark_invariant").GetString();
+
+        Assert.Contains("file identity, byte offset, and complete-line count", invariant, StringComparison.Ordinal);
+        Assert.Contains("across watcher restarts", invariant, StringComparison.Ordinal);
+        Assert.Contains("replay can duplicate a design decision", invariant, StringComparison.Ordinal);
+
+        foreach (var reader in eventsJson.GetProperty("readers").EnumerateObject())
+        {
+            var recipe = reader.Value.GetString()!;
+            foreach (var token in new[]
+                     {
+                         "durable",
+                         "restart",
+                         "file-identity/byte-offset/complete-line-count",
+                         "rotation",
+                         "truncation",
+                         "backwards",
+                         "file replacement",
+                         "fail closed",
+                         "never reset to the beginning",
+                     })
+            {
+                Assert.Contains(token, recipe, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        Assert.Contains("NEVER silently resets to the beginning", markdown, StringComparison.Ordinal);
+        Assert.Contains("replay can duplicate a design decision", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void F5_ApprovedOpenPastThresholdIsActionableAndHeartbeatCarriesIt()
+    {
+        var context = CreateStalledWorkContext();
+        WritePacket("G582");
+        var issue = BuildIssue(1267, "G582: Close herdr trial findings", "OPEN", "intent-target", "intent-pr-created");
+        var pr = BuildPr(1268, "G582: Close herdr trial findings", "OPEN", 1267,
+            FixedNow.AddMinutes(-90), false, "intent-pr-approved");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister([issue], [pr]);
+
+        using var stalledWriter = new StringWriter();
+        var stalledExit = AutomationStalledWorkCommand.Execute(
+            context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--stale-minutes", "45", "--format", "json"],
+            stalledWriter);
+
+        Assert.Equal(0, stalledExit);
+        using var stalled = JsonDocument.Parse(stalledWriter.ToString());
+        var item = Assert.Single(stalled.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindApprovedNotMerged, item.GetProperty("kind").GetString());
+        Assert.Equal(90, item.GetProperty("age_minutes").GetInt32());
+        Assert.False(item.GetProperty("is_informational").GetBoolean());
+        Assert.Contains("merge PR #1268", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+        Assert.Contains("closeout pr --pr 1268", item.GetProperty("recommended_action").GetString(), StringComparison.Ordinal);
+
+        using var heartbeatWriter = new StringWriter();
+        var heartbeatExit = AutomationHeartbeatCommand.Execute(
+            context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--stale-minutes", "45", "--format", "json"],
+            heartbeatWriter);
+
+        Assert.Equal(0, heartbeatExit);
+        using var heartbeat = JsonDocument.Parse(heartbeatWriter.ToString());
+        Assert.Contains(
+            AutomationStalledWorkCommand.KindApprovedNotMerged,
+            heartbeat.RootElement.GetProperty("message_body").GetString(),
+            StringComparison.Ordinal);
+        Assert.Equal(
+            AutomationStalledWorkCommand.KindApprovedNotMerged,
+            Assert.Single(heartbeat.RootElement.GetProperty("items").EnumerateArray()).GetProperty("kind").GetString());
+    }
+
+    [Fact]
+    public void F5_MergedClosedDraftRequestUpdateAndGithubBlockedCandidatesStaySilent()
+    {
+        var context = CreateStalledWorkContext();
+        var issues = new List<GitHubAutomationIssueCandidate>();
+        var prs = new List<GitHubAutomationPrCandidate>();
+
+        AddCandidate("G583", 1280, 1281, "MERGED", isDraft: false, issueBlocked: false, ["intent-pr-approved"]);
+        AddCandidate("G584", 1282, 1283, "CLOSED", isDraft: false, issueBlocked: false, ["intent-pr-approved"]);
+        AddCandidate("G585", 1284, 1285, "OPEN", isDraft: true, issueBlocked: false,
+            ["intent-pr-approved", "intent-pr-request-update"]);
+        AddCandidate("G586", 1286, 1287, "OPEN", isDraft: false, issueBlocked: true, ["intent-pr-approved"]);
+
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues, prs);
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--stale-minutes", "45", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var result = JsonDocument.Parse(writer.ToString());
+        Assert.DoesNotContain(
+            result.RootElement.GetProperty("items").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindApprovedNotMerged);
+
+        void AddCandidate(
+            string unit,
+            int issueNumber,
+            int prNumber,
+            string prState,
+            bool isDraft,
+            bool issueBlocked,
+            string[] prLabels)
+        {
+            WritePacket(unit);
+            var issueLabels = issueBlocked
+                ? new[] { "intent-target", "intent-pr-created", "intent-issue-blocked" }
+                : new[] { "intent-target", "intent-pr-created" };
+            issues.Add(BuildIssue(issueNumber, $"{unit}: exclusion", "OPEN", issueLabels));
+            prs.Add(BuildPr(prNumber, $"{unit}: exclusion", prState, issueNumber,
+                FixedNow.AddMinutes(-90), isDraft, prLabels));
+        }
+    }
+
+    [Fact]
+    public void F5_QueueBlockedUnitStaysSilent()
+    {
+        var context = CreateStalledWorkContext();
+        WritePacket("G587");
+        File.WriteAllText(
+            context.GetQueueStatePath(),
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-08-02T16:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G587",
+                  "title": "G587 blocked",
+                  "state": "blocked",
+                  "dependencies": [],
+                  "blocked_by": ["operator decision"],
+                  "clarification_return_path": "",
+                  "packet_paths": {"implementation":"a","review_context":"b","yaml":"c"},
+                  "linked_issue": null,
+                  "linked_pr": null,
+                  "worker_role": "implementation",
+                  "review_role": "review",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        var issue = BuildIssue(1288, "G587: blocked", "OPEN", "intent-target", "intent-pr-created");
+        var pr = BuildPr(1289, "G587: blocked", "OPEN", 1288,
+            FixedNow.AddMinutes(-90), false, "intent-pr-approved");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister([issue], [pr]);
+
+        using var writer = new StringWriter();
+        AutomationStalledWorkCommand.Execute(
+            context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--stale-minutes", "45", "--format", "json"],
+            writer);
+
+        using var result = JsonDocument.Parse(writer.ToString());
+        Assert.DoesNotContain(
+            result.RootElement.GetProperty("items").EnumerateArray(),
+            item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindApprovedNotMerged);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void EnJaDocsPinAllFiveFindingsAndPreserveG581WakeContract(string language)
+    {
+        var content = File.ReadAllText(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "12-agent-message-orchestration.md"));
+
+        foreach (var token in new[]
+                 {
+                     "Session-layer switch checklist",
+                     "per-project agmsg hook configuration",
+                     "delivery mode",
+                     "next-launch hook-trust screen",
+                     "focus-default",
+                     "currently focused pane",
+                     "G555",
+                     "file identity",
+                     "complete-line count",
+                     "backwards",
+                     "file replacement",
+                     "approved-not-merged",
+                     "merge",
+                     "closeout pr",
+                     "SECOND wake source",
+                     "pane.agent_status_changed",
+                     "intent-cli notify report",
+                 })
+        {
+            Assert.Contains(token, content, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private (CliContext Context, string Markdown, JsonElement Json) RenderGuide(bool herdrOnly)
+    {
+        var guideRoot = Path.Combine(root, $"guide-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(guideRoot, ".intent-cli"));
+        var context = ContextFor(guideRoot);
+        if (herdrOnly)
+        {
+            File.WriteAllText(
+                SessionLayerModeStore.ResolvePath(guideRoot),
+                """
+                {
+                  "schema_version": "1",
+                  "entries": [
+                    {
+                      "domain": "intent-cli",
+                      "team": "intent-cli-dev",
+                      "mode": "herdr-only",
+                      "updated_at": "2026-08-02T12:00:00+00:00",
+                      "transitions": [
+                        { "from": "agmsg", "to": "herdr-only", "at": "2026-08-02T12:00:00+00:00" }
+                      ]
+                    }
+                  ]
+                }
+                """);
+        }
+
+        var arguments = new[]
+        {
+            "guide", "orchestrator-thread", "--domain", "intent-cli", "--team", "intent-cli-dev",
+            "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude",
+        };
+        using var markdownWriter = new StringWriter();
+        Assert.Equal(0, CommandRouter.Execute([.. arguments, "--format", "markdown"], context, markdownWriter));
+        using var jsonWriter = new StringWriter();
+        Assert.Equal(0, CommandRouter.Execute([.. arguments, "--format", "json"], context, jsonWriter));
+        using var json = JsonDocument.Parse(jsonWriter.ToString());
+        return (context, markdownWriter.ToString(), json.RootElement.Clone());
+    }
+
+    private CliContext CreateStalledWorkContext()
+    {
+        Directory.CreateDirectory(Path.Combine(root, ".intent-cli"));
+        return ContextFor(root);
+    }
+
+    private static CliContext ContextFor(string repoRoot) => new()
+    {
+        RepoRoot = repoRoot,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private void WritePacket(string executionUnit)
+    {
+        var directory = Path.Combine(root, ".intent-cli", "issues", executionUnit);
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "packet.yaml"), $"domain: intent-cli\nsource_execution_unit: {executionUnit}\n");
+    }
+
+    private static GitHubAutomationIssueCandidate BuildIssue(
+        int number,
+        string title,
+        string state,
+        params string[] labels) => new()
+        {
+            Number = number,
+            Title = title,
+            Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{number}",
+            CreatedAt = FixedNow.AddHours(-4).ToString("O"),
+            UpdatedAt = FixedNow.AddMinutes(-90).ToString("O"),
+            State = state,
+            Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+        };
+
+    private static GitHubAutomationPrCandidate BuildPr(
+        int number,
+        string title,
+        string state,
+        int closingIssue,
+        DateTimeOffset updatedAt,
+        bool isDraft,
+        params string[] labels) => new()
+        {
+            Number = number,
+            Title = title,
+            Url = $"https://github.com/J-Tech-Japan/intent-system/pull/{number}",
+            CreatedAt = FixedNow.AddHours(-4).ToString("O"),
+            UpdatedAt = updatedAt.ToString("O"),
+            State = state,
+            IsDraft = isDraft,
+            Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+            ClosingIssuesReferences =
+            [
+                new GitHubPrClosingIssueReference
+                {
+                    Number = closingIssue,
+                    Repository = new GitHubPrClosingIssueRepository
+                    {
+                        Name = "intent-system",
+                        Owner = new GitHubPrClosingIssueRepositoryOwner { Login = "J-Tech-Japan" },
+                    },
+                },
+            ],
+        };
+
+    private static int Count(string value, string token) =>
+        (value.Length - value.Replace(token, string.Empty, StringComparison.Ordinal).Length) / token.Length;
+
+    public void Dispose()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = null;
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private sealed class FakeLister(
+        IReadOnlyList<GitHubAutomationIssueCandidate> issues,
+        IReadOnlyList<GitHubAutomationPrCandidate> prs) : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo, IReadOnlyCollection<string> requiredLabels) => prs;
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo, IReadOnlyCollection<string> requiredLabels) => issues;
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -133,14 +133,24 @@ public sealed class HerdrWakeSourcesG581Tests : IDisposable
     }
 
     [Fact]
-    public void AgmsgGuide_RemainsByteIdenticalToPreG581Baseline_G581()
+    public void AgmsgGuide_OutsideG582SwitchChecklist_RemainsByteIdenticalToPreG581Baseline_G581()
     {
         var markdown = Render(herdrOnly: false, format: "markdown");
-        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(markdown)));
+        var withoutG582Checklist = WithoutSection(markdown, SessionLayerSwitchChecklist.Heading);
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(withoutG582Checklist)));
 
         Assert.Equal(PreG581AgmsgGuideSha256, hash);
         Assert.DoesNotContain("## Herdr-only wake sources", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("pane.agent_status_changed", markdown, StringComparison.Ordinal);
+    }
+
+    private static string WithoutSection(string markdown, string heading)
+    {
+        var start = markdown.IndexOf(heading, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"missing section {heading}");
+        var end = markdown.IndexOf("\n## ", start + heading.Length, StringComparison.Ordinal);
+        Assert.True(end > start, $"section {heading} must be followed by another section");
+        return markdown[..start] + markdown[(end + 1)..];
     }
 
     private string Render(bool herdrOnly, string format)

--- a/tests/IntentSystem.Cli.Tests/SessionLayerModeG570Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerModeG570Tests.cs
@@ -147,9 +147,8 @@ public sealed class SessionLayerModeG570Tests : IDisposable
 
         var checklist = result.GetProperty("switch_checklist").GetString()!;
         Assert.Contains("guide orchestrator-thread", checklist, StringComparison.Ordinal);
-        Assert.Contains("Session-layer switch checklist", checklist, StringComparison.Ordinal);
-        // The pointer is honest about where the content lives: G571 ships it.
-        Assert.Contains("G571", checklist, StringComparison.Ordinal);
+        Assert.Contains(SessionLayerSwitchChecklist.Heading, checklist, StringComparison.Ordinal);
+        Assert.DoesNotContain("ships in G571", checklist, StringComparison.OrdinalIgnoreCase);
     }
 
     // ------------------------------------------------------------- the routing
@@ -274,6 +273,13 @@ public sealed class SessionLayerModeG570Tests : IDisposable
         var values = new List<string>();
         foreach (var property in document.RootElement.Clone().EnumerateObject())
         {
+            // G582's mode-independent switch checklist intentionally names
+            // BOTH transports in both modes. It is the handover boundary,
+            // not an instruction to operate agmsg in herdr-only.
+            if (property.Name == SessionLayerSwitchChecklist.JsonProperty)
+            {
+                continue;
+            }
             CollectStringValues(property.Value, path: property.Name, values);
         }
 
@@ -1924,7 +1930,8 @@ public sealed class SessionLayerModeG570Tests : IDisposable
             {
                 inSessionLayerSection =
                     line.StartsWith("## Session layer", StringComparison.Ordinal)
-                    || line.StartsWith(SessionLayerSections.ReplacementHeading, StringComparison.Ordinal);
+                    || line.StartsWith(SessionLayerSections.ReplacementHeading, StringComparison.Ordinal)
+                    || line.StartsWith(SessionLayerSwitchChecklist.Heading, StringComparison.Ordinal);
             }
 
             // The switch-checklist section is exempt for the same reason as the


### PR DESCRIPTION
## Summary
- Render one canonical Session-layer switch checklist in agmsg and herdr-only modes, with the session-layer pointer derived from the exact heading.
- Require outgoing per-project agmsg hook and delivery-mode teardown, including the observed next-launch hook-trust-screen blocker.
- Add fail-closed explicit herdr target-id guidance, restart-durable events reader watermarks, and EN/JA parity.
- Add the non-informational approved-not-merged stalled-work kind with GitHub/queue blocked exclusions and heartbeat propagation.

## Verification
- Focused G582/G581/G571 plus G570 isolation guard: 45 passed, 0 failed.
- Full G570 session-layer suite: 139 passed, 0 failed.
- Full CLI Release suite: 4283 passed, 1 pre-existing skipped, 0 failed.
- Release build: succeeded with 0 warnings and 0 errors.
- Full Release solution suite: 4613 passed, 1 pre-existing skipped, 0 failed.
- dotnet format verification passed for all changed C# files except the pre-existing unrelated whitespace baseline in SessionLayerModeG570Tests; the changed G570 assertions compile and pass all 139 tests.
- git diff --check: clean.

## Contract demos
- Both rendered modes contain exactly one matching checklist and the show pointer resolves to it.
- Every events reader JSON recipe independently asserts file identity, byte offset, complete-line count, restart survival, and fail-closed rotation/truncation/backwards/replacement handling.
- approved + open + 90 minutes emits age 90, is_informational false, canonical merge/closeout guidance, and the same heartbeat item.
- merged, closed, draft-with-request-update, GitHub-blocked, and queue-blocked fixtures emit no approved-not-merged item.
- G581 wake-source tests and the notify suite remain green; agmsg output outside the new checklist stays byte-identical to its pre-G581 baseline.

Closes #1267