### PR TITLE
G583: enforce warning-free builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>10.0</AnalysisLevel>
+  </PropertyGroup>
+</Project>

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -4476,10 +4476,10 @@ internal sealed record OrchestratorSetupInputs
     public string? ReviewerAgent { get; init; }
 
     [JsonPropertyName("team")]
-    public required string Team { get; init; }
+    public required string? Team { get; init; }
 
     [JsonPropertyName("delivery_mode")]
-    public required string DeliveryMode { get; init; }
+    public required string? DeliveryMode { get; init; }
 
     [JsonPropertyName("existing_loop_policy")]
     public string? ExistingLoopPolicy { get; init; }

--- a/src/IntentSystem.Cli/Commands/QueueDispatchCommandResult.cs
+++ b/src/IntentSystem.Cli/Commands/QueueDispatchCommandResult.cs
@@ -4,7 +4,7 @@ internal sealed record QueueDispatchCommandResult
 {
     public required string ExecutionUnit { get; init; }
 
-    public required string LinkedIssueUrl { get; init; }
+    public required string? LinkedIssueUrl { get; init; }
 
     public required bool ReusedExistingIssue { get; init; }
 }

--- a/src/IntentSystem.Supervisor/QueueStatePersistence.cs
+++ b/src/IntentSystem.Supervisor/QueueStatePersistence.cs
@@ -671,7 +671,7 @@ public sealed record QueueStatePersistResult
         ReappliedExecutionUnits = Array.Empty<string>(),
     };
 
-    public static QueueStatePersistResult Reapplied(QueueState state, IReadOnlyList<string> units) => new()
+    public static QueueStatePersistResult Reapplied(QueueState? state, IReadOnlyList<string> units) => new()
     {
         PersistedState = state,
         ReappliedOnFreshBase = true,

--- a/tests/IntentSystem.Cli.Tests/AutomationReconcileCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationReconcileCommandTests.cs
@@ -515,16 +515,16 @@ public sealed class AutomationReconcileCommandTests : IDisposable
         Assert.Equal(0, exitCode);
         var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
 
-        var linkedPrRepair = Assert.Single(result.SafeRepairs.Where(r =>
-            string.Equals(r.Type, AutomationReconcileRepairTypes.MissingLinkedPrMetadata, StringComparison.Ordinal)));
+        var linkedPrRepair = Assert.Single(result.SafeRepairs, r =>
+            string.Equals(r.Type, AutomationReconcileRepairTypes.MissingLinkedPrMetadata, StringComparison.Ordinal));
         Assert.Equal(AutomationReconcileConfidence.High, linkedPrRepair.Confidence);
         Assert.Equal("queue-state", linkedPrRepair.TargetKind);
         Assert.Equal("G284", linkedPrRepair.QueueStateExecutionUnit);
         Assert.Equal(492, linkedPrRepair.PrNumberToLink);
         Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/492", linkedPrRepair.QueueStateLinkedPrUrl);
         Assert.False(linkedPrRepair.Applied);
-        Assert.Empty(result.UnsafeStops.Where(s =>
-            string.Equals(s.Kind, AutomationReconcileUnsafeStopKinds.AmbiguousQueueLinkage, StringComparison.Ordinal)));
+        Assert.DoesNotContain(result.UnsafeStops, s =>
+            string.Equals(s.Kind, AutomationReconcileUnsafeStopKinds.AmbiguousQueueLinkage, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -556,8 +556,8 @@ public sealed class AutomationReconcileCommandTests : IDisposable
 
         Assert.Equal(0, exitCode);
         var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
-        var linkedPrRepair = Assert.Single(result.SafeRepairs.Where(r =>
-            string.Equals(r.Type, AutomationReconcileRepairTypes.MissingLinkedPrMetadata, StringComparison.Ordinal)));
+        var linkedPrRepair = Assert.Single(result.SafeRepairs, r =>
+            string.Equals(r.Type, AutomationReconcileRepairTypes.MissingLinkedPrMetadata, StringComparison.Ordinal));
         Assert.True(linkedPrRepair.Applied);
 
         var patched = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
@@ -598,8 +598,8 @@ public sealed class AutomationReconcileCommandTests : IDisposable
 
         Assert.Equal(0, exitCode);
         var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
-        var stop = Assert.Single(result.UnsafeStops.Where(s =>
-            string.Equals(s.Kind, AutomationReconcileUnsafeStopKinds.AmbiguousQueueLinkage, StringComparison.Ordinal)));
+        var stop = Assert.Single(result.UnsafeStops, s =>
+            string.Equals(s.Kind, AutomationReconcileUnsafeStopKinds.AmbiguousQueueLinkage, StringComparison.Ordinal));
         Assert.Equal(491, stop.TargetNumber);
         Assert.Contains("G284-a", stop.Reason, StringComparison.Ordinal);
         Assert.Contains("G284-b", stop.Reason, StringComparison.Ordinal);
@@ -802,8 +802,8 @@ public sealed class AutomationReconcileCommandTests : IDisposable
 
         Assert.Equal(0, exitCode);
         var result = JsonSerializer.Deserialize<AutomationReconcileResult>(writer.ToString())!;
-        var advisory = Assert.Single(result.SafeRepairs.Where(r =>
-            string.Equals(r.Type, AutomationReconcileRepairTypes.MissingLinkedPrMetadata, StringComparison.Ordinal)));
+        var advisory = Assert.Single(result.SafeRepairs, r =>
+            string.Equals(r.Type, AutomationReconcileRepairTypes.MissingLinkedPrMetadata, StringComparison.Ordinal));
         Assert.Equal(AutomationReconcileConfidence.Advisory, advisory.Confidence);
         Assert.NotNull(advisory.RequiresFollowupCommand);
         Assert.Contains("intent-cli closeout pr", advisory.RequiresFollowupCommand!, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/GuideCoherenceG563Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideCoherenceG563Tests.cs
@@ -161,8 +161,8 @@ public sealed class GuideCoherenceG563Tests
         // planners, so the carve-out has to live on the entry itself rather
         // than on each consumer.
         var entry = Assert.Single(
-            GuidanceProhibitionCatalog.All.Where(p =>
-                string.Equals(p.Id, GuidanceProhibitionCatalog.SkillFallbackForbidden, StringComparison.Ordinal)));
+            GuidanceProhibitionCatalog.All,
+            p => string.Equals(p.Id, GuidanceProhibitionCatalog.SkillFallbackForbidden, StringComparison.Ordinal));
 
         Assert.Contains(DispatcherSkillCarveOut.Sentence, entry.Description, StringComparison.Ordinal);
     }
@@ -179,9 +179,8 @@ public sealed class GuideCoherenceG563Tests
 
         using var document = JsonDocument.Parse(writer.ToString());
         var skill = Assert.Single(
-            document.RootElement.GetProperty("groups")
-                .EnumerateArray()
-                .Where(g => string.Equals(g.GetProperty("name").GetString(), "skill", StringComparison.Ordinal)));
+            document.RootElement.GetProperty("groups").EnumerateArray(),
+            g => string.Equals(g.GetProperty("name").GetString(), "skill", StringComparison.Ordinal));
 
         var purpose = skill.GetProperty("purpose").GetString()!;
         Assert.Contains("intent-cli skill list", purpose, StringComparison.Ordinal);
@@ -197,9 +196,9 @@ public sealed class GuideCoherenceG563Tests
         // The skill row is the first purpose containing `|` (the --target
         // alternatives). Unescaped, it silently splits into extra columns.
         var output = Render(["guide", "commands", "list"]);
-        var row = Assert.Single(output
-            .Split('\n')
-            .Where(line => line.StartsWith("| skill ", StringComparison.Ordinal)));
+        var row = Assert.Single(
+            output.Split('\n'),
+            line => line.StartsWith("| skill ", StringComparison.Ordinal));
 
         // A well-formed 6-column row is `|`+6 cells+`|`, so splitting on
         // UNESCAPED pipes yields 8 parts (two empties at the ends). Before the

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2494,7 +2494,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("read-only", attribution.GetProperty("unverifiable_is_read_only").GetString(), StringComparison.OrdinalIgnoreCase);
 
         Assert.Contains("G521", isolation.GetProperty("team_exclusive_role_folders").GetString(), StringComparison.Ordinal);
-        Assert.NotEmpty(isolation.GetProperty("one_workspace_per_team").GetString());
+        Assert.NotEmpty(Assert.IsType<string>(isolation.GetProperty("one_workspace_per_team").GetString()));
 
         // AC: EXACTLY four substrates, each with a sharing unit and an
         // ownership rule — the table is the whole set, so a fifth row or a
@@ -2597,7 +2597,7 @@ public sealed class GuideOrchestratorThreadCommandTests
             .GetProperty("verified_liveness");
 
         Assert.Contains("report alone", liveness.GetProperty("report_is_not_readiness").GetString(), StringComparison.Ordinal);
-        Assert.NotEmpty(liveness.GetProperty("settle_delay").GetString());
+        Assert.NotEmpty(Assert.IsType<string>(liveness.GetProperty("settle_delay").GetString()));
 
         // EXACTLY three post-report checks, each with a verification method —
         // the set is the contract, so a missing one would weaken readiness.

--- a/tests/IntentSystem.Cli.Tests/IntentAnalyzeTreeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentAnalyzeTreeCommandTests.cs
@@ -462,7 +462,7 @@ public sealed class IntentAnalyzeTreeCommandTests
         Assert.Equal(0, exitCode);
         using var document = System.Text.Json.JsonDocument.Parse(writer.ToString());
         var coverage = document.RootElement.GetProperty("facet_coverage");
-        Assert.Equal(0, coverage.EnumerateObject().Count());
+        Assert.Empty(coverage.EnumerateObject());
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IntentInitTreeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentInitTreeCommandTests.cs
@@ -137,7 +137,7 @@ public sealed class IntentInitTreeCommandTests
         var resolution = NextSliceDomainBindingsExecutionUnitRegex.Resolve(context, "auth");
         Assert.Equal(ExecutionUnitRegexResolutionKind.Present, resolution.Kind);
         Assert.NotNull(resolution.Regex);
-        Assert.True(resolution.Regex!.IsMatch("any-execution-unit-id"));
+        Assert.Matches(resolution.Regex!, "any-execution-unit-id");
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -3575,8 +3575,8 @@ public sealed class IntentNextSliceCommandTests
 
             Assert.NotNull(regex);
             // Parent regex matches `G42`; child's `^SKS-G[0-9]+$` would NOT.
-            Assert.True(regex!.IsMatch("G42"));
-            Assert.False(regex.IsMatch("SKS-G42"));
+            Assert.Matches(regex!, "G42");
+            Assert.DoesNotMatch(regex, "SKS-G42");
         }
         finally
         {
@@ -3618,7 +3618,7 @@ public sealed class IntentNextSliceCommandTests
             var regex = NextSliceDomainBindingsExecutionUnitRegex.TryLoad(context, "intent-cli");
 
             Assert.NotNull(regex);
-            Assert.True(regex!.IsMatch("SKS-G42"));
+            Assert.Matches(regex!, "SKS-G42");
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/InterviewCompileAndDraftCommandsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/InterviewCompileAndDraftCommandsTests.cs
@@ -111,7 +111,7 @@ public sealed class InterviewCompileAndDraftCommandsTests
     public void DraftFromInterview_Write_CreatesDraftFile()
     {
         using var workspace = new InterviewSessionWorkspace();
-        workspace.SeedSession("intent-cli", "alpha", new[]
+        workspace.SeedSession("intent-cli", "alpha", new (string Id, string Prompt, string? Answer)[]
         {
             (Id: "q1", Prompt: "Goal?", Answer: "deterministic CLI")
         });

--- a/tests/IntentSystem.Cli.Tests/InterviewSessionCommandsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/InterviewSessionCommandsTests.cs
@@ -38,7 +38,7 @@ public sealed class InterviewSessionCommandsTests
     public void NextQuestion_GivenAllAnswered_ReportsHasPendingFalse()
     {
         using var workspace = new InterviewSessionWorkspace();
-        workspace.SeedSession("intent-cli", "alpha", new[]
+        workspace.SeedSession("intent-cli", "alpha", new (string Id, string Prompt, string? Answer)[]
         {
             (Id: "q1", Prompt: "Done?", Answer: "yes")
         });

--- a/tests/IntentSystem.Cli.Tests/MigrateHostStateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/MigrateHostStateCommandTests.cs
@@ -31,8 +31,8 @@ public sealed class MigrateHostStateCommandTests : IDisposable
     {
         using var workspace = new MigrateWorkspace();
         workspace.WriteLegacyQueueState(BuildQueueState(
-            ("G331", "review", linkedIssue: ("J-Tech-Japan/intent-system", 765)),
-            ("OTHER", "queued", linkedIssue: ("J-Tech-Japan/Sekiban", 1))));
+            ("G331", "review", LinkedIssue: ("J-Tech-Japan/intent-system", 765)),
+            ("OTHER", "queued", LinkedIssue: ("J-Tech-Japan/Sekiban", 1))));
         workspace.WriteLegacyRuns(new[]
         {
             BuildRunLine("G331", "pr-merged", "J-Tech-Japan/intent-system")
@@ -76,8 +76,8 @@ public sealed class MigrateHostStateCommandTests : IDisposable
         // host owns J-Tech-Japan/intent-system review runtime state.
         using var workspace = new MigrateWorkspace();
         workspace.WriteLegacyQueueState(BuildQueueState(
-            ("G331", "review", linkedIssue: ("J-Tech-Japan/intent-system", 765)),
-            ("OTHER", "queued", linkedIssue: ("J-Tech-Japan/Sekiban", 1))));
+            ("G331", "review", LinkedIssue: ("J-Tech-Japan/intent-system", 765)),
+            ("OTHER", "queued", LinkedIssue: ("J-Tech-Japan/Sekiban", 1))));
         workspace.WriteLegacyRuns(new[]
         {
             BuildRunLine("G331", "pr-merged", "J-Tech-Japan/intent-system"),
@@ -130,8 +130,8 @@ public sealed class MigrateHostStateCommandTests : IDisposable
         // Sekiban items in the legacy file.
         using var workspace = new MigrateWorkspace();
         workspace.WriteLegacyQueueState(BuildQueueState(
-            ("G331", "queued", linkedIssue: ("J-Tech-Japan/intent-system", 765)),
-            ("SEKI-1", "queued", linkedIssue: ("J-Tech-Japan/SekibanAsAService", 99))));
+            ("G331", "queued", LinkedIssue: ("J-Tech-Japan/intent-system", 765)),
+            ("SEKI-1", "queued", LinkedIssue: ("J-Tech-Japan/SekibanAsAService", 99))));
         var legacyBefore = File.ReadAllText(workspace.LegacyQueuePath);
 
         using var writer = new StringWriter();
@@ -176,7 +176,7 @@ public sealed class MigrateHostStateCommandTests : IDisposable
         // not duplicate them.
         using var workspace = new MigrateWorkspace();
         workspace.WriteLegacyQueueState(BuildQueueState(
-            ("G331", "review", linkedIssue: ("J-Tech-Japan/intent-system", 765))));
+            ("G331", "review", LinkedIssue: ("J-Tech-Japan/intent-system", 765))));
         workspace.WriteLegacyRuns(new[]
         {
             BuildRunLine("G331", "pr-merged", "J-Tech-Japan/intent-system")
@@ -244,7 +244,7 @@ public sealed class MigrateHostStateCommandTests : IDisposable
         // authoring out of scope).
         using var workspace = new MigrateWorkspace();
         workspace.WriteLegacyQueueState(BuildQueueState(
-            ("G331", "review", linkedIssue: ("J-Tech-Japan/intent-system", 765))));
+            ("G331", "review", LinkedIssue: ("J-Tech-Japan/intent-system", 765))));
         var packetPath = Path.Combine(workspace.Context.RepoRoot,
             ".intent-cli", "issues", "G331", "packet.yaml");
         Directory.CreateDirectory(Path.GetDirectoryName(packetPath)!);

--- a/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueReprioritizeCommandTests.cs
@@ -29,7 +29,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     public void Execute_DryRunDefault_ReportsWouldChangeWithoutMutating()
     {
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         var queueStateBefore = File.ReadAllText(workspace.QueueStatePath);
 
         using var writer = new StringWriter();
@@ -55,7 +55,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     public void Execute_Write_MutatesPriorityAndAppendsReasonedRunEvent()
     {
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         var changedAt = new DateTimeOffset(2026, 7, 19, 3, 0, 0, TimeSpan.Zero);
         QueueReprioritizeCommand.UtcNowFactory = () => changedAt;
 
@@ -89,7 +89,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     public void Execute_RefusesOnNonQueuedState()
     {
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Active, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Active, "normal", LinkedIssue: null)));
 
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
@@ -133,7 +133,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     public void Execute_RefusesOnUnknownExecutionUnit()
     {
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
 
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
@@ -151,7 +151,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     public void Execute_RefusesWithoutReason()
     {
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
 
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
@@ -167,7 +167,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     public void Execute_RefusesUnsupportedPriorityValue()
     {
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
 
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
@@ -192,7 +192,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // needed for this; this test locks the existing behavior in as
         // the documented recipe.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G543", QueueItemState.Queued, "medium", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G543", QueueItemState.Queued, "medium", LinkedIssue: null)));
         var changedAt = new DateTimeOffset(2026, 7, 20, 8, 0, 0, TimeSpan.Zero);
         QueueReprioritizeCommand.UtcNowFactory = () => changedAt;
 
@@ -224,7 +224,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
     public void Execute_SamePriorityRequested_IsIdempotentNoOp()
     {
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "high", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "high", LinkedIssue: null)));
 
         using var writer = new StringWriter();
         var exitCode = QueueReprioritizeCommand.Execute(
@@ -246,7 +246,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // The audit event is written FIRST; if that fails, queue-state.json
         // must never be mutated at all — no silent, unaudited change.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         var queueStateBefore = File.ReadAllText(workspace.QueueStatePath);
         QueueReprioritizeCommand.AppendPriorityChangedEventOverride = (_, _) =>
             throw new IOException("simulated disk failure appending runs.jsonl");
@@ -276,7 +276,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // fails. Must fail loud and explain exactly what state the
         // operator is in.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         QueueReprioritizeCommand.WriteQueueStateOverride = (_, _) =>
             throw new IOException("simulated disk failure writing queue-state.json");
 
@@ -310,7 +310,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // (skip re-appending — no duplicate), retry ONLY the queue-state
         // write, and converge to a fully consistent, singly-audited state.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         QueueReprioritizeCommand.WriteQueueStateOverride = (_, _) =>
             throw new IOException("simulated disk failure writing queue-state.json");
 
@@ -364,7 +364,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // never repeats a value once consumed.
         using var workspace = new ReprioritizeWorkspace();
         var fixedNow = new DateTimeOffset(2026, 7, 19, 4, 0, 0, TimeSpan.Zero);
-        var originalRaw = BuildQueueStateWithUpdatedAt(("G537", QueueItemState.Queued, "normal", linkedIssue: null), fixedNow);
+        var originalRaw = BuildQueueStateWithUpdatedAt(("G537", QueueItemState.Queued, "normal", LinkedIssue: null), fixedNow);
         workspace.WriteQueueState(originalRaw);
         QueueReprioritizeCommand.UtcNowFactory = () => fixedNow;
 
@@ -408,7 +408,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // is EARLIER than op1's) must not break anything, since the
         // revision counter never consults time at all.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
 
         QueueReprioritizeCommand.UtcNowFactory = () => new DateTimeOffset(2026, 7, 19, 10, 0, 0, TimeSpan.Zero);
         Assert.Equal(0, QueueReprioritizeCommand.Execute(
@@ -446,7 +446,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // closed (never silently append a second, different claim on the
         // same pair).
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': OLD_REASON (revision 0->1)");
 
         using var writer = new StringWriter();
@@ -475,7 +475,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // records the OPPOSITE transition direction — also a conflict,
         // not a "wrong reason, append anyway" case.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         SeedHistoricalEvent(workspace, "G537", "priority changed from 'high' to 'normal': R (revision 0->1)");
 
         using var writer = new StringWriter();
@@ -506,7 +506,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // insertion order semantics exercised via conflictingIndex.
         _ = unusedIndex;
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         if (conflictingIndex == 0)
         {
             SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': DIFFERENT (revision 0->1)");
@@ -540,7 +540,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // problem (how did that happen?) — must fail closed, not be
         // silently treated as "one pending retry."
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': R (revision 0->1)");
         SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': R (revision 0->1)");
 
@@ -567,7 +567,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // durable state — must refuse before any preview/mutation, in
         // BOTH dry-run and write mode.
         using var workspace = new ReprioritizeWorkspace();
-        var baseState = QueueStateSerializer.Deserialize(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        var baseState = QueueStateSerializer.Deserialize(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         workspace.WriteQueueState(QueueStateSerializer.Serialize(
             baseState with { Items = new[] { baseState.Items.Single() with { PriorityRevision = -1 } } }));
 
@@ -596,7 +596,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // int.MinValue, directly violating the monotonic/injective
         // invariant. Must fail closed instead, in BOTH dry-run and write.
         using var workspace = new ReprioritizeWorkspace();
-        var baseState = QueueStateSerializer.Deserialize(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        var baseState = QueueStateSerializer.Deserialize(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         workspace.WriteQueueState(QueueStateSerializer.Serialize(
             baseState with { Items = new[] { baseState.Items.Single() with { PriorityRevision = int.MaxValue } } }));
 
@@ -667,7 +667,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // seam. The subsequent final write must detect the mismatch and
         // refuse, rather than blindly overwriting the concurrent change.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
 
         QueueReprioritizeCommand.AppendPriorityChangedEventOverride = (path, runEvent) =>
         {
@@ -723,7 +723,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // partially applying. After the outer call completes, exactly
         // ONE mutation and ONE event must exist.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
 
         int? innerExitCode = null;
         string? innerOutput = null;
@@ -784,7 +784,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // succeed even with the lock file already present/created by a
         // prior write.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
 
         // A prior --write created (and released) the lock file; it stays
         // on disk afterward (never deleted — only ever held/released).
@@ -817,7 +817,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // immediately — with the queue/runs state left byte-unchanged by
         // the failed first call.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
 
         QueueReprioritizeCommand.OnLockAcquiredForTest = () =>
         {
@@ -867,7 +867,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // for a DIFFERENT execution unit — must never dedupe this unit's
         // request.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         SeedHistoricalEvent(workspace, "G999", "priority changed from 'normal' to 'high': R (revision 0->1)");
 
         using var writer = new StringWriter();
@@ -892,7 +892,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // otherwise-matching unit/reason — a tagged expected reason can
         // never exact-match an untagged one, so this must never dedupe.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': R");
 
         using var writer = new StringWriter();
@@ -919,7 +919,7 @@ public sealed class QueueReprioritizeCommandTests : IDisposable
         // unit/event/reason, must be recognized as the pending audit for
         // an in-progress attempt and never duplicated.
         using var workspace = new ReprioritizeWorkspace();
-        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", linkedIssue: null)));
+        workspace.WriteQueueState(BuildQueueState(("G537", QueueItemState.Queued, "normal", LinkedIssue: null)));
         SeedHistoricalEvent(workspace, "G537", "priority changed from 'normal' to 'high': R (revision 0->1)");
 
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/QueueSeedDependenciesG568Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueSeedDependenciesG568Tests.cs
@@ -101,10 +101,10 @@ public sealed class QueueSeedDependenciesG568Tests : IDisposable
         var (exitCode, result) = workspace.RunSeed(write: false);
 
         Assert.Equal(0, exitCode);
-        Assert.Equal(
-            ["G999"],
+        Assert.Collection(
             result.GetProperty("seeded_item").GetProperty("blocked_by")
-                .EnumerateArray().Select(entry => entry.GetString()).ToArray());
+                .EnumerateArray().Select(entry => entry.GetString()),
+            dependency => Assert.Equal("G999", dependency));
     }
 
     // ------------------------------------------------------- selection gating
@@ -153,9 +153,9 @@ public sealed class QueueSeedDependenciesG568Tests : IDisposable
         Assert.Equal(0, exitCode);
         var finding = Assert.Single(result.GetProperty("items").EnumerateArray());
         Assert.Equal(AutomationQueueDependencyReconcileCommand.StatusDrifted, finding.GetProperty("status").GetString());
-        Assert.Equal(
-            ["G565"],
-            finding.GetProperty("packet_dependencies").EnumerateArray().Select(e => e.GetString()).ToArray());
+        Assert.Collection(
+            finding.GetProperty("packet_dependencies").EnumerateArray().Select(e => e.GetString()),
+            dependency => Assert.Equal("G565", dependency));
         Assert.Empty(finding.GetProperty("queue_dependencies").EnumerateArray());
 
         // Read-only really means read-only.
@@ -314,8 +314,8 @@ public sealed class QueueSeedDependenciesG568Tests : IDisposable
         Assert.Equal(0, workspace.RunReconcile(write: true).ExitCode);
 
         var events = RunLogSerializer.DeserializeAll(File.ReadAllText(workspace.RunsPath));
-        var reconciled = Assert.Single(events.Where(e =>
-            e.Event == AutomationQueueDependencyReconcileCommand.ReconcileEventName));
+        var reconciled = Assert.Single(events, e =>
+            e.Event == AutomationQueueDependencyReconcileCommand.ReconcileEventName);
         Assert.Equal(SeedWorkspace.Unit, reconciled.ExecutionUnit);
         Assert.Contains("G565", reconciled.Reason!, StringComparison.Ordinal);
     }

--- a/tests/IntentSystem.Cli.Tests/QueueSeedPacketParsingG567Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueSeedPacketParsingG567Tests.cs
@@ -118,9 +118,10 @@ public sealed class QueueSeedPacketParsingG567Tests : IDisposable
 
         var seeded = result.GetProperty("seeded_item");
         Assert.Equal("Queue seed parity", seeded.GetProperty("title").GetString());
-        Assert.Equal(
-            ["G565", "G566"],
-            seeded.GetProperty("dependencies").EnumerateArray().Select(d => d.GetString()).ToArray());
+        Assert.Collection(
+            seeded.GetProperty("dependencies").EnumerateArray().Select(d => d.GetString()),
+            dependency => Assert.Equal("G565", dependency),
+            dependency => Assert.Equal("G566", dependency));
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/QueueStatePersistenceTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueStatePersistenceTests.cs
@@ -520,7 +520,10 @@ public sealed class QueueStatePersistenceTests : IDisposable
 
         using var document = System.Text.Json.JsonDocument.Parse(File.ReadAllText(QueueStatePath));
         var items = document.RootElement.GetProperty("items").EnumerateArray().ToArray();
-        Assert.Equal(["SKS-G841", "G545"], items.Select(item => item.GetProperty("execution_unit").GetString()).ToArray());
+        Assert.Collection(
+            items.Select(item => item.GetProperty("execution_unit").GetString()),
+            executionUnit => Assert.Equal("SKS-G841", executionUnit),
+            executionUnit => Assert.Equal("G545", executionUnit));
         Assert.Equal("completed", items[0].GetProperty("state").GetString());
         // Fields the model does not know about survive on both sides.
         Assert.Equal("preserved", items[0].GetProperty("custom_host_field").GetString());


### PR DESCRIPTION
## Summary

- fix the 56 authored test-warning inventory at source using matching tuple names, analyzer-recommended xUnit assertions, and explicit nullable contracts
- fix the five additional nullable warnings present on the current main without changing runtime behavior or test semantics
- add solution-wide warnings-as-errors and enable .NET analyzers at AnalysisLevel 10.0

AnalysisLevel 10.0 matches the net10.0 target framework and 10.0.x CI baseline. Pinning the level keeps the enforced analyzer set predictable when a newer SDK happens to run the build, while still establishing .NET 10 as the minimum analyzer floor.

## Verification

- Before: dotnet clean -c Release -v minimal, then dotnet build -c Release -v n with SDK 10.0.100: 0 errors, 61 warnings. The current main contained the Issue inventory of 56 test warnings plus five additional nullable warnings.
- After: the same clean and dotnet build -c Release -v n command with SDK 10.0.100: 0 errors, 0 warnings across all 22 solution projects.
- Compatibility: dotnet build -c Release -v minimal --no-restore with the installed .NET 11 preview SDK: 0 errors, 0 warnings.
- Deliberate negative proof: a temporary test source returning null from a non-nullable string method made dotnet build -c Release -v minimal --no-restore fail with exit 1 and CS8603 promoted to an error; the scratch source was then deleted.
- Focused warning-fix coverage: 414 passed, 0 failed.
- CLI test project: exit 0 with the existing single skip.
- Full Release suite: dotnet test IntentSystem.sln -c Release --no-build --no-restore completed successfully across all 11 test projects; 0 failures and the existing single CLI skip.
- git diff --check: clean.
- No pragma suppression, NoWarn entry, severity downgrade, Directory.Packages.props, or .editorconfig was added.

Closes #1269