### PR TITLE
G584: refresh v0.8.0 release notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2528,16 +2528,20 @@ to keep in sync, and it goes stale on exactly the roll nobody is watching.
 ### Next release readiness (v0.8.0)
 
 **`v0.7.1` shipped** (GitHub Release + NuGet). The repository is now prepared
-for the **`0.8.0`** minor line: G570/G571/G573/G574/G575 are merged, the
-superseded 0.7.2 note copies have been removed, and real
+for the **`0.8.0`** minor line: the twelve shipped slices G570/G571/G573/G574/
+G575/G577/G578/G579/G580/G581/G582/G583 are merged, the superseded 0.7.2 note
+copies have been removed, and real
 [release-notes-v0.8.0.md](release-notes-v0.8.0.md) content defines the release
-and its operator gate. The minor rationale is the new top-level `session-layer`
-command group plus the broad persisted dual-mode behavior; agmsg remains
-PRIMARY and herdr-only remains PREVIEW only as a transport, never as a preview
-of the four-thread model.
+and its operator gate. G576 prepared the notes and G584 refreshes them; neither
+maintenance slice is counted as shipped. The minor rationale is the new
+top-level `session-layer` and `notify` command groups plus the broad persisted
+dual-mode and transport-neutral workflow behavior. Both session modes remain
+first-class, selectable, and reversible; agmsg remains PRIMARY and is not
+deprecated, while PREVIEW qualifies only the herdr-only session transport and
+never the four-thread model.
 
 No Release, tag, package publish, version roll, or announcement is performed by
-this preparation. After it merges, the operator must explicitly approve
+this notes maintenance. After it merges, the operator must explicitly approve
 creating the `v0.8.0` GitHub Release.
 
 **Release-readiness verification (run before merging the `v0.8.0`

--- a/docs/en/release-notes-v0.8.0.md
+++ b/docs/en/release-notes-v0.8.0.md
@@ -9,13 +9,17 @@
 
 ## What's in v0.8.0
 
-v0.8.0 covers exactly five slices merged after `v0.7.1`: **G570**, **G571**,
-**G573**, **G574**, and **G575**.
+v0.8.0 covers exactly twelve shipped slices merged after `v0.7.1`: **G570**,
+**G571**, **G573**, **G574**, **G575**, **G577**, **G578**, **G579**,
+**G580**, **G581**, **G582**, and **G583**. G576 prepared the first edition of
+these notes and G584 refreshes them; neither maintenance slice is counted as a
+shipped product slice.
 
-**Why minor.** G570 adds `session-layer` as a new top-level command group, and
-the persisted dual-mode session layer is a broad behavior addition across
-orchestrator guidance. That is an ongoing user capability rather than a bounded
-repair, so the documented policy calls for `0.8.0`, not `0.7.2`.
+**Why minor.** G570 adds `session-layer` and G578 adds `notify` as new top-level
+command groups. Together with the persisted dual-mode session layer and the
+transport-neutral role workflow, these are broad, ongoing user capabilities
+rather than bounded repairs, so the documented policy calls for `0.8.0`, not
+`0.7.2`.
 
 ### A persisted, reversible session layer (G570)
 
@@ -30,13 +34,15 @@ intent-cli session-layer set --domain <domain> --team <team> --mode herdr-only -
 ```
 
 The recorded mode routes `intent-cli guide orchestrator-thread`, so one team is
-never handed operating instructions for both transports at once. The
-positioning is deliberate: **agmsg is PRIMARY and herdr-only is PREVIEW. PREVIEW
-is scoped only to the session transport, never to the four-thread model.** The
-design / orchestrator / implementation / review roles and their authority
-boundaries remain the same in both modes.
+never handed operating instructions for both transports at once. **Both agmsg
+and herdr-only remain first-class session-layer modes: they are selectable and
+reversible, and agmsg is not deprecated.** agmsg remains the default and PRIMARY
+transport; herdr-only remains PREVIEW. **PREVIEW scopes only to the herdr-only
+session transport, never to the four-thread collaboration model.** The design /
+orchestrator / implementation / review roles and their authority boundaries
+remain the same in both modes.
 
-### The herdr-only operating model, proven before release (G571, G575)
+### The herdr-only operating contract (G571, G575)
 
 The herdr-only preview now has a complete, user-facing operating procedure:
 
@@ -59,9 +65,7 @@ The herdr-only preview now has a complete, user-facing operating procedure:
   3. **Codex Desktop uses a timer poll and durable byte-offset watermark.**
      This Desktop recipe is a new capability and was never supported by agmsg.
 
-Before release, the design team ran the full concept spike against merged main
-on 2026-08-02: **11/11 checks passed, with zero agmsg processes for the spike
-team**. The spike also found three procedure defects, all corrected in G575:
+G575 hardened three procedure defects found while exercising that contract:
 
 - a marker literal embedded in dispatched task text could be matched from its
   own pane echo, so dispatch now separates a fresh nonce from the prefix and a
@@ -71,8 +75,6 @@ team**. The spike also found three procedure defects, all corrected in G575:
   MAY/escalate boundary before re-entry; and
 - the documented `workspace_created` fields and `agent wait` idle shape now
   match installed herdr 0.7.5.
-
-No additional dogfood is claimed by this release-preparation change.
 
 ### Safe shipped-skill updates (G573)
 
@@ -98,6 +100,74 @@ participate in this classification and may be null. G574 introduced the
 `state-drift` classification for half-converged representations, and if a unit
 is unblocked its age restarts at the unblock transition.
 
+### Production-trial findings fixed in the same release (G577–G583)
+
+The evidence for herdr-only is now a real production trial. The intent-cli team
+used herdr-only for the actual work that published, implemented, reviewed,
+merged, and closed out G577 through G583, with **zero agmsg processes for the
+team**. The trial surfaced concrete defects and quality gaps; every one was
+fixed on this same release line:
+
+- **G577 — one `--workdir` rule.** Ten automation commands had private,
+  inconsistent relative-path handling. They now share one resolver: an omitted
+  or blank value uses the repository root, a relative value resolves from that
+  root rather than the caller cwd, and an absolute path is preserved.
+- **G578 — transport-neutral role workflow.** `intent-cli notify delegate`,
+  `report`, and `escalate` now validate logical roles, resolve the recorded
+  session mode internally, embed the canonical report command in delegated
+  work, and keep design-boundary escalation on the existing events channel.
+- **G579 — atomic canonical state writes.** Canonical queue-state persistence
+  now writes and flushes a uniquely named temporary sibling, publishes it with
+  one overwrite move, and removes the temporary file after success or
+  interruption, so a reader never observes a truncated target.
+- **G580 — shared-static race guard.** A discovery-based test reflects over
+  every settable CLI static seam, discovers assigning test classes from IL, and
+  fails with the seam and class names unless the classes are provably
+  serialized. The five accepted split-collection cases are explicit and bound
+  fail-closed to the supported xUnit v2 runner semantics.
+- **G581 — observation without worker cooperation.** herdr
+  `pane.agent_status_changed` became the normative second wake source. It uses
+  the recorded logical-role mapping, working-to-settled transitions, a settle
+  delay, and per-role dedupe; the event is only a reason to inspect, never proof
+  of success.
+- **G582 — five measured field findings.** Both modes now render the session
+  switch checklist; agmsg-to-herdr teardown removes the outgoing project hook
+  and delivery mode that could block the next launch at the hook-trust screen;
+  every herdr mutation resolves a non-empty explicit pane/workspace id and
+  fails closed instead of mutating another team's focused pane; every
+  `events.jsonl` reader keeps a restart-durable identity/offset/line watermark
+  and fails closed on rotation, truncation, backwards progress, or replacement;
+  and stalled-work now reports `approved-not-merged` for an approved open PR
+  that has exceeded its threshold.
+- **G583 — warning-free build floor.** The authored 56-test-warning inventory
+  plus five nullable warnings on then-current `main` were fixed at source.
+  Solution-wide .NET 10 analyzers and warnings-as-errors now make the next
+  warning fail the build; the deliberate CS8603 negative proof demonstrated the
+  floor before the scratch edit was removed.
+
+### Three wake sources, complementary failure modes (G578, G581, G582)
+
+herdr-only uses three wake sources; none is treated as an outcome by itself:
+
+1. **herdr state-change subscription** — `pane.agent_status_changed` needs no
+   worker cooperation, but carries no task outcome. After its settle/dedupe
+   gate, orchestration still checks pane state, a fresh completion marker, the
+   artifact, and canonical intent-cli/GitHub facts, including approval or
+   question pauses.
+2. **canonical notify report** — `intent-cli notify report` is the most
+   informative source because it carries task id, status, summary, and artifact,
+   but it depends on the worker reaching and executing the report step. Its
+   claims are still verified against the artifact and canonical state.
+3. **periodic stalled-work check** — this is the last net rather than a
+   real-time completion signal. It derives overdue work from canonical state and
+   recommends recovery, including merge and closeout for
+   `approved-not-merged`.
+
+The coverage standard is that **a stall must remain detectable even if every
+single wake source fails**: no source may be the sole detector. G582 added
+`approved-not-merged` precisely so an approved open PR cannot become invisible
+after its report or state-change wake is missed.
+
 ## Install
 
 ```bash
@@ -118,23 +188,30 @@ The default remains agmsg. Existing teams do not enter herdr-only unless the
 operator records that mode through `session-layer set`; mode changes are
 reversible and must follow the guide's drain/provision/READY checklist.
 
-## Release-readiness gate (G576)
+## Release-readiness gate (G576, refreshed by G584)
 
 These items must hold **before the GitHub Release for `v0.8.0` is created or
 published**. This gate fails closed.
 
-- [ ] The five release-bound slices are merged to `main`: G570 (PR #1246), G571
-      (PR #1248), G573 (PR #1250), G574 (PR #1252), and G575 (PR #1254), plus
-      this G576 release-preparation PR.
-- [ ] These EN/JA notes cover exactly that five-slice lineage, and neither
+- [ ] The twelve shipped slices are merged to `main`: G570 (PR #1246), G571
+      (PR #1248), G573 (PR #1250), G574 (PR #1252), G575 (PR #1254), G577
+      (PR #1258), G578 (PR #1260), G579 (PR #1262), G580 (PR #1264), G581
+      (PR #1266), G582 (PR #1268), and G583 (PR #1270). G576 (PR #1256) is
+      the initial release preparation and this G584 refresh is notes
+      maintenance; neither is a shipped slice.
+- [ ] These EN/JA notes cover exactly that twelve-slice lineage, and neither
       superseded `release-notes-v0.7.2.md` copy remains.
 - [ ] `eng/version.json` shows `stableVersion` `0.7.1` and `nextVersion` `0.8.0`.
 - [ ] The G475 next-version release-note/package guards pass with **zero
       current-state guard flips**, and the full test suite is green on the exact
-      release-preparation head.
-- [ ] The recorded pre-release evidence is still the verified 11/11 spike with
-      zero agmsg processes for its team; do not replace it with an unverified
-      marker-only or state-only claim.
+      G584 notes-maintenance head.
+- [ ] The recorded pre-release evidence is the intent-cli team's real
+      herdr-only production trial for G577–G583, including publish through
+      closeout with zero agmsg processes for the team, and every surfaced
+      finding is tied above to the slice that fixed it.
+- [ ] All three wake sources and their failure modes remain documented, and
+      `approved-not-merged` preserves the coverage standard when report or
+      state-change delivery is missed.
 - [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
       repository/project URLs point at this repository, the license is
       `Apache-2.0`, and README/docs links resolve.
@@ -144,9 +221,9 @@ published**. This gate fails closed.
 
 ## Publishing v0.8.0
 
-Merging this preparation does **not** create a Release, tag, package publish,
-version roll, or announcement. After merge, readiness evidence must be checked
-and the operator must explicitly approve Release creation.
+Merging this notes maintenance does **not** create a Release, tag, package
+publish, version roll, or announcement. After merge, readiness evidence must be
+checked and the operator must explicitly approve Release creation.
 
 Only then may a maintainer/operator (or explicitly authorized external release
 automation) create and publish the `v0.8.0` GitHub Release. Publishing it
@@ -162,4 +239,4 @@ Post-release verification includes:
 - [ ] After publication, perform the separately authorized immediate roll to
       `stableVersion → 0.8.0` / `nextVersion → 0.8.1`, with new EN/JA DRAFT
       stubs, refreshed readiness sections, and green post-roll child-main CI.
-      That roll is not part of G576.
+      That roll is not part of G576 or G584.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2612,13 +2612,16 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 ### 次リリース準備(v0.8.0)
 
 **`v0.7.1` は出荷済み**(GitHub Release + NuGet)です。リポジトリは **`0.8.0`** minor
-line の準備状態にあります: G570/G571/G573/G574/G575 は merge 済み、superseded 0.7.2
-notes copy は削除済みで、実際の [release-notes-v0.8.0.md](release-notes-v0.8.0.md) が
-release と operator gate を定義します。minor の根拠は新 top-level `session-layer` command
-group と広範な persisted dual-mode behavior です。agmsg は PRIMARY、herdr-only は transport
-についてだけ PREVIEW であり、4 スレッドモデルの preview では決してありません。
+line の準備状態にあります: shipped 12 slices G570/G571/G573/G574/G575/G577/G578/G579/
+G580/G581/G582/G583 は merge 済み、superseded 0.7.2 notes copy は削除済みで、実際の
+[release-notes-v0.8.0.md](release-notes-v0.8.0.md) が release と operator gate を定義します。
+G576 は notes を prepare し G584 は refresh しますが、どちらの maintenance slice も shipped
+には数えません。minor の根拠は新 top-level `session-layer` / `notify` command group と広範な
+persisted dual-mode / transport-neutral workflow behavior です。両 session mode は first-class、
+selectable、reversible のままです。agmsg は PRIMARY で deprecated ではなく、PREVIEW が
+qualify するのは herdr-only session transport だけで、4 スレッドモデルでは決してありません。
 
-この preparation は Release / tag / package publish / version roll / announcement を行いません。
+この notes maintenance は Release / tag / package publish / version roll / announcement を行いません。
 merge 後も `v0.8.0` GitHub Release 作成には operator の明示承認が必要です。
 
 **リリース準備検証(`v0.8.0` release-preparation のマージ前に実行):**

--- a/docs/ja/release-notes-v0.8.0.md
+++ b/docs/ja/release-notes-v0.8.0.md
@@ -8,13 +8,15 @@
 
 ## v0.8.0 の内容
 
-v0.8.0 が `v0.7.1` 以降から含むのは、マージ済みの 5 スライス **G570**、**G571**、
-**G573**、**G574**、**G575** だけです。
+v0.8.0 が `v0.7.1` 以降から含む shipped slice は、マージ済みの 12 件 **G570**、
+**G571**、**G573**、**G574**、**G575**、**G577**、**G578**、**G579**、
+**G580**、**G581**、**G582**、**G583** だけです。G576 は初版 notes の準備、G584 は
+その refresh であり、どちらの maintenance slice も shipped product slice には数えません。
 
-**minor バンプの理由。** G570 は新しい top-level command group `session-layer` を追加し、
-persist された dual-mode session layer は orchestrator guidance 全体に及ぶ広範な挙動追加です。
-限定的な repair ではなく継続利用する user capability であるため、文書化済み policy に従い
-`0.7.2` ではなく `0.8.0` とします。
+**minor バンプの理由。** G570 は `session-layer`、G578 は `notify` という新しい
+top-level command group を追加します。persist された dual-mode session layer と
+transport-neutral な role workflow を含む、限定的な repair ではなく継続利用する広範な
+user capability であるため、文書化済み policy に従い `0.7.2` ではなく `0.8.0` とします。
 
 ### Persist され、双方向に戻せる session layer (G570)
 
@@ -29,12 +31,14 @@ intent-cli session-layer set --domain <domain> --team <team> --mode herdr-only -
 ```
 
 記録済み mode が `intent-cli guide orchestrator-thread` を route するため、1 チームに 2 transport
-の運用指示が同時に渡ることはありません。位置付けは明確です: **agmsg は PRIMARY、
-herdr-only は PREVIEW です。PREVIEW の対象は session transport だけであり、4 スレッドモデル
+の運用指示が同時に渡ることはありません。**agmsg と herdr-only はどちらも first-class な
+session-layer mode として残り、選択可能かつ双方向に戻せます。agmsg は deprecated では
+ありません。** agmsg は引き続き default / PRIMARY transport、herdr-only は PREVIEW です。
+**PREVIEW の対象は herdr-only session transport だけであり、4 スレッド collaboration model
 では決してありません。** design / orchestrator / implementation / review の role と権限境界は
 どちらの mode でも同じです。
 
-### Release 前に実証した herdr-only 運用モデル (G571, G575)
+### herdr-only 運用 contract (G571, G575)
 
 herdr-only preview には、次の完全な user-facing 運用手順があります。
 
@@ -55,9 +59,7 @@ herdr-only preview には、次の完全な user-facing 運用手順がありま
   3. **Codex Desktop は timer poll と durable byte-offset watermark を使う。** この Desktop
      recipe は新機能であり、agmsg では一度も support されていません。
 
-release 前の 2026-08-02、design team は merged main に対して concept spike を全実行し、
-**11/11 checks passed、spike team の agmsg process はゼロ**でした。spike で見つかった 3 件の
-手順 defect もすべて G575 で修正しました。
+G575 はこの contract の exercise で見つかった 3 件の手順 defect を harden しました。
 
 - dispatch task text 内の marker literal が自分自身の pane echo から match できたため、現在は
   fresh nonce と prefix を分離し、marker match 単独では決して success にしません。
@@ -65,8 +67,6 @@ release 前の 2026-08-02、design team は merged main に対して concept spi
   pane inspection と既存 supervision MAY/escalate 境界を適用してから re-enter します。
 - 文書の `workspace_created` field と `agent wait` idle shape を installed herdr 0.7.5 に
   合わせました。
-
-この release-preparation では追加 dogfood を実施したとは主張しません。
 
 ### 安全な shipped-skill update (G573)
 
@@ -89,6 +89,60 @@ entry の `state` が `blocked` かつ `blocked_by` list が non-empty の場合
 `state-drift` classification を導入しました。unit が unblock された場合の age は unblock
 transition から再開します。
 
+### 同じ release 内で修正した production-trial findings (G577–G583)
+
+herdr-only の evidence は実際の production trial になりました。intent-cli team 自身が
+herdr-only で G577 から G583 の publish / implementation / review / merge / closeout という
+実 work を進め、**team の agmsg process はゼロ**でした。trial が露呈した
+具体的な defect と quality gap はすべて同じ release line で修正されています。
+
+- **G577 — 1 つの `--workdir` rule。** 10 automation command にあった private で不統一な
+  relative-path handling を shared resolver に統一しました。省略または blank は repository root、
+  relative value は caller cwd ではなくその root から resolve し、absolute path は維持します。
+- **G578 — transport-neutral role workflow。** `intent-cli notify delegate`、`report`、`escalate` が
+  logical role を validate し、記録済み session mode を内部で resolve、delegation に canonical
+  report command を埋め込み、design-boundary escalation は既存 events channel に保ちます。
+- **G579 — atomic な canonical state write。** canonical queue-state persistence は unique な
+  sibling temporary file へ write/flush し、1 回の overwrite move で publish し、success / interruption
+  のどちらでも temporary file を除去します。reader は truncate 済み target を観測しません。
+- **G580 — shared-static race guard。** discovery-based test が settable CLI static seam 全体を
+  reflection し、IL から assignment する test class を発見し、class が provably serialized でなければ
+  seam/class 名付きで fail します。許容する 5 つの split-collection case は explicit で、support 済み
+  xUnit v2 runner semantics に fail-closed で bind されています。
+- **G581 — worker cooperation 不要の observation。** herdr の
+  `pane.agent_status_changed` を normative な SECOND wake source にしました。recorded logical-role
+  mapping、working-to-settled transition、settle delay、per-role dedupe を使い、event は inspect の
+  理由にすぎず success proof ではありません。
+- **G582 — 実測した 5 findings。** 両 mode が session switch checklist を render します。
+  agmsg→herdr teardown は次回 launch を hook-trust screen で block し得る outgoing project hook と
+  delivery mode を除去します。すべての herdr mutation は non-empty な explicit pane/workspace id を
+  resolve し、別 team の focused pane を mutate せず fail closed します。すべての `events.jsonl`
+  reader は restart-durable な identity/offset/line watermark を持ち、rotation / truncation /
+  backwards progress / replacement で fail closed します。さらに threshold を超えた approved open
+  PR を stalled-work の `approved-not-merged` として報告します。
+- **G583 — warning-free build floor。** authored 56-test-warning inventory と当時の `main` にあった
+  nullable warning 5 件を source で修正しました。solution-wide の .NET 10 analyzer と
+  warnings-as-errors により次の warning は build を fail し、scratch edit 削除前の deliberate
+  CS8603 negative proof で floor を実証しました。
+
+### 3 wake sources と相補的な failure mode (G578, G581, G582)
+
+herdr-only は 3 つの wake source を使い、どれも単独では outcome とみなしません。
+
+1. **herdr state-change subscription** — `pane.agent_status_changed` は worker cooperation が不要ですが、
+   task outcome は運びません。settle/dedupe gate 後も orchestration は pane state、fresh completion
+   marker、artifact、canonical intent-cli/GitHub facts、approval/question pause を確認します。
+2. **canonical notify report** — `intent-cli notify report` は task id / status / summary / artifact を
+   運ぶ最も informative な source ですが、worker が report step に到達して実行することに依存します。
+   claim は artifact と canonical state に照らして再検証します。
+3. **periodic stalled-work check** — real-time completion signal ではなく最後の net です。canonical
+   state から overdue work と recovery recommendation を導き、`approved-not-merged` には merge と
+   closeout を推奨します。
+
+coverage standard は、**すべての wake source が fail しても stall を検出可能なままにする**
+ことです。どの source も唯一の detector にはできません。G582 が `approved-not-merged` を追加した
+理由は、report や state-change wake を逃した approved open PR を不可視にしないためです。
+
 ## Install
 
 ```bash
@@ -109,20 +163,26 @@ default は引き続き agmsg です。operator が `session-layer set` で mode
 が herdr-only へ移ることはありません。mode change は reversible で、guide の
 drain/provision/READY checklist に従う必要があります。
 
-## リリース準備ゲート (G576)
+## リリース準備ゲート (G576、G584 で refresh)
 
 以下は **`v0.8.0` GitHub Release を作成または publish する前**に満たす必要があります。
 この gate は fail closed です。
 
-- [ ] release-bound 5 slices が `main` に merge 済み: G570 (PR #1246)、G571 (PR #1248)、
-      G573 (PR #1250)、G574 (PR #1252)、G575 (PR #1254)、および本 G576 release-preparation PR。
-- [ ] EN/JA notes がその 5-slice lineage だけを cover し、superseded
+- [ ] shipped 12 slices が `main` に merge 済み: G570 (PR #1246)、G571 (PR #1248)、
+      G573 (PR #1250)、G574 (PR #1252)、G575 (PR #1254)、G577 (PR #1258)、
+      G578 (PR #1260)、G579 (PR #1262)、G580 (PR #1264)、G581 (PR #1266)、
+      G582 (PR #1268)、G583 (PR #1270)。G576 (PR #1256) は初回 release preparation、
+      本 G584 refresh は notes maintenance であり、どちらも shipped slice には数えない。
+- [ ] EN/JA notes がその 12-slice lineage だけを cover し、superseded
       `release-notes-v0.7.2.md` がどちらにも残っていない。
 - [ ] `eng/version.json` が `stableVersion` `0.7.1`、`nextVersion` `0.8.0` を示す。
 - [ ] G475 next-version release-note/package guard が **current-state guard flip ゼロ**で通り、
-      exact release-preparation head で full test suite が green。
-- [ ] pre-release evidence は検証済み 11/11 spike と team の agmsg process ゼロであること。
-      未検証の marker-only / state-only claim へ置き換えない。
+      exact G584 notes-maintenance head で full test suite が green。
+- [ ] pre-release evidence は intent-cli team が G577–G583 を publish から closeout まで進めた
+      real herdr-only production trial で、team の agmsg process はゼロであり、surfaced finding は
+      fixing slice と上記で対応している。
+- [ ] 3 wake source と各 failure mode が文書化されたままで、report / state-change delivery を
+      逃しても `approved-not-merged` が coverage standard を維持する。
 - [ ] package metadata が正しい: `PackageId = JTechJapan.IntentSystem.Cli`、repository/project URL、
       license `Apache-2.0`、README/docs link を確認。
 - [ ] Main CI (`Build and test (source contract)`) と preview-pack が green で、merge commit 上の
@@ -131,9 +191,9 @@ drain/provision/READY checklist に従う必要があります。
 
 ## v0.8.0 の publish
 
-この準備の merge は Release / tag / package publish / version roll / announcement のいずれも
-行いません。merge 後に readiness evidence を確認し、operator が Release 作成を明示承認する
-必要があります。
+この notes maintenance の merge は Release / tag / package publish / version roll /
+announcement のいずれも行いません。merge 後に readiness evidence を確認し、operator が
+Release 作成を明示承認する必要があります。
 
 その後に限り、maintainer/operator (または明示 authorize された外部 release automation)が
 `v0.8.0` GitHub Release を作成・publish できます。publish が `release.yml` を trigger し、
@@ -147,4 +207,4 @@ post-release verification:
 - [ ] platform archive の checksum が通り、binary が `0.8.0` を報告する。
 - [ ] publish 後、別途 authorize された immediate roll を `stableVersion → 0.8.0` /
       `nextVersion → 0.8.1` へ行い、新しい EN/JA DRAFT stubs、refresh 済み readiness section、
-      roll 後の child-main CI green を揃える。この roll は G576 の一部ではありません。
+      roll 後の child-main CI green を揃える。この roll は G576 / G584 の一部ではありません。


### PR DESCRIPTION
## Summary

- refresh the EN/JA v0.8.0 notes for the exact shipped set G570, G571, G573, G574, G575, G577, G578, G579, G580, G581, G582, and G583
- preserve agmsg and herdr-only as first-class, selectable, reversible modes while limiting PREVIEW to the herdr-only session transport
- replace the old spike claim with the real G577-G583 herdr-only production trial, its fixes, all three wake sources, and the coverage standard
- refresh the EN/JA developer-reference readiness summary

## Merged-main lineage

Verified against the first-parent history of `origin/main` from `v0.7.1` through exact base `742c006`:

- G570 #1246
- G571 #1248
- G573 #1250
- G574 #1252
- G575 #1254
- G577 #1258
- G578 #1260
- G579 #1262
- G580 #1264
- G581 #1266
- G582 #1268
- G583 #1270

G576 (#1256) is release preparation and G584 is notes maintenance; neither is counted as a shipped slice.

## Prepare-only boundary

The diff is limited to four EN/JA documentation files. `eng/version.json` is unchanged. This PR creates no Release, tag, package publish, version roll, CLI, guide, skill, or announcement change.

## Verification

Exact local head: `7624f41`

- G475/current-state guards: 39 passed, 0 failed
  - `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV061DocsTests"`
- Full Release suite: 4,613 passed, 1 pre-existing skipped, 0 failed (4,614 total)
  - `dotnet test IntentSystem.sln -c Release --no-restore`
- `git diff --check`: passed
- `git diff --exit-code origin/main -- eng/version.json`: passed

Closes #1271