### PR TITLE
G585: disclose omitted session-layer team

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -90,10 +90,13 @@ internal static class GuideOrchestratorThreadCommand
         SessionLayerModeResolution sessionLayer;
         try
         {
+            var requestedTeam = string.Equals(values["<team>"], "<team>", StringComparison.Ordinal)
+                ? null
+                : values["<team>"];
             sessionLayer = SessionLayerModeStore.Resolve(
                 context.RepoRoot,
                 values["<domain>"],
-                string.IsNullOrWhiteSpace(values["<team>"]) ? null : values["<team>"]);
+                requestedTeam);
         }
         catch (InvalidOperationException exception)
         {
@@ -144,13 +147,22 @@ internal static class GuideOrchestratorThreadCommand
         SessionLayerModeResolution sessionLayer,
         IReadOnlyDictionary<string, string> values)
     {
+        var teamOmission = SessionLayerTeamOmissionDisclosure.Create(
+            sessionLayer,
+            values["<domain>"],
+            entry =>
+                $"intent-cli guide orchestrator-thread --domain {values["<domain>"]} "
+                + $"--target-repo {values["<owner/repo>"]} --agent {values["<agent>"]} --team {entry.Team}");
         var block = new OrchestratorSessionLayer
         {
             Mode = sessionLayer.Mode,
             Source = sessionLayer.Source == SessionLayerModeSource.Recorded ? "recorded" : "default",
-            Summary = sessionLayer.Source == SessionLayerModeSource.Recorded
-                ? $"Session layer: {SessionLayerMode.Describe(sessionLayer.Mode)} — recorded for this domain/team."
-                : $"Session layer: {SessionLayerMode.Describe(SessionLayerMode.Default)} — no selection recorded, so the default is in force.",
+            Summary = teamOmission is not null
+                ? $"Session layer: {SessionLayerMode.Describe(sessionLayer.Mode)} — in force for this invocation "
+                    + "because no team scope was supplied; team-scoped records are disclosed below."
+                : sessionLayer.Source == SessionLayerModeSource.Recorded
+                    ? $"Session layer: {SessionLayerMode.Describe(sessionLayer.Mode)} — recorded for this domain/team."
+                    : $"Session layer: {SessionLayerMode.Describe(SessionLayerMode.Default)} — no selection recorded, so the default is in force.",
             Exclusivity = SessionLayerMode.ExclusivitySentence,
             PreviewScoping = SessionLayerMode.PreviewScopingSentence,
             Selection =
@@ -163,15 +175,19 @@ internal static class GuideOrchestratorThreadCommand
                     + "examples in them govern only their named transport; the concrete herdr-only counterparts below "
                     + "govern this mode."
                 : null,
+            TeamOmission = teamOmission,
         };
 
-        var intakeNote =
-            $"Recorded session layer for this setup: {SessionLayerMode.Describe(sessionLayer.Mode)} "
-            + $"({(sessionLayer.Source == SessionLayerModeSource.Recorded ? "recorded" : "default — nothing recorded yet")}). "
-            + $"Record or change it with `intent-cli session-layer set --domain {values["<domain>"]} "
-            + (string.IsNullOrWhiteSpace(values["<team>"]) ? string.Empty : $"--team {values["<team>"]} ")
-            + "--mode agmsg|herdr-only --write`. A herdr-only request made at first setup is honoured from then on; "
-            + "the choice is reversible in both directions.";
+        var intakeNote = teamOmission is not null
+            ? teamOmission.Summary + " " + string.Join(
+                " ",
+                teamOmission.CorrectiveCommands.Select(correction => $"`{correction.Command}`"))
+            : $"Recorded session layer for this setup: {SessionLayerMode.Describe(sessionLayer.Mode)} "
+                + $"({(sessionLayer.Source == SessionLayerModeSource.Recorded ? "recorded" : "default — nothing recorded yet")}). "
+                + $"Record or change it with `intent-cli session-layer set --domain {values["<domain>"]} "
+                + (string.IsNullOrWhiteSpace(values["<team>"]) ? string.Empty : $"--team {values["<team>"]} ")
+                + "--mode agmsg|herdr-only --write`. A herdr-only request made at first setup is honoured from then on; "
+                + "the choice is reversible in both directions.";
 
         return guide with
         {
@@ -3664,6 +3680,15 @@ internal static class GuideOrchestratorThreadCommand
             writer.WriteLine("## Session layer");
             writer.WriteLine();
             writer.WriteLine(sessionLayer.Summary);
+            if (sessionLayer.TeamOmission is { } teamOmission)
+            {
+                writer.WriteLine();
+                writer.WriteLine($"**{SessionLayerTeamOmissionDisclosure.MarkdownHeading}:** {teamOmission.Summary}");
+                foreach (var correction in teamOmission.CorrectiveCommands)
+                {
+                    writer.WriteLine($"- correct for `{correction.Team}`: `{correction.Command}`");
+                }
+            }
             writer.WriteLine();
             writer.WriteLine($"- {sessionLayer.Exclusivity}");
             writer.WriteLine($"- {sessionLayer.PreviewScoping}");
@@ -5885,6 +5910,9 @@ internal sealed record OrchestratorSessionLayer
 
     [JsonPropertyName("selection")]
     public required string Selection { get; init; }
+
+    [JsonPropertyName("team_omission")]
+    public SessionLayerTeamOmissionDisclosure? TeamOmission { get; init; }
 
     /// <summary>
     /// G570: honest about the boundary of this slice. Wholly agmsg-specific

--- a/src/IntentSystem.Cli/Commands/SessionLayerCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerCommand.cs
@@ -77,7 +77,24 @@ internal static class SessionLayerCommand
             return 1;
         }
 
-        Emit(writer, format, BuildResult(domain!, team, resolution, mode: "show", applied: false, changed: false));
+        var result = BuildResult(domain!, team, resolution, mode: "show", applied: false, changed: false);
+        var teamOmission = SessionLayerTeamOmissionDisclosure.Create(
+            resolution,
+            domain!,
+            entry => $"intent-cli session-layer show --domain {domain} --team {entry.Team}");
+        if (teamOmission is not null)
+        {
+            result = result with
+            {
+                TeamOmission = teamOmission,
+                Summary = resolution.Source == SessionLayerModeSource.Recorded
+                    ? result.Summary
+                    : $"domain `{domain}`: no domain-wide session layer is recorded, so the default "
+                        + $"{SessionLayerMode.Describe(SessionLayerMode.Default)} is in force.",
+            };
+        }
+
+        Emit(writer, format, result);
         return 0;
     }
 
@@ -250,6 +267,15 @@ internal static class SessionLayerCommand
 
         writer.WriteLine();
         writer.WriteLine(result.Summary);
+        if (result.TeamOmission is { } teamOmission)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"**{SessionLayerTeamOmissionDisclosure.MarkdownHeading}:** {teamOmission.Summary}");
+            foreach (var correction in teamOmission.CorrectiveCommands)
+            {
+                writer.WriteLine($"- correct for `{correction.Team}`: `{correction.Command}`");
+            }
+        }
         writer.WriteLine();
         writer.WriteLine($"- {result.Exclusivity}");
         writer.WriteLine($"- {result.PreviewScoping}");
@@ -424,4 +450,7 @@ internal sealed record SessionLayerResult
 
     [JsonPropertyName("summary")]
     public required string Summary { get; init; }
+
+    [JsonPropertyName("team_omission")]
+    public SessionLayerTeamOmissionDisclosure? TeamOmission { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/SessionLayerMode.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerMode.cs
@@ -74,7 +74,89 @@ internal sealed record SessionLayerModeResolution
     /// <summary>The recorded entry this resolved to, when one exists.</summary>
     public SessionLayerModeEntry? Entry { get; init; }
 
+    /// <summary>
+    /// Team-scoped entries in the requested domain when the caller omitted a
+    /// team. They do not change resolution: they are disclosure evidence for
+    /// surfaces that would otherwise make those records disappear silently.
+    /// </summary>
+    public IReadOnlyList<SessionLayerModeEntry> TeamScopedEntriesInDomain { get; init; } = [];
+
     public bool IsHerdrOnly => string.Equals(Mode, SessionLayerMode.HerdrOnly, StringComparison.Ordinal);
+}
+
+internal sealed record SessionLayerTeamCorrection
+{
+    [JsonPropertyName("team")]
+    public required string Team { get; init; }
+
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+
+    [JsonPropertyName("command")]
+    public required string Command { get; init; }
+}
+
+/// <summary>
+/// G585: the structured disclosure emitted when team-scoped records exist but
+/// a mode-reading caller omitted --team. Resolution remains deterministic; the
+/// disclosure makes its scope and the one-step correction impossible to miss.
+/// </summary>
+internal sealed record SessionLayerTeamOmissionDisclosure
+{
+    public const string MarkdownHeading = "TEAM NOT SUPPLIED — ROUTING DISCLOSURE";
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("mode_in_force")]
+    public required string ModeInForce { get; init; }
+
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    [JsonPropertyName("corrective_commands")]
+    public required IReadOnlyList<SessionLayerTeamCorrection> CorrectiveCommands { get; init; }
+
+    public static SessionLayerTeamOmissionDisclosure? Create(
+        SessionLayerModeResolution resolution,
+        string domain,
+        Func<SessionLayerModeEntry, string> correctiveCommand)
+    {
+        ArgumentNullException.ThrowIfNull(resolution);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentNullException.ThrowIfNull(correctiveCommand);
+
+        if (resolution.TeamScopedEntriesInDomain.Count == 0)
+        {
+            return null;
+        }
+
+        var corrections = resolution.TeamScopedEntriesInDomain
+            .Select(entry => new SessionLayerTeamCorrection
+            {
+                Team = entry.Team!,
+                Mode = entry.Mode,
+                Command = correctiveCommand(entry),
+            })
+            .ToArray();
+        var recordedTeams = string.Join(
+            ", ",
+            corrections.Select(correction =>
+                $"`{correction.Team}` = {SessionLayerMode.Describe(correction.Mode)}"));
+        var source = resolution.Source == SessionLayerModeSource.Recorded ? "recorded" : "default";
+
+        return new SessionLayerTeamOmissionDisclosure
+        {
+            Summary =
+                $"`--team` was not supplied. This invocation therefore uses "
+                + $"{SessionLayerMode.Describe(resolution.Mode)} ({source}). Team-scoped session-layer records also "
+                + $"exist in domain `{domain}`: {recordedTeams}. Run the command for the intended team below to "
+                + "correct this invocation in one step.",
+            ModeInForce = resolution.Mode,
+            Source = source,
+            CorrectiveCommands = corrections,
+        };
+    }
 }
 
 internal sealed record SessionLayerModeTransition
@@ -351,6 +433,15 @@ internal static class SessionLayerModeStore
             return new SessionLayerModeResolution { Mode = SessionLayerMode.Default, Source = SessionLayerModeSource.Default };
         }
 
+        var teamScopedEntriesInDomain = team is null
+            ? state.Entries
+                .Where(entry =>
+                    string.Equals(entry.Domain, domain, StringComparison.Ordinal)
+                    && entry.Team is not null)
+                .OrderBy(entry => entry.Team, StringComparer.Ordinal)
+                .ToArray()
+            : [];
+
         var teamScoped = team is null
             ? null
             : state.Entries.FirstOrDefault(entry =>
@@ -362,12 +453,18 @@ internal static class SessionLayerModeStore
 
         var match = teamScoped ?? domainWide;
         return match is null
-            ? new SessionLayerModeResolution { Mode = SessionLayerMode.Default, Source = SessionLayerModeSource.Default }
+            ? new SessionLayerModeResolution
+            {
+                Mode = SessionLayerMode.Default,
+                Source = SessionLayerModeSource.Default,
+                TeamScopedEntriesInDomain = teamScopedEntriesInDomain,
+            }
             : new SessionLayerModeResolution
             {
                 Mode = match.Mode,
                 Source = SessionLayerModeSource.Recorded,
                 Entry = match,
+                TeamScopedEntriesInDomain = teamScopedEntriesInDomain,
             };
     }
 

--- a/tests/IntentSystem.Cli.Tests/SessionLayerResolutionG585Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerResolutionG585Tests.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G585: omitting --team must never make a team-scoped session-layer record
+/// disappear silently from either the record surface or a routing consumer.
+/// </summary>
+public sealed class SessionLayerResolutionG585Tests
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+    private const string OtherTeam = "other-team";
+    private const string Repo = "J-Tech-Japan/intent-system";
+
+    [Theory]
+    [InlineData("no-team", null, true, SessionLayerMode.Agmsg, "default", true)]
+    [InlineData("wrong-team", OtherTeam, true, SessionLayerMode.Agmsg, "default", false)]
+    [InlineData("correct-team", Team, true, SessionLayerMode.HerdrOnly, "recorded", false)]
+    [InlineData("no-record", null, false, SessionLayerMode.Agmsg, "default", false)]
+    public void ShowAndOrchestratorGuide_AgreeAcrossArgumentMatrix_G585(
+        string scenario,
+        string? requestedTeam,
+        bool createTeamRecord,
+        string expectedMode,
+        string expectedSource,
+        bool expectTeamOmissionDisclosure)
+    {
+        using var workspace = new ResolutionWorkspace();
+        if (createTeamRecord)
+        {
+            workspace.SetTeamMode(Team, SessionLayerMode.HerdrOnly);
+        }
+
+        var show = workspace.RunShow(requestedTeam, "json");
+        var guide = workspace.RunGuide(requestedTeam, "json");
+        Assert.Equal(0, show.ExitCode);
+        Assert.Equal(0, guide.ExitCode);
+
+        var showJson = JsonDocument.Parse(show.Output).RootElement;
+        var guideJson = JsonDocument.Parse(guide.Output).RootElement;
+        var routed = guideJson.GetProperty("session_layer");
+
+        Assert.Equal(expectedMode, showJson.GetProperty("mode").GetString());
+        Assert.Equal(expectedMode, routed.GetProperty("mode").GetString());
+        Assert.Equal(expectedSource, showJson.GetProperty("source").GetString());
+        Assert.Equal(expectedSource, routed.GetProperty("source").GetString());
+
+        var showDiscloses = showJson.TryGetProperty("team_omission", out var showDisclosure);
+        var guideDiscloses = routed.TryGetProperty("team_omission", out var guideDisclosure);
+        Assert.Equal(expectTeamOmissionDisclosure, showDiscloses);
+        Assert.Equal(expectTeamOmissionDisclosure, guideDiscloses);
+
+        if (!expectTeamOmissionDisclosure)
+        {
+            return;
+        }
+
+        AssertDisclosure(
+            showDisclosure,
+            expectedMode,
+            $"intent-cli session-layer show --domain {Domain} --team {Team}");
+        AssertDisclosure(
+            guideDisclosure,
+            expectedMode,
+            $"intent-cli guide orchestrator-thread --domain {Domain} --target-repo {Repo} --agent codex --team {Team}");
+        Assert.Equal("no-team", scenario);
+    }
+
+    [Fact]
+    public void NoTeamDisclosure_IsProminentAndActionableInEachMarkdownSurface_G585()
+    {
+        using var workspace = new ResolutionWorkspace();
+        workspace.SetTeamMode(Team, SessionLayerMode.HerdrOnly);
+
+        var show = workspace.RunShow(team: null, format: "markdown");
+        var guide = workspace.RunGuide(team: null, format: "markdown");
+
+        Assert.Equal(0, show.ExitCode);
+        Assert.Equal(0, guide.ExitCode);
+        Assert.Contains("**TEAM NOT SUPPLIED — ROUTING DISCLOSURE:**", show.Output, StringComparison.Ordinal);
+        Assert.Contains("**TEAM NOT SUPPLIED — ROUTING DISCLOSURE:**", guide.Output, StringComparison.Ordinal);
+        Assert.Contains("`--team` was not supplied", show.Output, StringComparison.Ordinal);
+        Assert.Contains("`--team` was not supplied", guide.Output, StringComparison.Ordinal);
+        Assert.Contains(SessionLayerMode.Describe(SessionLayerMode.Agmsg), show.Output, StringComparison.Ordinal);
+        Assert.Contains(SessionLayerMode.Describe(SessionLayerMode.Agmsg), guide.Output, StringComparison.Ordinal);
+        Assert.Contains(
+            $"`intent-cli session-layer show --domain {Domain} --team {Team}`",
+            show.Output,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            $"`intent-cli guide orchestrator-thread --domain {Domain} --target-repo {Repo} --agent codex --team {Team}`",
+            guide.Output,
+            StringComparison.Ordinal);
+    }
+
+    private static void AssertDisclosure(JsonElement disclosure, string expectedMode, string expectedCommand)
+    {
+        Assert.Contains("`--team` was not supplied", disclosure.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Equal(expectedMode, disclosure.GetProperty("mode_in_force").GetString());
+
+        var correction = Assert.Single(disclosure.GetProperty("corrective_commands").EnumerateArray());
+        Assert.Equal(Team, correction.GetProperty("team").GetString());
+        Assert.Equal(expectedCommand, correction.GetProperty("command").GetString());
+    }
+
+    private sealed class ResolutionWorkspace : IDisposable
+    {
+        public ResolutionWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("session-layer-g585-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = Domain,
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+        }
+
+        private string RootPath { get; }
+
+        private CliContext Context { get; }
+
+        public void SetTeamMode(string team, string mode)
+        {
+            var result = Run([
+                "session-layer", "set", "--domain", Domain, "--team", team,
+                "--mode", mode, "--write", "--format", "json",
+            ]);
+            Assert.Equal(0, result.ExitCode);
+        }
+
+        public CommandResult RunShow(string? team, string format)
+        {
+            var args = new List<string> { "session-layer", "show", "--domain", Domain };
+            if (team is not null)
+            {
+                args.AddRange(["--team", team]);
+            }
+            args.AddRange(["--format", format]);
+            return Run(args.ToArray());
+        }
+
+        public CommandResult RunGuide(string? team, string format)
+        {
+            var args = new List<string>
+            {
+                "guide", "orchestrator-thread", "--domain", Domain,
+                "--target-repo", Repo, "--agent", "codex",
+            };
+            if (team is not null)
+            {
+                args.AddRange(["--team", team]);
+            }
+            args.AddRange(["--format", format]);
+            return Run(args.ToArray());
+        }
+
+        private CommandResult Run(string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = CommandRouter.Execute(args, Context, writer);
+            return new CommandResult(exitCode, writer.ToString());
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+
+    private sealed record CommandResult(int ExitCode, string Output);
+}


### PR DESCRIPTION
## Summary

- retain the existing resolution semantics while carrying team-scoped record evidence when a mode-reading caller omits `--team`
- add a prominent structured `team_omission` disclosure to `session-layer show` and `guide orchestrator-thread`, naming the actual mode/source in force and an exact corrective command for every recorded team
- preserve no-record, wrong-team, and correct-team behavior and leave mode storage, reversibility, transition history, mode-specific operating content, and G586 topology wording unchanged
- add the required no-team / wrong-team / correct-team / no-record matrix across the record and routing surfaces

## Reproduction and after-state

On unmodified `origin/main`, the new five-case focused test reproduced the defect: 3 passed and 2 failed, with both failures naming the missing no-team disclosure in JSON and Markdown.

After the fix, a temporary canonical record for `intent-cli-dev=herdr-only` produced:

- no-team guide: `agmsg (PRIMARY)` is explicitly identified as the default for that invocation, followed at the top by `TEAM NOT SUPPLIED — ROUTING DISCLOSURE`, the recorded herdr-only team, and `intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent codex --team intent-cli-dev`
- correct-team guide: `herdr-only (PREVIEW — session transport only) — recorded for this domain/team`, with herdr-only sections
- no-team `session-layer show`: the same `agmsg/default` result and an exact `session-layer show ... --team intent-cli-dev` correction

## Verification

Exact local head: `b07975bd44cc8e0adc6633a502b31b5bacb62c2b`

- focused G585 matrix: 5 passed, 0 failed
- focused G570/G571/G578/G580/G581/G582 routing/consumer regression set: 195 passed, 0 failed
  - `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~SessionLayerResolutionG585Tests|FullyQualifiedName~SessionLayerModeG570Tests|FullyQualifiedName~HerdrOnlyOperatingGuideG571Tests|FullyQualifiedName~NotifyCommandG578Tests|FullyQualifiedName~HerdrWakeSourcesG581Tests|FullyQualifiedName~HerdrTrialFindingsG582Tests|FullyQualifiedName~SharedStaticSeamSerializationMetaTests"`
- full Release suite: 4,618 passed, 1 pre-existing skipped, 0 failed (4,619 total)
  - `dotnet test IntentSystem.sln -c Release --no-restore`
- `git diff --check`: passed

Closes #1273