### PR TITLE
G587: make packet readiness answer in one shot

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -192,6 +192,22 @@ resolved from one shared source, so `automation summary --domain <d>` and
 valid. A unit that does not match the active domain's regex is refused with a
 precise diagnostic that names the consulted bindings source.
 
+Before pushing a packet or handing it to queue seeding, run the one-shot
+readiness check:
+
+```text
+intent-cli packet draft --execution-unit <unit> --domain <d> --target-repo <owner/repo> --dry-run --format json
+```
+
+This checks the current on-disk packet; a valid planned scaffold does not count
+as an existing file. In this check, green means every canonical packet file
+currently exists and every required contract section is present
+(`contract_publishable: true`), and that the other publication checks reported
+no refusal. A refusal returns `missing_canonical_files`,
+`missing_contract_sections`, `refusal_reasons`, and `recommended_actions`
+together. Repair every reported item, then rerun the same command; do not push
+after fixing only the first item.
+
 ### Domain resolution order for execution-unit-resolving surfaces (G522)
 
 Surfaces that resolve an execution unit from `--pr` or `--execution-unit`

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -181,6 +181,20 @@ packet の正規の publish 経路は **`automation queue-seed-from-packet` →
 アクティブなドメインの regex に一致しない unit は、参照した bindings ソースを明示する精密な
 診断とともに拒否されます。
 
+packet を push する、または queue seed に渡す前に、次の one-shot readiness check を
+実行します:
+
+```text
+intent-cli packet draft --execution-unit <unit> --domain <d> --target-repo <owner/repo> --dry-run --format json
+```
+
+これは現在 disk 上にある packet を検査し、妥当な planned scaffold を既存 file として
+数えません。green は、すべての canonical packet file が現在存在し、すべての required contract
+section が存在することを意味します（`contract_publishable: true`）。さらに、その他の publication
+check に refusal がないことも保証します。refusal は `missing_canonical_files`、
+`missing_contract_sections`、`refusal_reasons`、`recommended_actions` をまとめて返します。
+最初の 1 件だけ直して push せず、報告されたすべてを修正して同じ command を再実行します。
+
 ### execution-unit を解決するサーフェスの domain 解決順序 (G522)
 
 `--pr` や `--execution-unit` から execution unit を解決するサーフェス

--- a/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationQueueSeedFromPacketCommand.cs
@@ -42,6 +42,7 @@ internal static class AutomationQueueSeedFromPacketCommand
     public const string ClassificationApplied = "queue-seed-applied";
     public const string ClassificationUnsafe = "unsafe-prepared-packet";
     public const string ClassificationPacketDirectoryMissing = "packet-directory-missing";
+    public const string ReasonDomainResolutionFailed = "domain-resolution-failed";
 
     public const string SeedEventName = "queue_seeded_from_packet";
 
@@ -69,13 +70,30 @@ internal static class AutomationQueueSeedFromPacketCommand
         var packetDirectoryAbsolute = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit);
         if (!Directory.Exists(packetDirectoryAbsolute))
         {
+            var missingFiles = PreparedPacketCommitReadyAnalyzer.CanonicalFileNames
+                .Select(name => packetDirectoryRelative + name)
+                .ToArray();
             var missing = new QueueSeedFromPacketResult
             {
                 Classification = ClassificationPacketDirectoryMissing,
                 ExecutionUnit = executionUnit,
                 PacketDirectory = packetDirectoryRelative,
                 Write = write,
-                Summary = $"prepared packet directory `{packetDirectoryRelative}` does not exist on disk; nothing to seed.",
+                ContractPublishable = false,
+                UnsafeReason = PreparedPacketCommitReadyAnalyzer.ReasonMissingCanonicalFile,
+                RefusalReasons =
+                [
+                    PreparedPacketCommitReadyAnalyzer.ReasonMissingCanonicalFile,
+                    PreparedPacketCommitReadyAnalyzer.ReasonGithubBodyMissingSection,
+                ],
+                MissingCanonicalFiles = missingFiles,
+                MissingContractSections = PreparedPacketCommitReadyAnalyzer.RequiredGithubBodySections,
+                RecommendedActions =
+                [
+                    $"Create `{packetDirectoryRelative}` and author all four canonical packet files: {string.Join(", ", missingFiles)}.",
+                    BuildReadinessRerun(executionUnit, domain, targetRepo),
+                ],
+                Summary = $"prepared packet directory `{packetDirectoryRelative}` does not exist; all four canonical files and every required github-body.md section are missing.",
             };
             EmitResult(writer, format, missing);
             return 1;
@@ -104,25 +122,16 @@ internal static class AutomationQueueSeedFromPacketCommand
         // surface upstream and on a mutation path — where the cost is a
         // malformed unit sitting in the queue and failing later at publish or
         // preflight, far from its cause.
-        if (!TryReadPacketDocument(packetDirectoryAbsolute, out var packetDocument, out var packetParseError))
-        {
-            var unparseable = new QueueSeedFromPacketResult
-            {
-                Classification = ClassificationUnsafe,
-                ExecutionUnit = executionUnit,
-                PacketDirectory = packetDirectoryRelative,
-                Write = write,
-                UnsafeReason = PreparedPacketCommitReadyAnalyzer.ReasonPacketYamlUnparseable,
-                Summary = $"refusing to seed queue-state from `{packetDirectoryRelative}`: {packetParseError} "
-                    + "No queue-state or runs.jsonl mutation was planned or applied. Repair the packet and re-run — "
-                    + "this is the same acceptance the packet schema and projection surfaces apply.",
-            };
-            EmitResult(writer, format, unparseable);
-            return 1;
-        }
+        var packetYaml = TryReadFile(Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNamePacketYaml));
+        var implementationMarkdown = TryReadFile(Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNameImplementationMarkdown));
+        var reviewContextMarkdown = TryReadFile(Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNameReviewContextMarkdown));
+        var githubBodyMarkdown = TryReadFile(Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNameGithubBodyMarkdown));
 
-        var packetFields = packetDocument.Fields;
-        var packetDeclaredDomain = LookupScalar(packetFields, "domain");
+        PacketYamlDocument? packetDocument = null;
+        var packetDeclaredDomain = packetYaml is not null
+            && PacketYamlDocument.TryParse(packetYaml, out packetDocument, out _)
+                ? LookupScalar(packetDocument!.Fields, "domain")
+                : null;
         var domainResolution = PacketDomainResolution.Resolve(
             domain,
             packetDeclaredDomain,
@@ -131,7 +140,41 @@ internal static class AutomationQueueSeedFromPacketCommand
                 + (string.IsNullOrWhiteSpace(targetRepo) ? string.Empty : $" --target-repo {targetRepo}"));
         if (domainResolution.IsError)
         {
-            writer.WriteLine(domainResolution.ErrorMessage);
+            var contentValidation = PreparedPacketCommitReadyAnalyzer.Analyze(new PreparedPacketCommitReadyInput
+            {
+                ExecutionUnit = executionUnit,
+                PacketYaml = packetYaml,
+                ImplementationMarkdown = implementationMarkdown,
+                ReviewContextMarkdown = reviewContextMarkdown,
+                GithubBodyMarkdown = githubBodyMarkdown,
+                RequestedTargetRepo = targetRepo,
+                RequireDomainBinding = false,
+            });
+            var refusalReasons = contentValidation.RefusalReasons
+                .Append(ReasonDomainResolutionFailed)
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            var domainFailure = new QueueSeedFromPacketResult
+            {
+                Classification = ClassificationUnsafe,
+                ExecutionUnit = executionUnit,
+                PacketDirectory = packetDirectoryRelative,
+                Write = write,
+                ContractPublishable = false,
+                UnsafeReason = contentValidation.Reason ?? ReasonDomainResolutionFailed,
+                RefusalReasons = refusalReasons,
+                MissingCanonicalFiles = contentValidation.MissingFiles,
+                MissingContractSections = contentValidation.MissingContractSections,
+                RecommendedActions =
+                [
+                    .. contentValidation.RecommendedActions,
+                    domainResolution.ErrorMessage ?? "Resolve the packet domain explicitly, then re-run readiness.",
+                    BuildReadinessRerun(executionUnit, domain, targetRepo),
+                ],
+                Summary = $"refusing to seed queue-state from `{packetDirectoryRelative}`: {contentValidation.Summary} "
+                    + (domainResolution.ErrorMessage ?? "The packet domain could not be resolved."),
+            };
+            EmitResult(writer, format, domainFailure);
             return 1;
         }
         var effectiveDomain = domainResolution.Domain!;
@@ -150,10 +193,10 @@ internal static class AutomationQueueSeedFromPacketCommand
         var validation = PreparedPacketCommitReadyAnalyzer.Analyze(new PreparedPacketCommitReadyInput
         {
             ExecutionUnit = executionUnit,
-            PacketYaml = TryReadFile(Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNamePacketYaml)),
-            ImplementationMarkdown = TryReadFile(Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNameImplementationMarkdown)),
-            ReviewContextMarkdown = TryReadFile(Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNameReviewContextMarkdown)),
-            GithubBodyMarkdown = TryReadFile(Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNameGithubBodyMarkdown)),
+            PacketYaml = packetYaml,
+            ImplementationMarkdown = implementationMarkdown,
+            ReviewContextMarkdown = reviewContextMarkdown,
+            GithubBodyMarkdown = githubBodyMarkdown,
             ExecutionUnitRegex = regexResolution.Pattern,
             RequestedTargetRepo = targetRepo,
             // Always require a domain binding now that `effectiveDomain`
@@ -171,10 +214,26 @@ internal static class AutomationQueueSeedFromPacketCommand
                 ExecutionUnit = executionUnit,
                 PacketDirectory = packetDirectoryRelative,
                 Write = write,
+                ContractPublishable = false,
                 UnsafeReason = validation.Reason,
+                RefusalReasons = validation.RefusalReasons,
+                MissingCanonicalFiles = validation.MissingFiles,
+                MissingContractSections = validation.MissingContractSections,
+                RecommendedActions =
+                [
+                    .. validation.RecommendedActions,
+                    BuildReadinessRerun(executionUnit, domain, targetRepo),
+                ],
                 Summary = $"refusing to seed queue-state from `{packetDirectoryRelative}`: "
                     + validation.Summary
-                    + DescribeBindingResolution(validation.Reason, effectiveDomain, regexResolution),
+                    + DescribeBindingResolution(
+                        validation.RefusalReasons.Contains(
+                            PreparedPacketCommitReadyAnalyzer.ReasonMissingDomainBindingRegex,
+                            StringComparer.Ordinal)
+                            ? PreparedPacketCommitReadyAnalyzer.ReasonMissingDomainBindingRegex
+                            : null,
+                        effectiveDomain,
+                        regexResolution),
             };
             EmitResult(writer, format, unsafeResult);
             return 1;
@@ -193,6 +252,7 @@ internal static class AutomationQueueSeedFromPacketCommand
         // `effectiveDomain` is already resolved above (G522: --domain >
         // packet-declared domain > fail-loud) so the clarification path
         // computation reuses the same value rather than re-deriving it.
+        var packetFields = packetDocument!.Fields;
         var defaultClarificationReturnPath = $"intents/{effectiveDomain}/clarifications/open.md";
 
         // PR #830 review repair #3 (08:27 comment): align role /
@@ -254,6 +314,7 @@ internal static class AutomationQueueSeedFromPacketCommand
                 ExecutionUnit = executionUnit,
                 PacketDirectory = packetDirectoryRelative,
                 Write = write,
+                ContractPublishable = true,
                 Summary = $"queue-state already contains an entry for `{executionUnit}`; nothing to seed.",
                 SeededItem = seed,
             };
@@ -269,6 +330,7 @@ internal static class AutomationQueueSeedFromPacketCommand
                 ExecutionUnit = executionUnit,
                 PacketDirectory = packetDirectoryRelative,
                 Write = false,
+                ContractPublishable = true,
                 SeededItem = seed,
                 Summary = $"prepared packet `{packetDirectoryRelative}` validated; queue-state would be seeded with a new queued item for `{executionUnit}`. "
                     + "Re-run with `--write` to persist.",
@@ -318,6 +380,7 @@ internal static class AutomationQueueSeedFromPacketCommand
             ExecutionUnit = executionUnit,
             PacketDirectory = packetDirectoryRelative,
             Write = true,
+            ContractPublishable = true,
             SeededItem = seed,
             Summary = $"seeded queue-state with a new queued item for `{executionUnit}` from validated packet `{packetDirectoryRelative}`. "
                 + $"Appended `{SeedEventName}` event to `.intent-cli/runs.jsonl`.",
@@ -438,43 +501,6 @@ internal static class AutomationQueueSeedFromPacketCommand
         return item;
     }
 
-    /// <summary>
-    /// G567: reads the packet's fields THROUGH a whole-document YAML parse
-    /// (<see cref="PacketYamlDocument"/>), the same acceptance G565 gave
-    /// projection. Returns <see langword="false"/> with a named error when the
-    /// file is present but is not valid YAML — the caller fails closed on that
-    /// rather than seeding from a partial read.
-    ///
-    /// A MISSING or empty packet.yaml is not this method's failure to report:
-    /// it stays an empty map so
-    /// <see cref="PreparedPacketCommitReadyAnalyzer"/> produces its own
-    /// missing-file diagnostic downstream, exactly as before.
-    /// </summary>
-    private static bool TryReadPacketDocument(
-        string packetDirectoryAbsolute,
-        out PacketYamlDocument document,
-        out string error)
-    {
-        error = string.Empty;
-        var packetYamlPath = Path.Combine(packetDirectoryAbsolute, PreparedPacketCommitReadyAnalyzer.FileNamePacketYaml);
-        var content = TryReadFile(packetYamlPath);
-        if (string.IsNullOrEmpty(content))
-        {
-            document = PacketYamlDocument.Empty;
-            return true;
-        }
-
-        if (!PacketYamlDocument.TryParse(content!, out var parsed, out var parseError))
-        {
-            document = PacketYamlDocument.Empty;
-            error = parseError;
-            return false;
-        }
-
-        document = parsed!;
-        return true;
-    }
-
     private static string? LookupScalar(IReadOnlyDictionary<string, string> fields, params string[] keys)
     {
         foreach (var key in keys)
@@ -501,6 +527,18 @@ internal static class AutomationQueueSeedFromPacketCommand
         {
             return null;
         }
+    }
+
+    private static string BuildReadinessRerun(
+        string executionUnit,
+        string? domain,
+        string? targetRepo)
+    {
+        var command = $"intent-cli automation queue-seed-from-packet --execution-unit {executionUnit}"
+            + (string.IsNullOrWhiteSpace(domain) ? " --domain <name>" : $" --domain {domain}")
+            + (string.IsNullOrWhiteSpace(targetRepo) ? " --target-repo <owner/repo>" : $" --target-repo {targetRepo}")
+            + " --format json";
+        return $"After repairing every reported item, re-run `{command}` and proceed only when `contract_publishable` is true.";
     }
 
     /// <summary>
@@ -547,9 +585,34 @@ internal static class AutomationQueueSeedFromPacketCommand
         writer.WriteLine($"- classification: **{result.Classification}**");
         writer.WriteLine($"- packet directory: `{result.PacketDirectory}`");
         writer.WriteLine($"- write: {(result.Write ? "yes" : "no (dry-run)")}");
+        writer.WriteLine($"- contract publishable: {(result.ContractPublishable ? "yes" : "no")}");
         if (!string.IsNullOrWhiteSpace(result.UnsafeReason))
         {
             writer.WriteLine($"- unsafe reason: `{result.UnsafeReason}`");
+        }
+        if (result.RefusalReasons.Count > 0)
+        {
+            writer.WriteLine("- refusal reasons:");
+            foreach (var reason in result.RefusalReasons)
+            {
+                writer.WriteLine($"  - {reason}");
+            }
+        }
+        if (result.MissingCanonicalFiles.Count > 0)
+        {
+            writer.WriteLine("- missing canonical files:");
+            foreach (var file in result.MissingCanonicalFiles)
+            {
+                writer.WriteLine($"  - {file}");
+            }
+        }
+        if (result.MissingContractSections.Count > 0)
+        {
+            writer.WriteLine("- missing contract sections:");
+            foreach (var section in result.MissingContractSections)
+            {
+                writer.WriteLine($"  - {section}");
+            }
         }
         writer.WriteLine();
         writer.WriteLine(result.Summary);
@@ -647,8 +710,12 @@ internal sealed record QueueSeedFromPacketResult
     public required string ExecutionUnit { get; init; }
     public required string PacketDirectory { get; init; }
     public required bool Write { get; init; }
+    public required bool ContractPublishable { get; init; }
     public required string Summary { get; init; }
     public string? UnsafeReason { get; init; }
+    public IReadOnlyList<string> RefusalReasons { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> MissingCanonicalFiles { get; init; } = Array.Empty<string>();
+    public IReadOnlyList<string> MissingContractSections { get; init; } = Array.Empty<string>();
     public QueueItem? SeededItem { get; init; }
-    public IReadOnlyList<string>? RecommendedActions { get; init; }
+    public IReadOnlyList<string> RecommendedActions { get; init; } = Array.Empty<string>();
 }

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -199,26 +199,38 @@ internal static class PacketDraftCommand
         // four-file layout regardless of the dedicated handling below.
         files.Insert(2, WriteOrUpdateReviewContext(packetDirectory, executionUnit, facetSelection, dryRun));
 
-        // Validate contract sections against whatever github-body.md ends up on disk
-        // (skeleton if newly written, existing content if previously authored).
-        var githubBodyPath = Path.Combine(packetDirectory, "github-body.md");
-        IReadOnlyList<string> missingSections = Array.Empty<string>();
-        if (File.Exists(githubBodyPath))
+        // G587: readiness describes what exists NOW, not the valid skeleton a
+        // dry-run could create. Feed the same four on-disk files, domain binding,
+        // target repo, and publish-section source into the analyzer used by
+        // queue-seed-from-packet. This eliminates the old vacuous green where an
+        // absent github-body.md yielded zero missing sections merely because the
+        // planned scaffold would contain them.
+        string? ReadPacketFile(string name)
         {
-            var content = File.ReadAllText(githubBodyPath);
-            missingSections = RequiredContractSections
-                .Where(section => !ContainsSectionHeading(content, section))
-                .ToArray();
+            var path = Path.Combine(packetDirectory, name);
+            return File.Exists(path) ? File.ReadAllText(path) : null;
         }
-        else if (dryRun)
+
+        var regexResolution = NextSliceDomainBindingsExecutionUnitRegex.Resolve(context, domain);
+        var readiness = PreparedPacketCommitReadyAnalyzer.Analyze(new PreparedPacketCommitReadyInput
         {
-            // Dry-run did not write the skeleton, but the planned content satisfies all
-            // required headings, so the validation result mirrors that intent.
-            missingSections = Array.Empty<string>();
-        }
-        else
+            ExecutionUnit = executionUnit,
+            PacketYaml = ReadPacketFile(PreparedPacketCommitReadyAnalyzer.FileNamePacketYaml),
+            ImplementationMarkdown = ReadPacketFile(PreparedPacketCommitReadyAnalyzer.FileNameImplementationMarkdown),
+            ReviewContextMarkdown = ReadPacketFile(PreparedPacketCommitReadyAnalyzer.FileNameReviewContextMarkdown),
+            GithubBodyMarkdown = ReadPacketFile(PreparedPacketCommitReadyAnalyzer.FileNameGithubBodyMarkdown),
+            ExecutionUnitRegex = regexResolution.Pattern,
+            RequestedTargetRepo = targetRepo,
+            RequireDomainBinding = true,
+        });
+
+        IReadOnlyList<string> recommendedActions = readiness.RecommendedActions;
+        if (readiness.Classification != PreparedPacketCommitReadyAnalyzer.ClassificationCommitReady)
         {
-            missingSections = RequiredContractSections;
+            var rerun = $"intent-cli packet draft --execution-unit {executionUnit} --domain {domain}"
+                + (string.IsNullOrWhiteSpace(targetRepo) ? string.Empty : $" --target-repo {targetRepo}")
+                + " --dry-run --format json";
+            recommendedActions = [.. recommendedActions, $"After repairing every reported item, re-run `{rerun}` and proceed only when `contract_publishable` is true."];
         }
 
         return new PacketDraftResult
@@ -229,13 +241,11 @@ internal static class PacketDraftCommand
             PacketDirectory = packetDirectory,
             Mode = mode,
             Files = files,
-            MissingContractSections = missingSections,
-            // G449: derive the packet's publish-readiness verdict through the
-            // SHARED NextSliceReadinessEvaluator so packet-draft validation
-            // agrees with next-slice / publish-flow / diagnostics on contract
-            // completeness (no missing required sections → publishable).
-            ContractPublishable = NextSliceReadinessEvaluator.IsPublishable(
-                executionUnit, contractComplete: missingSections.Count == 0)
+            MissingCanonicalFiles = readiness.MissingFiles,
+            MissingContractSections = readiness.MissingContractSections,
+            RefusalReasons = readiness.RefusalReasons,
+            RecommendedActions = recommendedActions,
+            ContractPublishable = readiness.Classification == PreparedPacketCommitReadyAnalyzer.ClassificationCommitReady,
         };
     }
 
@@ -730,27 +740,6 @@ internal static class PacketDraftCommand
             """;
     }
 
-    private static bool ContainsSectionHeading(string content, string section)
-    {
-        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
-        foreach (var rawLine in lines)
-        {
-            var line = rawLine.Trim();
-            if (!line.StartsWith("##", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var heading = line.TrimStart('#').Trim();
-            if (string.Equals(heading, section, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     private static void WriteMarkdown(TextWriter writer, PacketDraftResult result)
     {
         writer.WriteLine($"# Packet draft — {result.ExecutionUnit}");
@@ -773,6 +762,19 @@ internal static class PacketDraftCommand
         writer.WriteLine();
 
         writer.WriteLine("## Contract validation");
+        writer.WriteLine($"- contract publishable: {(result.ContractPublishable ? "yes" : "no")}");
+        if (result.MissingCanonicalFiles.Count == 0)
+        {
+            writer.WriteLine("- missing canonical files: none");
+        }
+        else
+        {
+            writer.WriteLine("- missing canonical files:");
+            foreach (var file in result.MissingCanonicalFiles)
+            {
+                writer.WriteLine($"  - {file}");
+            }
+        }
         if (result.MissingContractSections.Count == 0)
         {
             writer.WriteLine("- missing sections: none");
@@ -783,6 +785,23 @@ internal static class PacketDraftCommand
             foreach (var section in result.MissingContractSections)
             {
                 writer.WriteLine($"  - {section}");
+            }
+        }
+        if (result.RefusalReasons.Count > 0)
+        {
+            writer.WriteLine("- refusal reasons:");
+            foreach (var reason in result.RefusalReasons)
+            {
+                writer.WriteLine($"  - {reason}");
+            }
+        }
+        if (result.RecommendedActions.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Recommended actions");
+            foreach (var action in result.RecommendedActions)
+            {
+                writer.WriteLine($"- {action}");
             }
         }
     }
@@ -914,15 +933,22 @@ internal sealed record PacketDraftResult
     [JsonPropertyName("files")]
     public required IReadOnlyList<PacketDraftFile> Files { get; init; }
 
+    [JsonPropertyName("missing_canonical_files")]
+    public required IReadOnlyList<string> MissingCanonicalFiles { get; init; }
+
     [JsonPropertyName("missing_contract_sections")]
     public required IReadOnlyList<string> MissingContractSections { get; init; }
 
+    [JsonPropertyName("refusal_reasons")]
+    public required IReadOnlyList<string> RefusalReasons { get; init; }
+
+    [JsonPropertyName("recommended_actions")]
+    public required IReadOnlyList<string> RecommendedActions { get; init; }
+
     /// <summary>
-    /// G449: the packet's publish-readiness verdict from the shared
-    /// <see cref="NextSliceReadinessEvaluator"/> — true only when the contract
-    /// is complete (no missing required sections). Routes packet-draft
-    /// validation through the same engine as next-slice / publish-flow /
-    /// diagnostics so the surfaces never contradict on contract completeness.
+    /// G587: true only when the same complete packet readiness analyzer used by
+    /// queue-seed-from-packet finds no missing files, sections, binding mismatch,
+    /// malformed packet.yaml, or other publication refusal.
     /// </summary>
     [JsonPropertyName("contract_publishable")]
     public bool ContractPublishable { get; init; }

--- a/src/IntentSystem.Cli/Commands/PreparedPacketCommitReadyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PreparedPacketCommitReadyAnalyzer.cs
@@ -32,10 +32,12 @@ namespace IntentSystem.Cli.Commands;
 ///   operator hand-editing.</item>
 /// </list>
 ///
-/// Anything else is <c>unsafe-prepared-packet</c> with a structured
-/// reason: <c>missing-canonical-file</c>, <c>packet-yaml-unparseable</c>,
-/// <c>wrong-domain</c>, <c>wrong-target-repo</c>, or
-/// <c>github-body-missing-section</c>.
+/// Anything else is <c>unsafe-prepared-packet</c> with every structured
+/// refusal discovered in the same analysis: <c>missing-canonical-file</c>,
+/// <c>packet-yaml-unparseable</c>, <c>wrong-domain</c>,
+/// <c>wrong-target-repo</c>, <c>github-body-missing-section</c>, and the
+/// domain-binding refusals below. The legacy singular reason remains the
+/// first item for compatibility.
 ///
 /// Pure data in / pure data out: callers (the durable-state preflight
 /// command's probe in particular) read the working-tree files, resolve
@@ -98,30 +100,13 @@ internal static class PreparedPacketCommitReadyAnalyzer
     };
 
     /// <summary>
-    /// PR #824 review repair #5: canonical github-body section
-    /// headings the analyzer requires for commit-ready
-    /// classification. The match is EXACT (case-insensitive after
-    /// trimming trailing punctuation), so non-standalone variants
-    /// (`## My Goal`, `## Goal - notes`) are rejected. The list
-    /// mirrors the IntentNextSliceCommand contract sections and the
-    /// canonical github-body shape produced by the packet draft
-    /// surface — including the full `Target Repo / Path / Part`
-    /// heading rather than the looser MetadataValidate substring
-    /// `Target Repo`.
+    /// Canonical github-body headings required for commit-ready
+    /// classification. G587 routes this through the existing publish-contract
+    /// source so packet draft and queue seed cannot drift. The match is exact
+    /// (case-insensitive after trimming trailing punctuation), so
+    /// non-standalone variants (`## My Goal`, `## Goal - notes`) are rejected.
     /// </summary>
-    public static readonly IReadOnlyList<string> RequiredGithubBodySections = new[]
-    {
-        "Goal",
-        "Why This Slice Exists Now",
-        "Current Observed State",
-        "Accepted Baseline You May Assume",
-        "Target Repo / Path / Part",
-        "In Scope",
-        "Out Of Scope",
-        "Acceptance Criteria",
-        "Verification",
-        "Related Links",
-    };
+    public static IReadOnlyList<string> RequiredGithubBodySections => PublishContractSections.Required;
 
     public static PreparedPacketCommitReadyResult Analyze(PreparedPacketCommitReadyInput input)
     {
@@ -129,6 +114,22 @@ internal static class PreparedPacketCommitReadyAnalyzer
         ArgumentException.ThrowIfNullOrWhiteSpace(input.ExecutionUnit);
 
         var packetDirectory = $".intent-cli/issues/{input.ExecutionUnit}/";
+        var refusalReasons = new List<string>();
+        var refusalDetails = new List<string>();
+        var recommendedActions = new List<string>();
+
+        void Refuse(string reason, string detail, string action)
+        {
+            if (!refusalReasons.Contains(reason, StringComparer.Ordinal))
+            {
+                refusalReasons.Add(reason);
+            }
+            refusalDetails.Add(detail);
+            if (!recommendedActions.Contains(action, StringComparer.Ordinal))
+            {
+                recommendedActions.Add(action);
+            }
+        }
 
         // 1. Missing canonical files -------------------------------------
         var missing = new List<string>();
@@ -150,17 +151,11 @@ internal static class PreparedPacketCommitReadyAnalyzer
         }
         if (missing.Count > 0)
         {
-            return new PreparedPacketCommitReadyResult
-            {
-                Classification = ClassificationUnsafe,
-                Reason = ReasonMissingCanonicalFile,
-                ExecutionUnit = input.ExecutionUnit,
-                PacketDirectory = packetDirectory,
-                MissingFiles = missing,
-                Summary = $"prepared packet `{packetDirectory}` is missing canonical file(s): "
-                    + string.Join(", ", missing)
-                    + ". A complete packet must carry packet.yaml, implementation.md, review-context.md, and github-body.md before host-loop auto-commit.",
-            };
+            Refuse(
+                ReasonMissingCanonicalFile,
+                "missing canonical file(s): " + string.Join(", ", missing),
+                "Author every missing canonical file, preserving the four-file packet contract: "
+                    + string.Join(", ", missing) + ".");
         }
 
         // 2. Domain binding regex check ---------------------------------
@@ -173,23 +168,15 @@ internal static class PreparedPacketCommitReadyAnalyzer
         // regex supplied) is the check skipped.
         if (input.RequireDomainBinding && string.IsNullOrWhiteSpace(input.ExecutionUnitRegex))
         {
-            return new PreparedPacketCommitReadyResult
-            {
-                Classification = ClassificationUnsafe,
-                Reason = ReasonMissingDomainBindingRegex,
-                ExecutionUnit = input.ExecutionUnit,
-                PacketDirectory = packetDirectory,
-                Summary = $"prepared packet `{packetDirectory}` cannot be classified commit-ready: "
-                    + "the active domain has no `execution_unit_regex` in its bindings.md "
-                    + "(either the bindings file is missing or the field is absent). Host-loop "
-                    + "auto-commit refuses to accept a prepared packet without verifying the "
-                    + "active domain boundary.",
-            };
+            Refuse(
+                ReasonMissingDomainBindingRegex,
+                "the active domain has no `execution_unit_regex` in its bindings.md, so the domain boundary cannot be verified",
+                "Add the active domain's top-level `execution_unit_regex` to bindings.md, then re-run readiness.");
         }
 
+        Regex? regex = null;
         if (!string.IsNullOrWhiteSpace(input.ExecutionUnitRegex))
         {
-            Regex regex;
             try
             {
                 regex = new Regex(input.ExecutionUnitRegex, RegexOptions.CultureInvariant, TimeSpan.FromMilliseconds(200));
@@ -202,37 +189,22 @@ internal static class PreparedPacketCommitReadyAnalyzer
                     // unparseable binding regex when the host requested
                     // the binding. A malformed bindings.md must never
                     // silently bypass the cross-domain check.
-                    return new PreparedPacketCommitReadyResult
-                    {
-                        Classification = ClassificationUnsafe,
-                        Reason = ReasonInvalidDomainBindingRegex,
-                        ExecutionUnit = input.ExecutionUnit,
-                        PacketDirectory = packetDirectory,
-                        DomainRegex = input.ExecutionUnitRegex,
-                        Summary = $"prepared packet `{packetDirectory}` cannot be classified commit-ready: "
-                            + $"the active domain's `execution_unit_regex` `{input.ExecutionUnitRegex}` does not "
-                            + $"compile ({exception.Message}). Fix the bindings.md pattern before "
-                            + "the host loop can verify the domain boundary.",
-                    };
+                    Refuse(
+                        ReasonInvalidDomainBindingRegex,
+                        $"the active domain's `execution_unit_regex` `{input.ExecutionUnitRegex}` does not compile ({exception.Message})",
+                        "Fix the active domain's `execution_unit_regex` in bindings.md, then re-run readiness.");
                 }
                 // Legacy fail-open path retained ONLY when the host did
                 // not require a binding (no --domain configured).
-                regex = null!;
+                regex = null;
             }
 
             if (regex is not null && !regex.IsMatch(input.ExecutionUnit))
             {
-                return new PreparedPacketCommitReadyResult
-                {
-                    Classification = ClassificationUnsafe,
-                    Reason = ReasonWrongDomain,
-                    ExecutionUnit = input.ExecutionUnit,
-                    PacketDirectory = packetDirectory,
-                    DomainRegex = input.ExecutionUnitRegex,
-                    Summary = $"prepared packet `{packetDirectory}` declares execution-unit `{input.ExecutionUnit}` "
-                        + $"which does not match the active domain binding regex `{input.ExecutionUnitRegex}`; "
-                        + "host-loop auto-commit must not publish cross-domain packet directories.",
-                };
+                Refuse(
+                    ReasonWrongDomain,
+                    $"execution-unit `{input.ExecutionUnit}` does not match the active domain binding regex `{input.ExecutionUnitRegex}`",
+                    "Move the packet to the correct domain or correct its execution-unit so it matches the active binding.");
             }
         }
 
@@ -246,20 +218,17 @@ internal static class PreparedPacketCommitReadyAnalyzer
         //
         // The fields used below come from that same parse, so the parsed
         // document is authoritative for both the gate and the lookups.
-        if (!PacketYamlDocument.TryParse(input.PacketYaml!, out var packetDocument, out var packetParseError))
+        PacketYamlDocument? packetDocument = null;
+        if (input.PacketYaml is not null
+            && !PacketYamlDocument.TryParse(input.PacketYaml, out packetDocument, out var packetParseError))
         {
-            return new PreparedPacketCommitReadyResult
-            {
-                Classification = ClassificationUnsafe,
-                Reason = ReasonPacketYamlUnparseable,
-                ExecutionUnit = input.ExecutionUnit,
-                PacketDirectory = packetDirectory,
-                Summary = $"prepared packet `{packetDirectory}` packet.yaml does not parse "
-                    + $"as YAML: {packetParseError} Operator review required before auto-commit.",
-            };
+            Refuse(
+                ReasonPacketYamlUnparseable,
+                $"packet.yaml does not parse as YAML: {packetParseError}",
+                "Repair packet.yaml so the complete document parses as YAML, then re-run readiness.");
         }
 
-        IReadOnlyDictionary<string, string> packetFields = packetDocument!.Fields;
+        IReadOnlyDictionary<string, string>? packetFields = packetDocument?.Fields;
 
         // 4. Target repo check ------------------------------------------
         // PR #824 review repair #7: the prepared-packet lane MUST NOT
@@ -271,56 +240,33 @@ internal static class PreparedPacketCommitReadyAnalyzer
         // bypass the child-repo binding check.
         if (string.IsNullOrWhiteSpace(input.RequestedTargetRepo))
         {
-            return new PreparedPacketCommitReadyResult
-            {
-                Classification = ClassificationUnsafe,
-                Reason = ReasonMissingTargetRepo,
-                ExecutionUnit = input.ExecutionUnit,
-                PacketDirectory = packetDirectory,
-                Summary = $"prepared packet `{packetDirectory}` cannot be classified commit-ready: "
-                    + "no `--target-repo` was supplied, so the analyzer cannot verify the packet's "
-                    + "declared `target_repo` matches the intended child repo. Re-run "
-                    + "`automation durable-state-preflight --target-repo <owner/repo>` "
-                    + "(and `--domain <name>` for cross-domain scoping).",
-            };
+            Refuse(
+                ReasonMissingTargetRepo,
+                "no `--target-repo` was supplied, so the packet's intended child repo cannot be verified",
+                "Re-run readiness with `--target-repo <owner/repo>` (and `--domain <name>` for cross-domain scoping).");
         }
 
-        if (!string.IsNullOrWhiteSpace(input.RequestedTargetRepo))
+        string? declaredRepo = null;
+        if (!string.IsNullOrWhiteSpace(input.RequestedTargetRepo) && packetFields is not null)
         {
-            var declaredRepo = LookupScalar(
+            declaredRepo = LookupScalar(
                 packetFields,
                 "implementation_issue.target_repo",
                 "target_repo",
                 "implementation_issue_packet.target_repo");
             if (string.IsNullOrWhiteSpace(declaredRepo))
             {
-                return new PreparedPacketCommitReadyResult
-                {
-                    Classification = ClassificationUnsafe,
-                    Reason = ReasonWrongTargetRepo,
-                    ExecutionUnit = input.ExecutionUnit,
-                    PacketDirectory = packetDirectory,
-                    RequestedTargetRepo = input.RequestedTargetRepo,
-                    DeclaredTargetRepo = null,
-                    Summary = $"prepared packet `{packetDirectory}` does not declare a target_repo "
-                        + $"while the host loop expects target_repo=`{input.RequestedTargetRepo}`; host-loop "
-                        + "auto-commit refuses ambiguous publication target.",
-                };
+                Refuse(
+                    ReasonWrongTargetRepo,
+                    $"packet.yaml does not declare target_repo while readiness expects `{input.RequestedTargetRepo}`",
+                    $"Declare target_repo `{input.RequestedTargetRepo}` in packet.yaml, then re-run readiness.");
             }
-            if (!string.Equals(declaredRepo, input.RequestedTargetRepo, StringComparison.Ordinal))
+            else if (!string.Equals(declaredRepo, input.RequestedTargetRepo, StringComparison.Ordinal))
             {
-                return new PreparedPacketCommitReadyResult
-                {
-                    Classification = ClassificationUnsafe,
-                    Reason = ReasonWrongTargetRepo,
-                    ExecutionUnit = input.ExecutionUnit,
-                    PacketDirectory = packetDirectory,
-                    RequestedTargetRepo = input.RequestedTargetRepo,
-                    DeclaredTargetRepo = declaredRepo,
-                    Summary = $"prepared packet `{packetDirectory}` declares target_repo=`{declaredRepo}` "
-                        + $"but host loop expects `{input.RequestedTargetRepo}`; host-loop auto-commit refuses "
-                        + "to publish a packet aimed at a different child repo.",
-                };
+                Refuse(
+                    ReasonWrongTargetRepo,
+                    $"packet.yaml declares target_repo=`{declaredRepo}` but readiness expects `{input.RequestedTargetRepo}`",
+                    "Correct packet.yaml target_repo or re-run with the intended `--target-repo` value.");
             }
         }
 
@@ -329,22 +275,39 @@ internal static class PreparedPacketCommitReadyAnalyzer
         // RequiredGithubBodySections (with the full canonical heading
         // names) plus the strict exact-match HasMatchingHeading helper
         // so non-standalone headings like `## My Goal` are rejected.
-        var headings = ExtractHeadings(input.GithubBodyMarkdown!);
-        foreach (var section in RequiredGithubBodySections)
+        var headings = input.GithubBodyMarkdown is null
+            ? Array.Empty<string>()
+            : ExtractHeadings(input.GithubBodyMarkdown);
+        var missingSections = RequiredGithubBodySections
+            .Where(section => !HasMatchingHeading(headings, section))
+            .ToArray();
+        if (missingSections.Length > 0)
         {
-            if (!HasMatchingHeading(headings, section))
+            Refuse(
+                ReasonGithubBodyMissingSection,
+                "github-body.md is missing required section(s): " + string.Join(", ", missingSections),
+                "Add every missing required section to github-body.md: " + string.Join(", ", missingSections) + ".");
+        }
+
+        if (refusalReasons.Count > 0)
+        {
+            return new PreparedPacketCommitReadyResult
             {
-                return new PreparedPacketCommitReadyResult
-                {
-                    Classification = ClassificationUnsafe,
-                    Reason = ReasonGithubBodyMissingSection,
-                    ExecutionUnit = input.ExecutionUnit,
-                    PacketDirectory = packetDirectory,
-                    MissingGithubBodySection = section,
-                    Summary = $"prepared packet `{packetDirectory}` github-body.md is missing required "
-                        + $"section `{section}`; host-loop auto-commit refuses an incomplete child issue contract.",
-                };
-            }
+                Classification = ClassificationUnsafe,
+                Reason = refusalReasons[0],
+                RefusalReasons = refusalReasons,
+                ExecutionUnit = input.ExecutionUnit,
+                PacketDirectory = packetDirectory,
+                MissingFiles = missing,
+                MissingGithubBodySection = missingSections.FirstOrDefault(),
+                MissingContractSections = missingSections,
+                DomainRegex = input.ExecutionUnitRegex,
+                RequestedTargetRepo = input.RequestedTargetRepo,
+                DeclaredTargetRepo = declaredRepo,
+                RecommendedActions = recommendedActions,
+                Summary = $"prepared packet `{packetDirectory}` is not publishable; "
+                    + string.Join("; ", refusalDetails) + ".",
+            };
         }
 
         // 6. Commit-ready -----------------------------------------------
@@ -353,13 +316,13 @@ internal static class PreparedPacketCommitReadyAnalyzer
             Classification = ClassificationCommitReady,
             ExecutionUnit = input.ExecutionUnit,
             PacketDirectory = packetDirectory,
+            RefusalReasons = Array.Empty<string>(),
+            MissingFiles = Array.Empty<string>(),
+            MissingContractSections = Array.Empty<string>(),
+            RecommendedActions = Array.Empty<string>(),
             VerifiedFiles = CanonicalFileNames.Select(name => packetDirectory + name).ToArray(),
             RequestedTargetRepo = input.RequestedTargetRepo,
-            DeclaredTargetRepo = LookupScalar(
-                packetFields,
-                "implementation_issue.target_repo",
-                "target_repo",
-                "implementation_issue_packet.target_repo"),
+            DeclaredTargetRepo = declaredRepo,
             DomainRegex = input.ExecutionUnitRegex,
             Summary = $"prepared packet `{packetDirectory}` has the four canonical files, packet.yaml parses, "
                 + "github-body.md carries the required standalone sections, and the domain/target-repo bindings match; "
@@ -508,11 +471,19 @@ internal sealed record PreparedPacketCommitReadyResult
     /// <summary>Structured unsafe reason; null when <see cref="Classification"/> is commit-ready.</summary>
     public string? Reason { get; init; }
 
-    public IReadOnlyList<string>? MissingFiles { get; init; }
+    /// <summary>
+    /// Every structured refusal reason discovered in one analysis. <see cref="Reason"/>
+    /// remains the first reason for compatibility with callers that predate G587.
+    /// </summary>
+    public IReadOnlyList<string> RefusalReasons { get; init; } = Array.Empty<string>();
+
+    public IReadOnlyList<string> MissingFiles { get; init; } = Array.Empty<string>();
     public string? MissingGithubBodySection { get; init; }
+    public IReadOnlyList<string> MissingContractSections { get; init; } = Array.Empty<string>();
     public string? DomainRegex { get; init; }
     public string? RequestedTargetRepo { get; init; }
     public string? DeclaredTargetRepo { get; init; }
+    public IReadOnlyList<string> RecommendedActions { get; init; } = Array.Empty<string>();
 
     /// <summary>Set on commit-ready: full relative paths the host loop should stage.</summary>
     public IReadOnlyList<string>? VerifiedFiles { get; init; }

--- a/tests/IntentSystem.Cli.Tests/AutomationDurableStatePreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationDurableStatePreflightCommandTests.cs
@@ -474,7 +474,7 @@ public sealed class AutomationDurableStatePreflightCommandTests : IDisposable
             File.WriteAllText(Path.Combine(dir, "implementation.md"), "# impl\n");
             File.WriteAllText(Path.Combine(dir, "review-context.md"), "# review\n");
             File.WriteAllText(Path.Combine(dir, "github-body.md"),
-                "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+                "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n## Base Branch Policy\nx\n");
         }
 
         public void WriteBindings(string domain, string executionUnitRegex)

--- a/tests/IntentSystem.Cli.Tests/AutomationQueueSeedFromPacketCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationQueueSeedFromPacketCommandTests.cs
@@ -310,7 +310,7 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
         File.WriteAllText(Path.Combine(dir, "implementation.md"), "# impl\n");
         File.WriteAllText(Path.Combine(dir, "review-context.md"), "# review\n");
         File.WriteAllText(Path.Combine(dir, "github-body.md"),
-            "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+            "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n## Base Branch Policy\nx\n");
         workspace.WriteBindings("intent-cli", "^Z4R-G[0-9]+$");
 
         using var writer = new StringWriter();
@@ -415,7 +415,7 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
         File.WriteAllText(Path.Combine(dir, "implementation.md"), "# impl\n");
         File.WriteAllText(Path.Combine(dir, "review-context.md"), "# review\n");
         File.WriteAllText(Path.Combine(dir, "github-body.md"),
-            "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+            "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n## Base Branch Policy\nx\n");
         workspace.WriteBindings("intent-cli", "^Z4R-G[0-9]+$");
 
         using var writer = new StringWriter();
@@ -464,7 +464,7 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
         File.WriteAllText(Path.Combine(dir, "implementation.md"), "# impl\n");
         File.WriteAllText(Path.Combine(dir, "review-context.md"), "# review\n");
         File.WriteAllText(Path.Combine(dir, "github-body.md"),
-            "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+            "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n## Base Branch Policy\nx\n");
         workspace.WriteBindings("intent-cli", "^Z4R-G[0-9]+$");
 
         using var writer = new StringWriter();
@@ -629,9 +629,21 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
             writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("--domain could not be derived", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("Candidate domains:", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("--execution-unit Z4R-G10 --domain <name>", writer.ToString(), StringComparison.Ordinal);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        var details = root.GetProperty("summary").GetString()
+            + string.Join(
+                ' ',
+                root.GetProperty("recommended_actions")
+                    .EnumerateArray()
+                    .Select(action => action.GetString()));
+        Assert.Contains("--domain could not be derived", details, StringComparison.Ordinal);
+        Assert.Contains("Candidate domains:", details, StringComparison.Ordinal);
+        Assert.Contains("--execution-unit Z4R-G10 --domain <name>", details, StringComparison.Ordinal);
+        Assert.Contains(
+            AutomationQueueSeedFromPacketCommand.ReasonDomainResolutionFailed,
+            root.GetProperty("refusal_reasons").EnumerateArray().Select(reason => reason.GetString()),
+            StringComparer.Ordinal);
     }
 
     [Fact]
@@ -857,7 +869,7 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
         File.WriteAllText(Path.Combine(dir, "implementation.md"), "# impl\n");
         File.WriteAllText(Path.Combine(dir, "review-context.md"), "# review\n");
         File.WriteAllText(Path.Combine(dir, "github-body.md"),
-            "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+            "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n## Base Branch Policy\nx\n");
     }
 
     private sealed class TestWorkspace : IDisposable
@@ -896,7 +908,7 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
             File.WriteAllText(Path.Combine(dir, "implementation.md"), "# impl\n");
             File.WriteAllText(Path.Combine(dir, "review-context.md"), "# review\n");
             File.WriteAllText(Path.Combine(dir, "github-body.md"),
-                "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+                "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n## Base Branch Policy\nx\n");
         }
 
         public void WriteBindings(string domain, string executionUnitRegex)

--- a/tests/IntentSystem.Cli.Tests/PacketReadinessG587Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketReadinessG587Tests.cs
@@ -1,0 +1,255 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class PacketReadinessG587Tests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string ExecutionUnit = "G587";
+    private const string TargetRepo = "J-Tech-Japan/intent-system";
+
+    private readonly string root = Directory.CreateTempSubdirectory("packet-readiness-g587-").FullName;
+    private readonly CliContext context;
+
+    public PacketReadinessG587Tests()
+    {
+        context = new CliContext
+        {
+            RepoRoot = root,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = Domain,
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                },
+            },
+        };
+        WriteBinding("^G[0-9]+$");
+    }
+
+    [Theory]
+    [InlineData("only-packet-yaml", false, 3, true)]
+    [InlineData("body-present-missing-sections", false, 0, true)]
+    [InlineData("all-four-files-complete", true, 0, false)]
+    [InlineData("body-present-and-complete", false, 2, false)]
+    public void PacketDraftAndQueueSeed_AgreeAcrossRequiredMatrix_G587(
+        string state,
+        bool expectedPublishable,
+        int expectedMissingFileCount,
+        bool expectMissingSections)
+    {
+        WritePacketYaml(TargetRepo);
+        switch (state)
+        {
+            case "only-packet-yaml":
+                break;
+            case "body-present-missing-sections":
+                WriteImplementationAndReview();
+                WriteGithubBody("# Title\n\n## Goal\nPresent.\n");
+                break;
+            case "all-four-files-complete":
+                WriteImplementationAndReview();
+                WriteGithubBody(CompleteGithubBody());
+                break;
+            case "body-present-and-complete":
+                WriteGithubBody(CompleteGithubBody());
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown matrix state: {state}");
+        }
+
+        using var draft = ExecutePacketDraft();
+        using var seed = ExecuteQueueSeed(out var seedExitCode);
+
+        Assert.Equal(expectedPublishable, draft.RootElement.GetProperty("contract_publishable").GetBoolean());
+        Assert.Equal(expectedPublishable, seed.RootElement.GetProperty("contract_publishable").GetBoolean());
+        Assert.Equal(expectedPublishable ? 0 : 1, seedExitCode);
+        Assert.Equal(
+            PreparedPacketCommitReadyAnalyzer.CanonicalFileNames.Count - expectedMissingFileCount,
+            Directory.EnumerateFiles(PacketDirectory()).Count());
+
+        var draftMissingFiles = Strings(draft.RootElement, "missing_canonical_files");
+        var seedMissingFiles = Strings(seed.RootElement, "missing_canonical_files");
+        Assert.Equal(expectedMissingFileCount, draftMissingFiles.Length);
+        Assert.Equal(draftMissingFiles, seedMissingFiles);
+
+        var draftMissingSections = Strings(draft.RootElement, "missing_contract_sections");
+        var seedMissingSections = Strings(seed.RootElement, "missing_contract_sections");
+        Assert.Equal(expectMissingSections, draftMissingSections.Length > 0);
+        Assert.Equal(draftMissingSections, seedMissingSections);
+
+        var draftReasons = Strings(draft.RootElement, "refusal_reasons");
+        var seedReasons = Strings(seed.RootElement, "refusal_reasons");
+        Assert.Equal(draftReasons, seedReasons);
+        Assert.Equal(expectedPublishable, draftReasons.Length == 0);
+
+        var draftActions = Strings(draft.RootElement, "recommended_actions");
+        var seedActions = Strings(seed.RootElement, "recommended_actions");
+        if (expectedPublishable)
+        {
+            Assert.Empty(draftActions);
+        }
+        else
+        {
+            Assert.NotEmpty(draftActions);
+            Assert.NotEmpty(seedActions);
+        }
+    }
+
+    [Fact]
+    public void Readiness_ReportsFilesSectionsAndEveryOtherRefusalTogether_G587()
+    {
+        WriteBinding("^Z4R-G[0-9]+$");
+        WritePacketYaml("Other/Repo");
+        WriteGithubBody("# Title\n\n## Goal\nPresent.\n");
+
+        using var draft = ExecutePacketDraft();
+        using var seed = ExecuteQueueSeed(out var seedExitCode);
+
+        var expectedReasons = new[]
+        {
+            PreparedPacketCommitReadyAnalyzer.ReasonMissingCanonicalFile,
+            PreparedPacketCommitReadyAnalyzer.ReasonWrongDomain,
+            PreparedPacketCommitReadyAnalyzer.ReasonWrongTargetRepo,
+            PreparedPacketCommitReadyAnalyzer.ReasonGithubBodyMissingSection,
+        };
+        Assert.Equal(expectedReasons, Strings(draft.RootElement, "refusal_reasons"));
+        Assert.Equal(expectedReasons, Strings(seed.RootElement, "refusal_reasons"));
+        Assert.Equal(1, seedExitCode);
+        Assert.Equal(2, Strings(seed.RootElement, "missing_canonical_files").Length);
+        Assert.Contains("Acceptance Criteria", Strings(seed.RootElement, "missing_contract_sections"));
+        Assert.Contains("Base Branch Policy", Strings(seed.RootElement, "missing_contract_sections"));
+        Assert.True(Strings(draft.RootElement, "recommended_actions").Length >= expectedReasons.Length);
+        Assert.True(Strings(seed.RootElement, "recommended_actions").Length >= expectedReasons.Length);
+        Assert.Equal(
+            PreparedPacketCommitReadyAnalyzer.ReasonMissingCanonicalFile,
+            seed.RootElement.GetProperty("unsafe_reason").GetString());
+    }
+
+    [Fact]
+    public void RequiredSections_StayOnTheExistingPublishContractSource_G587()
+    {
+        Assert.Same(
+            PublishContractSections.Required,
+            PreparedPacketCommitReadyAnalyzer.RequiredGithubBodySections);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperGuidance_NamesOneShotCheckAndGreenGuarantee_G587(string language)
+    {
+        var path = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "docs",
+            language,
+            "09-developer-reference.md");
+        var doc = NormalizeWhitespace(File.ReadAllText(path));
+
+        Assert.Contains(
+            "intent-cli packet draft --execution-unit <unit> --domain <d> --target-repo <owner/repo> --dry-run --format json",
+            doc,
+            StringComparison.Ordinal);
+        Assert.Contains("missing_canonical_files", doc, StringComparison.Ordinal);
+        Assert.Contains("missing_contract_sections", doc, StringComparison.Ordinal);
+        Assert.Contains("refusal_reasons", doc, StringComparison.Ordinal);
+        Assert.Contains("recommended_actions", doc, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en"
+                ? "green means every canonical packet file currently exists and every required contract section is present"
+                : "green は、すべての canonical packet file が現在存在し、すべての required contract section が存在することを意味します",
+            doc,
+            StringComparison.Ordinal);
+    }
+
+    private JsonDocument ExecutePacketDraft()
+    {
+        using var writer = new StringWriter();
+        var exitCode = PacketDraftCommand.Execute(
+            context,
+            [
+                "--execution-unit", ExecutionUnit,
+                "--domain", Domain,
+                "--target-repo", TargetRepo,
+                "--dry-run",
+                "--format", "json",
+            ],
+            writer);
+        Assert.Equal(0, exitCode);
+        return JsonDocument.Parse(writer.ToString());
+    }
+
+    private JsonDocument ExecuteQueueSeed(out int exitCode)
+    {
+        using var writer = new StringWriter();
+        exitCode = AutomationQueueSeedFromPacketCommand.Execute(
+            context,
+            [
+                "--execution-unit", ExecutionUnit,
+                "--domain", Domain,
+                "--target-repo", TargetRepo,
+                "--format", "json",
+            ],
+            writer);
+        return JsonDocument.Parse(writer.ToString());
+    }
+
+    private void WritePacketYaml(string targetRepo)
+    {
+        Directory.CreateDirectory(PacketDirectory());
+        File.WriteAllText(
+            Path.Combine(PacketDirectory(), "packet.yaml"),
+            $$"""
+            domain: {{Domain}}
+            implementation_issue_packet:
+              source_execution_unit: {{ExecutionUnit}}
+              issue_title: G587 readiness matrix
+              target_repo: {{targetRepo}}
+            """);
+    }
+
+    private void WriteImplementationAndReview()
+    {
+        File.WriteAllText(Path.Combine(PacketDirectory(), "implementation.md"), "# Implementation\n");
+        File.WriteAllText(Path.Combine(PacketDirectory(), "review-context.md"), "# Review context\n");
+    }
+
+    private void WriteGithubBody(string content) =>
+        File.WriteAllText(Path.Combine(PacketDirectory(), "github-body.md"), content);
+
+    private void WriteBinding(string regex)
+    {
+        var directory = Path.Combine(root, "intents", Domain, "automation");
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(
+            Path.Combine(directory, "bindings.md"),
+            $"---\nexecution_unit_regex: '{regex}'\n---\n");
+    }
+
+    private string PacketDirectory() =>
+        Path.Combine(root, ".intent-cli", "issues", ExecutionUnit);
+
+    private static string CompleteGithubBody() =>
+        "# G587 readiness matrix\n\n"
+        + string.Join("\n\n", PublishContractSections.Required.Select(section => $"## {section}\nComplete."))
+        + "\n";
+
+    private static string[] Strings(JsonElement rootElement, string property) =>
+        rootElement.GetProperty(property).EnumerateArray().Select(value => value.GetString()!).ToArray();
+
+    private static string NormalizeWhitespace(string value) =>
+        string.Join(' ', value.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/PacketYamlParityG565Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketYamlParityG565Tests.cs
@@ -192,7 +192,7 @@ public sealed class PacketYamlParityG565Tests : IDisposable
             File.WriteAllText(Path.Combine(PacketDirectory, "github-body.md"),
                 "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n"
                 + "## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n"
-                + "## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+                + "## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n## Base Branch Policy\nx\n");
             WriteReviewContextMarkdown();
         }
 

--- a/tests/IntentSystem.Cli.Tests/PreparedPacketCommitReadyAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PreparedPacketCommitReadyAnalyzerTests.cs
@@ -43,6 +43,10 @@ Demo.
 
 ## Related Links
 Demo.
+
+## Base Branch Policy
+Policy: direct-main
+Expected PR base branch: main
 """;
 
     private const string CanonicalReviewContext = """
@@ -410,6 +414,9 @@ Demo.
 
             ## Related Links
             x
+
+            ## Base Branch Policy
+            x
             """;
         var result = PreparedPacketCommitReadyAnalyzer.Analyze(new PreparedPacketCommitReadyInput
         {
@@ -464,6 +471,9 @@ Demo.
             x
 
             ## Related Links
+            x
+
+            ## Base Branch Policy
             x
             """;
         var result = PreparedPacketCommitReadyAnalyzer.Analyze(new PreparedPacketCommitReadyInput
@@ -523,6 +533,9 @@ Demo.
             x
 
             ## Related Links
+            x
+
+            ## Base Branch Policy
             x
             """;
         var result = PreparedPacketCommitReadyAnalyzer.Analyze(new PreparedPacketCommitReadyInput

--- a/tests/IntentSystem.Cli.Tests/QueueSeedDependenciesG568Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueSeedDependenciesG568Tests.cs
@@ -383,7 +383,7 @@ public sealed class QueueSeedDependenciesG568Tests : IDisposable
             File.WriteAllText(Path.Combine(directory, "github-body.md"),
                 "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n"
                 + "## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n"
-                + "## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+                + "## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n## Base Branch Policy\nx\n");
         }
 
         public void WriteQueueStateWithDependencies(string[] dependencies, string[]? extraUnits = null)

--- a/tests/IntentSystem.Cli.Tests/QueueSeedPacketParsingG567Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueSeedPacketParsingG567Tests.cs
@@ -250,7 +250,7 @@ public sealed class QueueSeedPacketParsingG567Tests : IDisposable
             File.WriteAllText(Path.Combine(directory, "github-body.md"),
                 "# Title\n## Goal\nx\n## Why This Slice Exists Now\nx\n## Current Observed State\nx\n"
                 + "## Accepted Baseline You May Assume\nx\n## Target Repo / Path / Part\nx\n## In Scope\nx\n"
-                + "## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n");
+                + "## Out Of Scope\nx\n## Acceptance Criteria\nx\n## Verification\nx\n## Related Links\nx\n## Base Branch Policy\nx\n");
         }
 
         public void WriteExistingQueueState() => File.WriteAllText(QueueStatePath, """


### PR DESCRIPTION
## Summary
- Make `packet draft --dry-run` evaluate the current four-file packet rather than a planned scaffold, eliminating the missing-body false green.
- Aggregate every missing canonical file, every missing contract section, binding/YAML/target refusal, and actionable repair in one structured answer.
- Give `queue-seed-from-packet` the same `contract_publishable`, `missing_canonical_files`, `missing_contract_sections`, `refusal_reasons`, and populated unsafe `recommended_actions` shape while preserving legacy `unsafe_reason` as the first reason.
- Keep both surfaces on the existing publish-section source and document the one-shot check and green guarantee in EN/JA.

## Verification
- Before, packet.yaml-only reproduced `packet draft`: `contract_publishable=true`, `missing_contract_sections=[]`; queue seed refused with three missing files only in prose and `recommended_actions=null`.
- After, the same packet.yaml-only fixture reports not publishable on both surfaces, names all three absent files and all 11 required sections, includes every refusal reason, and returns actionable recommendations in one invocation.
- Required four-state cross-surface matrix plus compound files/sections/domain/target refusal and EN/JA guidance tests: 8 passed, 0 failed.
- Focused packet/readiness/queue/durable-state/parsing/dependency suite: 145 passed, 0 failed.
- Full Release suite: 4,630 passed, 1 skipped, 0 failed (4,631 total).
- Dry-run matrix confirms no packet content is generated.
- `git diff --check`: passed.

Closes #1277