### PR TITLE
Fix notify routing for recorded external roles

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -46,11 +46,27 @@ and complete canonical report command (including the transport-neutral
 `--routing-root` needed from an isolated child checkout) in the delivered task. Running that
 report command is the receiver's required final step after all other work, so a
 herdr-only completion actively wakes the orchestration role instead of merely
-printing into the receiver pane. Unknown roles and delivery failures fail
-closed with a named cause. `notify escalate` appends the unchanged six-field
-event schema; none of these commands merges, labels, publishes, or mutates queue
-state. Direct transport commands remain provisioning/readiness diagnostics,
-not workflow send instructions.
+printing into the receiver pane. In herdr-only mode the source of truth is
+`<routing-root>/.intent-cli/role-pane-mapping.json`: every sender, recipient,
+and delegate `report-to` role must exist in that team's recorded roster, but
+**only the recipient must be deliverable**. A `resident: external` role therefore
+may send and may be `report-to` without a pane. When that external role is the
+recipient, `delegate` and `report` deliver by appending exactly one unchanged
+six-field event to its safe routing-root-relative recorded `reader` (`delegate`
+uses `question`; `report` uses its existing status), and return `eventAppended:
+true`; a herdr-resident recipient is prompted at its explicit
+recorded pane in the team's recorded workspace. Agents found only in another
+workspace are never eligible.
+
+`--dry-run` performs the same topology, team-workspace, recipient-state, and
+reader resolution as `--write`, returning the same refusal verdict and cause
+without prompting or appending. Unknown-role failures name the source actually
+consulted, the team/workspace scope, the roles found there, and a corrective
+action. All resolution remains fail-closed: there is no fallback to a foreign
+workspace or another transport. `notify escalate` continues to append the same
+six-field event schema; none of these commands merges, labels, publishes, or
+mutates queue state. Direct transport commands remain provisioning/readiness
+diagnostics, not workflow send instructions.
 
 ## Starting orchestrator mode (design-thread setup)
 
@@ -296,6 +312,18 @@ attribution rules remain authoritative and unchanged; reference them rather
 than inventing another attribution policy. An external design frontend is
 recorded as a reader type rather than fabricated as a pane.
 
+Persist that team-scoped topology at
+`<host-repo>/.intent-cli/role-pane-mapping.json`. Record the team
+`workspace_id`; under `roles`, give each pane-backed role `resident: herdr` plus
+its explicit `workspace_id` and `pane_id`, and give a role outside herdr
+`resident: external` plus its routing-root-relative `reader` (normally
+`.intent-cli/events/<team>.jsonl`). All recorded roles may be senders and
+delegate report targets. On receipt, herdr residents require a running agent at
+the recorded pane in that exact team workspace; external residents receive the
+canonical delegate/report event through the recorded reader. A missing/unsafe
+reader, stale pane, foreign-workspace-only name, or ambiguous mapping fails
+closed with no prompt or append.
+
 Launch with the typed surface:
 
 ```text
@@ -406,18 +434,25 @@ team subdirectories and no hard-coded absolute paths. Before constructing the
 path, fail closed on an empty name, a leading dot, `/` or `\`, or any `..`
 sequence. Never sanitize an invalid name.
 
-The orchestrator is the only writer. Open with `O_APPEND`, append one complete
-JSON object per line, permit no embedded newline, and normalize `summary` to one
-line. The required schema is:
+The canonical `intent-cli notify` surface is the only writer; callers never
+append by hand. The orchestrator normally writes delegate/escalate events, and
+a receiver's canonical report may append when its recorded recipient is
+external. Open with `O_APPEND`, append one complete JSON object per line, permit
+no embedded newline, and normalize `summary` to one line. The required schema
+is:
 
 ```json
 {"timestamp":"<RFC3339>","team":"<team>","kind":"completion|blocked|question|escalation","unit":"<execution-unit-or-task-id>","summary":"<one-line-summary>","artifact":"<repo-relative-path-or-URL>"}
 ```
 
-Write only design-relevant completion, blocked, question, and escalation
-events. This mode-independent channel is the design boundary only—never an
-inter-agent bus and never a replacement for `intent-cli notify`, GitHub, or
-intent-cli workflow state.
+Write only canonical notifications addressed to a recorded external reader and
+design-relevant completion, blocked, question, and escalation events. A
+delegation to an external reader uses `question`; an external report uses its
+existing `completed|blocked|question` status. Pane-resident dispatch, routine
+progress, pane output, and acknowledgements are never mirrored here. This
+mode-independent channel remains the explicit external-reader/design boundary,
+never a fallback inter-agent bus and never a replacement for `intent-cli
+notify`, GitHub, or intent-cli workflow state.
 
 Every reader persists a durable watermark across watcher restarts containing
 the file identity, byte offset, and complete-line count. Before each read it

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -53,7 +53,8 @@ and delegate `report-to` role must exist in that team's recorded roster, but
 may send and may be `report-to` without a pane. When that external role is the
 recipient, `delegate` and `report` deliver by appending exactly one unchanged
 six-field event to its safe routing-root-relative recorded `reader` (`delegate`
-uses `question`; `report` uses its existing status), and return `eventAppended:
+uses `question`; `report` maps status `completed|blocked|question` to event kind
+`completion|blocked|question`), and return `eventAppended:
 true`; a herdr-resident recipient is prompted at its explicit
 recorded pane in the team's recorded workspace. Agents found only in another
 workspace are never eligible.
@@ -448,7 +449,8 @@ is:
 Write only canonical notifications addressed to a recorded external reader and
 design-relevant completion, blocked, question, and escalation events. A
 delegation to an external reader uses `question`; an external report uses its
-existing `completed|blocked|question` status. Pane-resident dispatch, routine
+`completed|blocked|question` status to write event kind
+`completion|blocked|question`. Pane-resident dispatch, routine
 progress, pane output, and acknowledgements are never mirrored here. This
 mode-independent channel remains the explicit external-reader/design boundary,
 never a fallback inter-agent bus and never a replacement for `intent-cli

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -50,7 +50,8 @@ command を final step として実行するため、herdr-only の完了が rec
 recipient must be deliverable** です。このため `resident: external` role は pane なしで sender
 および `report-to` になれます。その external role が recipient の場合、`delegate` / `report`
 は安全な routing-root-relative の recorded `reader` へ変更されていない 6-field event を正確に
-1 件 append して配信します（`delegate` は `question`、`report` は既存 status を使います）。
+1 件 append して配信します（`delegate` は `question`、`report` は status
+`completed|blocked|question` を event kind `completion|blocked|question` へ map します）。
 そして `eventAppended: true` を返します。herdr-resident recipient は team の recorded workspace
 内にある明示的な recorded pane を target にします。他 workspace にだけ存在する agent は
 決して eligible ではありません。
@@ -417,7 +418,8 @@ receiver の canonical report も append できます。`O_APPEND` で開き、1
 
 recorded external reader 宛ての canonical notification と、design-relevant な completion /
 blocked / question / escalation だけを書きます。external reader 宛て delegation は `question`、
-external report は既存の `completed|blocked|question` status を使います。pane-resident dispatch、
+external report は `completed|blocked|question` status を event kind
+`completion|blocked|question` へ map します。pane-resident dispatch、
 routine progress、pane output、acknowledgement はここへ mirror しません。この mode-independent
 channel は explicit external-reader/design boundary のままで、fallback inter-agent bus ではなく、
 `intent-cli notify`、GitHub、intent-cli workflow state の代替でもありません。

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -44,11 +44,24 @@ intent-cli notify escalate --domain <domain> --team <team> --from <sender-role> 
 checkout から必要な transport-neutral `--routing-root` を含む完全な canonical report
 command を配信 task に埋め込みます。receiver は他のすべての作業後、その report
 command を final step として実行するため、herdr-only の完了が receiver pane に表示される
-だけで終わらず orchestration role を能動的に wake します。unknown role と delivery failure
-は named cause と non-zero で fail closed します。`notify escalate` は変更していない 6-field
-event schema を append します。いずれも merge / label / publish / queue mutation を行いません。
-direct transport command は provisioning/readiness diagnostics に限り、workflow send instruction
-には使いません。
+だけで終わらず orchestration role を能動的に wake します。herdr-only mode の source of truth は
+`<routing-root>/.intent-cli/role-pane-mapping.json` です。sender、recipient、delegate の
+`report-to` はすべてその team の recorded roster に存在する必要がありますが、**only the
+recipient must be deliverable** です。このため `resident: external` role は pane なしで sender
+および `report-to` になれます。その external role が recipient の場合、`delegate` / `report`
+は安全な routing-root-relative の recorded `reader` へ変更されていない 6-field event を正確に
+1 件 append して配信します（`delegate` は `question`、`report` は既存 status を使います）。
+そして `eventAppended: true` を返します。herdr-resident recipient は team の recorded workspace
+内にある明示的な recorded pane を target にします。他 workspace にだけ存在する agent は
+決して eligible ではありません。
+
+`--dry-run` は `--write` と同じ topology、team-workspace、recipient-state、reader resolution を
+実行し、prompt / append の副作用なしで同じ refusal verdict と cause を返します。unknown-role
+failure は実際に参照した source、team/workspace scope、その scope で見つかった role、corrective
+action を明示します。resolution はすべて fail closed で、foreign workspace や別 transport への
+fallback はありません。`notify escalate` は同じ 6-field event schema を引き続き append します。
+いずれも merge / label / publish / queue mutation を行いません。direct transport command は
+provisioning/readiness diagnostics に限り、workflow send instruction には使いません。
 
 ## orchestrator モードの開始（設計スレッドのセットアップ）
 
@@ -281,6 +294,16 @@ currently focused pane を mutate する可能性があります。既存 G555 c
 rules が変わらず authoritative であり、別の attribution policy を再定義せずそれを reference
 します。herdr 外の design frontend は架空 pane ではなく reader type として記録します。
 
+この team-scoped topology は
+`<host-repo>/.intent-cli/role-pane-mapping.json` に persist します。team の
+`workspace_id` を記録し、`roles` 配下で pane-backed role には `resident: herdr` と明示的な
+`workspace_id` / `pane_id`、herdr 外の role には `resident: external` と routing-root-relative
+な `reader`（通常は `.intent-cli/events/<team>.jsonl`）を記録します。すべての recorded role は
+sender と delegate report target になれます。受信時は herdr resident に、その正確な team
+workspace の recorded pane で running agent が必要です。external resident は recorded reader
+を通して canonical delegate/report event を受け取ります。missing/unsafe reader、stale pane、
+foreign-workspace-only name、ambiguous mapping は prompt / append なしで fail closed になります。
+
 typed launch は次の surface です。
 
 ```text
@@ -383,15 +406,20 @@ host root を実行時に解決し、`<host-repo>/.intent-cli/events/<team>.json
 path 構築前に、空文字、先頭 dot、`/` または `\`、任意の `..` sequence を fail closed で
 拒否します。不正名を sanitize してはいけません。
 
-writer は orchestrator だけです。`O_APPEND` で開き、1 行に完全な JSON object を 1 つ
-append し、embedded newline を許さず、`summary` を 1 行へ normalize します。必須 schema:
+canonical `intent-cli notify` surface だけが writer で、caller は手動 append しません。
+通常は orchestrator が delegate/escalate event を書き、recorded recipient が external の場合は
+receiver の canonical report も append できます。`O_APPEND` で開き、1 行に完全な JSON object
+を 1 つ append し、embedded newline を許さず、`summary` を 1 行へ normalize します。必須 schema:
 
 ```json
 {"timestamp":"<RFC3339>","team":"<team>","kind":"completion|blocked|question|escalation","unit":"<execution-unit-or-task-id>","summary":"<one-line-summary>","artifact":"<repo-relative-path-or-URL>"}
 ```
 
-design-relevant な completion / blocked / question / escalation だけを書きます。この
-mode-independent channel は design boundary のみで、inter-agent bus ではなく、
+recorded external reader 宛ての canonical notification と、design-relevant な completion /
+blocked / question / escalation だけを書きます。external reader 宛て delegation は `question`、
+external report は既存の `completed|blocked|question` status を使います。pane-resident dispatch、
+routine progress、pane output、acknowledgement はここへ mirror しません。この mode-independent
+channel は explicit external-reader/design boundary のままで、fallback inter-agent bus ではなく、
 `intent-cli notify`、GitHub、intent-cli workflow state の代替でもありません。
 
 すべての reader は watcher restart をまたいで durable watermark を永続化し、file identity、

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -158,7 +158,7 @@ internal static class GuideCommandsListCommand
             Classification = ClassificationPrimary,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerChatAgent,
-            Purpose = "Transport-neutral role workflow (G578): `intent-cli notify delegate|report|escalate`. The CLI resolves the recorded session-layer mode internally, validates logical roles before delivery, embeds the canonical report command in delegated work, and appends escalation events to the existing design-boundary JSONL channel. Dry-run is read-only; delivery and event append require `--write`."
+            Purpose = "Transport-neutral role workflow (G578/G588): `intent-cli notify delegate|report|escalate`. The CLI resolves the recorded session-layer mode internally, validates roles in the requested team topology, requires only the recipient to be deliverable, and embeds the canonical report command in delegated work. In herdr-only mode pane residents receive at their recorded team-workspace pane while external residents receive delegate/report events through their recorded reader. Dry-run performs the same route resolution without prompting or appending; delivery and event append require `--write`."
         },
         new CommandGroupEntry
         {

--- a/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
+++ b/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
@@ -52,6 +52,8 @@ internal static class HerdrOnlyOperatingGuide
 
         Submit through the transport-neutral notify surface. The CLI resolves the recorded `herdr-only` mode, validates the logical-role mapping, and invokes the herdr adapter internally; workflow prompts never hand-write `herdr agent prompt`:
 
+        Persist the team-scoped delivery topology at `<host-repo>/.intent-cli/role-pane-mapping.json`: record the team `workspace_id`; under `roles`, give pane-backed roles `resident: herdr` with explicit workspace/pane ids and roles outside herdr `resident: external` with a safe routing-root-relative `reader`. Every recorded role can send or be the delegate `report-to`; ONLY the recipient must be deliverable. A herdr recipient requires a running agent at its recorded pane inside that exact team workspace. An external recipient receives one canonical delegate/report event through its recorded reader and returns `eventAppended: true`. `--dry-run` performs the same topology and recipient resolution as `--write`, including team-scoped unknown-role diagnostics, but never prompts or appends. Missing/unsafe readers, foreign-workspace-only agents, and stale mappings fail closed without fallback.
+
         ```bash
         intent-cli notify delegate --domain <domain> --team <team> --from <sender-role> \
           --to <logical-role> --report-to <orchestrator-role> --task-id <task-id> \
@@ -112,9 +114,9 @@ internal static class HerdrOnlyOperatingGuide
 
         - **Location:** resolve the host repository root at runtime, then use `<host-repo>/.intent-cli/events/<team>.jsonl`. The team name is the agmsg/herdr team name verbatim in one flat filename (example: `intent-cli-dev.jsonl`); there are no team subdirectories and readers never hard-code an absolute path.
         - **Fail closed before path construction:** reject an empty team name, a leading dot, `/` or `\`, and any `..` sequence. Do not sanitize or silently rewrite an invalid name.
-        - **Append contract:** the orchestrator is the only writer. Open with append semantics (`O_APPEND`), append exactly one complete JSON object per line, include no embedded newline, and normalize `summary` to one line.
+        - **Append contract:** the canonical `intent-cli notify` surface is the only writer; callers never append by hand. The orchestrator normally writes delegate/escalate events, while a receiver's canonical report may append when its recorded recipient is external. Open with append semantics (`O_APPEND`), append exactly one complete JSON object per line, include no embedded newline, and normalize `summary` to one line.
         - **Schema:** `{"timestamp":"<RFC3339>","team":"<team>","kind":"completion|blocked|question|escalation","unit":"<execution-unit-or-task-id>","summary":"<one-line-summary>","artifact":"<repo-relative-path-or-URL>"}`. These six fields are required; `artifact` identifies the inspectable handoff or the decision input.
-        - **Writer boundary:** append only design-relevant completion, blocked, question, and escalation events. Routine progress, dispatch traffic, pane output, acknowledgements, and workflow label changes do not belong here.
+        - **Writer boundary:** append only canonical notifications addressed to a recorded external reader plus design-relevant completion, blocked, question, and escalation events. An external delegation uses `question`; an external report uses its existing `completed|blocked|question` status. Routine pane-resident dispatch, progress, pane output, acknowledgements, and workflow label changes do not belong here.
 
         Reader recipes:
 
@@ -158,6 +160,9 @@ internal static class HerdrOnlyOperatingGuide
         ["dispatch"] = new JsonObject
         {
             ["command"] = "intent-cli notify delegate --domain <domain> --team <team> --from <sender-role> --to <logical-role> --report-to <orchestrator-role> --task-id <task-id> --objective <outcome> --input <reference> --expected-artifact <artifact> --result-nonce <nonce> --write --format json",
+            ["topology"] = "Read <host-repo>/.intent-cli/role-pane-mapping.json for the requested team workspace. Each role records resident: herdr plus explicit workspace/pane ids, or resident: external plus a safe routing-root-relative reader.",
+            ["deliverability"] = "Every sender, recipient, and report-to must exist in the team roster, but only the recipient must be deliverable. Herdr recipients require a running agent at the recorded pane in the exact team workspace; external recipients receive one event through the recorded reader with eventAppended: true.",
+            ["dry_run_parity"] = "Dry-run performs the same topology and recipient resolution as write and returns the same refusal cause, without prompting or appending; foreign-workspace-only agents and unsafe readers fail closed without fallback.",
             ["required_fields"] = new JsonArray("domain", "team", "from", "to", "report-to", "task-id", "objective", "inputs", "expected-artifacts", "result-prefix", "result-nonce", "completion-marker"),
             ["reporting_contract"] = "The generated payload embeds task id, expected artifact, and the complete intent-cli notify report command (including transport-neutral --routing-root for isolated child checkouts) as the receiver's required final step; never hand-write a transport call.",
             ["marker_construction"] = "Concatenate result-prefix, space, fresh-per-dispatch result-nonce, space, status, space, artifact; never embed the composed wait needle in the task block.",
@@ -199,9 +204,10 @@ internal static class HerdrOnlyOperatingGuide
             ["path"] = "<host-repo>/.intent-cli/events/<team>.jsonl",
             ["team_encoding"] = "Team name verbatim as one flat filename; no subdirectories.",
             ["validation"] = "Reject empty, leading-dot, path separators, and any '..' sequence before path construction.",
-            ["append"] = "Orchestrator-only O_APPEND writer; one object per line, no embedded newline, summary normalized to one line.",
+            ["append"] = "The canonical intent-cli notify surface is the only O_APPEND writer; callers never append by hand. Orchestration normally writes delegate/escalate, and canonical report may append for an external recipient. One object per line, no embedded newline, summary normalized to one line.",
             ["schema"] = "timestamp, team, kind, unit, summary, artifact",
             ["kinds"] = new JsonArray("completion", "blocked", "question", "escalation"),
+            ["external_delivery_kinds"] = "A delegate to a recorded external reader uses question; a report uses its existing completed, blocked, or question status. Pane-resident dispatch is never mirrored to the file.",
             ["watermark_invariant"] = "Every reader persists file identity, byte offset, and complete-line count durably across watcher restarts; rotation, truncation, backwards byte/line count, or file replacement fails closed and never resets to the beginning because replay can duplicate a design decision.",
             ["readers"] = new JsonObject
             {

--- a/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
+++ b/src/IntentSystem.Cli/Commands/HerdrOnlyOperatingGuide.cs
@@ -116,7 +116,7 @@ internal static class HerdrOnlyOperatingGuide
         - **Fail closed before path construction:** reject an empty team name, a leading dot, `/` or `\`, and any `..` sequence. Do not sanitize or silently rewrite an invalid name.
         - **Append contract:** the canonical `intent-cli notify` surface is the only writer; callers never append by hand. The orchestrator normally writes delegate/escalate events, while a receiver's canonical report may append when its recorded recipient is external. Open with append semantics (`O_APPEND`), append exactly one complete JSON object per line, include no embedded newline, and normalize `summary` to one line.
         - **Schema:** `{"timestamp":"<RFC3339>","team":"<team>","kind":"completion|blocked|question|escalation","unit":"<execution-unit-or-task-id>","summary":"<one-line-summary>","artifact":"<repo-relative-path-or-URL>"}`. These six fields are required; `artifact` identifies the inspectable handoff or the decision input.
-        - **Writer boundary:** append only canonical notifications addressed to a recorded external reader plus design-relevant completion, blocked, question, and escalation events. An external delegation uses `question`; an external report uses its existing `completed|blocked|question` status. Routine pane-resident dispatch, progress, pane output, acknowledgements, and workflow label changes do not belong here.
+        - **Writer boundary:** append only canonical notifications addressed to a recorded external reader plus design-relevant completion, blocked, question, and escalation events. An external delegation uses `question`; an external report maps status `completed|blocked|question` to event kind `completion|blocked|question`. Routine pane-resident dispatch, progress, pane output, acknowledgements, and workflow label changes do not belong here.
 
         Reader recipes:
 
@@ -207,7 +207,7 @@ internal static class HerdrOnlyOperatingGuide
             ["append"] = "The canonical intent-cli notify surface is the only O_APPEND writer; callers never append by hand. Orchestration normally writes delegate/escalate, and canonical report may append for an external recipient. One object per line, no embedded newline, summary normalized to one line.",
             ["schema"] = "timestamp, team, kind, unit, summary, artifact",
             ["kinds"] = new JsonArray("completion", "blocked", "question", "escalation"),
-            ["external_delivery_kinds"] = "A delegate to a recorded external reader uses question; a report uses its existing completed, blocked, or question status. Pane-resident dispatch is never mirrored to the file.",
+            ["external_delivery_kinds"] = "A delegate to a recorded external reader uses question; a report maps completed, blocked, or question status to completion, blocked, or question event kind. Pane-resident dispatch is never mirrored to the file.",
             ["watermark_invariant"] = "Every reader persists file identity, byte offset, and complete-line count durably across watcher restarts; rotation, truncation, backwards byte/line count, or file replacement fails closed and never resets to the beginning because replay can duplicate a design decision.",
             ["readers"] = new JsonObject
             {

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -9,6 +9,9 @@ internal static class NotifyCommand
     private const string OperationDelegate = "delegate";
     private const string OperationReport = "report";
     private const string OperationEscalate = "escalate";
+    private const string CompletionEventKind = "completion";
+    private const string BlockedEventKind = "blocked";
+    private const string QuestionEventKind = "question";
     private const string EscalationEventKind = "escalation";
     private const string FormatJson = "json";
     private const string FormatMarkdown = "markdown";
@@ -34,6 +37,16 @@ internal static class NotifyCommand
         WriteIndented = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     };
+
+    private static readonly IReadOnlyDictionary<string, string> ReportReaderEventKinds =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["completed"] = CompletionEventKind,
+            ["blocked"] = BlockedEventKind,
+            ["question"] = QuestionEventKind,
+        };
+
+    internal static IEnumerable<string> SupportedReportStatuses => ReportReaderEventKinds.Keys;
 
     internal static Func<INotifyProcessRunner>? ProcessRunnerFactory { get; set; }
 
@@ -198,11 +211,7 @@ internal static class NotifyCommand
     {
         Timestamp = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
         Team = options.Team!,
-        // A delegation is an actionable request to the external reader; a
-        // report already carries one of the three existing outcome kinds.
-        Kind = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
-            ? "question"
-            : options.Status!,
+        Kind = ReaderEventKind(operation, options.Status),
         Unit = options.TaskId!,
         Summary = NotifyEventWriter.NormalizeSummary(
             string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
@@ -212,6 +221,22 @@ internal static class NotifyCommand
             ? options.Inputs.FirstOrDefault() ?? options.ExpectedArtifacts[0]
             : options.Artifact!,
     };
+
+    private static string ReaderEventKind(string operation, string? status)
+    {
+        if (string.Equals(operation, OperationDelegate, StringComparison.Ordinal))
+        {
+            return QuestionEventKind;
+        }
+
+        if (status is not null && ReportReaderEventKinds.TryGetValue(status, out var eventKind))
+        {
+            return eventKind;
+        }
+
+        throw new InvalidOperationException(
+            $"Report status '{status}' does not map to a documented reader-event kind.");
+    }
 
     private static int ExecuteEscalation(
         TextWriter writer,
@@ -543,7 +568,8 @@ internal static class NotifyCommand
         else if (string.Equals(operation, OperationReport, StringComparison.Ordinal))
         {
             if (!IsSafeIdentity(options.ToRole)
-                || options.Status is not ("completed" or "blocked" or "question")
+                || options.Status is null
+                || !ReportReaderEventKinds.ContainsKey(options.Status)
                 || string.IsNullOrWhiteSpace(options.Artifact)
                 || string.IsNullOrWhiteSpace(options.Summary))
             {

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -122,20 +122,6 @@ internal static class NotifyCommand
             ? BuildDelegatePayload(options, reportCommand!)
             : BuildReportPayload(options);
 
-        if (!options.Write)
-        {
-            Emit(writer, options.Format, SuccessResult(
-                operation,
-                options,
-                resolution,
-                delivered: false,
-                eventAppended: false,
-                payload,
-                reportCommand,
-                $"Dry-run: would deliver {operation} through {resolution.Mode}."));
-            return 0;
-        }
-
         var runner = ProcessRunnerFactory?.Invoke() ?? new NotifyProcessRunner();
         var transport = string.Equals(resolution.Mode, SessionLayerMode.HerdrOnly, StringComparison.Ordinal)
             ? (INotifyTransport)new HerdrNotifyTransport(
@@ -148,13 +134,15 @@ internal static class NotifyCommand
             ? new[] { options.FromRole!, options.ToRole!, options.ReportToRole! }
             : new[] { options.FromRole!, options.ToRole! };
         var delivery = transport.Deliver(
+            options.RoutingRoot!,
             options.Team!,
             options.FromRole!,
             options.ToRole!,
             roles,
-            payload);
+            payload,
+            options.Write);
 
-        if (!delivery.Delivered)
+        if (!delivery.Resolved)
         {
             Emit(writer, options.Format, FailureResult(
                 operation,
@@ -167,17 +155,63 @@ internal static class NotifyCommand
             return 1;
         }
 
+        var eventAppended = false;
+        if (delivery.ReaderPath is not null && options.Write)
+        {
+            try
+            {
+                NotifyEventWriter.Append(delivery.ReaderPath, BuildReaderEvent(operation, options));
+                eventAppended = true;
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                Emit(writer, options.Format, FailureResult(
+                    operation,
+                    options,
+                    resolution.Mode,
+                    "event-append-failed",
+                    $"Could not append notification to external role '{options.ToRole}' through recorded reader "
+                    + $"'{delivery.ReaderPath}': {exception.Message} Fix reader access and retry notify.",
+                    payload,
+                    reportCommand));
+                return 1;
+            }
+        }
+
         Emit(writer, options.Format, SuccessResult(
             operation,
             options,
             resolution,
-            delivered: true,
-            eventAppended: false,
+            delivered: delivery.Delivered || eventAppended,
+            eventAppended,
             payload,
             reportCommand,
-            delivery.Summary));
+            eventAppended
+                ? $"Delivered {operation} to external logical role '{options.ToRole}' in team '{options.Team}' "
+                  + $"through recorded reader '{delivery.ReaderPath}'."
+                : delivery.Summary,
+            eventPath: delivery.ReaderPath));
         return 0;
     }
+
+    private static NotifyDesignEvent BuildReaderEvent(string operation, NotifyOptions options) => new()
+    {
+        Timestamp = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
+        Team = options.Team!,
+        // A delegation is an actionable request to the external reader; a
+        // report already carries one of the three existing outcome kinds.
+        Kind = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+            ? "question"
+            : options.Status!,
+        Unit = options.TaskId!,
+        Summary = NotifyEventWriter.NormalizeSummary(
+            string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+                ? options.Objective!
+                : options.Summary!),
+        Artifact = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+            ? options.Inputs.FirstOrDefault() ?? options.ExpectedArtifacts[0]
+            : options.Artifact!,
+    };
 
     private static int ExecuteEscalation(
         TextWriter writer,

--- a/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
@@ -1,0 +1,287 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record NotifyRecordedRole(
+    string Resident,
+    string? WorkspaceId,
+    string? PaneId,
+    string? Reader)
+{
+    public const string HerdrResident = "herdr";
+    public const string ExternalResident = "external";
+}
+
+internal sealed record NotifyTeamTopology(
+    string SourcePath,
+    string WorkspaceId,
+    IReadOnlyDictionary<string, NotifyRecordedRole> Roles);
+
+internal sealed record NotifyTopologyResolution
+{
+    public required bool Resolved { get; init; }
+    public NotifyTeamTopology? Topology { get; init; }
+    public string? Cause { get; init; }
+    public required string Summary { get; init; }
+}
+
+/// <summary>
+/// Reads the operator-owned herdr logical-role topology. This is deliberately a
+/// read-only consumer: provisioning owns the mapping, while notify refuses
+/// missing, ambiguous, or unsafe records instead of inventing a destination.
+/// </summary>
+internal static class NotifyRoleTopologyStore
+{
+    public const string RelativePath = ".intent-cli/role-pane-mapping.json";
+
+    public static NotifyTopologyResolution Resolve(string routingRoot, string team)
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            routingRoot,
+            RelativePath.Replace('/', Path.DirectorySeparatorChar)));
+        if (!File.Exists(path))
+        {
+            return Failure(
+                "topology-missing",
+                $"Recorded role topology for team '{team}' was not found at '{path}'. Provision and record the "
+                + "team's workspace, roles, residences, panes/readers, then retry notify.");
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            if (!TrySelectTeam(document.RootElement, team, out var teamElement, out var teamError))
+            {
+                return Failure("topology-team-missing", $"Recorded role topology '{path}' {teamError}");
+            }
+
+            var rolesElement = teamElement.TryGetProperty("roles", out var nestedRoles)
+                ? nestedRoles
+                : teamElement;
+            if (rolesElement.ValueKind != JsonValueKind.Object)
+            {
+                return Failure(
+                    "topology-invalid",
+                    $"Recorded role topology '{path}' for team '{team}' has no object-valued 'roles'. Record the "
+                    + "team roster before retrying notify.");
+            }
+
+            var roles = new Dictionary<string, NotifyRecordedRole>(StringComparer.Ordinal);
+            foreach (var property in rolesElement.EnumerateObject())
+            {
+                if (IsTopologyEnvelopeProperty(property.Name))
+                {
+                    continue;
+                }
+
+                if (property.Value.ValueKind != JsonValueKind.Object)
+                {
+                    return Failure(
+                        "topology-invalid",
+                        $"Recorded role '{property.Name}' for team '{team}' in '{path}' is not an object. Repair "
+                        + "the role record before retrying notify.");
+                }
+
+                var resident = ReadString(property.Value, "resident");
+                if (resident is not (NotifyRecordedRole.HerdrResident or NotifyRecordedRole.ExternalResident))
+                {
+                    return Failure(
+                        "topology-invalid",
+                        $"Recorded role '{property.Name}' for team '{team}' in '{path}' has unsupported resident "
+                        + $"'{resident ?? "missing"}'. Use 'herdr' or 'external' and retry.");
+                }
+
+                roles.Add(property.Name, new NotifyRecordedRole(
+                    resident,
+                    ReadString(property.Value, "workspace_id"),
+                    ReadString(property.Value, "pane_id"),
+                    ReadString(property.Value, "reader")));
+            }
+
+            if (roles.Count == 0)
+            {
+                return Failure(
+                    "topology-invalid",
+                    $"Recorded role topology '{path}' for team '{team}' contains no roles. Record the team roster "
+                    + "before retrying notify.");
+            }
+
+            var workspaceId = ReadString(teamElement, "workspace_id")
+                ?? ReadNestedWorkspaceId(teamElement)
+                ?? ConsistentWorkspaceFromRoles(roles.Values);
+            if (string.IsNullOrWhiteSpace(workspaceId))
+            {
+                return Failure(
+                    "topology-invalid",
+                    $"Recorded role topology '{path}' for team '{team}' has no unambiguous workspace_id. Record "
+                    + "the team's workspace explicitly before retrying notify.");
+            }
+
+            foreach (var (role, record) in roles)
+            {
+                if (string.Equals(record.Resident, NotifyRecordedRole.HerdrResident, StringComparison.Ordinal)
+                    && !string.IsNullOrWhiteSpace(record.WorkspaceId)
+                    && !string.Equals(record.WorkspaceId, workspaceId, StringComparison.Ordinal))
+                {
+                    return Failure(
+                        "topology-invalid",
+                        $"Recorded herdr role '{role}' uses workspace '{record.WorkspaceId}', outside team '{team}' "
+                        + $"workspace '{workspaceId}' in '{path}'. Repair the team-scoped mapping before retrying.");
+                }
+            }
+
+            return new NotifyTopologyResolution
+            {
+                Resolved = true,
+                Topology = new NotifyTeamTopology(path, workspaceId, roles),
+                Summary = $"Resolved recorded role topology for team '{team}' from '{path}'.",
+            };
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return Failure(
+                "topology-unreadable",
+                $"Recorded role topology '{path}' for team '{team}' could not be read: {exception.Message} "
+                + "Repair the file and retry notify.");
+        }
+    }
+
+    public static bool TryResolveReaderPath(
+        string routingRoot,
+        string? recordedReader,
+        out string readerPath,
+        out string error)
+    {
+        readerPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(recordedReader))
+        {
+            error = "the reader field is missing or empty.";
+            return false;
+        }
+
+        if (Path.IsPathRooted(recordedReader))
+        {
+            error = "the reader must be relative to --routing-root, not an absolute path.";
+            return false;
+        }
+
+        try
+        {
+            var root = Path.GetFullPath(routingRoot);
+            var candidate = Path.GetFullPath(Path.Combine(root, recordedReader));
+            var rootPrefix = root.EndsWith(Path.DirectorySeparatorChar)
+                ? root
+                : root + Path.DirectorySeparatorChar;
+            var pathComparison = OperatingSystem.IsWindows()
+                ? StringComparison.OrdinalIgnoreCase
+                : StringComparison.Ordinal;
+            if (!candidate.StartsWith(rootPrefix, pathComparison))
+            {
+                error = "the reader escapes --routing-root.";
+                return false;
+            }
+
+            readerPath = candidate;
+            error = string.Empty;
+            return true;
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            error = $"the reader path is invalid: {exception.Message}";
+            return false;
+        }
+    }
+
+    private static bool TrySelectTeam(
+        JsonElement root,
+        string team,
+        out JsonElement teamElement,
+        out string error)
+    {
+        teamElement = default;
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            error = "is not a JSON object. Repair it before retrying notify.";
+            return false;
+        }
+
+        if (root.TryGetProperty("teams", out var teams) && teams.ValueKind == JsonValueKind.Object)
+        {
+            if (teams.TryGetProperty(team, out teamElement) && teamElement.ValueKind == JsonValueKind.Object)
+            {
+                error = string.Empty;
+                return true;
+            }
+
+            error = $"does not contain team '{team}' under 'teams'. Record that team before retrying notify.";
+            return false;
+        }
+
+        var recordedTeam = ReadString(root, "team");
+        if (string.Equals(recordedTeam, team, StringComparison.Ordinal))
+        {
+            teamElement = root;
+            error = string.Empty;
+            return true;
+        }
+
+        if (root.TryGetProperty(team, out teamElement) && teamElement.ValueKind == JsonValueKind.Object)
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        error = $"records team '{recordedTeam ?? "none"}', not requested team '{team}'. Record the requested team "
+            + "before retrying notify.";
+        return false;
+    }
+
+    private static string? ConsistentWorkspaceFromRoles(IEnumerable<NotifyRecordedRole> roles)
+    {
+        var workspaceIds = roles
+            .Where(role => string.Equals(role.Resident, NotifyRecordedRole.HerdrResident, StringComparison.Ordinal))
+            .Select(role => role.WorkspaceId ?? WorkspaceFromPane(role.PaneId))
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        return workspaceIds.Length == 1 ? workspaceIds[0] : null;
+    }
+
+    private static string? WorkspaceFromPane(string? paneId)
+    {
+        var separator = paneId?.IndexOf(':', StringComparison.Ordinal) ?? -1;
+        return separator > 0 ? paneId![..separator] : null;
+    }
+
+    private static string? ReadNestedWorkspaceId(JsonElement element)
+    {
+        if (!element.TryGetProperty("workspace", out var workspace))
+        {
+            return null;
+        }
+
+        if (workspace.ValueKind == JsonValueKind.String)
+        {
+            return workspace.GetString();
+        }
+
+        return workspace.ValueKind == JsonValueKind.Object
+            ? ReadString(workspace, "workspace_id") ?? ReadString(workspace, "id")
+            : null;
+    }
+
+    private static bool IsTopologyEnvelopeProperty(string property) => property is
+        "schema_version" or "team" or "workspace" or "workspace_id" or "tab_id" or "updated_at" or "roles";
+
+    private static string? ReadString(JsonElement element, string property) =>
+        element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static NotifyTopologyResolution Failure(string cause, string summary) => new()
+    {
+        Resolved = false,
+        Cause = cause,
+        Summary = summary,
+    };
+}

--- a/src/IntentSystem.Cli/Commands/NotifyTransport.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyTransport.cs
@@ -52,9 +52,13 @@ internal sealed class NotifyProcessRunner : INotifyProcessRunner
 
 internal sealed record NotifyDeliveryResult
 {
+    public required bool Resolved { get; init; }
+
     public required bool Delivered { get; init; }
 
     public string? Cause { get; init; }
+
+    public string? ReaderPath { get; init; }
 
     public required string Summary { get; init; }
 }
@@ -62,11 +66,13 @@ internal sealed record NotifyDeliveryResult
 internal interface INotifyTransport
 {
     NotifyDeliveryResult Deliver(
+        string routingRoot,
         string team,
         string fromRole,
         string toRole,
         IReadOnlyList<string> rolesToValidate,
-        string payload);
+        string payload,
+        bool write);
 }
 
 internal sealed class AgmsgNotifyTransport : INotifyTransport
@@ -81,11 +87,13 @@ internal sealed class AgmsgNotifyTransport : INotifyTransport
     }
 
     public NotifyDeliveryResult Deliver(
+        string routingRoot,
         string team,
         string fromRole,
         string toRole,
         IReadOnlyList<string> rolesToValidate,
-        string payload)
+        string payload,
+        bool write)
     {
         var teamScript = Path.Combine(scriptsDirectory, "team.sh");
         var sendScript = Path.Combine(scriptsDirectory, "send.sh");
@@ -125,6 +133,16 @@ internal sealed class AgmsgNotifyTransport : INotifyTransport
             }
         }
 
+        if (!write)
+        {
+            return new NotifyDeliveryResult
+            {
+                Resolved = true,
+                Delivered = false,
+                Summary = $"Dry-run: would deliver notification to agmsg role '{toRole}' in team '{team}'.",
+            };
+        }
+
         NotifyProcessResult delivery;
         try
         {
@@ -138,6 +156,7 @@ internal sealed class AgmsgNotifyTransport : INotifyTransport
         return delivery.ExitCode == 0
             ? new NotifyDeliveryResult
             {
+                Resolved = true,
                 Delivered = true,
                 Summary = $"Delivered notification to agmsg role '{toRole}' in team '{team}'.",
             }
@@ -165,6 +184,7 @@ internal sealed class AgmsgNotifyTransport : INotifyTransport
 
     private static NotifyDeliveryResult Failure(string cause, string summary) => new()
     {
+        Resolved = false,
         Delivered = false,
         Cause = cause,
         Summary = summary,
@@ -189,12 +209,60 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
     }
 
     public NotifyDeliveryResult Deliver(
+        string routingRoot,
         string team,
         string fromRole,
         string toRole,
         IReadOnlyList<string> rolesToValidate,
-        string payload)
+        string payload,
+        bool write)
     {
+        var topologyResolution = NotifyRoleTopologyStore.Resolve(routingRoot, team);
+        if (!topologyResolution.Resolved)
+        {
+            return Failure(topologyResolution.Cause!, topologyResolution.Summary);
+        }
+
+        var topology = topologyResolution.Topology!;
+        foreach (var role in rolesToValidate.Distinct(StringComparer.Ordinal))
+        {
+            if (!topology.Roles.ContainsKey(role))
+            {
+                return Failure(
+                    "unknown-role",
+                    $"Recorded role topology '{topology.SourcePath}' for team '{team}' workspace "
+                    + $"'{topology.WorkspaceId}' does not contain logical role '{role}' (found in that team scope: "
+                    + $"{FormatRoles(topology.Roles.Keys)}). Record that role for this team before retrying notify.");
+            }
+        }
+
+        var recipient = topology.Roles[toRole];
+        if (string.Equals(recipient.Resident, NotifyRecordedRole.ExternalResident, StringComparison.Ordinal))
+        {
+            if (!NotifyRoleTopologyStore.TryResolveReaderPath(
+                    routingRoot,
+                    recipient.Reader,
+                    out var readerPath,
+                    out var readerError))
+            {
+                return Failure(
+                    "reader-unavailable",
+                    $"External logical role '{toRole}' in team '{team}' has no deliverable recorded reader in "
+                    + $"'{topology.SourcePath}': {readerError} Record a safe routing-root-relative reader and retry.");
+            }
+
+            return new NotifyDeliveryResult
+            {
+                Resolved = true,
+                Delivered = false,
+                ReaderPath = readerPath,
+                Summary = write
+                    ? $"Resolved external logical role '{toRole}' in team '{team}' to recorded reader '{readerPath}'."
+                    : $"Dry-run: would append notification for external logical role '{toRole}' in team '{team}' "
+                      + $"to recorded reader '{readerPath}'.",
+            };
+        }
+
         NotifyProcessResult agentList;
         try
         {
@@ -202,71 +270,122 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
         }
         catch (InvalidOperationException exception)
         {
-            return Failure("transport-unavailable", exception.Message);
+            return Failure(
+                "transport-unavailable",
+                $"{exception.Message} Verify the installed herdr executable and retry notify.");
         }
 
         if (agentList.ExitCode != 0)
         {
             return Failure(
                 "transport-failure",
-                $"herdr logical-role lookup failed: {OneLine(agentList.StandardError, agentList.StandardOutput)}");
+                $"herdr agent list lookup for team '{team}' workspace '{topology.WorkspaceId}' failed: "
+                + $"{OneLine(agentList.StandardError, agentList.StandardOutput)} Inspect herdr agent list/API state "
+                + "for that workspace and retry notify.");
         }
 
         IReadOnlyDictionary<string, HerdrRoleState> roles;
         try
         {
-            roles = ParseRoles(agentList.StandardOutput);
+            roles = ParseRoles(agentList.StandardOutput, topology.WorkspaceId);
         }
         catch (InvalidOperationException exception)
         {
-            return Failure("transport-invalid-response", exception.Message);
+            return Failure(
+                "transport-invalid-response",
+                $"{exception.Message} Inspect the installed herdr agent-list response schema and retry notify.");
         }
 
-        foreach (var role in rolesToValidate.Distinct(StringComparer.Ordinal))
+        if (!roles.TryGetValue(toRole, out var state))
         {
-            if (!roles.TryGetValue(role, out var state))
-            {
-                return Failure(
-                    "unknown-role",
-                    $"herdr logical role '{role}' is not present in the recorded agent mapping.");
-            }
+            return Failure(
+                "unknown-role",
+                $"herdr agent list for team '{team}' workspace '{topology.WorkspaceId}' does not contain logical "
+                + $"role '{toRole}' (found in that workspace: {FormatRoles(roles.Keys)}). Verify the team's recorded "
+                + "workspace and start the intended recipient there before retrying; agents in other workspaces are "
+                + "not eligible.");
+        }
 
-            if (string.IsNullOrWhiteSpace(state.PaneId))
-            {
-                return Failure("pane-absent", $"herdr logical role '{role}' has no mapped pane.");
-            }
+        if (string.IsNullOrWhiteSpace(recipient.PaneId))
+        {
+            return Failure(
+                "pane-absent",
+                $"Recorded topology '{topology.SourcePath}' gives herdr recipient '{toRole}' in team '{team}' no "
+                + "pane_id. Record its explicit pane and retry.");
+        }
 
-            if (!state.AgentRunning)
+        if (string.IsNullOrWhiteSpace(state.PaneId))
+        {
+            return Failure(
+                "pane-absent",
+                $"herdr agent list found logical role '{toRole}' in team '{team}' workspace "
+                + $"'{topology.WorkspaceId}' without a pane. Re-provision the recorded recipient before retrying.");
+        }
+
+        if (!string.Equals(state.PaneId, recipient.PaneId, StringComparison.Ordinal))
+        {
+            return Failure(
+                "pane-mismatch",
+                $"herdr agent list found logical role '{toRole}' in team '{team}' workspace "
+                + $"'{topology.WorkspaceId}' at pane '{state.PaneId ?? "none"}', but '{topology.SourcePath}' records "
+                + $"pane '{recipient.PaneId}'. Refresh the recorded topology before retrying.");
+        }
+
+        if (!state.AgentRunning)
+        {
+            return Failure(
+                "agent-not-running",
+                $"herdr logical role '{toRole}' in team '{team}' workspace '{topology.WorkspaceId}' has no running "
+                + "agent. Start and verify that recorded recipient before retrying.");
+        }
+
+        if (!write)
+        {
+            return new NotifyDeliveryResult
             {
-                return Failure("agent-not-running", $"herdr logical role '{role}' has no running agent.");
-            }
+                Resolved = true,
+                Delivered = false,
+                Summary = $"Dry-run: would deliver notification to herdr logical role '{toRole}' in team '{team}' "
+                    + $"workspace '{topology.WorkspaceId}' at recorded pane '{recipient.PaneId}'.",
+            };
         }
 
         NotifyProcessResult delivery;
         try
         {
-            delivery = runner.Run(executable, ["agent", "prompt", toRole, payload]);
+            // A pane id is globally unique and is the explicit target recorded for this
+            // team's workspace. Passing the logical name here would re-enter herdr's
+            // global name namespace after we had just scoped validation to the team.
+            delivery = runner.Run(executable, ["agent", "prompt", recipient.PaneId, payload]);
         }
         catch (InvalidOperationException exception)
         {
-            return Failure("transport-unavailable", exception.Message);
+            return Failure(
+                "transport-unavailable",
+                $"{exception.Message} Verify the installed herdr executable and recorded recipient pane, then "
+                + "retry notify.");
         }
 
         if (delivery.ExitCode == 0)
         {
             return new NotifyDeliveryResult
             {
+                Resolved = true,
                 Delivered = true,
-                Summary = $"Delivered notification to herdr logical role '{toRole}' in team '{team}'.",
+                Summary = $"Delivered notification to herdr logical role '{toRole}' in team '{team}' workspace "
+                    + $"'{topology.WorkspaceId}' at recorded pane '{recipient.PaneId}'.",
             };
         }
 
         var detail = OneLine(delivery.StandardError, delivery.StandardOutput);
         var cause = ClassifyPromptFailure(detail);
-        return Failure(cause, $"herdr delivery to logical role '{toRole}' failed: {detail}");
+        return Failure(
+            cause,
+            $"herdr delivery to logical role '{toRole}' in team '{team}' workspace '{topology.WorkspaceId}' failed: "
+            + $"{detail} Inspect the recorded recipient pane and running-agent state, then retry notify.");
     }
 
-    internal static IReadOnlyDictionary<string, HerdrRoleState> ParseRoles(string output)
+    internal static IReadOnlyDictionary<string, HerdrRoleState> ParseRoles(string output, string workspaceId)
     {
         try
         {
@@ -288,6 +407,12 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
                 }
 
                 var paneId = ReadString(agent, "pane_id");
+                var agentWorkspaceId = ReadString(agent, "workspace_id") ?? WorkspaceFromPane(paneId);
+                if (!string.Equals(agentWorkspaceId, workspaceId, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
                 var agentKind = ReadString(agent, "agent");
                 var status = ReadString(agent, "agent_status");
                 var explicitlyNotReady = agent.TryGetProperty("interactive_ready", out var ready)
@@ -299,10 +424,11 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
                     && !explicitlyNotReady
                     && !string.Equals(status, "unknown", StringComparison.Ordinal);
 
-                if (!roles.TryAdd(name, new HerdrRoleState(paneId, running)))
+                if (!roles.TryAdd(name, new HerdrRoleState(agentWorkspaceId, paneId, running)))
                 {
                     throw new InvalidOperationException(
-                        $"herdr agent list returned duplicate logical-role mapping '{name}'.");
+                        $"herdr agent list returned duplicate logical role '{name}' in workspace '{workspaceId}'. "
+                        + "Rename or remove the competing agent before retrying.");
                 }
             }
 
@@ -320,6 +446,18 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
         element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
             ? value.GetString()
             : null;
+
+    private static string? WorkspaceFromPane(string? paneId)
+    {
+        var separator = paneId?.IndexOf(':', StringComparison.Ordinal) ?? -1;
+        return separator > 0 ? paneId![..separator] : null;
+    }
+
+    private static string FormatRoles(IEnumerable<string> roles)
+    {
+        var ordered = roles.OrderBy(value => value, StringComparer.Ordinal).ToArray();
+        return ordered.Length == 0 ? "none" : string.Join(", ", ordered);
+    }
 
     private static string ClassifyPromptFailure(string detail)
     {
@@ -348,6 +486,7 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
 
     private static NotifyDeliveryResult Failure(string cause, string summary) => new()
     {
+        Resolved = false,
         Delivered = false,
         Cause = cause,
         Summary = summary,
@@ -360,7 +499,7 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
     }
 }
 
-internal sealed record HerdrRoleState(string? PaneId, bool AgentRunning);
+internal sealed record HerdrRoleState(string? WorkspaceId, string? PaneId, bool AgentRunning);
 
 internal static class NotifyTransportPaths
 {

--- a/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
@@ -57,7 +57,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
         var delivery = Assert.Single(runner.Calls, call =>
             mode == SessionLayerMode.Agmsg
                 ? call.Arguments.Any(argument => argument.EndsWith("send.sh", StringComparison.Ordinal))
-                : call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "implementation"]));
+                : call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "wH:p2"]));
         Assert.Equal(payload, delivery.Arguments[^1]);
     }
 
@@ -74,6 +74,27 @@ public sealed class NotifyCommandG578Tests : IDisposable
         Assert.Equal("default", result.GetProperty("mode_source").GetString());
         Assert.Contains(runner.Calls, call => call.Arguments.Any(argument =>
             argument.EndsWith("send.sh", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void AgmsgDryRun_ResolvesItsTeamRosterWithoutSendingOrStartingHerdr_G588()
+    {
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var args = DelegateArgs();
+        args[^3] = "--dry-run";
+
+        var (exitCode, result) = workspace.Run(args);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(SessionLayerMode.Agmsg, result.GetProperty("mode").GetString());
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+        Assert.Contains(runner.Calls, call =>
+            call.Arguments.Any(argument => argument.EndsWith("team.sh", StringComparison.Ordinal)));
+        Assert.DoesNotContain(runner.Calls, call =>
+            call.Arguments.Any(argument => argument.EndsWith("send.sh", StringComparison.Ordinal))
+            || call.Arguments.Take(2).SequenceEqual(["agent", "list"])
+            || call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
     }
 
     [Theory]
@@ -205,7 +226,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
             Assert.Equal(SessionLayerMode.HerdrOnly, result.RootElement.GetProperty("mode").GetString());
             Assert.Equal(workspace.RootPath, result.RootElement.GetProperty("routing_root").GetString());
             Assert.Contains(runner.Calls, call =>
-                call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "orchestration"]));
+                call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "wH:p1"]));
         }
         finally
         {
@@ -366,6 +387,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
     private static object HerdrAgent(string name, string? paneId, bool running) => new
     {
         name,
+        workspace_id = "wH",
         pane_id = paneId,
         agent = running ? "codex" : null,
         agent_session = running ? new { id = name } : null,
@@ -403,6 +425,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
         {
             RootPath = Directory.CreateTempSubdirectory("notify-g578-").FullName;
             Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            WriteTopology();
             AgmsgScriptsPath = Path.Combine(RootPath, "agmsg-scripts");
             Directory.CreateDirectory(AgmsgScriptsPath);
             File.WriteAllText(Path.Combine(AgmsgScriptsPath, "team.sh"), "fixture");
@@ -427,6 +450,45 @@ public sealed class NotifyCommandG578Tests : IDisposable
         public string AgmsgScriptsPath { get; }
         public string EventPath => Path.Combine(RootPath, ".intent-cli", "events", $"{Team}.jsonl");
         public CliContext Context { get; }
+
+        private void WriteTopology()
+        {
+            var topology = new
+            {
+                team = Team,
+                workspace_id = "wH",
+                roles = new Dictionary<string, object>
+                {
+                    ["design"] = new
+                    {
+                        resident = "external",
+                        frontend = "claude-app",
+                        reader = $".intent-cli/events/{Team}.jsonl",
+                    },
+                    ["orchestration"] = new
+                    {
+                        resident = "herdr",
+                        workspace_id = "wH",
+                        pane_id = "wH:p1",
+                    },
+                    ["implementation"] = new
+                    {
+                        resident = "herdr",
+                        workspace_id = "wH",
+                        pane_id = "wH:p2",
+                    },
+                    ["review"] = new
+                    {
+                        resident = "herdr",
+                        workspace_id = "wH",
+                        pane_id = "wH:p3",
+                    },
+                },
+            };
+            File.WriteAllText(
+                Path.Combine(RootPath, NotifyRoleTopologyStore.RelativePath.Replace('/', Path.DirectorySeparatorChar)),
+                JsonSerializer.Serialize(topology));
+        }
 
         public void SetMode(string mode)
         {

--- a/tests/IntentSystem.Cli.Tests/NotifyRecordedRolesG588Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyRecordedRolesG588Tests.cs
@@ -1,0 +1,405 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifyRecordedRolesG588Tests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 2, 20, 30, 0, TimeSpan.Zero);
+    private readonly Workspace workspace = new();
+
+    public NotifyRecordedRolesG588Tests()
+    {
+        NotifyCommand.HerdrExecutableFactory = () => "fake-herdr";
+        NotifyCommand.UtcNowFactory = () => FixedNow;
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifyCommand.AgmsgScriptsDirectoryFactory = null;
+        NotifyCommand.HerdrExecutableFactory = null;
+        NotifyCommand.UtcNowFactory = null;
+        workspace.Dispose();
+    }
+
+    [Fact]
+    public void ExternalResidentSenderAndReportTo_NeedTopologyExistenceButNotAPane_G588()
+    {
+        workspace.WriteTopology(externalReader: null);
+        var runner = Runner((_, arguments) => arguments.SequenceEqual(["agent", "list"])
+            ? Success(Roster(
+                Agent("orchestration", "wH", "wH:p1"),
+                Agent("implementation", "wH", "wH:p2")))
+            : Success());
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs(
+            from: "design",
+            to: "implementation",
+            reportTo: "design",
+            write: true));
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        Assert.False(result.GetProperty("event_appended").GetBoolean());
+        var prompt = Assert.Single(runner.Calls, call =>
+            call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        Assert.Equal("wH:p2", prompt.Arguments[2]);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Contains("design"));
+    }
+
+    [Fact]
+    public void DelegateToExternalResident_AppendsExactlyOneUnchangedSchemaEvent_G588()
+    {
+        var runner = Runner((_, _) => throw new InvalidOperationException(
+            "an external-reader route must not start herdr"));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs(
+            from: "orchestration",
+            to: "design",
+            reportTo: "orchestration",
+            write: true));
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        Assert.True(result.GetProperty("event_appended").GetBoolean());
+        Assert.Equal(workspace.EventPath, result.GetProperty("event_path").GetString());
+        var line = Assert.Single(File.ReadAllLines(workspace.EventPath));
+        using var document = JsonDocument.Parse(line);
+        Assert.Equal(
+            ["timestamp", "team", "kind", "unit", "summary", "artifact"],
+            document.RootElement.EnumerateObject().Select(property => property.Name));
+        Assert.Equal(FixedNow, document.RootElement.GetProperty("timestamp").GetDateTimeOffset());
+        Assert.Equal("question", document.RootElement.GetProperty("kind").GetString());
+        Assert.Equal("G588-demo", document.RootElement.GetProperty("unit").GetString());
+        Assert.Equal("Implement external routing", document.RootElement.GetProperty("summary").GetString());
+        Assert.Equal("issue #1279", document.RootElement.GetProperty("artifact").GetString());
+        Assert.Empty(runner.Calls);
+    }
+
+    [Fact]
+    public void ReportToExternalResident_AppendsExactlyOneOutcomeEvent_G588()
+    {
+        var runner = Runner((_, _) => throw new InvalidOperationException(
+            "an external-reader route must not start herdr"));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(ReportArgs(from: "implementation", to: "design", write: true));
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        Assert.True(result.GetProperty("event_appended").GetBoolean());
+        var line = Assert.Single(File.ReadAllLines(workspace.EventPath));
+        using var document = JsonDocument.Parse(line);
+        Assert.Equal("completed", document.RootElement.GetProperty("kind").GetString());
+        Assert.Equal("https://example.test/pr/1280", document.RootElement.GetProperty("artifact").GetString());
+        Assert.Equal("external routing completed", document.RootElement.GetProperty("summary").GetString());
+        Assert.Empty(runner.Calls);
+    }
+
+    [Fact]
+    public void ForeignWorkspaceOnlyRecipient_IsRefusedWithScopedRoster_AndNeverPrompted_G588()
+    {
+        var runner = Runner((_, arguments) => arguments.SequenceEqual(["agent", "list"])
+            ? Success(Roster(
+                Agent("orchestration", "wH", "wH:p1"),
+                Agent("implementation", "wH", "wH:p2"),
+                Agent("review", "wForeign", "wForeign:p9")))
+            : throw new InvalidOperationException("a refused route must never prompt"));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs(
+            from: "orchestration",
+            to: "review",
+            reportTo: "orchestration",
+            write: true));
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("unknown-role", result.GetProperty("cause").GetString());
+        var summary = result.GetProperty("summary").GetString()!;
+        Assert.Contains("team 'intent-cli-dev' workspace 'wH'", summary, StringComparison.Ordinal);
+        Assert.Contains("found in that workspace: implementation, orchestration", summary, StringComparison.Ordinal);
+        Assert.Contains("agents in other workspaces are not eligible", summary, StringComparison.Ordinal);
+        Assert.DoesNotContain("recorded agent mapping", summary, StringComparison.Ordinal);
+        Assert.DoesNotContain(runner.Calls, call =>
+            call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+    }
+
+    [Fact]
+    public void UnrecordedRole_ReportsTheRecordedTeamWorkspaceAndRoster_G588()
+    {
+        var runner = Runner((_, _) => throw new InvalidOperationException(
+            "topology refusal must happen before herdr lookup"));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs(
+            from: "orchestration",
+            to: "missing",
+            reportTo: "orchestration",
+            write: true));
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("unknown-role", result.GetProperty("cause").GetString());
+        var summary = result.GetProperty("summary").GetString()!;
+        Assert.Contains(NotifyRoleTopologyStore.RelativePath, summary, StringComparison.Ordinal);
+        Assert.Contains("team 'intent-cli-dev' workspace 'wH'", summary, StringComparison.Ordinal);
+        Assert.Contains(
+            "found in that team scope: design, implementation, orchestration, review",
+            summary,
+            StringComparison.Ordinal);
+        Assert.Contains("Record that role for this team", summary, StringComparison.Ordinal);
+        Assert.Empty(runner.Calls);
+    }
+
+    [Fact]
+    public void DryRunAndWrite_HaveTheSameDeliverableResolution_WithoutDryRunPrompt_G588()
+    {
+        var runner = Runner((_, arguments) => arguments.SequenceEqual(["agent", "list"])
+            ? Success(Roster(
+                Agent("orchestration", "wH", "wH:p1"),
+                Agent("implementation", "wH", "wH:p2")))
+            : Success());
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (dryExit, dry) = workspace.Run(DelegateArgs(
+            from: "design",
+            to: "implementation",
+            reportTo: "design",
+            write: false));
+        Assert.Equal(0, dryExit);
+        Assert.False(dry.TryGetProperty("cause", out _));
+        Assert.False(dry.GetProperty("delivered").GetBoolean());
+        Assert.DoesNotContain(runner.Calls, call =>
+            call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+
+        var (writeExit, write) = workspace.Run(DelegateArgs(
+            from: "design",
+            to: "implementation",
+            reportTo: "design",
+            write: true));
+        Assert.Equal(dryExit, writeExit);
+        Assert.False(write.TryGetProperty("cause", out _));
+        Assert.True(write.GetProperty("delivered").GetBoolean());
+        Assert.Single(runner.Calls, call =>
+            call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        Assert.False(File.Exists(workspace.EventPath));
+    }
+
+    [Fact]
+    public void DryRunAndWrite_HaveTheSameRefusalCause_WithoutSideEffects_G588()
+    {
+        var runner = Runner((_, arguments) => arguments.SequenceEqual(["agent", "list"])
+            ? Success(Roster(
+                Agent("orchestration", "wH", "wH:p1"),
+                Agent("implementation", "wH", "wH:p2"),
+                Agent("review", "wForeign", "wForeign:p9")))
+            : throw new InvalidOperationException("a refused route must never prompt"));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var args = DelegateArgs("orchestration", "review", "orchestration", write: false);
+
+        var (dryExit, dry) = workspace.Run(args);
+        args[^3] = "--write";
+        var (writeExit, write) = workspace.Run(args);
+
+        Assert.Equal(1, dryExit);
+        Assert.Equal(dryExit, writeExit);
+        Assert.Equal("unknown-role", dry.GetProperty("cause").GetString());
+        Assert.Equal(dry.GetProperty("cause").GetString(), write.GetProperty("cause").GetString());
+        Assert.Equal(dry.GetProperty("summary").GetString(), write.GetProperty("summary").GetString());
+        Assert.DoesNotContain(runner.Calls, call =>
+            call.Arguments.Take(2).SequenceEqual(["agent", "prompt"]));
+        Assert.False(File.Exists(workspace.EventPath));
+    }
+
+    [Fact]
+    public void UnsafeExternalReader_IsRefusedInDryRunAndWriteWithoutAppend_G588()
+    {
+        workspace.WriteTopology("../../outside-intent-cli-events.jsonl");
+        var runner = Runner((_, _) => throw new InvalidOperationException(
+            "an unsafe external-reader route must not start herdr"));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var dryArgs = ReportArgs(from: "implementation", to: "design", write: false);
+        var writeArgs = ReportArgs(from: "implementation", to: "design", write: true);
+        var (dryExit, dry) = workspace.Run(dryArgs);
+        var (writeExit, write) = workspace.Run(writeArgs);
+
+        Assert.Equal(1, dryExit);
+        Assert.Equal(dryExit, writeExit);
+        Assert.Equal("reader-unavailable", dry.GetProperty("cause").GetString());
+        Assert.Equal(dry.GetProperty("cause").GetString(), write.GetProperty("cause").GetString());
+        Assert.Contains("escapes --routing-root", dry.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Empty(runner.Calls);
+        Assert.False(File.Exists(workspace.EventPath));
+        Assert.False(File.Exists(Path.GetFullPath(Path.Combine(workspace.RootPath, "../../outside-intent-cli-events.jsonl"))));
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void Guidance_ExplainsRecordedResidenceAndResolutionContract_G588(string language)
+    {
+        var content = File.ReadAllText(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "docs",
+            language,
+            "12-agent-message-orchestration.md"));
+
+        Assert.Contains(".intent-cli/role-pane-mapping.json", content, StringComparison.Ordinal);
+        Assert.Contains("resident: external", content, StringComparison.Ordinal);
+        Assert.Contains("reader", content, StringComparison.Ordinal);
+        Assert.Contains("recipient must be deliverable", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("dry-run", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("workspace", content, StringComparison.Ordinal);
+
+        var runtimeGuide = HerdrOnlyOperatingGuide.RenderMarkdown([]);
+        Assert.Contains(".intent-cli/role-pane-mapping.json", runtimeGuide, StringComparison.Ordinal);
+        Assert.Contains("resident: external", runtimeGuide, StringComparison.Ordinal);
+        Assert.Contains("ONLY the recipient must be deliverable", runtimeGuide, StringComparison.Ordinal);
+        Assert.Contains("team-scoped unknown-role diagnostics", runtimeGuide, StringComparison.Ordinal);
+    }
+
+    private static FakeRunner Runner(
+        Func<string, IReadOnlyList<string>, NotifyProcessResult> handler) => new(handler);
+
+    private static NotifyProcessResult Success(string output = "") => new(0, output, "");
+
+    private static string Roster(params object[] agents) =>
+        JsonSerializer.Serialize(new { result = new { agents } });
+
+    private static object Agent(string name, string workspaceId, string paneId) => new
+    {
+        name,
+        workspace_id = workspaceId,
+        pane_id = paneId,
+        agent = "codex",
+        agent_session = new { id = name },
+        agent_status = "idle",
+        interactive_ready = true,
+    };
+
+    private static string[] DelegateArgs(string from, string to, string reportTo, bool write) =>
+    [
+        "notify", "delegate", "--domain", Workspace.Domain, "--team", Workspace.Team,
+        "--from", from, "--to", to, "--report-to", reportTo,
+        "--task-id", "G588-demo", "--objective", "Implement external routing",
+        "--input", "issue #1279", "--expected-artifact", "draft PR URL",
+        "--result-nonce", "g588-nonce", write ? "--write" : "--dry-run", "--format", "json",
+    ];
+
+    private static string[] ReportArgs(string from, string to, bool write) =>
+    [
+        "notify", "report", "--domain", Workspace.Domain, "--team", Workspace.Team,
+        "--from", from, "--to", to, "--task-id", "G588-demo", "--status", "completed",
+        "--artifact", "https://example.test/pr/1280", "--summary", "external routing completed",
+        write ? "--write" : "--dry-run", "--format", "json",
+    ];
+
+    private sealed class FakeRunner(
+        Func<string, IReadOnlyList<string>, NotifyProcessResult> handler) : INotifyProcessRunner
+    {
+        public List<(string FileName, IReadOnlyList<string> Arguments)> Calls { get; } = [];
+
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            Calls.Add((fileName, arguments.ToArray()));
+            return handler(fileName, arguments);
+        }
+    }
+
+    private sealed class Workspace : IDisposable
+    {
+        public const string Domain = "intent-cli";
+        public const string Team = "intent-cli-dev";
+
+        public Workspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("notify-g588-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            WriteTopology($".intent-cli/events/{Team}.jsonl");
+            using var writer = new StringWriter();
+            var setExit = SessionLayerCommand.ExecuteSet(
+                CreateContext(),
+                ["--domain", Domain, "--team", Team, "--mode", SessionLayerMode.HerdrOnly, "--write", "--format", "json"],
+                writer);
+            if (setExit != 0)
+            {
+                throw new InvalidOperationException(writer.ToString());
+            }
+        }
+
+        public string RootPath { get; }
+        public string EventPath => Path.Combine(RootPath, ".intent-cli", "events", $"{Team}.jsonl");
+
+        public void WriteTopology(string? externalReader)
+        {
+            File.WriteAllText(
+                Path.Combine(RootPath, NotifyRoleTopologyStore.RelativePath.Replace('/', Path.DirectorySeparatorChar)),
+                JsonSerializer.Serialize(new
+                {
+                    team = Team,
+                    workspace_id = "wH",
+                    roles = new Dictionary<string, object>
+                    {
+                        ["design"] = new
+                        {
+                            resident = "external",
+                            frontend = "claude-app",
+                            reader = externalReader,
+                        },
+                        ["orchestration"] = new
+                        {
+                            resident = "herdr",
+                            workspace_id = "wH",
+                            pane_id = "wH:p1",
+                        },
+                        ["implementation"] = new
+                        {
+                            resident = "herdr",
+                            workspace_id = "wH",
+                            pane_id = "wH:p2",
+                        },
+                        ["review"] = new
+                        {
+                            resident = "herdr",
+                            workspace_id = "wH",
+                            pane_id = "wH:p3",
+                        },
+                    },
+                }));
+        }
+
+        public (int ExitCode, JsonElement Result) Run(string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = CommandRouter.Execute(args, CreateContext(), writer);
+            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+        }
+
+        private CliContext CreateContext() => new()
+        {
+            RepoRoot = RootPath,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = Domain,
+                    ArtifactRoot = ".intent-cli",
+                },
+            },
+        };
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/NotifyRecordedRolesG588Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyRecordedRolesG588Tests.cs
@@ -96,9 +96,56 @@ public sealed class NotifyRecordedRolesG588Tests : IDisposable
         Assert.True(result.GetProperty("event_appended").GetBoolean());
         var line = Assert.Single(File.ReadAllLines(workspace.EventPath));
         using var document = JsonDocument.Parse(line);
-        Assert.Equal("completed", document.RootElement.GetProperty("kind").GetString());
+        Assert.Equal("completion", document.RootElement.GetProperty("kind").GetString());
         Assert.Equal("https://example.test/pr/1280", document.RootElement.GetProperty("artifact").GetString());
         Assert.Equal("external routing completed", document.RootElement.GetProperty("summary").GetString());
+        Assert.Empty(runner.Calls);
+    }
+
+    [Fact]
+    public void EveryEventKindNotifyCanEmit_BelongsToTheDocumentedSchema_G588()
+    {
+        var runner = Runner((_, _) => throw new InvalidOperationException(
+            "external-reader and escalation routes must not start herdr"));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        Assert.Equal(0, workspace.Run(DelegateArgs(
+            from: "orchestration",
+            to: "design",
+            reportTo: "orchestration",
+            write: true)).ExitCode);
+        var reportStatuses = NotifyCommand.SupportedReportStatuses.ToArray();
+        foreach (var status in reportStatuses)
+        {
+            Assert.Equal(0, workspace.Run(ReportArgs(
+                from: "implementation",
+                to: "design",
+                write: true,
+                status: status)).ExitCode);
+        }
+
+        Assert.Equal(0, workspace.Run(EscalateArgs()).ExitCode);
+
+        var emittedKinds = File.ReadAllLines(workspace.EventPath)
+            .Select(line =>
+            {
+                using var document = JsonDocument.Parse(line);
+                return document.RootElement.GetProperty("kind").GetString()!;
+            })
+            .ToArray();
+        var documentedKinds = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "completion",
+            "blocked",
+            "question",
+            "escalation",
+        };
+
+        Assert.Equal(reportStatuses.Length + 2, emittedKinds.Length);
+        Assert.All(emittedKinds, kind => Assert.Contains(kind, documentedKinds));
+        Assert.Equal(
+            documentedKinds.Order(StringComparer.Ordinal),
+            emittedKinds.Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal));
         Assert.Empty(runner.Calls);
     }
 
@@ -292,12 +339,20 @@ public sealed class NotifyRecordedRolesG588Tests : IDisposable
         "--result-nonce", "g588-nonce", write ? "--write" : "--dry-run", "--format", "json",
     ];
 
-    private static string[] ReportArgs(string from, string to, bool write) =>
+    private static string[] ReportArgs(string from, string to, bool write, string status = "completed") =>
     [
         "notify", "report", "--domain", Workspace.Domain, "--team", Workspace.Team,
-        "--from", from, "--to", to, "--task-id", "G588-demo", "--status", "completed",
+        "--from", from, "--to", to, "--task-id", "G588-demo", "--status", status,
         "--artifact", "https://example.test/pr/1280", "--summary", "external routing completed",
         write ? "--write" : "--dry-run", "--format", "json",
+    ];
+
+    private static string[] EscalateArgs() =>
+    [
+        "notify", "escalate", "--domain", Workspace.Domain, "--team", Workspace.Team,
+        "--from", "implementation", "--task-id", "G588-demo",
+        "--artifact", "https://example.test/pr/1280", "--summary", "needs design input",
+        "--write", "--format", "json",
     ];
 
     private sealed class FakeRunner(


### PR DESCRIPTION
## Summary

- resolve herdr-only notify roles from the requested team's recorded role topology
- require only the recipient to be deliverable, route external residents through their recorded reader, and target pane residents by the explicit recorded pane
- make dry-run execute the same route resolution as write, improve fail-closed diagnostics, and mirror the contract in EN/JA guidance

## Root cause

Notify validated sender, recipient, and report-to against the global herdr agent-name roster and required every role to have a live pane. Dry-run returned before that resolution. Delegate/report also never used an external resident's recorded reader.

## Verification

- focused G571/G578/G581/G582/G586/G588 matrix: 62 passed
- dedicated notify matrix: 30 passed, covering external sender/report-to, exactly-one delegate/report reader append, foreign-workspace refusal without prompt, unknown-role roster diagnostics, dry/write parity, unsafe-reader refusal, and EN/JA guidance
- Release build: 0 warnings, 0 errors
- full Release suite at 203856c1a6bfe683d63efde97b289f32978f574e: 4,641 passed, 1 skipped, 0 failed
- changed-file dotnet format verification: clean
- git diff --check: clean

Closes #1279