### PR TITLE
G589: make CI waits observable without timers

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -920,12 +920,27 @@ either trigger runs exactly one pass:
 ### CI wait state
 
 A PR with pending/running CI is an **active wait state**, not a blocker.
-GitHub checks are authoritative. Re-check the required checks on each wake;
+GitHub checks are authoritative. Use the mode's named re-check producer below;
 pending CI by itself never triggers a request-update label, a repair message,
 or an operator question. Always re-verify required checks immediately before
 delegating review, merge, or closeout — an earlier green read can go stale.
 
-- **pending / running** — wait and re-check next wake. No message, no
+- **timer-loop** — the configured recurring timer produces the exact-head CI
+  re-check; timer-loop behavior is unchanged.
+- **herdr-only** — before yielding on pending CI, explicitly arm an exact-head
+  CI-completion watch with `gh pr checks <pr> --repo <owner/repo> --watch`.
+  A controller outside intent-cli owns the watch. When it reaches a terminal
+  result, wake the recorded orchestration role at the pane ID resolved from the
+  team's logical-role mapping; never hard-code a pane ID. intent-cli does not
+  launch or manage this background process. The wake only says the wait ended:
+  re-read `stalled-work` and exact-head GitHub facts to determine success or
+  failure.
+- **agmsg orchestrator-message** — an explicitly configured fallback
+  orchestrator timer may produce the re-check; without one, arm the same
+  exact-head `gh pr checks ... --watch` surface. A receiver report alone does
+  not prove that CI completed.
+
+- **pending / running** — wait using the named producer above. No message, no
   request-update, no operator question; track the PR as in-flight and move on.
 - **green** — all required checks passed. Delegate review/closeout through
   intent-cli review surfaces; re-verify green at delegation time.
@@ -936,6 +951,14 @@ delegating review, merge, or closeout — an earlier green read can go stale.
 - **stuck / ambiguous** — checks never started, hung well past a reasonable
   window, or report conflicting/unknown status. Escalate one operator decision
   (fail closed); do not guess green.
+
+`intent-cli automation stalled-work` reports the same PR as informational
+`ci-pending` while any exact-head check is running, as actionable
+`ci-all-green-not-transitioned` when all checks are terminal without a failure, or
+as actionable `ci-failed-not-transitioned` when any terminal check failed.
+Each CI-aware item includes `pr_head_sha`, a pass/fail/skip/pending breakdown,
+and a stable kind + PR + head-SHA `dedupe_key`. This inventory is strictly
+read-only: it never delegates, relabels, or writes queue-state.
 
 ## Next-slice publication
 
@@ -1025,7 +1048,8 @@ Routing by dependency status:
   move → route it (implementation, review, closeout, or repair) using
   intent-cli / GitHub facts.
 - **dependency-waiting** — the dependency is in flight (e.g. PR CI pending) →
-  wait and re-check next wake; keep the dependent held.
+  wait using the CI wait state's named mode-specific re-check producer; keep
+  the dependent held.
 - **dependency-ambiguous** — cannot be resolved deterministically (missing
   dependency packet, conflicting GitHub linkage, cross-domain with no route
   mapping) → escalate one operator decision.
@@ -1076,7 +1100,10 @@ needs a human.
 Kept internal by default (no design-thread message):
 
 - normal progress / accepted / in-flight delegations;
-- CI waiting (pending checks are an active wait state);
+- CI waiting (pending checks are an active wait state); when the exact head
+  becomes terminal, the end of the wait is a legitimate orchestration wake
+  signal and must be classified as green or failed rather than deduped as the
+  pending wait;
 - successful implementation (PR opened, CI green);
 - successful review / approval;
 - closeout of an already-approved PR;

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -851,12 +851,25 @@ orchestrator がメッセージ駆動で動作する場合でも fallback/legacy
 ### CI 待ち状態
 
 pending/running の CI を持つ PR は **アクティブな待ち状態** であり、ブロッカーでは
-ありません。GitHub checks が権威です。各 wake で必須チェックを再確認します。pending な CI
+ありません。GitHub checks が権威です。以下の mode ごとに名前を付けた再確認 producer を使います。pending な CI
 はそれ単独では request-update label、repair メッセージ、オペレーターへの質問を引き起こしません。
 review / merge / closeout を委譲する直前には必ず必須チェックを再検証してください — 以前読んだ
 green は古くなっている可能性があります。
 
-- **pending / running** — 次の wake で待って再確認する。メッセージなし、request-update なし、
+- **timer-loop** — 設定済みの定期タイマーが exact-head CI の再確認を発生させます。timer-loop の
+  挙動は変更しません。
+- **herdr-only** — pending CI で yield する前に、
+  `gh pr checks <pr> --repo <owner/repo> --watch` で exact-head の CI-completion watch を明示的に
+  arm します。intent-cli の外側の controller が watch を所有します。terminal に達したら、team の
+  logical-role mapping から解決した pane ID の recorded orchestration role を wake します。pane ID を
+  hard-code してはいけません。intent-cli はこの background process を起動も管理もしません。この
+  wake が示すのは待ちが終わったことだけです。成功か失敗かを判定するため、`stalled-work` と
+  exact-head の GitHub facts を再読します。
+- **agmsg orchestrator-message** — 明示的に設定した fallback orchestrator timer が再確認を発生
+  させられます。それがない場合は、同じ exact-head `gh pr checks ... --watch` surface を arm します。
+  receiver report だけでは CI 完了の証明になりません。
+
+- **pending / running** — 上で名前を付けた producer を使って待つ。メッセージなし、request-update なし、
   オペレーター質問なし。PR を in-flight として追跡し、先へ進む。
 - **green** — すべての必須チェックが通過。intent-cli review surface 経由で review/closeout を
   委譲する。委譲時に green を再検証する。
@@ -866,6 +879,13 @@ green は古くなっている可能性があります。
 - **stuck / ambiguous** — チェックが開始されない、妥当な時間を大きく超えてハングする、または
   矛盾/不明なステータスを報告する。1 件のオペレーター判断にエスカレーション（fail closed）。
   green を推測しない。
+
+`intent-cli automation stalled-work` は、同じ PR について exact-head のチェックが 1 つでも実行中なら
+informational な `ci-pending`、すべて terminal で失敗がなければ actionable な
+`ci-all-green-not-transitioned`、terminal の失敗が 1 つでもあれば actionable な
+`ci-failed-not-transitioned` を報告します。各 CI-aware item は `pr_head_sha`、
+pass/fail/skip/pending の breakdown、kind + PR + head SHA による安定した `dedupe_key` を含みます。
+この inventory は厳密に read-only であり、delegate、relabel、queue-state write を行いません。
 
 ## next-slice の publish
 
@@ -947,8 +967,8 @@ handwritten transport invocation で検証を迂回したりしてはいけま�
   hold のまま。
 - **dependency-actionable** — 依存にすでに issue または PR があり進められる → intent-cli /
   GitHub の事実を使ってルーティング（実装・レビュー・closeout・repair）。
-- **dependency-waiting** — 依存が in flight（例: PR の CI が pending）→ 次の wake まで待って
-  再確認。依存元は hold のまま。
+- **dependency-waiting** — 依存が in flight（例: PR の CI が pending）→ CI wait state で名前を付けた
+  mode-specific re-check producer を使って待つ。依存元は hold のまま。
 - **dependency-ambiguous** — 決定論的に解決できない（依存 packet 欠落、GitHub linkage の矛盾、
   ルートマッピングのない cross-domain）→ 1 件のオペレーター判断にエスカレーション。
 - **dependency-cycle** — 依存が循環している → エスカレーション（fail closed）。
@@ -992,7 +1012,9 @@ status-request は receiver に次のいずれかで返信するよう求めま�
 デフォルトで内部に留める（設計スレッドへ送らない）:
 
 - 通常の進捗 / accepted / in-flight な委譲;
-- CI 待ち（pending チェックはアクティブな待ち状態）;
+- CI 待ち（pending チェックはアクティブな待ち状態）。exact head が terminal になったとき、待ちの
+  終了は正当な orchestration wake signal であり、pending wait として dedupe せず green または
+  failed に分類する;
 - 成功した実装（PR open、CI green）;
 - 成功したレビュー / 承認;
 - 承認済み PR の closeout;

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -31,6 +31,13 @@ namespace IntentSystem.Cli.Commands;
 ///   <c>rereview-pending</c> below — G533 review repair, field finding: PR
 ///   #1750 was misreported this way with a wrong review-start
 ///   recommendation mid-repair).</item>
+/// <item><c>ci-all-green-not-transitioned</c> — the same PR lifecycle point,
+///   with every reported check terminal and no failed conclusion. Carries
+///   the exact head SHA, normalized outcome breakdown, and a stable dedupe
+///   key; recommends the existing review-start transition but never runs it.</item>
+/// <item><c>ci-failed-not-transitioned</c> — every reported check is terminal
+///   and at least one failed. Carries the same stable evidence but routes the
+///   next action to repair/escalation by ownership rather than review.</item>
 /// <item><c>merged-not-closed-out</c> — a MERGED PR's linked queue item is
 ///   not <see cref="QueueItemState.Completed"/>.</item>
 /// <item><c>approved-not-merged</c> — an OPEN PR carries
@@ -68,6 +75,10 @@ namespace IntentSystem.Cli.Commands;
 ///   would be actively wrong mid-repair.</item>
 /// <item><c>rereview-pending</c> — a PR carrying
 ///   <c>intent-pr-rereview-ready</c>; repair pushed, awaiting re-review.</item>
+/// <item><c>ci-pending</c> — a PR at the pre-review lifecycle point whose exact
+///   head still has pending/running checks. This is a legitimate active wait,
+///   not a blocker or transition recommendation; its terminal counterpart is
+///   deliberately a different kind so a watcher can wake exactly when useful.</item>
 /// <item><c>claimed-but-silent</c> — an issue carrying
 ///   <c>intent-issue-in-progress</c> (no PR yet) with no observable activity
 ///   for longer than <c>--claimed-silent-minutes</c> (default
@@ -144,6 +155,9 @@ internal static class AutomationStalledWorkCommand
 
     public const string KindPublishedNotDelegated = "published-not-delegated";
     public const string KindPrCreatedNotReviewing = "pr-created-not-reviewing";
+    public const string KindCiPending = "ci-pending";
+    public const string KindCiAllGreenNotTransitioned = "ci-all-green-not-transitioned";
+    public const string KindCiFailedNotTransitioned = "ci-failed-not-transitioned";
     public const string KindMergedNotClosedOut = "merged-not-closed-out";
 
     /// <summary>
@@ -513,7 +527,12 @@ internal static class AutomationStalledWorkCommand
             Repo = repo,
             StaleMinutesThreshold = staleMinutes,
             BacklogIdleMinutesThreshold = backlogIdleMinutes,
-            Stalled = filtered.Length > 0,
+            // G589: a still-pending CI item remains visible, but it must not
+            // by itself trip a heartbeat/watcher wake. The kind changes when
+            // the exact head becomes terminal, and that terminal item is the
+            // dedupe-ready actionable signal. Other historical informational
+            // kinds retain their established stalled semantics.
+            Stalled = filtered.Any(item => item.Kind != KindCiPending),
             Items = filtered,
             Excluded = excluded,
             Warnings = warnings,
@@ -777,6 +796,7 @@ internal static class AutomationStalledWorkCommand
             string kind;
             bool isInformational;
             string recommendedAction;
+            StalledWorkCiProjection? ci = null;
             if (prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrRequestUpdate)
                 || prLabels.Contains(WorkerNextActionConstants.Labels.IntentPrUpdateInProgress))
             {
@@ -796,10 +816,38 @@ internal static class AutomationStalledWorkCommand
             }
             else
             {
-                kind = KindPrCreatedNotReviewing;
-                isInformational = false;
-                recommendedAction =
-                    $"intent-cli automation pr-transition --repo {repo} --pr {pr.Number} --transition review-start --write";
+                ci = ProjectCiState(pr);
+                if (ci is { Outcome: StalledWorkCiOutcomes.Pending })
+                {
+                    kind = KindCiPending;
+                    isInformational = true;
+                    recommendedAction =
+                        $"none — CI for PR #{pr.Number} head {pr.HeadRefOid} is still pending; keep it as an active "
+                        + "wait and let the mode-specific CI completion wake producer re-check the exact head.";
+                }
+                else if (ci is { Outcome: StalledWorkCiOutcomes.AllGreen })
+                {
+                    kind = KindCiAllGreenNotTransitioned;
+                    isInformational = false;
+                    recommendedAction =
+                        $"intent-cli automation pr-transition --repo {repo} --pr {pr.Number} --transition review-start --write";
+                }
+                else if (ci is { Outcome: StalledWorkCiOutcomes.Failed })
+                {
+                    kind = KindCiFailedNotTransitioned;
+                    isInformational = false;
+                    recommendedAction =
+                        $"inspect failed checks for PR #{pr.Number} at head {pr.HeadRefOid}; route branch-owned "
+                        + "failures to implementation repair and product/design or canonical failures to escalation; "
+                        + "do not start review.";
+                }
+                else
+                {
+                    kind = KindPrCreatedNotReviewing;
+                    isInformational = false;
+                    recommendedAction =
+                        $"intent-cli automation pr-transition --repo {repo} --pr {pr.Number} --transition review-start --write";
+                }
             }
 
             var resolution = ResolveExecutionUnit(context, matchedIssue.Title);
@@ -829,14 +877,15 @@ internal static class AutomationStalledWorkCommand
             // timestamps, and `updatedAt` reflects the PR's most recent
             // modification of ANY kind (which may postdate the specific
             // label change) unless a dedicated label-event fetch is added.
-            var ageSource = isInformational ? pr.UpdatedAt : pr.CreatedAt;
+            var isRepairLifecycle = kind is KindRepairPending or KindRereviewPending;
+            var ageSource = isRepairLifecycle ? pr.UpdatedAt : pr.CreatedAt;
             var ageMinutes = ComputeAgeMinutes(ageSource, now);
 
             // G546: promote a repair-lifecycle PR that has been observably
             // silent past the threshold. Inside the threshold — and whenever
             // the silence cannot be established at all — the G533
             // informational item below is emitted completely unchanged.
-            if (isInformational
+            if (isRepairLifecycle
                 && TryPromoteToRepairStalled(pr, prLabels, repo, now, repairSilentMinutes, out var promotedAction, out var silentMinutes))
             {
                 kind = KindRepairStalled;
@@ -854,8 +903,103 @@ internal static class AutomationStalledWorkCommand
                 AgeMinutes = ageMinutes,
                 IsInformational = isInformational,
                 RecommendedAction = recommendedAction,
+                PrHeadSha = ci is null ? null : pr.HeadRefOid,
+                CiOutcome = ci?.Outcome,
+                CiBreakdown = ci?.Breakdown,
+                DedupeKey = ci is null ? null : $"{kind}:pr-{pr.Number}:{pr.HeadRefOid}",
             });
         }
+    }
+
+    /// <summary>
+    /// G589: normalize GitHub's CheckRun / StatusContext union for the exact
+    /// PR head. Pending dominates until every row is terminal; after that,
+    /// any failed/error/cancelled conclusion makes the outcome failed.
+    /// A zero-row or headless rollup is not a completed CI run and preserves
+    /// the pre-G589 stalled-work kind.
+    /// </summary>
+    private static StalledWorkCiProjection? ProjectCiState(GitHubAutomationPrCandidate pr)
+    {
+        if (string.IsNullOrWhiteSpace(pr.HeadRefOid) || pr.StatusCheckRollup.Count == 0)
+        {
+            return null;
+        }
+
+        var passed = 0;
+        var failed = 0;
+        var skipped = 0;
+        var pending = 0;
+        foreach (var check in pr.StatusCheckRollup)
+        {
+            switch (ClassifyCheck(check))
+            {
+                case StalledWorkCheckOutcome.Passed:
+                    passed++;
+                    break;
+                case StalledWorkCheckOutcome.Failed:
+                    failed++;
+                    break;
+                case StalledWorkCheckOutcome.Skipped:
+                    skipped++;
+                    break;
+                default:
+                    pending++;
+                    break;
+            }
+        }
+
+        var outcome = pending > 0
+            ? StalledWorkCiOutcomes.Pending
+            : failed > 0
+                ? StalledWorkCiOutcomes.Failed
+                : StalledWorkCiOutcomes.AllGreen;
+        return new StalledWorkCiProjection(
+            outcome,
+            new StalledWorkCiBreakdown
+            {
+                Passed = passed,
+                Failed = failed,
+                Skipped = skipped,
+                Pending = pending,
+                Total = passed + failed + skipped + pending,
+            });
+    }
+
+    private static StalledWorkCheckOutcome ClassifyCheck(GitHubAutomationStatusCheckCandidate check)
+    {
+        var status = check.Status.Trim().ToUpperInvariant();
+        if (status.Length > 0 && !string.Equals(status, "COMPLETED", StringComparison.Ordinal))
+        {
+            return StalledWorkCheckOutcome.Pending;
+        }
+
+        var conclusion = check.Conclusion.Trim().ToUpperInvariant();
+        if (conclusion.Length > 0)
+        {
+            return conclusion switch
+            {
+                "SUCCESS" => StalledWorkCheckOutcome.Passed,
+                "SKIPPED" or "NEUTRAL" => StalledWorkCheckOutcome.Skipped,
+                _ => StalledWorkCheckOutcome.Failed,
+            };
+        }
+
+        var state = check.State.Trim().ToUpperInvariant();
+        if (state.Length > 0)
+        {
+            return state switch
+            {
+                "SUCCESS" => StalledWorkCheckOutcome.Passed,
+                "PENDING" or "EXPECTED" => StalledWorkCheckOutcome.Pending,
+                _ => StalledWorkCheckOutcome.Failed,
+            };
+        }
+
+        // A completed CheckRun with no conclusion is terminal but not green;
+        // an otherwise shape-less row cannot prove terminality and waits.
+        return string.Equals(status, "COMPLETED", StringComparison.Ordinal)
+            ? StalledWorkCheckOutcome.Failed
+            : StalledWorkCheckOutcome.Pending;
     }
 
     /// <summary>
@@ -2921,6 +3065,24 @@ internal static class AutomationStalledWorkCommand
                 {
                     writer.WriteLine($"- pr: #{pr.Number} — {pr.Url}");
                 }
+                if (item.PrHeadSha is { } headSha)
+                {
+                    writer.WriteLine($"- pr_head_sha: {headSha}");
+                }
+                if (item.CiOutcome is { } ciOutcome)
+                {
+                    writer.WriteLine($"- ci_outcome: {ciOutcome}");
+                }
+                if (item.CiBreakdown is { } breakdown)
+                {
+                    writer.WriteLine(
+                        $"- ci_breakdown: passed={breakdown.Passed}, failed={breakdown.Failed}, "
+                        + $"skipped={breakdown.Skipped}, pending={breakdown.Pending}, total={breakdown.Total}");
+                }
+                if (item.DedupeKey is { } dedupeKey)
+                {
+                    writer.WriteLine($"- dedupe_key: {dedupeKey}");
+                }
                 // G564: the declared targets belong in the item itself, so a
                 // reader knows WHAT the packet promised without opening it.
                 if (item.DeclaredWriteBackTargets is { Count: > 0 } declaredTargets)
@@ -3050,6 +3212,26 @@ internal sealed record StalledWorkItem
     [JsonPropertyName("recommended_action")]
     public required string RecommendedAction { get; init; }
 
+    /// <summary>G589: exact PR head SHA for CI-aware kinds.</summary>
+    [JsonPropertyName("pr_head_sha")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PrHeadSha { get; init; }
+
+    /// <summary>G589: pending / all-green / failed normalized terminal state.</summary>
+    [JsonPropertyName("ci_outcome")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? CiOutcome { get; init; }
+
+    /// <summary>G589: stable pass/fail/skip/pending counts for the exact head.</summary>
+    [JsonPropertyName("ci_breakdown")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public StalledWorkCiBreakdown? CiBreakdown { get; init; }
+
+    /// <summary>G589: stable watcher key; kind + PR number + exact head SHA.</summary>
+    [JsonPropertyName("dedupe_key")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DedupeKey { get; init; }
+
     /// <summary>
     /// G564: for <see cref="AutomationStalledWorkCommand.KindKnowledgeWritebackPending"/>,
     /// the target paths the packet DECLARED — so the report says what was
@@ -3058,6 +3240,43 @@ internal sealed record StalledWorkItem
     /// </summary>
     [JsonPropertyName("declared_write_back_targets")]
     public IReadOnlyList<string>? DeclaredWriteBackTargets { get; init; }
+}
+
+internal sealed record StalledWorkCiBreakdown
+{
+    [JsonPropertyName("passed")]
+    public required int Passed { get; init; }
+
+    [JsonPropertyName("failed")]
+    public required int Failed { get; init; }
+
+    [JsonPropertyName("skipped")]
+    public required int Skipped { get; init; }
+
+    [JsonPropertyName("pending")]
+    public required int Pending { get; init; }
+
+    [JsonPropertyName("total")]
+    public required int Total { get; init; }
+}
+
+internal static class StalledWorkCiOutcomes
+{
+    public const string Pending = "pending";
+    public const string AllGreen = "all-green";
+    public const string Failed = "failed";
+}
+
+internal readonly record struct StalledWorkCiProjection(
+    string Outcome,
+    StalledWorkCiBreakdown Breakdown);
+
+internal enum StalledWorkCheckOutcome
+{
+    Pending,
+    Passed,
+    Failed,
+    Skipped,
 }
 
 internal sealed record StalledWorkExcluded

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -667,6 +667,24 @@ internal static class GuideOrchestratorThreadCommand
             .Replace("<owner/repo>", repo, StringComparison.Ordinal)
             .Replace("<agent>", agent, StringComparison.Ordinal);
 
+        // G589: a CI wait is only survivable when the rendered mode names the
+        // thing that will observe the exact head becoming terminal. intent-cli
+        // describes that arrangement but never launches or owns a watcher.
+        var ciRecheckProducer = herdrOnly
+            ? Apply(
+                "HERDR-ONLY re-check producer: before yielding on pending CI, explicitly arm an exact-head "
+                + "CI-completion watch with `gh pr checks <pr> --repo <owner/repo> --watch`. A controller outside "
+                + "intent-cli owns that watch; when it reaches a terminal result, it wakes the recorded "
+                + "orchestration role at the pane ID resolved from the team's logical-role mapping (never hard-code "
+                + "a pane ID). intent-cli does not launch or manage this background process. The wake is a signal "
+                + "to re-read stalled-work plus exact-head GitHub facts, never proof of success.")
+            : Apply(
+                "TIMER-LOOP re-check producer: the configured recurring timer produces the next exact-head CI "
+                + "re-check; this preserves timer-loop behavior. In agmsg orchestrator-message mode, if no explicit "
+                + "fallback orchestrator timer is configured, explicitly arm the same exact-head GitHub surface, "
+                + "`gh pr checks <pr> --repo <owner/repo> --watch`; a receiver report alone does not prove CI "
+                + "completion. intent-cli does not launch or manage that watch.");
+
         // G489: the orchestrator prompt carries a mode-specific routing clause —
         // single-domain orchestrators stay scoped to one domain; multi-domain
         // orchestrators must attach explicit routing metadata to each delegation.
@@ -868,7 +886,7 @@ internal static class GuideOrchestratorThreadCommand
                     Apply("Ask intent-cli for worker state: `intent-cli worker next-action --repo <owner/repo> --github-only --format json`."),
                     Apply("Check host review readiness: `intent-cli automation host-review-preflight --repo <owner/repo> --format json`."),
                     "Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge state, and closeout/label state.",
-                    "Classify each open PR's CI: pending = wait-and-recheck next wake (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate. Pending CI is normal progress, not a reason to message the operator.",
+                    "Classify each open PR's CI: pending = wait using the named mode-specific CI re-check producer (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate. Pending CI is normal progress, not a reason to message the operator.",
                     "Detect stale blockers and no-reply receivers: a delegation with no accepted/progress reply within the expected window, or a thread stuck off the official workflow.",
                     "On a no-reply receiver past the threshold (default 30m), run the SAFE stale-thread health check: send one non-destructive status-request, check read-only intent-cli/GitHub facts, keep watching if there is progress, treat waiting-permission as an operator notice (never auto-clear), and only after repeated no-reply with no progress send one idempotent re-entry or escalate.",
                     "If intent-cli reports an `issue-cut-ready` candidate and all gates pass (same-domain or routed, complete contract, no open clarification, dependencies satisfied, under WIP, clean host-sync/preflight), publish ONE issue this wake via canonical publish-flow / issue-publish, verify it, THEN delegate that same issue to implementation in THIS SAME WAKE (G524) — do not ask the operator to create it, and do not stop after publishing to wait for a future wake to send the delegation.",
@@ -895,19 +913,20 @@ internal static class GuideOrchestratorThreadCommand
             {
                 Summary =
                     "A PR with pending/running CI is an ACTIVE WAIT STATE, not a blocker. GitHub checks are "
-                    + "authoritative for CI state. Re-check the required checks on each scheduled wake; pending CI is "
+                    + "authoritative for CI state. Use the named re-check producer below; pending CI is "
                     + "normal progress and by itself NEVER triggers a request-update label, a repair message, or an "
                     + "operator question. Always re-verify the required checks immediately before delegating review, "
                     + "merge, or closeout — a green status read on an earlier wake can go stale.",
+                RecheckProducer = ciRecheckProducer,
                 States = new[]
                 {
                     new OrchestratorCiState
                     {
                         State = "pending",
                         Routing =
-                            "PENDING / RUNNING — wait and re-check on the next wake. Do not send a message, do not apply "
-                            + "request-update, and do not ask the operator. Track the PR as in-flight and move on; the "
-                            + "scheduled cadence re-evaluates it.",
+                            "PENDING / RUNNING — wait using the named mode-specific re-check producer. Do not send a "
+                            + "message, do not apply request-update, and do not ask the operator. Track the PR as "
+                            + "in-flight and move on.",
                     },
                     new OrchestratorCiState
                     {
@@ -1050,8 +1069,9 @@ internal static class GuideOrchestratorThreadCommand
                     {
                         Status = "dependency-waiting",
                         Action =
-                            "The dependency is published and in flight (e.g. PR CI pending) — wait and re-check on the "
-                            + "next wake; do not ask the operator. Keep the dependent candidate held.",
+                            "The dependency is published and in flight (e.g. PR CI pending) — wait using the CI wait "
+                            + "state's named mode-specific re-check producer; do not ask the operator. Keep the "
+                            + "dependent candidate held.",
                     },
                     new OrchestratorDependencyStatus
                     {
@@ -1138,7 +1158,9 @@ internal static class GuideOrchestratorThreadCommand
                 KeptInternal = new[]
                 {
                     "Normal progress, accepted, and in-flight delegations.",
-                    "CI waiting — pending checks are an active wait state, not a design-thread event.",
+                    "CI waiting — pending checks are an active wait state, not a design-thread event; when the exact "
+                    + "head becomes terminal, the end of the CI wait is a legitimate orchestration wake signal and "
+                    + "must be classified as green or failed rather than deduped as the pending wait.",
                     "Successful implementation (PR opened, CI green).",
                     "Successful review / approval.",
                     "Closeout of an already-approved PR.",
@@ -4016,6 +4038,7 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine();
         writer.WriteLine(guide.CiWaitState.Summary);
         writer.WriteLine();
+        writer.WriteLine($"- **re-check producer** — {guide.CiWaitState.RecheckProducer}");
         foreach (var state in guide.CiWaitState.States)
         {
             writer.WriteLine($"- **{state.State}** — {state.Routing}");
@@ -4729,6 +4752,9 @@ internal sealed record OrchestratorCiWaitState
 {
     [JsonPropertyName("summary")]
     public required string Summary { get; init; }
+
+    [JsonPropertyName("recheck_producer")]
+    public required string RecheckProducer { get; init; }
 
     [JsonPropertyName("states")]
     public required IReadOnlyList<OrchestratorCiState> States { get; init; }

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -80,6 +80,42 @@ internal sealed record GitHubAutomationPrCandidate
     /// </summary>
     [JsonPropertyName("isDraft")]
     public bool IsDraft { get; init; }
+
+    /// <summary>
+    /// G589: exact PR head the check rollup belongs to. Empty for callers and
+    /// fixtures that pre-date CI-aware stalled-work; those callers retain the
+    /// existing non-CI classification.
+    /// </summary>
+    [JsonPropertyName("headRefOid")]
+    public string HeadRefOid { get; init; } = string.Empty;
+
+    /// <summary>
+    /// G589: authoritative GitHub check/status rollup for <see cref="HeadRefOid"/>.
+    /// The stalled-work analyzer normalizes CheckRun and StatusContext entries
+    /// without performing any workflow transition.
+    /// </summary>
+    [JsonPropertyName("statusCheckRollup")]
+    public IReadOnlyList<GitHubAutomationStatusCheckCandidate> StatusCheckRollup { get; init; }
+        = Array.Empty<GitHubAutomationStatusCheckCandidate>();
+}
+
+/// <summary>G589: union-shaped row from GitHub's PR statusCheckRollup.</summary>
+internal sealed record GitHubAutomationStatusCheckCandidate
+{
+    [JsonPropertyName("__typename")]
+    public string TypeName { get; init; } = string.Empty;
+
+    /// <summary>CheckRun lifecycle status, normally QUEUED / IN_PROGRESS / COMPLETED.</summary>
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = string.Empty;
+
+    /// <summary>CheckRun terminal conclusion, e.g. SUCCESS / FAILURE / SKIPPED.</summary>
+    [JsonPropertyName("conclusion")]
+    public string Conclusion { get; init; } = string.Empty;
+
+    /// <summary>StatusContext state, e.g. PENDING / EXPECTED / SUCCESS / FAILURE / ERROR.</summary>
+    [JsonPropertyName("state")]
+    public string State { get; init; } = string.Empty;
 }
 
 /// <summary>
@@ -156,7 +192,8 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
     // G319: also request `isDraft` so the host-loop-next-action analyzer
     // can map an approved-but-draft PR to `approved-pr-draft-blocked`
     // (G297) instead of attempting a merge.
-    internal const string PrListJsonFields = "number,title,url,body,createdAt,updatedAt,labels,closingIssuesReferences,state,isDraft";
+    internal const string PrListJsonFields =
+        "number,title,url,body,createdAt,updatedAt,labels,closingIssuesReferences,state,isDraft,headRefOid,statusCheckRollup";
 
     /// <summary>
     /// G206: builds the <c>gh pr list</c> argument list shared by the live

--- a/src/IntentSystem.Cli/Commands/SessionLayerFragments.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerFragments.cs
@@ -636,7 +636,7 @@ internal static class SessionLayerFragments
         Fragment(S4, Operative("- Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge state, and closeout/label state.")),
         Fragment(
             S4,
-            Operative("- Classify each open PR's CI: pending = wait-and-recheck next wake (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate."),
+            Operative("- Classify each open PR's CI: pending = wait using the named mode-specific CI re-check producer (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate."),
             Scaffold(" "),
             Descriptive("Pending CI is normal progress, not a reason to message the operator.")),
         Fragment(S4, Operative("- Detect stale blockers and no-reply receivers: a delegation with no accepted/progress reply within the expected window, or a thread stuck off the official workflow.")),
@@ -1532,7 +1532,7 @@ internal static class SessionLayerFragments
         Fragment("scheduling", Operative("Verify GitHub facts directly: open PRs, CI conclusion, approvals, merge state, and closeout/label state.")),
         Fragment(
             "scheduling",
-            Operative("Classify each open PR's CI: pending = wait-and-recheck next wake (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate."),
+            Operative("Classify each open PR's CI: pending = wait using the named mode-specific CI re-check producer (no message); green = delegate review/closeout; red = repair or escalate by ownership; stuck = escalate."),
             Scaffold(" "),
             Descriptive("Pending CI is normal progress, not a reason to message the operator.")),
         Fragment("scheduling", Operative("Detect stale blockers and no-reply receivers: a delegation with no accepted/progress reply within the expected window, or a thread stuck off the official workflow.")),

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -161,6 +161,135 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_CiPendingAndTerminalGreen_ForSamePr_ProduceDistinctDedupeReadyEvidence()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G589", "intent-cli");
+        var issue = BuildIssue(1281, "G589: CI wait must be survivable without a timer",
+            FixedNow.AddDays(-2), "intent-pr-created");
+        const string headSha = "589abc123def4567890abc123def4567890abc12";
+        var pendingPr = BuildPr(
+            1282,
+            issue.Title,
+            FixedNow.AddMinutes(-90),
+            state: "OPEN",
+            closingIssueNumber: issue.Number,
+            headRefOid: headSha,
+            statusCheckRollup:
+            [
+                CheckRun("COMPLETED", "SUCCESS"),
+                CheckRun("IN_PROGRESS"),
+            ]);
+
+        var pending = RunJson(workspace, issue, pendingPr);
+        Assert.False(pending.RootElement.GetProperty("stalled").GetBoolean());
+        var pendingItem = Assert.Single(pending.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindCiPending, pendingItem.GetProperty("kind").GetString());
+        Assert.True(pendingItem.GetProperty("is_informational").GetBoolean());
+        Assert.Equal(headSha, pendingItem.GetProperty("pr_head_sha").GetString());
+        Assert.Equal("pending", pendingItem.GetProperty("ci_outcome").GetString());
+        AssertCiBreakdown(pendingItem, passed: 1, failed: 0, skipped: 0, pending: 1, total: 2);
+        Assert.Equal($"ci-pending:pr-1282:{headSha}", pendingItem.GetProperty("dedupe_key").GetString());
+        Assert.DoesNotContain("pr-transition", pendingItem.GetProperty("recommended_action").GetString(),
+            StringComparison.Ordinal);
+
+        var greenPr = pendingPr with
+        {
+            StatusCheckRollup =
+            [
+                CheckRun("COMPLETED", "SUCCESS"),
+                CheckRun("COMPLETED", "SKIPPED"),
+            ],
+        };
+        var green = RunJson(workspace, issue, greenPr);
+        Assert.True(green.RootElement.GetProperty("stalled").GetBoolean());
+        var greenItem = Assert.Single(green.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindCiAllGreenNotTransitioned,
+            greenItem.GetProperty("kind").GetString());
+        Assert.False(greenItem.GetProperty("is_informational").GetBoolean());
+        Assert.Equal("all-green", greenItem.GetProperty("ci_outcome").GetString());
+        AssertCiBreakdown(greenItem, passed: 1, failed: 0, skipped: 1, pending: 0, total: 2);
+        Assert.Equal($"ci-all-green-not-transitioned:pr-1282:{headSha}",
+            greenItem.GetProperty("dedupe_key").GetString());
+        Assert.Contains("--transition review-start", greenItem.GetProperty("recommended_action").GetString(),
+            StringComparison.Ordinal);
+        Assert.NotEqual(pendingItem.GetProperty("kind").GetString(), greenItem.GetProperty("kind").GetString());
+    }
+
+    [Fact]
+    public void Execute_CiTerminalFailure_IsActionableAndCarriesOutcomeBreakdown()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G589", "intent-cli");
+        var issue = BuildIssue(1281, "G589: CI wait must be survivable without a timer",
+            FixedNow.AddDays(-2), "intent-pr-created");
+        const string headSha = "589fff123def4567890abc123def4567890abc12";
+        var failedPr = BuildPr(
+            1282,
+            issue.Title,
+            FixedNow.AddMinutes(-90),
+            state: "OPEN",
+            closingIssueNumber: issue.Number,
+            headRefOid: headSha,
+            statusCheckRollup:
+            [
+                StatusContext("SUCCESS"),
+                CheckRun("COMPLETED", "SKIPPED"),
+                StatusContext("FAILURE"),
+            ]);
+
+        var result = RunJson(workspace, issue, failedPr);
+        var item = Assert.Single(result.RootElement.GetProperty("items").EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindCiFailedNotTransitioned,
+            item.GetProperty("kind").GetString());
+        Assert.False(item.GetProperty("is_informational").GetBoolean());
+        Assert.Equal("failed", item.GetProperty("ci_outcome").GetString());
+        AssertCiBreakdown(item, passed: 1, failed: 1, skipped: 1, pending: 0, total: 3);
+        Assert.Equal($"ci-failed-not-transitioned:pr-1282:{headSha}",
+            item.GetProperty("dedupe_key").GetString());
+        var action = item.GetProperty("recommended_action").GetString();
+        Assert.Contains("repair", action, StringComparison.Ordinal);
+        Assert.Contains("escalation", action, StringComparison.Ordinal);
+        Assert.DoesNotContain("review-start", action, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_CiClassification_IsStrictlyReadOnlyAcrossAllOutcomes()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WritePacketDomain("G589", "intent-cli");
+        workspace.WriteFile("sentinel.txt", "workflow state must remain untouched\n");
+        var issue = BuildIssue(1281, "G589: CI wait must be survivable without a timer",
+            FixedNow.AddDays(-2), "intent-pr-created");
+        const string headSha = "589ddd123def4567890abc123def4567890abc12";
+        var before = SnapshotFiles(workspace.RootPath);
+
+        foreach (var checks in new IReadOnlyList<GitHubAutomationStatusCheckCandidate>[]
+                 {
+                     [CheckRun("IN_PROGRESS")],
+                     [CheckRun("COMPLETED", "SUCCESS")],
+                     [CheckRun("COMPLETED", "FAILURE")],
+                 })
+        {
+            var pr = BuildPr(1282, issue.Title, FixedNow.AddMinutes(-90), "OPEN", issue.Number,
+                headRefOid: headSha, statusCheckRollup: checks);
+            _ = RunJson(workspace, issue, pr);
+        }
+
+        var after = SnapshotFiles(workspace.RootPath);
+        Assert.Equal(before, after);
+    }
+
+    [Fact]
+    public void LiveLister_RequestsExactHeadAndStatusRollup()
+    {
+        Assert.Contains("headRefOid", GhCliGitHubAutomationCandidateLister.PrListJsonFields,
+            StringComparison.Ordinal);
+        Assert.Contains("statusCheckRollup", GhCliGitHubAutomationCandidateLister.PrListJsonFields,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_PrCreatedNotReviewing_ExcludesPrAlreadyReviewing()
     {
         using var workspace = new StalledWorkWorkspace();
@@ -3046,6 +3175,59 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
             Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
         };
 
+    private static JsonDocument RunJson(
+        StalledWorkWorkspace workspace,
+        GitHubAutomationIssueCandidate issue,
+        GitHubAutomationPrCandidate pr)
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue], prs: [pr]);
+        using var writer = new StringWriter();
+        var exitCode = AutomationStalledWorkCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--stale-minutes", "0",
+                "--repair-silent-minutes", "0", "--format", "json"],
+            writer);
+        Assert.Equal(0, exitCode);
+        return JsonDocument.Parse(writer.ToString());
+    }
+
+    private static GitHubAutomationStatusCheckCandidate CheckRun(string status, string conclusion = "") => new()
+    {
+        TypeName = "CheckRun",
+        Status = status,
+        Conclusion = conclusion,
+    };
+
+    private static GitHubAutomationStatusCheckCandidate StatusContext(string state) => new()
+    {
+        TypeName = "StatusContext",
+        State = state,
+    };
+
+    private static void AssertCiBreakdown(
+        JsonElement item,
+        int passed,
+        int failed,
+        int skipped,
+        int pending,
+        int total)
+    {
+        var breakdown = item.GetProperty("ci_breakdown");
+        Assert.Equal(passed, breakdown.GetProperty("passed").GetInt32());
+        Assert.Equal(failed, breakdown.GetProperty("failed").GetInt32());
+        Assert.Equal(skipped, breakdown.GetProperty("skipped").GetInt32());
+        Assert.Equal(pending, breakdown.GetProperty("pending").GetInt32());
+        Assert.Equal(total, breakdown.GetProperty("total").GetInt32());
+    }
+
+    private static IReadOnlyDictionary<string, string> SnapshotFiles(string rootPath) =>
+        Directory.GetFiles(rootPath, "*", SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToDictionary(
+                path => Path.GetRelativePath(rootPath, path),
+                path => Convert.ToHexString(File.ReadAllBytes(path)),
+                StringComparer.Ordinal);
+
     private static GitHubAutomationPrCandidate BuildPr(
         int number,
         string title,
@@ -3054,7 +3236,9 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         int? closingIssueNumber = null,
         string[]? extraLabels = null,
         DateTimeOffset? updatedAt = null,
-        bool isDraft = false) => new()
+        bool isDraft = false,
+        string headRefOid = "",
+        IReadOnlyList<GitHubAutomationStatusCheckCandidate>? statusCheckRollup = null) => new()
         {
             Number = number,
             Title = title,
@@ -3063,6 +3247,8 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
             UpdatedAt = (updatedAt ?? createdAt).ToString("O"),
             State = state,
             IsDraft = isDraft,
+            HeadRefOid = headRefOid,
+            StatusCheckRollup = statusCheckRollup ?? Array.Empty<GitHubAutomationStatusCheckCandidate>(),
             Labels = (extraLabels ?? Array.Empty<string>()).Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
             ClosingIssuesReferences = closingIssueNumber is int n
                 ? new[]

--- a/tests/IntentSystem.Cli.Tests/CiWaitWakeG589Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/CiWaitWakeG589Tests.cs
@@ -1,0 +1,197 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G589: the CI wait instruction must name a real re-check producer in every
+/// rendered session-layer mode. A terminal exact head is a new wake signal,
+/// while pending remains quiet and non-escalating.
+/// </summary>
+public sealed class CiWaitWakeG589Tests
+{
+    [Fact]
+    public void BothSessionModes_NameAConcreteProducer_AndNeverPromiseAnUnscheduledNextWake()
+    {
+        using var workspace = new GuideWorkspace();
+
+        var agmsg = workspace.Render(SessionLayerMode.Agmsg);
+        var agmsgCi = SectionFrom(agmsg, "## CI wait state");
+        Assert.Contains("TIMER-LOOP re-check producer", agmsgCi, StringComparison.Ordinal);
+        Assert.Contains("configured recurring timer", agmsgCi, StringComparison.Ordinal);
+        Assert.Contains("gh pr checks <pr> --repo J-Tech-Japan/intent-system --watch", agmsgCi,
+            StringComparison.Ordinal);
+
+        var herdr = workspace.Render(SessionLayerMode.HerdrOnly);
+        var herdrCi = SectionFrom(herdr, "## CI wait state");
+        Assert.Contains("HERDR-ONLY re-check producer", herdrCi, StringComparison.Ordinal);
+        Assert.Contains("explicitly arm an exact-head CI-completion watch", herdrCi, StringComparison.Ordinal);
+        Assert.Contains("gh pr checks <pr> --repo J-Tech-Japan/intent-system --watch", herdrCi,
+            StringComparison.Ordinal);
+        Assert.Contains("logical-role mapping", herdrCi, StringComparison.Ordinal);
+        Assert.Contains("never hard-code a pane ID", herdrCi, StringComparison.Ordinal);
+        Assert.Contains("intent-cli does not launch or manage", herdrCi, StringComparison.Ordinal);
+
+        foreach (var section in new[] { agmsgCi, herdrCi })
+        {
+            Assert.Contains("pending CI", section, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("NEVER triggers", section, StringComparison.Ordinal);
+            Assert.DoesNotContain("re-check on the next wake", section, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("wait-and-recheck next wake", section, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public void PendingDependencyUsesNamedProducer_AndTerminalEndIsALegitimateWakeSignal()
+    {
+        using var workspace = new GuideWorkspace();
+
+        foreach (var mode in new[] { SessionLayerMode.Agmsg, SessionLayerMode.HerdrOnly })
+        {
+            var output = workspace.Render(mode);
+            var dependency = SectionFrom(output, "## Dependency planning");
+            Assert.Contains("named mode-specific re-check producer", dependency, StringComparison.Ordinal);
+            Assert.DoesNotContain("wait and re-check on the next wake", dependency,
+                StringComparison.OrdinalIgnoreCase);
+
+            var escalation = SectionFrom(output, "## Design-thread escalation filter");
+            Assert.Contains("pending checks are an active wait state", escalation, StringComparison.Ordinal);
+            Assert.Contains("end of the CI wait is a legitimate orchestration wake signal", escalation,
+                StringComparison.Ordinal);
+            Assert.Contains("classified as green or failed", escalation, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void JsonCarriesTheSameModeSpecificProducerContract()
+    {
+        using var workspace = new GuideWorkspace();
+
+        using var agmsg = workspace.RenderJson(SessionLayerMode.Agmsg);
+        Assert.Contains("TIMER-LOOP", agmsg.RootElement.GetProperty("ci_wait_state")
+            .GetProperty("recheck_producer").GetString(), StringComparison.Ordinal);
+
+        using var herdr = workspace.RenderJson(SessionLayerMode.HerdrOnly);
+        var producer = herdr.RootElement.GetProperty("ci_wait_state")
+            .GetProperty("recheck_producer").GetString();
+        Assert.Contains("HERDR-ONLY", producer, StringComparison.Ordinal);
+        Assert.Contains("gh pr checks", producer, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperDocsPinKindsEvidenceReadOnlyBoundaryAndBothWakeProducers(string language)
+    {
+        var path = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "docs",
+            language,
+            "12-agent-message-orchestration.md");
+        var docs = File.ReadAllText(path);
+
+        Assert.Contains("ci-pending", docs, StringComparison.Ordinal);
+        Assert.Contains("ci-all-green-not-transitioned", docs, StringComparison.Ordinal);
+        Assert.Contains("ci-failed-not-transitioned", docs, StringComparison.Ordinal);
+        Assert.Contains("pr_head_sha", docs, StringComparison.Ordinal);
+        Assert.Contains("dedupe_key", docs, StringComparison.Ordinal);
+        Assert.Contains("read-only", docs, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("timer-loop", docs, StringComparison.Ordinal);
+        Assert.Contains("gh pr checks <pr> --repo <owner/repo> --watch", docs, StringComparison.Ordinal);
+        Assert.Contains("logical-role mapping", docs, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "configured recurring timer" : "設定済みの定期タイマー", docs,
+            StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "intent-cli does not" : "intent-cli はこの background process を起動も管理もしません",
+            docs, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("wait and re-check next wake", docs, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string SectionFrom(string output, string heading)
+    {
+        var start = output.IndexOf(heading, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"missing section heading: {heading}");
+        var next = output.IndexOf("\n## ", start + heading.Length, StringComparison.Ordinal);
+        return next < 0 ? output[start..] : output[start..next];
+    }
+
+    private sealed class GuideWorkspace : IDisposable
+    {
+        private const string Domain = "intent-cli";
+        private const string Team = "intent-cli-dev";
+        private const string Repo = "J-Tech-Japan/intent-system";
+
+        public GuideWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("g589-guide-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = Domain,
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+        }
+
+        private string RootPath { get; }
+
+        private CliContext Context { get; }
+
+        public string Render(string mode)
+        {
+            SetMode(mode);
+            using var writer = new StringWriter();
+            var exitCode = GuideOrchestratorThreadCommand.Execute(
+                Context,
+                ["--domain", Domain, "--target-repo", Repo, "--agent", "claude", "--team", Team,
+                    "--format", "markdown"],
+                writer);
+            Assert.Equal(0, exitCode);
+            return writer.ToString();
+        }
+
+        public JsonDocument RenderJson(string mode)
+        {
+            SetMode(mode);
+            using var writer = new StringWriter();
+            var exitCode = GuideOrchestratorThreadCommand.Execute(
+                Context,
+                ["--domain", Domain, "--target-repo", Repo, "--agent", "claude", "--team", Team,
+                    "--format", "json"],
+                writer);
+            Assert.Equal(0, exitCode);
+            return JsonDocument.Parse(writer.ToString());
+        }
+
+        private void SetMode(string mode)
+        {
+            var recordPath = SessionLayerModeStore.ResolvePath(RootPath);
+            if (File.Exists(recordPath))
+            {
+                File.Delete(recordPath);
+            }
+
+            using var writer = new StringWriter();
+            var exitCode = SessionLayerCommand.ExecuteSet(
+                Context,
+                ["--domain", Domain, "--team", Team, "--mode", mode, "--write", "--format", "json"],
+                writer);
+            Assert.True(exitCode == 0, writer.ToString());
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -611,7 +611,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
 
         Assert.Contains("## CI wait state", output, StringComparison.Ordinal);
-        // Pending is wait-and-recheck and does not trigger request-update/operator question.
+        // Pending uses the named mode-specific producer and does not trigger request-update/operator question.
         Assert.Contains("active wait state", output, StringComparison.Ordinal);
         Assert.Contains("- **pending**", output, StringComparison.Ordinal);
         Assert.Contains("do not apply request-update", output, StringComparison.Ordinal);
@@ -640,6 +640,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         var ci = doc.RootElement.GetProperty("ci_wait_state");
 
         Assert.True(ci.TryGetProperty("summary", out _));
+        Assert.True(ci.TryGetProperty("recheck_producer", out _));
         var states = ci.GetProperty("states").EnumerateArray()
             .Select(s => s.GetProperty("state").GetString())
             .ToArray();
@@ -649,7 +650,8 @@ public sealed class GuideOrchestratorThreadCommandTests
         var wake = doc.RootElement.GetProperty("scheduling").GetProperty("wake_responsibilities").EnumerateArray()
             .Select(w => w.GetString()!)
             .ToArray();
-        Assert.Contains(wake, w => w.Contains("pending = wait-and-recheck", StringComparison.Ordinal));
+        Assert.Contains(wake, w => w.Contains("pending = wait using the named mode-specific CI re-check producer",
+            StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -12,7 +12,7 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     private const string Domain = "intent-cli";
     private const string Team = "intent-cli-dev";
     private const string Repo = "J-Tech-Japan/intent-system";
-    private const string AgmsgBaselineSha256 = "305e7096344bc726f988734a04bf64445b25ae2167051bcc66d26d99c70b76f5";
+    private const string G589AgmsgBaselineSha256 = "90be8c7999369dc4dffa4fba58c13456e5f90319116473ad11cb9efd7baa47d8";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 
@@ -91,12 +91,12 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     }
 
     [Fact]
-    public void AgmsgRendering_IsByteIdenticalToMergedMainBaseline_G586()
+    public void AgmsgRendering_MatchesG589CiWakeContractBaseline_G589()
     {
         var markdown = Render(herdrOnly: false, format: "markdown");
         var hash = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(markdown)));
 
-        Assert.Equal(AgmsgBaselineSha256, hash);
+        Assert.Equal(G589AgmsgBaselineSha256, hash);
     }
 
     private string Render(bool herdrOnly, string format)

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -9,8 +9,8 @@ namespace IntentSystem.Cli.Tests;
 
 public sealed class HerdrWakeSourcesG581Tests : IDisposable
 {
-    private const string PreG581AgmsgGuideSha256 =
-        "F1ED7A4DE358012BC19B197359DB5163CBC4FF04A8CE744E3A2DA4AD34248406";
+    private const string G589AgmsgGuideSha256 =
+        "F4D975FCAD0313DDD561924DE138FAB37A0307331CF01716387C8459EAEF98F2";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 
@@ -133,13 +133,13 @@ public sealed class HerdrWakeSourcesG581Tests : IDisposable
     }
 
     [Fact]
-    public void AgmsgGuide_OutsideG582SwitchChecklist_RemainsByteIdenticalToPreG581Baseline_G581()
+    public void AgmsgGuide_OutsideG582SwitchChecklist_MatchesG589CiWakeContractBaseline_G589()
     {
         var markdown = Render(herdrOnly: false, format: "markdown");
         var withoutG582Checklist = WithoutSection(markdown, SessionLayerSwitchChecklist.Heading);
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(withoutG582Checklist)));
 
-        Assert.Equal(PreG581AgmsgGuideSha256, hash);
+        Assert.Equal(G589AgmsgGuideSha256, hash);
         Assert.DoesNotContain("## Herdr-only wake sources", markdown, StringComparison.Ordinal);
         Assert.DoesNotContain("pane.agent_status_changed", markdown, StringComparison.Ordinal);
     }


### PR DESCRIPTION
## Summary

- classify exact-head CI as informational `ci-pending`, actionable `ci-all-green-not-transitioned`, or actionable `ci-failed-not-transitioned`
- include head SHA, normalized pass/fail/skip/pending breakdown, and a stable kind/PR/head dedupe key while keeping stalled-work strictly read-only
- name the CI re-check producer in timer-loop, agmsg, and herdr-only guidance; make terminal completion a legitimate wake signal while pending remains quiet
- keep EN/JA developer guidance and guide JSON/Markdown renderings aligned

## Verification

- focused G589 + stalled-work + orchestrator/session-layer regression matrix: 361 passed, 0 failed
- `dotnet test IntentSystem.sln -c Release --no-restore`: 4,321 passed, 1 skipped, 0 failed
- `dotnet format IntentSystem.sln --verify-no-changes --no-restore --include <9 changed C# files>`: clean
- `git diff --check`: clean

Closes #1281