### PR TITLE
G590: prepare v0.8.1 patch release notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2543,23 +2543,22 @@ to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
 ### Next release readiness (v0.8.1)
 
-**`v0.8.0` shipped** (GitHub Release + NuGet) and the version policy was rolled
-to the `0.8.1` development line. The v0.8.0 batch was a **minor** bump covering twelve slices — G570, G571,
-G573, G574, G575, G577, G578, G579, G580, G581, G582 and G583 — whose
-headline is the persisted, reversible session-layer dual mode with the
-transport-neutral `notify` surface. Minor rather than patch because it ships
-the new `session-layer` and `notify` command groups; both session modes stay
-first-class and agmsg is not deprecated.
+**`v0.8.0` shipped** (GitHub Release + NuGet), and the version policy remains
+`stableVersion: 0.8.0` with `nextVersion: 0.8.1`. The prepare-only `v0.8.1`
+notes cover exactly G585, G586, G587, G588, and G589; see
+[release-notes-v0.8.1.md](release-notes-v0.8.1.md) for the merged PR and commit
+evidence.
 
-The repository is now on the in-development **`0.8.1`** `nextVersion`. What
-ships in `v0.8.1` is not decided here: the next release-prep packet selects the
-merged slices, authors the real
-[release-notes-v0.8.1.md](release-notes-v0.8.1.md) content over the DRAFT
-stubs, and states the bump rationale. Until then the notes remain stubs and no
-`v0.8.1` GitHub Release may be published.
+`v0.8.1` is a **PATCH** under the version policy: all five slices are
+correctness fixes, with no new command surface or broad behavior change. The
+two documented additive output-shape changes remain non-breaking: external-
+resident `notify delegate` / `notify report` delivery can append the team event
+and set `event_appended=true`, and `automation stalled-work` can return new
+finding kinds. This preparation does not create a Release, tag, or package and
+does not roll the version file.
 
-**Release-readiness verification (run before merging the `v0.8.1` version
-bump):**
+**Release-readiness verification (run before merging the `v0.8.1`
+release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
@@ -2568,15 +2567,19 @@ cat eng/version.json   # stableVersion 0.8.0 (published), nextVersion 0.8.1 (to 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.8.1-<sha>-G56x   (NOT a stale literal)
+#   expected shape: intent-cli 0.8.1-<sha>-G590   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
 ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.8.1.nupkg
 
-# 4. Confirm package metadata (id / command / license / project URL).
+# 4. Confirm the G475 package/release guard and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
-  -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
+  -c Release --filter \
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+
+# 5. Run the complete Release suite.
+dotnet test IntentSystem.sln -c Release
 ```
 
 After the preparation merge lands on `main` and the readiness evidence holds,

--- a/docs/en/release-notes-v0.8.1.md
+++ b/docs/en/release-notes-v0.8.1.md
@@ -1,41 +1,155 @@
-# Release Notes — intent-cli v0.8.1 (DRAFT — UNRELEASED)
+# Release Notes — intent-cli v0.8.1
 
-> **⚠️ DRAFT / UNRELEASED.** This is a **stub**, not release notes. It exists
-> because `eng/version.json` names `0.8.1` as the release-to-be-cut, and the
-> G475 guard requires notes to exist for that version before it can be
-> published. **The v0.8.1 release-prep packet authors the real content**;
-> nothing here describes shipped behavior, and this file must not be treated as
-> a changelog.
+> **Release model:** this change is **prepare-only**. It does not create a
+> GitHub Release or tag, publish a package, roll the version policy, or change
+> product behavior. After this preparation is merged and the readiness gate
+> below is satisfied, the operator must explicitly approve Release creation.
+> Publishing that GitHub Release triggers `.github/workflows/release.yml`
+> (`on: release: published`) to build and publish the NuGet package and
+> platform artifacts.
 
-## Status
+## What's in v0.8.1
 
-Created by the post-release version roll (G554 rule as amended by G557) at the
-moment `nextVersion` became `0.8.1`. Until the release-prep packet fills it in:
+v0.8.1 covers exactly five correctness slices merged after `v0.8.0`: **G585**,
+**G586**, **G587**, **G588**, and **G589**. Their PRs and merge commits are:
 
-- **No slices are listed yet.** What ships in `v0.8.1` is decided by the
-  release-prep packet, not by this stub.
-- **No bump rationale yet** (patch vs minor is a release-prep decision).
-- **No readiness gate yet.** Do **not** publish a `v0.8.1` GitHub Release while
-  this file is still a draft — an unfilled stub means release-prep has not run.
+- **G585** — [PR #1274](https://github.com/J-Tech-Japan/intent-system/pull/1274),
+  “G585: disclose omitted session-layer team,”
+  merge [`9e87d0973f53bd56e03af0622c54dd4d505eedbd`](https://github.com/J-Tech-Japan/intent-system/commit/9e87d0973f53bd56e03af0622c54dd4d505eedbd).
+- **G586** — [PR #1276](https://github.com/J-Tech-Japan/intent-system/pull/1276),
+  “G586: restore herdr pane-first topology,”
+  merge [`0e93973c95cd992dbceda1c8416818a20ab1c319`](https://github.com/J-Tech-Japan/intent-system/commit/0e93973c95cd992dbceda1c8416818a20ab1c319).
+- **G587** — [PR #1278](https://github.com/J-Tech-Japan/intent-system/pull/1278),
+  “G587: make packet readiness answer in one shot,”
+  merge [`bdadd711f6e6ed9960a2542f82369c886e3bb163`](https://github.com/J-Tech-Japan/intent-system/commit/bdadd711f6e6ed9960a2542f82369c886e3bb163).
+- **G588** — [PR #1280](https://github.com/J-Tech-Japan/intent-system/pull/1280),
+  “Fix notify routing for recorded external roles,”
+  merge [`e4f18f50c31ddb327f598d6fe5017a7674e1685b`](https://github.com/J-Tech-Japan/intent-system/commit/e4f18f50c31ddb327f598d6fe5017a7674e1685b).
+- **G589** — [PR #1282](https://github.com/J-Tech-Japan/intent-system/pull/1282),
+  “G589: make CI waits observable without timers,”
+  merge [`d6a5110a6d9d2c6fd4575b6b8c28b46ca6820a23`](https://github.com/J-Tech-Japan/intent-system/commit/d6a5110a6d9d2c6fd4575b6b8c28b46ca6820a23).
 
-## What the release-prep packet must replace this with
+All five merge commits were verified on `main` during release preparation.
+Together, the five fixes make wake reliability under herdr-only the release
+theme: correct mode and topology guidance, fail-closed packet readiness,
+delivery to every recorded role, and an observable end to CI waits.
 
-Follow the shape of the previous notes
-([v0.8.0](release-notes-v0.8.0.md), [v0.7.1](release-notes-v0.7.1.md)):
+**Why patch, not minor.** The documented policy reserves MINOR for a new
+command surface or a broad behavior change. None of these five slices adds a
+command surface, and every slice is a correctness fix to an existing surface.
+The release therefore advances from `0.8.0` to `0.8.1` as a PATCH.
 
-- what shipped, grouped by theme, covering exactly the merged slices;
-- the bump rationale (patch vs minor) stated, not just labelled;
-- the prepare-only publishing section and the release-readiness gate;
-- an upgrade section separating additive surfaces from corrective behavior
-  changes;
-- the post-release roll reminder.
+### Correct session-mode resolution and visible herdr topology (G585, G586)
 
-## Install (placeholder — the version below is what the guard checks)
+- **G585** fixes the omitted-team routing defect. When a caller omits `--team`,
+  the session-layer resolver no longer silently answers from the wrong scope;
+  guidance discloses the team-scoped records and gives corrective commands.
+- **G586** restores the literal herdr-only topology: one workspace per team,
+  one team-named tab, and one role-cwd pane per role. Pane split is the default;
+  tab creation is an explicitly justified exception. Explicit-id and
+  fail-closed mutation rules remain in force.
+
+### Packet readiness now fails closed in one actionable answer (G587)
+
+Packet readiness no longer reports green when only `packet.yaml` exists. The
+packet-draft and queue-seed surfaces consistently report every missing
+canonical file, missing contract section, and other refusal reason together,
+so an author can repair the whole packet without repeated one-error cycles.
+
+### Canonical notify reaches every recorded role (G588)
+
+`intent-cli notify delegate` and `notify report` now route to team-recorded
+external residents through their recorded reader. Sender and report-to roles
+must exist in the team topology, while only the recipient must be deliverable.
+herdr resolution stays scoped to the caller team's workspace, dry-run and
+write share the same resolution verdict, and unresolved routes still fail
+closed without prompting a foreign pane.
+
+### CI wait completion is observable without a timer (G589)
+
+`automation stalled-work` now distinguishes a legitimate pending exact-head CI
+wait from terminal all-green and terminal failed outcomes. CI-aware findings
+carry the PR head SHA, pass/fail/skip/pending breakdown, and a stable dedupe key;
+pending alone remains non-escalating and every path stays read-only. The
+orchestrator guide names the re-check producer: the configured timer in
+timer-loop, or an explicitly armed exact-head CI-completion watch in
+herdr-only. The end of the wait is a legitimate wake signal, never proof of
+success.
+
+## Install
 
 ```bash
 dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.8.1
 ```
 
-Once published, the self-contained binaries will be attached to the
+After the operator has approved and published it, self-contained binaries are
+available from the
 [v0.8.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.8.1).
 Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.8.0
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.8.1
+```
+
+No command, argument, flag, or documented session-layer mode was removed or
+renamed. All five slices correct existing behavior. Two **additive,
+non-breaking output-shape changes** deserve explicit attention:
+
+1. For an `external` recipient, `notify delegate` and `notify report` can now
+   append the team event and return `event_appended=true`; previously those
+   routes always reported `false`. The existing event and command-result
+   schemas are unchanged.
+2. `automation stalled-work` can now emit the finding kinds `ci-pending`,
+   `ci-all-green-not-transitioned`, and `ci-failed-not-transitioned`. Consumers
+   that switch exhaustively on `kind` must accept these additive values. The
+   finding schema is unchanged.
+
+## Release-readiness gate (G590)
+
+These items must hold **before the GitHub Release for `v0.8.1` is created or
+published**. This gate fails closed.
+
+- [ ] The five shipped slices above are merged to `main` at exactly the listed
+      PRs and merge commits; there are no additional shipped slices in these
+      notes.
+- [ ] Both EN/JA `release-notes-v0.8.1.md` files contain real, parity-matched
+      notes with no DRAFT-stub banner, and both disclose the two additive
+      output-shape changes.
+- [ ] `eng/version.json` remains unchanged at `stableVersion` `0.8.0` and
+      `nextVersion` `0.8.1`.
+- [ ] The G475 next-version notes/package guard, release-note/version-policy
+      guards, and full Release suite are green with no current-state guard
+      flips on the exact G590 preparation head.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      repository/project URLs point at this repository, the license is
+      `Apache-2.0`, and README/docs links resolve.
+- [ ] Main CI (`Build and test (source contract)`) and preview-pack are green,
+      and post-merge build + pack evidence is recorded on the preparation
+      merge commit.
+- [ ] The operator has explicitly approved creating the `v0.8.1` Release.
+
+## Publishing v0.8.1
+
+Merging this preparation does **not** create a GitHub Release or tag, publish a
+package, roll to `0.8.2`, remove a stub for a future version, or announce a
+release. After merge, the readiness evidence must be checked and the operator
+must explicitly approve Release creation.
+
+Only then may a maintainer/operator (or explicitly authorized external release
+automation) create and publish the `v0.8.1` GitHub Release. Publishing it
+triggers `release.yml`, which publishes the NuGet package and platform
+archives.
+
+Post-release verification includes:
+
+- [ ] NuGet and GitHub asset links resolve and downloaded checksums match.
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.8.1`
+      followed by `intent-cli --version` reports `0.8.1`.
+- [ ] A platform archive passes checksum verification and its binary reports
+      `0.8.1`.
+- [ ] After publication, perform the separately authorized immediate roll to
+      `stableVersion → 0.8.1` / `nextVersion → 0.8.2`, with new EN/JA DRAFT
+      stubs, refreshed readiness sections, and green post-roll child-main CI.
+      That roll is not part of G590.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2625,21 +2625,21 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 
 ### 次リリース準備(v0.8.1)
 
-**`v0.8.0` は出荷済み**(GitHub Release + NuGet)で、version policy は `0.8.1`
-開発ラインへ roll されました。v0.8.0 バッチは **minor** バンプで、12 スライス(G570、G571、G573、G574、
-G575、G577、G578、G579、G580、G581、G582、G583)をカバーします。目玉は
-記録・可逆な session-layer dual mode と transport 非依存の `notify` サーフェス
-です。新コマンド群(`session-layer` / `notify`)を出荷するため patch ではなく
-minor です。両 session mode は対等なままで、agmsg は非推奨化しません。
+**`v0.8.0` は出荷済み**(GitHub Release + NuGet)で、version policy は
+`stableVersion: 0.8.0`、`nextVersion: 0.8.1` のままです。prepare-only の
+`v0.8.1` notes は G585、G586、G587、G588、G589 の 5 件だけを対象にします。
+マージ済み PR と commit の証跡は
+[release-notes-v0.8.1.md](release-notes-v0.8.1.md) を参照してください。
 
-リポジトリは in-development の **`0.8.1`** `nextVersion` 上にあります。`v0.8.1`
-で何を出荷するかはここでは決めません: 次の release-prep パケットがマージ済み
-スライスを選定し、DRAFT スタブに代えて実際の
-[release-notes-v0.8.1.md](release-notes-v0.8.1.md) を執筆し、バンプ根拠を
-記述します。それまで notes はスタブのままであり、`v0.8.1` の GitHub Release を
-publish してはいけません。
+`v0.8.1` は version policy 上の **PATCH** です。5 件すべてが correctness fix で、
+新しい command surface や広範な behavior change はありません。文書化する 2 件の
+additive な output-shape 変更も非破壊です: external resident への
+`notify delegate` / `notify report` delivery は team event を append して
+`event_appended=true` を返せるようになり、`automation stalled-work` は新しい
+finding kind を返せるようになります。この準備では Release、tag、package の作成も、
+version file の roll も行いません。
 
-**リリース準備検証(`v0.8.1` release-preparation のマージ前に実行):**
+**リリース準備検証(`v0.8.1` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
@@ -2648,22 +2648,23 @@ cat eng/version.json   # stableVersion 0.8.0 (published), nextVersion 0.8.1 (to 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待される形: intent-cli 0.8.1-<sha>-G576   (stale literal ではない)
+#   期待される形: intent-cli 0.8.1-<sha>-G590   (stale literal ではない)
 
 # 3. pack して NuGet package バージョンが policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
 ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.8.1.nupkg
 
-# 4. package metadata(id / command / license / project URL)を確認。
+# 4. G475 package/release guard と release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
-  -c Release --filter "FullyQualifiedName~ReleasePackageMetadataTests"
+  -c Release --filter \
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
-# 5. skill サーフェスのスモーク(本リリースの見出し)。
-dotnet run --project src/IntentSystem.Cli -c Release --no-build -- skill list
+# 5. Release full suite を実行。
+dotnet test IntentSystem.sln -c Release
 ```
 
-**リリース準備検証(`v0.8.1` preparation の merge が `main` に入り readiness evidence が揃った後も、Release 作成には
-operator の明示承認が必要です。その後に限り maintainer/operator (または authorize された
+`v0.8.1` preparation の merge が `main` に入り readiness evidence が揃った後も、
+Release 作成には operator の明示承認が必要です。その後に限り maintainer/operator (または authorize された
 外部 release automation)が `v0.8.1` GitHub Release を作成・publish できます。publish が
 `release.yml` (`on: release: published`)を trigger し、NuGet package と platform binary
 artifact を build・publish します。**その後すぐに `eng/version.json` を roll します** —

--- a/docs/ja/release-notes-v0.8.1.md
+++ b/docs/ja/release-notes-v0.8.1.md
@@ -1,40 +1,138 @@
-# リリースノート — intent-cli v0.8.1（DRAFT — 未リリース）
+# リリースノート — intent-cli v0.8.1
 
-> **⚠️ DRAFT / 未リリース。** これはリリースノートではなく **stub** です。
-> `eng/version.json` が `0.8.1` を「これからカットするリリース」として指しており、
-> G475 のガードが publish 前にそのバージョンのノートの存在を要求するため置かれています。
-> **実際の内容は v0.8.1 の release-prep パケットが author します**。ここには出荷済みの
-> 挙動は一切書かれておらず、このファイルを changelog として扱ってはいけません。
+> **リリースモデル:** この変更は **prepare-only** です。GitHub Release / tag の作成、
+> package publish、version policy の roll、product behavior の変更は行いません。この準備が
+> merge され、下記 readiness gate を満たした後も、Release 作成には operator の明示承認が
+> 必要です。GitHub Release の publish により `.github/workflows/release.yml`
+> (`on: release: published`) が起動し、NuGet package と platform artifact を build / publish
+> します。
 
-## ステータス
+## v0.8.1 の内容
 
-`nextVersion` が `0.8.1` になった時点で、リリース後の version roll（G554 のルール、
-G557 による改訂版）によって作成されました。release-prep パケットが埋めるまでは:
+v0.8.1 が `v0.8.0` 以降から含む correctness slice は、マージ済みの 5 件 **G585**、
+**G586**、**G587**、**G588**、**G589** だけです。各 PR と merge commit は次のとおりです。
 
-- **スライスは未記載です。** `v0.8.1` で何が出荷されるかを決めるのはこの stub ではなく
-  release-prep パケットです。
-- **バンプ根拠も未記載です**（patch か minor かは release-prep の判断です）。
-- **リリース準備ゲートも未記載です。** このファイルが draft のままの間は `v0.8.1` の
-  GitHub Release を publish **しないでください** — 埋まっていない stub は release-prep が
-  未実行であることを意味します。
+- **G585** — [PR #1274](https://github.com/J-Tech-Japan/intent-system/pull/1274)、
+  “G585: disclose omitted session-layer team”、
+  merge [`9e87d0973f53bd56e03af0622c54dd4d505eedbd`](https://github.com/J-Tech-Japan/intent-system/commit/9e87d0973f53bd56e03af0622c54dd4d505eedbd)。
+- **G586** — [PR #1276](https://github.com/J-Tech-Japan/intent-system/pull/1276)、
+  “G586: restore herdr pane-first topology”、
+  merge [`0e93973c95cd992dbceda1c8416818a20ab1c319`](https://github.com/J-Tech-Japan/intent-system/commit/0e93973c95cd992dbceda1c8416818a20ab1c319)。
+- **G587** — [PR #1278](https://github.com/J-Tech-Japan/intent-system/pull/1278)、
+  “G587: make packet readiness answer in one shot”、
+  merge [`bdadd711f6e6ed9960a2542f82369c886e3bb163`](https://github.com/J-Tech-Japan/intent-system/commit/bdadd711f6e6ed9960a2542f82369c886e3bb163)。
+- **G588** — [PR #1280](https://github.com/J-Tech-Japan/intent-system/pull/1280)、
+  “Fix notify routing for recorded external roles”、
+  merge [`e4f18f50c31ddb327f598d6fe5017a7674e1685b`](https://github.com/J-Tech-Japan/intent-system/commit/e4f18f50c31ddb327f598d6fe5017a7674e1685b)。
+- **G589** — [PR #1282](https://github.com/J-Tech-Japan/intent-system/pull/1282)、
+  “G589: make CI waits observable without timers”、
+  merge [`d6a5110a6d9d2c6fd4575b6b8c28b46ca6820a23`](https://github.com/J-Tech-Japan/intent-system/commit/d6a5110a6d9d2c6fd4575b6b8c28b46ca6820a23)。
 
-## release-prep パケットがこれを置き換える際に必要なもの
+release preparation で、5 件すべての merge commit が `main` 上にあることを検証済みです。
+この 5 fix は、herdr-only での wake reliability という 1 つのテーマを構成します: 正しい
+mode / topology guidance、fail-closed packet readiness、recorded role 全員への delivery、CI wait
+終了の観測可能性です。
 
-過去のノート（[v0.8.0](release-notes-v0.8.0.md)、[v0.7.1](release-notes-v0.7.1.md)）の
-形に従ってください:
+**minor ではなく patch とする理由。** 文書化済み policy は、新しい command surface または
+広範な behavior change を MINOR に予約しています。この 5 slice はどれも command surface を
+追加せず、すべて既存 surface の correctness fix です。そのため本リリースは `0.8.0` から
+`0.8.1` への PATCH です。
 
-- 出荷内容をテーマ別にグループ化し、マージされたスライスを正確にカバーする;
-- バンプ根拠（patch か minor か）をラベルだけでなく理由まで記述する;
-- prepare-only の publishing セクションとリリース準備ゲート;
-- 追加サーフェスと是正的な挙動変更を分離した upgrade セクション;
-- リリース後の roll のリマインド。
+### 正しい session-mode 解決と可視な herdr topology (G585, G586)
 
-## インストール（プレースホルダー — 下記バージョンがガードの検査対象です）
+- **G585** は team 省略時の routing defect を修正します。caller が `--team` を省略しても
+  session-layer resolver は誤った scope の答えを黙って返さず、guidance が team-scoped record と
+  corrective command を開示します。
+- **G586** は herdr-only topology を literal に復元します: 1 team につき 1 workspace、team 名の
+  1 tab、role-cwd の pane を role ごとに 1 つ。pane split が default で、tab creation は明示的に
+  justify された例外です。explicit-id / fail-closed mutation rule は維持されます。
+
+### packet readiness が 1 回の actionable answer で fail closed (G587)
+
+`packet.yaml` しか存在しない packet を readiness が green と報告しなくなりました。packet-draft と
+queue-seed surface は、欠けている canonical file、欠けている contract section、その他すべての
+refusal reason を一貫してまとめて報告するため、author は 1-error cycle を繰り返さず packet 全体を
+修復できます。
+
+### canonical notify が recorded role の全員へ到達 (G588)
+
+`intent-cli notify delegate` と `notify report` は、team に記録された external resident に、その
+recorded reader 経由で route します。sender と report-to role は team topology 上に存在する必要が
+ありますが、deliverable でなければならないのは recipient だけです。herdr resolution は caller
+team の workspace に scoped され、dry-run / write は同じ resolution verdict を使い、解決不能 route
+は foreign pane を prompt せず引き続き fail closed します。
+
+### timer がなくても CI wait completion を観測可能 (G589)
+
+`automation stalled-work` は、正当な pending exact-head CI wait と、terminal な all-green / failed
+outcome を区別します。CI-aware finding は PR head SHA、pass/fail/skip/pending breakdown、安定した
+dedupe key を運びます。pending 単独は non-escalating のままで、すべての path は read-only です。
+orchestrator guide は re-check producer を明記します: timer-loop では configured timer、
+herdr-only では明示的に arm した exact-head CI-completion watch です。wait の終了は正当な wake
+signal ですが、success proof ではありません。
+
+## インストール
 
 ```bash
 dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.8.1
 ```
 
-publish 後、self-contained バイナリは
+operator が承認・publish した後は、self-contained binary を
 [v0.8.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.8.1)
-に添付されます。使用前に `.sha256` サイドカーを検証してください。
+から取得できます。使用前に `.sha256` sidecar を検証してください。
+
+## v0.8.0 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.8.1
+```
+
+command / argument / flag / 文書化済み session-layer mode の削除・改名はありません。5 slice は
+すべて既存 behavior の correctness fix です。次の 2 件は **additive かつ non-breaking な
+output-shape change** なので、明示的に注意してください。
+
+1. `external` recipient に対する `notify delegate` / `notify report` は team event を append し、
+   `event_appended=true` を返せるようになりました。以前この route は常に `false` を返していました。
+   既存の event / command-result schema は変わりません。
+2. `automation stalled-work` は新しい finding kind `ci-pending`、
+   `ci-all-green-not-transitioned`、`ci-failed-not-transitioned` を返す場合があります。`kind` を exhaustive
+   に switch する consumer はこれらの additive value を受理する必要があります。finding schema は
+   変わりません。
+
+## リリース準備ゲート (G590)
+
+以下は **`v0.8.1` GitHub Release を作成または publish する前**に満たす必要があります。この gate
+は fail closed です。
+
+- [ ] 上記 shipped 5 slices が、記載した PR / merge commit どおり `main` に merge 済みであり、
+      notes に追加の shipped slice が含まれていない。
+- [ ] EN/JA 両方の `release-notes-v0.8.1.md` が parity のある real notes で、DRAFT-stub banner が
+      残らず、2 件の additive output-shape change を両方開示している。
+- [ ] `eng/version.json` が変更されず、`stableVersion` `0.8.0` / `nextVersion` `0.8.1` のまま。
+- [ ] G475 next-version notes/package guard、release-note/version-policy guard、full Release suite が
+      current-state guard flip なしで exact G590 preparation head 上 green。
+- [ ] package metadata が正しい: `PackageId = JTechJapan.IntentSystem.Cli`、repository/project URL が
+      この repository を指す、license が `Apache-2.0`、README/docs link が解決する。
+- [ ] Main CI (`Build and test (source contract)`) と preview-pack が green で、preparation merge commit
+      上の post-merge build + pack evidence が記録されている。
+- [ ] operator が `v0.8.1` Release 作成を明示承認している。
+
+## v0.8.1 の publish
+
+この preparation の merge は GitHub Release / tag の作成、package publish、`0.8.2` への roll、
+future version の stub removal、release announcement のいずれも行いません。merge 後に readiness
+evidence を確認し、operator が Release 作成を明示承認する必要があります。
+
+その後に限り、maintainer/operator (または明示 authorize された外部 release automation)が
+`v0.8.1` GitHub Release を作成・publish できます。publish が `release.yml` を trigger し、
+NuGet package と platform archive を publish します。
+
+post-release verification:
+
+- [ ] NuGet / GitHub asset link が解決し、download checksum が一致する。
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.8.1` 後の
+      `intent-cli --version` が `0.8.1` を報告する。
+- [ ] platform archive の checksum が通り、binary が `0.8.1` を報告する。
+- [ ] publish 後、別途 authorize された immediate roll を `stableVersion → 0.8.1` /
+      `nextVersion → 0.8.2` へ行い、新しい EN/JA DRAFT stubs、refresh 済み readiness section、
+      green な post-roll child-main CI を揃える。この roll は G590 の一部ではありません。


### PR DESCRIPTION
Closes #1283

## Summary

- Replace the EN/JA v0.8.1 DRAFT stub bodies with parity-matched release notes covering exactly G585-G589.
- Record each merged PR title, number, and full merge commit verified on `main`; state the PATCH rationale and the herdr-only wake-reliability theme.
- Disclose the two additive, non-breaking output-shape changes and refresh only the existing EN/JA next-release readiness sections.
- Preserve `eng/version.json` at `stableVersion=0.8.0` / `nextVersion=0.8.1`; no Release, tag, package publication, retarget, 0.8.2 roll, or product behavior change.

## Verification

- G475 + release/version guards: 42 passed, 0 failed
- Full Release suite: 4,651 passed, 1 skipped, 0 failed (4,652 total)
- Release build: 0 warnings, 0 errors
- Local package: `JTechJapan.IntentSystem.Cli.0.8.1.nupkg` created outside the worktree
- Version identity: `intent-cli 0.8.1-290a0e3-G590`
- All five recorded merge commits verified as ancestors of `origin/main`
- `git diff --check`: clean
- Changed paths: the two v0.8.1 release-note files and the two existing developer-reference readiness sections only

Exact-head GitHub CI evidence will be recorded after checks settle.