### PR TITLE
G591: make host-local CLI refresh fail closed

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -78,7 +78,8 @@ The CLI is packaged as a .NET tool (package id `JTechJapan.IntentSystem.Cli`,
 command `intent-cli`). To smoke-test a locally built package:
 
 ```bash
-export INTENT_CLI_LOCAL_VERSION="0.3.2-local.$(date -u +%Y%m%d%H%M%S)"
+INTENT_CLI_BASE_VERSION="$(sed -n 's/^[[:space:]]*"nextVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' eng/version.json)"
+export INTENT_CLI_LOCAL_VERSION="$INTENT_CLI_BASE_VERSION-local.$(date -u +%Y%m%d%H%M%S)"
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
   -p:Version="$INTENT_CLI_LOCAL_VERSION" \
   -o .artifacts/packages
@@ -96,6 +97,33 @@ Equivalent `dnx` path:
 ```bash
 (cd .artifacts/smoke-repo && dnx --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" JTechJapan.IntentSystem.Cli project status)
 ```
+
+### Refresh the host-local wrapper safely
+
+Use the repository helper when the host-local orchestration CLI must track this
+checkout:
+
+```bash
+eng/refresh-host-local-intent-cli.sh /path/to/host-repo
+```
+
+The helper derives the local version base from `eng/version.json`
+`nextVersion` and reads the package id from the CLI project. It packs a unique
+candidate without deleting the package used by the installed wrapper, then
+runs the candidate wrapper from its `.tmp` path to verify:
+
+1. `--version` reports the derived local version;
+2. `automation summary --format json` emits
+   `automationCommandSurfaceVersion`; and
+3. every required automation capability is present.
+
+Only after all checks pass does one same-filesystem rename promote the
+candidate over `.intent-cli/bin/intent-cli`. A failed check names the check and
+a remedy, exits non-zero, removes the candidate package and `.tmp` wrapper, and
+leaves the previously installed wrapper byte-identical and runnable. The
+`HOST_ROOT`, `CHILD_INTENT_SYSTEM`, and `INTENT_CLI_LOCAL_VERSION` overrides
+remain available; an override may not reuse the fixed version derived from
+`nextVersion`.
 
 ---
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -78,7 +78,8 @@ CLI は .NET ツールとしてパッケージ化されています（パッケ�
 コマンド `intent-cli`）。ローカルビルドパッケージのスモークテスト:
 
 ```bash
-export INTENT_CLI_LOCAL_VERSION="0.3.2-local.$(date -u +%Y%m%d%H%M%S)"
+INTENT_CLI_BASE_VERSION="$(sed -n 's/^[[:space:]]*"nextVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' eng/version.json)"
+export INTENT_CLI_LOCAL_VERSION="$INTENT_CLI_BASE_VERSION-local.$(date -u +%Y%m%d%H%M%S)"
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj \
   -p:Version="$INTENT_CLI_LOCAL_VERSION" \
   -o .artifacts/packages
@@ -96,6 +97,29 @@ EOF
 ```bash
 (cd .artifacts/smoke-repo && dnx --yes --source ../packages --version "$INTENT_CLI_LOCAL_VERSION" JTechJapan.IntentSystem.Cli project status)
 ```
+
+### host-local wrapper の安全な refresh
+
+host-local orchestration CLI をこの checkout に追従させる場合は repository helper を使います:
+
+```bash
+eng/refresh-host-local-intent-cli.sh /path/to/host-repo
+```
+
+helper は local version の base を `eng/version.json` の `nextVersion` から導出し、package id を
+CLI project から読み取ります。installed wrapper が使う package は削除せず、一意な candidate を
+pack してから `.tmp` path の candidate wrapper で次を検証します。
+
+1. `--version` が導出した local version を報告する;
+2. `automation summary --format json` が `automationCommandSurfaceVersion` を出力する; および
+3. required automation capability がすべて存在する。
+
+すべての check が通った後に限り、同一 filesystem 上の 1 回の rename で candidate を
+`.intent-cli/bin/intent-cli` へ promote します。check が失敗すると、失敗した check と remedy を
+明示して non-zero で終了し、candidate package と `.tmp` wrapper を削除します。以前の installed
+wrapper は byte-identical かつ runnable なままです。`HOST_ROOT`、`CHILD_INTENT_SYSTEM`、
+`INTENT_CLI_LOCAL_VERSION` override は引き続き利用できますが、override は `nextVersion` から
+導出した fixed version を再利用できません。
 
 ---
 

--- a/eng/refresh-host-local-intent-cli.sh
+++ b/eng/refresh-host-local-intent-cli.sh
@@ -23,32 +23,109 @@ CHILD_INTENT_SYSTEM="${CHILD_INTENT_SYSTEM:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 CHILD_INTENT_SYSTEM="$(cd "$CHILD_INTENT_SYSTEM" && pwd)"
 
 PROJECT_PATH="$CHILD_INTENT_SYSTEM/src/IntentSystem.Cli/IntentSystem.Cli.csproj"
+VERSION_POLICY_PATH="$CHILD_INTENT_SYSTEM/eng/version.json"
 PACKAGES_DIR="$HOST_ROOT/.intent-cli/packages"
 BIN_DIR="$HOST_ROOT/.intent-cli/bin"
 WRAPPER_PATH="$BIN_DIR/intent-cli"
+TEMP_WRAPPER_PATH="$WRAPPER_PATH.tmp"
+CANDIDATE_PACKAGE_PATH=""
+CANDIDATE_PACKAGES_DIR=""
+
+cleanup_candidate() {
+  rm -f "$TEMP_WRAPPER_PATH" || true
+  if [[ -n "$CANDIDATE_PACKAGE_PATH" ]]; then
+    rm -f "$CANDIDATE_PACKAGE_PATH" || true
+  fi
+  if [[ -n "$CANDIDATE_PACKAGES_DIR" && -d "$CANDIDATE_PACKAGES_DIR" ]]; then
+    find "$CANDIDATE_PACKAGES_DIR" -maxdepth 1 -type f -delete || true
+    rmdir "$CANDIDATE_PACKAGES_DIR" || true
+  fi
+}
+
+refresh_failed() {
+  local check="$1"
+  local remedy="$2"
+  local details="${3:-}"
+
+  echo "host-local intent-cli refresh failed during $check." >&2
+  if [[ -n "$details" ]]; then
+    echo "$details" >&2
+  fi
+  echo "The previously installed wrapper was not changed." >&2
+  echo "Remedy: $remedy" >&2
+  exit 1
+}
+
+trap cleanup_candidate EXIT
 
 if [[ ! -f "$PROJECT_PATH" ]]; then
   echo "intent-cli project not found: $PROJECT_PATH" >&2
   exit 1
 fi
 
+if [[ ! -f "$VERSION_POLICY_PATH" ]]; then
+  echo "intent-cli version policy not found: $VERSION_POLICY_PATH" >&2
+  exit 1
+fi
+
+PACKAGE_ID="$(sed -n 's:.*<PackageId>\([^<]*\)</PackageId>.*:\1:p' "$PROJECT_PATH")"
+if [[ -z "$PACKAGE_ID" ]]; then
+  echo "PackageId not found in intent-cli project: $PROJECT_PATH" >&2
+  exit 1
+fi
+
+INTENT_CLI_BASE_VERSION="$(sed -n 's/^[[:space:]]*"nextVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$VERSION_POLICY_PATH")"
+if [[ -z "$INTENT_CLI_BASE_VERSION" ]]; then
+  echo "nextVersion not found in intent-cli version policy: $VERSION_POLICY_PATH" >&2
+  exit 1
+fi
+
 CHILD_SHA="$(git -C "$CHILD_INTENT_SYSTEM" rev-parse --short=12 HEAD)"
 LOCAL_STAMP="$(date -u +%Y%m%d%H%M%S)"
-INTENT_CLI_LOCAL_VERSION="${INTENT_CLI_LOCAL_VERSION:-0.3.2-local.$LOCAL_STAMP.$$.g$CHILD_SHA}"
+INTENT_CLI_LOCAL_VERSION="${INTENT_CLI_LOCAL_VERSION:-$INTENT_CLI_BASE_VERSION-local.$LOCAL_STAMP.$$.g$CHILD_SHA}"
 
-if [[ "$INTENT_CLI_LOCAL_VERSION" == "0.3.2" ]]; then
-  echo "INTENT_CLI_LOCAL_VERSION must not be the fixed package version 0.3.2." >&2
+if [[ "$INTENT_CLI_LOCAL_VERSION" == "$INTENT_CLI_BASE_VERSION" ]]; then
+  echo "INTENT_CLI_LOCAL_VERSION must not reuse the derived fixed package version $INTENT_CLI_BASE_VERSION." >&2
   exit 1
 fi
 
 mkdir -p "$PACKAGES_DIR" "$BIN_DIR"
-find "$PACKAGES_DIR" -maxdepth 1 -type f -name 'JTechJapan.IntentSystem.Cli.*.nupkg' -delete
+CANDIDATE_PACKAGES_DIR="$PACKAGES_DIR/.refresh-$LOCAL_STAMP-$$"
+mkdir "$CANDIDATE_PACKAGES_DIR"
 
-dotnet pack "$PROJECT_PATH" \
-  -p:Version="$INTENT_CLI_LOCAL_VERSION" \
-  -o "$PACKAGES_DIR"
+if ! dotnet pack "$PROJECT_PATH" \
+    -p:Version="$INTENT_CLI_LOCAL_VERSION" \
+    -o "$CANDIDATE_PACKAGES_DIR"; then
+  refresh_failed \
+    "package build" \
+    "Fix the reported dotnet pack error, then retry the refresh."
+fi
 
-cat > "$WRAPPER_PATH.tmp" <<EOF
+shopt -s nullglob
+candidate_packages=("$CANDIDATE_PACKAGES_DIR"/"$PACKAGE_ID".*.nupkg)
+shopt -u nullglob
+if [[ "${#candidate_packages[@]}" -ne 1 ]]; then
+  refresh_failed \
+    "package resolution" \
+    "Confirm PackageId and nextVersion in the child checkout, then retry." \
+    "Expected exactly one $PACKAGE_ID nupkg, found ${#candidate_packages[@]}."
+fi
+
+PACKAGE_FILENAME="$(basename "${candidate_packages[0]}")"
+CANDIDATE_PACKAGE_PATH="$PACKAGES_DIR/$PACKAGE_FILENAME"
+if [[ -e "$CANDIDATE_PACKAGE_PATH" ]]; then
+  CANDIDATE_PACKAGE_PATH=""
+  refresh_failed \
+    "candidate package preparation" \
+    "Choose a new INTENT_CLI_LOCAL_VERSION and retry; the requested package version already exists." \
+    "Refusing to overwrite existing package: $PACKAGES_DIR/$PACKAGE_FILENAME"
+fi
+
+mv "${candidate_packages[0]}" "$CANDIDATE_PACKAGE_PATH"
+rmdir "$CANDIDATE_PACKAGES_DIR"
+CANDIDATE_PACKAGES_DIR=""
+
+cat > "$TEMP_WRAPPER_PATH" <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 HOST_ROOT="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -57,17 +134,46 @@ exec dotnet tool exec \\
   --yes \\
   --source "\$HOST_ROOT/.intent-cli/packages" \\
   --version "\$INTENT_CLI_LOCAL_VERSION" \\
-  intent-cli -- \\
+  $PACKAGE_ID -- \\
   "\$@"
 EOF
 
-chmod +x "$WRAPPER_PATH.tmp"
-mv "$WRAPPER_PATH.tmp" "$WRAPPER_PATH"
+chmod +x "$TEMP_WRAPPER_PATH"
 
-SUMMARY_OUTPUT="$("$WRAPPER_PATH" automation summary --format json)"
+if ! VERSION_OUTPUT="$("$TEMP_WRAPPER_PATH" --version 2>&1)"; then
+  refresh_failed \
+    "version invocation" \
+    "Inspect the package source and dotnet tool exec error above, then retry." \
+    "$VERSION_OUTPUT"
+fi
+
+VERSION_IDENTITY_MATCHED=false
+while IFS= read -r version_line; do
+  if [[ "$version_line" == "intent-cli $INTENT_CLI_LOCAL_VERSION" \
+      || "$version_line" == "intent-cli $INTENT_CLI_LOCAL_VERSION-"* ]]; then
+    VERSION_IDENTITY_MATCHED=true
+    break
+  fi
+done <<< "$VERSION_OUTPUT"
+
+if [[ "$VERSION_IDENTITY_MATCHED" != "true" ]]; then
+  refresh_failed \
+    "version identity" \
+    "Confirm eng/version.json and the local package version, then retry." \
+    "Candidate reported an unexpected version: $VERSION_OUTPUT"
+fi
+
+if ! SUMMARY_OUTPUT="$("$TEMP_WRAPPER_PATH" automation summary --format json 2>&1)"; then
+  refresh_failed \
+    "automation summary" \
+    "Inspect the candidate CLI error above, repair it, and retry the refresh." \
+    "$SUMMARY_OUTPUT"
+fi
+
 if [[ "$SUMMARY_OUTPUT" != *'"automationCommandSurfaceVersion"'* ]]; then
-  echo "refreshed wrapper did not emit automationCommandSurfaceVersion." >&2
-  exit 1
+  refresh_failed \
+    "automation summary schema" \
+    "Restore automationCommandSurfaceVersion in the candidate summary, then retry."
 fi
 
 REQUIRED_CAPABILITIES=(
@@ -78,10 +184,18 @@ REQUIRED_CAPABILITIES=(
 )
 for capability in "${REQUIRED_CAPABILITIES[@]}"; do
   if [[ "$SUMMARY_OUTPUT" != *"\"$capability\""* ]]; then
-    echo "refreshed wrapper missing required automation capability: $capability" >&2
-    exit 1
+    refresh_failed \
+      "required capability check ($capability)" \
+      "Restore the missing automation capability in the candidate CLI, then retry."
   fi
 done
+
+# Promotion is deliberately the final state-changing step. The candidate has
+# passed every check above, and this same-filesystem rename replaces the old
+# wrapper atomically. Until this line, the installed wrapper is untouched.
+mv "$TEMP_WRAPPER_PATH" "$WRAPPER_PATH"
+CANDIDATE_PACKAGE_PATH=""
+trap - EXIT
 
 echo "Refreshed $WRAPPER_PATH"
 echo "Package version: $INTENT_CLI_LOCAL_VERSION"

--- a/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PackagedInvocationSmokeTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.Json;
 using System.Xml.Linq;
 using Xunit;
 
@@ -155,7 +156,10 @@ public sealed class PackagedInvocationSmokeTests
 
         Assert.Contains("mkdir -p .artifacts/smoke-repo/.intent-cli", devRef, StringComparison.Ordinal);
         Assert.Contains("cat > .artifacts/smoke-repo/.intent-cli/config.toml <<'EOF'", devRef, StringComparison.Ordinal);
-        Assert.Contains("export INTENT_CLI_LOCAL_VERSION=\"0.3.2-local.$(date -u +%Y%m%d%H%M%S)\"", devRef, StringComparison.Ordinal);
+        Assert.Contains("INTENT_CLI_BASE_VERSION=\"$(sed -n", devRef, StringComparison.Ordinal);
+        Assert.Contains("\"nextVersion\"", devRef, StringComparison.Ordinal);
+        Assert.Contains("export INTENT_CLI_LOCAL_VERSION=\"$INTENT_CLI_BASE_VERSION-local.$(date -u +%Y%m%d%H%M%S)\"", devRef, StringComparison.Ordinal);
+        Assert.DoesNotContain("INTENT_CLI_LOCAL_VERSION=\"0.3.2-local", devRef, StringComparison.Ordinal);
         // G407: package id is JTechJapan.IntentSystem.Cli; dotnet tool exec / dnx uses the
         // package id to locate the nupkg. The installed command remains intent-cli.
         Assert.Contains("(cd .artifacts/smoke-repo && dotnet tool exec --yes --source ../packages --version \"$INTENT_CLI_LOCAL_VERSION\" JTechJapan.IntentSystem.Cli project status)", devRef, StringComparison.Ordinal);
@@ -163,23 +167,182 @@ public sealed class PackagedInvocationSmokeTests
     }
 
     [Fact]
-    public void HostRefreshScript_UsesUniqueLocalVersionAndVerifiesAutomationSurface()
+    public void HostRefreshScript_DerivesVersionAndVerifiesBeforePromotion()
     {
         var script = File.ReadAllText(Path.Combine(GetSolutionRoot(), "eng", "refresh-host-local-intent-cli.sh"));
 
-        Assert.Contains("0.3.2-local.$LOCAL_STAMP.$$.g$CHILD_SHA", script, StringComparison.Ordinal);
+        Assert.Contains("INTENT_CLI_BASE_VERSION=\"$(sed -n", script, StringComparison.Ordinal);
+        Assert.Contains("\"nextVersion\"", script, StringComparison.Ordinal);
+        Assert.Contains("$INTENT_CLI_BASE_VERSION-local.$LOCAL_STAMP.$$.g$CHILD_SHA", script, StringComparison.Ordinal);
         Assert.Contains("-p:Version=\"$INTENT_CLI_LOCAL_VERSION\"", script, StringComparison.Ordinal);
         Assert.Contains("--version \"\\$INTENT_CLI_LOCAL_VERSION\"", script, StringComparison.Ordinal);
-        Assert.Contains("find \"$PACKAGES_DIR\" -maxdepth 1 -type f -name 'JTechJapan.IntentSystem.Cli.*.nupkg' -delete", script, StringComparison.Ordinal);
-        Assert.Contains("automation summary --format json", script, StringComparison.Ordinal);
+        Assert.Contains("PACKAGE_ID=\"$(sed -n", script, StringComparison.Ordinal);
+        Assert.Contains("\"$TEMP_WRAPPER_PATH\" --version", script, StringComparison.Ordinal);
+        Assert.Contains("\"$TEMP_WRAPPER_PATH\" automation summary --format json", script, StringComparison.Ordinal);
         Assert.Contains("\"automationCommandSurfaceVersion\"", script, StringComparison.Ordinal);
         Assert.Contains("\"issue-publish\"", script, StringComparison.Ordinal);
         Assert.Contains("\"pr-transition.review-start\"", script, StringComparison.Ordinal);
         Assert.Contains("\"pr-transition.request-update\"", script, StringComparison.Ordinal);
         Assert.Contains("\"pr-transition.approved\"", script, StringComparison.Ordinal);
-        Assert.Contains("intent-cli -- \\\\", script, StringComparison.Ordinal);
+        Assert.Contains("$PACKAGE_ID -- \\\\", script, StringComparison.Ordinal);
+        Assert.Contains("trap cleanup_candidate EXIT", script, StringComparison.Ordinal);
+        Assert.Contains("Remedy: $remedy", script, StringComparison.Ordinal);
+        Assert.True(
+            script.IndexOf("\"$TEMP_WRAPPER_PATH\" automation summary --format json", StringComparison.Ordinal)
+            < script.IndexOf("mv \"$TEMP_WRAPPER_PATH\" \"$WRAPPER_PATH\"", StringComparison.Ordinal));
         Assert.DoesNotContain("automation pr-transition --help", script, StringComparison.Ordinal);
         Assert.DoesNotContain("--version 0.1.0", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("0.3.2-local", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("find \"$PACKAGES_DIR\"", script, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void HostRefreshGuidance_DocumentsFailClosedPromotionContract(string language)
+    {
+        var devRef = File.ReadAllText(
+            Path.Combine(GetSolutionRoot(), "docs", language, "09-developer-reference.md"));
+
+        Assert.Contains("eng/refresh-host-local-intent-cli.sh /path/to/host-repo", devRef, StringComparison.Ordinal);
+        Assert.Contains("`nextVersion`", devRef, StringComparison.Ordinal);
+        Assert.Contains("`automationCommandSurfaceVersion`", devRef, StringComparison.Ordinal);
+        Assert.Contains("`.tmp`", devRef, StringComparison.Ordinal);
+        Assert.Contains("byte-identical", devRef, StringComparison.Ordinal);
+        Assert.Contains("remedy", devRef, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HostRefreshScript_PromotesOnlyAfterCandidateVerification_AndWrapperRuns()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        lock (ProcessStateLock)
+        {
+            using var tempDirectory = new TemporaryDirectory();
+            var hostRoot = tempDirectory.CreateDirectory("host");
+            var binDirectory = tempDirectory.CreateDirectory(Path.Combine("host", ".intent-cli", "bin"));
+            var packagesDirectory = tempDirectory.CreateDirectory(Path.Combine("host", ".intent-cli", "packages"));
+            var wrapperPath = Path.Combine(binDirectory, "intent-cli");
+            File.WriteAllText(wrapperPath, "old working wrapper\n");
+
+            var fakeBin = tempDirectory.CreateDirectory("fake-bin");
+            var fakeDotnetLog = tempDirectory.GetPath("fake-dotnet.log");
+            CreateFakeDotnet(Path.Combine(fakeBin, "dotnet"));
+            var environment = BuildRefreshEnvironment(fakeBin, fakeDotnetLog);
+
+            var refresh = RunCapturedCommand(
+                "/usr/bin/env",
+                ["bash", Path.Combine(GetSolutionRoot(), "eng", "refresh-host-local-intent-cli.sh"), hostRoot],
+                GetSolutionRoot(),
+                environment);
+
+            Assert.Equal(0, refresh.ExitCode);
+            Assert.False(File.Exists(wrapperPath + ".tmp"));
+            Assert.DoesNotContain("old working wrapper", File.ReadAllText(wrapperPath), StringComparison.Ordinal);
+
+            var nextVersion = GetNextVersion();
+            var package = Assert.Single(Directory.GetFiles(packagesDirectory, "*.nupkg"));
+            Assert.Contains($"JTechJapan.IntentSystem.Cli.{nextVersion}-local.", Path.GetFileName(package), StringComparison.Ordinal);
+
+            var invocation = RunCapturedCommand(
+                wrapperPath,
+                ["--version"],
+                hostRoot,
+                environment);
+
+            Assert.Equal(0, invocation.ExitCode);
+            Assert.Contains($"intent-cli {nextVersion}-local.", invocation.StandardOutput, StringComparison.Ordinal);
+            Assert.Contains("JTechJapan.IntentSystem.Cli -- --version", File.ReadAllText(fakeDotnetLog), StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("version", "version invocation")]
+    [InlineData("summary", "automation summary")]
+    public void HostRefreshScript_VerificationFailure_PreservesInstalledWrapperAndCleansCandidate(
+        string forcedFailure,
+        string failedCheck)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        lock (ProcessStateLock)
+        {
+            using var tempDirectory = new TemporaryDirectory();
+            var hostRoot = tempDirectory.CreateDirectory("host");
+            var binDirectory = tempDirectory.CreateDirectory(Path.Combine("host", ".intent-cli", "bin"));
+            var packagesDirectory = tempDirectory.CreateDirectory(Path.Combine("host", ".intent-cli", "packages"));
+            var wrapperPath = Path.Combine(binDirectory, "intent-cli");
+            var originalWrapper = new byte[] { 0x23, 0x21, 0x2f, 0x62, 0x69, 0x6e, 0x2f, 0x73, 0x68, 0x0a, 0x00, 0xff };
+            File.WriteAllBytes(wrapperPath, originalWrapper);
+            var oldPackagePath = Path.Combine(packagesDirectory, "JTechJapan.IntentSystem.Cli.0.8.1-local.old.nupkg");
+            var oldPackage = new byte[] { 0x01, 0x02, 0x03, 0xfe };
+            File.WriteAllBytes(oldPackagePath, oldPackage);
+
+            var fakeBin = tempDirectory.CreateDirectory("fake-bin");
+            var fakeDotnetLog = tempDirectory.GetPath("fake-dotnet.log");
+            CreateFakeDotnet(Path.Combine(fakeBin, "dotnet"));
+            var environment = BuildRefreshEnvironment(fakeBin, fakeDotnetLog, forcedFailure);
+
+            var refresh = RunCapturedCommand(
+                "/usr/bin/env",
+                ["bash", Path.Combine(GetSolutionRoot(), "eng", "refresh-host-local-intent-cli.sh"), hostRoot],
+                GetSolutionRoot(),
+                environment);
+
+            Assert.NotEqual(0, refresh.ExitCode);
+            Assert.Equal(originalWrapper, File.ReadAllBytes(wrapperPath));
+            Assert.Equal(oldPackage, File.ReadAllBytes(oldPackagePath));
+            Assert.False(File.Exists(wrapperPath + ".tmp"));
+            Assert.Equal(new[] { oldPackagePath }, Directory.GetFiles(packagesDirectory, "*.nupkg"));
+            Assert.Contains(failedCheck, refresh.StandardError, StringComparison.Ordinal);
+            Assert.Contains("The previously installed wrapper was not changed.", refresh.StandardError, StringComparison.Ordinal);
+            Assert.Contains("Remedy:", refresh.StandardError, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void HostRefreshScript_RejectsDerivedFixedVersionWithoutTouchingInstalledWrapper()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        lock (ProcessStateLock)
+        {
+            using var tempDirectory = new TemporaryDirectory();
+            var hostRoot = tempDirectory.CreateDirectory("host");
+            var binDirectory = tempDirectory.CreateDirectory(Path.Combine("host", ".intent-cli", "bin"));
+            tempDirectory.CreateDirectory(Path.Combine("host", ".intent-cli", "packages"));
+            var wrapperPath = Path.Combine(binDirectory, "intent-cli");
+            const string originalWrapper = "old working wrapper\n";
+            File.WriteAllText(wrapperPath, originalWrapper);
+
+            var fakeBin = tempDirectory.CreateDirectory("fake-bin");
+            var fakeDotnetLog = tempDirectory.GetPath("fake-dotnet.log");
+            CreateFakeDotnet(Path.Combine(fakeBin, "dotnet"));
+            var nextVersion = GetNextVersion();
+            var environment = BuildRefreshEnvironment(fakeBin, fakeDotnetLog);
+            environment["INTENT_CLI_LOCAL_VERSION"] = nextVersion;
+
+            var refresh = RunCapturedCommand(
+                "/usr/bin/env",
+                ["bash", Path.Combine(GetSolutionRoot(), "eng", "refresh-host-local-intent-cli.sh"), hostRoot],
+                GetSolutionRoot(),
+                environment);
+
+            Assert.NotEqual(0, refresh.ExitCode);
+            Assert.Equal(originalWrapper, File.ReadAllText(wrapperPath));
+            Assert.Contains($"must not reuse the derived fixed package version {nextVersion}", refresh.StandardError, StringComparison.Ordinal);
+            Assert.False(File.Exists(fakeDotnetLog));
+        }
     }
 
     private static ProcessResult RunShellCommand(string script, string workingDirectory)
@@ -208,6 +371,167 @@ public sealed class PackagedInvocationSmokeTests
         return new ProcessResult(process.ExitCode);
     }
 
+    private static Dictionary<string, string> BuildRefreshEnvironment(
+        string fakeBin,
+        string fakeDotnetLog,
+        string forcedFailure = "")
+    {
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["PATH"] = fakeBin + Path.PathSeparator + (Environment.GetEnvironmentVariable("PATH") ?? string.Empty),
+            ["CHILD_INTENT_SYSTEM"] = GetSolutionRoot(),
+            ["FAKE_DOTNET_LOG"] = fakeDotnetLog,
+            ["FAKE_DOTNET_FAILURE"] = forcedFailure
+        };
+    }
+
+    private static void CreateFakeDotnet(string path)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException("The host refresh script requires a Unix shell.");
+        }
+
+        File.WriteAllText(
+            path,
+            """
+            #!/usr/bin/env bash
+            set -euo pipefail
+
+            printf '%s\n' "$*" >> "$FAKE_DOTNET_LOG"
+
+            if [[ "${1:-}" == "pack" ]]; then
+              shift
+              version=""
+              output=""
+              while (($# > 0)); do
+                case "$1" in
+                  -p:Version=*)
+                    version="${1#-p:Version=}"
+                    shift
+                    ;;
+                  -o)
+                    output="$2"
+                    shift 2
+                    ;;
+                  *)
+                    shift
+                    ;;
+                esac
+              done
+              mkdir -p "$output"
+              printf 'fake package\n' > "$output/JTechJapan.IntentSystem.Cli.$version.nupkg"
+              exit 0
+            fi
+
+            if [[ "${1:-}" == "tool" && "${2:-}" == "exec" ]]; then
+              all_arguments="$*"
+              version=""
+              payload=()
+              while (($# > 0)); do
+                case "$1" in
+                  --version)
+                    version="$2"
+                    shift 2
+                    ;;
+                  --)
+                    shift
+                    payload=("$@")
+                    break
+                    ;;
+                  *)
+                    shift
+                    ;;
+                esac
+              done
+
+              if [[ "$all_arguments" != *"JTechJapan.IntentSystem.Cli --"* ]]; then
+                echo "wrong package id" >&2
+                exit 77
+              fi
+
+              if [[ "${payload[0]:-}" == "--version" ]]; then
+                if [[ "${FAKE_DOTNET_FAILURE:-}" == "version" ]]; then
+                  echo "forced version failure" >&2
+                  exit 42
+                fi
+                echo "Skipping NuGet package signature verification."
+                echo "intent-cli $version-fakesha-G591"
+                exit 0
+              fi
+
+              if [[ "${payload[0]:-}" == "automation" && "${payload[1]:-}" == "summary" ]]; then
+                if [[ "${FAKE_DOTNET_FAILURE:-}" == "summary" ]]; then
+                  echo "forced automation summary failure" >&2
+                  exit 43
+                fi
+                echo '{"automationCommandSurfaceVersion":"automation-command-surface/v1","automationCommandCapabilities":[{"capability":"issue-publish"},{"capability":"pr-transition.review-start"},{"capability":"pr-transition.request-update"},{"capability":"pr-transition.approved"}]}'
+                exit 0
+              fi
+            fi
+
+            echo "unexpected fake dotnet invocation: $*" >&2
+            exit 78
+            """);
+
+        File.SetUnixFileMode(
+            path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+            | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+            | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+    }
+
+    private static CapturedProcessResult RunCapturedCommand(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string> environment)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        startInfo.Environment.Remove("INTENT_CLI_LOCAL_VERSION");
+        foreach (var (name, value) in environment)
+        {
+            startInfo.Environment[name] = value;
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start {fileName}.");
+        var standardOutput = process.StandardOutput.ReadToEndAsync();
+        var standardError = process.StandardError.ReadToEndAsync();
+
+        if (!process.WaitForExit(milliseconds: 120000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException($"{fileName} did not exit within the timeout.");
+        }
+
+        return new CapturedProcessResult(
+            process.ExitCode,
+            standardOutput.GetAwaiter().GetResult(),
+            standardError.GetAwaiter().GetResult());
+    }
+
+    private static string GetNextVersion()
+    {
+        using var document = JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(GetSolutionRoot(), "eng", "version.json")));
+        return document.RootElement.GetProperty("nextVersion").GetString()
+            ?? throw new InvalidOperationException("eng/version.json nextVersion was null.");
+    }
+
     private static string? GetPropertyValue(XElement propertyGroup, string propertyName)
     {
         return propertyGroup.Elements()
@@ -227,10 +551,12 @@ public sealed class PackagedInvocationSmokeTests
 
     private static string CreateLocalPackageVersion()
     {
-        return $"0.3.2-local.{Guid.NewGuid():N}";
+        return $"{GetNextVersion()}-local.{Guid.NewGuid():N}";
     }
 
     private sealed record ProcessResult(int ExitCode);
+
+    private sealed record CapturedProcessResult(int ExitCode, string StandardOutput, string StandardError);
 
     private sealed class TemporaryDirectory : IDisposable
     {


### PR DESCRIPTION
Closes #1285

## Summary

- Resolve the generated package by the CLI project `PackageId` (`JTechJapan.IntentSystem.Cli`) instead of the tool command name.
- Derive local versions from `eng/version.json` `nextVersion` and reject an override that reuses that fixed package version.
- Pack into an isolated candidate directory, verify the temporary wrapper version, summary schema, and unchanged required-capability set, then atomically promote the wrapper only as the final state-changing step.
- On verification failure, emit the failed check and remedy, preserve the installed wrapper/package byte-for-byte, and remove the candidate package and temporary wrapper.
- Document the same fail-closed refresh contract in EN/JA guidance.

## Verification

Exact local head: `07f5d5f94845eecf8a02e99df742ef9a1b4a06d8`

- Packet-focused host-refresh tests: 7 passed, 0 failed
- Related packaged-invocation smoke class: 11 passed, 0 failed
- Controlled failures: version invocation and automation-summary failure both leave the old wrapper/package byte-identical and no candidate/`.tmp` artifact
- Real scratch-host refresh: success; generated wrapper reports `intent-cli 0.8.2-local...-07f5d5f-G591`
- Full Release suite: 4,657 passed, 1 skipped, 0 failed (4,658 total)
- `bash -n eng/refresh-host-local-intent-cli.sh`: clean
- `git diff --check`: clean

Exact-head GitHub CI evidence will be recorded after checks settle.