### PR TITLE
G595: prepare v0.9.1 patch release notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2571,22 +2571,21 @@ to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
 ### Next release readiness (v0.9.1)
 
-**`v0.9.0` shipped** (GitHub Release + NuGet) and the version policy was rolled
-to the `0.9.1` development line. The v0.9.0 batch was a **minor** bump covering
-two slices — G591 and G592 — whose headline is that herdr-only stops requiring
-hand-authored state: the host-local CLI refresh now verifies a candidate before
-promoting it, so a failed refresh leaves the working install untouched, and the
-delivery topology has a canonical writer and validator in the new
-`session-layer topology` command group. Minor rather than patch because G592
-adds that command surface. See
-[release-notes-v0.9.0.md](release-notes-v0.9.0.md) for the shipped scope, and
-[release-notes-v0.8.1.md](release-notes-v0.8.1.md) for the five
-wake-reliability slices that shipped silently before it.
+**`v0.9.0` shipped** (GitHub Release + NuGet), and the version policy remains
+`stableVersion: 0.9.0` with `nextVersion: 0.9.1`. The prepare-only `v0.9.1`
+notes cover exactly one merged correctness slice, G594 (PR #1292, merge
+`022e7ec2acbc354aeb6a054f675165ba0e2a9238`). See
+[release-notes-v0.9.1.md](release-notes-v0.9.1.md) for the measured PATCH
+rationale and exact merge evidence.
 
-**Nothing is decided for `v0.9.1` yet.** What ships is chosen by the v0.9.1
-release-prep packet, not by this section, and
-[release-notes-v0.9.1.md](release-notes-v0.9.1.md) is a DRAFT stub until that
-packet fills it in.
+`v0.9.1` is a **PATCH**: merged-code inspection found no new command surface,
+and the named-team doctor preflight is opt-in through the optional paired
+`--domain` / `--team` arguments. On the same record-less host, the scoped
+doctor reports `session-layer-not-ready` while the unscoped doctor still
+reports `ok`. The notes disclose the stricter bounded herdr delivery
+acknowledgement and the scoped doctor result, both without changing the PRIMARY
+agmsg path. This preparation creates no Release, tag, package, announcement, or
+version roll.
 
 **Release-readiness verification (run before merging the `v0.9.1`
 release-preparation PR):**
@@ -2598,7 +2597,7 @@ cat eng/version.json   # stableVersion 0.9.0 (published), nextVersion 0.9.1 (to 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.9.1-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.9.1-<sha>-G595   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages

--- a/docs/en/release-notes-v0.9.1.md
+++ b/docs/en/release-notes-v0.9.1.md
@@ -1,41 +1,142 @@
-# Release Notes — intent-cli v0.9.1 (DRAFT — UNRELEASED)
+# Release Notes — intent-cli v0.9.1
 
-> **⚠️ DRAFT / UNRELEASED.** This is a **stub**, not release notes. It exists
-> because `eng/version.json` names `0.9.1` as the release-to-be-cut, and the
-> G475 guard requires notes to exist for that version before it can be
-> published. **The v0.9.1 release-prep packet authors the real content**;
-> nothing here describes shipped behavior, and this file must not be treated as
-> a changelog.
+> **Release model:** this change is **prepare-only**. It does not create a
+> GitHub Release or tag, publish a package, perform the post-release version
+> roll, announce the release, or change product behavior. After this
+> preparation is merged and the readiness gate below is satisfied, the
+> operator must explicitly approve Release creation. Publishing that GitHub
+> Release triggers `.github/workflows/release.yml` (`on: release: published`)
+> to build and publish the NuGet package and platform artifacts.
 
-## Status
+## What's in v0.9.1
 
-Created by the post-release version roll (G554 rule as amended by G557) at the
-moment `nextVersion` became `0.9.1`. Until the release-prep packet fills it in:
+v0.9.1 contains exactly one merged correctness slice after `v0.9.0`: **G594**.
 
-- **No slices are listed yet.** What ships in `v0.9.1` is decided by the
-  release-prep packet, not by this stub.
-- **No bump rationale yet** (patch vs minor is a release-prep decision).
-- **No readiness gate yet.** Do **not** publish a `v0.9.1` GitHub Release while
-  this file is still a draft — an unfilled stub means release-prep has not run.
+- **G594** — [PR #1292](https://github.com/J-Tech-Japan/intent-system/pull/1292),
+  “G594: make session-layer readiness record-first,”
+  merge [`022e7ec2acbc354aeb6a054f675165ba0e2a9238`](https://github.com/J-Tech-Japan/intent-system/commit/022e7ec2acbc354aeb6a054f675165ba0e2a9238).
 
-## What the release-prep packet must replace this with
+That merge commit was verified as an ancestor of `main` during release
+preparation. No other shipped slice is included in these notes.
 
-Follow the shape of the previous notes
-([v0.9.0](release-notes-v0.9.0.md), [v0.7.1](release-notes-v0.7.1.md)):
+**Why PATCH, not MINOR.** Inspection of the merged implementation confirmed
+that G594 adds no new user-facing command surface: its shared record-first
+preflight is consumed through the existing `automation doctor`, guide, and
+`notify` surfaces. The doctor check is opt-in for a named scope because its
+paired `--domain` and `--team` arguments are optional. Existing unscoped doctor
+invocations and CI jobs retain their status behavior.
 
-- what shipped, grouped by theme, covering exactly the merged slices;
-- the bump rationale (patch vs minor) stated, not just labelled;
-- the prepare-only publishing section and the release-readiness gate;
-- an upgrade section separating additive surfaces from corrective behavior
-  changes;
-- the post-release roll reminder.
+The release-preparation measurement used the same host root containing
+`config.toml` and `host-binding.toml` but no session-layer mode record. The
+source-built merged CLI reported exactly:
 
-## Install (placeholder — the version below is what the guard checks)
+```text
+intent-cli automation doctor --domain intent-cli --team sekiban-workers --format json
+→ exit 1; status: session-layer-not-ready; preflight verdict: configuration-incomplete
+
+intent-cli automation doctor --format json
+→ exit 0; status: ok; preflight verdict: unjudged
+```
+
+The scoped check therefore closes a false-green readiness gap without flipping
+existing unscoped callers. This measured compatibility is the PATCH rationale;
+it is not inferred from the issue label or copied from planning text.
+
+### Readiness is record-first and delivery identity is operational (G594)
+
+One machine-readable session-layer preflight now supplies the answer consumed
+by `automation doctor`, the orchestrator guide's READY definition, and
+`notify`. A named team with no recorded mode is configuration-incomplete rather
+than vacuously green, topology is correlated with the recorded mode, and
+contradictions remain diagnostic-only without inference or repair.
+
+For herdr-only delivery, a logical role now resolves to its recorded workspace
+plus pane. It no longer has to equal the herdr agent name, which is globally
+unique on a machine. This unblocks multiple teams on one machine: each team can
+use the canonical logical roles while its herdr agents keep distinct global
+names. Credit goes to the **sekiban design thread**, whose production report
+surfaced the collision and prompted the independent verification folded into
+G594.
+
+## Install
 
 ```bash
 dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.9.1
 ```
 
-Once published, the self-contained binaries will be attached to the
+After the operator has approved and published it, self-contained binaries are
+available from the
 [v0.9.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.9.1).
 Verify the `.sha256` sidecar before use.
+
+## Upgrade from v0.9.0
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.9.1
+```
+
+No command, argument, flag, session-layer mode, topology schema, or record
+writer was removed or renamed. Two non-breaking-for-existing-callers changes
+on the PREVIEW herdr-only path deserve explicit attention:
+
+1. **`delivered: true` is stricter.** For a settled herdr recipient, notify now
+   requires a bounded observed unattended working transition followed by a
+   fresh settled acknowledgement. A prompt left in a composer is not reported
+   delivered. An already-working recipient remains deliverable and reports its
+   working transition as `unobservable`.
+2. **`automation doctor` gains the scoped preflight.** Supplying the optional
+   `--domain <d> --team <t>` pair judges that named team record-first; omitting
+   the pair leaves an anonymous record-less root unjudged and preserves the
+   existing `ok` status shown above.
+
+The **herdr-only session transport remains PREVIEW**. The agmsg transport and
+its delivery behavior are unchanged, and **agmsg remains PRIMARY**. PREVIEW
+qualifies only the transport, never the four-thread model.
+
+## Release-readiness gate (G595)
+
+These items must hold **before the GitHub Release for `v0.9.1` is created or
+published**. This gate fails closed.
+
+- [ ] The only shipped slice in these notes is G594, merged through PR #1292 at
+      `022e7ec2acbc354aeb6a054f675165ba0e2a9238`, and that commit is an ancestor
+      of `main`.
+- [ ] Both EN/JA `release-notes-v0.9.1.md` files contain parity-matched real
+      notes with no DRAFT-stub banner and disclose both non-breaking changes.
+- [ ] `eng/version.json` is byte-unchanged at `stableVersion` `0.9.0` and
+      `nextVersion` `0.9.1`.
+- [ ] The record-less-host measurement still returns
+      `session-layer-not-ready` for the scoped doctor and `ok` for the unscoped
+      doctor on the same host.
+- [ ] The G475 next-version notes/package guard, release/version guards, full
+      Release suite, build, pack, and diff check are green on the exact G595
+      preparation head.
+- [ ] Package metadata is correct: `PackageId = JTechJapan.IntentSystem.Cli`,
+      repository/project URLs point at this repository, the license is
+      `Apache-2.0`, and README/docs links resolve.
+- [ ] Exact-head GitHub CI (`Build and test (source contract)`) is green and the
+      preparation PR records its verification evidence.
+- [ ] The operator has explicitly approved creating the `v0.9.1` Release.
+
+## Publishing v0.9.1
+
+Merging this preparation does **not** create a GitHub Release or tag, publish a
+package, announce the release, roll to `0.9.2`, create new DRAFT stubs, or make
+any product behavior change. After merge, the readiness evidence must be
+checked and the operator must explicitly approve Release creation.
+
+Only then may a maintainer/operator (or explicitly authorized external release
+automation) create and publish the `v0.9.1` GitHub Release. Publishing it
+triggers `release.yml`, which publishes the NuGet package and platform
+archives.
+
+Post-release verification includes:
+
+- [ ] NuGet and GitHub asset links resolve and downloaded checksums match.
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.9.1`
+      followed by `intent-cli --version` reports `0.9.1`.
+- [ ] A platform archive passes checksum verification and its binary reports
+      `0.9.1`.
+- [ ] Only after publication, perform the separately authorized immediate
+      version roll and create the next EN/JA DRAFT stubs. That post-release
+      work is not part of G595.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2649,21 +2649,20 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 
 ### 次リリース準備(v0.9.1)
 
-**`v0.9.0` は出荷済み**(GitHub Release + NuGet)で、version policy は `0.9.1`
-開発ラインへ roll 済みです。v0.9.0 は **minor** bump で、G591 と G592 の 2 件を
-対象としました。見出しは **herdr-only が手書きの状態を必要としなくなったこと**です ——
-host-local CLI refresh は候補を検証してから昇格するようになり、失敗しても稼働中の
-install は無傷のままです。delivery topology には新しい `session-layer topology`
-command group という canonical な writer と validator が付きました。patch ではなく
-minor なのは、G592 がその command surface を追加するためです。出荷範囲は
-[release-notes-v0.9.0.md](release-notes-v0.9.0.md)、その前に silent で出荷した
-5 件の wake 信頼性スライスは
-[release-notes-v0.8.1.md](release-notes-v0.8.1.md) を参照してください。
+**`v0.9.0` は出荷済み**(GitHub Release + NuGet)で、version policy は
+`stableVersion: 0.9.0`、`nextVersion: 0.9.1` のままです。prepare-only の
+`v0.9.1` notes が対象とする merged correctness slice は G594 の正確に 1 件です
+(PR #1292、merge `022e7ec2acbc354aeb6a054f675165ba0e2a9238`)。実測した PATCH
+根拠と正確な merge 証跡は
+[release-notes-v0.9.1.md](release-notes-v0.9.1.md) を参照してください。
 
-**`v0.9.1` の内容はまだ何も決まっていません。** 何を出荷するかを決めるのは v0.9.1 の
-release-prep パケットであってこのセクションではなく、
-[release-notes-v0.9.1.md](release-notes-v0.9.1.md) はそのパケットが埋めるまで
-DRAFT stub のままです。
+`v0.9.1` は **PATCH** です。merged code の inspection で新しい command surface が
+ないこと、named-team doctor preflight は optional な paired `--domain` / `--team`
+引数による opt-in であることを確認しました。同一の record-less host で scoped doctor は
+`session-layer-not-ready`、unscoped doctor は引き続き `ok` を返します。notes は
+bounded な herdr delivery acknowledgement の厳密化と scoped doctor result を開示し、
+PRIMARY agmsg path は変更しません。この preparation は Release、tag、package、
+announcement、version roll を作成しません。
 
 **リリース準備検証(`v0.9.1` release-preparation PR のマージ前に実行):**
 
@@ -2674,7 +2673,7 @@ cat eng/version.json   # stableVersion 0.9.0 (published), nextVersion 0.9.1 (to 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.9.1-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.9.1-<sha>-G595   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages

--- a/docs/ja/release-notes-v0.9.1.md
+++ b/docs/ja/release-notes-v0.9.1.md
@@ -1,40 +1,132 @@
-# リリースノート — intent-cli v0.9.1（DRAFT — 未リリース）
+# リリースノート — intent-cli v0.9.1
 
-> **⚠️ DRAFT / 未リリース。** これはリリースノートではなく **stub** です。
-> `eng/version.json` が `0.9.1` を「これからカットするリリース」として指しており、
-> G475 のガードが publish 前にそのバージョンのノートの存在を要求するため置かれています。
-> **実際の内容は v0.9.1 の release-prep パケットが author します**。ここには出荷済みの
-> 挙動は一切書かれておらず、このファイルを changelog として扱ってはいけません。
+> **リリースモデル:** この変更は **prepare-only** です。GitHub Release や tag の
+> 作成、package の publish、リリース後の version roll、アナウンス、product behavior
+> の変更は行いません。この準備が merge され、下記 readiness gate を満たした後も、
+> Release 作成には operator の明示承認が必要です。GitHub Release の publish が
+> `.github/workflows/release.yml`（`on: release: published`）を trigger し、NuGet
+> package と platform artifact を build/publish します。
 
-## ステータス
+## v0.9.1 の内容
 
-`nextVersion` が `0.9.1` になった時点で、リリース後の version roll（G554 のルール、
-G557 による改訂版）によって作成されました。release-prep パケットが埋めるまでは:
+v0.9.1 が `v0.9.0` 以降から含む merged correctness slice は **G594** の正確に
+1 件です。
 
-- **スライスは未記載です。** `v0.9.1` で何が出荷されるかを決めるのはこの stub ではなく
-  release-prep パケットです。
-- **バンプ根拠も未記載です**（patch か minor かは release-prep の判断です）。
-- **リリース準備ゲートも未記載です。** このファイルが draft のままの間は `v0.9.1` の
-  GitHub Release を publish **しないでください** — 埋まっていない stub は release-prep が
-  未実行であることを意味します。
+- **G594** — [PR #1292](https://github.com/J-Tech-Japan/intent-system/pull/1292)、
+  「G594: make session-layer readiness record-first」、
+  merge [`022e7ec2acbc354aeb6a054f675165ba0e2a9238`](https://github.com/J-Tech-Japan/intent-system/commit/022e7ec2acbc354aeb6a054f675165ba0e2a9238)。
 
-## release-prep パケットがこれを置き換える際に必要なもの
+release preparation 中に、この merge commit が `main` の ancestor であることを検証
+しました。この notes に含める shipped slice はほかにありません。
 
-過去のノート（[v0.9.0](release-notes-v0.9.0.md)、[v0.7.1](release-notes-v0.7.1.md)）の
-形に従ってください:
+**MINOR ではなく PATCH である理由。** merge 済み実装のinspectionにより、G594が新しい
+user-facing command surfaceを追加していないことを確認しました。共有record-first
+preflightは既存の`automation doctor`、guide、`notify` surfaceから利用されます。
+doctor checkはpairedな`--domain`と`--team`がoptionalなので、named scopeに対して
+opt-inです。既存のunscoped doctor呼び出しとCI jobはstatus behaviorを維持します。
 
-- 出荷内容をテーマ別にグループ化し、マージされたスライスを正確にカバーする;
-- バンプ根拠（patch か minor か）をラベルだけでなく理由まで記述する;
-- prepare-only の publishing セクションとリリース準備ゲート;
-- 追加サーフェスと是正的な挙動変更を分離した upgrade セクション;
-- リリース後の roll のリマインド。
+release preparationでは、`config.toml`と`host-binding.toml`だけがあり
+session-layer mode recordがない同一host rootを使用しました。source buildしたmerged CLI
+の実測値は次のとおりです。
 
-## インストール（プレースホルダー — 下記バージョンがガードの検査対象です）
+```text
+intent-cli automation doctor --domain intent-cli --team sekiban-workers --format json
+→ exit 1; status: session-layer-not-ready; preflight verdict: configuration-incomplete
+
+intent-cli automation doctor --format json
+→ exit 0; status: ok; preflight verdict: unjudged
+```
+
+したがってscoped checkはfalse-green readiness gapを閉じますが、既存のunscoped callerを
+反転させません。この実測互換性がPATCH根拠であり、Issue labelやplanning textからの
+推測・転記ではありません。
+
+### readinessはrecord-first、delivery identityは運用可能に（G594）
+
+単一のmachine-readableなsession-layer preflightが、`automation doctor`、
+orchestrator guideのREADY定義、`notify`で共有されるようになりました。mode recordがない
+named teamはvacuous greenではなくconfiguration-incompleteになり、topologyをrecorded
+modeと相関し、矛盾はinferenceやrepairをせずdiagnostic-onlyとして扱います。
+
+herdr-only deliveryではlogical roleをrecorded workspaceとpaneの組で解決します。
+logical roleはmachine全体でglobally uniqueなherdr agent nameと一致する必要がなくなり
+ました。これにより1台のmachine上で複数teamが、それぞれ異なるglobal agent nameを
+維持しながらcanonical logical roleを使用できます。この衝突をproduction useから報告し、
+G594へ組み込む独立検証の契機を作った **sekiban design thread** にcreditします。
+
+## インストール
 
 ```bash
 dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.9.1
 ```
 
-publish 後、self-contained バイナリは
+operatorが承認・publishした後、self-contained binaryは
 [v0.9.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.9.1)
-に添付されます。使用前に `.sha256` サイドカーを検証してください。
+から取得できます。使用前に`.sha256` sidecarを検証してください。
+
+## v0.9.0 からのアップグレード
+
+```bash
+dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.9.1
+```
+
+command、argument、flag、session-layer mode、topology schema、record writerの削除・改名は
+ありません。PREVIEW herdr-only pathにある、既存callerに対して非破壊な変更2件を明示
+します。
+
+1. **`delivered: true`の条件が厳密になります。** settled状態のherdr recipientでは、
+   boundedに観測したunattended working transitionと、それに続くfresh settled
+   acknowledgementが必要です。composerに残った未submit promptをdeliveredとは報告
+   しません。already-working recipientは引き続きdeliverableで、working transitionは
+   `unobservable`と報告します。
+2. **`automation doctor`にscoped preflightが加わります。** optionalな
+   `--domain <d> --team <t>`の組を指定すると、そのnamed teamをrecord-firstで判定します。
+   省略時はanonymousなrecord-less rootをunjudgedとし、上記の既存`ok` statusを維持
+   します。
+
+**herdr-only session transportは引き続きPREVIEW**です。agmsg transportとdelivery
+behaviorは変更せず、**agmsgは引き続きPRIMARY**です。PREVIEWが修飾するのはtransport
+だけで、four-thread modelではありません。
+
+## リリース準備ゲート（G595）
+
+以下は **`v0.9.1` GitHub Releaseを作成またはpublishする前**に満たす必要があります。
+このgateはfail closedです。
+
+- [ ] このnotesのshipped sliceはG594だけで、PR #1292の
+      `022e7ec2acbc354aeb6a054f675165ba0e2a9238`としてmergeされ、そのcommitが`main`の
+      ancestorである。
+- [ ] EN/JA両方の`release-notes-v0.9.1.md`がparity-matchedなreal notesで、
+      DRAFT-stub bannerがなく、非破壊な変更2件を開示している。
+- [ ] `eng/version.json`が`stableVersion` `0.9.0`、`nextVersion` `0.9.1`のまま
+      byte-unchangedである。
+- [ ] 同一のrecord-less hostに対する実測が、scoped doctorで
+      `session-layer-not-ready`、unscoped doctorで`ok`を返す。
+- [ ] G475 next-version notes/package guard、release/version guard、full Release suite、
+      build、pack、diff checkがexact G595 preparation headでgreenである。
+- [ ] package metadataが正しい: `PackageId = JTechJapan.IntentSystem.Cli`、
+      repository/project URLはこのrepository、licenseは`Apache-2.0`、README/docs linkは
+      resolveする。
+- [ ] exact-head GitHub CI（`Build and test (source contract)`）がgreenで、preparation PR
+      にverification evidenceが記録されている。
+- [ ] operatorが`v0.9.1` Release作成を明示承認している。
+
+## v0.9.1 のpublish
+
+このpreparationをmergeしても、GitHub Release/tagの作成、package publish、
+アナウンス、`0.9.2`へのroll、新しいDRAFT stubの作成、product behavior changeは行い
+ません。merge後にreadiness evidenceを確認し、operatorがRelease作成を明示承認する
+必要があります。
+
+その後に限りmaintainer/operator（または明示承認済みのexternal release automation）が
+`v0.9.1` GitHub Releaseを作成・publishできます。publishが`release.yml`をtriggerし、
+NuGet packageとplatform archiveをpublishします。
+
+リリース後の検証項目:
+
+- [ ] NuGetとGitHub assetのlinkがresolveし、downloadしたchecksumが一致する。
+- [ ] `dotnet tool update -g JTechJapan.IntentSystem.Cli --version 0.9.1`後の
+      `intent-cli --version`が`0.9.1`を報告する。
+- [ ] platform archiveのchecksum検証が成功し、そのbinaryが`0.9.1`を報告する。
+- [ ] publish後にのみ、別途承認されたimmediate version rollを行い、次のEN/JA DRAFT
+      stubを作成する。このpost-release workはG595に含まれない。


### PR DESCRIPTION
Closes #1293

## Summary

- replace the EN/JA v0.9.1 DRAFT stubs in place with real prepare-only release notes covering exactly G594 / PR #1292 / merge `022e7ec2acbc354aeb6a054f675165ba0e2a9238`
- document the measured PATCH rationale from merged code: no new command surface, and the named-team doctor preflight is opt-in
- disclose the stricter bounded herdr delivery acknowledgement and scoped doctor preflight while keeping herdr-only PREVIEW and agmsg PRIMARY/unchanged
- record the multi-team operational unblock and credit the sekiban design thread
- refresh the existing EN/JA Next-release readiness sections without changing version policy or product behavior

## Measured patch rationale

Inspection of merged commit `022e7ec2acbc354aeb6a054f675165ba0e2a9238` found no new registration in `Program` or `CommandRouter`. G594 adds a shared predicate behind existing doctor/guide/notify surfaces. The existing `automation doctor` command accepts optional paired `--domain`/`--team` arguments, so the new named-scope verdict is opt-in.

On one scratch host containing only `.intent-cli/config.toml` and `.intent-cli/host-binding.toml`, with no mode record, the source-built merged CLI reported:

```text
automation doctor --domain intent-cli --team sekiban-workers --format json
exit 1; status=session-layer-not-ready; preflight=configuration-incomplete

automation doctor --format json
exit 0; status=ok; preflight=unjudged
```

## Scope guards

- changed files: exactly the two v0.9.1 notes and two existing EN/JA readiness references
- shipped slice bullets: exactly one in each notes file, G594
- G594 merge is an ancestor of `origin/main`
- `eng/version.json` is byte-identical to `origin/main` at `stableVersion=0.9.0`, `nextVersion=0.9.1`
- no Release, tag, publish, announcement, post-release roll, product code, test code, or future stub change

## Verification

- exact local head: `abbe36883c4e0472591eb5f802c38a644a1eb5c3`
- `dotnet build IntentSystem.sln -c Release --no-restore --nologo` — 0 warnings, 0 errors
- source display — `intent-cli 0.9.1-abbe368-G595`
- `dotnet pack ...` — created `JTechJapan.IntentSystem.Cli.0.9.1.nupkg`
- G475/release/version guards — 42 passed, 0 failed
- full Release suite — 4,684 passed, 1 skipped, 0 failed
- `git diff HEAD^ HEAD --check` — clean

Exact-head GitHub CI evidence will be added after the draft PR checks complete.
