### PR TITLE
G596: add durable operator-attention lifecycle

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -657,6 +657,49 @@ wake procedure and from an external heartbeat are separate follow-up slices.
 informational one, so a reader (human or orchestrator) can never mistake
 "no transition needed" for an actionable next command.
 
+### Durable operator attention (G596)
+
+Human-required work is state, not a notification that may scroll past. Use
+the explicit lifecycle surface:
+
+```text
+intent-cli operator-attention open --record <id> --domain <d> --team <t> --owner <owner> --blocking-reference <issue|pr|unit|release> --action-needed <action> --evidence <evidence> [--supersedes <id>] --write --format json
+intent-cli operator-attention resolve --record <id> --resolution-evidence <evidence> --write --format json
+intent-cli operator-attention supersede --record <id> --evidence <evidence> --write --format json
+intent-cli operator-attention query [--domain <d>] [--team <t>] --format json
+```
+
+Open a record whenever progress requires a human operator's decision or act
+and the requirement is not already the unchanged clarification mechanism.
+The opening thread must name an owner, the blocking reference, a specific
+action a reader can perform without reconstructing chat, and establishing
+evidence. It remains that thread's obligation to route the record to the
+operator and later run an explicit terminal command with evidence.
+
+The lifecycle is exactly `open`, `resolved`, and `superseded`. Superseded does
+not mean answered: it carries no `resolution_evidence`. If the obligation
+returns, first supersede the old record and open a new ID with `--supersedes`;
+the terminal old record is never mutated or reopened. Every transition and
+its evidence/timestamp remains in `.intent-cli/operator-attention.json`,
+published through the shared atomic durable writer.
+
+Only these explicit commands write or transition the store. Pane text,
+`events.jsonl`, `intent-cli notify escalate`, and prose/event heuristics can
+announce that something happened but never open, resolve, or supersede a
+record. Querying by domain, by team, or both reports every matching record,
+the current open set, and age since opening. A missing store or no history at
+the selected scope returns `check-not-completed`; malformed or unreadable
+state returns `cannot-determine`, never `no-attention-pending`.
+
+An open record appears immediately in the existing `automation stalled-work`
+and `automation heartbeat` output as `operator-attention-pending`. The item
+names the record and carries `required_actor: operator` plus
+`orchestrator_actionable: false`; a heartbeat whose only item is that record
+sets `route_to: operator` and says `ROUTE TO OPERATOR`. The orchestrator routes
+the obligation but must not pretend it can clear the human decision itself.
+No new watchdog, scheduler, timer, polling loop, process launch, or automatic
+open/resolve path is introduced.
+
 ### Session-layer mode: which transport the four threads use (G570)
 
 `intent-cli session-layer show --domain <d> [--team <t>] [--format markdown|json]`

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -672,6 +672,50 @@ kind では `— FYI:` prose `` で終わります — そのため読み手（�
 orchestrator でも）が「transition は不要」を actionable な次コマンドと
 取り違えることはありません。
 
+### operator attention の durable state (G596)
+
+人間にしか処理できない作業は、流れて消える通知ではなく state です。次の
+明示的な lifecycle surface を使います。
+
+```text
+intent-cli operator-attention open --record <id> --domain <d> --team <t> --owner <owner> --blocking-reference <issue|pr|unit|release> --action-needed <action> --evidence <evidence> [--supersedes <id>] --write --format json
+intent-cli operator-attention resolve --record <id> --resolution-evidence <evidence> --write --format json
+intent-cli operator-attention supersede --record <id> --evidence <evidence> --write --format json
+intent-cli operator-attention query [--domain <d>] [--team <t>] --format json
+```
+
+進行に human operator の判断または作業が必要で、かつ既存の clarification
+mechanism（この仕組みでは変更しません）で扱うものではないとき、record を
+open します。open した thread は owner、blocking reference、chat を再構成せず
+実行できる具体的 action、establishing evidence を記録しなければなりません。
+その record を operator に route し、後で evidence 付きの明示的 terminal
+command を実行することも、その thread の責務です。
+
+lifecycle は厳密に `open`、`resolved`、`superseded` の 3 つです。
+superseded は回答済みではなく、`resolution_evidence` を持ちません。同じ義務が
+再発した場合、古い record をまず supersede し、`--supersedes` でそれを参照する
+新しい ID を open します。terminal な古い record を変更したり reopen したりは
+しません。全 transition と evidence/timestamp は
+`.intent-cli/operator-attention.json` に残り、共有 atomic durable writer で
+publish されます。
+
+store を write/transition するのはこれらの明示 command だけです。pane text、
+`events.jsonl`、`intent-cli notify escalate`、prose/event heuristic は何かが
+起きたことを通知できますが、record を open / resolve / supersede することは
+ありません。domain 単独、team 単独、または両方で query すると、該当する全
+record、現在 open の集合、open からの age が返ります。store が無い、または選択
+scope に履歴が無ければ `check-not-completed`、malformed または unreadable なら
+`cannot-determine` であり、
+`no-attention-pending` には決してなりません。
+
+open record は既存の `automation stalled-work` と `automation heartbeat` に
+`operator-attention-pending` として即時に現れます。item は record を名指しし、
+`required_actor: operator` と `orchestrator_actionable: false` を持ちます。その
+record だけが item の heartbeat は `route_to: operator` と `ROUTE TO OPERATOR`
+を返します。orchestrator は義務を route しますが、人間の判断を自分で clear
+できるかのように扱ってはいけません。新しい watchdog、scheduler、timer、
+polling loop、process launch、automatic open/resolve path は追加しません。
+
 ### session-layer モード: 4 スレッドがどの transport を使うか (G570)
 
 `intent-cli session-layer show --domain <d> [--team <t>] [--format markdown|json]`

--- a/src/IntentSystem.Cli/CliRuntimeContracts.cs
+++ b/src/IntentSystem.Cli/CliRuntimeContracts.cs
@@ -6,6 +6,7 @@ internal static class CliRuntimeContracts
     public const string ConfigFileName = "config.toml";
     public const string QueueStateFileName = "queue-state.json";
     public const string RunLogFileName = "runs.jsonl";
+    public const string OperatorAttentionFileName = "operator-attention.json";
     public const string ProjectSectionName = "project";
     public const string DefaultDomainKey = "default_domain";
     public const string DomainKey = "domain";
@@ -109,5 +110,10 @@ internal static class CliRuntimeContracts
     public static string GetRunLogPath(string repoRoot)
     {
         return Path.Combine(GetIntentCliDirectoryPath(repoRoot), RunLogFileName);
+    }
+
+    public static string GetOperatorAttentionPath(string repoRoot)
+    {
+        return Path.Combine(GetIntentCliDirectoryPath(repoRoot), OperatorAttentionFileName);
     }
 }

--- a/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
@@ -87,6 +87,9 @@ internal static class AutomationHeartbeatCommand
             Stale = stalledWork.Stalled,
             Items = stalledWork.Items,
             Warnings = stalledWork.Warnings,
+            OperatorAttentionStatus = stalledWork.OperatorAttentionStatus,
+            OperatorAttentionError = stalledWork.OperatorAttentionError,
+            RouteTo = ResolveRoute(stalledWork),
             MessageBody = stalledWork.Stalled ? BuildMessageBody(stalledWork) : null,
         };
 
@@ -119,14 +122,31 @@ internal static class AutomationHeartbeatCommand
     /// </summary>
     private static string BuildMessageBody(AutomationStalledWorkResult stalledWork)
     {
-        var actionableCount = stalledWork.Items.Count(item => !item.IsInformational);
+        var operatorRequiredCount = stalledWork.Items.Count(item =>
+            string.Equals(item.RequiredActor, "operator", StringComparison.Ordinal));
+        var actionableCount = stalledWork.Items.Count(item =>
+            !item.IsInformational && item.OrchestratorActionable is not false);
         var informationalCount = stalledWork.Items.Count(item => item.IsInformational);
 
         var builder = new StringBuilder();
+        builder.Append("WAKE (heartbeat): ");
+        if (operatorRequiredCount > 0)
+        {
+            builder
+                .Append("ROUTE TO OPERATOR — ")
+                .Append(operatorRequiredCount)
+                .Append(" operator-required attention item(s), ");
+        }
         builder
-            .Append("WAKE (heartbeat): ")
             .Append(actionableCount)
             .Append(" pending transition(s)");
+        if (operatorRequiredCount > 0)
+        {
+            builder
+                .Append(" (")
+                .Append(actionableCount)
+                .Append(" orchestrator-actionable)");
+        }
         if (informationalCount > 0)
         {
             builder.Append(", ").Append(informationalCount).Append(" informational note(s)");
@@ -160,7 +180,21 @@ internal static class AutomationHeartbeatCommand
             }
 
             builder.Append(')');
-            if (item.IsInformational)
+            if (string.Equals(item.RequiredActor, "operator", StringComparison.Ordinal))
+            {
+                builder
+                    .Append(" — OPERATOR REQUIRED (orchestrator_actionable=false): ")
+                    .Append(item.RecommendedAction);
+                if (item.OperatorAttentionOwner is { } owner)
+                {
+                    builder.Append(" Owner: ").Append(owner).Append('.');
+                }
+                if (item.BlockingReference is { } blockingReference)
+                {
+                    builder.Append(" Blocking reference: ").Append(blockingReference).Append('.');
+                }
+            }
+            else if (item.IsInformational)
             {
                 builder.Append(" — FYI: ").Append(item.RecommendedAction);
             }
@@ -171,6 +205,29 @@ internal static class AutomationHeartbeatCommand
         }
 
         return builder.ToString();
+    }
+
+    private static string? ResolveRoute(AutomationStalledWorkResult stalledWork)
+    {
+        if (!stalledWork.Stalled)
+        {
+            return null;
+        }
+
+        var hasOperator = stalledWork.Items.Any(item =>
+            string.Equals(item.RequiredActor, "operator", StringComparison.Ordinal));
+        if (!hasOperator)
+        {
+            return null;
+        }
+        var hasOrchestrator = stalledWork.Items.Any(item =>
+            !item.IsInformational && item.OrchestratorActionable is not false);
+        return (hasOperator, hasOrchestrator) switch
+        {
+            (true, true) => "operator-and-orchestration",
+            (true, false) => "operator",
+            _ => null,
+        };
     }
 
     private static bool TryParseArguments(
@@ -260,6 +317,14 @@ internal static class AutomationHeartbeatCommand
         writer.WriteLine($"- stale_minutes_threshold: {result.StaleMinutesThreshold}");
         writer.WriteLine($"- stale: {(result.Stale ? "true" : "false")}");
         writer.WriteLine($"- items: {result.Items.Count}");
+        if (result.OperatorAttentionStatus is not null)
+        {
+            writer.WriteLine($"- operator_attention_status: {result.OperatorAttentionStatus}");
+        }
+        if (result.RouteTo is not null)
+        {
+            writer.WriteLine($"- route_to: {result.RouteTo}");
+        }
         writer.WriteLine();
 
         if (result.Items.Count == 0)
@@ -287,6 +352,14 @@ internal static class AutomationHeartbeatCommand
                 else
                 {
                     writer.WriteLine($"- recommended_action: `{item.RecommendedAction}`");
+                }
+                if (item.RequiredActor is { } requiredActor)
+                {
+                    writer.WriteLine($"- required_actor: {requiredActor}");
+                }
+                if (item.OrchestratorActionable is { } orchestratorActionable)
+                {
+                    writer.WriteLine($"- orchestrator_actionable: {(orchestratorActionable ? "true" : "false")}");
                 }
                 writer.WriteLine();
             }
@@ -330,6 +403,18 @@ internal sealed record AutomationHeartbeatResult
 
     [JsonPropertyName("warnings")]
     public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("operator_attention_status")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required string? OperatorAttentionStatus { get; init; }
+
+    [JsonPropertyName("operator_attention_error")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required string? OperatorAttentionError { get; init; }
+
+    [JsonPropertyName("route_to")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required string? RouteTo { get; init; }
 
     /// <summary>
     /// Ready-to-send orchestrator reconcile status-request, present only

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -161,6 +161,18 @@ internal static class AutomationStalledWorkCommand
     public const string KindMergedNotClosedOut = "merged-not-closed-out";
 
     /// <summary>
+    /// G596: an explicitly opened durable obligation that only the human
+    /// operator can clear. It is actionable, but never orchestrator-actionable.
+    /// </summary>
+    public const string KindOperatorAttentionPending = "operator-attention-pending";
+
+    /// <summary>
+    /// G596: the durable store exists but cannot be trusted. A corrupt store
+    /// can never be collapsed into a healthy/no-attention result.
+    /// </summary>
+    public const string KindOperatorAttentionCannotDetermine = "operator-attention-cannot-determine";
+
+    /// <summary>
     /// G582: an approved PR is an intermediate workflow state, not completion.
     /// This actionable kind closes the last-net gap when an open approved PR
     /// sits past <c>--stale-minutes</c> without any wake source advancing the
@@ -516,8 +528,14 @@ internal static class AutomationStalledWorkCommand
             items,
             excluded);
 
+        var operatorAttention = CollectOperatorAttention(context, domain, now, items);
+
         var filtered = items
-            .Where(item => item.AgeMinutes >= staleMinutes)
+            // G596: explicit human obligations and unreadable human-obligation
+            // state are load-bearing immediately; they do not wait for the
+            // generic GitHub staleness threshold before becoming visible.
+            .Where(item => item.Kind is KindOperatorAttentionPending or KindOperatorAttentionCannotDetermine
+                || item.AgeMinutes >= staleMinutes)
             .OrderByDescending(item => item.AgeMinutes)
             .ToArray();
 
@@ -536,6 +554,88 @@ internal static class AutomationStalledWorkCommand
             Items = filtered,
             Excluded = excluded,
             Warnings = warnings,
+            // A host that has never used the new lifecycle retains the exact
+            // pre-G596 stalled-work shape. Its independent query still says
+            // check-not-completed; once a store exists (or is corrupt), this
+            // scanner emits the load-bearing status.
+            OperatorAttentionStatus = operatorAttention.Status == OperatorAttentionReadStatus.Missing
+                ? null
+                : operatorAttention.Status,
+            OperatorAttentionError = operatorAttention.Status == OperatorAttentionReadStatus.Missing
+                ? null
+                : operatorAttention.Error,
+        };
+    }
+
+    private static OperatorAttentionReadResult CollectOperatorAttention(
+        CliContext context,
+        string domain,
+        DateTimeOffset now,
+        List<StalledWorkItem> items)
+    {
+        var read = OperatorAttentionStore.Read(context.RepoRoot);
+        if (read.Status == OperatorAttentionReadStatus.CannotDetermine)
+        {
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindOperatorAttentionCannotDetermine,
+                ExecutionUnit = "operator-attention-store",
+                Issue = null,
+                Pr = null,
+                AgeMinutes = 0,
+                IsInformational = false,
+                RecommendedAction = read.Error!,
+                RequiredActor = "operator",
+                OrchestratorActionable = false,
+                OperatorAttentionRecordId = null,
+                OperatorAttentionOwner = "operator",
+                BlockingReference = OperatorAttentionStore.RelativePath,
+                DedupeKey = $"operator-attention:cannot-determine:{domain}",
+            });
+            return read;
+        }
+
+        if (read.Status != OperatorAttentionReadStatus.Readable)
+        {
+            // Missing is deliberately exposed as check-not-completed on the
+            // result, but it is not invented into an open obligation. Only an
+            // explicit `operator-attention open --write` may create one.
+            return read;
+        }
+
+        var domainRecords = read.Document!.Records
+            .Where(record => string.Equals(record.Domain, domain, StringComparison.Ordinal))
+            .ToArray();
+        var openRecords = domainRecords
+            .Where(record => string.Equals(record.Status, OperatorAttentionStatus.Open, StringComparison.Ordinal))
+            .ToArray();
+        foreach (var record in openRecords)
+        {
+            items.Add(new StalledWorkItem
+            {
+                Kind = KindOperatorAttentionPending,
+                ExecutionUnit = record.RecordId,
+                Issue = null,
+                Pr = null,
+                AgeMinutes = Math.Max(0, (int)Math.Floor((now - record.OpenedAt).TotalMinutes)),
+                IsInformational = false,
+                RecommendedAction = record.ActionNeeded,
+                RequiredActor = "operator",
+                OrchestratorActionable = false,
+                OperatorAttentionRecordId = record.RecordId,
+                OperatorAttentionOwner = record.Owner,
+                BlockingReference = record.BlockingReference,
+                DedupeKey = $"operator-attention:{record.Domain}:{record.Team}:{record.RecordId}",
+            });
+        }
+
+        return read with
+        {
+            Status = openRecords.Length > 0
+                ? OperatorAttentionQueryStatus.AttentionPending
+                : domainRecords.Length > 0
+                    ? OperatorAttentionQueryStatus.NoAttentionPending
+                    : OperatorAttentionQueryStatus.CheckNotCompleted,
         };
     }
 
@@ -3045,6 +3145,14 @@ internal static class AutomationStalledWorkCommand
         writer.WriteLine($"- stalled: {(result.Stalled ? "true" : "false")}");
         writer.WriteLine($"- items: {result.Items.Count}");
         writer.WriteLine($"- excluded: {result.Excluded.Count}");
+        if (result.OperatorAttentionStatus is not null)
+        {
+            writer.WriteLine($"- operator_attention_status: {result.OperatorAttentionStatus}");
+        }
+        if (result.OperatorAttentionError is not null)
+        {
+            writer.WriteLine($"- operator_attention_error: {result.OperatorAttentionError}");
+        }
         writer.WriteLine();
 
         if (result.Items.Count == 0)
@@ -3082,6 +3190,26 @@ internal static class AutomationStalledWorkCommand
                 if (item.DedupeKey is { } dedupeKey)
                 {
                     writer.WriteLine($"- dedupe_key: {dedupeKey}");
+                }
+                if (item.RequiredActor is { } requiredActor)
+                {
+                    writer.WriteLine($"- required_actor: {requiredActor}");
+                }
+                if (item.OrchestratorActionable is { } orchestratorActionable)
+                {
+                    writer.WriteLine($"- orchestrator_actionable: {(orchestratorActionable ? "true" : "false")}");
+                }
+                if (item.OperatorAttentionRecordId is { } recordId)
+                {
+                    writer.WriteLine($"- operator_attention_record_id: {recordId}");
+                }
+                if (item.OperatorAttentionOwner is { } owner)
+                {
+                    writer.WriteLine($"- operator_attention_owner: {owner}");
+                }
+                if (item.BlockingReference is { } blockingReference)
+                {
+                    writer.WriteLine($"- blocking_reference: {blockingReference}");
                 }
                 // G564: the declared targets belong in the item itself, so a
                 // reader knows WHAT the packet promised without opening it.
@@ -3177,6 +3305,14 @@ internal sealed record AutomationStalledWorkResult
 
     [JsonPropertyName("warnings")]
     public required IReadOnlyList<string> Warnings { get; init; }
+
+    [JsonPropertyName("operator_attention_status")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required string? OperatorAttentionStatus { get; init; }
+
+    [JsonPropertyName("operator_attention_error")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required string? OperatorAttentionError { get; init; }
 }
 
 internal sealed record StalledWorkItem
@@ -3240,6 +3376,28 @@ internal sealed record StalledWorkItem
     /// </summary>
     [JsonPropertyName("declared_write_back_targets")]
     public IReadOnlyList<string>? DeclaredWriteBackTargets { get; init; }
+
+    /// <summary>G596: actor that can actually discharge the finding.</summary>
+    [JsonPropertyName("required_actor")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RequiredActor { get; init; }
+
+    /// <summary>G596: false for human obligations; orchestration must route, not act.</summary>
+    [JsonPropertyName("orchestrator_actionable")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? OrchestratorActionable { get; init; }
+
+    [JsonPropertyName("operator_attention_record_id")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? OperatorAttentionRecordId { get; init; }
+
+    [JsonPropertyName("operator_attention_owner")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? OperatorAttentionOwner { get; init; }
+
+    [JsonPropertyName("blocking_reference")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? BlockingReference { get; init; }
 }
 
 internal sealed record StalledWorkCiBreakdown

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -33,7 +33,9 @@ internal static class CommandRouter
         // G570: session-layer transport selection (agmsg | herdr-only).
         "session-layer",
         // G578: transport-neutral role notification surface.
-        "notify"
+        "notify",
+        // G596: explicit durable lifecycle for obligations requiring a human operator.
+        "operator-attention"
     ];
 
     /// <summary>
@@ -127,6 +129,13 @@ internal static class CommandRouter
                 ["delegate"] = NotifyCommand.ExecuteDelegate,
                 ["report"] = NotifyCommand.ExecuteReport,
                 ["escalate"] = NotifyCommand.ExecuteEscalate
+            },
+            ["operator-attention"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
+            {
+                ["open"] = OperatorAttentionCommand.ExecuteOpen,
+                ["resolve"] = OperatorAttentionCommand.ExecuteResolve,
+                ["supersede"] = OperatorAttentionCommand.ExecuteSupersede,
+                ["query"] = OperatorAttentionCommand.ExecuteQuery
             },
             // G559: cross-platform agent skill install surface.
             ["skill"] = new Dictionary<string, CommandHandler>(StringComparer.Ordinal)
@@ -583,6 +592,7 @@ internal static class CommandRouter
             ["automation"] = "`intent-cli automation summary --domain <d> --format json` (capability JSON), `intent-cli automation doctor --format json` (CLI freshness).",
             ["session-layer"] = "`intent-cli session-layer show --domain <d> [--team <t>]` (which transport is in force), `session-layer set` to change it, and `session-layer topology record|show|validate --team <t>` for the delivery mapping.",
             ["notify"] = "`intent-cli notify delegate|report|escalate --domain <d> --team <t> ...` (canonical role workflow; transport follows the recorded session-layer mode).",
+            ["operator-attention"] = "`intent-cli operator-attention query --domain <d> [--team <t>] --format json` (durable human-operator obligations); use `open|resolve|supersede --write` for explicit lifecycle transitions.",
             ["bug"] = "`intent-cli guide worker pr-comment-fix --format json` (repair guidance), `intent-cli bug report`/`triage` for new-bug intake.",
             ["worker"] = "`intent-cli worker next-action --repo <r> --workdir <child> --format json` then claim / result-summary / complete.",
             ["metadata"] = "`intent-cli metadata validate --format json` (read-only); use `intent-cli metadata update --mode completed-closeout --write` for the bounded controlled writer instead of hand-editing.",

--- a/src/IntentSystem.Cli/Commands/OperatorAttentionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/OperatorAttentionCommand.cs
@@ -1,0 +1,972 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Supervisor;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G596: explicit command-only lifecycle for durable obligations that require
+/// a human operator. A notification stream can announce one of these records,
+/// but it can never create or transition one.
+/// </summary>
+internal static class OperatorAttentionCommand
+{
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    internal static Func<DateTimeOffset>? UtcNowFactory { get; set; }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int ExecuteOpen(CliContext context, string[] args, TextWriter writer)
+    {
+        if (IsHelp(args))
+        {
+            writer.WriteLine(OpenUsage);
+            return 0;
+        }
+        if (!TryParseMutationArguments(args, OperatorAttentionOperation.Open, out var input, out var error))
+        {
+            return EmitArgumentError(writer, error, OpenUsage);
+        }
+
+        var read = OperatorAttentionStore.Read(context.RepoRoot);
+        if (read.Status == OperatorAttentionReadStatus.CannotDetermine)
+        {
+            return EmitMutationFailure(writer, input!, read.Status, read.Error!);
+        }
+
+        var existingRecords = read.Document?.Records ?? Array.Empty<OperatorAttentionRecord>();
+        if (existingRecords.Any(record => string.Equals(record.RecordId, input!.RecordId, StringComparison.Ordinal)))
+        {
+            return EmitMutationFailure(
+                writer,
+                input!,
+                OperatorAttentionReadStatus.Readable,
+                $"record '{input!.RecordId}' already exists; records are never overwritten or reopened in place.");
+        }
+
+        if (input!.SupersedesRecordId is { } supersededId)
+        {
+            var superseded = existingRecords.FirstOrDefault(record =>
+                string.Equals(record.RecordId, supersededId, StringComparison.Ordinal));
+            if (superseded is null)
+            {
+                return EmitMutationFailure(writer, input, OperatorAttentionReadStatus.Readable,
+                    $"--supersedes names unknown record '{supersededId}'.");
+            }
+            if (!string.Equals(superseded.Status, OperatorAttentionStatus.Superseded, StringComparison.Ordinal))
+            {
+                return EmitMutationFailure(writer, input, OperatorAttentionReadStatus.Readable,
+                    $"record '{supersededId}' is '{superseded.Status}', not superseded; reopening is a new record that may reference only a terminal superseded record.");
+            }
+            if (!string.Equals(superseded.Domain, input.Domain, StringComparison.Ordinal)
+                || !string.Equals(superseded.Team, input.Team, StringComparison.Ordinal))
+            {
+                return EmitMutationFailure(writer, input, OperatorAttentionReadStatus.Readable,
+                    $"record '{supersededId}' belongs to domain '{superseded.Domain}' / team '{superseded.Team}', not '{input.Domain}' / '{input.Team}'.");
+            }
+        }
+
+        var now = Now();
+        var record = new OperatorAttentionRecord
+        {
+            RecordId = input.RecordId!,
+            Domain = input.Domain!,
+            Team = input.Team!,
+            Owner = input.Owner!,
+            BlockingReference = input.BlockingReference!,
+            ActionNeeded = input.ActionNeeded!,
+            EstablishingEvidence = input.Evidence!,
+            Status = OperatorAttentionStatus.Open,
+            OpenedAt = now,
+            ResolutionEvidence = null,
+            SupersedesRecordId = input.SupersedesRecordId,
+            Transitions =
+            [
+                new OperatorAttentionTransition
+                {
+                    FromStatus = null,
+                    ToStatus = OperatorAttentionStatus.Open,
+                    TransitionedAt = now,
+                    Evidence = input.Evidence!,
+                },
+            ],
+        };
+
+        var document = OperatorAttentionStore.BuildUpdated(read.Document, [.. existingRecords, record], now);
+        return ApplyAndEmit(context, writer, input, document, record);
+    }
+
+    public static int ExecuteResolve(CliContext context, string[] args, TextWriter writer)
+    {
+        if (IsHelp(args))
+        {
+            writer.WriteLine(ResolveUsage);
+            return 0;
+        }
+        return ExecuteTerminalTransition(context, args, writer, OperatorAttentionOperation.Resolve);
+    }
+
+    public static int ExecuteSupersede(CliContext context, string[] args, TextWriter writer)
+    {
+        if (IsHelp(args))
+        {
+            writer.WriteLine(SupersedeUsage);
+            return 0;
+        }
+        return ExecuteTerminalTransition(context, args, writer, OperatorAttentionOperation.Supersede);
+    }
+
+    public static int ExecuteQuery(CliContext context, string[] args, TextWriter writer)
+    {
+        if (IsHelp(args))
+        {
+            writer.WriteLine(QueryUsage);
+            return 0;
+        }
+        if (!TryParseQueryArguments(args, out var domain, out var team, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(QueryUsage);
+            return 1;
+        }
+
+        var now = Now();
+        var read = OperatorAttentionStore.Read(context.RepoRoot);
+        var matched = read.Document?.Records
+            .Where(record => domain is null || string.Equals(record.Domain, domain, StringComparison.Ordinal))
+            .Where(record => team is null || string.Equals(record.Team, team, StringComparison.Ordinal))
+            .OrderBy(record => record.OpenedAt)
+            .ThenBy(record => record.RecordId, StringComparer.Ordinal)
+            .Select(record => OperatorAttentionQueryRecord.From(record, now))
+            .ToArray()
+            ?? Array.Empty<OperatorAttentionQueryRecord>();
+        var open = matched.Where(record => string.Equals(record.Status, OperatorAttentionStatus.Open, StringComparison.Ordinal)).ToArray();
+
+        var result = new OperatorAttentionQueryResult
+        {
+            Status = read.Status switch
+            {
+                OperatorAttentionReadStatus.Missing => OperatorAttentionQueryStatus.CheckNotCompleted,
+                OperatorAttentionReadStatus.CannotDetermine => OperatorAttentionQueryStatus.CannotDetermine,
+                _ when open.Length > 0 => OperatorAttentionQueryStatus.AttentionPending,
+                _ when matched.Length == 0 => OperatorAttentionQueryStatus.CheckNotCompleted,
+                _ => OperatorAttentionQueryStatus.NoAttentionPending,
+            },
+            Domain = domain,
+            Team = team,
+            CheckedAt = now,
+            StorePath = OperatorAttentionStore.RelativePath,
+            OpenCount = open.Length,
+            OpenRecords = open,
+            Records = matched,
+            Error = read.Error,
+        };
+
+        EmitQuery(writer, format, result);
+        return result.Status is OperatorAttentionQueryStatus.AttentionPending
+            or OperatorAttentionQueryStatus.NoAttentionPending
+            ? 0
+            : 1;
+    }
+
+    private static int ExecuteTerminalTransition(
+        CliContext context,
+        string[] args,
+        TextWriter writer,
+        OperatorAttentionOperation operation)
+    {
+        var usage = operation == OperatorAttentionOperation.Resolve ? ResolveUsage : SupersedeUsage;
+        if (!TryParseMutationArguments(args, operation, out var input, out var error))
+        {
+            return EmitArgumentError(writer, error, usage);
+        }
+
+        var read = OperatorAttentionStore.Read(context.RepoRoot);
+        if (read.Status != OperatorAttentionReadStatus.Readable)
+        {
+            return EmitMutationFailure(
+                writer,
+                input!,
+                read.Status,
+                read.Error ?? $"operator-attention store is {read.Status}; no transition can be established.");
+        }
+
+        var records = read.Document!.Records.ToArray();
+        var index = Array.FindIndex(records, record =>
+            string.Equals(record.RecordId, input!.RecordId, StringComparison.Ordinal));
+        if (index < 0)
+        {
+            return EmitMutationFailure(writer, input!, read.Status, $"record '{input!.RecordId}' was not found.");
+        }
+
+        var existing = records[index];
+        if (!string.Equals(existing.Status, OperatorAttentionStatus.Open, StringComparison.Ordinal))
+        {
+            return EmitMutationFailure(
+                writer,
+                input!,
+                read.Status,
+                $"record '{existing.RecordId}' is terminal '{existing.Status}' and can never be reopened or transitioned again.");
+        }
+
+        var now = Now();
+        var nextStatus = operation == OperatorAttentionOperation.Resolve
+            ? OperatorAttentionStatus.Resolved
+            : OperatorAttentionStatus.Superseded;
+        var evidence = operation == OperatorAttentionOperation.Resolve
+            ? input!.ResolutionEvidence!
+            : input!.Evidence!;
+        var updated = existing with
+        {
+            Status = nextStatus,
+            ResolutionEvidence = operation == OperatorAttentionOperation.Resolve ? evidence : null,
+            Transitions =
+            [
+                .. existing.Transitions,
+                new OperatorAttentionTransition
+                {
+                    FromStatus = OperatorAttentionStatus.Open,
+                    ToStatus = nextStatus,
+                    TransitionedAt = now,
+                    Evidence = evidence,
+                },
+            ],
+        };
+        records[index] = updated;
+
+        var document = OperatorAttentionStore.BuildUpdated(read.Document, records, now);
+        return ApplyAndEmit(context, writer, input, document, updated);
+    }
+
+    private static int ApplyAndEmit(
+        CliContext context,
+        TextWriter writer,
+        OperatorAttentionMutationInput input,
+        OperatorAttentionStoreDocument document,
+        OperatorAttentionRecord record)
+    {
+        if (input.Write)
+        {
+            OperatorAttentionStore.Write(context.RepoRoot, document);
+        }
+
+        var result = new OperatorAttentionMutationResult
+        {
+            Status = "ok",
+            Mode = input.Write ? "write" : "dry-run",
+            Applied = input.Write,
+            Operation = input.Operation.ToString().ToLowerInvariant(),
+            StorePath = OperatorAttentionStore.RelativePath,
+            Record = OperatorAttentionQueryRecord.From(record, Now()),
+            Error = null,
+        };
+        EmitMutation(writer, input.Format, result);
+        return 0;
+    }
+
+    private static int EmitMutationFailure(
+        TextWriter writer,
+        OperatorAttentionMutationInput input,
+        string readStatus,
+        string error)
+    {
+        var result = new OperatorAttentionMutationResult
+        {
+            Status = readStatus == OperatorAttentionReadStatus.CannotDetermine
+                ? OperatorAttentionQueryStatus.CannotDetermine
+                : "refused",
+            Mode = "refused",
+            Applied = false,
+            Operation = input.Operation.ToString().ToLowerInvariant(),
+            StorePath = OperatorAttentionStore.RelativePath,
+            Record = null,
+            Error = error,
+        };
+        EmitMutation(writer, input.Format, result);
+        return 1;
+    }
+
+    private static void EmitMutation(TextWriter writer, string format, OperatorAttentionMutationResult result)
+    {
+        if (format == FormatJson)
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        writer.WriteLine($"# operator-attention {result.Operation}");
+        writer.WriteLine();
+        writer.WriteLine($"- status: {result.Status}");
+        writer.WriteLine($"- mode: {result.Mode}");
+        writer.WriteLine($"- applied: {(result.Applied ? "true" : "false")}");
+        writer.WriteLine($"- store_path: `{result.StorePath}`");
+        if (result.Record is not null)
+        {
+            writer.WriteLine($"- record: `{result.Record.RecordId}` ({result.Record.Status})");
+        }
+        if (result.Error is not null)
+        {
+            writer.WriteLine($"- error: {result.Error}");
+        }
+    }
+
+    private static void EmitQuery(TextWriter writer, string format, OperatorAttentionQueryResult result)
+    {
+        if (format == FormatJson)
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine();
+            return;
+        }
+
+        writer.WriteLine("# operator-attention query");
+        writer.WriteLine();
+        writer.WriteLine($"- status: {result.Status}");
+        writer.WriteLine($"- domain: {result.Domain ?? "(all)"}");
+        writer.WriteLine($"- team: {result.Team ?? "(all)"}");
+        writer.WriteLine($"- open_count: {result.OpenCount}");
+        writer.WriteLine($"- store_path: `{result.StorePath}`");
+        foreach (var record in result.OpenRecords)
+        {
+            writer.WriteLine($"- `{record.RecordId}` ({record.AgeMinutes}m): {record.ActionNeeded} — owner `{record.Owner}`");
+        }
+        if (result.Error is not null)
+        {
+            writer.WriteLine($"- error: {result.Error}");
+        }
+    }
+
+    private static int EmitArgumentError(TextWriter writer, string error, string usage)
+    {
+        writer.WriteLine(error);
+        writer.WriteLine(usage);
+        return 1;
+    }
+
+    private static DateTimeOffset Now() =>
+        (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+
+    private static bool IsHelp(string[] args) =>
+        args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal);
+
+    private static bool TryParseMutationArguments(
+        string[] args,
+        OperatorAttentionOperation operation,
+        out OperatorAttentionMutationInput? input,
+        out string error)
+    {
+        input = null;
+        error = string.Empty;
+        string? recordId = null;
+        string? domain = null;
+        string? team = null;
+        string? owner = null;
+        string? blockingReference = null;
+        string? actionNeeded = null;
+        string? evidence = null;
+        string? resolutionEvidence = null;
+        string? supersedes = null;
+        var write = false;
+        var format = FormatMarkdown;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--record":
+                case "--record-id":
+                    if (!TryTakeValue(args, ref index, argument, out recordId, out error)) return false;
+                    break;
+                case "--domain":
+                    if (!TryTakeValue(args, ref index, argument, out domain, out error)) return false;
+                    break;
+                case "--team":
+                    if (!TryTakeValue(args, ref index, argument, out team, out error)) return false;
+                    break;
+                case "--owner":
+                    if (!TryTakeValue(args, ref index, argument, out owner, out error)) return false;
+                    break;
+                case "--blocking-reference":
+                    if (!TryTakeValue(args, ref index, argument, out blockingReference, out error)) return false;
+                    break;
+                case "--action-needed":
+                    if (!TryTakeValue(args, ref index, argument, out actionNeeded, out error)) return false;
+                    break;
+                case "--evidence":
+                    if (!TryTakeValue(args, ref index, argument, out evidence, out error)) return false;
+                    break;
+                case "--resolution-evidence":
+                    if (!TryTakeValue(args, ref index, argument, out resolutionEvidence, out error)) return false;
+                    break;
+                case "--supersedes":
+                    if (!TryTakeValue(args, ref index, argument, out supersedes, out error)) return false;
+                    break;
+                case "--write":
+                    write = true;
+                    break;
+                case "--dry-run":
+                    write = false;
+                    break;
+                case "--format":
+                    if (!TryTakeValue(args, ref index, argument, out var requestedFormat, out error)) return false;
+                    format = requestedFormat!;
+                    break;
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (!TryValidateIdentifier(recordId, "--record", out error)) return false;
+        if (!TryValidateFormat(format, out error)) return false;
+
+        if (operation == OperatorAttentionOperation.Open)
+        {
+            if (!TryValidateIdentifier(domain, "--domain", out error)
+                || !TryValidateIdentifier(team, "--team", out error)
+                || !RequireText(owner, "--owner", out error)
+                || !RequireText(blockingReference, "--blocking-reference", out error)
+                || !RequireText(actionNeeded, "--action-needed", out error)
+                || !RequireText(evidence, "--evidence", out error))
+            {
+                return false;
+            }
+            if (supersedes is not null && !TryValidateIdentifier(supersedes, "--supersedes", out error)) return false;
+        }
+        else if (operation == OperatorAttentionOperation.Resolve)
+        {
+            if (!RequireText(resolutionEvidence, "--resolution-evidence", out error)) return false;
+        }
+        else if (!RequireText(evidence, "--evidence", out error))
+        {
+            return false;
+        }
+
+        input = new OperatorAttentionMutationInput
+        {
+            Operation = operation,
+            RecordId = recordId,
+            Domain = domain,
+            Team = team,
+            Owner = owner?.Trim(),
+            BlockingReference = blockingReference?.Trim(),
+            ActionNeeded = actionNeeded?.Trim(),
+            Evidence = evidence?.Trim(),
+            ResolutionEvidence = resolutionEvidence?.Trim(),
+            SupersedesRecordId = supersedes,
+            Write = write,
+            Format = format,
+        };
+        return true;
+    }
+
+    private static bool TryParseQueryArguments(
+        string[] args,
+        out string? domain,
+        out string? team,
+        out string format,
+        out string error)
+    {
+        domain = null;
+        team = null;
+        format = FormatMarkdown;
+        error = string.Empty;
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            switch (argument)
+            {
+                case "--domain":
+                    if (!TryTakeValue(args, ref index, argument, out domain, out error)) return false;
+                    break;
+                case "--team":
+                    if (!TryTakeValue(args, ref index, argument, out team, out error)) return false;
+                    break;
+                case "--format":
+                    if (!TryTakeValue(args, ref index, argument, out var requestedFormat, out error)) return false;
+                    format = requestedFormat!;
+                    break;
+                default:
+                    error = $"Unknown argument '{argument}'.";
+                    return false;
+            }
+        }
+
+        if (domain is null && team is null)
+        {
+            error = "operator-attention query requires --domain, --team, or both; an unscoped host-wide answer is refused.";
+            return false;
+        }
+        if (domain is not null && !TryValidateIdentifier(domain, "--domain", out error)) return false;
+        if (team is not null && !TryValidateIdentifier(team, "--team", out error)) return false;
+        return TryValidateFormat(format, out error);
+    }
+
+    private static bool TryTakeValue(
+        string[] args,
+        ref int index,
+        string argument,
+        out string? value,
+        out string error)
+    {
+        value = null;
+        error = string.Empty;
+        if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+        {
+            error = $"{argument} requires a non-blank value.";
+            return false;
+        }
+        value = args[++index].Trim();
+        return true;
+    }
+
+    private static bool TryValidateIdentifier(string? value, string argument, out string error)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            error = $"{argument} is required.";
+            return false;
+        }
+        if (value.Length > 128 || value[0] == '.' || value.Contains("..", StringComparison.Ordinal)
+            || value.Any(character => !char.IsAsciiLetterOrDigit(character) && character is not ('-' or '_' or '.')))
+        {
+            error = $"{argument} '{value}' must be a canonical identifier using ASCII letters, digits, '-', '_' or '.', with no leading dot or '..'.";
+            return false;
+        }
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool RequireText(string? value, string argument, out string error)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            error = $"{argument} is required and must state actionable evidence or context.";
+            return false;
+        }
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool TryValidateFormat(string format, out string error)
+    {
+        if (format is FormatJson or FormatMarkdown)
+        {
+            error = string.Empty;
+            return true;
+        }
+        error = $"--format must be 'json' or 'markdown' (got '{format}').";
+        return false;
+    }
+
+    private const string OpenUsage =
+        "Usage: intent-cli operator-attention open --record <id> --domain <d> --team <t> --owner <owner> --blocking-reference <ref> --action-needed <text> --evidence <text> [--supersedes <record>] [--dry-run|--write] [--format json|markdown]";
+    private const string ResolveUsage =
+        "Usage: intent-cli operator-attention resolve --record <id> --resolution-evidence <text> [--dry-run|--write] [--format json|markdown]";
+    private const string SupersedeUsage =
+        "Usage: intent-cli operator-attention supersede --record <id> --evidence <text> [--dry-run|--write] [--format json|markdown]";
+    private const string QueryUsage =
+        "Usage: intent-cli operator-attention query [--domain <d>] [--team <t>] [--format json|markdown]";
+
+    private enum OperatorAttentionOperation
+    {
+        Open,
+        Resolve,
+        Supersede,
+    }
+
+    private sealed record OperatorAttentionMutationInput
+    {
+        public required OperatorAttentionOperation Operation { get; init; }
+        public required string? RecordId { get; init; }
+        public required string? Domain { get; init; }
+        public required string? Team { get; init; }
+        public required string? Owner { get; init; }
+        public required string? BlockingReference { get; init; }
+        public required string? ActionNeeded { get; init; }
+        public required string? Evidence { get; init; }
+        public required string? ResolutionEvidence { get; init; }
+        public required string? SupersedesRecordId { get; init; }
+        public required bool Write { get; init; }
+        public required string Format { get; init; }
+    }
+}
+
+internal static class OperatorAttentionStore
+{
+    public const string RelativePath = $".intent-cli/{CliRuntimeContracts.OperatorAttentionFileName}";
+    public const string ArtifactKind = "operator-attention-store";
+    public const string SchemaVersion = "1";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow,
+    };
+
+    public static OperatorAttentionReadResult Read(string repoRoot)
+    {
+        var path = ResolvePath(repoRoot);
+        if (!File.Exists(path))
+        {
+            return new OperatorAttentionReadResult
+            {
+                Status = OperatorAttentionReadStatus.Missing,
+                Document = null,
+                Error = $"`{RelativePath}` is absent; the operator-attention check has not been completed for this host.",
+            };
+        }
+
+        try
+        {
+            var document = JsonSerializer.Deserialize<OperatorAttentionStoreDocument>(File.ReadAllText(path), JsonOptions)
+                ?? throw new InvalidOperationException("store payload is JSON null.");
+            Validate(document);
+            return new OperatorAttentionReadResult
+            {
+                Status = OperatorAttentionReadStatus.Readable,
+                Document = document,
+                Error = null,
+            };
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException or InvalidOperationException)
+        {
+            return new OperatorAttentionReadResult
+            {
+                Status = OperatorAttentionReadStatus.CannotDetermine,
+                Document = null,
+                Error = $"`{RelativePath}` cannot be read as authoritative operator-attention state: {exception.Message}",
+            };
+        }
+    }
+
+    public static OperatorAttentionStoreDocument BuildUpdated(
+        OperatorAttentionStoreDocument? existing,
+        IReadOnlyList<OperatorAttentionRecord> records,
+        DateTimeOffset updatedAt) => new()
+        {
+            ArtifactKind = ArtifactKind,
+            SchemaVersion = existing?.SchemaVersion ?? SchemaVersion,
+            UpdatedAt = updatedAt.ToUniversalTime(),
+            Records = records,
+        };
+
+    public static void Write(string repoRoot, OperatorAttentionStoreDocument document)
+    {
+        Validate(document);
+        AtomicFileWriter.WriteAllText(
+            ResolvePath(repoRoot),
+            JsonSerializer.Serialize(document, JsonOptions) + Environment.NewLine);
+    }
+
+    public static string ResolvePath(string repoRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        return CliRuntimeContracts.GetOperatorAttentionPath(repoRoot);
+    }
+
+    private static void Validate(OperatorAttentionStoreDocument document)
+    {
+        if (!string.Equals(document.ArtifactKind, ArtifactKind, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"artifact_kind must be '{ArtifactKind}'.");
+        }
+        if (!string.Equals(document.SchemaVersion, SchemaVersion, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"schema_version must be '{SchemaVersion}'.");
+        }
+        if (document.Records is null)
+        {
+            throw new InvalidOperationException("records must be an array.");
+        }
+
+        var recordsById = new Dictionary<string, OperatorAttentionRecord>(StringComparer.Ordinal);
+        foreach (var record in document.Records)
+        {
+            ValidateRecord(record);
+            if (!recordsById.TryAdd(record.RecordId, record))
+            {
+                throw new InvalidOperationException($"record_id '{record.RecordId}' appears more than once.");
+            }
+        }
+
+        foreach (var record in document.Records.Where(record => record.SupersedesRecordId is not null))
+        {
+            if (!recordsById.TryGetValue(record.SupersedesRecordId!, out var superseded))
+            {
+                throw new InvalidOperationException($"record '{record.RecordId}' supersedes missing record '{record.SupersedesRecordId}'.");
+            }
+            if (!string.Equals(superseded.Status, OperatorAttentionStatus.Superseded, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"record '{record.RecordId}' references '{superseded.RecordId}', which is not superseded.");
+            }
+            if (!string.Equals(record.Domain, superseded.Domain, StringComparison.Ordinal)
+                || !string.Equals(record.Team, superseded.Team, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"record '{record.RecordId}' and superseded record '{superseded.RecordId}' must share domain and team.");
+            }
+        }
+    }
+
+    private static void ValidateRecord(OperatorAttentionRecord record)
+    {
+        Require(record.RecordId, "record_id");
+        Require(record.Domain, $"record '{record.RecordId}' domain");
+        Require(record.Team, $"record '{record.RecordId}' team");
+        Require(record.Owner, $"record '{record.RecordId}' owner");
+        Require(record.BlockingReference, $"record '{record.RecordId}' blocking_reference");
+        Require(record.ActionNeeded, $"record '{record.RecordId}' action_needed");
+        Require(record.EstablishingEvidence, $"record '{record.RecordId}' establishing_evidence");
+        if (!OperatorAttentionStatus.All.Contains(record.Status, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException($"record '{record.RecordId}' has unknown status '{record.Status}'; only open, resolved, superseded are valid.");
+        }
+        if (record.Transitions is null || record.Transitions.Count == 0)
+        {
+            throw new InvalidOperationException($"record '{record.RecordId}' must carry transition timestamps.");
+        }
+
+        var first = record.Transitions[0];
+        if (first.FromStatus is not null
+            || !string.Equals(first.ToStatus, OperatorAttentionStatus.Open, StringComparison.Ordinal)
+            || first.TransitionedAt != record.OpenedAt
+            || !string.Equals(first.Evidence, record.EstablishingEvidence, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"record '{record.RecordId}' must begin with one establishing transition to open at opened_at.");
+        }
+
+        for (var index = 0; index < record.Transitions.Count; index++)
+        {
+            var transition = record.Transitions[index];
+            Require(transition.ToStatus, $"record '{record.RecordId}' transition to_status");
+            Require(transition.Evidence, $"record '{record.RecordId}' transition evidence");
+            if (!OperatorAttentionStatus.All.Contains(transition.ToStatus, StringComparer.Ordinal)
+                || (transition.FromStatus is not null && !OperatorAttentionStatus.All.Contains(transition.FromStatus, StringComparer.Ordinal)))
+            {
+                throw new InvalidOperationException($"record '{record.RecordId}' transition contains a status outside open/resolved/superseded.");
+            }
+            if (index > 0 && transition.TransitionedAt < record.Transitions[index - 1].TransitionedAt)
+            {
+                throw new InvalidOperationException($"record '{record.RecordId}' transition timestamps move backwards.");
+            }
+        }
+
+        if (!string.Equals(record.Transitions[^1].ToStatus, record.Status, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"record '{record.RecordId}' status does not match its last transition.");
+        }
+
+        if (record.Status == OperatorAttentionStatus.Open)
+        {
+            if (record.Transitions.Count != 1 || record.ResolutionEvidence is not null)
+            {
+                throw new InvalidOperationException($"open record '{record.RecordId}' cannot carry a terminal transition or resolution evidence.");
+            }
+            return;
+        }
+
+        if (record.Transitions.Count != 2
+            || !string.Equals(record.Transitions[1].FromStatus, OperatorAttentionStatus.Open, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException($"terminal record '{record.RecordId}' must have exactly one open-to-terminal transition.");
+        }
+        if (record.Status == OperatorAttentionStatus.Resolved)
+        {
+            Require(record.ResolutionEvidence, $"resolved record '{record.RecordId}' resolution_evidence");
+            if (!string.Equals(record.ResolutionEvidence, record.Transitions[1].Evidence, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"resolved record '{record.RecordId}' has inconsistent resolution evidence.");
+            }
+        }
+        else if (record.ResolutionEvidence is not null)
+        {
+            throw new InvalidOperationException($"superseded record '{record.RecordId}' is not resolved and cannot carry resolution_evidence.");
+        }
+    }
+
+    private static void Require(string? value, string field)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"{field} must not be blank.");
+        }
+    }
+}
+
+internal static class OperatorAttentionStatus
+{
+    public const string Open = "open";
+    public const string Resolved = "resolved";
+    public const string Superseded = "superseded";
+    public static readonly IReadOnlyList<string> All = [Open, Resolved, Superseded];
+}
+
+internal static class OperatorAttentionReadStatus
+{
+    public const string Readable = "readable";
+    public const string Missing = "check-not-completed";
+    public const string CannotDetermine = "cannot-determine";
+}
+
+internal static class OperatorAttentionQueryStatus
+{
+    public const string AttentionPending = "attention-pending";
+    public const string NoAttentionPending = "no-attention-pending";
+    public const string CheckNotCompleted = "check-not-completed";
+    public const string CannotDetermine = "cannot-determine";
+}
+
+internal sealed record OperatorAttentionStoreDocument
+{
+    [JsonPropertyName("artifact_kind")]
+    public required string ArtifactKind { get; init; }
+    [JsonPropertyName("schema_version")]
+    public required string SchemaVersion { get; init; }
+    [JsonPropertyName("updated_at")]
+    public required DateTimeOffset UpdatedAt { get; init; }
+    [JsonPropertyName("records")]
+    public required IReadOnlyList<OperatorAttentionRecord> Records { get; init; }
+}
+
+internal sealed record OperatorAttentionRecord
+{
+    [JsonPropertyName("record_id")]
+    public required string RecordId { get; init; }
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+    [JsonPropertyName("team")]
+    public required string Team { get; init; }
+    [JsonPropertyName("owner")]
+    public required string Owner { get; init; }
+    [JsonPropertyName("blocking_reference")]
+    public required string BlockingReference { get; init; }
+    [JsonPropertyName("action_needed")]
+    public required string ActionNeeded { get; init; }
+    [JsonPropertyName("establishing_evidence")]
+    public required string EstablishingEvidence { get; init; }
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+    [JsonPropertyName("opened_at")]
+    public required DateTimeOffset OpenedAt { get; init; }
+    [JsonPropertyName("resolution_evidence")]
+    public required string? ResolutionEvidence { get; init; }
+    [JsonPropertyName("supersedes_record_id")]
+    public required string? SupersedesRecordId { get; init; }
+    [JsonPropertyName("transitions")]
+    public required IReadOnlyList<OperatorAttentionTransition> Transitions { get; init; }
+}
+
+internal sealed record OperatorAttentionTransition
+{
+    [JsonPropertyName("from_status")]
+    public required string? FromStatus { get; init; }
+    [JsonPropertyName("to_status")]
+    public required string ToStatus { get; init; }
+    [JsonPropertyName("transitioned_at")]
+    public required DateTimeOffset TransitionedAt { get; init; }
+    [JsonPropertyName("evidence")]
+    public required string Evidence { get; init; }
+}
+
+internal sealed record OperatorAttentionReadResult
+{
+    public required string Status { get; init; }
+    public required OperatorAttentionStoreDocument? Document { get; init; }
+    public required string? Error { get; init; }
+}
+
+internal sealed record OperatorAttentionQueryRecord
+{
+    [JsonPropertyName("record_id")]
+    public required string RecordId { get; init; }
+    [JsonPropertyName("domain")]
+    public required string Domain { get; init; }
+    [JsonPropertyName("team")]
+    public required string Team { get; init; }
+    [JsonPropertyName("owner")]
+    public required string Owner { get; init; }
+    [JsonPropertyName("blocking_reference")]
+    public required string BlockingReference { get; init; }
+    [JsonPropertyName("action_needed")]
+    public required string ActionNeeded { get; init; }
+    [JsonPropertyName("establishing_evidence")]
+    public required string EstablishingEvidence { get; init; }
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+    [JsonPropertyName("opened_at")]
+    public required DateTimeOffset OpenedAt { get; init; }
+    [JsonPropertyName("age_minutes")]
+    public required int AgeMinutes { get; init; }
+    [JsonPropertyName("resolution_evidence")]
+    public required string? ResolutionEvidence { get; init; }
+    [JsonPropertyName("supersedes_record_id")]
+    public required string? SupersedesRecordId { get; init; }
+    [JsonPropertyName("transitions")]
+    public required IReadOnlyList<OperatorAttentionTransition> Transitions { get; init; }
+
+    public static OperatorAttentionQueryRecord From(OperatorAttentionRecord record, DateTimeOffset now) => new()
+    {
+        RecordId = record.RecordId,
+        Domain = record.Domain,
+        Team = record.Team,
+        Owner = record.Owner,
+        BlockingReference = record.BlockingReference,
+        ActionNeeded = record.ActionNeeded,
+        EstablishingEvidence = record.EstablishingEvidence,
+        Status = record.Status,
+        OpenedAt = record.OpenedAt,
+        AgeMinutes = Math.Max(0, (int)Math.Floor((now - record.OpenedAt).TotalMinutes)),
+        ResolutionEvidence = record.ResolutionEvidence,
+        SupersedesRecordId = record.SupersedesRecordId,
+        Transitions = record.Transitions,
+    };
+}
+
+internal sealed record OperatorAttentionMutationResult
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+    [JsonPropertyName("mode")]
+    public required string Mode { get; init; }
+    [JsonPropertyName("applied")]
+    public required bool Applied { get; init; }
+    [JsonPropertyName("operation")]
+    public required string Operation { get; init; }
+    [JsonPropertyName("store_path")]
+    public required string StorePath { get; init; }
+    [JsonPropertyName("record")]
+    public required OperatorAttentionQueryRecord? Record { get; init; }
+    [JsonPropertyName("error")]
+    public required string? Error { get; init; }
+}
+
+internal sealed record OperatorAttentionQueryResult
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+    [JsonPropertyName("domain")]
+    public required string? Domain { get; init; }
+    [JsonPropertyName("team")]
+    public required string? Team { get; init; }
+    [JsonPropertyName("checked_at")]
+    public required DateTimeOffset CheckedAt { get; init; }
+    [JsonPropertyName("store_path")]
+    public required string StorePath { get; init; }
+    [JsonPropertyName("open_count")]
+    public required int OpenCount { get; init; }
+    [JsonPropertyName("open_records")]
+    public required IReadOnlyList<OperatorAttentionQueryRecord> OpenRecords { get; init; }
+    [JsonPropertyName("records")]
+    public required IReadOnlyList<OperatorAttentionQueryRecord> Records { get; init; }
+    [JsonPropertyName("error")]
+    public required string? Error { get; init; }
+}

--- a/tests/IntentSystem.Cli.Tests/OperatorAttentionG596Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/OperatorAttentionG596Tests.cs
@@ -1,0 +1,345 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>G596 lifecycle, no-inference, routing, and fail-closed contract.</summary>
+[Collection(AutomationStalledWorkSharedStateCollection.Name)]
+public sealed class OperatorAttentionG596Tests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 3, 18, 0, 0, TimeSpan.Zero);
+    private readonly Workspace workspace = new();
+
+    public OperatorAttentionG596Tests()
+    {
+        OperatorAttentionCommand.UtcNowFactory = () => FixedNow;
+        AutomationStalledWorkCommand.UtcNowFactory = () => FixedNow;
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new EmptyLister();
+    }
+
+    public void Dispose()
+    {
+        OperatorAttentionCommand.UtcNowFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = null;
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        workspace.Dispose();
+    }
+
+    [Fact]
+    public void Query_AbsentStore_IsCheckNotCompletedAndNeverGreen_G596()
+    {
+        var (exitCode, result) = workspace.Run(
+            "operator-attention", "query", "--domain", "intent-cli", "--format", "json");
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("check-not-completed", result.GetProperty("status").GetString());
+        Assert.Equal(0, result.GetProperty("open_count").GetInt32());
+        Assert.Contains("has not been completed", result.GetProperty("error").GetString(), StringComparison.Ordinal);
+        Assert.False(File.Exists(workspace.StorePath));
+    }
+
+    [Fact]
+    public void Open_QueryByDomainAndTeam_CarriesActionableFieldsTransitionsAndAge_G596()
+    {
+        OperatorAttentionCommand.UtcNowFactory = () => FixedNow.AddMinutes(-75);
+        var (openExit, openResult) = workspace.Open("release-091", write: true);
+        Assert.Equal(0, openExit);
+        Assert.True(openResult.GetProperty("applied").GetBoolean());
+
+        OperatorAttentionCommand.UtcNowFactory = () => FixedNow;
+        var (domainExit, domainResult) = workspace.Run(
+            "operator-attention", "query", "--domain", "intent-cli", "--format", "json");
+        var (teamExit, teamResult) = workspace.Run(
+            "operator-attention", "query", "--team", "intent-cli-dev", "--format", "json");
+
+        Assert.Equal(0, domainExit);
+        Assert.Equal(0, teamExit);
+        foreach (var result in new[] { domainResult, teamResult })
+        {
+            Assert.Equal("attention-pending", result.GetProperty("status").GetString());
+            var record = Assert.Single(result.GetProperty("open_records").EnumerateArray());
+            Assert.Equal("release-091", record.GetProperty("record_id").GetString());
+            Assert.Equal("release-operator", record.GetProperty("owner").GetString());
+            Assert.Equal("release:v0.9.1", record.GetProperty("blocking_reference").GetString());
+            Assert.Equal("Approve and publish v0.9.1", record.GetProperty("action_needed").GetString());
+            Assert.Equal("release candidate checks are green", record.GetProperty("establishing_evidence").GetString());
+            Assert.Equal(75, record.GetProperty("age_minutes").GetInt32());
+            var transition = Assert.Single(record.GetProperty("transitions").EnumerateArray());
+            Assert.Equal(JsonValueKind.Null, transition.GetProperty("from_status").ValueKind);
+            Assert.Equal("open", transition.GetProperty("to_status").GetString());
+            Assert.Equal(FixedNow.AddMinutes(-75), transition.GetProperty("transitioned_at").GetDateTimeOffset());
+        }
+    }
+
+    [Fact]
+    public void Query_DomainAndTeamScopesAreIndependentAndIntersectionIsExact_G596()
+    {
+        Assert.Equal(0, workspace.OpenScoped("intent-main", "intent-cli", "intent-cli-dev").ExitCode);
+        Assert.Equal(0, workspace.OpenScoped("intent-other-team", "intent-cli", "release-team").ExitCode);
+        Assert.Equal(0, workspace.OpenScoped("other-same-team", "sekiban", "intent-cli-dev").ExitCode);
+
+        var domain = workspace.Run(
+            "operator-attention", "query", "--domain", "intent-cli", "--format", "json").Result;
+        var team = workspace.Run(
+            "operator-attention", "query", "--team", "intent-cli-dev", "--format", "json").Result;
+        var intersection = workspace.Run(
+            "operator-attention", "query", "--domain", "intent-cli", "--team", "intent-cli-dev", "--format", "json").Result;
+
+        Assert.Equal(
+            ["intent-main", "intent-other-team"],
+            domain.GetProperty("open_records").EnumerateArray().Select(record => record.GetProperty("record_id").GetString()));
+        Assert.Equal(
+            ["intent-main", "other-same-team"],
+            team.GetProperty("open_records").EnumerateArray().Select(record => record.GetProperty("record_id").GetString()));
+        Assert.Equal(
+            "intent-main",
+            Assert.Single(intersection.GetProperty("open_records").EnumerateArray()).GetProperty("record_id").GetString());
+    }
+
+    [Fact]
+    public void Resolve_RequiresResolutionEvidenceAndRecordsTerminalTimestamp_G596()
+    {
+        Assert.Equal(0, workspace.Open("release-091", write: true).ExitCode);
+        OperatorAttentionCommand.UtcNowFactory = () => FixedNow.AddMinutes(10);
+
+        var (exitCode, result) = workspace.Run(
+            "operator-attention", "resolve", "--record", "release-091",
+            "--resolution-evidence", "operator approved release in signed change record", "--write", "--format", "json");
+
+        Assert.Equal(0, exitCode);
+        var record = result.GetProperty("record");
+        Assert.Equal("resolved", record.GetProperty("status").GetString());
+        Assert.Equal("operator approved release in signed change record", record.GetProperty("resolution_evidence").GetString());
+        Assert.Equal(2, record.GetProperty("transitions").GetArrayLength());
+        Assert.Equal(FixedNow.AddMinutes(10), record.GetProperty("transitions")[1].GetProperty("transitioned_at").GetDateTimeOffset());
+
+        var query = workspace.Run("operator-attention", "query", "--domain", "intent-cli", "--format", "json").Result;
+        Assert.Equal("no-attention-pending", query.GetProperty("status").GetString());
+        Assert.Equal(0, query.GetProperty("open_count").GetInt32());
+        Assert.Equal("resolved", Assert.Single(query.GetProperty("records").EnumerateArray()).GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void SupersedeThenReopen_CreatesNewReferencingRecordWithoutMutatingOld_G596()
+    {
+        Assert.Equal(0, workspace.Open("release-091-old", write: true).ExitCode);
+        OperatorAttentionCommand.UtcNowFactory = () => FixedNow.AddMinutes(5);
+        Assert.Equal(0, workspace.Run(
+            "operator-attention", "supersede", "--record", "release-091-old",
+            "--evidence", "approval scope changed", "--write", "--format", "json").ExitCode);
+
+        OperatorAttentionCommand.UtcNowFactory = () => FixedNow.AddMinutes(6);
+        var (exitCode, result) = workspace.Open("release-091-new", write: true, supersedes: "release-091-old");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("release-091-old", result.GetProperty("record").GetProperty("supersedes_record_id").GetString());
+        var query = workspace.Run(
+            "operator-attention", "query", "--domain", "intent-cli", "--team", "intent-cli-dev", "--format", "json").Result;
+        var records = query.GetProperty("records").EnumerateArray().ToDictionary(
+            record => record.GetProperty("record_id").GetString()!, record => record.Clone(), StringComparer.Ordinal);
+        Assert.Equal("superseded", records["release-091-old"].GetProperty("status").GetString());
+        Assert.Equal(JsonValueKind.Null, records["release-091-old"].GetProperty("resolution_evidence").ValueKind);
+        Assert.Equal(2, records["release-091-old"].GetProperty("transitions").GetArrayLength());
+        Assert.Equal("open", records["release-091-new"].GetProperty("status").GetString());
+        Assert.Single(query.GetProperty("open_records").EnumerateArray());
+    }
+
+    [Fact]
+    public void NotifyEscalationAlone_AppendsEventButLeavesAttentionStoreAbsent_G596()
+    {
+        workspace.RecordAgmsgMode();
+        var before = File.Exists(workspace.StorePath) ? File.ReadAllText(workspace.StorePath) : null;
+
+        var (exitCode, result) = workspace.Run(
+            "notify", "escalate", "--domain", "intent-cli", "--team", "intent-cli-dev",
+            "--from", "orchestration", "--task-id", "G596-inference-guard",
+            "--artifact", "https://example.test/blocker", "--summary", "operator approval required",
+            "--write", "--format", "json");
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("event_appended").GetBoolean());
+        Assert.True(File.Exists(Path.Combine(workspace.RootPath, ".intent-cli", "events", "intent-cli-dev.jsonl")));
+        Assert.Equal(before, File.Exists(workspace.StorePath) ? File.ReadAllText(workspace.StorePath) : null);
+        Assert.False(File.Exists(workspace.StorePath));
+    }
+
+    [Fact]
+    public void IdlePipelineWithOpenRecord_RoutesHeartbeatToOperatorNotOrchestrator_G596()
+    {
+        OperatorAttentionCommand.UtcNowFactory = () => FixedNow.AddMinutes(-1);
+        Assert.Equal(0, workspace.Open("release-approval", write: true).ExitCode);
+
+        var stalled = AutomationStalledWorkCommand.Analyze(
+            workspace.Context, "intent-cli", "J-Tech-Japan/intent-system", staleMinutes: 45);
+        var item = Assert.Single(stalled.Items);
+        Assert.Equal("operator-attention-pending", item.Kind);
+        Assert.Equal("release-approval", item.OperatorAttentionRecordId);
+        Assert.Equal("operator", item.RequiredActor);
+        Assert.False(item.OrchestratorActionable);
+        Assert.True(stalled.Stalled);
+
+        var (heartbeatExit, heartbeat) = workspace.Run(
+            "automation", "heartbeat", "--domain", "intent-cli",
+            "--repo", "J-Tech-Japan/intent-system", "--format", "json");
+        Assert.Equal(0, heartbeatExit);
+        Assert.Equal("operator", heartbeat.GetProperty("route_to").GetString());
+        var message = heartbeat.GetProperty("message_body").GetString()!;
+        Assert.Contains("ROUTE TO OPERATOR", message, StringComparison.Ordinal);
+        Assert.Contains("orchestrator_actionable=false", message, StringComparison.Ordinal);
+        Assert.Contains("release-approval", message, StringComparison.Ordinal);
+        Assert.DoesNotContain("1 orchestrator-actionable", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MalformedStore_IsCannotDetermineInQueryStalledWorkAndHeartbeat_G596()
+    {
+        File.WriteAllText(workspace.StorePath, "{ not-json");
+
+        var (queryExit, query) = workspace.Run(
+            "operator-attention", "query", "--domain", "intent-cli", "--format", "json");
+        Assert.Equal(1, queryExit);
+        Assert.Equal("cannot-determine", query.GetProperty("status").GetString());
+
+        var stalled = AutomationStalledWorkCommand.Analyze(
+            workspace.Context, "intent-cli", "J-Tech-Japan/intent-system", staleMinutes: 45);
+        var item = Assert.Single(stalled.Items);
+        Assert.Equal("operator-attention-cannot-determine", item.Kind);
+        Assert.Equal("operator", item.RequiredActor);
+        Assert.False(item.OrchestratorActionable);
+        Assert.Equal("cannot-determine", stalled.OperatorAttentionStatus);
+
+        var (_, heartbeat) = workspace.Run(
+            "automation", "heartbeat", "--domain", "intent-cli",
+            "--repo", "J-Tech-Japan/intent-system", "--format", "json");
+        Assert.True(heartbeat.GetProperty("stale").GetBoolean());
+        Assert.Equal("operator", heartbeat.GetProperty("route_to").GetString());
+        Assert.Equal("cannot-determine", heartbeat.GetProperty("operator_attention_status").GetString());
+    }
+
+    [Fact]
+    public void AtomicWriterInterruption_PreservesPriorParseableLifecycleAndCleansTemp_G596()
+    {
+        Assert.Equal(0, workspace.Open("release-091", write: true).ExitCode);
+        var before = File.ReadAllText(workspace.StorePath);
+        using var hook = AtomicFileWriter.RegisterBeforeMoveHook(
+            workspace.StorePath,
+            _ => throw new IOException("controlled interruption"));
+
+        Assert.Throws<IOException>(() => workspace.Run(
+            "operator-attention", "resolve", "--record", "release-091",
+            "--resolution-evidence", "not published", "--write", "--format", "json"));
+
+        Assert.Equal(before, File.ReadAllText(workspace.StorePath));
+        using var document = JsonDocument.Parse(File.ReadAllText(workspace.StorePath));
+        Assert.Equal("open", document.RootElement.GetProperty("records")[0].GetProperty("status").GetString());
+        Assert.Empty(Directory.GetFiles(Path.GetDirectoryName(workspace.StorePath)!, ".operator-attention.json.*.tmp"));
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperReference_DocumentsExplicitLifecycleAndNoInference_G596(string language)
+    {
+        var content = File.ReadAllText(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
+
+        Assert.Contains("operator-attention open", content, StringComparison.Ordinal);
+        Assert.Contains("operator-attention resolve", content, StringComparison.Ordinal);
+        Assert.Contains("operator-attention supersede", content, StringComparison.Ordinal);
+        Assert.Contains("operator-attention query", content, StringComparison.Ordinal);
+        Assert.Contains("operator-attention-pending", content, StringComparison.Ordinal);
+        Assert.Contains("cannot-determine", content, StringComparison.Ordinal);
+        Assert.Contains("events.jsonl", content, StringComparison.Ordinal);
+    }
+
+    private sealed class EmptyLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo, IReadOnlyCollection<string> requiredLabels) => Array.Empty<GitHubAutomationPrCandidate>();
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo, IReadOnlyCollection<string> requiredLabels) => Array.Empty<GitHubAutomationIssueCandidate>();
+    }
+
+    private sealed class Workspace : IDisposable
+    {
+        public Workspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("operator-attention-g596-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+        public string StorePath => Path.Combine(RootPath, ".intent-cli", "operator-attention.json");
+
+        public (int ExitCode, JsonElement Result) Open(string record, bool write, string? supersedes = null)
+        {
+            var args = new List<string>
+            {
+                "operator-attention", "open", "--record", record,
+                "--domain", "intent-cli", "--team", "intent-cli-dev",
+                "--owner", "release-operator", "--blocking-reference", "release:v0.9.1",
+                "--action-needed", "Approve and publish v0.9.1",
+                "--evidence", "release candidate checks are green",
+            };
+            if (supersedes is not null)
+            {
+                args.AddRange(["--supersedes", supersedes]);
+            }
+            args.Add(write ? "--write" : "--dry-run");
+            args.AddRange(["--format", "json"]);
+            return Run(args.ToArray());
+        }
+
+        public (int ExitCode, JsonElement Result) OpenScoped(string record, string domain, string team)
+        {
+            return Run(
+                "operator-attention", "open", "--record", record,
+                "--domain", domain, "--team", team, "--owner", "operator",
+                "--blocking-reference", $"unit:{record}", "--action-needed", $"Decide {record}",
+                "--evidence", $"Evidence for {record}", "--write", "--format", "json");
+        }
+
+        public void RecordAgmsgMode()
+        {
+            using var writer = new StringWriter();
+            var exitCode = SessionLayerCommand.ExecuteSet(
+                Context,
+                ["--domain", "intent-cli", "--team", "intent-cli-dev", "--mode", "agmsg", "--write", "--format", "json"],
+                writer);
+            Assert.True(exitCode == 0, writer.ToString());
+        }
+
+        public (int ExitCode, JsonElement Result) Run(params string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = CommandRouter.Execute(args, Context, writer);
+            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add explicit `operator-attention open|resolve|supersede|query` commands backed by strict durable state and the shared flush-to-disk atomic writer
- keep lifecycle writes command-only; `notify escalate` and its event stream never create or transition attention state
- surface open or unreadable operator-attention state through existing stalled-work and heartbeat output with operator routing, plus EN/JA guidance

## Contract evidence

- lifecycle is exactly `open`, `resolved`, `superseded`; every record carries owner, blocking reference, actionable request, establishing evidence, transition timestamps, and resolution evidence where resolved
- reopening creates a new record with `supersedes_record_id`; terminal records are never reopened or overwritten
- query supports domain-only, team-only, and intersected scope with age; absent scope is `check-not-completed`, malformed state is `cannot-determine`
- an idle pipeline with one open record emits `operator-attention-pending`, `required_actor=operator`, `orchestrator_actionable=false`, and heartbeat `route_to=operator`
- controlled notify escalation proof appends one escalation event while `.intent-cli/operator-attention.json` remains absent
- controlled atomic interruption proof preserves the prior parseable lifecycle and removes the temp sibling

## Verification

- focused lifecycle/inference/routing/fail-closed plus affected stalled-work/heartbeat/notify/writer matrix: 148 passed, 0 failed
- full Release solution: 4,695 passed, 1 existing skipped, 0 failed
- Release build: 0 warnings, 0 errors
- changed-file formatter verification: clean
- `git diff --check`: clean
- local verified head: `b1877d4`

Closes #1295