### PR TITLE
G597: add scheduler-agnostic heartbeat decisions

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1462,9 +1462,11 @@ something must still notice a stall the message-driven path itself cannot
 self-report. The **RECOMMENDED DEFAULT** safety net (G539, superseding G526's
 external-scheduler recommendation) is a watchdog loop run from the **design**
 thread at a **30-minute-class** interval: it calls `intent-cli automation
-heartbeat` and, when `stale=true`, sends **at most one** canonical nudge to
-the orchestrator using the returned `message_body` — completely silent
-otherwise. It runs **inside** a live, human-monitored agent session rather
+heartbeat` as the one scheduler-agnostic decision surface. Each valid result
+has exactly one verdict: `healthy-active-wait`, `actionable-stall`,
+`operator-required`, or `cannot-determine`. The external loop owns cadence,
+watermark, and dedupe persistence; intent-cli never schedules, sleeps, sends,
+or persists poll state. It runs **inside** a live, human-monitored agent session rather
 than an invisible external process, needs no separate credential/keychain
 setup (it authenticates the same way the rest of the session does), and is
 visible on the operator's screen the moment it breaks.
@@ -1476,21 +1478,23 @@ visible on the operator's screen the moment it breaks.
 - **Loop setup prompt** (paste into the design thread) — run `/loop 30m`
   (Claude same-thread) or a Codex automation firing every 30 minutes, with a
   prompt that on each wake runs
-  `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --format json`;
-  when the result's `stale` field is `true`, send its `message_body` to the
-  orchestrator with exactly **one** `intent-cli notify report` call (`--from
-  design --to orchestrator --status question`, a fresh heartbeat task id, and
-  the heartbeat evidence artifact);
-  when `stale` is `false`, send nothing and exit quietly — silence is
-  reserved for this healthy case **only**. A heartbeat command execution
+  `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --team <team> --format json`.
+  Key external dedupe on the returned `dedupe_key` (the stable dedupe key), never age or poll time.
+  For `healthy-active-wait`, send nothing: the result names the awaited
+  condition, observable end signal, and finite bound; re-evaluate when the
+  signal occurs or the bound expires. For `actionable-stall`, run the returned
+  canonical `intent-cli notify` command at most once for that key. For
+  `operator-required`, surface the named record and action to the operator,
+  never nudge orchestration. For `cannot-determine`, visibly repair or escalate
+  the named monitor/routing failure; it is never a healthy/silent result. A heartbeat command execution
   failure or malformed/non-object output is **never** silent: state the
   failure explicitly in this wake's own turn output, visible to the operator
   watching this live session — the exact advantage an in-session watchdog
   has over the retired invisible external scheduler (see Retired below) —
   while still never fabricating or sending a notify nudge from broken input;
   only a genuine `stale=true` result ever produces a sent message.
-- **Failure visibility** — silence is reserved for a healthy `stale=false`
-  heartbeat result ONLY. A heartbeat command execution failure or
+- **Failure visibility** — silence is reserved for `healthy-active-wait`
+  ONLY. A heartbeat command execution failure or
   malformed/non-object output must be surfaced **visibly** in the watchdog's
   own turn output this wake — never silently swallowed or silently retried,
   since silent failure is exactly the defect this slice retires the external
@@ -1502,12 +1506,14 @@ visible on the operator's screen the moment it breaks.
   intent-cli/GitHub facts (`worker next-action --github-only`, open PR/CI/
   label state) compared against the last known orchestrator activity; and,
   as the RECOMMENDED primary check, `intent-cli automation heartbeat`
-  itself — it wraps `automation stalled-work` (G523) and returns a
-  ready-to-send `message_body` naming every stale item and its canonical
-  next command.
-- **Action** — when staleness, an unanswered HITL message, or a heartbeat
-  `stale=true` result is detected, send **at most one** canonical
-  repair/status request or heartbeat nudge to the orchestrator:
+  itself — it wraps `automation stalled-work` (G523), operator-attention,
+  and recorded topology into one verdict, evidence/age basis, stable dedupe
+  key, owner, and canonical notify command.
+- **Action** — act only on that one verdict: wait for the named signal within
+  its bound, run at most one returned canonical notify command for an
+  `actionable-stall` key, route `operator-required` to a human, and visibly
+  repair/escalate `cannot-determine`. Do not infer an action from any other
+  field or send a hand-written transport request.
 
   ```json
   {"type":"status-request","to":"orchestrator","from":"design-watchdog","ask":"non-destructive liveness check: reply with current state and next action, or confirm idle"}

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1492,15 +1492,17 @@ visible on the operator's screen the moment it breaks.
   watching this live session — the exact advantage an in-session watchdog
   has over the retired invisible external scheduler (see Retired below) —
   while still never fabricating or sending a notify nudge from broken input;
-  only a genuine `stale=true` result ever produces a sent message.
+  only an `actionable-stall` verdict with its returned canonical notify command
+  ever produces a sent nudge. Do not use `stale` or `message_body` to infer the
+  action; the closed verdict is the sole decision trigger.
 - **Failure visibility** — silence is reserved for `healthy-active-wait`
   ONLY. A heartbeat command execution failure or
   malformed/non-object output must be surfaced **visibly** in the watchdog's
   own turn output this wake — never silently swallowed or silently retried,
   since silent failure is exactly the defect this slice retires the external
   OS scheduler for — while still never fabricating or sending a notify nudge
-  from broken input; only a genuine `stale=true` result ever produces a sent
-  message.
+  from broken input; only an `actionable-stall` verdict with its returned
+  canonical notify command ever produces a sent nudge.
 - **Checks** — the design/HITL inbox for unread human-facing escalations
   (`inbox.sh` on the design role); orchestrator staleness via read-only
   intent-cli/GitHub facts (`worker next-action --github-only`, open PR/CI/
@@ -1561,8 +1563,8 @@ The **selectable alternative** to the design-thread watchdog: the same
 `intent-cli automation heartbeat` call, run directly from a long-interval
 automation **in the orchestrator's own thread** (Codex automation or Claude
 same-thread `/loop`) rather than from the design thread. On each wake it
-calls `automation heartbeat` itself and, when stale, acts on the returned
-state in the **same** wake — there is no design-to-orchestrator message hop,
+calls `automation heartbeat` itself and acts on its closed verdict in the
+**same** wake — there is no design-to-orchestrator message hop,
 because the orchestrator is the one running the check.
 
 - **Frequency** — 30-60 minute class — the same low-frequency band as the
@@ -1577,13 +1579,15 @@ because the orchestrator is the one running the check.
   Choose orchestrator-side only when an operator has a specific reason to
   prefer one fewer hop over keeping the orchestrator loopless.
 - **Command** —
-  `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --format json`
+  `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --team <team> --format json`
 - **Setup prompt** (paste into the orchestrator thread) — run a Codex
   automation or Claude same-thread `/loop` firing every 30-60 minutes in the
   orchestrator thread; each wake runs `automation heartbeat` in addition to
-  the normal orchestrator wake checks, and when `stale` is `true` treats the
-  returned `message_body` as this wake's repair/escalation signal (still at
-  most one message per wake, per the G524 wake contract).
+  the normal orchestrator wake checks. It waits for `healthy-active-wait`,
+  runs the returned canonical notify command only for `actionable-stall`,
+  routes `operator-required` to the operator, and visibly repairs/escalates
+  `cannot-determine` (still at most one nudge per dedupe key, per the G524
+  wake contract). It never infers this from `stale` or `message_body`.
 
 ### Retired: external OS-scheduler heartbeat (G526 → G539)
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -1333,9 +1333,11 @@ resume）します。その後 orchestrator がループを自律的に駆動し
 経路自身が自己報告できないスタールは、依然として何かが検知しなければなりません。
 **RECOMMENDED なデフォルト** のセーフティネット(G539。G526 の外部スケジューラ推奨を
 supersede します)は、**design** スレッドから実行する **30 分クラス** の間隔の
-watchdog loop です: `intent-cli automation heartbeat` を呼び出し、`stale=true` の
-場合は返された `message_body` を使って orchestrator へ **最大 1 通** の canonical な
-nudge を送ります — それ以外は完全に沈黙します。生きた、人間が監視しているエージェント
+watchdog loop です: `intent-cli automation heartbeat` を唯一の scheduler-agnostic な
+decision surface として呼び出します。各 valid result は `healthy-active-wait`、
+`actionable-stall`、`operator-required`、`cannot-determine` のちょうど一つの verdict を持ちます。
+外部 loop が cadence、watermark、dedupe persistence を所有し、intent-cli は schedule、sleep、send、
+poll state の永続化をしません。生きた、人間が監視しているエージェント
 セッションの **内側** で動作するため、見えない外部プロセスとは異なり、別途の
 credential/keychain セットアップも不要で(セッションの他の部分と同じ方法で
 authenticate します)、壊れた瞬間にオペレーターの画面上で可視化されます。
@@ -1346,19 +1348,21 @@ authenticate します)、壊れた瞬間にオペレーターの画面上で可
 - **loop setup プロンプト**(design スレッドに貼り付ける)— design スレッドで
   `/loop 30m`(Claude 同一スレッド)、または 30 分ごとに発火する Codex automation を
   実行します。プロンプトは各 wake で
-  `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --format json`
-  を実行し、結果の `stale` フィールドが `true` であれば `message_body` をそのまま
-  `intent-cli notify report`（`--from design --to orchestrator --status question`、fresh な
-  heartbeat task id、heartbeat evidence artifact）で orchestrator に送ります（正確に **1 通**）。`stale` が
-  `false` であれば何も送らず静かに終了します — 沈黙は **この健全なケースにのみ**
-  許されます。heartbeat コマンドの実行失敗や不正な/オブジェクトでない出力は
+  `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --team <team> --format json`
+  を実行します。外部 dedupe は age や poll time ではなく返された `dedupe_key` を key にします。
+  `healthy-active-wait` では何も送らず、result が示す awaited condition、observable end signal、有限の
+  bound に従って signal または bound 超過時に再評価します。`actionable-stall` では返された canonical
+  `intent-cli notify` command をその key に対して最大 **1 回** 実行します。`operator-required` は named
+  record と action を operator に提示し、orchestration を nudge しません。`cannot-determine` は named
+  monitor/routing failure を可視化して repair または escalate し、healthy/silent として扱いません。
+  heartbeat コマンドの実行失敗や不正な/オブジェクトでない出力は
   **決して沈黙しません**: この wake 自身の turn 出力で、生きたこのセッションを
   監視しているオペレーターに見える形で、失敗を明示的に述べます — これこそが、
   retire された見えない外部スケジューラに対して in-session の watchdog が持つ
   正確な優位性です(下記 Retired を参照)— その一方で、壊れた入力から notify の
   nudge を捏造・送信することは決してありません。実際に送信されるメッセージは、
   本物の `stale=true` 結果の場合だけです。
-- **failure visibility** — 沈黙は健全な `stale=false` の heartbeat 結果にのみ
+- **failure visibility** — 沈黙は `healthy-active-wait` の heartbeat 結果にのみ
   許されます。heartbeat コマンドの実行失敗や不正な/オブジェクトでない出力は、
   この wake の watchdog 自身の turn 出力で **可視的に** 表面化させなければ
   なりません — 決して黙って飲み込んだり、黙ってリトライしたりしません。沈黙した
@@ -1370,11 +1374,12 @@ authenticate します)、壊れた瞬間にオペレーターの画面上で可
   (`worker next-action --github-only`、open PR/CI/label 状態)を最後に確認した
   orchestrator の活動と比較して orchestrator の停滞を確認、そして RECOMMENDED な
   primary チェックとして `intent-cli automation heartbeat` 自体 — これは
-  `automation stalled-work`(G523)をラップし、スタールした各項目とその canonical な
-  次のコマンドを示す `message_body` を返します。
-- **アクション** — 停滞、未回答の HITL メッセージ、または heartbeat の `stale=true`
-  結果を検知したら、orchestrator へ canonical な repair/status リクエストまたは
-  heartbeat の nudge を最大 1 通だけ送ります:
+  `automation stalled-work`(G523)、operator-attention、recorded topology を一つの verdict、
+  evidence/age basis、stable dedupe key、owner、canonical notify command に統合します。
+- **アクション** — その一つの verdict だけに従います: named signal を bound 内で待ち、
+  `actionable-stall` key には返された canonical notify command を最大 1 回実行し、
+  `operator-required` は human に route し、`cannot-determine` は可視化して repair/escalate します。
+  他の field から action を推論せず、hand-written transport request を送ってはいけません。
 
   ```json
   {"type":"status-request","to":"orchestrator","from":"design-watchdog","ask":"non-destructive liveness check: reply with current state and next action, or confirm idle"}

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -1360,15 +1360,17 @@ authenticate します)、壊れた瞬間にオペレーターの画面上で可
   監視しているオペレーターに見える形で、失敗を明示的に述べます — これこそが、
   retire された見えない外部スケジューラに対して in-session の watchdog が持つ
   正確な優位性です(下記 Retired を参照)— その一方で、壊れた入力から notify の
-  nudge を捏造・送信することは決してありません。実際に送信されるメッセージは、
-  本物の `stale=true` 結果の場合だけです。
+  nudge を捏造・送信することは決してありません。送信する nudge は
+  `actionable-stall` verdict とともに返された canonical notify command の場合だけです。
+  `stale` や `message_body` から action を推論せず、closed verdict だけを decision trigger にします。
 - **failure visibility** — 沈黙は `healthy-active-wait` の heartbeat 結果にのみ
   許されます。heartbeat コマンドの実行失敗や不正な/オブジェクトでない出力は、
   この wake の watchdog 自身の turn 出力で **可視的に** 表面化させなければ
   なりません — 決して黙って飲み込んだり、黙ってリトライしたりしません。沈黙した
   失敗こそが、このスライスが外部 OS スケジューラを retire する理由そのものだから
   です — その一方で、壊れた入力から notify の nudge を捏造・送信することは決して
-  ありません。実際に送信されるメッセージは、本物の `stale=true` 結果の場合だけです。
+  ありません。送信する nudge は `actionable-stall` verdict とともに返された
+  canonical notify command の場合だけです。
 - **チェック内容** — design/HITL inbox で未読の人間向けエスカレーションを確認
   (design ロールの `inbox.sh`)、read-only な intent-cli/GitHub の事実
   (`worker next-action --github-only`、open PR/CI/label 状態)を最後に確認した
@@ -1425,7 +1427,7 @@ design-thread watchdog に対する **選択可能な alternative** です: 同�
 `intent-cli automation heartbeat` の呼び出しを、design スレッドではなく
 **orchestrator 自身のスレッド** の中で、長間隔の automation(Codex automation または
 Claude 同一スレッド `/loop`)から直接実行します。各 wake で `automation heartbeat`
-を自分自身で呼び出し、stale であれば **同じ** wake の中でその結果に対して行動します
+を自分自身で呼び出し、その closed verdict に従って **同じ** wake の中で行動します
 — design から orchestrator へのメッセージのホップは発生しません。なぜなら
 orchestrator 自身がそのチェックを実行しているからです。
 
@@ -1441,13 +1443,15 @@ orchestrator 自身がそのチェックを実行しているからです。
   を選ぶのは、オペレーターが orchestrator を loopless に保つことよりも 1 ホップ少ない
   ことを優先する特定の理由がある場合だけにしてください。
 - **コマンド** —
-  `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --format json`
+  `intent-cli automation heartbeat --domain <domain> --repo <owner/repo> --team <team> --format json`
 - **setup プロンプト**(orchestrator スレッドに貼り付ける)— orchestrator スレッドの
   中で、30〜60 分ごとに発火する Codex automation または Claude 同一スレッド `/loop`
   を実行します。各 wake は通常の orchestrator wake チェックに加えて
-  `automation heartbeat` を実行し、`stale` が `true` であれば返された `message_body`
-  をその wake の repair/escalation シグナルとして扱います(引き続き 1 wake につき
-  最大 1 通、G524 の wake contract に従います)。
+  `automation heartbeat` を実行します。`healthy-active-wait` は待機し、
+  `actionable-stall` だけが返された canonical notify command を実行し、
+  `operator-required` は operator に route し、`cannot-determine` は可視化して
+  repair/escalate します（G524 の wake contract に従い、dedupe key ごとに最大 1 nudge）。
+  `stale` や `message_body` から action を推論しません。
 
 ### Retired: 外部 OS スケジューラの heartbeat(G526 → G539)
 

--- a/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
@@ -86,13 +86,21 @@ internal static class AutomationHeartbeatCommand
             Repo = repo!,
             Team = team,
             StaleMinutesThreshold = staleMinutes,
-            Stale = stalledWork.Stalled,
+            // G597: the closed decision is the authoritative heartbeat
+            // outcome. Keep the legacy field aligned so pre-decision callers
+            // cannot suppress an overdue CI wait merely because stalled-work
+            // intentionally treats a pending check as non-stale.
+            Stale = stalledWork.Stalled
+                || string.Equals(decision.Verdict, "actionable-stall", StringComparison.Ordinal),
             Items = stalledWork.Items,
             Warnings = stalledWork.Warnings,
             OperatorAttentionStatus = stalledWork.OperatorAttentionStatus,
             OperatorAttentionError = stalledWork.OperatorAttentionError,
             RouteTo = ResolveRoute(stalledWork),
-            MessageBody = stalledWork.Stalled ? BuildMessageBody(stalledWork) : null,
+            MessageBody = stalledWork.Stalled
+                || string.Equals(decision.Verdict, "actionable-stall", StringComparison.Ordinal)
+                ? BuildMessageBody(stalledWork)
+                : null,
             Verdict = decision.Verdict,
             Reason = decision.Reason,
             LastProgressBasis = decision.LastProgressBasis,
@@ -297,6 +305,18 @@ internal static class AutomationHeartbeatCommand
             return CannotDetermine(route.Reason!, stalledWork.Items.FirstOrDefault(), "recorded topology");
         }
 
+        // A concrete actionable finding always wins over a legitimate active
+        // wait. Otherwise one fresh PR CI run could hide an unrelated stale
+        // pipeline and force callers to re-derive the answer from Items.
+        var actionable = stalledWork.Items.FirstOrDefault(item =>
+            !item.IsInformational
+            && !string.Equals(item.RequiredActor, "operator", StringComparison.Ordinal)
+            && !string.Equals(item.Kind, AutomationStalledWorkCommand.KindCiPending, StringComparison.Ordinal));
+        if (actionable is not null)
+        {
+            return ActionableStall(actionable, route, staleMinutes);
+        }
+
         var ciPending = stalledWork.Items.FirstOrDefault(item =>
             string.Equals(item.Kind, AutomationStalledWorkCommand.KindCiPending, StringComparison.Ordinal));
         if (ciPending is not null && ciPending.AgeMinutes < staleMinutes)
@@ -317,30 +337,9 @@ internal static class AutomationHeartbeatCommand
                 SuggestedAction: "Wait for the named CI completion signal, then re-evaluate this heartbeat decision.");
         }
 
-        var actionable = ciPending is not null && ciPending.AgeMinutes >= staleMinutes
-            ? ciPending
-            : stalledWork.Items.FirstOrDefault(item =>
-                !item.IsInformational
-                && !string.Equals(item.RequiredActor, "operator", StringComparison.Ordinal));
-        if (actionable is not null)
+        if (ciPending is not null)
         {
-            var overdueReason = string.Equals(actionable.Kind, AutomationStalledWorkCommand.KindCiPending, StringComparison.Ordinal)
-                ? $"CI wait for PR #{actionable.Pr?.Number} exceeded its {staleMinutes}-minute bound without a terminal signal."
-                : $"Stalled-work reports actionable '{actionable.Kind}' for '{actionable.ExecutionUnit}'.";
-            return new HeartbeatDecision(
-                Verdict: "actionable-stall",
-                Reason: overdueReason,
-                LastProgressBasis: ProgressBasis(actionable),
-                LastProgressSource: ProgressSource(actionable),
-                LastProgressAgeMinutes: actionable.AgeMinutes,
-                DedupeKey: MaterialKey("actionable-stall", actionable, "orchestration", route.TargetRole!),
-                ActionOwner: "orchestration",
-                TargetRole: route.TargetRole,
-                CanonicalNotifyCommand: route.CanonicalNotifyCommand!,
-                WaitCondition: null,
-                WaitEndSignal: null,
-                WaitBoundMinutes: null,
-                SuggestedAction: $"Run the canonical notify command once for dedupe key '{MaterialKey("actionable-stall", actionable, "orchestration", route.TargetRole!)}'.");
+            return ActionableStall(ciPending, route, staleMinutes);
         }
 
         if (stalledWork.Items.Count > 0)
@@ -353,19 +352,45 @@ internal static class AutomationHeartbeatCommand
         }
 
         return new HeartbeatDecision(
-            Verdict: "healthy-active-wait",
-            Reason: "No pending pipeline transition is currently reported.",
+            Verdict: "actionable-stall",
+            Reason: "No pending pipeline transition or named active wait is currently reported.",
             LastProgressBasis: "current successful stalled-work observation",
             LastProgressSource: "automation.stalled-work",
             LastProgressAgeMinutes: 0,
-            DedupeKey: $"heartbeat:healthy-active-wait:{domain}:{repo}:{team}:no-pending-transition",
+            DedupeKey: $"heartbeat:actionable-stall:orchestration:{route.TargetRole}:no-pending-transition:{domain}:{repo}:{team}",
             ActionOwner: "orchestration",
             TargetRole: route.TargetRole,
-            CanonicalNotifyCommand: null,
-            WaitCondition: "the next canonical pipeline transition",
-            WaitEndSignal: "a GitHub or canonical intent-cli state change observed on the next external wake",
-            WaitBoundMinutes: staleMinutes,
-            SuggestedAction: "Wait for the named signal, then re-evaluate this heartbeat decision.");
+            CanonicalNotifyCommand: route.CanonicalNotifyCommand,
+            WaitCondition: null,
+            WaitEndSignal: null,
+            WaitBoundMinutes: null,
+            SuggestedAction: "Run the canonical notify command once for this no-pending-transition dedupe key.");
+    }
+
+    private static HeartbeatDecision ActionableStall(
+        StalledWorkItem item,
+        HeartbeatRoute route,
+        int staleMinutes)
+    {
+        var isOverdueCi = string.Equals(item.Kind, AutomationStalledWorkCommand.KindCiPending, StringComparison.Ordinal);
+        var reason = isOverdueCi
+            ? $"CI wait for PR #{item.Pr?.Number} exceeded its {staleMinutes}-minute bound without a terminal signal."
+            : $"Stalled-work reports actionable '{item.Kind}' for '{item.ExecutionUnit}'.";
+        var dedupeKey = MaterialKey("actionable-stall", item, "orchestration", route.TargetRole!);
+        return new HeartbeatDecision(
+            Verdict: "actionable-stall",
+            Reason: reason,
+            LastProgressBasis: ProgressBasis(item),
+            LastProgressSource: ProgressSource(item),
+            LastProgressAgeMinutes: item.AgeMinutes,
+            DedupeKey: dedupeKey,
+            ActionOwner: "orchestration",
+            TargetRole: route.TargetRole,
+            CanonicalNotifyCommand: route.CanonicalNotifyCommand!,
+            WaitCondition: null,
+            WaitEndSignal: null,
+            WaitBoundMinutes: null,
+            SuggestedAction: $"Run the canonical notify command once for dedupe key '{dedupeKey}'.");
     }
 
     private static HeartbeatDecision CannotDetermine(string reason, StalledWorkItem? item, string source) => new(

--- a/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
@@ -47,7 +47,7 @@ internal static class AutomationHeartbeatCommand
     };
 
     private const string UsageLine =
-        "Usage: intent-cli automation heartbeat --domain <name> --repo <owner/repo> [--stale-minutes <m, default 45>] [--format json|markdown]";
+        "Usage: intent-cli automation heartbeat --domain <name> --repo <owner/repo> [--team <logical-team>] [--stale-minutes <m, default 45>] [--format json|markdown]";
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
@@ -61,7 +61,7 @@ internal static class AutomationHeartbeatCommand
             return 0;
         }
 
-        if (!TryParseArguments(args, out var domain, out var repo, out var staleMinutes, out var format, out var error))
+        if (!TryParseArguments(args, out var domain, out var repo, out var team, out var staleMinutes, out var format, out var error))
         {
             writer.WriteLine(error);
             writer.WriteLine(UsageLine);
@@ -79,10 +79,12 @@ internal static class AutomationHeartbeatCommand
             return 1;
         }
 
+        var decision = Decide(context, domain!, repo!, team, staleMinutes, stalledWork);
         var result = new AutomationHeartbeatResult
         {
             Domain = domain!,
             Repo = repo!,
+            Team = team,
             StaleMinutesThreshold = staleMinutes,
             Stale = stalledWork.Stalled,
             Items = stalledWork.Items,
@@ -91,6 +93,19 @@ internal static class AutomationHeartbeatCommand
             OperatorAttentionError = stalledWork.OperatorAttentionError,
             RouteTo = ResolveRoute(stalledWork),
             MessageBody = stalledWork.Stalled ? BuildMessageBody(stalledWork) : null,
+            Verdict = decision.Verdict,
+            Reason = decision.Reason,
+            LastProgressBasis = decision.LastProgressBasis,
+            LastProgressSource = decision.LastProgressSource,
+            LastProgressAgeMinutes = decision.LastProgressAgeMinutes,
+            DedupeKey = decision.DedupeKey,
+            ActionOwner = decision.ActionOwner,
+            TargetRole = decision.TargetRole,
+            CanonicalNotifyCommand = decision.CanonicalNotifyCommand,
+            WaitCondition = decision.WaitCondition,
+            WaitEndSignal = decision.WaitEndSignal,
+            WaitBoundMinutes = decision.WaitBoundMinutes,
+            SuggestedAction = decision.SuggestedAction,
         };
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
@@ -230,16 +245,203 @@ internal static class AutomationHeartbeatCommand
         };
     }
 
+    private static HeartbeatDecision Decide(
+        CliContext context,
+        string domain,
+        string repo,
+        string? team,
+        int staleMinutes,
+        AutomationStalledWorkResult stalledWork)
+    {
+        var operatorStateUnknown = stalledWork.Items.FirstOrDefault(item =>
+            string.Equals(item.Kind, AutomationStalledWorkCommand.KindOperatorAttentionCannotDetermine, StringComparison.Ordinal));
+        if (operatorStateUnknown is not null)
+        {
+            return CannotDetermine(
+                $"Operator-attention state cannot be determined: {operatorStateUnknown.RecommendedAction}",
+                operatorStateUnknown,
+                "operator-attention store");
+        }
+
+        var operatorRecord = stalledWork.Items.FirstOrDefault(item =>
+            string.Equals(item.Kind, AutomationStalledWorkCommand.KindOperatorAttentionPending, StringComparison.Ordinal));
+        if (operatorRecord is not null)
+        {
+            return new HeartbeatDecision(
+                Verdict: "operator-required",
+                Reason: $"Open operator-attention record '{operatorRecord.OperatorAttentionRecordId}' requires a human decision.",
+                LastProgressBasis: $"operator-attention record '{operatorRecord.OperatorAttentionRecordId}' opened",
+                LastProgressSource: "operator-attention.opened_at",
+                LastProgressAgeMinutes: operatorRecord.AgeMinutes,
+                DedupeKey: MaterialKey("operator-required", operatorRecord, "operator", null),
+                ActionOwner: "operator",
+                TargetRole: null,
+                CanonicalNotifyCommand: null,
+                WaitCondition: null,
+                WaitEndSignal: null,
+                WaitBoundMinutes: null,
+                SuggestedAction: $"Operator action required for '{operatorRecord.OperatorAttentionRecordId}': {operatorRecord.RecommendedAction}");
+        }
+
+        if (string.IsNullOrWhiteSpace(team))
+        {
+            return CannotDetermine(
+                "Recorded routing cannot be resolved because --team is required for this heartbeat decision.",
+                stalledWork.Items.FirstOrDefault(),
+                "heartbeat routing context");
+        }
+
+        var route = ResolveOrchestratorRoute(context, domain, team);
+        if (!route.Resolved)
+        {
+            return CannotDetermine(route.Reason!, stalledWork.Items.FirstOrDefault(), "recorded topology");
+        }
+
+        var ciPending = stalledWork.Items.FirstOrDefault(item =>
+            string.Equals(item.Kind, AutomationStalledWorkCommand.KindCiPending, StringComparison.Ordinal));
+        if (ciPending is not null && ciPending.AgeMinutes < staleMinutes)
+        {
+            return new HeartbeatDecision(
+                Verdict: "healthy-active-wait",
+                Reason: $"CI for PR #{ciPending.Pr?.Number} remains pending at its recorded exact head.",
+                LastProgressBasis: $"PR #{ciPending.Pr?.Number} exact-head CI pending observation",
+                LastProgressSource: "github.pr.status_check_rollup",
+                LastProgressAgeMinutes: ciPending.AgeMinutes,
+                DedupeKey: MaterialKey("healthy-active-wait", ciPending, "orchestration", route.TargetRole!),
+                ActionOwner: "orchestration",
+                TargetRole: route.TargetRole,
+                CanonicalNotifyCommand: null,
+                WaitCondition: $"CI for PR #{ciPending.Pr?.Number} head {ciPending.PrHeadSha} to reach a terminal outcome",
+                WaitEndSignal: "the mode-specific CI-completion wake followed by an exact-head GitHub re-check",
+                WaitBoundMinutes: staleMinutes,
+                SuggestedAction: "Wait for the named CI completion signal, then re-evaluate this heartbeat decision.");
+        }
+
+        var actionable = ciPending is not null && ciPending.AgeMinutes >= staleMinutes
+            ? ciPending
+            : stalledWork.Items.FirstOrDefault(item =>
+                !item.IsInformational
+                && !string.Equals(item.RequiredActor, "operator", StringComparison.Ordinal));
+        if (actionable is not null)
+        {
+            var overdueReason = string.Equals(actionable.Kind, AutomationStalledWorkCommand.KindCiPending, StringComparison.Ordinal)
+                ? $"CI wait for PR #{actionable.Pr?.Number} exceeded its {staleMinutes}-minute bound without a terminal signal."
+                : $"Stalled-work reports actionable '{actionable.Kind}' for '{actionable.ExecutionUnit}'.";
+            return new HeartbeatDecision(
+                Verdict: "actionable-stall",
+                Reason: overdueReason,
+                LastProgressBasis: ProgressBasis(actionable),
+                LastProgressSource: ProgressSource(actionable),
+                LastProgressAgeMinutes: actionable.AgeMinutes,
+                DedupeKey: MaterialKey("actionable-stall", actionable, "orchestration", route.TargetRole!),
+                ActionOwner: "orchestration",
+                TargetRole: route.TargetRole,
+                CanonicalNotifyCommand: route.CanonicalNotifyCommand!,
+                WaitCondition: null,
+                WaitEndSignal: null,
+                WaitBoundMinutes: null,
+                SuggestedAction: $"Run the canonical notify command once for dedupe key '{MaterialKey("actionable-stall", actionable, "orchestration", route.TargetRole!)}'.");
+        }
+
+        if (stalledWork.Items.Count > 0)
+        {
+            var unresolved = stalledWork.Items[0];
+            return CannotDetermine(
+                $"No action owner can be determined for informational stalled-work kind '{unresolved.Kind}'.",
+                unresolved,
+                "stalled-work classification");
+        }
+
+        return new HeartbeatDecision(
+            Verdict: "healthy-active-wait",
+            Reason: "No pending pipeline transition is currently reported.",
+            LastProgressBasis: "current successful stalled-work observation",
+            LastProgressSource: "automation.stalled-work",
+            LastProgressAgeMinutes: 0,
+            DedupeKey: $"heartbeat:healthy-active-wait:{domain}:{repo}:{team}:no-pending-transition",
+            ActionOwner: "orchestration",
+            TargetRole: route.TargetRole,
+            CanonicalNotifyCommand: null,
+            WaitCondition: "the next canonical pipeline transition",
+            WaitEndSignal: "a GitHub or canonical intent-cli state change observed on the next external wake",
+            WaitBoundMinutes: staleMinutes,
+            SuggestedAction: "Wait for the named signal, then re-evaluate this heartbeat decision.");
+    }
+
+    private static HeartbeatDecision CannotDetermine(string reason, StalledWorkItem? item, string source) => new(
+        Verdict: "cannot-determine",
+        Reason: reason,
+        LastProgressBasis: item is null ? source : ProgressBasis(item),
+        LastProgressSource: item is null ? source : ProgressSource(item),
+        LastProgressAgeMinutes: item?.AgeMinutes ?? 0,
+        DedupeKey: $"heartbeat:cannot-determine:monitor:{source}:{reason}",
+        ActionOwner: "monitor",
+        TargetRole: null,
+        CanonicalNotifyCommand: null,
+        WaitCondition: null,
+        WaitEndSignal: null,
+        WaitBoundMinutes: null,
+        SuggestedAction: $"Repair or inspect the named {source} failure before treating this heartbeat as healthy.");
+
+    private static HeartbeatRoute ResolveOrchestratorRoute(
+        CliContext context,
+        string domain,
+        string team)
+    {
+        var topology = NotifyRoleTopologyStore.Resolve(context.RepoRoot, team);
+        if (!topology.Resolved)
+        {
+            return HeartbeatRoute.Failure(topology.Summary);
+        }
+
+        var sender = NotifyRoleTopologyStore.ResolveDeliveryTarget(context.RepoRoot, topology.Topology!, "design");
+        var recipient = NotifyRoleTopologyStore.ResolveDeliveryTarget(context.RepoRoot, topology.Topology!, "orchestration");
+        if (!sender.Resolved || !recipient.Resolved)
+        {
+            return HeartbeatRoute.Failure($"Recorded routing for team '{team}' is unresolved: "
+                + $"{sender.Summary} {recipient.Summary}");
+        }
+
+        var command = "intent-cli notify report"
+            + $" --domain {domain} --team {team} --from design --to orchestration"
+            + " --task-id <heartbeat-dedupe-key> --status question --artifact <heartbeat-evidence>"
+            + " --summary <one-line-summary>"
+            + $" --routing-root '{context.RepoRoot.Replace("'", "'\\''", StringComparison.Ordinal)}'"
+            + " --write --format json";
+        return new HeartbeatRoute(true, null, "orchestration", command);
+    }
+
+    private static string MaterialKey(string verdict, StalledWorkItem? item, string owner, string? targetRole) =>
+        $"heartbeat:{verdict}:{owner}:{targetRole ?? "none"}:{item?.DedupeKey ?? $"{item?.Kind ?? "none"}:{item?.ExecutionUnit ?? "none"}:{item?.Issue?.Number}:{item?.Pr?.Number}"}";
+
+    private static string ProgressBasis(StalledWorkItem item) => item.Kind switch
+    {
+        AutomationStalledWorkCommand.KindOperatorAttentionPending =>
+            $"operator-attention record '{item.OperatorAttentionRecordId}' opened",
+        AutomationStalledWorkCommand.KindCiPending =>
+            $"PR #{item.Pr?.Number} exact-head CI pending observation",
+        _ => $"stalled-work kind '{item.Kind}' for '{item.ExecutionUnit}'",
+    };
+
+    private static string ProgressSource(StalledWorkItem item) => item.Kind switch
+    {
+        AutomationStalledWorkCommand.KindOperatorAttentionPending => "operator-attention.opened_at",
+        AutomationStalledWorkCommand.KindCiPending => "github.pr.status_check_rollup",
+        _ => "automation.stalled-work",
+    };
+
     private static bool TryParseArguments(
         string[] args,
         out string? domain,
         out string? repo,
+        out string? team,
         out int staleMinutes,
         out string format,
         out string error)
     {
         domain = null;
         repo = null;
+        team = null;
         staleMinutes = DefaultStaleMinutes;
         format = FormatMarkdown;
         error = string.Empty;
@@ -263,6 +465,14 @@ internal static class AutomationHeartbeatCommand
                         return false;
                     }
                     repo = args[++index].Trim();
+                    break;
+                case "--team":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--team requires a value.";
+                        return false;
+                    }
+                    team = args[++index].Trim();
                     break;
                 case "--stale-minutes":
                     if (index + 1 >= args.Length
@@ -316,6 +526,29 @@ internal static class AutomationHeartbeatCommand
         writer.WriteLine();
         writer.WriteLine($"- stale_minutes_threshold: {result.StaleMinutesThreshold}");
         writer.WriteLine($"- stale: {(result.Stale ? "true" : "false")}");
+        writer.WriteLine($"- verdict: {result.Verdict}");
+        writer.WriteLine($"- dedupe_key: {result.DedupeKey}");
+        writer.WriteLine($"- last_progress: {result.LastProgressBasis} ({result.LastProgressSource}, {result.LastProgressAgeMinutes}m)");
+        writer.WriteLine($"- action_owner: {result.ActionOwner}");
+        if (result.TargetRole is not null)
+        {
+            writer.WriteLine($"- target_role: {result.TargetRole}");
+        }
+        if (result.WaitCondition is not null)
+        {
+            writer.WriteLine($"- wait: {result.WaitCondition}");
+            writer.WriteLine($"- wait_end_signal: {result.WaitEndSignal}");
+            writer.WriteLine($"- wait_bound_minutes: {result.WaitBoundMinutes}");
+        }
+        if (result.CanonicalNotifyCommand is not null)
+        {
+            writer.WriteLine($"- canonical_notify_command: `{result.CanonicalNotifyCommand}`");
+        }
+        if (result.Reason is not null)
+        {
+            writer.WriteLine($"- reason: {result.Reason}");
+        }
+        writer.WriteLine($"- suggested_action: {result.SuggestedAction}");
         writer.WriteLine($"- items: {result.Items.Count}");
         if (result.OperatorAttentionStatus is not null)
         {
@@ -392,6 +625,10 @@ internal sealed record AutomationHeartbeatResult
     [JsonPropertyName("repo")]
     public required string Repo { get; init; }
 
+    [JsonPropertyName("team")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required string? Team { get; init; }
+
     [JsonPropertyName("stale_minutes_threshold")]
     public required int StaleMinutesThreshold { get; init; }
 
@@ -425,4 +662,68 @@ internal sealed record AutomationHeartbeatResult
     /// </summary>
     [JsonPropertyName("message_body")]
     public string? MessageBody { get; init; }
+
+    [JsonPropertyName("verdict")]
+    public required string Verdict { get; init; }
+
+    [JsonPropertyName("reason")]
+    public required string? Reason { get; init; }
+
+    [JsonPropertyName("last_progress_basis")]
+    public required string LastProgressBasis { get; init; }
+
+    [JsonPropertyName("last_progress_source")]
+    public required string LastProgressSource { get; init; }
+
+    [JsonPropertyName("last_progress_age_minutes")]
+    public required int LastProgressAgeMinutes { get; init; }
+
+    [JsonPropertyName("dedupe_key")]
+    public required string DedupeKey { get; init; }
+
+    [JsonPropertyName("action_owner")]
+    public required string ActionOwner { get; init; }
+
+    [JsonPropertyName("target_role")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required string? TargetRole { get; init; }
+
+    [JsonPropertyName("canonical_notify_command")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required string? CanonicalNotifyCommand { get; init; }
+
+    [JsonPropertyName("wait_condition")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required string? WaitCondition { get; init; }
+
+    [JsonPropertyName("wait_end_signal")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required string? WaitEndSignal { get; init; }
+
+    [JsonPropertyName("wait_bound_minutes")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public required int? WaitBoundMinutes { get; init; }
+
+    [JsonPropertyName("suggested_action")]
+    public required string SuggestedAction { get; init; }
+}
+
+internal sealed record HeartbeatDecision(
+    string Verdict,
+    string Reason,
+    string LastProgressBasis,
+    string LastProgressSource,
+    int LastProgressAgeMinutes,
+    string DedupeKey,
+    string ActionOwner,
+    string? TargetRole,
+    string? CanonicalNotifyCommand,
+    string? WaitCondition,
+    string? WaitEndSignal,
+    int? WaitBoundMinutes,
+    string SuggestedAction);
+
+internal sealed record HeartbeatRoute(bool Resolved, string? Reason, string? TargetRole, string? CanonicalNotifyCommand)
+{
+    public static HeartbeatRoute Failure(string reason) => new(false, reason, null, null);
 }

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -534,7 +534,7 @@ internal static class AutomationStalledWorkCommand
             // G596: explicit human obligations and unreadable human-obligation
             // state are load-bearing immediately; they do not wait for the
             // generic GitHub staleness threshold before becoming visible.
-            .Where(item => item.Kind is KindOperatorAttentionPending or KindOperatorAttentionCannotDetermine
+            .Where(item => item.Kind is KindOperatorAttentionPending or KindOperatorAttentionCannotDetermine or KindCiPending
                 || item.AgeMinutes >= staleMinutes)
             .OrderByDescending(item => item.AgeMinutes)
             .ToArray();

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -534,7 +534,8 @@ internal static class AutomationStalledWorkCommand
             // G596: explicit human obligations and unreadable human-obligation
             // state are load-bearing immediately; they do not wait for the
             // generic GitHub staleness threshold before becoming visible.
-            .Where(item => item.Kind is KindOperatorAttentionPending or KindOperatorAttentionCannotDetermine or KindCiPending
+            .Where(item => item.Kind is KindOperatorAttentionPending or KindOperatorAttentionCannotDetermine
+                or KindCiPending or KindCiAllGreenNotTransitioned or KindCiFailedNotTransitioned
                 || item.AgeMinutes >= staleMinutes)
             .OrderByDescending(item => item.AgeMinutes)
             .ToArray();

--- a/tests/IntentSystem.Cli.Tests/AutomationHeartbeatDecisionG597Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHeartbeatDecisionG597Tests.cs
@@ -1,0 +1,281 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(AutomationStalledWorkSharedStateCollection.Name)]
+public sealed class AutomationHeartbeatDecisionG597Tests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 3, 10, 0, 0, TimeSpan.Zero);
+
+    public AutomationHeartbeatDecisionG597Tests()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = () => FixedNow;
+        OperatorAttentionCommand.UtcNowFactory = () => FixedNow;
+    }
+
+    public void Dispose()
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = null;
+        AutomationStalledWorkCommand.UtcNowFactory = null;
+        OperatorAttentionCommand.UtcNowFactory = null;
+    }
+
+    [Fact]
+    public void Execute_ClosedVerdictsCoverHealthyActionableOperatorAndCannotDetermine_G597()
+    {
+        using var healthy = new HeartbeatWorkspace();
+        healthy.WriteTopology();
+        healthy.WritePacketDomain("G589");
+        var ciIssue = Issue(1281, "G589: CI wait", FixedNow.AddHours(-2), "intent-pr-created");
+        var pendingPr = Pr(1282, ciIssue.Title, FixedNow.AddMinutes(-20), ciIssue.Number,
+            [CheckRun("IN_PROGRESS")]);
+        var healthyResult = Run(healthy, new FakeLister([ciIssue], [pendingPr]));
+        Assert.Equal("healthy-active-wait", healthyResult.GetProperty("verdict").GetString());
+        Assert.Equal("github.pr.status_check_rollup", healthyResult.GetProperty("last_progress_source").GetString());
+        Assert.Equal("CI for PR #1282 head deadbeef to reach a terminal outcome",
+            healthyResult.GetProperty("wait_condition").GetString());
+        Assert.Equal("the mode-specific CI-completion wake followed by an exact-head GitHub re-check",
+            healthyResult.GetProperty("wait_end_signal").GetString());
+        Assert.Equal(45, healthyResult.GetProperty("wait_bound_minutes").GetInt32());
+        Assert.Equal("orchestration", healthyResult.GetProperty("target_role").GetString());
+
+        using var actionable = new HeartbeatWorkspace();
+        actionable.WriteTopology();
+        actionable.WritePacketDomain("G600");
+        var oldIssue = Issue(1600, "G600: action needed", FixedNow.AddHours(-2), "intent-target");
+        var actionableResult = Run(actionable, new FakeLister([oldIssue]));
+        Assert.Equal("actionable-stall", actionableResult.GetProperty("verdict").GetString());
+        Assert.Equal("orchestration", actionableResult.GetProperty("action_owner").GetString());
+        Assert.Equal("orchestration", actionableResult.GetProperty("target_role").GetString());
+        Assert.Contains("intent-cli notify report", actionableResult.GetProperty("canonical_notify_command").GetString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("herdr agent prompt", actionableResult.GetProperty("canonical_notify_command").GetString(), StringComparison.Ordinal);
+
+        using var operatorRequired = new HeartbeatWorkspace();
+        operatorRequired.WriteTopology();
+        operatorRequired.OpenAttention("G596-operator", "Approve the operator decision");
+        var operatorResult = Run(operatorRequired, new FakeLister());
+        Assert.Equal("operator-required", operatorResult.GetProperty("verdict").GetString());
+        Assert.Equal("operator", operatorResult.GetProperty("action_owner").GetString());
+        Assert.Contains("G596-operator", operatorResult.GetProperty("reason").GetString(), StringComparison.Ordinal);
+        Assert.Contains("Operator action required", operatorResult.GetProperty("suggested_action").GetString(), StringComparison.Ordinal);
+        Assert.False(operatorResult.TryGetProperty("canonical_notify_command", out _));
+
+        using var unresolved = new HeartbeatWorkspace();
+        var cannotDetermine = Run(unresolved, new FakeLister());
+        Assert.Equal("cannot-determine", cannotDetermine.GetProperty("verdict").GetString());
+        Assert.Contains("Recorded role topology", cannotDetermine.GetProperty("reason").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_DedupeKeyIsStableAcrossPollsAndChangesOnlyWithMaterialState_G597()
+    {
+        using var workspace = new HeartbeatWorkspace();
+        workspace.WriteTopology();
+        workspace.WritePacketDomain("G600");
+        workspace.WritePacketDomain("G601");
+        var firstIssue = Issue(1600, "G600: action needed", FixedNow.AddHours(-2), "intent-target");
+        var first = Run(workspace, new FakeLister([firstIssue]));
+        var repeated = Run(workspace, new FakeLister([firstIssue]));
+        var secondIssue = Issue(1601, "G601: different action", FixedNow.AddHours(-2), "intent-target");
+        var changed = Run(workspace, new FakeLister([secondIssue]));
+
+        var key = first.GetProperty("dedupe_key").GetString()!;
+        Assert.Equal(key, repeated.GetProperty("dedupe_key").GetString());
+        Assert.NotEqual(key, changed.GetProperty("dedupe_key").GetString());
+        Assert.DoesNotContain("120", key, StringComparison.Ordinal);
+        Assert.DoesNotContain("2026", key, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_OverdueCiWaitBecomesActionableAndNeverRemainsHealthy_G597()
+    {
+        using var workspace = new HeartbeatWorkspace();
+        workspace.WriteTopology();
+        workspace.WritePacketDomain("G589");
+        var issue = Issue(1281, "G589: CI wait", FixedNow.AddHours(-2), "intent-pr-created");
+        var overduePr = Pr(1282, issue.Title, FixedNow.AddMinutes(-46), issue.Number, [CheckRun("IN_PROGRESS")]);
+
+        var result = Run(workspace, new FakeLister([issue], [overduePr]));
+
+        Assert.Equal("actionable-stall", result.GetProperty("verdict").GetString());
+        Assert.Contains("exceeded its 45-minute bound", result.GetProperty("reason").GetString(), StringComparison.Ordinal);
+        Assert.True(result.TryGetProperty("canonical_notify_command", out _));
+    }
+
+    [Fact]
+    public void Execute_IsReadOnlyAndDoesNotPersistPollOrDedupeState_G597()
+    {
+        using var workspace = new HeartbeatWorkspace();
+        workspace.WriteTopology();
+        workspace.WritePacketDomain("G600");
+        var issue = Issue(1600, "G600: action needed", FixedNow.AddHours(-2), "intent-target");
+        var before = SnapshotFiles(workspace.RootPath);
+
+        _ = Run(workspace, new FakeLister([issue]));
+
+        Assert.Equal(before, SnapshotFiles(workspace.RootPath));
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void GuidancePinsOneReadOnlyDecisionContractForBothModes_G597(string language)
+    {
+        var path = Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, "12-agent-message-orchestration.md");
+        var content = File.ReadAllText(path);
+
+        Assert.Contains("healthy-active-wait", content, StringComparison.Ordinal);
+        Assert.Contains("actionable-stall", content, StringComparison.Ordinal);
+        Assert.Contains("operator-required", content, StringComparison.Ordinal);
+        Assert.Contains("cannot-determine", content, StringComparison.Ordinal);
+        Assert.Contains("dedupe key", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("canonical `intent-cli notify", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static JsonElement Run(HeartbeatWorkspace workspace, FakeLister lister)
+    {
+        AutomationStalledWorkCommand.CandidateListerFactory = () => lister;
+        using var writer = new StringWriter();
+        var exitCode = AutomationHeartbeatCommand.Execute(
+            workspace.Context,
+            ["--domain", "intent-cli", "--repo", "J-Tech-Japan/intent-system", "--team", "intent-cli-dev", "--format", "json"],
+            writer);
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        return document.RootElement.Clone();
+    }
+
+    private static GitHubAutomationIssueCandidate Issue(int number, string title, DateTimeOffset createdAt, params string[] labels) => new()
+    {
+        Number = number,
+        Title = title,
+        Url = $"https://github.com/J-Tech-Japan/intent-system/issues/{number}",
+        CreatedAt = createdAt.ToString("O"),
+        UpdatedAt = createdAt.ToString("O"),
+        State = "OPEN",
+        Labels = labels.Select(name => new GitHubAutomationLabel { Name = name }).ToArray(),
+    };
+
+    private static GitHubAutomationPrCandidate Pr(
+        int number,
+        string title,
+        DateTimeOffset createdAt,
+        int issueNumber,
+        IReadOnlyList<GitHubAutomationStatusCheckCandidate> checks) => new()
+    {
+        Number = number,
+        Title = title,
+        Url = $"https://github.com/J-Tech-Japan/intent-system/pull/{number}",
+        CreatedAt = createdAt.ToString("O"),
+        UpdatedAt = createdAt.ToString("O"),
+        State = "OPEN",
+        IsDraft = false,
+        HeadRefOid = "deadbeef",
+        Labels = [],
+        StatusCheckRollup = checks,
+        ClosingIssuesReferences =
+        [
+            new GitHubPrClosingIssueReference
+            {
+                Number = issueNumber,
+                Repository = new GitHubPrClosingIssueRepository
+                {
+                    Name = "intent-system",
+                    Owner = new GitHubPrClosingIssueRepositoryOwner { Login = "J-Tech-Japan" },
+                },
+            },
+        ],
+    };
+
+    private static GitHubAutomationStatusCheckCandidate CheckRun(string status) => new()
+    {
+        TypeName = "CheckRun",
+        Status = status,
+        Conclusion = string.Empty,
+    };
+
+    private static IReadOnlyDictionary<string, string> SnapshotFiles(string rootPath) =>
+        Directory.GetFiles(rootPath, "*", SearchOption.AllDirectories)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToDictionary(
+                path => Path.GetRelativePath(rootPath, path),
+                path => Convert.ToHexString(File.ReadAllBytes(path)),
+                StringComparer.Ordinal);
+
+    private sealed class FakeLister(
+        IReadOnlyList<GitHubAutomationIssueCandidate>? issues = null,
+        IReadOnlyList<GitHubAutomationPrCandidate>? prs = null) : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) =>
+            prs ?? [];
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) =>
+            issues ?? [];
+
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => [];
+    }
+
+    private sealed class HeartbeatWorkspace : IDisposable
+    {
+        public HeartbeatWorkspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("heartbeat-g597-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig { Project = new ProjectConfig { Domain = "intent-cli", ArtifactRoot = ".intent-cli" } },
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+
+        public void WritePacketDomain(string executionUnit)
+        {
+            var directory = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, "packet.yaml"), "domain: intent-cli\n");
+        }
+
+        public void WriteTopology()
+        {
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, JsonSerializer.Serialize(new
+            {
+                team = "intent-cli-dev",
+                workspace_id = "wH",
+                roles = new Dictionary<string, object>
+                {
+                    ["design"] = new { resident = "herdr", workspace_id = "wH", pane_id = "wH:p3" },
+                    ["orchestration"] = new { resident = "herdr", workspace_id = "wH", pane_id = "wH:p1" },
+                },
+            }));
+        }
+
+        public void OpenAttention(string record, string action)
+        {
+            using var writer = new StringWriter();
+            var exitCode = OperatorAttentionCommand.ExecuteOpen(
+                Context,
+                ["--record", record, "--domain", "intent-cli", "--team", "intent-cli-dev", "--owner", "operator",
+                    "--blocking-reference", "https://example.test/decision", "--action-needed", action,
+                    "--evidence", "operator must decide", "--write", "--format", "json"],
+                writer);
+            Assert.Equal(0, exitCode);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/AutomationHeartbeatDecisionG597Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHeartbeatDecisionG597Tests.cs
@@ -103,7 +103,70 @@ public sealed class AutomationHeartbeatDecisionG597Tests : IDisposable
 
         Assert.Equal("actionable-stall", result.GetProperty("verdict").GetString());
         Assert.Contains("exceeded its 45-minute bound", result.GetProperty("reason").GetString(), StringComparison.Ordinal);
+        Assert.True(result.GetProperty("stale").GetBoolean());
+        Assert.True(result.TryGetProperty("message_body", out var messageBody));
+        Assert.False(string.IsNullOrWhiteSpace(messageBody.GetString()));
         Assert.True(result.TryGetProperty("canonical_notify_command", out _));
+    }
+
+    [Fact]
+    public void Execute_SameIdlePipelineClassifiesNoWaitCiWaitAndOperatorAttention_G597()
+    {
+        using var neither = new HeartbeatWorkspace();
+        neither.WriteTopology();
+        var neitherResult = Run(neither, new FakeLister());
+        Assert.Equal("actionable-stall", neitherResult.GetProperty("verdict").GetString());
+
+        using var ciWait = new HeartbeatWorkspace();
+        ciWait.WriteTopology();
+        ciWait.WritePacketDomain("G589");
+        var ciIssue = Issue(1281, "G589: CI wait", FixedNow.AddHours(-2), "intent-pr-created");
+        var pendingPr = Pr(1282, ciIssue.Title, FixedNow.AddMinutes(-20), ciIssue.Number,
+            [CheckRun("IN_PROGRESS")]);
+        var ciWaitResult = Run(ciWait, new FakeLister([ciIssue], [pendingPr]));
+        Assert.Equal("healthy-active-wait", ciWaitResult.GetProperty("verdict").GetString());
+
+        using var operatorWait = new HeartbeatWorkspace();
+        operatorWait.WriteTopology();
+        operatorWait.OpenAttention("same-idle-pipeline", "Approve the operator decision");
+        var operatorResult = Run(operatorWait, new FakeLister());
+        Assert.Equal("operator-required", operatorResult.GetProperty("verdict").GetString());
+    }
+
+    [Fact]
+    public void Execute_ActionableStallOutranksFreshCiWait_G597()
+    {
+        using var workspace = new HeartbeatWorkspace();
+        workspace.WriteTopology();
+        workspace.WritePacketDomain("G600");
+        workspace.WritePacketDomain("G589");
+        var stalledIssue = Issue(1600, "G600: action needed", FixedNow.AddHours(-6), "intent-target");
+        var ciIssue = Issue(1281, "G589: CI wait", FixedNow.AddHours(-2), "intent-pr-created");
+        var pendingPr = Pr(1282, ciIssue.Title, FixedNow.AddMinutes(-5), ciIssue.Number,
+            [CheckRun("IN_PROGRESS")]);
+
+        var result = Run(workspace, new FakeLister([stalledIssue, ciIssue], [pendingPr]));
+
+        Assert.Equal("actionable-stall", result.GetProperty("verdict").GetString());
+        Assert.Contains("G600", result.GetProperty("reason").GetString(), StringComparison.Ordinal);
+        Assert.Contains("intent-cli notify report", result.GetProperty("canonical_notify_command").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_TerminalCiEndSignalNoLongerReportsHealthyActiveWait_G597()
+    {
+        using var workspace = new HeartbeatWorkspace();
+        workspace.WriteTopology();
+        workspace.WritePacketDomain("G589");
+        var issue = Issue(1281, "G589: CI wait", FixedNow.AddHours(-2), "intent-pr-created");
+        var completedPr = Pr(1282, issue.Title, FixedNow.AddMinutes(-20), issue.Number,
+            [CheckRun("COMPLETED", "SUCCESS")]);
+
+        var result = Run(workspace, new FakeLister([issue], [completedPr]));
+
+        Assert.Equal("actionable-stall", result.GetProperty("verdict").GetString());
+        Assert.Contains("ci-all-green-not-transitioned", result.GetProperty("reason").GetString(), StringComparison.Ordinal);
+        Assert.True(result.GetProperty("stale").GetBoolean());
     }
 
     [Fact]
@@ -134,6 +197,8 @@ public sealed class AutomationHeartbeatDecisionG597Tests : IDisposable
         Assert.Contains("cannot-determine", content, StringComparison.Ordinal);
         Assert.Contains("dedupe key", content, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("canonical `intent-cli notify", content, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("only a genuine `stale=true` result ever produces", content, StringComparison.Ordinal);
+        Assert.Contains("actionable-stall", content, StringComparison.Ordinal);
     }
 
     private static JsonElement Run(HeartbeatWorkspace workspace, FakeLister lister)
@@ -191,11 +256,11 @@ public sealed class AutomationHeartbeatDecisionG597Tests : IDisposable
         ],
     };
 
-    private static GitHubAutomationStatusCheckCandidate CheckRun(string status) => new()
+    private static GitHubAutomationStatusCheckCandidate CheckRun(string status, string conclusion = "") => new()
     {
         TypeName = "CheckRun",
         Status = status,
-        Conclusion = string.Empty,
+        Conclusion = conclusion,
     };
 
     private static IReadOnlyDictionary<string, string> SnapshotFiles(string rootPath) =>


### PR DESCRIPTION
Closes #1299

## Summary
- evolves the existing read-only automation heartbeat into one closed, scheduler-agnostic decision surface
- returns exactly `healthy-active-wait`, `actionable-stall`, `operator-required`, or `cannot-determine`, with progress basis, material-state dedupe, ownership, and canonical notify routing
- preserves G596 operator-attention handling and adds EN/JA operational guidance

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --no-restore --filter "FullyQualifiedName~AutomationHeartbeatDecisionG597Tests"` — 6 passed
- `dotnet test IntentSystem.sln -c Release --no-restore` — 4,702 passed, 1 skipped
- `git diff --check` — clean

The implementation is read-only: it adds no scheduler, sleep, process launch, send, persisted poll state, or persisted dedupe state.