### PR TITLE
G599: preserve recorded attention owners

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -699,8 +699,10 @@ carries. An open record appears immediately in the existing `automation
 stalled-work` and `automation heartbeat` output as `operator-attention-pending`.
 The item names the record and carries its recorded `required_actor` plus
 `orchestrator_actionable: false`; a heartbeat whose only item is that record
-sets `route_to: operator` and says `ROUTE TO OPERATOR`. The orchestrator routes
-the obligation but must not pretend it can clear the human decision itself.
+sets `route_to` to the recorded owner and says `ROUTE TO <RECORDED OWNER>`,
+including the owner and blocking reference in the reader-facing item. The
+orchestrator routes the obligation but must not pretend it can clear another
+party's judgment itself.
 No new watchdog, scheduler, timer, polling loop, process launch, or automatic
 open/resolve path is introduced.
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -669,8 +669,11 @@ intent-cli operator-attention supersede --record <id> --evidence <evidence> --wr
 intent-cli operator-attention query [--domain <d>] [--team <t>] --format json
 ```
 
-Open a record whenever progress requires a human operator's decision or act
-and the requirement is not already the unchanged clarification mechanism.
+Open a record whenever progress is blocked awaiting another party's judgment —
+the human operator or a logical thread such as design — and the requirement is
+not already the unchanged clarification mechanism. In particular, a thread
+that needs a design ruling opens this record rather than posting the question
+only as a GitHub comment.
 The opening thread must name an owner, the blocking reference, a specific
 action a reader can perform without reconstructing chat, and establishing
 evidence. It remains that thread's obligation to route the record to the
@@ -691,9 +694,10 @@ the current open set, and age since opening. A missing store or no history at
 the selected scope returns `check-not-completed`; malformed or unreadable
 state returns `cannot-determine`, never `no-attention-pending`.
 
-An open record appears immediately in the existing `automation stalled-work`
-and `automation heartbeat` output as `operator-attention-pending`. The item
-names the record and carries `required_actor: operator` plus
+The compatibility name `operator-attention` is narrower than the obligation it
+carries. An open record appears immediately in the existing `automation
+stalled-work` and `automation heartbeat` output as `operator-attention-pending`.
+The item names the record and carries its recorded `required_actor` plus
 `orchestrator_actionable: false`; a heartbeat whose only item is that record
 sets `route_to: operator` and says `ROUTE TO OPERATOR`. The orchestrator routes
 the obligation but must not pretend it can clear the human decision itself.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -713,8 +713,9 @@ scope に履歴が無ければ `check-not-completed`、malformed または unrea
 `operator-attention` は、この obligation に対しては狭い compatibility name です。open record は既存の
 `automation stalled-work` と `automation heartbeat` に `operator-attention-pending` として即時に現れます。
 item は record を名指しし、recorded `required_actor` と `orchestrator_actionable: false` を持ちます。その
-record だけが item の heartbeat は `route_to: operator` と `ROUTE TO OPERATOR`
-を返します。orchestrator は義務を route しますが、人間の判断を自分で clear
+record だけが item の heartbeat は recorded owner の `route_to` と
+`ROUTE TO <RECORDED OWNER>` を返し、reader-facing item に owner と blocking reference を含めます。
+orchestrator は義務を route しますが、別の party の判断を自分で clear
 できるかのように扱ってはいけません。新しい watchdog、scheduler、timer、
 polling loop、process launch、automatic open/resolve path は追加しません。
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -684,9 +684,11 @@ intent-cli operator-attention supersede --record <id> --evidence <evidence> --wr
 intent-cli operator-attention query [--domain <d>] [--team <t>] --format json
 ```
 
-進行に human operator の判断または作業が必要で、かつ既存の clarification
+進行が別の party の判断待ちで止まっており、かつ既存の clarification
 mechanism（この仕組みでは変更しません）で扱うものではないとき、record を
-open します。open した thread は owner、blocking reference、chat を再構成せず
+open します。party は human operator でも design のような logical thread でも構いません。
+特に design の ruling が必要な thread は、GitHub comment だけを投稿せず、この record を open
+します。open した thread は owner、blocking reference、chat を再構成せず
 実行できる具体的 action、establishing evidence を記録しなければなりません。
 その record を operator に route し、後で evidence 付きの明示的 terminal
 command を実行することも、その thread の責務です。
@@ -708,9 +710,9 @@ scope に履歴が無ければ `check-not-completed`、malformed または unrea
 `cannot-determine` であり、
 `no-attention-pending` には決してなりません。
 
-open record は既存の `automation stalled-work` と `automation heartbeat` に
-`operator-attention-pending` として即時に現れます。item は record を名指しし、
-`required_actor: operator` と `orchestrator_actionable: false` を持ちます。その
+`operator-attention` は、この obligation に対しては狭い compatibility name です。open record は既存の
+`automation stalled-work` と `automation heartbeat` に `operator-attention-pending` として即時に現れます。
+item は record を名指しし、recorded `required_actor` と `orchestrator_actionable: false` を持ちます。その
 record だけが item の heartbeat は `route_to: operator` と `ROUTE TO OPERATOR`
 を返します。orchestrator は義務を route しますが、人間の判断を自分で clear
 できるかのように扱ってはいけません。新しい watchdog、scheduler、timer、

--- a/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
@@ -237,20 +237,21 @@ internal static class AutomationHeartbeatCommand
             return null;
         }
 
-        var hasOperator = stalledWork.Items.Any(item =>
-            string.Equals(item.RequiredActor, "operator", StringComparison.Ordinal));
-        if (!hasOperator)
+        var attentionOwners = stalledWork.Items
+            .Where(item => item.Kind is AutomationStalledWorkCommand.KindOperatorAttentionPending
+                or AutomationStalledWorkCommand.KindOperatorAttentionCannotDetermine)
+            .Select(item => item.RequiredActor)
+            .Where(owner => !string.IsNullOrWhiteSpace(owner))
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+        if (attentionOwners.Length == 0)
         {
             return null;
         }
         var hasOrchestrator = stalledWork.Items.Any(item =>
             !item.IsInformational && item.OrchestratorActionable is not false);
-        return (hasOperator, hasOrchestrator) switch
-        {
-            (true, true) => "operator-and-orchestration",
-            (true, false) => "operator",
-            _ => null,
-        };
+        var ownerRoute = string.Join("-and-", attentionOwners);
+        return hasOrchestrator ? $"{ownerRoute}-and-orchestration" : ownerRoute;
     }
 
     private static HeartbeatDecision Decide(
@@ -275,20 +276,35 @@ internal static class AutomationHeartbeatCommand
             string.Equals(item.Kind, AutomationStalledWorkCommand.KindOperatorAttentionPending, StringComparison.Ordinal));
         if (operatorRecord is not null)
         {
-            return new HeartbeatDecision(
-                Verdict: "operator-required",
-                Reason: $"Open operator-attention record '{operatorRecord.OperatorAttentionRecordId}' requires a human decision.",
-                LastProgressBasis: $"operator-attention record '{operatorRecord.OperatorAttentionRecordId}' opened",
-                LastProgressSource: "operator-attention.opened_at",
-                LastProgressAgeMinutes: operatorRecord.AgeMinutes,
-                DedupeKey: MaterialKey("operator-required", operatorRecord, "operator", null),
-                ActionOwner: "operator",
-                TargetRole: null,
-                CanonicalNotifyCommand: null,
-                WaitCondition: null,
-                WaitEndSignal: null,
-                WaitBoundMinutes: null,
-                SuggestedAction: $"Operator action required for '{operatorRecord.OperatorAttentionRecordId}': {operatorRecord.RecommendedAction}");
+            var owner = operatorRecord.OperatorAttentionOwner;
+            if (string.IsNullOrWhiteSpace(owner))
+            {
+                return CannotDetermine(
+                    $"Open operator-attention record '{operatorRecord.OperatorAttentionRecordId}' has no recorded owner.",
+                    operatorRecord,
+                    "operator-attention owner");
+            }
+
+            if (!string.Equals(owner, "operator", StringComparison.Ordinal))
+            {
+                if (string.IsNullOrWhiteSpace(team))
+                {
+                    return CannotDetermine(
+                        $"Recorded owner '{owner}' cannot be routed because --team is required for this heartbeat decision.",
+                        operatorRecord,
+                        "operator-attention owner routing");
+                }
+
+                var ownerRoute = ResolveAttentionOwnerRoute(context, domain, team, owner);
+                if (!ownerRoute.Resolved)
+                {
+                    return CannotDetermine(ownerRoute.Reason!, operatorRecord, "operator-attention owner routing");
+                }
+
+                return AttentionRequired(operatorRecord, owner, ownerRoute);
+            }
+
+            return AttentionRequired(operatorRecord, owner, null);
         }
 
         if (string.IsNullOrWhiteSpace(team))
@@ -310,7 +326,7 @@ internal static class AutomationHeartbeatCommand
         // pipeline and force callers to re-derive the answer from Items.
         var actionable = stalledWork.Items.FirstOrDefault(item =>
             !item.IsInformational
-            && !string.Equals(item.RequiredActor, "operator", StringComparison.Ordinal)
+            && !string.Equals(item.Kind, AutomationStalledWorkCommand.KindOperatorAttentionPending, StringComparison.Ordinal)
             && !string.Equals(item.Kind, AutomationStalledWorkCommand.KindCiPending, StringComparison.Ordinal));
         if (actionable is not null)
         {
@@ -365,6 +381,29 @@ internal static class AutomationHeartbeatCommand
             WaitEndSignal: null,
             WaitBoundMinutes: null,
             SuggestedAction: "Run the canonical notify command once for this no-pending-transition dedupe key.");
+    }
+
+    private static HeartbeatDecision AttentionRequired(StalledWorkItem record, string owner, HeartbeatRoute? route)
+    {
+        var targetRole = route?.TargetRole;
+        var dedupeKey = MaterialKey("operator-required", record, owner, targetRole);
+        var action = string.Equals(owner, "operator", StringComparison.Ordinal)
+            ? $"Operator action required for '{record.OperatorAttentionRecordId}': {record.RecommendedAction}"
+            : $"{owner} action required for '{record.OperatorAttentionRecordId}': {record.RecommendedAction}";
+        return new HeartbeatDecision(
+            Verdict: "operator-required",
+            Reason: $"Open operator-attention record '{record.OperatorAttentionRecordId}' requires the recorded owner '{owner}'.",
+            LastProgressBasis: $"operator-attention record '{record.OperatorAttentionRecordId}' opened",
+            LastProgressSource: "operator-attention.opened_at",
+            LastProgressAgeMinutes: record.AgeMinutes,
+            DedupeKey: dedupeKey,
+            ActionOwner: owner,
+            TargetRole: targetRole,
+            CanonicalNotifyCommand: route?.CanonicalNotifyCommand,
+            WaitCondition: null,
+            WaitEndSignal: null,
+            WaitBoundMinutes: null,
+            SuggestedAction: action);
     }
 
     private static HeartbeatDecision ActionableStall(
@@ -434,6 +473,30 @@ internal static class AutomationHeartbeatCommand
             + $" --routing-root '{context.RepoRoot.Replace("'", "'\\''", StringComparison.Ordinal)}'"
             + " --write --format json";
         return new HeartbeatRoute(true, null, "orchestration", command);
+    }
+
+    private static HeartbeatRoute ResolveAttentionOwnerRoute(CliContext context, string domain, string team, string owner)
+    {
+        var topology = NotifyRoleTopologyStore.Resolve(context.RepoRoot, team);
+        if (!topology.Resolved)
+        {
+            return HeartbeatRoute.Failure(topology.Summary);
+        }
+
+        var sender = NotifyRoleTopologyStore.ResolveDeliveryTarget(context.RepoRoot, topology.Topology!, "orchestration");
+        var recipient = NotifyRoleTopologyStore.ResolveDeliveryTarget(context.RepoRoot, topology.Topology!, owner);
+        if (!sender.Resolved || !recipient.Resolved)
+        {
+            return HeartbeatRoute.Failure($"Recorded owner '{owner}' cannot be resolved for team '{team}': {sender.Summary} {recipient.Summary}");
+        }
+
+        var command = "intent-cli notify report"
+            + $" --domain {domain} --team {team} --from orchestration --to {owner}"
+            + " --task-id <heartbeat-dedupe-key> --status question --artifact <heartbeat-evidence>"
+            + " --summary <one-line-summary>"
+            + $" --routing-root '{context.RepoRoot.Replace("'", "'\\''", StringComparison.Ordinal)}'"
+            + " --write --format json";
+        return new HeartbeatRoute(true, null, owner, command);
     }
 
     private static string MaterialKey(string verdict, StalledWorkItem? item, string owner, string? targetRole) =>

--- a/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
@@ -145,25 +145,31 @@ internal static class AutomationHeartbeatCommand
     /// </summary>
     private static string BuildMessageBody(AutomationStalledWorkResult stalledWork)
     {
-        var operatorRequiredCount = stalledWork.Items.Count(item =>
-            string.Equals(item.RequiredActor, "operator", StringComparison.Ordinal));
+        var attentionItems = stalledWork.Items
+            .Where(item => item.OrchestratorActionable is false && !string.IsNullOrWhiteSpace(item.RequiredActor))
+            .ToArray();
+        var attentionOwners = attentionItems
+            .Select(item => item.RequiredActor!)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
         var actionableCount = stalledWork.Items.Count(item =>
             !item.IsInformational && item.OrchestratorActionable is not false);
         var informationalCount = stalledWork.Items.Count(item => item.IsInformational);
 
         var builder = new StringBuilder();
         builder.Append("WAKE (heartbeat): ");
-        if (operatorRequiredCount > 0)
+        if (attentionItems.Length > 0)
         {
+            var ownerRoute = string.Join(" AND ", attentionOwners).ToUpperInvariant();
             builder
-                .Append("ROUTE TO OPERATOR — ")
-                .Append(operatorRequiredCount)
-                .Append(" operator-required attention item(s), ");
+                .Append("ROUTE TO ").Append(ownerRoute).Append(" — ")
+                .Append(attentionItems.Length).Append(" ")
+                .Append(string.Join("-and-", attentionOwners)).Append("-required attention item(s), ");
         }
         builder
             .Append(actionableCount)
             .Append(" pending transition(s)");
-        if (operatorRequiredCount > 0)
+        if (attentionItems.Length > 0)
         {
             builder
                 .Append(" (")
@@ -203,10 +209,11 @@ internal static class AutomationHeartbeatCommand
             }
 
             builder.Append(')');
-            if (string.Equals(item.RequiredActor, "operator", StringComparison.Ordinal))
+            if (item.OrchestratorActionable is false && item.RequiredActor is { } requiredActor)
             {
                 builder
-                    .Append(" — OPERATOR REQUIRED (orchestrator_actionable=false): ")
+                    .Append(" — ").Append(requiredActor.ToUpperInvariant())
+                    .Append(" REQUIRED (orchestrator_actionable=false): ")
                     .Append(item.RecommendedAction);
                 if (item.OperatorAttentionOwner is { } owner)
                 {

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -621,12 +621,14 @@ internal static class AutomationStalledWorkCommand
                 AgeMinutes = Math.Max(0, (int)Math.Floor((now - record.OpenedAt).TotalMinutes)),
                 IsInformational = false,
                 RecommendedAction = record.ActionNeeded,
-                RequiredActor = "operator",
+                // G599: the compatibility-named lifecycle records an owner;
+                // this projection must not replace it with a literal.
+                RequiredActor = record.Owner,
                 OrchestratorActionable = false,
                 OperatorAttentionRecordId = record.RecordId,
                 OperatorAttentionOwner = record.Owner,
                 BlockingReference = record.BlockingReference,
-                DedupeKey = $"operator-attention:{record.Domain}:{record.Team}:{record.RecordId}",
+                DedupeKey = $"operator-attention:{record.Domain}:{record.Team}:{record.Owner}:{record.RecordId}",
             });
         }
 

--- a/tests/IntentSystem.Cli.Tests/OperatorAttentionG596Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/OperatorAttentionG596Tests.cs
@@ -214,6 +214,12 @@ public sealed class OperatorAttentionG596Tests : IDisposable
         Assert.Equal("design", heartbeat.GetProperty("route_to").GetString());
         Assert.Contains("--to design", heartbeat.GetProperty("canonical_notify_command").GetString(), StringComparison.Ordinal);
         Assert.Contains(":design:", heartbeat.GetProperty("dedupe_key").GetString(), StringComparison.Ordinal);
+        var message = heartbeat.GetProperty("message_body").GetString()!;
+        Assert.Contains("ROUTE TO DESIGN", message, StringComparison.Ordinal);
+        Assert.Contains("design-required attention item", message, StringComparison.Ordinal);
+        Assert.Contains("DESIGN REQUIRED (orchestrator_actionable=false)", message, StringComparison.Ordinal);
+        Assert.Contains("Owner: design.", message, StringComparison.Ordinal);
+        Assert.Contains("Blocking reference: design:design-gate.", message, StringComparison.Ordinal);
 
         Assert.Equal(0, workspace.Run("operator-attention", "resolve", "--record", "design-gate",
             "--resolution-evidence", "design ruling recorded", "--write", "--format", "json").ExitCode);

--- a/tests/IntentSystem.Cli.Tests/OperatorAttentionG596Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/OperatorAttentionG596Tests.cs
@@ -170,7 +170,7 @@ public sealed class OperatorAttentionG596Tests : IDisposable
     public void IdlePipelineWithOpenRecord_RoutesHeartbeatToOperatorNotOrchestrator_G596()
     {
         OperatorAttentionCommand.UtcNowFactory = () => FixedNow.AddMinutes(-1);
-        Assert.Equal(0, workspace.Open("release-approval", write: true).ExitCode);
+        Assert.Equal(0, workspace.OpenOwned("release-approval", "operator", write: true).ExitCode);
 
         var stalled = AutomationStalledWorkCommand.Analyze(
             workspace.Context, "intent-cli", "J-Tech-Japan/intent-system", staleMinutes: 45);
@@ -191,6 +191,51 @@ public sealed class OperatorAttentionG596Tests : IDisposable
         Assert.Contains("orchestrator_actionable=false", message, StringComparison.Ordinal);
         Assert.Contains("release-approval", message, StringComparison.Ordinal);
         Assert.DoesNotContain("1 orchestrator-actionable", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DesignOwnedLifecycle_PropagatesOwnerThroughStalledWorkHeartbeatAndResolution_G599()
+    {
+        workspace.WriteTopology();
+        Assert.Equal(0, workspace.OpenOwned("design-gate", "design", write: true).ExitCode);
+
+        var stalled = AutomationStalledWorkCommand.Analyze(
+            workspace.Context, "intent-cli", "J-Tech-Japan/intent-system", staleMinutes: 45);
+        var item = Assert.Single(stalled.Items);
+        Assert.Equal("design", item.RequiredActor);
+        Assert.Equal("design", item.OperatorAttentionOwner);
+        Assert.Contains(":design:", item.DedupeKey, StringComparison.Ordinal);
+
+        var (_, heartbeat) = workspace.Run("automation", "heartbeat", "--domain", "intent-cli",
+            "--repo", "J-Tech-Japan/intent-system", "--team", "intent-cli-dev", "--format", "json");
+        Assert.Equal("operator-required", heartbeat.GetProperty("verdict").GetString());
+        Assert.Equal("design", heartbeat.GetProperty("action_owner").GetString());
+        Assert.Equal("design", heartbeat.GetProperty("target_role").GetString());
+        Assert.Equal("design", heartbeat.GetProperty("route_to").GetString());
+        Assert.Contains("--to design", heartbeat.GetProperty("canonical_notify_command").GetString(), StringComparison.Ordinal);
+        Assert.Contains(":design:", heartbeat.GetProperty("dedupe_key").GetString(), StringComparison.Ordinal);
+
+        Assert.Equal(0, workspace.Run("operator-attention", "resolve", "--record", "design-gate",
+            "--resolution-evidence", "design ruling recorded", "--write", "--format", "json").ExitCode);
+        var (_, restored) = workspace.Run("automation", "heartbeat", "--domain", "intent-cli",
+            "--repo", "J-Tech-Japan/intent-system", "--team", "intent-cli-dev", "--format", "json");
+        Assert.Equal("actionable-stall", restored.GetProperty("verdict").GetString());
+    }
+
+    [Fact]
+    public void UnknownOwnerAndCommentOnlyBlock_FailClosedOrRemainActionable_G599()
+    {
+        workspace.WriteTopology();
+        var (_, commentOnly) = workspace.Run("automation", "heartbeat", "--domain", "intent-cli",
+            "--repo", "J-Tech-Japan/intent-system", "--team", "intent-cli-dev", "--format", "json");
+        Assert.Equal("actionable-stall", commentOnly.GetProperty("verdict").GetString());
+
+        Assert.Equal(0, workspace.OpenOwned("unknown-gate", "unrecorded-owner", write: true).ExitCode);
+        var (_, unknown) = workspace.Run("automation", "heartbeat", "--domain", "intent-cli",
+            "--repo", "J-Tech-Japan/intent-system", "--team", "intent-cli-dev", "--format", "json");
+        Assert.Equal("cannot-determine", unknown.GetProperty("verdict").GetString());
+        Assert.Contains("unrecorded-owner", unknown.GetProperty("reason").GetString(), StringComparison.Ordinal);
+        Assert.NotEqual("operator", unknown.GetProperty("action_owner").GetString());
     }
 
     [Fact]
@@ -315,6 +360,28 @@ public sealed class OperatorAttentionG596Tests : IDisposable
                 "--domain", domain, "--team", team, "--owner", "operator",
                 "--blocking-reference", $"unit:{record}", "--action-needed", $"Decide {record}",
                 "--evidence", $"Evidence for {record}", "--write", "--format", "json");
+        }
+
+        public (int ExitCode, JsonElement Result) OpenOwned(string record, string owner, bool write)
+        {
+            return Run("operator-attention", "open", "--record", record,
+                "--domain", "intent-cli", "--team", "intent-cli-dev", "--owner", owner,
+                "--blocking-reference", $"design:{record}", "--action-needed", "Record a design ruling",
+                "--evidence", "implementation is blocked", write ? "--write" : "--dry-run", "--format", "json");
+        }
+
+        public void WriteTopology()
+        {
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, JsonSerializer.Serialize(new
+            {
+                team = "intent-cli-dev", workspace_id = "workspace", roles = new Dictionary<string, object>
+                {
+                    ["design"] = new { resident = "herdr", workspace_id = "workspace", pane_id = "workspace:p1" },
+                    ["orchestration"] = new { resident = "herdr", workspace_id = "workspace", pane_id = "workspace:p2" },
+                },
+            }));
         }
 
         public void RecordAgmsgMode()


### PR DESCRIPTION
Closes #1301

## Summary
- propagate each recorded attention owner through stalled-work, heartbeat action owner, route, and material dedupe key
- resolve logical-role owners through recorded topology; unknown owners fail closed as `cannot-determine`
- retain the operator-attention command/file/kind compatibility names and document the broader obligation in EN/JA

## Verification
- focused `OperatorAttentionG596Tests`: 13 passed
- Release solution: 4,707 passed, 1 skipped
- `git diff --check`: clean

No inference, auto-open, new command surface, alias, lifecycle rename, or verdict-enum migration was added.