### PR TITLE
G602: plan mode-switch follow-up

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -382,6 +382,21 @@ label (for example, `<team> · herdr-only`). That label is human-facing and
 non-authoritative: intent-cli neither writes herdr state nor reads the label as
 mode evidence.
 
+#### Mode switches require a manual migration review
+
+When `session-layer set --write` actually changes a recorded mode, it emits an
+ordered **manual migration plan**. Review the other mode's session hooks, inbox
+watchers or monitors, then regenerate the G601 visibility marker. Each item is
+an operator action: intent-cli never deletes, rewrites, or disables user
+configuration. A no-op set emits no plan.
+
+The shared preflight checks only declared locations for known other-mode
+residue. For example, project-level agmsg session hooks in `.codex/hooks.json`
+are reported on a herdr-only team. Such `other-mode-residue` findings name the
+path and owning mode, state the one-mode exclusivity contract and removal
+guidance, but remain advisory: residue is a hazard rather than proof of active
+mixing and never infers, flips, or overrides the canonical mode record.
+
 #### Shared record-first session-layer preflight
 
 `automation doctor`, the guide's READY definition, and `notify` consume one

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -354,6 +354,19 @@ herdr workspace を provision するときは、recorded mode を workspace labe
 `<team> · herdr-only`）。この label は human-facing かつ non-authoritative です。intent-cli は herdr
 state を書かず、label を mode evidence として読みません。
 
+#### mode switch 後の manual migration review
+
+`session-layer set --write` が recorded mode を実際に変更したときは、順序付きの **manual migration
+plan** を出力します。other mode の session hooks、inbox watchers / monitors を review し、続けて G601
+visibility marker を regenerate してください。各項目は operator action です。intent-cli は user
+configuration を delete、rewrite、disable しません。no-op の set は plan を出しません。
+
+shared preflight は declared location だけで known other-mode residue を確認します。たとえば
+herdr-only team 上の `.codex/hooks.json` にある project-level agmsg session hooks は報告対象です。
+`other-mode-residue` finding は path と owning mode、one-mode exclusivity contract、removal guidance を
+明記しますが advisory のままです。residue は active mixing の証明ではなく hazard であり、canonical
+mode record を infer、flip、override しません。
+
 #### shared record-first session-layer preflight
 
 `automation doctor`、guide の READY definition、`notify` は、同じ production predicate が返す

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -116,12 +116,12 @@ internal static class NotifyCommand
             };
             if (preflight.Ready is not true)
             {
-                // G601 marker absence is intentionally informational. It must
-                // never hide the actionable structural cause that made this
-                // delivery preflight fail (for example, an unsafe external
-                // reader).
+                // G601 marker absence and G602 other-mode residue are
+                // intentionally advisory. They must never hide the actionable
+                // structural cause that made this delivery preflight fail
+                // (for example, missing topology or an unsafe external reader).
                 var primaryFinding = scope.Findings.FirstOrDefault(finding =>
-                    !string.Equals(finding.Cause, "marker-not-generated", StringComparison.Ordinal))
+                    !IsAdvisoryPreflightFinding(finding))
                     ?? scope.Findings.FirstOrDefault();
                 var cause = primaryFinding?.Cause ?? "session-layer-not-ready";
                 Emit(writer, options.Format, FailureResult(
@@ -157,6 +157,10 @@ internal static class NotifyCommand
 
         return ExecuteEscalation(writer, options, escalationResolution);
     }
+
+    private static bool IsAdvisoryPreflightFinding(SessionLayerPreflightFinding finding) =>
+        string.Equals(finding.Cause, "marker-not-generated", StringComparison.Ordinal)
+        || string.Equals(finding.Cause, SessionLayerMigration.ResidueCause, StringComparison.Ordinal);
 
     private static int ExecuteDelivery(
         TextWriter writer,

--- a/src/IntentSystem.Cli/Commands/SessionLayerCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerCommand.cs
@@ -199,6 +199,9 @@ internal static class SessionLayerCommand
             RequestedMode = requested,
             PreviousMode = existing?.Mode ?? SessionLayerMode.Default,
             AlreadyRecorded = alreadyRecorded,
+            MigrationPlan = applied
+                ? SessionLayerMigration.Plan(domain!, team, existing?.Mode ?? SessionLayerMode.Default, requested!)
+                : null,
         };
 
         Emit(writer, format, result);
@@ -292,6 +295,18 @@ internal static class SessionLayerCommand
             foreach (var transition in result.Transitions)
             {
                 writer.WriteLine($"- {transition.At:O}: {transition.From} → {transition.To}");
+            }
+        }
+
+        if (result.MigrationPlan is { Count: > 0 })
+        {
+            writer.WriteLine();
+            writer.WriteLine("## Manual migration plan");
+            writer.WriteLine();
+            writer.WriteLine("Review these user-managed artifacts; this command did not change any of them.");
+            foreach (var item in result.MigrationPlan)
+            {
+                writer.WriteLine($"1. {item.Action}");
             }
         }
     }
@@ -453,4 +468,7 @@ internal sealed record SessionLayerResult
 
     [JsonPropertyName("team_omission")]
     public SessionLayerTeamOmissionDisclosure? TeamOmission { get; init; }
+
+    [JsonPropertyName("migration_plan")]
+    public IReadOnlyList<SessionLayerMigrationPlanItem>? MigrationPlan { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/SessionLayerMigration.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerMigration.cs
@@ -1,0 +1,100 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G602: mode switches name operator-owned follow-up without attempting to
+/// rewrite it. Residue discovery is intentionally limited to declared project
+/// locations; it is advisory evidence and never a source of mode truth.
+/// </summary>
+internal static class SessionLayerMigration
+{
+    public const string ProjectHooksPath = ".codex/hooks.json";
+
+    public const string ResidueCause = "other-mode-residue";
+
+    public static IReadOnlyList<SessionLayerMigrationPlanItem> Plan(
+        string domain,
+        string? team,
+        string previousMode,
+        string requestedMode) =>
+    [
+        new()
+        {
+            Artifact = "other-mode-session-hooks",
+            OtherMode = previousMode,
+            Action = $"Review project-level session hooks in `{ProjectHooksPath}` for '{previousMode}' and manually remove or disable only the hooks that no longer belong to this team.",
+        },
+        new()
+        {
+            Artifact = "other-mode-inbox-watchers-monitors",
+            OtherMode = previousMode,
+            Action = $"Review inbox watchers and monitors for '{previousMode}' and stop or reconfigure only the user-managed processes that no longer belong to this team.",
+        },
+        new()
+        {
+            Artifact = "g601-visibility-marker",
+            OtherMode = previousMode,
+            Action = $"Regenerate the visibility marker for the recorded '{requestedMode}' mode with `intent-cli session-layer marker generate --domain {domain}"
+                + (team is null ? string.Empty : $" --team {team}")
+                + " --file <AGENTS.md|CLAUDE.md> --write`.",
+        },
+    ];
+
+    public static IReadOnlyList<SessionLayerResidue> Discover(string repoRoot, string recordedMode)
+    {
+        var otherMode = string.Equals(recordedMode, SessionLayerMode.HerdrOnly, StringComparison.Ordinal)
+            ? SessionLayerMode.Agmsg
+            : string.Equals(recordedMode, SessionLayerMode.Agmsg, StringComparison.Ordinal)
+                ? SessionLayerMode.HerdrOnly
+                : null;
+        if (otherMode is null)
+        {
+            return [];
+        }
+
+        var path = Path.Combine(repoRoot, ProjectHooksPath);
+        if (!File.Exists(path))
+        {
+            return [];
+        }
+
+        try
+        {
+            var content = File.ReadAllText(path);
+            return HasSessionHookForMode(content, otherMode)
+                ? [new(ProjectHooksPath, otherMode, "project-level-session-hooks")]
+                : [];
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // User configuration is not a record of mode truth. A file we
+            // cannot read cannot support a residue conclusion, and this slice
+            // must neither repair it nor turn it into a mode decision.
+            return [];
+        }
+    }
+
+    private static bool HasSessionHookForMode(string content, string mode) =>
+        content.Contains(
+            string.Equals(mode, SessionLayerMode.HerdrOnly, StringComparison.Ordinal) ? "herdr" : mode,
+            StringComparison.OrdinalIgnoreCase)
+        && (content.Contains("session-start", StringComparison.OrdinalIgnoreCase)
+            || content.Contains("session-end", StringComparison.OrdinalIgnoreCase)
+            || content.Contains("sessionstart", StringComparison.OrdinalIgnoreCase)
+            || content.Contains("sessionend", StringComparison.OrdinalIgnoreCase));
+}
+
+internal sealed record SessionLayerMigrationPlanItem
+{
+    [JsonPropertyName("artifact")]
+    public required string Artifact { get; init; }
+
+    [JsonPropertyName("other_mode")]
+    public required string OtherMode { get; init; }
+
+    [JsonPropertyName("action")]
+    public required string Action { get; init; }
+}
+
+internal sealed record SessionLayerResidue(string Path, string OwningMode, string Artifact);

--- a/src/IntentSystem.Cli/Commands/SessionLayerPreflight.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerPreflight.cs
@@ -219,6 +219,7 @@ internal static class SessionLayerPreflight
         if (resolution.Source == SessionLayerModeSource.Recorded)
         {
             AddMarkerFindings(findings, markers, domain!, team, resolution);
+            AddResidueFindings(findings, repoRoot, team, resolution);
         }
 
         if (topology.Error is not null && resolution.Source != SessionLayerModeSource.Recorded)
@@ -500,6 +501,30 @@ internal static class SessionLayerPreflight
             RecordedMode = recordedMode,
             TopologyMode = null,
         });
+    }
+
+    private static void AddResidueFindings(
+        List<SessionLayerPreflightFinding> findings,
+        string repoRoot,
+        string team,
+        SessionLayerModeResolution resolution)
+    {
+        foreach (var residue in SessionLayerMigration.Discover(repoRoot, resolution.Mode))
+        {
+            findings.Add(new SessionLayerPreflightFinding
+            {
+                Team = team,
+                Role = residue.Path,
+                Field = "residue",
+                Cause = SessionLayerMigration.ResidueCause,
+                Message = $"Known '{residue.OwningMode}' {residue.Artifact} residue is present at '{residue.Path}', "
+                    + $"while the canonical record names '{resolution.Mode}'. A team runs exactly ONE session-layer "
+                    + "mode at a time; review and remove or disable this user-managed residue. This advisory finding "
+                    + "never infers, changes, or overrides the recorded mode.",
+                RecordedMode = resolution.Mode,
+                TopologyMode = null,
+            });
+        }
     }
 
     private static SessionLayerPreflightScopeResult Scope(

--- a/tests/IntentSystem.Cli.Tests/SessionLayerMigrationG602Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerMigrationG602Tests.cs
@@ -1,0 +1,178 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class SessionLayerMigrationG602Tests : IDisposable
+{
+    private readonly Workspace workspace = new();
+
+    public void Dispose() => workspace.Dispose();
+
+    [Fact]
+    public void RealSwitch_EmitsOrderedManualPlanWithoutChangingNamedArtifacts_AndNoOpEmitsNone_G602()
+    {
+        workspace.Record(SessionLayerMode.Agmsg);
+        workspace.WriteHooks("""
+            { "hooks": { "session-start": [{ "command": "agmsg watch.sh" }], "session-end": [{ "command": "agmsg leave.sh" }] } }
+            """);
+        var hooksBefore = File.ReadAllBytes(workspace.HooksPath);
+
+        var switchResult = workspace.Set(SessionLayerMode.HerdrOnly);
+
+        Assert.Equal(0, switchResult.ExitCode);
+        Assert.True(switchResult.Result.GetProperty("applied").GetBoolean());
+        var plan = switchResult.Result.GetProperty("migration_plan").EnumerateArray().ToArray();
+        Assert.Equal(
+            ["other-mode-session-hooks", "other-mode-inbox-watchers-monitors", "g601-visibility-marker"],
+            plan.Select(item => item.GetProperty("artifact").GetString()));
+        Assert.All(plan, item => Assert.False(string.IsNullOrWhiteSpace(item.GetProperty("action").GetString())));
+        Assert.Contains("marker generate --domain intent-cli --team alpha", plan[2].GetProperty("action").GetString(), StringComparison.Ordinal);
+        Assert.Equal(hooksBefore, File.ReadAllBytes(workspace.HooksPath));
+
+        var noOp = workspace.Set(SessionLayerMode.HerdrOnly);
+
+        Assert.Equal(0, noOp.ExitCode);
+        Assert.True(noOp.Result.GetProperty("already_recorded").GetBoolean());
+        Assert.False(noOp.Result.TryGetProperty("migration_plan", out _));
+    }
+
+    [Fact]
+    public void HerdrOnlyAgmsgHooks_AreAdvisoryResidueAndDoNotChangeTheRecordedMode_G602()
+    {
+        workspace.Record(SessionLayerMode.HerdrOnly);
+        workspace.WriteTopology();
+        workspace.WriteAndGenerateMarker(SessionLayerMode.HerdrOnly);
+        workspace.WriteHooks("""
+            { "hooks": { "session-start": [{ "command": "agmsg watch.sh" }], "session-end": [{ "command": "agmsg leave.sh" }] } }
+            """);
+        var recordBefore = File.ReadAllBytes(workspace.RecordPath);
+
+        var preflight = SessionLayerPreflight.Analyze(workspace.RootPath, Workspace.Domain, Workspace.Team);
+
+        Assert.Equal(SessionLayerPreflight.Ready, preflight.Verdict);
+        var finding = Assert.Single(Assert.Single(preflight.Scopes).Findings,
+            item => item.Cause == SessionLayerMigration.ResidueCause);
+        Assert.Equal(SessionLayerMigration.ProjectHooksPath, finding.Role);
+        Assert.Contains("'agmsg'", finding.Message, StringComparison.Ordinal);
+        Assert.Contains("exactly ONE session-layer mode", finding.Message, StringComparison.Ordinal);
+        Assert.Contains("remove or disable", finding.Message, StringComparison.Ordinal);
+        Assert.Contains("never infers, changes, or overrides", finding.Message, StringComparison.Ordinal);
+        Assert.Equal(recordBefore, File.ReadAllBytes(workspace.RecordPath));
+        Assert.Equal(SessionLayerMode.HerdrOnly,
+            SessionLayerModeStore.Resolve(workspace.RootPath, Workspace.Domain, Workspace.Team).Mode);
+    }
+
+    [Fact]
+    public void AgmsgHerdrHooks_AreDetectedWhenTheReverseResidueIsDeclared_G602()
+    {
+        workspace.Record(SessionLayerMode.Agmsg);
+        workspace.WriteAndGenerateMarker(SessionLayerMode.Agmsg);
+        workspace.WriteHooks("""
+            { "hooks": { "SessionStart": [{ "command": "herdr agent start" }] } }
+            """);
+
+        var preflight = SessionLayerPreflight.Analyze(workspace.RootPath, Workspace.Domain, Workspace.Team);
+
+        Assert.Equal(SessionLayerPreflight.Ready, preflight.Verdict);
+        var finding = Assert.Single(Assert.Single(preflight.Scopes).Findings,
+            item => item.Cause == SessionLayerMigration.ResidueCause);
+        Assert.Contains("'herdr-only'", finding.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain(Assert.Single(preflight.Scopes).Findings, item => item.Cause == "marker-drift");
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void Guidance_ExplainsManualMigrationAndAdvisoryResidue_G602(string language)
+    {
+        var content = File.ReadAllText(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "docs",
+            language,
+            "12-agent-message-orchestration.md"));
+
+        Assert.Contains("manual migration", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("G601", content, StringComparison.Ordinal);
+        Assert.Contains("other-mode-residue", content, StringComparison.Ordinal);
+        Assert.Contains("never", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private sealed class Workspace : IDisposable
+    {
+        public const string Domain = "intent-cli";
+        public const string Team = "alpha";
+
+        public Workspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("session-layer-migration-g602-").FullName;
+            Context = new CliContext
+            {
+                RepoRoot = RootPath,
+                Config = new CliConfig { Project = new ProjectConfig { Domain = Domain, ArtifactRoot = ".intent-cli" } },
+            };
+        }
+
+        public string RootPath { get; }
+        public CliContext Context { get; }
+        public string RecordPath => SessionLayerModeStore.ResolvePath(RootPath);
+        public string HooksPath => Path.Combine(RootPath, SessionLayerMigration.ProjectHooksPath);
+
+        public void Record(string mode)
+        {
+            var result = Set(mode);
+            Assert.Equal(0, result.ExitCode);
+        }
+
+        public (int ExitCode, JsonElement Result) Set(string mode)
+        {
+            using var writer = new StringWriter();
+            var exitCode = SessionLayerCommand.ExecuteSet(Context,
+                ["--domain", Domain, "--team", Team, "--mode", mode, "--write", "--format", "json"], writer);
+            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+        }
+
+        public void WriteHooks(string content)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(HooksPath)!);
+            File.WriteAllText(HooksPath, content);
+        }
+
+        public void WriteAndGenerateMarker(string mode)
+        {
+            var path = Path.Combine(RootPath, "AGENTS.md");
+            File.WriteAllText(path,
+                $"<!-- intent-cli:session-layer-marker:start domain=\"{Domain}\" team=\"{Team}\" -->\n"
+                + "<!-- intent-cli:session-layer-marker:end -->\n");
+            using var writer = new StringWriter();
+            var exitCode = SessionLayerMarkerCommand.Execute(Context,
+                ["generate", "--domain", Domain, "--team", Team, "--file", path, "--write", "--format", "json"], writer);
+            Assert.True(exitCode == 0, writer.ToString());
+            Assert.Contains($"mode=\"{mode}\"", File.ReadAllText(path), StringComparison.Ordinal);
+        }
+
+        public void WriteTopology()
+        {
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, JsonSerializer.Serialize(new
+            {
+                team = Team,
+                workspace_id = "w",
+                roles = new
+                {
+                    implementation = new { resident = "herdr", workspace_id = "w", pane_id = "w:p2" },
+                    orchestration = new { resident = "herdr", workspace_id = "w", pane_id = "w:p1" },
+                },
+            }));
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath)) Directory.Delete(RootPath, recursive: true);
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/SessionLayerMigrationG602Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerMigrationG602Tests.cs
@@ -67,6 +67,25 @@ public sealed class SessionLayerMigrationG602Tests : IDisposable
     }
 
     [Fact]
+    public void Notify_UsesTopologyCauseWhenAdvisoryResidueIsAlsoPresent_G602()
+    {
+        workspace.Record(SessionLayerMode.HerdrOnly);
+        workspace.WriteAndGenerateMarker(SessionLayerMode.HerdrOnly);
+        workspace.WriteHooks("""
+            { "hooks": { "session-start": [{ "command": "agmsg watch.sh" }] } }
+            """);
+
+        var (exitCode, result) = workspace.RunNotify();
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("topology-missing", result.GetProperty("cause").GetString());
+        var findings = result.GetProperty("session_layer_preflight").GetProperty("scopes")[0]
+            .GetProperty("findings").EnumerateArray().ToArray();
+        Assert.Contains(findings, finding => finding.GetProperty("cause").GetString() == SessionLayerMigration.ResidueCause);
+        Assert.Contains(findings, finding => finding.GetProperty("cause").GetString() == "topology-missing");
+    }
+
+    [Fact]
     public void AgmsgHerdrHooks_AreDetectedWhenTheReverseResidueIsDeclared_G602()
     {
         workspace.Record(SessionLayerMode.Agmsg);
@@ -168,6 +187,28 @@ public sealed class SessionLayerMigrationG602Tests : IDisposable
                     orchestration = new { resident = "herdr", workspace_id = "w", pane_id = "w:p1" },
                 },
             }));
+        }
+
+        public (int ExitCode, JsonElement Result) RunNotify()
+        {
+            using var writer = new StringWriter();
+            var exitCode = CommandRouter.Execute(
+                [
+                    "notify", "report",
+                    "--domain", Domain,
+                    "--team", Team,
+                    "--from", "implementation",
+                    "--to", "orchestration",
+                    "--task-id", "G602-ac4",
+                    "--status", "completed",
+                    "--artifact", "https://example.test/pr/1308",
+                    "--summary", "residue precedence verification",
+                    "--write",
+                    "--format", "json",
+                ],
+                Context,
+                writer);
+            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
         }
 
         public void Dispose()


### PR DESCRIPTION
## Summary

- emit an ordered manual migration plan only for real session-layer mode switches
- surface known other-mode session-hook residue as advisory record-first preflight evidence
- document the operator-owned migration review in English and Japanese

## Verification

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~SessionLayerMigrationG602Tests|FullyQualifiedName~SessionLayerModeG570Tests|FullyQualifiedName~SessionLayerPreflightG594Tests|FullyQualifiedName~SessionLayerMarkerG601Tests" --no-restore` (173 passed)
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --logger "console;verbosity=minimal"` (4392 passed, 1 skipped)
- `git diff --check`

Closes #1307