### PR TITLE
G603: qualify worker linkage identities

### DIFF
--- a/docs/en/07-recovery.md
+++ b/docs/en/07-recovery.md
@@ -89,6 +89,21 @@ you whether a child-loop-owned repair exists. Host-owned categories surface as
 > `--issue <n>`. Child `--github-only` loops never write `linked_pr`; this recovery
 > belongs to the host closeout surface.
 
+> **Repository-qualified linkage and completed repairs (G603).** A GitHub
+> issue or PR number is an identity only together with `owner/repo`. Worker
+> completion, closeout, review planning, and stalled-work therefore reject a
+> bare or wrong-repository linkage rather than letting a colliding number pick
+> a foreign queue item. In host context, `worker complete` also refuses a
+> queue write when the selected unit's declared domain disagrees with the
+> command domain. For a completed unit whose `linked_pr` points at the wrong
+> repository, use `automation host-queue-item-recovery --repo <owner/repo>
+> --unit <unit> --issue <n> --pr <n> --write`: it requires GitHub evidence
+> that the proposed PR exists, is merged, and closes that unit's own issue,
+> then appends a `completed-linkage-repair` run event containing the evidence.
+> A legacy packet without a readable `publish.yaml` identity stops with
+> `legacy-publish-identity-missing` and names the missing evidence; it never
+> guesses or changes a completed linkage.
+
 ### Repeated-stall recovery (G408)
 
 When an automation loop hits the same blocker on the same target for **two or more

--- a/docs/ja/07-recovery.md
+++ b/docs/ja/07-recovery.md
@@ -88,6 +88,19 @@ child-loop 所有の修復が存在するかを示す。host 所有のカテゴ�
 > `linkage-ambiguous` エラーで fail closed する。その場合のみ正しい `--issue <n>` で再実行する。
 > child `--github-only` ループは `linked_pr` を書かない。この recovery は host closeout surface の責務。
 
+> **repo-qualified linkage と completed repair（G603）。** GitHub の issue / PR
+> 番号は `owner/repo` と組になって初めて identity になる。worker complete、closeout、
+> review planning、stalled-work は bare な番号または別 repo の linkage を拒否し、
+> 同じ番号の foreign queue item を選ばない。host context の `worker complete` は、
+> 選ばれた unit の declared domain と command domain が違う write も拒否する。
+> completed unit の `linked_pr` が別 repo を指す場合は
+> `automation host-queue-item-recovery --repo <owner/repo> --unit <unit> --issue <n> --pr <n> --write`
+> を使う。提案する PR の存在・merged・その unit 自身の issue を closes することを
+> GitHub facts で確認してから、evidence を含む `completed-linkage-repair` run event を追加する。
+> readable な `publish.yaml` identity が無い legacy packet は
+> `legacy-publish-identity-missing` で不足 evidence を明示して停止し、推測や completed
+> linkage の変更は行わない。
+
 ### 繰り返しストール回復（G408）
 
 同じターゲットで同じブロッカーに **2 回以上連続** してヒットした場合は、

--- a/src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostQueueItemRecoveryCommand.cs
@@ -143,6 +143,13 @@ internal static class AutomationHostQueueItemRecoveryCommand
             .Where(a => a.Artifact is null || ArtifactBelongsToRepo(a.Artifact, repo!))
             .ToList();
 
+        // G603 legacy packets can lack publish.yaml identity fields. Do not
+        // silently skip the requested completed unit: emit a concrete finding
+        // that names the missing evidence and tells the operator how to
+        // restore it. This is intentionally fail-closed rather than guessing.
+        var legacyRequestedUnit = !string.IsNullOrWhiteSpace(unit)
+            && scopedArtifacts.All(a => !string.Equals(a.Unit, unit, StringComparison.Ordinal));
+
         // Build a map of issue-number → units that claim it (after repo
         // filter), so the analyzer can flag multiple-matching-packets.
         var issueToUnits = new Dictionary<int, List<string>>();
@@ -310,6 +317,18 @@ internal static class AutomationHostQueueItemRecoveryCommand
             });
         }
 
+        if (legacyRequestedUnit)
+        {
+            perCandidate.Add(new HostQueueItemRecoveryRecord
+            {
+                Unit = unit!,
+                PublishArtifactPath = $".intent-cli/issues/{unit}/publish.yaml",
+                Result = HostQueueItemRecoveryAnalyzer.ResultUnsafeStop,
+                ReasonCode = HostQueueItemRecoveryAnalyzer.ReasonLegacyPublishIdentityMissing,
+                Explanation = $"legacy packet '{unit}' has no readable publish.yaml issue identity. Restore or supply publish evidence that identifies {repo}#<issue>, then rerun host-queue-item-recovery with --unit {unit} --issue <n> --pr <n>; no completed linkage is changed without that evidence.",
+            });
+        }
+
         // Apply repairs if --write.
         var appliedUnits = new List<string>();
         var warnings = new List<string>();
@@ -323,6 +342,7 @@ internal static class AutomationHostQueueItemRecoveryCommand
                 try
                 {
                     queueState = ApplyRepair(context, repo!, domain, queueLocation, queueState, record.ProposedQueueItem!);
+                    AppendRepairEvidence(context, repo!, domain, queueLocation, record);
                     appliedUnits.Add(record.Unit);
                 }
                 catch (Exception exception) when (exception is IOException or InvalidOperationException)
@@ -481,6 +501,34 @@ internal static class AutomationHostQueueItemRecoveryCommand
         return newState;
     }
 
+    private static void AppendRepairEvidence(
+        CliContext context,
+        string repo,
+        string domain,
+        StateLocation queueLocation,
+        HostQueueItemRecoveryRecord record)
+    {
+        var runsPath = queueLocation.Kind == StateLocationKind.Legacy
+            ? RuntimeScopedStateResolver.GetLegacyRunLogPath(context.RepoRoot)
+            : RuntimeScopedStateResolver.GetScopedRunLogPath(context.RepoRoot, domain, repo);
+        Directory.CreateDirectory(Path.GetDirectoryName(runsPath)!);
+        var proposed = record.ProposedQueueItem!;
+        var evidence = string.Join(" | ", record.Evidence ?? Array.Empty<string>());
+        var runEvent = new RunEvent
+        {
+            Ts = DateTimeOffset.UtcNow,
+            ExecutionUnit = record.Unit,
+            Event = "completed-linkage-repair",
+            By = "intent-cli automation host-queue-item-recovery (G603)",
+            LinkedIssue = proposed.LinkedIssueUrl,
+            LinkedPr = proposed.LinkedPrUrl,
+            Repo = repo,
+            Pr = proposed.LinkedPrNumber,
+            Reason = evidence,
+        };
+        File.AppendAllText(runsPath, RunLogSerializer.SerializeLine(runEvent) + Environment.NewLine);
+    }
+
     private static GitHubPrLookupResult? LookupPr(
         IGitHubPrLookup prLookup,
         Dictionary<int, GitHubPrLookupResult?> cache,
@@ -533,7 +581,8 @@ internal static class AutomationHostQueueItemRecoveryCommand
         // PR view. The PR must explicitly close this issue (i.e. the
         // GitHub "linked issues" relation) for the recovery to be
         // deterministic.
-        var closesIssue = prView?.ClosingIssuesReferences?.Any(r => r.Number == issueNumber) == true;
+        var closesIssue = prView?.ClosingIssuesReferences?.Any(r =>
+            GitHubWorkItemIdentity.MatchesClosingIssue(r, repo, issueNumber)) == true;
         if (prView is null || !closesIssue)
         {
             return ClosingIssueResolution.PrDoesNotCloseIssue();
@@ -601,8 +650,19 @@ internal static class AutomationHostQueueItemRecoveryCommand
             ExecutionUnit = item.ExecutionUnit,
             LinkedPrNumber = prNumber,
             LinkedIssueNumber = issueNumber,
+            LinkedIssueRepo = item.LinkedIssue?.Repo,
+            LinkedPrRepo = TryParseRepoFromUrl(item.LinkedPr),
+            State = item.State,
             Title = item.Title,
         };
+    }
+
+    private static string? TryParseRepoFromUrl(string? url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            || !string.Equals(uri.Host, "github.com", StringComparison.OrdinalIgnoreCase)) return null;
+        var parts = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 2 ? $"{parts[0]}/{parts[1]}" : null;
     }
 
     private static int? TryParsePrNumberFromUrl(string? linkedPr)

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -1338,7 +1338,7 @@ internal static class AutomationStalledWorkCommand
             // every ACTIVE (non-completed) match first; more than one is
             // never resolved by picking one, it is reported as ambiguous.
             var activeMatches = queueState.Items
-                .Where(item => MatchesLinkedPr(item.LinkedPr, repo, prToken) && item.State != QueueItemState.Completed)
+                .Where(item => MatchesLinkedPr(item, repo, prToken) && item.State != QueueItemState.Completed)
                 .ToArray();
             if (activeMatches.Length == 0)
             {
@@ -2708,25 +2708,10 @@ internal static class AutomationStalledWorkCommand
         return string.Equals(candidateRepo, repo, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static bool MatchesLinkedPr(string? linkedPr, string repo, string prToken)
+    private static bool MatchesLinkedPr(QueueItem item, string repo, string prToken)
     {
-        if (string.IsNullOrWhiteSpace(linkedPr))
-        {
-            return false;
-        }
-
-        if (string.Equals(linkedPr, prToken, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        if (linkedPr!.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase))
-        {
-            return linkedPr.StartsWith($"https://github.com/{repo}/pull/", StringComparison.OrdinalIgnoreCase)
-                && linkedPr.EndsWith($"/{prToken}", StringComparison.Ordinal);
-        }
-
-        return linkedPr!.EndsWith($"/{prToken}", StringComparison.Ordinal);
+        return int.TryParse(prToken, out var number)
+            && GitHubWorkItemIdentity.MatchesPullRequest(item, repo, number);
     }
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -150,14 +150,14 @@ internal static class CloseoutPrCommand
         }
 
         var prToken = pr!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-        var matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item.LinkedPr, repo!, prToken));
+        var matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item, repo!, prToken));
 
         // Fallback A (operator-supplied): when linked_pr is absent, resolve via
         // --issue (linked_issue.Number). Deterministic operator input wins.
         if (matchedItem is null && linkedIssueNumber.HasValue)
         {
             matchedItem = queueState.Items.FirstOrDefault(item =>
-                item.LinkedIssue?.Number == linkedIssueNumber.Value);
+                GitHubWorkItemIdentity.MatchesIssue(item.LinkedIssue, repo!, linkedIssueNumber.Value));
         }
 
         // G477 Fallback B (automatic, deterministic): when linked_pr is missing
@@ -337,25 +337,10 @@ internal static class CloseoutPrCommand
         return 0;
     }
 
-    private static bool MatchesLinkedPr(string? linkedPr, string repo, string prToken)
+    private static bool MatchesLinkedPr(QueueItem item, string repo, string prToken)
     {
-        if (string.IsNullOrWhiteSpace(linkedPr))
-        {
-            return false;
-        }
-
-        if (string.Equals(linkedPr, prToken, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        if (linkedPr!.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase))
-        {
-            return linkedPr.StartsWith($"https://github.com/{repo}/pull/", StringComparison.OrdinalIgnoreCase)
-                && linkedPr.EndsWith($"/{prToken}", StringComparison.Ordinal);
-        }
-
-        return linkedPr!.EndsWith($"/{prToken}", StringComparison.Ordinal);
+        return int.TryParse(prToken, out var number)
+            && GitHubWorkItemIdentity.MatchesPullRequest(item, repo, number);
     }
 
     private static QueueItem UpdateItemState(QueueItem item, QueueItemState state, string? recoveredLinkedPr = null)

--- a/src/IntentSystem.Cli/Commands/GitHubWorkItemIdentity.cs
+++ b/src/IntentSystem.Cli/Commands/GitHubWorkItemIdentity.cs
@@ -50,10 +50,27 @@ internal static class GitHubWorkItemIdentity
     public static bool MatchesClosingIssue(GitHubPrClosingIssueReference reference, string repo, int number)
     {
         if (reference.Number != number) return false;
-        var owner = reference.Repository?.Owner?.Login;
-        var name = reference.Repository?.Name;
         // GitHub may omit the repository descriptor for same-repo refs.
-        return string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(name)
-            || string.Equals($"{owner}/{name}", repo, StringComparison.OrdinalIgnoreCase);
+        if (reference.Repository is null) return true;
+        var owner = reference.Repository.Owner?.Login;
+        var name = reference.Repository.Name;
+        return !string.IsNullOrWhiteSpace(owner)
+            && !string.IsNullOrWhiteSpace(name)
+            && string.Equals($"{owner}/{name}", repo, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static int? GetPullRequestNumberForRepo(string? linkedPr, string repo)
+    {
+        if (string.IsNullOrWhiteSpace(linkedPr)
+            || !Uri.TryCreate(linkedPr, UriKind.Absolute, out var uri)
+            || !string.Equals(uri.Host, "github.com", StringComparison.OrdinalIgnoreCase)) return null;
+        var parts = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length == 4
+            && string.Equals($"{parts[0]}/{parts[1]}", repo, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(parts[2], "pull", StringComparison.OrdinalIgnoreCase)
+            && int.TryParse(parts[3], System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture, out var number)
+            ? number
+            : null;
     }
 }

--- a/src/IntentSystem.Cli/Commands/GitHubWorkItemIdentity.cs
+++ b/src/IntentSystem.Cli/Commands/GitHubWorkItemIdentity.cs
@@ -1,0 +1,59 @@
+using IntentSystem.Supervisor.Models;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G603: GitHub issue and pull-request numbers are scoped by repository.
+/// Keep the comparison at the boundary so a number from another repository
+/// can never be treated as the same work item on a shared host.
+/// </summary>
+internal static class GitHubWorkItemIdentity
+{
+    public static bool MatchesIssue(LinkedIssue? issue, string repo, int number) =>
+        issue is { Number: { } recordedNumber, Repo: { Length: > 0 } recordedRepo }
+        && recordedNumber == number
+        && string.Equals(recordedRepo, repo, StringComparison.OrdinalIgnoreCase);
+
+    public static bool MatchesPullRequest(string? linkedPr, string repo, int number)
+    {
+        if (string.IsNullOrWhiteSpace(linkedPr)
+            || !Uri.TryCreate(linkedPr, UriKind.Absolute, out var uri)
+            || !string.Equals(uri.Host, "github.com", StringComparison.OrdinalIgnoreCase))
+        {
+            // A legacy bare number has no repository identity. Failing closed
+            // is safer than resolving a same-number PR in a different repo.
+            return false;
+        }
+
+        var parts = uri.AbsolutePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length == 4
+            && string.Equals($"{parts[0]}/{parts[1]}", repo, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(parts[2], "pull", StringComparison.OrdinalIgnoreCase)
+            && int.TryParse(parts[3], System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture, out var recordedNumber)
+            && recordedNumber == number;
+    }
+
+    public static bool MatchesPullRequest(QueueItem item, string repo, int number)
+    {
+        if (MatchesPullRequest(item.LinkedPr, repo, number)) return true;
+        // Legacy queue-state can contain a bare linked_pr number. Its only
+        // safe compatibility interpretation is alongside a linked_issue that
+        // itself names the requested repository; otherwise it is ambiguous.
+        return int.TryParse(item.LinkedPr, System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture, out var recordedNumber)
+            && recordedNumber == number
+            && item.LinkedIssue is { Repo: { Length: > 0 } linkedIssueRepo }
+            && string.Equals(linkedIssueRepo, repo, StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static bool MatchesClosingIssue(GitHubPrClosingIssueReference reference, string repo, int number)
+    {
+        if (reference.Number != number) return false;
+        var owner = reference.Repository?.Owner?.Login;
+        var name = reference.Repository?.Name;
+        // GitHub may omit the repository descriptor for same-repo refs.
+        return string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(name)
+            || string.Equals($"{owner}/{name}", repo, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideReviewCommand.cs
@@ -268,7 +268,7 @@ internal static class GuideReviewCommand
         if (queueState is not null)
         {
             var prToken = pr!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item.LinkedPr, repo!, prToken));
+            matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item, repo!, prToken));
             if (matchedItem is null)
             {
                 gaps.Add($"no queue item found with linked_pr matching #{pr}.");
@@ -467,25 +467,10 @@ internal static class GuideReviewCommand
         return examples;
     }
 
-    private static bool MatchesLinkedPr(string? linkedPr, string repo, string prToken)
+    private static bool MatchesLinkedPr(QueueItem item, string repo, string prToken)
     {
-        if (string.IsNullOrWhiteSpace(linkedPr))
-        {
-            return false;
-        }
-
-        if (string.Equals(linkedPr, prToken, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        if (linkedPr!.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase))
-        {
-            return linkedPr.StartsWith($"https://github.com/{repo}/pull/", StringComparison.OrdinalIgnoreCase)
-                && linkedPr.EndsWith($"/{prToken}", StringComparison.Ordinal);
-        }
-
-        return linkedPr!.EndsWith($"/{prToken}", StringComparison.Ordinal);
+        return int.TryParse(prToken, out var number)
+            && GitHubWorkItemIdentity.MatchesPullRequest(item, repo, number);
     }
 
     private static void WriteMarkdown(TextWriter writer, GuideReviewResult result)

--- a/src/IntentSystem.Cli/Commands/HostQueueItemRecoveryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/HostQueueItemRecoveryAnalyzer.cs
@@ -203,9 +203,9 @@ internal static class HostQueueItemRecoveryAnalyzer
         var sameUnitItem = (candidate.ExistingQueueItems ?? Array.Empty<HostQueueItemRecoveryExistingItem>())
             .FirstOrDefault(i => string.Equals(i.ExecutionUnit, unit, StringComparison.Ordinal));
         var completedLinkageRepair = sameUnitItem is { State: QueueItemState.Completed }
-            && SameOrImplicitRepo(sameUnitItem.LinkedIssueRepo, repo)
+            && string.Equals(sameUnitItem.LinkedIssueRepo, repo, StringComparison.OrdinalIgnoreCase)
             && sameUnitItem.LinkedIssueNumber == publishIssueNumber
-            && !SameOrImplicitRepo(sameUnitItem.LinkedPrRepo, repo);
+            && !string.Equals(sameUnitItem.LinkedPrRepo, repo, StringComparison.OrdinalIgnoreCase);
 
         // An open non-draft PR is the normal review recovery. G603 also
         // permits a merged PR only for a completed unit whose existing PR
@@ -215,7 +215,16 @@ internal static class HostQueueItemRecoveryAnalyzer
             || string.Equals(candidate.PrState, "MERGED", StringComparison.OrdinalIgnoreCase)
             || string.Equals(candidate.PrState, "closed", StringComparison.OrdinalIgnoreCase)
             || string.Equals(candidate.PrState, "merged", StringComparison.OrdinalIgnoreCase);
-        if (prClosed && !completedLinkageRepair)
+        var prMerged = string.Equals(candidate.PrState, "MERGED", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(candidate.PrState, "merged", StringComparison.OrdinalIgnoreCase);
+        if (completedLinkageRepair && !prMerged)
+        {
+            return UnsafeStop(
+                ReasonClosedPr,
+                $"completed linkage repair for '{unit}' requires merged PR #{candidate.PrNumber} in '{repo}'; "
+                + $"GitHub reports state '{candidate.PrState}'.");
+        }
+        if (prClosed && !(completedLinkageRepair && prMerged))
         {
             return UnsafeStop(
                 ReasonClosedPr,

--- a/src/IntentSystem.Cli/Commands/HostQueueItemRecoveryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/HostQueueItemRecoveryAnalyzer.cs
@@ -35,6 +35,7 @@ internal static class HostQueueItemRecoveryAnalyzer
     public const string ReasonClosedIssue = "closed-issue";
     public const string ReasonClosedPr = "closed-pr";
     public const string ReasonPrIsDraft = "pr-is-draft";
+    public const string ReasonLegacyPublishIdentityMissing = "legacy-publish-identity-missing";
 
     /// <summary>
     /// G344 second-round repair: emitted when the GitHub issue the PR
@@ -199,13 +200,22 @@ internal static class HostQueueItemRecoveryAnalyzer
                 + "(both 'intent-target' and 'intent-pr-created') before reconstructing queue state.");
         }
 
-        // PR must be open and non-draft. A merged / closed PR is not a
-        // recoverable review wake.
+        var sameUnitItem = (candidate.ExistingQueueItems ?? Array.Empty<HostQueueItemRecoveryExistingItem>())
+            .FirstOrDefault(i => string.Equals(i.ExecutionUnit, unit, StringComparison.Ordinal));
+        var completedLinkageRepair = sameUnitItem is { State: QueueItemState.Completed }
+            && SameOrImplicitRepo(sameUnitItem.LinkedIssueRepo, repo)
+            && sameUnitItem.LinkedIssueNumber == publishIssueNumber
+            && !SameOrImplicitRepo(sameUnitItem.LinkedPrRepo, repo);
+
+        // An open non-draft PR is the normal review recovery. G603 also
+        // permits a merged PR only for a completed unit whose existing PR
+        // linkage is demonstrably from another repository; GitHub's closing
+        // reference remains the evidence for replacing it.
         var prClosed = string.Equals(candidate.PrState, "CLOSED", StringComparison.OrdinalIgnoreCase)
             || string.Equals(candidate.PrState, "MERGED", StringComparison.OrdinalIgnoreCase)
             || string.Equals(candidate.PrState, "closed", StringComparison.OrdinalIgnoreCase)
             || string.Equals(candidate.PrState, "merged", StringComparison.OrdinalIgnoreCase);
-        if (prClosed)
+        if (prClosed && !completedLinkageRepair)
         {
             return UnsafeStop(
                 ReasonClosedPr,
@@ -239,8 +249,10 @@ internal static class HostQueueItemRecoveryAnalyzer
         foreach (var existing in candidate.ExistingQueueItems ?? Array.Empty<HostQueueItemRecoveryExistingItem>())
         {
             var sameUnit = string.Equals(existing.ExecutionUnit, unit, StringComparison.Ordinal);
-            var bindsThisPr = existing.LinkedPrNumber == candidate.PrNumber;
-            var bindsThisIssue = existing.LinkedIssueNumber == publishIssueNumber;
+            var bindsThisPr = existing.LinkedPrNumber == candidate.PrNumber
+                && SameOrImplicitRepo(existing.LinkedPrRepo, repo);
+            var bindsThisIssue = existing.LinkedIssueNumber == publishIssueNumber
+                && SameOrImplicitRepo(existing.LinkedIssueRepo, repo);
 
             if (!sameUnit && (bindsThisPr || bindsThisIssue))
             {
@@ -251,7 +263,7 @@ internal static class HostQueueItemRecoveryAnalyzer
                     $" — cannot reconstruct queue item for '{unit}' without resolving the conflict first.");
             }
 
-            if (sameUnit
+            if (sameUnit && !completedLinkageRepair
                 && existing.LinkedPrNumber is int otherPr && otherPr > 0 && otherPr != candidate.PrNumber)
             {
                 return UnsafeStop(
@@ -272,11 +284,11 @@ internal static class HostQueueItemRecoveryAnalyzer
 
         // If queue-state already has a fully-linked entry for this unit
         // pointing at the correct PR + issue, nothing to recover.
-        var sameUnitItem = (candidate.ExistingQueueItems ?? Array.Empty<HostQueueItemRecoveryExistingItem>())
-            .FirstOrDefault(i => string.Equals(i.ExecutionUnit, unit, StringComparison.Ordinal));
         if (sameUnitItem is not null
             && sameUnitItem.LinkedPrNumber == candidate.PrNumber
-            && sameUnitItem.LinkedIssueNumber == publishIssueNumber)
+            && SameOrImplicitRepo(sameUnitItem.LinkedPrRepo, repo)
+            && sameUnitItem.LinkedIssueNumber == publishIssueNumber
+            && SameOrImplicitRepo(sameUnitItem.LinkedIssueRepo, repo))
         {
             return new HostQueueItemRecoveryAnalysis
             {
@@ -319,6 +331,10 @@ internal static class HostQueueItemRecoveryAnalyzer
             $"GitHub issue #{publishIssueNumber} state = '{candidate.ClosingIssue.State}', labels = [{string.Join(", ", candidate.ClosingIssue.Labels)}].",
             $"no other packet/publish artifact in repo '{repo}' claims this issue; recovery is deterministic.",
         };
+        if (completedLinkageRepair)
+        {
+            evidence.Add($"completed unit '{unit}' previously linked PR #{sameUnitItem!.LinkedPrNumber} in '{sameUnitItem.LinkedPrRepo}'; replacing only the repo-mismatched linkage with GitHub-verified {repo}#{candidate.PrNumber}.");
+        }
 
         return new HostQueueItemRecoveryAnalysis
         {
@@ -347,6 +363,10 @@ internal static class HostQueueItemRecoveryAnalyzer
         var marker = $"github.com/{repo}/issues/";
         return artifactUrl.IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0;
     }
+
+    private static bool SameOrImplicitRepo(string? recordedRepo, string repo) =>
+        string.IsNullOrWhiteSpace(recordedRepo)
+        || string.Equals(recordedRepo, repo, StringComparison.OrdinalIgnoreCase);
 }
 
 /// <summary>
@@ -406,6 +426,9 @@ internal sealed record HostQueueItemRecoveryExistingItem
     public required string ExecutionUnit { get; init; }
     public required int? LinkedPrNumber { get; init; }
     public required int? LinkedIssueNumber { get; init; }
+    public string? LinkedIssueRepo { get; init; }
+    public string? LinkedPrRepo { get; init; }
+    public QueueItemState State { get; init; }
     public string? Title { get; init; }
 }
 

--- a/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
@@ -689,11 +689,12 @@ internal static class ReviewCloseoutPlanCommand
                 string.Equals(i.ExecutionUnit, matchedUnit, StringComparison.Ordinal));
             if (existing is not null)
             {
-                if (existing.LinkedIssue is { Number: int existingIssue } && existingIssue != matchedIssue)
+                if (existing.LinkedIssue is { Number: int }
+                    && !GitHubWorkItemIdentity.MatchesIssue(existing.LinkedIssue, repo, matchedIssue))
                 {
                     return null;
                 }
-                var existingPr = TryParsePrNumberFromLinkedPr(existing.LinkedPr);
+                var existingPr = GitHubWorkItemIdentity.GetPullRequestNumberForRepo(existing.LinkedPr, repo);
                 if (existingPr is int otherPr && otherPr != prNumber)
                 {
                     return null;
@@ -707,11 +708,11 @@ internal static class ReviewCloseoutPlanCommand
                 {
                     continue;
                 }
-                if (item.LinkedIssue is { Number: int otherIssue } && otherIssue == matchedIssue)
+                if (GitHubWorkItemIdentity.MatchesIssue(item.LinkedIssue, repo, matchedIssue))
                 {
                     return null;
                 }
-                if (TryParsePrNumberFromLinkedPr(item.LinkedPr) == prNumber)
+                if (GitHubWorkItemIdentity.GetPullRequestNumberForRepo(item.LinkedPr, repo) == prNumber)
                 {
                     return null;
                 }
@@ -731,28 +732,6 @@ internal static class ReviewCloseoutPlanCommand
                 + $"which is the closing-issue for PR #{prNumber} in '{repo}'; host-queue-item-recovery can "
                 + "deterministically reconstruct the missing queue item.",
         };
-    }
-
-    private static int? TryParsePrNumberFromLinkedPr(string? linkedPr)
-    {
-        if (string.IsNullOrWhiteSpace(linkedPr))
-        {
-            return null;
-        }
-        if (int.TryParse(linkedPr, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var direct))
-        {
-            return direct;
-        }
-        var idx = linkedPr.LastIndexOf('/');
-        if (idx >= 0 && idx + 1 < linkedPr.Length)
-        {
-            var tail = linkedPr[(idx + 1)..];
-            if (int.TryParse(tail, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var n))
-            {
-                return n;
-            }
-        }
-        return null;
     }
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ReviewCloseoutPlanCommand.cs
@@ -214,7 +214,7 @@ internal static class ReviewCloseoutPlanCommand
         if (queueState is not null)
         {
             var prToken = pr!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
-            matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item.LinkedPr, repo!, prToken));
+            matchedItem = queueState.Items.FirstOrDefault(item => MatchesLinkedPr(item, repo!, prToken));
             if (matchedItem is null)
             {
                 // G329 review fix: auto-fetch closing issues from
@@ -875,25 +875,10 @@ internal static class ReviewCloseoutPlanCommand
     private static ReviewCloseoutPlanGap LinkageAmbiguousGap(string description) =>
         new() { Description = description, Classification = GapClassificationLinkageAmbiguous };
 
-    private static bool MatchesLinkedPr(string? linkedPr, string repo, string prToken)
+    private static bool MatchesLinkedPr(QueueItem item, string repo, string prToken)
     {
-        if (string.IsNullOrWhiteSpace(linkedPr))
-        {
-            return false;
-        }
-
-        if (string.Equals(linkedPr, prToken, StringComparison.Ordinal))
-        {
-            return true;
-        }
-
-        if (linkedPr!.StartsWith("https://github.com/", StringComparison.OrdinalIgnoreCase))
-        {
-            return linkedPr.StartsWith($"https://github.com/{repo}/pull/", StringComparison.OrdinalIgnoreCase)
-                && linkedPr.EndsWith($"/{prToken}", StringComparison.Ordinal);
-        }
-
-        return linkedPr!.EndsWith($"/{prToken}", StringComparison.Ordinal);
+        return int.TryParse(prToken, out var number)
+            && GitHubWorkItemIdentity.MatchesPullRequest(item, repo, number);
     }
 
     private static string DeriveSubmodulePath(string repo)

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
@@ -119,6 +119,17 @@ internal static class WorkerCompleteCommand
             return 1;
         }
 
+        // G603: the host-side linked_pr projection is a write path. Verify
+        // the command's declared domain agrees with the selected queue item
+        // before touching GitHub labels or durable state. A child github-only
+        // worker never reads queue state, so this guard is host-only.
+        if (isPrCreatedOutcome && !inChildCwdMode
+            && TryFindDomainDisagreement(context, repo!, number, out var disagreement))
+        {
+            writer.WriteLine(disagreement);
+            return 1;
+        }
+
         // G389: refuse to complete an issue whose contract bundles multiple
         // execution-unit / packet identities — `issue-to-pr` requires a single
         // self-contained unit of work, not a multi-packet issue. Best-effort:
@@ -171,8 +182,7 @@ internal static class WorkerCompleteCommand
             // for the source issue, accept that even if the body wording
             // differs. Otherwise fall back to text parsing.
             var resolvedByGitHub = prLookupResult.ClosingIssuesReferences.Any(reference =>
-                reference.Number == number
-                && IsSameRepo(reference.Repository, repo!));
+                GitHubWorkItemIdentity.MatchesClosingIssue(reference, repo!, number));
             if (resolvedByGitHub)
             {
                 closingRefResult = new PrClosingReferenceResult
@@ -427,7 +437,7 @@ internal static class WorkerCompleteCommand
             for (var index = 0; index < queueState.Items.Count; index++)
             {
                 var linkedIssue = queueState.Items[index].LinkedIssue;
-                if (linkedIssue is { Number: { } linkedNumber } && linkedNumber == sourceIssueNumber)
+                if (GitHubWorkItemIdentity.MatchesIssue(linkedIssue, repo, sourceIssueNumber))
                 {
                     matchedIndex = index;
                     break;
@@ -436,7 +446,7 @@ internal static class WorkerCompleteCommand
 
             if (matchedIndex < 0)
             {
-                return (false, $"queue-state.json has no item with linked_issue.number={sourceIssueNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)}; PR-side intent-target was applied but linked_pr could not be synced.");
+                return (false, $"queue-state.json has no item with linked_issue identity {repo}#{sourceIssueNumber.ToString(System.Globalization.CultureInfo.InvariantCulture)}; PR-side intent-target was applied but linked_pr could not be synced.");
             }
 
             var existingItem = queueState.Items[matchedIndex];
@@ -462,6 +472,41 @@ internal static class WorkerCompleteCommand
         {
             return (false, $"failed to sync linked_pr for issue #{sourceIssueNumber} in queue-state.json: {exception.Message}");
         }
+    }
+
+    private static bool TryFindDomainDisagreement(CliContext context, string repo, int issueNumber, out string message)
+    {
+        message = string.Empty;
+        var queueStatePath = ResolveQueueStatePath(context);
+        if (!File.Exists(queueStatePath)) return false;
+
+        try
+        {
+            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            foreach (var item in queueState.Items)
+            {
+                if (!GitHubWorkItemIdentity.MatchesIssue(item.LinkedIssue, repo, issueNumber)) continue;
+                var marker = "intents/";
+                var path = item.ClarificationReturnPath.Replace('\\', '/');
+                var start = path.IndexOf(marker, StringComparison.Ordinal);
+                if (start < 0) continue;
+                var remainder = path[(start + marker.Length)..];
+                var slash = remainder.IndexOf('/');
+                var itemDomain = slash < 0 ? remainder : remainder[..slash];
+                if (!string.IsNullOrWhiteSpace(itemDomain)
+                    && !string.Equals(itemDomain, context.Config.Project.Domain, StringComparison.Ordinal))
+                {
+                    message = $"refused queue write: command identity '{context.Config.Project.Domain}/{repo}#{issueNumber}' conflicts with queue identity '{itemDomain}/{repo}#{issueNumber}' on unit '{item.ExecutionUnit}'.";
+                    return true;
+                }
+            }
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+        {
+            // Existing sync handling emits the precise persistence warning.
+            _ = exception;
+        }
+        return false;
     }
 
     /// <summary>
@@ -656,29 +701,6 @@ internal static class WorkerCompleteCommand
         return File.Exists(parentQueueStatePath)
             ? parentQueueStatePath
             : localQueueStatePath;
-    }
-
-    /// <summary>
-    /// G311: returns true when the GitHub-reported closing-issue
-    /// repository matches <paramref name="repo"/>. <paramref name="repo"/>
-    /// is in <c>owner/name</c> form. A null repository (same-repo
-    /// closing reference) is also treated as matching.
-    /// </summary>
-    private static bool IsSameRepo(GitHubPrClosingIssueRepository? repository, string repo)
-    {
-        if (repository is null)
-        {
-            return true;
-        }
-        var ownerLogin = repository.Owner?.Login ?? string.Empty;
-        if (string.IsNullOrWhiteSpace(ownerLogin) || string.IsNullOrWhiteSpace(repository.Name))
-        {
-            return false;
-        }
-        return string.Equals(
-            $"{ownerLogin}/{repository.Name}",
-            repo,
-            StringComparison.OrdinalIgnoreCase);
     }
 
     private static IReadOnlyList<string> LabelNames(IReadOnlyList<GitHubAutomationLabel>? labels)

--- a/tests/IntentSystem.Cli.Tests/AutomationHostQueueItemRecoveryCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHostQueueItemRecoveryCommandTests.cs
@@ -193,6 +193,25 @@ public sealed class AutomationHostQueueItemRecoveryCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_LegacyPacketWithoutPublishIdentity_ReportsSpecificFinding()
+    {
+        using var workspace = new RecoveryWorkspace();
+        workspace.WritePacketYaml(Unit, Repo);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationHostQueueItemRecoveryCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--unit", Unit, "--pr", PrNumber.ToString(), "--format", "json"], writer);
+
+        Assert.Equal(1, exitCode);
+        using var doc = JsonDocument.Parse(writer.ToString());
+        var record = Assert.Single(doc.RootElement.GetProperty("records").EnumerateArray());
+        Assert.Equal("legacy-publish-identity-missing", record.GetProperty("reason_code").GetString());
+        Assert.Contains("publish.yaml", record.GetProperty("explanation").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("no completed linkage", record.GetProperty("explanation").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_ConflictingExistingQueueItem_UnsafeStop_NoApply()
     {
         using var workspace = new RecoveryWorkspace();

--- a/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
@@ -572,7 +572,7 @@ public sealed class CloseoutPrCommandTests : IDisposable
     public void Execute_PrMergedFalse_RefusesAndDoesNotMutate()
     {
         using var workspace = new CloseoutPrWorkspace();
-        workspace.WriteQueueState(BuildQueueState("G297", "review", linkedPr: "523"));
+        workspace.WriteQueueState(BuildQueueState("G297", "review", linkedPr: "https://github.com/owner/repo/pull/523"));
         using var writer = new StringWriter();
 
         var exitCode = CloseoutPrCommand.Execute(
@@ -593,7 +593,7 @@ public sealed class CloseoutPrCommandTests : IDisposable
         Assert.Contains("G297", json, StringComparison.Ordinal);
 
         // Mutation invariant: queue-state must not have been modified.
-        Assert.Equal(BuildQueueState("G297", "review", linkedPr: "523"),
+        Assert.Equal(BuildQueueState("G297", "review", linkedPr: "https://github.com/owner/repo/pull/523"),
             File.ReadAllText(workspace.Context.GetQueueStatePath()));
         Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
     }
@@ -602,7 +602,7 @@ public sealed class CloseoutPrCommandTests : IDisposable
     public void Execute_PrMergedTrue_AllowsCloseout()
     {
         using var workspace = new CloseoutPrWorkspace();
-        workspace.WriteQueueState(BuildQueueState("G297", "review", linkedPr: "523"));
+        workspace.WriteQueueState(BuildQueueState("G297", "review", linkedPr: "https://github.com/owner/repo/pull/523"));
         using var writer = new StringWriter();
 
         var exitCode = CloseoutPrCommand.Execute(
@@ -626,7 +626,7 @@ public sealed class CloseoutPrCommandTests : IDisposable
     public void Execute_PrMergedOmitted_BackwardsCompatible_AllowsCloseout()
     {
         using var workspace = new CloseoutPrWorkspace();
-        workspace.WriteQueueState(BuildQueueState("G297", "review", linkedPr: "523"));
+        workspace.WriteQueueState(BuildQueueState("G297", "review", linkedPr: "https://github.com/owner/repo/pull/523"));
         using var writer = new StringWriter();
 
         var exitCode = CloseoutPrCommand.Execute(
@@ -841,7 +841,10 @@ public sealed class CloseoutPrCommandTests : IDisposable
 
     private static string BuildQueueState(string executionUnit, string state, string? linkedPr)
     {
-        var linked = linkedPr is null ? "null" : $"\"{linkedPr}\"";
+        var qualified = linkedPr is not null && int.TryParse(linkedPr, out var number)
+            ? $"https://github.com/J-Tech-Japan/intent-system/pull/{number}"
+            : linkedPr;
+        var linked = qualified is null ? "null" : $"\"{qualified}\"";
         return $$"""
             {
               "schema_version": "1",
@@ -869,8 +872,14 @@ public sealed class CloseoutPrCommandTests : IDisposable
         (string ExecutionUnit, string State, string? LinkedPr) completing,
         (string ExecutionUnit, string State, string? LinkedPr) waiting)
     {
-        var completingLinked = completing.LinkedPr is null ? "null" : $"\"{completing.LinkedPr}\"";
-        var waitingLinked = waiting.LinkedPr is null ? "null" : $"\"{waiting.LinkedPr}\"";
+        var completingQualified = completing.LinkedPr is not null && int.TryParse(completing.LinkedPr, out var completingNumber)
+            ? $"https://github.com/J-Tech-Japan/intent-system/pull/{completingNumber}"
+            : completing.LinkedPr;
+        var waitingQualified = waiting.LinkedPr is not null && int.TryParse(waiting.LinkedPr, out var waitingNumber)
+            ? $"https://github.com/J-Tech-Japan/intent-system/pull/{waitingNumber}"
+            : waiting.LinkedPr;
+        var completingLinked = completingQualified is null ? "null" : $"\"{completingQualified}\"";
+        var waitingLinked = waitingQualified is null ? "null" : $"\"{waitingQualified}\"";
         return $$"""
             {
               "schema_version": "1",

--- a/tests/IntentSystem.Cli.Tests/GuideReviewCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideReviewCommandTests.cs
@@ -709,7 +709,10 @@ public sealed class GuideReviewCommandTests
 
     private static string BuildQueueState(string executionUnit, string state, string title, string? linkedPr)
     {
-        var linked = linkedPr is null ? "null" : $"\"{linkedPr}\"";
+        var qualified = linkedPr is not null && int.TryParse(linkedPr, out var number)
+            ? $"https://github.com/J-Tech-Japan/intent-system/pull/{number}"
+            : linkedPr;
+        var linked = qualified is null ? "null" : $"\"{qualified}\"";
         return $$"""
             {
               "schema_version": "1",

--- a/tests/IntentSystem.Cli.Tests/HostQueueItemRecoveryAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/HostQueueItemRecoveryAnalyzerTests.cs
@@ -350,6 +350,59 @@ public sealed class HostQueueItemRecoveryAnalyzerTests
     }
 
     [Fact]
+    public void Analyze_CompletedUnitWithWrongRepoLinkedPr_RejectsClosedUnmergedPr()
+    {
+        var candidate = BuildCandidate() with
+        {
+            PrState = "CLOSED",
+            ExistingQueueItems = new[]
+            {
+                new HostQueueItemRecoveryExistingItem
+                {
+                    ExecutionUnit = Unit,
+                    LinkedIssueNumber = IssueNumber,
+                    LinkedIssueRepo = Repo,
+                    LinkedPrNumber = PrNumber,
+                    LinkedPrRepo = "J-Tech-Japan/intent-system",
+                    State = QueueItemState.Completed,
+                }
+            }
+        };
+
+        var result = HostQueueItemRecoveryAnalyzer.Analyze(candidate);
+
+        Assert.Equal(HostQueueItemRecoveryAnalyzer.ResultUnsafeStop, result.Result);
+        Assert.Equal(HostQueueItemRecoveryAnalyzer.ReasonClosedPr, result.ReasonCode);
+    }
+
+    [Fact]
+    public void Analyze_CompletedUnitWithWrongRepoLinkedPr_RejectsOpenPr()
+    {
+        var candidate = BuildCandidate() with
+        {
+            PrState = "OPEN",
+            ExistingQueueItems = new[]
+            {
+                new HostQueueItemRecoveryExistingItem
+                {
+                    ExecutionUnit = Unit,
+                    LinkedIssueNumber = IssueNumber,
+                    LinkedIssueRepo = Repo,
+                    LinkedPrNumber = PrNumber,
+                    LinkedPrRepo = "J-Tech-Japan/intent-system",
+                    State = QueueItemState.Completed,
+                }
+            }
+        };
+
+        var result = HostQueueItemRecoveryAnalyzer.Analyze(candidate);
+
+        Assert.Equal(HostQueueItemRecoveryAnalyzer.ResultUnsafeStop, result.Result);
+        Assert.Equal(HostQueueItemRecoveryAnalyzer.ReasonClosedPr, result.ReasonCode);
+        Assert.Contains("requires merged PR", result.Explanation, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Analyze_RejectsDraftPrAsUnsafeStop()
     {
         // Every other field is the happy path, but PrIsDraft = true must

--- a/tests/IntentSystem.Cli.Tests/HostQueueItemRecoveryAnalyzerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/HostQueueItemRecoveryAnalyzerTests.cs
@@ -1,4 +1,5 @@
 using IntentSystem.Cli.Commands;
+using IntentSystem.Supervisor.Models;
 
 namespace IntentSystem.Cli.Tests;
 
@@ -319,6 +320,33 @@ public sealed class HostQueueItemRecoveryAnalyzerTests
 
         Assert.Equal(HostQueueItemRecoveryAnalyzer.ResultUnsafeStop, result.Result);
         Assert.Equal(HostQueueItemRecoveryAnalyzer.ReasonClosedPr, result.ReasonCode);
+    }
+
+    [Fact]
+    public void Analyze_CompletedUnitWithWrongRepoLinkedPr_RepairsFromMergedEvidence()
+    {
+        var candidate = BuildCandidate() with
+        {
+            PrState = "MERGED",
+            ExistingQueueItems = new[]
+            {
+                new HostQueueItemRecoveryExistingItem
+                {
+                    ExecutionUnit = Unit,
+                    LinkedIssueNumber = IssueNumber,
+                    LinkedIssueRepo = Repo,
+                    LinkedPrNumber = PrNumber,
+                    LinkedPrRepo = "J-Tech-Japan/intent-system",
+                    State = QueueItemState.Completed,
+                }
+            }
+        };
+
+        var result = HostQueueItemRecoveryAnalyzer.Analyze(candidate);
+
+        Assert.Equal(HostQueueItemRecoveryAnalyzer.ResultRecoverable, result.Result);
+        Assert.Contains(result.Evidence, e => e.Contains("completed unit", StringComparison.Ordinal));
+        Assert.Equal($"https://github.com/{Repo}/pull/{PrNumber}", result.ProposedQueueItem!.LinkedPrUrl);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
@@ -265,6 +265,41 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_G603_RecoveryLane_IgnoresForeignRepoCollisionPrefilters()
+    {
+        using var workspace = new ReviewCloseoutPlanWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithTwoItems(
+            ("SKS-G593", "completed", "https://github.com/J-Tech-Japan/intent-system/pull/647",
+                ("J-Tech-Japan/intent-system", 646, null)),
+            ("OTHER", "review", "https://github.com/J-Tech-Japan/intent-system/pull/999",
+                ("J-Tech-Japan/intent-system", 999, null))));
+        var publishArtifact = new IssuePublishArtifact
+        {
+            ExecutionUnit = "SKS-G263",
+            PublishStatus = "issue-created",
+            PacketPath = ".intent-cli/issues/SKS-G263/packet.yaml",
+            IssueBodyPath = ".intent-cli/issues/SKS-G263/github-body.md",
+            CreatedIssueNumber = 646,
+            CreatedIssueUrl = "https://github.com/J-Tech-Japan/SekibanAsAService/issues/646",
+            PublishedLabelName = "intent-target",
+        };
+        workspace.WriteFile(".intent-cli/issues/SKS-G263/publish.yaml", IssuePublishArtifactYaml.Serialize(publishArtifact));
+        workspace.WriteFile(".intent-cli/issues/SKS-G263/packet.yaml", "implementation_issue_packet:\n  target_repo: J-Tech-Japan/SekibanAsAService\n");
+        ReviewCloseoutPlanCommand.PrClosingIssuesFetcherFactory = () => new FakePrClosingIssuesFetcher(new[] { 646 });
+
+        using var writer = new StringWriter();
+        var exitCode = ReviewCloseoutPlanCommand.Execute(workspace.Context,
+            ["--repo", "J-Tech-Japan/SekibanAsAService", "--domain", "intent-cli", "--pr", "647", "--format", "json"], writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var lane = document.RootElement.GetProperty("recovery_lane");
+        Assert.Equal("SKS-G263", lane.GetProperty("execution_unit").GetString());
+        Assert.Equal(646, lane.GetProperty("linked_issue").GetInt32());
+        Assert.Equal(647, lane.GetProperty("linked_pr").GetInt32());
+    }
+
+    [Fact]
     public void Execute_G455_EmptyGitHubRefs_BodyClosesRecoversLinkage_ReadyWithBodyFallbackSource()
     {
         // AIC #3750 shape: PR targets a non-default base, GitHub

--- a/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewCloseoutPlanCommandTests.cs
@@ -1319,7 +1319,10 @@ public sealed class ReviewCloseoutPlanCommandTests : IDisposable
 
     private static string BuildQueueState(string executionUnit, string state, string? linkedPr, (string Repo, int Number, string? Url)? linkedIssue)
     {
-        var linkedPrToken = linkedPr is null ? "null" : $"\"{linkedPr}\"";
+        var qualified = linkedPr is not null && int.TryParse(linkedPr, out var number)
+            ? $"https://github.com/J-Tech-Japan/intent-system/pull/{number}"
+            : linkedPr;
+        var linkedPrToken = qualified is null ? "null" : $"\"{qualified}\"";
         var linkedIssueBlock = linkedIssue is null
             ? ""
             : $@",

--- a/tests/IntentSystem.Cli.Tests/ReviewStandingPolicyRegistryTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReviewStandingPolicyRegistryTests.cs
@@ -277,7 +277,7 @@ public sealed class ReviewStandingPolicyRegistryTests : IDisposable
                         ReviewContext = ".intent-cli/issues/G248/review-context.md",
                     },
                     LinkedIssue = null,
-                    LinkedPr = "598",
+                    LinkedPr = "https://github.com/J-Tech-Japan/intent-system/pull/598",
                     WorkerRole = "Claude",
                     ReviewRole = "Codex",
                     Priority = "normal",

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -215,6 +215,51 @@ public sealed class WorkerCompleteCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_CollidingIssueNumbers_UpdatesOnlyRepoQualifiedUnit()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        workspace.WriteQueueState(
+            workspace.CreateItem("G603", "J-Tech-Japan/intent-system", 525, "intent-cli"),
+            workspace.CreateItem("SKS-G593", "J-Tech-Japan/SekibanAsAService", 525, "sekiban-as-a-service",
+                existingLinkedPr: "https://github.com/J-Tech-Japan/SekibanAsAService/pull/1306"));
+        var foreignBefore = File.ReadAllBytes(workspace.QueueStatePath);
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "525",
+             "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated, "--pr", "1306", "--write", "--format", "json"], writer);
+
+        Assert.Equal(0, exitCode);
+        var state = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
+        Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/1306", state.Items[0].LinkedPr);
+        Assert.Equal("https://github.com/J-Tech-Japan/SekibanAsAService/pull/1306", state.Items[1].LinkedPr);
+        Assert.NotEqual(foreignBefore, File.ReadAllBytes(workspace.QueueStatePath));
+    }
+
+    [Fact]
+    public void Execute_DomainDisagreement_RefusesBeforeLabelOrQueueWrite()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        workspace.WriteQueueState(workspace.CreateItem("SKS-G593", "J-Tech-Japan/intent-system", 1305, "sekiban-as-a-service"));
+        var before = File.ReadAllBytes(workspace.QueueStatePath);
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "1305",
+             "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated, "--pr", "1306", "--write", "--format", "json"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("J-Tech-Japan/intent-system#1305", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("sekiban-as-a-service", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(mutator.AppliedTransitions);
+        Assert.Equal(before, File.ReadAllBytes(workspace.QueueStatePath));
+    }
+
+    [Fact]
     public void Execute_IssuePrCreatedOutcomeWithParentIntentRoot_SyncsParentQueueStateLinkedPr()
     {
         using var parentWorkspace = new WorkerCompleteWorkspace();
@@ -2037,6 +2082,31 @@ public sealed class WorkerCompleteCommandTests : IDisposable
             };
             File.WriteAllText(QueueStatePath, QueueStateSerializer.Serialize(state));
         }
+
+        public QueueItem CreateItem(string executionUnit, string repo, int issue, string domain, string? existingLinkedPr = null) =>
+            new()
+            {
+                ExecutionUnit = executionUnit,
+                Title = executionUnit,
+                State = QueueItemState.Queued,
+                Dependencies = Array.Empty<string>(),
+                BlockedBy = Array.Empty<string>(),
+                ClarificationReturnPath = $"intents/{domain}/clarifications/open.md",
+                PacketPaths = new PacketPaths { Implementation = "i", ReviewContext = "r", Yaml = "p" },
+                LinkedIssue = new LinkedIssue { Repo = repo, Number = issue, Url = $"https://github.com/{repo}/issues/{issue}" },
+                LinkedPr = existingLinkedPr,
+                WorkerRole = "child-impl",
+                ReviewRole = "host-review",
+                Priority = "normal",
+            };
+
+        public void WriteQueueState(params QueueItem[] items) => File.WriteAllText(QueueStatePath,
+            QueueStateSerializer.Serialize(new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = DateTimeOffset.UtcNow,
+                Items = items,
+            }));
 
         public IReadOnlyDictionary<string, string> SnapshotWorkspace()
         {

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -222,7 +222,7 @@ public sealed class WorkerCompleteCommandTests : IDisposable
             workspace.CreateItem("G603", "J-Tech-Japan/intent-system", 525, "intent-cli"),
             workspace.CreateItem("SKS-G593", "J-Tech-Japan/SekibanAsAService", 525, "sekiban-as-a-service",
                 existingLinkedPr: "https://github.com/J-Tech-Japan/SekibanAsAService/pull/1306"));
-        var foreignBefore = File.ReadAllBytes(workspace.QueueStatePath);
+        var foreignBefore = QueueItemBytes(workspace.QueueStatePath, index: 1);
         var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
         WorkerCompleteCommand.MutatorFactory = () => mutator;
 
@@ -235,7 +235,7 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         var state = QueueStateSerializer.Deserialize(File.ReadAllText(workspace.QueueStatePath));
         Assert.Equal("https://github.com/J-Tech-Japan/intent-system/pull/1306", state.Items[0].LinkedPr);
         Assert.Equal("https://github.com/J-Tech-Japan/SekibanAsAService/pull/1306", state.Items[1].LinkedPr);
-        Assert.NotEqual(foreignBefore, File.ReadAllBytes(workspace.QueueStatePath));
+        Assert.Equal(foreignBefore, QueueItemBytes(workspace.QueueStatePath, index: 1));
     }
 
     [Fact]
@@ -257,6 +257,25 @@ public sealed class WorkerCompleteCommandTests : IDisposable
         Assert.Contains("sekiban-as-a-service", writer.ToString(), StringComparison.Ordinal);
         Assert.Empty(mutator.AppliedTransitions);
         Assert.Equal(before, File.ReadAllBytes(workspace.QueueStatePath));
+    }
+
+    [Theory]
+    [InlineData("", "intent-system")]
+    [InlineData("J-Tech-Japan", "")]
+    public void MatchesClosingIssue_PartialRepositoryDescriptor_IsRejected(string owner, string name)
+    {
+        var reference = new GitHubPrClosingIssueReference
+        {
+            Number = 1309,
+            Repository = new GitHubPrClosingIssueRepository
+            {
+                Name = name,
+                Owner = new GitHubPrClosingIssueRepositoryOwner { Login = owner },
+            },
+        };
+
+        Assert.False(GitHubWorkItemIdentity.MatchesClosingIssue(
+            reference, "J-Tech-Japan/intent-system", 1309));
     }
 
     [Fact]
@@ -2127,5 +2146,12 @@ public sealed class WorkerCompleteCommandTests : IDisposable
                 Directory.Delete(RootPath, recursive: true);
             }
         }
+    }
+
+    private static byte[] QueueItemBytes(string queueStatePath, int index)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(queueStatePath));
+        return System.Text.Encoding.UTF8.GetBytes(
+            document.RootElement.GetProperty("items")[index].GetRawText());
     }
 }


### PR DESCRIPTION
Closes #1309

## Summary
- Introduces a shared repo-qualified GitHub work-item identity helper for worker completion, closeout, review planning, and stalled-work PR resolution.
- Fails closed before a worker host-context write when the selected queue unit declares a different domain.
- Adds evidence-based completed-unit linkage repair for a repo-mismatched linked PR. A completed repair requires a merged PR, a matching closing issue, and the unit recorded repository; it records a completed-linkage-repair run event. Legacy packets without publish identity return a specific actionable finding.
- Documents the identity rule and recovery procedure in English and Japanese.

## Resolution-site audit
- WorkerCompleteCommand queue linkage: fixed from bare issue number to repo plus issue. Its GitHub closing-reference check is repo-qualified and rejects partial repository descriptors.
- AutomationHostQueueItemRecoveryCommand GitHub closing reference: rejects explicit foreign or partial-repository references; completed repair retains GitHub merge and closing evidence.
- CloseoutPrCommand direct PR and issue fallback, GuideReviewCommand, ReviewCloseoutPlanCommand direct match and recovery-lane prefilters, and AutomationStalledWorkCommand use the shared PR or issue identity. A legacy bare PR number is accepted only with a same-repo linked issue corroborator.
- GitHubLinkageReconstructor was already repo-scoped by the caller repo and recorded linked issue repo; that qualified behavior remains.

## Knowledge maintenance / node 03 evidence
The durable rule is recorded in the shipped ja/en recovery guidance: a number is an identity only with its repository; a write checks domain agreement; reachable completed-linkage corruption requires a canonical, evidence-recording repair path. This is the requested node-03 write-back statement without directly mutating parent host intent files from the child loop.

## Verification
- Full CLI suite: dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --logger console;verbosity=minimal.
- Focused worker-complete, completed-recovery, and review-closeout-plan tests: 123 passed.
- dotnet format IntentSystem.sln with touched files.
- git diff --check.