### PR TITLE
G607: add orchestration-first onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ repository and paste one of these prompts:
 > I want to start agmsg orchestrator mode for `<owner>/<repo>` with intent-cli.
 > Ask intent-cli for the orchestrator setup checklist.
 
+**Start a collocated four-thread herdr-only team (PREVIEW transport):**
+
+> I want to start a collocated single-machine four-thread team for
+> `<owner>/<repo>` with intent-cli using the herdr-only transport. Ask intent-cli
+> for the orchestration setup checklist and guide me through new-team stand-up.
+
 **Start an implementation loop (timer-loop alternative):**
 
 > Set up a child implementation loop for `<owner>/<repo>`.

--- a/docs/en/02a-getting-started-orchestration.md
+++ b/docs/en/02a-getting-started-orchestration.md
@@ -1,0 +1,174 @@
+# Getting started: the road to the first packet
+
+← [docs index](README.md) | [Start a project](02-project-start.md) | → [Organize & maintain intents](03-intents.md)
+
+This page is the **orchestration-first** route from an empty workspace to the
+first published packet. It does not replace [Start a project](02-project-start.md)
+or the [agent-message orchestration contract](12-agent-message-orchestration.md):
+those pages remain authoritative for repository topology and session-layer
+semantics.
+
+## What you are setting up
+
+The four-thread model is the **primary** model: design authors intent,
+orchestration coordinates, implementation delivers the child PR, and review
+checks it. For a collocated team on one machine, this route recommends the
+`herdr-only` transport. `herdr-only` is **PREVIEW only as a transport**; the
+four-thread model is not preview.
+
+## 1. Choose repositories and folders
+
+First choose topology A or B using [02's repository-topology comparison](02-project-start.md#repository-topology-choices).
+Do not copy its table here; it decides where durable host state belongs.
+
+For a separate host repository, a practical four-role layout is:
+
+```text
+~/work/my-project-host/          # design and orchestration open this host checkout
+~/work/my-project/               # implementation opens this target-repo checkout
+~/work/my-project-review/        # review opens this isolated target-repo checkout
+```
+
+Design and orchestration share the host checkout because they own host-side
+intent and workflow decisions. Implementation opens only the implementation
+checkout and follows the GitHub issue/PR contract. Review uses its own checkout
+so inspection, test artifacts, and a potential repair never disturb an active
+implementation worktree.
+
+## 2. Install and initialize the host
+
+Follow [Install](01-install.md), then use [02's initialization flow](02-project-start.md#what-the-agent-will-run-for-maintainers-and-troubleshooting)
+from the host checkout. When the host check is complete, stand up a **new** team
+as follows.
+
+> **New team only.** This order records new truth before it is displayed. An
+> existing team changing transports follows [doc 12's Session-layer switch
+> checklist](12-agent-message-orchestration.md#session-layer-switch-checklist),
+> where `session-layer set --write` is the final canonical step. Do not use the
+> new-team sequence as a transport-switch procedure.
+
+### 2.1 Record the transport
+
+Paste this prompt to the design/orchestration agent:
+
+> In the host checkout, record `herdr-only` for new team `<team>` in domain
+> `<domain>`. Run `intent-cli session-layer set --domain <domain> --team <team> --mode herdr-only --write --format json` and show the returned JSON. Do not
+> infer a mode from residue or a workspace.
+
+In an isolated scratch host, the shipped `intent-cli 0.11.0-7b3800e-G606`
+returned this success shape (dynamic timestamps and migration items omitted):
+
+```json
+{
+  "domain": "onboarding",
+  "team": "docs-team",
+  "mode": "herdr-only",
+  "source": "recorded",
+  "command_mode": "write",
+  "applied": true,
+  "changed": true,
+  "summary": "team `docs-team` in domain `onboarding`: session layer is herdr-only (PREVIEW — session transport only) (recorded)."
+}
+```
+
+The observed first record also returned a `migration_plan` array. It is output
+from the mode change; use doc 12, not this page, for an existing team's
+migration procedure.
+
+### 2.2 Record topology for every role
+
+Paste this prompt to the design/orchestration agent after the real herdr
+workspace and pane IDs are known:
+
+> Record the `design`, `orchestration`, `implementation`, and `review` roles
+> for domain `<domain>` and team `<team>`. For each role run
+> `intent-cli session-layer topology record --domain <domain> --team <team> --role <role> --resident herdr --workspace-id <workspace-id> --pane-id <pane-id> --cwd <role-cwd> --write --format json`. Pass the explicit domain,
+> the operator-supplied workspace/pane IDs, and the folder from the layout
+> above; do not guess IDs or edit topology files.
+
+Each run in the scratch host returned the same success shape, with `role`
+equal to the role just recorded:
+
+```json
+{
+  "team": "docs-team",
+  "role": "design",
+  "resident": "herdr",
+  "mode": "write",
+  "record_path": ".intent-cli/topology/onboarding/docs-team.json",
+  "applied": true,
+  "changed": true,
+  "already_recorded": false,
+  "conflict": false,
+  "summary": "Recorded operator-supplied role 'design' for team 'docs-team'."
+}
+```
+
+The observed runs recorded all four roles before continuing. The record command
+is a controlled writer; the exact residency variants and validation rules stay
+in [doc 12](12-agent-message-orchestration.md).
+
+### 2.3 Generate the visible marker
+
+Before generating, add the one empty managed marker block for this domain/team
+to `AGENTS.md` or `CLAUDE.md` exactly as [doc 12's generated-marker
+section](12-agent-message-orchestration.md#visible-generated-mode-markers)
+specifies. Then paste this prompt:
+
+> Generate the marker for the recorded domain `<domain>` and team `<team>`.
+> Run `intent-cli session-layer marker generate --domain <domain> --team <team> --file AGENTS.md --write --format json`, then show the JSON. Change only the
+> managed marker block.
+
+The scratch-host run returned this success shape (the record hash is dynamic):
+
+```json
+{
+  "written": true,
+  "file": "AGENTS.md",
+  "domain": "onboarding",
+  "team": "docs-team",
+  "mode": "herdr-only",
+  "verify_command": "intent-cli session-layer show --domain onboarding --team docs-team",
+  "summary": "Generated the managed session-layer marker for team 'docs-team' in 'AGENTS.md'."
+}
+```
+
+### 2.4 Confirm structural readiness
+
+Paste this prompt to the design/orchestration agent:
+
+> Check the new team's shared preflight with `intent-cli automation doctor --domain <domain> --team <team> --format json`. Report the
+> `session_layer_preflight` result; do not claim delivery readiness from doctor.
+
+The scratch-host run was structurally ready:
+
+```json
+{
+  "status": "ok",
+  "topology_health": { "status": "valid", "required": true },
+  "session_layer_preflight": {
+    "verdict": "ready",
+    "ready": true,
+    "passive_phase": { "status": "ready", "contacted_receiver": false },
+    "active_phase": { "status": "skipped", "contacted_receiver": false }
+  }
+}
+```
+
+`ready` here is the shared **passive structural** verdict. A delivery surface
+performs its own bounded receiver check before it claims delivery.
+
+## 3. Create the first packet
+
+The session layer is now recorded and visible. Continue with [Organize &
+maintain intents](03-intents.md), then [Create packets & publish
+issues](04-packets-issues.md). Those pages take over when the first packet is
+ready to publish.
+
+## Alternatives
+
+- **agmsg:** use the [agent-message orchestration contract](12-agent-message-orchestration.md)
+  for the primary transport's provisioning guidance.
+- **timer-loop:** use [Implementation loop setup](05-implementation-loop.md)
+  and [Review / next-slice loop setup](06-review-next-slice-loop.md). It is an
+  alternative to the orchestration-first route above.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -17,12 +17,19 @@ The agent runs `intent-cli` internally and brings back questions or results. You
 
 1. [Install](01-install.md)
 2. [Start a project](02-project-start.md)
+2a. [Getting started: the road to the first packet](02a-getting-started-orchestration.md) — **primary model** onboarding; collocated `herdr-only` is a **PREVIEW transport**
 3. [Intent Storming & organize intents](03-intents.md)
 4. [Create packets & publish issues](04-packets-issues.md)
 4a. [GitHub workflow labels and what they mean](04a-workflow-labels.md) — label meanings and how to read them
-12. [Agent-message orchestration](12-agent-message-orchestration.md) — **primary**: the four-thread (design/orchestrator/implementation/review) agmsg orchestrator model; single-domain vs multi-domain routing
+12. [Agent-message orchestration](12-agent-message-orchestration.md) — four-thread contract reference; single-domain vs multi-domain routing
+
+### Alternative paths
+
 5. [Implementation loop setup](05-implementation-loop.md) — timer-loop **alternative** setup
 6. [Review / next-slice loop setup](06-review-next-slice-loop.md) — timer-loop **alternative** setup
+
+### Reference and recovery
+
 7. [Recover when a loop looks wrong](07-recovery.md)
 8. [Command reference](08-command-reference.md) — agent-facing and power-user command surfaces
 9. [Developer reference](09-developer-reference.md) — packaged invocation, preview channel, version flow

--- a/docs/ja/02a-getting-started-orchestration.md
+++ b/docs/ja/02a-getting-started-orchestration.md
@@ -1,0 +1,163 @@
+# はじめに: 最初の packet までの道のり
+
+← [ドキュメント索引](README.md) | [プロジェクト開始](02-project-start.md) | → [intent の整理・保守](03-intents.md)
+
+このページは、空の workspace から最初の公開 packet まで進む **orchestration-first** の経路です。
+[プロジェクト開始](02-project-start.md) と [agent メッセージオーケストレーションの
+contract](12-agent-message-orchestration.md) を置き換えません。repository topology と
+session-layer semantics の authority は引き続きそれらのページです。
+
+## これから設定するもの
+
+4 スレッドモデルが **primary** です。design は intent を author し、orchestration は
+coordinate し、implementation は child PR を deliver し、review は確認します。1 台の
+machine に collocate する team には、この経路では `herdr-only` transport を推奨します。
+`herdr-only` が **PREVIEW** なのは transport だけで、4 スレッドモデルではありません。
+
+## 1. repository と folder を選ぶ
+
+まず [02 の repository topology 比較](02-project-start.md#リポジトリトポロジーの選択)で
+topology A/B を選びます。ここには table を複写しません。durable host state の置き場は
+02 が決めます。
+
+別 host repository を使う場合の実用的な 4-role layout は次のとおりです。
+
+```text
+~/work/my-project-host/          # design と orchestration がこの host checkout を開く
+~/work/my-project/               # implementation がこの target-repo checkout を開く
+~/work/my-project-review/        # review がこの分離した target-repo checkout を開く
+```
+
+design と orchestration は host-side intent / workflow decision を所有するため host checkout を
+共有します。implementation は implementation checkout だけを開き、GitHub issue/PR contract に
+従います。review は inspection、test artifact、必要になった repair が active な implementation
+worktree を乱さないよう独立 checkout を使います。
+
+## 2. host を install・initialize する
+
+[インストール](01-install.md) に従い、host checkout から [02 の初期化フロー](02-project-start.md#agent-が実行するコマンドメンテナトラブルシューティング向け)
+を実行します。host check が済んだら、**新しい** team を次の順で stand-up します。
+
+> **新規 team 専用。** この順番は new truth を表示する前に record します。transport を変更する
+> 既存 team は、`session-layer set --write` が final canonical step になる
+> [doc 12 の Session-layer switch checklist](12-agent-message-orchestration.md#session-layer-switch-checklist)
+> に従います。新規 team の順番を transport switch の手順として使わないでください。
+
+### 2.1 transport を record する
+
+design/orchestration agent に次の prompt を貼り付けます。
+
+> host checkout で domain `<domain>` の新規 team `<team>` に `herdr-only` を record してください。
+> `intent-cli session-layer set --domain <domain> --team <team> --mode herdr-only --write --format json`
+> を実行し、返った JSON を表示してください。residue や workspace から mode を infer してはいけません。
+
+隔離 scratch host で shipped `intent-cli 0.11.0-7b3800e-G606` を実行したときの success shape は
+次のとおりです（dynamic timestamp と migration item は省略）。
+
+```json
+{
+  "domain": "onboarding",
+  "team": "docs-team",
+  "mode": "herdr-only",
+  "source": "recorded",
+  "command_mode": "write",
+  "applied": true,
+  "changed": true,
+  "summary": "team `docs-team` in domain `onboarding`: session layer is herdr-only (PREVIEW — session transport only) (recorded)."
+}
+```
+
+この初回 record は `migration_plan` array も返しました。これは mode change の出力です。既存 team の
+migration procedure はこのページではなく doc 12 を使用してください。
+
+### 2.2 すべての role の topology を record する
+
+実際の herdr workspace/pane ID が分かった後、design/orchestration agent に次の prompt を貼り付けます。
+
+> domain `<domain>`、team `<team>` に `design`、`orchestration`、`implementation`、`review`
+> role を record してください。各 role に対して `intent-cli session-layer topology record --domain <domain> --team <team> --role <role> --resident herdr --workspace-id <workspace-id> --pane-id <pane-id> --cwd <role-cwd> --write --format json` を実行してください。明示的な domain、operator が
+> supplied した workspace/pane ID、上記 layout の folder を渡し、ID を推測したり topology file を
+> 手編集したりしてはいけません。
+
+scratch host の各 run は、record した role を `role` に持つ同じ success shape を返しました。
+
+```json
+{
+  "team": "docs-team",
+  "role": "design",
+  "resident": "herdr",
+  "mode": "write",
+  "record_path": ".intent-cli/topology/onboarding/docs-team.json",
+  "applied": true,
+  "changed": true,
+  "already_recorded": false,
+  "conflict": false,
+  "summary": "Recorded operator-supplied role 'design' for team 'docs-team'."
+}
+```
+
+観測では継続前に 4 role すべてを record しました。record command は controlled writer です。
+residency variant と validation rule の詳細は [doc 12](12-agent-message-orchestration.md) に残します。
+
+### 2.3 visible marker を generate する
+
+generate の前に、domain/team 用の空の managed marker block を `AGENTS.md` または `CLAUDE.md` に
+[doc 12 の generated marker 節](12-agent-message-orchestration.md#visible-generated-mode-markers)の
+指定どおり 1 つ置きます。続けて次の prompt を貼り付けます。
+
+> recorded domain `<domain>`、team `<team>` の marker を generate してください。
+> `intent-cli session-layer marker generate --domain <domain> --team <team> --file AGENTS.md --write --format json`
+> を実行して JSON を表示してください。managed marker block だけを変更してください。
+
+scratch-host run の success shape は次のとおりです（record hash は dynamic）。
+
+```json
+{
+  "written": true,
+  "file": "AGENTS.md",
+  "domain": "onboarding",
+  "team": "docs-team",
+  "mode": "herdr-only",
+  "verify_command": "intent-cli session-layer show --domain onboarding --team docs-team",
+  "summary": "Generated the managed session-layer marker for team 'docs-team' in 'AGENTS.md'."
+}
+```
+
+### 2.4 structural readiness を確認する
+
+design/orchestration agent に次の prompt を貼り付けます。
+
+> `intent-cli automation doctor --domain <domain> --team <team> --format json` で新しい team の
+> shared preflight を確認してください。`session_layer_preflight` result を報告し、doctor だけから
+> delivery readiness を主張しないでください。
+
+scratch-host run は structural ready でした。
+
+```json
+{
+  "status": "ok",
+  "topology_health": { "status": "valid", "required": true },
+  "session_layer_preflight": {
+    "verdict": "ready",
+    "ready": true,
+    "passive_phase": { "status": "ready", "contacted_receiver": false },
+    "active_phase": { "status": "skipped", "contacted_receiver": false }
+  }
+}
+```
+
+ここでの `ready` は shared **passive structural** verdict です。delivery surface は delivery を
+claim する前に自身の bounded receiver check を実行します。
+
+## 3. 最初の packet を作る
+
+session layer は record され visibility も得ました。[intent の整理・保守](03-intents.md)、続けて
+[packet 作成と issue 公開](04-packets-issues.md) に進んでください。最初の packet が公開可能になった
+時点から、それらのページが引き継ぎます。
+
+## 代替経路
+
+- **agmsg:** primary transport の provisioning guidance は [agent message orchestration contract](12-agent-message-orchestration.md) を使います。
+- **timer-loop:** [実装ループの設定](05-implementation-loop.md) と
+  [レビュー / next-slice ループの設定](06-review-next-slice-loop.md) を使います。上の
+  orchestration-first route の alternative です。

--- a/docs/ja/02a-getting-started-orchestration.md
+++ b/docs/ja/02a-getting-started-orchestration.md
@@ -102,7 +102,7 @@ residency variant と validation rule の詳細は [doc 12](12-agent-message-orc
 ### 2.3 visible marker を generate する
 
 generate の前に、domain/team 用の空の managed marker block を `AGENTS.md` または `CLAUDE.md` に
-[doc 12 の generated marker 節](12-agent-message-orchestration.md#visible-generated-mode-markers)の
+[doc 12 の generated marker 節](12-agent-message-orchestration.md#可視な生成済み-mode-marker)の
 指定どおり 1 つ置きます。続けて次の prompt を貼り付けます。
 
 > recorded domain `<domain>`、team `<team>` の marker を generate してください。

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -17,12 +17,19 @@ agent が内部で `intent-cli` を実行し、質問や結果を返します。
 
 1. [インストール](01-install.md)
 2. [プロジェクト開始](02-project-start.md)
+2a. [はじめに: 最初の packet までの道のり](02a-getting-started-orchestration.md) — **primary model** の onboarding。collocate する `herdr-only` は **PREVIEW transport**
 3. [Intent Storming と intent の整理](03-intents.md)
 4. [packet 作成と issue 公開](04-packets-issues.md)
 4a. [GitHub ワークフローラベルで見る現在地](04a-workflow-labels.md) — ラベルの意味と読み方
-12. [agent メッセージオーケストレーション](12-agent-message-orchestration.md) — **primary**: 4 スレッド(design/orchestrator/implementation/review)の agmsg orchestrator モデル、single-domain と multi-domain のルーティング
+12. [agent メッセージオーケストレーション](12-agent-message-orchestration.md) — 4 スレッドの contract reference。single-domain と multi-domain の routing
+
+### 代替経路
+
 5. [実装ループの設定](05-implementation-loop.md) — timer-loop の **alternative** セットアップ
 6. [レビュー / next-slice ループの設定](06-review-next-slice-loop.md) — timer-loop の **alternative** セットアップ
+
+### リファレンスと復旧
+
 7. [ループがおかしいときの復旧](07-recovery.md)
 8. [コマンドリファレンス](08-command-reference.md) — agent 向け・パワーユーザー向けコマンド一覧
 9. [開発者リファレンス](09-developer-reference.md) — パッケージ化された実行、preview チャンネル、バージョンフロー

--- a/tests/IntentSystem.Cli.Tests/GettingStartedOrchestrationDocsG607Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GettingStartedOrchestrationDocsG607Tests.cs
@@ -1,0 +1,90 @@
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G607: guards the concise EN/JA onboarding path. The full session-layer
+/// contract remains in document 12; this protects the links, observed v0.11.0
+/// success shapes, and the new-team ordering without turning the short guide
+/// into a second normative operating procedure.
+/// </summary>
+public sealed class GettingStartedOrchestrationDocsG607Tests
+{
+    private const string GettingStartedPath = "02a-getting-started-orchestration.md";
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void GettingStartedPage_RecordsNewTeamInObservedV0110Order_G607(string language)
+    {
+        var doc = ReadDoc(language, GettingStartedPath);
+
+        Assert.Contains("intent-cli 0.11.0-7b3800e-G606", doc, StringComparison.Ordinal);
+        Assert.Contains("session-layer set --domain <domain> --team <team> --mode herdr-only --write --format json", doc, StringComparison.Ordinal);
+        Assert.Contains("session-layer topology record --domain", doc, StringComparison.Ordinal);
+        Assert.Contains("session-layer marker generate --domain <domain> --team <team> --file AGENTS.md --write --format json", doc, StringComparison.Ordinal);
+        Assert.Contains("automation doctor --domain <domain> --team <team> --format json", doc, StringComparison.Ordinal);
+        Assert.Contains("\"mode\": \"herdr-only\"", doc, StringComparison.Ordinal);
+        Assert.Contains("\"verdict\": \"ready\"", doc, StringComparison.Ordinal);
+
+        foreach (var role in new[] { "design", "orchestration", "implementation", "review" })
+        {
+            Assert.Contains($"`{role}`", doc, StringComparison.Ordinal);
+        }
+
+        var set = doc.IndexOf("session-layer set --domain", StringComparison.Ordinal);
+        var record = doc.IndexOf("session-layer topology record --domain", StringComparison.Ordinal);
+        var marker = doc.IndexOf("session-layer marker generate --domain", StringComparison.Ordinal);
+        var doctor = doc.IndexOf("automation doctor --domain", StringComparison.Ordinal);
+        Assert.True(set < record && record < marker && marker < doctor, "New-team commands must remain set → record → marker → doctor.");
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void GettingStartedPage_LinksAuthoritiesAndKeepsSwitchChecklistOutOfLine_G607(string language)
+    {
+        var doc = ReadDoc(language, GettingStartedPath);
+
+        Assert.Contains("02-project-start.md", doc, StringComparison.Ordinal);
+        Assert.Contains("12-agent-message-orchestration.md#session-layer-switch-checklist", doc, StringComparison.Ordinal);
+        Assert.Contains("12-agent-message-orchestration.md#visible-generated-mode-markers", doc, StringComparison.Ordinal);
+        Assert.Contains("05-implementation-loop.md", doc, StringComparison.Ordinal);
+        Assert.Contains("06-review-next-slice-loop.md", doc, StringComparison.Ordinal);
+
+        // A new-team guide links the existing-team migration authority instead
+        // of copying either directional checklist into a second normative text.
+        Assert.DoesNotContain("**agmsg → herdr-only**", doc, StringComparison.Ordinal);
+        Assert.DoesNotContain("**herdr-only → agmsg**", doc, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DocumentationIndex_PresentsOrchestrationPathBeforeTimerLoopAlternatives_G607(string language)
+    {
+        var index = ReadDoc(language, "README.md");
+
+        var projectStart = index.IndexOf("02-project-start.md", StringComparison.Ordinal);
+        var gettingStarted = index.IndexOf(GettingStartedPath, StringComparison.Ordinal);
+        var intents = index.IndexOf("03-intents.md", StringComparison.Ordinal);
+        var packets = index.IndexOf("04-packets-issues.md", StringComparison.Ordinal);
+        var contract = index.IndexOf("12-agent-message-orchestration.md", StringComparison.Ordinal);
+        var implementationLoop = index.IndexOf("05-implementation-loop.md", StringComparison.Ordinal);
+        var reviewLoop = index.IndexOf("06-review-next-slice-loop.md", StringComparison.Ordinal);
+
+        Assert.True(projectStart < gettingStarted && gettingStarted < intents && intents < packets && packets < contract);
+        Assert.True(contract < implementationLoop && implementationLoop < reviewLoop);
+    }
+
+    [Fact]
+    public void RootReadme_OffersCollocatedFourThreadPromptAlongsideExistingPrompts_G607()
+    {
+        var root = File.ReadAllText(Path.Combine(RepoVersionPolicySource.RepoRoot(), "README.md"));
+
+        Assert.Contains("Start a collocated four-thread herdr-only team", root, StringComparison.Ordinal);
+        Assert.Contains("PREVIEW transport", root, StringComparison.Ordinal);
+        Assert.Contains("Start an implementation loop (timer-loop alternative)", root, StringComparison.Ordinal);
+    }
+
+    private static string ReadDoc(string language, string path) =>
+        File.ReadAllText(Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, path));
+}

--- a/tests/IntentSystem.Cli.Tests/GettingStartedOrchestrationDocsG607Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GettingStartedOrchestrationDocsG607Tests.cs
@@ -43,10 +43,17 @@ public sealed class GettingStartedOrchestrationDocsG607Tests
     public void GettingStartedPage_LinksAuthoritiesAndKeepsSwitchChecklistOutOfLine_G607(string language)
     {
         var doc = ReadDoc(language, GettingStartedPath);
+        var generatedMarkerAnchor = language == "en"
+            ? "visible-generated-mode-markers"
+            : "可視な生成済み-mode-marker";
+        var generatedMarkerHeading = language == "en"
+            ? "#### Visible, generated mode markers"
+            : "#### 可視な生成済み mode marker";
 
         Assert.Contains("02-project-start.md", doc, StringComparison.Ordinal);
         Assert.Contains("12-agent-message-orchestration.md#session-layer-switch-checklist", doc, StringComparison.Ordinal);
-        Assert.Contains("12-agent-message-orchestration.md#visible-generated-mode-markers", doc, StringComparison.Ordinal);
+        Assert.Contains($"12-agent-message-orchestration.md#{generatedMarkerAnchor}", doc, StringComparison.Ordinal);
+        Assert.Contains(generatedMarkerHeading, ReadDoc(language, "12-agent-message-orchestration.md"), StringComparison.Ordinal);
         Assert.Contains("05-implementation-loop.md", doc, StringComparison.Ordinal);
         Assert.Contains("06-review-next-slice-loop.md", doc, StringComparison.Ordinal);
 


### PR DESCRIPTION
Closes #1317

Adds EN/JA 02a onboarding pages, orchestration-first navigation, and the collocated herdr-only start prompt. Documents the new-team-only record → topology → marker → doctor path while linking (rather than duplicating) document 02 and document 12 authorities.

Observed v0.11.0 evidence: installed intent-cli 0.11.0-7b3800e-G606 was run in an isolated scratch host. `session-layer set` returned recorded herdr-only with applied/changed true; four explicit-domain topology records returned applied true; marker generate returned written true; automation doctor returned session_layer_preflight verdict ready (passive ready, active skipped).

Verification:
- GettingStartedOrchestrationDocsG607Tests: 7 passed
- dotnet test IntentSystem.sln -c Release
- local 02a links verified for EN/JA
- git diff --check; no renames