### PR TITLE
G608: align onboarding front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,28 +53,31 @@ or `%USERPROFILE%\.dotnet\tools` (Windows) to your `PATH`.
 intent-cli --version
 ```
 
-### 3. Ask an AI agent
+### 3. Start with an AI agent
 
-Open Claude, Codex, Copilot, or another coding assistant with access to your
-repository and paste one of these prompts:
+For a new project, create two empty repositories: the implementation repository
+and an intents host repository. Check out **only the host repository**, open an
+AI agent there, and paste this one prompt:
 
-**Start or continue a project:**
+> I am setting up intent-cli for target implementation repository
+> `<owner>/<implementation-repo>`. I have the empty intents host repository
+> open. First understand intent-cli using its installed guidance, then guide me
+> through initialization. Ask me for one decision at a time.
 
-> I want to work on `<owner>/<repo>` with intent-cli.
-> Ask intent-cli what phase I'm in and what I should decide next.
+The agent uses the shipped skill and `guide onboarding`, verifies the version,
+plans initialization before applying it, writes the nine host files, checks the
+host, and then records the team's session layer before team provisioning. You
+choose only the repository topology, base-branch policy, transport, and the
+agent kind for each role. If you prefer a single repository, use
+[topology B in the project-start guide](docs/en/02-project-start.md#topology-b--same-repo-with-a-metadata-branch).
 
-**Start four-thread agmsg orchestration (primary path):**
+For a collocated, single-machine team, choose the supported `herdr-only`
+transport first; its **PREVIEW** label is a maturity note only. Choose the
+supported `agmsg` + herdr route for a distributed or multi-machine team, or
+when you already invest in agmsg. Record either choice with `intent-cli
+session-layer set`; the **four-thread model**, not a transport, is primary.
 
-> I want to start agmsg orchestrator mode for `<owner>/<repo>` with intent-cli.
-> Ask intent-cli for the orchestrator setup checklist.
-
-**Start a collocated four-thread herdr-only team (PREVIEW transport):**
-
-> I want to start a collocated single-machine four-thread team for
-> `<owner>/<repo>` with intent-cli using the herdr-only transport. Ask intent-cli
-> for the orchestration setup checklist and guide me through new-team stand-up.
-
-**Start an implementation loop (timer-loop alternative):**
+**Timer-loop alternative:**
 
 > Set up a child implementation loop for `<owner>/<repo>`.
 > Ask intent-cli for the next step.
@@ -116,10 +119,10 @@ each answer until a stop condition is reached.
   — agent-facing and power-user command surfaces.
 - **Developer reference:** [`docs/en/09-developer-reference.md`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/09-developer-reference.md)
   — packaged invocation smoke test, preview channel, version flow.
-- **Agent-message orchestration (primary):** [`docs/en/12-agent-message-orchestration.md`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/12-agent-message-orchestration.md)
-  — the primary four-thread agmsg orchestrator model (日本語: [`docs/ja/12`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/ja/12-agent-message-orchestration.md)).
+- **Agent-message orchestration:** [`docs/en/12-agent-message-orchestration.md`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/12-agent-message-orchestration.md)
+  — the primary four-thread model and its supported transport choices (日本語: [`docs/ja/12`](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/ja/12-agent-message-orchestration.md)).
 
-> **Four-thread agmsg orchestration is the primary way to run intent-cli.** A
+> **The four-thread model is the primary way to run intent-cli.** A
 > **design** thread authors intent and packets; an **orchestrator** thread
 > moves ready packets through the workflow and paces the loopless
 > **implementation** and **review** threads over a local message bus (agmsg)

--- a/README.md
+++ b/README.md
@@ -55,27 +55,20 @@ intent-cli --version
 
 ### 3. Start with an AI agent
 
-For a new project, create two empty repositories: the implementation repository
-and an intents host repository. Check out **only the host repository**, open an
-AI agent there, and paste this one prompt:
+Choose your onboarding pattern **before** making any files. Where will host
+metadata live, and are you starting a new project or adding intent-cli to one?
 
-> I am setting up intent-cli for target implementation repository
-> `<owner>/<implementation-repo>`. I have the empty intents host repository
-> open. First understand intent-cli using its installed guidance, then guide me
-> through initialization. Ask me for one decision at a time.
+| Host metadata | Brand-new project | Existing project |
+| --- | --- | --- |
+| Separate host repository | [Separate host × brand-new](docs/en/02b-separate-host-brand-new.md) | [Separate host × existing](docs/en/02c-separate-host-existing.md) |
+| Same repository, metadata branch | [Same repo × brand-new](docs/en/02d-same-repo-brand-new.md) | [Same repo × existing](docs/en/02e-same-repo-existing.md) |
 
-The agent uses the shipped skill and `guide onboarding`, verifies the version,
-plans initialization before applying it, writes the nine host files, checks the
-host, and then records the team's session layer before team provisioning. You
-choose only the repository topology, base-branch policy, transport, and the
-agent kind for each role. If you prefer a single repository, use
-[topology B in the project-start guide](docs/en/02-project-start.md#topology-b--same-repo-with-a-metadata-branch).
-
-For a collocated, single-machine team, choose the supported `herdr-only`
-transport first; its **PREVIEW** label is a maturity note only. Choose the
-supported `agmsg` + herdr route for a distributed or multi-machine team, or
-when you already invest in agmsg. Record either choice with `intent-cli
-session-layer set`; the **four-thread model**, not a transport, is primary.
+Each pattern is self-contained and gives two paste-ready initial prompts: choose
+supported `herdr-only` first for a collocated single-machine team (its
+**PREVIEW** label is a maturity note), or choose supported `agmsg` + herdr for
+a distributed/multi-machine team or an existing agmsg investment. Record the
+choice with `intent-cli session-layer set`; the **four-thread model**, not a
+transport, is primary.
 
 **Timer-loop alternative:**
 

--- a/docs/en/02-project-start.md
+++ b/docs/en/02-project-start.md
@@ -1,6 +1,6 @@
 # Start a project
 
-← [docs index](README.md) | → [Organize & maintain intents](03-intents.md)
+← [docs index](README.md) | → [Getting started: the road to the first packet](02a-getting-started-orchestration.md)
 
 This is **host/design** work. Paste the prompt below into your AI agent
 design thread; the agent will run the intent-cli commands and bring back
@@ -111,4 +111,4 @@ Both topologies are valid. Pick whichever fits your team's existing conventions.
 
 ## Next
 
-[Organize & maintain intents](03-intents.md).
+[Getting started: the road to the first packet](02a-getting-started-orchestration.md).

--- a/docs/en/02a-getting-started-orchestration.md
+++ b/docs/en/02a-getting-started-orchestration.md
@@ -1,12 +1,35 @@
 # Getting started: the road to the first packet
 
-← [docs index](README.md) | [Start a project](02-project-start.md) | → [Organize & maintain intents](03-intents.md)
+← [Start a project](02-project-start.md) | [docs index](README.md) | → [Organize & maintain intents](03-intents.md)
 
-This page is the **orchestration-first** route from an empty workspace to the
-first published packet. It does not replace [Start a project](02-project-start.md)
-or the [agent-message orchestration contract](12-agent-message-orchestration.md):
-those pages remain authoritative for repository topology and session-layer
-semantics.
+## Minimal start: two empty repositories, one prompt
+
+Create an empty implementation repository and an empty intents host repository.
+Check out **only the host**, open an AI agent there, and paste:
+
+> I am setting up intent-cli for target implementation repository
+> `<owner>/<implementation-repo>`. I have the empty intents host repository
+> open. First understand intent-cli using its installed guidance, then guide me
+> through initialization. Ask me for one decision at a time.
+
+For the one-repository option, first choose [topology B](02-project-start.md#topology-b--same-repo-with-a-metadata-branch);
+do not create a second repository. The agent follows the shipped skill to
+`guide onboarding`, verifies `intent-cli --version`, reads `guide model`, runs
+`intent init` once as a dry-run and once with `--write`, and checks the host.
+The observed v0.11.0 write creates **nine files** and `host-check` returns
+`"classification": "ok"`. The human makes four decisions: repository topology,
+base-branch policy, transport, and the agent kind for each role.
+
+Choose `herdr-only` first when all four agents are collocated on one machine;
+its **PREVIEW** status is a maturity note, not a recommendation against it.
+Choose `agmsg` + herdr when the team is distributed or already invests in
+agmsg. Both are supported choices, recorded with `session-layer set`; the
+**four-thread model** is primary, never either transport.
+
+This page is the **orchestration-first** route from that minimal start to the
+first published packet. [Start a project](02-project-start.md) remains
+authoritative for topology, and the [agent-message orchestration contract](12-agent-message-orchestration.md)
+remains authoritative for session-layer semantics.
 
 ## What you are setting up
 
@@ -167,8 +190,12 @@ ready to publish.
 
 ## Alternatives
 
-- **agmsg:** use the [agent-message orchestration contract](12-agent-message-orchestration.md)
-  for the primary transport's provisioning guidance.
+- **agmsg + herdr:** for the distributed or existing-agmsg choice, use the
+  [agent-message orchestration contract](12-agent-message-orchestration.md).
 - **timer-loop:** use [Implementation loop setup](05-implementation-loop.md)
   and [Review / next-slice loop setup](06-review-next-slice-loop.md). It is an
   alternative to the orchestration-first route above.
+
+## Next
+
+[Organize & maintain intents](03-intents.md).

--- a/docs/en/02a-getting-started-orchestration.md
+++ b/docs/en/02a-getting-started-orchestration.md
@@ -2,29 +2,24 @@
 
 ← [Start a project](02-project-start.md) | [docs index](README.md) | → [Organize & maintain intents](03-intents.md)
 
-## Minimal start: two empty repositories, one prompt
+## First decision: choose your 2×2 onboarding pattern
 
-Create an empty implementation repository and an empty intents host repository.
-Check out **only the host**, open an AI agent there, and paste:
+Choose where host metadata lives and whether the project is brand-new or
+existing. Do this first; each linked page is deliberately self-contained, so
+you never combine instructions from two patterns.
 
-> I am setting up intent-cli for target implementation repository
-> `<owner>/<implementation-repo>`. I have the empty intents host repository
-> open. First understand intent-cli using its installed guidance, then guide me
-> through initialization. Ask me for one decision at a time.
+| Host metadata | Brand-new project | Adding intent-cli to an existing project |
+| --- | --- | --- |
+| Separate host repository | [Separate host × brand-new](02b-separate-host-brand-new.md) | [Separate host × existing](02c-separate-host-existing.md) |
+| Same repository, metadata branch | [Same repo × brand-new](02d-same-repo-brand-new.md) | [Same repo × existing](02e-same-repo-existing.md) |
 
-For the one-repository option, first choose [topology B](02-project-start.md#topology-b--same-repo-with-a-metadata-branch);
-do not create a second repository. The agent follows the shipped skill to
-`guide onboarding`, verifies `intent-cli --version`, reads `guide model`, runs
-`intent init` once as a dry-run and once with `--write`, and checks the host.
-The observed v0.11.0 write creates **nine files** and `host-check` returns
-`"classification": "ok"`. The human makes four decisions: repository topology,
-base-branch policy, transport, and the agent kind for each role.
-
+Each pattern starts with exactly two coexisting paste-ready initial prompts.
 Choose `herdr-only` first when all four agents are collocated on one machine;
-its **PREVIEW** status is a maturity note, not a recommendation against it.
-Choose `agmsg` + herdr when the team is distributed or already invests in
-agmsg. Both are supported choices, recorded with `session-layer set`; the
-**four-thread model** is primary, never either transport.
+its **PREVIEW** status is a maturity note. Choose `agmsg` + herdr for a
+distributed team or an existing agmsg investment. Both are supported choices,
+recorded with `session-layer set`; the **four-thread model** is primary, never
+either transport. After the initial prompt, follow the recorded mode and the
+current installed guides instead of combining transport-specific instructions.
 
 This page is the **orchestration-first** route from that minimal start to the
 first published packet. [Start a project](02-project-start.md) remains

--- a/docs/en/02b-separate-host-brand-new.md
+++ b/docs/en/02b-separate-host-brand-new.md
@@ -1,0 +1,29 @@
+# Pattern: separate host × brand-new project
+
+← [Choose an onboarding pattern](02a-getting-started-orchestration.md) | [docs index](README.md)
+
+## Your setup
+
+Create two empty repositories: `<owner>/<implementation-repo>` for product code and `<owner>/<intents-host-repo>` for host metadata. Check out **only the empty host repository**. Name the implementation repository in the prompt; do not check it out for this initial host session.
+
+## Initial prompts — choose exactly one
+
+### Herdr-only
+
+> I am setting up intent-cli for new target implementation repository `<owner>/<implementation-repo>`. I have only the empty intents host repository open. First understand intent-cli using its installed guidance, then initialize it and record `herdr-only` for a collocated single-machine four-thread team.
+
+### Agmsg + herdr
+
+> I am setting up intent-cli for new target implementation repository `<owner>/<implementation-repo>`. I have only the empty intents host repository open. First understand intent-cli using its installed guidance, then initialize it and record `agmsg` for a distributed team or our existing agmsg investment.
+
+## What the agent does
+
+The shipped skill leads to `guide onboarding`. The agent verifies the version, reads `guide model`, runs `intent init` as a dry-run and then with `--write`, and verifies `host-check: ok`. The observed v0.11.0 write creates nine files. It records the selected session layer with `intent-cli session-layer set`, then uses the current guide to provision the four-thread team. The two prompts end at that initial choice: downstream follows the recorded mode and installed guides.
+
+## Your remaining decisions
+
+Confirm the base-branch policy, the transport selection (herdr-only is first for collocation; agmsg + herdr suits distributed/existing-agmsg teams), and the agent kind for each design, orchestration, implementation, and review role.
+
+## Then
+
+Continue with [Organize & maintain intents](03-intents.md).

--- a/docs/en/02c-separate-host-existing.md
+++ b/docs/en/02c-separate-host-existing.md
@@ -1,0 +1,29 @@
+# Pattern: separate host × existing project
+
+← [Choose an onboarding pattern](02a-getting-started-orchestration.md) | [docs index](README.md)
+
+## Your setup
+
+Keep the existing `<owner>/<implementation-repo>` unchanged. Create a separate empty `<owner>/<intents-host-repo>` for host metadata and check out **only that host repository** for the initial session. Name the existing implementation repository in the prompt; do not mix its checkout with the host checkout now.
+
+## Initial prompts — choose exactly one
+
+### Herdr-only
+
+> I am adding intent-cli to existing target implementation repository `<owner>/<implementation-repo>`. I have only the empty separate intents host repository open. First understand intent-cli using installed guidance, then initialize the host and record `herdr-only` for a collocated single-machine team.
+
+### Agmsg + herdr
+
+> I am adding intent-cli to existing target implementation repository `<owner>/<implementation-repo>`. I have only the empty separate intents host repository open. First understand intent-cli using installed guidance, then initialize the host and record `agmsg` for a distributed or existing-agmsg team.
+
+## What the agent does
+
+The shipped skill leads to `guide onboarding`. The agent verifies the version, reads `guide model`, dry-runs `intent init`, applies `init --write`, and checks that the host is ok before recording the selected session layer with `intent-cli session-layer set` and provisioning the four-thread team from current guides. A fresh v0.11.0 host write creates nine files. The prompt variants only choose the initial transport; do not merge their downstream procedures.
+
+## Your remaining decisions
+
+Confirm the base-branch policy for child PRs, the transport choice (herdr-only first for collocation; agmsg + herdr for distributed/existing-agmsg teams), and the agent kind for each design, orchestration, implementation, and review role.
+
+## Then
+
+Continue with [Organize & maintain intents](03-intents.md).

--- a/docs/en/02d-same-repo-brand-new.md
+++ b/docs/en/02d-same-repo-brand-new.md
@@ -1,0 +1,29 @@
+# Pattern: same repository metadata branch × brand-new project
+
+← [Choose an onboarding pattern](02a-getting-started-orchestration.md) | [docs index](README.md)
+
+## Your setup
+
+Create one new `<owner>/<implementation-repo>` with its intended implementation base branch, then create a metadata branch from it (for example `main-metadata`) before initialization. Check out **only that metadata-branch checkout** for this session. Product code and child PRs remain on the implementation base branch; host metadata stays on the metadata branch.
+
+## Initial prompts — choose exactly one
+
+### Herdr-only
+
+> I am setting up intent-cli for new repository `<owner>/<implementation-repo>`. I have only its metadata-branch checkout open. First understand intent-cli using installed guidance, then initialize this host and record `herdr-only` for a collocated single-machine four-thread team.
+
+### Agmsg + herdr
+
+> I am setting up intent-cli for new repository `<owner>/<implementation-repo>`. I have only its metadata-branch checkout open. First understand intent-cli using installed guidance, then initialize this host and record `agmsg` for a distributed team or our existing agmsg investment.
+
+## What the agent does
+
+The shipped skill dispatches to `guide onboarding`. The agent verifies the version, reads `guide model`, dry-runs `intent init`, applies `init --write`, and checks that the host is ok before recording the session layer with `intent-cli session-layer set` and using current guides for four-thread provisioning. A fresh v0.11.0 write creates nine files. Only the initial prompt differs; follow the recorded mode afterwards.
+
+## Your remaining decisions
+
+Confirm the base-branch policy, transport selection (herdr-only first for collocation; agmsg + herdr for distributed/existing-agmsg teams), and the agent kind for each design, orchestration, implementation, and review role.
+
+## Then
+
+Continue with [Organize & maintain intents](03-intents.md).

--- a/docs/en/02e-same-repo-existing.md
+++ b/docs/en/02e-same-repo-existing.md
@@ -1,0 +1,29 @@
+# Pattern: same repository metadata branch × existing project
+
+← [Choose an onboarding pattern](02a-getting-started-orchestration.md) | [docs index](README.md)
+
+## Your setup
+
+Keep the existing `<owner>/<implementation-repo>` and create a metadata branch (for example `main-metadata`) from its intended implementation base branch before initialization. Check out **only the metadata-branch checkout** for the initial host session. The implementation branch and existing code remain separate from host metadata work.
+
+## Initial prompts — choose exactly one
+
+### Herdr-only
+
+> I am adding intent-cli to existing repository `<owner>/<implementation-repo>`. I have only its metadata-branch checkout open. First understand intent-cli using installed guidance, then initialize this host and record `herdr-only` for a collocated single-machine four-thread team.
+
+### Agmsg + herdr
+
+> I am adding intent-cli to existing repository `<owner>/<implementation-repo>`. I have only its metadata-branch checkout open. First understand intent-cli using installed guidance, then initialize this host and record `agmsg` for a distributed team or our existing agmsg investment.
+
+## What the agent does
+
+The shipped skill leads to `guide onboarding`. The agent verifies the version, reads `guide model`, runs the `intent init` dry-run, applies `init --write`, and checks the host before recording the selected session layer with `intent-cli session-layer set` and provisioning the four-thread team from the current guides. A fresh v0.11.0 write creates nine files. The two prompts only choose an initial transport; downstream uses the recorded mode, not blended instructions.
+
+## Your remaining decisions
+
+Confirm the base-branch policy for child PRs, transport choice (herdr-only first for collocation; agmsg + herdr for distributed/existing-agmsg teams), and the agent kind for each design, orchestration, implementation, and review role.
+
+## Then
+
+Continue with [Organize & maintain intents](03-intents.md).

--- a/docs/en/04-packets-issues.md
+++ b/docs/en/04-packets-issues.md
@@ -1,6 +1,6 @@
 # Create packets & publish issues
 
-← [docs index](README.md) | → [GitHub workflow labels](04a-workflow-labels.md) | → [Implementation loop setup](05-implementation-loop.md)
+← [Organize & maintain intents](03-intents.md) | [docs index](README.md) | → [Agent-message orchestration](12-agent-message-orchestration.md)
 
 This is **host/design** work. When your intent is clear enough to act on, the design thread splits it into **packets** — focused implementation units — and publishes one at a time as a GitHub Issue for a child implementation agent to pick up.
 
@@ -51,6 +51,12 @@ intent-cli issue publish-flow <id> --repo <owner>/<repo> --write --format json
 intent-cli automation issue-publish --issue <n> --write --format json
 ```
 
+## Alternative: timer-loop setup
+
+Use [Implementation loop setup](05-implementation-loop.md) and then
+[Review / next-slice loop setup](06-review-next-slice-loop.md) only when you
+choose the timer-loop alternative.
+
 ## Next
 
-[Implementation loop setup](05-implementation-loop.md).
+[Agent-message orchestration](12-agent-message-orchestration.md).

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -715,13 +715,15 @@ The four-thread model (design / orchestrator / implementation / review) is one
 thing; the SESSION LAYER those threads talk over is another, and per the
 operator ruling of 2026-08-01 it is now selectable rather than fixed.
 
-- **`agmsg` is PRIMARY** — the practiced, maintained transport, and the default
-  when nothing is recorded.
-- **`herdr-only` is PREVIEW** — a single-machine alternative where herdr is the
-  terminal controller and no separate message bridge runs. **The preview
-  qualifier scopes the TRANSPORT only.** The four-thread model itself stays
-  PRIMARY and unqualified in both modes, exactly as G540 ruled; choosing a
-  transport never makes the model provisional.
+- **`herdr-only` (PREVIEW maturity)** — the supported first choice when every
+  team agent is collocated on one machine: herdr is the terminal controller and
+  no separate message bridge runs. **The preview qualifier scopes the
+  TRANSPORT only.**
+- **`agmsg` + herdr** — the supported choice when team members are distributed
+  across machines or the team already invests in agmsg. `agmsg` remains the
+  default when nothing is recorded.
+- **The four-thread model is PRIMARY** and unqualified in both modes, exactly
+  as G540 ruled; choosing a transport never makes the model provisional.
 - **One mode per team.** Mixing agmsg and herdr-only delivery inside one team is
   a contract violation, not a fallback: two transports mean two views of who was
   told what.

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1,13 +1,16 @@
 # Agent-message orchestration (single-domain vs multi-domain)
 
-← [Review standing policy](11-review-standing-policy.md) | [docs index](README.md)
+← [Create packets & publish issues](04-packets-issues.md) | [docs index](README.md)
 
-This page describes the **primary** agmsg-backed four-thread orchestrator
-model (design / orchestrator / implementation / review) and, in particular,
-how it stays safe when a single host repository holds **several intent
-domains**. The authoritative, paste-ready prompts come from installed
-intent-cli guidance — do not copy prompts from this page by hand. Generate the
-current prompts with:
+This page describes the **primary four-thread model** (design / orchestrator /
+implementation / review) and, in particular, how it stays safe when a single
+host repository holds **several intent domains**. Choose the supported
+`herdr-only` transport first for a collocated single-machine team (its
+**PREVIEW** label is a maturity note), or choose supported `agmsg` + herdr for
+a distributed team or an existing agmsg investment. Record the choice with
+`session-layer set`; neither transport is primary. The authoritative,
+paste-ready prompts come from installed intent-cli guidance — do not copy
+prompts from this page by hand. Generate the current prompts with:
 
 ```text
 intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --mode single-domain|multi-domain --format markdown
@@ -257,7 +260,7 @@ provided the same rules hold: one dedicated folder per role as the pane cwd,
 shim-safe typed launch, attended first-run prompts, actas + readiness before the
 ping test, and one holder per role with a graceful drop on handover.
 
-## Herdr-only (PREVIEW) operating procedure
+## Herdr-only operating procedure (PREVIEW maturity)
 
 This section is operative only when the team has recorded `herdr-only`. It is
 the concrete counterpart to the agmsg provisioning/receiver sections. PREVIEW

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -6,18 +6,25 @@
 
 `intent-cli` is **deterministic support tooling** for an intent-driven development workflow on top of GitHub.
 
-Once installed, open a design thread in your AI agent and paste a prompt like:
+For a new project, create an implementation repository and an intents host
+repository, then check out only the host. Open your AI agent there and paste:
 
-> I want to work on `<owner>/<repo>` with intent-cli.
-> Ask intent-cli what phase I'm in and what I should decide next.
+> I am setting up intent-cli for target implementation repository
+> `<owner>/<implementation-repo>`. I have the empty intents host repository
+> open. First understand intent-cli using its installed guidance, then guide me
+> through initialization. Ask me for one decision at a time.
 
-The agent runs `intent-cli` internally and brings back questions or results. You do not need to memorize commands.
+The agent runs `intent-cli` internally and brings back questions or results.
+For a collocated single-machine team, `herdr-only` is the first supported
+choice (PREVIEW is a maturity note); choose `agmsg` + herdr for distributed
+teams or an existing agmsg investment. The primary thing is the four-thread
+model, not either transport.
 
 ## Pages
 
 1. [Install](01-install.md)
 2. [Start a project](02-project-start.md)
-2a. [Getting started: the road to the first packet](02a-getting-started-orchestration.md) — **primary model** onboarding; collocated `herdr-only` is a **PREVIEW transport**
+2a. [Getting started: the road to the first packet](02a-getting-started-orchestration.md) — minimal start and the primary four-thread model; collocated `herdr-only` is supported (PREVIEW maturity note)
 3. [Intent Storming & organize intents](03-intents.md)
 4. [Create packets & publish issues](04-packets-issues.md)
 4a. [GitHub workflow labels and what they mean](04a-workflow-labels.md) — label meanings and how to read them

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -6,15 +6,9 @@
 
 `intent-cli` is **deterministic support tooling** for an intent-driven development workflow on top of GitHub.
 
-For a new project, create an implementation repository and an intents host
-repository, then check out only the host. Open your AI agent there and paste:
-
-> I am setting up intent-cli for target implementation repository
-> `<owner>/<implementation-repo>`. I have the empty intents host repository
-> open. First understand intent-cli using its installed guidance, then guide me
-> through initialization. Ask me for one decision at a time.
-
-The agent runs `intent-cli` internally and brings back questions or results.
+Start by choosing one [self-contained onboarding pattern](02a-getting-started-orchestration.md):
+separate host repository or same-repository metadata branch, crossed with a
+brand-new or existing project. Each pattern has two paste-ready initial prompts.
 For a collocated single-machine team, `herdr-only` is the first supported
 choice (PREVIEW is a maturity note); choose `agmsg` + herdr for distributed
 teams or an existing agmsg investment. The primary thing is the four-thread
@@ -25,6 +19,10 @@ model, not either transport.
 1. [Install](01-install.md)
 2. [Start a project](02-project-start.md)
 2a. [Getting started: the road to the first packet](02a-getting-started-orchestration.md) — minimal start and the primary four-thread model; collocated `herdr-only` is supported (PREVIEW maturity note)
+   - [Separate host × brand-new](02b-separate-host-brand-new.md)
+   - [Separate host × existing](02c-separate-host-existing.md)
+   - [Same repo × brand-new](02d-same-repo-brand-new.md)
+   - [Same repo × existing](02e-same-repo-existing.md)
 3. [Intent Storming & organize intents](03-intents.md)
 4. [Create packets & publish issues](04-packets-issues.md)
 4a. [GitHub workflow labels and what they mean](04a-workflow-labels.md) — label meanings and how to read them

--- a/docs/ja/02-project-start.md
+++ b/docs/ja/02-project-start.md
@@ -1,6 +1,6 @@
 # プロジェクト開始
 
-← [ドキュメント索引](README.md) | → [intent の整理・保守](03-intents.md)
+← [ドキュメント索引](README.md) | → [はじめに: 最初の packet までの道のり](02a-getting-started-orchestration.md)
 
 これは **host/design** 作業です。以下のプロンプトを AI agent のデザインスレッドに
 貼り付けてください。agent が intent-cli コマンドを実行し、質問や結果を返します。
@@ -106,4 +106,4 @@ myorg/my-project           ← 単一リポジトリ
 
 ## 次へ
 
-[intent の整理・保守](03-intents.md)。
+[はじめに: 最初の packet までの道のり](02a-getting-started-orchestration.md)。

--- a/docs/ja/02a-getting-started-orchestration.md
+++ b/docs/ja/02a-getting-started-orchestration.md
@@ -2,27 +2,22 @@
 
 ← [プロジェクト開始](02-project-start.md) | [ドキュメント索引](README.md) | → [intent の整理・保守](03-intents.md)
 
-## Minimal start: 空の 2 repository と 1 つの prompt
+## 最初の decision: 2×2 onboarding pattern を選ぶ
 
-空の implementation repository と空の intents host repository を作成します。**host だけを**
-checkout し、そこで AI agent を開いて次を貼り付けます:
+host metadata の置き場と project が brand-new / existing のどちらかを最初に選びます。
+各リンク先は意図的に自己完結しており、2 つの pattern の手順を混ぜる必要はありません。
 
-> target implementation repository `<owner>/<implementation-repo>` 用に intent-cli を
-> 設定します。空の intents host repository を開いています。まずインストール済みの
-> guidance で intent-cli を理解し、それから初期化を案内してください。1 回に 1 つずつ
-> decision を聞いてください。
+| Host metadata | Brand-new project | Existing project に intent-cli を追加 |
+| --- | --- | --- |
+| Separate host repository | [Separate host × brand-new](02b-separate-host-brand-new.md) | [Separate host × existing](02c-separate-host-existing.md) |
+| Same repository, metadata branch | [Same repo × brand-new](02d-same-repo-brand-new.md) | [Same repo × existing](02e-same-repo-existing.md) |
 
-1 repository の選択肢では、先に [topology B](02-project-start.md#トポロジー-b--metadata-ブランチを使う同一リポジトリ)
-を選び、2 つ目の repository は作りません。agent は shipped skill から `guide onboarding` に進み、
-`intent-cli --version` を確認し、`guide model` を読み、`intent init` を dry-run と `--write` で
-各 1 回実行して host を確認します。観測した v0.11.0 の write は **9 files** を生成し、
-`host-check` は `"classification": "ok"` を返しました。human が決めるのは repository topology、
-base-branch policy、transport、role ごとの agent kind の 4 点です。
-
-4 agent 全員が 1 台に collocate する場合は `herdr-only` を最初に選びます。**PREVIEW** は
-maturity note であり、非推奨という意味ではありません。distributed team または既存の agmsg
-investment がある場合は `agmsg` + herdr を選びます。どちらも supported choice であり、
-`session-layer set` で record します。primary なのは transport ではなく **4 スレッドモデル**です。
+各 pattern は共存する貼り付け可能な initial prompt をちょうど 2 つ提示します。4 agent 全員が
+1 台に collocate する場合は `herdr-only` を最初に選びます。**PREVIEW** は maturity note です。
+distributed team または既存 agmsg investment には `agmsg` + herdr を選びます。どちらも
+supported choice で、`session-layer set` で record します。primary なのは transport ではなく
+**4 スレッドモデル**です。initial prompt の後は transport 固有の手順を混ぜず、record された
+mode と current installed guides に従います。
 
 このページは minimal start から最初の公開 packet までの **orchestration-first** 経路です。
 [プロジェクト開始](02-project-start.md) は topology の authority、[agent メッセージ

--- a/docs/ja/02a-getting-started-orchestration.md
+++ b/docs/ja/02a-getting-started-orchestration.md
@@ -1,11 +1,33 @@
 # はじめに: 最初の packet までの道のり
 
-← [ドキュメント索引](README.md) | [プロジェクト開始](02-project-start.md) | → [intent の整理・保守](03-intents.md)
+← [プロジェクト開始](02-project-start.md) | [ドキュメント索引](README.md) | → [intent の整理・保守](03-intents.md)
 
-このページは、空の workspace から最初の公開 packet まで進む **orchestration-first** の経路です。
-[プロジェクト開始](02-project-start.md) と [agent メッセージオーケストレーションの
-contract](12-agent-message-orchestration.md) を置き換えません。repository topology と
-session-layer semantics の authority は引き続きそれらのページです。
+## Minimal start: 空の 2 repository と 1 つの prompt
+
+空の implementation repository と空の intents host repository を作成します。**host だけを**
+checkout し、そこで AI agent を開いて次を貼り付けます:
+
+> target implementation repository `<owner>/<implementation-repo>` 用に intent-cli を
+> 設定します。空の intents host repository を開いています。まずインストール済みの
+> guidance で intent-cli を理解し、それから初期化を案内してください。1 回に 1 つずつ
+> decision を聞いてください。
+
+1 repository の選択肢では、先に [topology B](02-project-start.md#トポロジー-b--metadata-ブランチを使う同一リポジトリ)
+を選び、2 つ目の repository は作りません。agent は shipped skill から `guide onboarding` に進み、
+`intent-cli --version` を確認し、`guide model` を読み、`intent init` を dry-run と `--write` で
+各 1 回実行して host を確認します。観測した v0.11.0 の write は **9 files** を生成し、
+`host-check` は `"classification": "ok"` を返しました。human が決めるのは repository topology、
+base-branch policy、transport、role ごとの agent kind の 4 点です。
+
+4 agent 全員が 1 台に collocate する場合は `herdr-only` を最初に選びます。**PREVIEW** は
+maturity note であり、非推奨という意味ではありません。distributed team または既存の agmsg
+investment がある場合は `agmsg` + herdr を選びます。どちらも supported choice であり、
+`session-layer set` で record します。primary なのは transport ではなく **4 スレッドモデル**です。
+
+このページは minimal start から最初の公開 packet までの **orchestration-first** 経路です。
+[プロジェクト開始](02-project-start.md) は topology の authority、[agent メッセージ
+オーケストレーション contract](12-agent-message-orchestration.md) は session-layer semantics の
+authority として残ります。
 
 ## これから設定するもの
 
@@ -157,7 +179,12 @@ session layer は record され visibility も得ました。[intent の整理�
 
 ## 代替経路
 
-- **agmsg:** primary transport の provisioning guidance は [agent message orchestration contract](12-agent-message-orchestration.md) を使います。
+- **agmsg + herdr:** distributed または既存 agmsg の選択では [agent message
+  orchestration contract](12-agent-message-orchestration.md) を使います。
 - **timer-loop:** [実装ループの設定](05-implementation-loop.md) と
   [レビュー / next-slice ループの設定](06-review-next-slice-loop.md) を使います。上の
   orchestration-first route の alternative です。
+
+## 次へ
+
+[intent の整理・保守](03-intents.md)。

--- a/docs/ja/02b-separate-host-brand-new.md
+++ b/docs/ja/02b-separate-host-brand-new.md
@@ -1,0 +1,29 @@
+# Pattern: separate host × brand-new project
+
+← [onboarding pattern を選ぶ](02a-getting-started-orchestration.md) | [docs インデックス](README.md)
+
+## この setup
+
+product code 用の空の `<owner>/<implementation-repo>` と host metadata 用の空の `<owner>/<intents-host-repo>` を作成します。**空の host repository だけを** checkout します。implementation repository は prompt で指定し、この最初の host session では checkout しません。
+
+## Initial prompt — ちょうど 1 つを選ぶ
+
+### Herdr-only
+
+> 新しい target implementation repository `<owner>/<implementation-repo>` 用に intent-cli を設定します。空の intents host repository だけを開いています。まずインストール済み guidance で intent-cli を理解し、初期化して collocate した single-machine 4 スレッド team 用に `herdr-only` を record してください。
+
+### Agmsg + herdr
+
+> 新しい target implementation repository `<owner>/<implementation-repo>` 用に intent-cli を設定します。空の intents host repository だけを開いています。まずインストール済み guidance で intent-cli を理解し、初期化して distributed team または既存 agmsg investment 用に `agmsg` を record してください。
+
+## agent が行うこと
+
+shipped skill は `guide onboarding` に進みます。agent は version を確認し、`guide model` を読み、`intent init` を dry-run と `--write` で実行し、`host-check: ok` を確認します。観測した v0.11.0 の write は 9 files を生成します。選んだ session layer を `intent-cli session-layer set` で record してから、current guide で 4 スレッド team を provision します。2 つの prompt は最初の選択だけです。以降は recorded mode と installed guides に従います。
+
+## 残る human decision
+
+base-branch policy、transport の選択（collocation は herdr-only を最初に、distributed / existing-agmsg team は agmsg + herdr）、design・orchestration・implementation・review 各 role の agent kind を確認します。
+
+## 次へ
+
+[intent の整理・保守](03-intents.md) に進みます。

--- a/docs/ja/02c-separate-host-existing.md
+++ b/docs/ja/02c-separate-host-existing.md
@@ -1,0 +1,29 @@
+# Pattern: separate host × existing project
+
+← [onboarding pattern を選ぶ](02a-getting-started-orchestration.md) | [docs インデックス](README.md)
+
+## この setup
+
+既存の `<owner>/<implementation-repo>` は変更しません。host metadata 用に空の `<owner>/<intents-host-repo>` を別に作り、最初の session では **その host repository だけを** checkout します。既存 implementation repository は prompt で指定し、ここで host checkout と混ぜません。
+
+## Initial prompt — ちょうど 1 つを選ぶ
+
+### Herdr-only
+
+> 既存 target implementation repository `<owner>/<implementation-repo>` に intent-cli を追加します。空の separate intents host repository だけを開いています。まず installed guidance で intent-cli を理解し、host を初期化して collocate した single-machine team 用に `herdr-only` を record してください。
+
+### Agmsg + herdr
+
+> 既存 target implementation repository `<owner>/<implementation-repo>` に intent-cli を追加します。空の separate intents host repository だけを開いています。まず installed guidance で intent-cli を理解し、host を初期化して distributed または existing-agmsg team 用に `agmsg` を record してください。
+
+## agent が行うこと
+
+shipped skill は `guide onboarding` に進みます。agent は version を確認し、`guide model` を読み、`intent init` を dry-run し、`init --write` を適用して host が ok であることを確認します。その後 session layer を `intent-cli session-layer set` で record し、current guide で 4 スレッド team を provision します。新規 v0.11.0 host write は 9 files を作ります。prompt variant は最初の transport だけを選び、下流の手順を混ぜません。
+
+## 残る human decision
+
+child PR 用の base-branch policy、transport の選択（collocation は herdr-only を最初に、distributed / existing-agmsg team は agmsg + herdr）、各 role の agent kind を確認します。
+
+## 次へ
+
+[intent の整理・保守](03-intents.md) に進みます。

--- a/docs/ja/02d-same-repo-brand-new.md
+++ b/docs/ja/02d-same-repo-brand-new.md
@@ -1,0 +1,29 @@
+# Pattern: same repository metadata branch × brand-new project
+
+← [onboarding pattern を選ぶ](02a-getting-started-orchestration.md) | [docs インデックス](README.md)
+
+## この setup
+
+新しい `<owner>/<implementation-repo>` に intended implementation base branch を作り、初期化前にそこから metadata branch（例: `main-metadata`）を作成します。この session では **その metadata-branch checkout だけを**開きます。product code と child PR は implementation base branch、host metadata は metadata branch に置きます。
+
+## Initial prompt — ちょうど 1 つを選ぶ
+
+### Herdr-only
+
+> 新しい repository `<owner>/<implementation-repo>` 用に intent-cli を設定します。metadata-branch checkout だけを開いています。まず installed guidance で intent-cli を理解し、この host を初期化して collocate した single-machine 4 スレッド team 用に `herdr-only` を record してください。
+
+### Agmsg + herdr
+
+> 新しい repository `<owner>/<implementation-repo>` 用に intent-cli を設定します。metadata-branch checkout だけを開いています。まず installed guidance で intent-cli を理解し、この host を初期化して distributed team または既存 agmsg investment 用に `agmsg` を record してください。
+
+## agent が行うこと
+
+shipped skill は `guide onboarding` に dispatch します。agent は version を確認し、`guide model` を読み、`intent init` を dry-run し、`init --write` を適用して host が ok か確認します。それから session layer を `intent-cli session-layer set` で record し、current guide で 4 スレッド team を provision します。新規 v0.11.0 write は 9 files を作ります。違うのは initial prompt だけで、以降は recorded mode に従います。
+
+## 残る human decision
+
+base-branch policy、transport の選択（collocation は herdr-only を最初に、distributed / existing-agmsg team は agmsg + herdr）、各 role の agent kind を確認します。
+
+## 次へ
+
+[intent の整理・保守](03-intents.md) に進みます。

--- a/docs/ja/02e-same-repo-existing.md
+++ b/docs/ja/02e-same-repo-existing.md
@@ -1,0 +1,29 @@
+# Pattern: same repository metadata branch × existing project
+
+← [onboarding pattern を選ぶ](02a-getting-started-orchestration.md) | [docs インデックス](README.md)
+
+## この setup
+
+既存の `<owner>/<implementation-repo>` を維持し、初期化前に intended implementation base branch から metadata branch（例: `main-metadata`）を作成します。最初の host session では **metadata-branch checkout だけを**開きます。implementation branch と既存 code は host metadata の作業から分けます。
+
+## Initial prompt — ちょうど 1 つを選ぶ
+
+### Herdr-only
+
+> 既存 repository `<owner>/<implementation-repo>` に intent-cli を追加します。metadata-branch checkout だけを開いています。まず installed guidance で intent-cli を理解し、この host を初期化して collocate した single-machine 4 スレッド team 用に `herdr-only` を record してください。
+
+### Agmsg + herdr
+
+> 既存 repository `<owner>/<implementation-repo>` に intent-cli を追加します。metadata-branch checkout だけを開いています。まず installed guidance で intent-cli を理解し、この host を初期化して distributed team または既存 agmsg investment 用に `agmsg` を record してください。
+
+## agent が行うこと
+
+shipped skill は `guide onboarding` に進みます。agent は version を確認し、`guide model` を読み、`intent init` dry-run を実行し、`init --write` を適用して host を確認します。その後、選んだ session layer を `intent-cli session-layer set` で record し、current guide で 4 スレッド team を provision します。新規 v0.11.0 write は 9 files を作ります。2 つの prompt は initial transport だけを選び、以降は recorded mode を使います。
+
+## 残る human decision
+
+child PR 用の base-branch policy、transport の選択（collocation は herdr-only を最初に、distributed / existing-agmsg team は agmsg + herdr）、各 role の agent kind を確認します。
+
+## 次へ
+
+[intent の整理・保守](03-intents.md) に進みます。

--- a/docs/ja/04-packets-issues.md
+++ b/docs/ja/04-packets-issues.md
@@ -1,6 +1,6 @@
 # packet 作成と issue 公開
 
-← [ドキュメント索引](README.md) | → [GitHub ワークフローラベル](04a-workflow-labels.md) | → [実装ループの設定](05-implementation-loop.md)
+← [intent の整理・保守](03-intents.md) | [ドキュメント索引](README.md) | → [agent メッセージオーケストレーション](12-agent-message-orchestration.md)
 
 これは **host/design** 作業です。intent が十分に固まったら、デザインスレッドがそれを **packet**（実行可能な実装単位）に分割し、1つずつ GitHub Issue として公開します。child implementation agent がその issue を受け取って実装します。
 
@@ -51,6 +51,11 @@ intent-cli issue publish-flow <id> --repo <owner>/<repo> --write --format json
 intent-cli automation issue-publish --issue <n> --write --format json
 ```
 
+## 代替: timer-loop のセットアップ
+
+timer-loop の alternative を選ぶときだけ、[実装ループの設定](05-implementation-loop.md)、続けて
+[レビュー / next-slice ループの設定](06-review-next-slice-loop.md) を使います。
+
 ## 次へ
 
-[実装ループの設定](05-implementation-loop.md)。
+[agent メッセージオーケストレーション](12-agent-message-orchestration.md)。

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -728,12 +728,13 @@ polling loop、process launch、automatic open/resolve path は追加しませ�
 会話する **session layer** は別の話です。2026-08-01 のオペレーター裁定により、後者は
 固定ではなく**選択可能**になりました。
 
-- **`agmsg` が PRIMARY** — 実運用され保守されている transport であり、記録が無いときの
-  既定値です。
-- **`herdr-only` は PREVIEW** — herdr が terminal controller となり、別立ての message
-  bridge を動かさない単一マシン向けの代替です。**PREVIEW という限定詞は transport のみ**
-  に掛かります。4 スレッドモデル自体は両モードで PRIMARY かつ無限定のままであり
-  (G540 の裁定どおり)、transport を選ぶことがモデルを暫定的にすることはありません。
+- **`herdr-only`（PREVIEW maturity）** — team agent 全員が 1 台に collocate する場合の
+  supported な最初の選択です。herdr が terminal controller になり、別立ての message bridge
+  を動かしません。**PREVIEW という限定詞は transport のみ**に掛かります。
+- **`agmsg` + herdr** — team member が複数 machine に分散する場合、または既存の agmsg
+  investment がある場合の supported choice です。記録が無いときは `agmsg` が既定値です。
+- **primary で無限定なのは 4 スレッドモデル**であり、両モードで変わりません（G540 の裁定
+  どおり）。transport を選んでもモデルが暫定的になることはありません。
 - **1 チーム 1 モード。** 1 つのチーム内で agmsg と herdr-only の配送を混在させることは
   fallback ではなく contract violation です。transport が 2 つあるということは「誰に何を
   伝えたか」の見え方が 2 つあるということです。

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -1,13 +1,15 @@
 # agent メッセージオーケストレーション（single-domain と multi-domain）
 
-← [レビュー standing-policy](11-review-standing-policy.md) | [docs インデックス](README.md)
+← [packet 作成と issue 公開](04-packets-issues.md) | [docs インデックス](README.md)
 
-このページは **主要な(primary)** agmsg ベースの 4 スレッドの orchestrator
-モデル(design / orchestrator / implementation / review)と、特に 1 つの
-host リポジトリが **複数の intent ドメイン** を保持する場合に、それをどう
-安全に保つかを説明します。権威ある貼り付け可能なプロンプトはインストール済み
-の intent-cli ガイダンスから生成され、このページのプロンプトを手で写してはいけません。
-現在のプロンプトは次で生成します:
+このページは **primary な 4 スレッドモデル**（design / orchestrator / implementation /
+review）と、特に 1 つの host リポジトリが **複数の intent ドメイン** を保持する場合に
+それを安全に保つ方法を説明します。1 台に collocate する team は supported な
+`herdr-only` transport を最初に選びます（**PREVIEW** は maturity note）。distributed team
+または既存 agmsg investment には supported な `agmsg` + herdr を選びます。選択は
+`session-layer set` で record し、どちらの transport も primary ではありません。権威ある
+貼り付け可能なプロンプトはインストール済みの intent-cli ガイダンスから生成され、このページの
+プロンプトを手で写してはいけません。現在のプロンプトは次で生成します:
 
 ```text
 intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --mode single-domain|multi-domain --format markdown
@@ -242,7 +244,7 @@ agmsg internals と同じくリンクアウトし、herdr 自身のドキュメ�
 立ち会う、ping テスト前の actas + readiness、1 ロール 1 保持者と handover 時の graceful
 drop）が満たされるなら、**任意の** 同等なワークスペースマネージャーで置き換えられます。
 
-## herdr-only（PREVIEW）の運用手順
+## herdr-only の運用手順（PREVIEW maturity）
 
 この節はチームが `herdr-only` を記録している場合だけ operative です。agmsg の
 provisioning / receiver 節に対する具体的な counterpart です。PREVIEW が限定するのは

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -6,24 +6,22 @@
 
 `intent-cli` は、AI agent に Intent System の正規手順を確認させながら Intent-Driven Development を進めるための **決定論的なサポートツール** です。
 
-新しい project では implementation repository と intents host repository を作り、host だけを
-checkout します。そこで AI agent を開き、次を貼り付けます:
-
-> target implementation repository `<owner>/<implementation-repo>` 用に intent-cli を
-> 設定します。空の intents host repository を開いています。まずインストール済みの
-> guidance で intent-cli を理解し、それから初期化を案内してください。1 回に 1 つずつ
-> decision を聞いてください。
-
-agent が内部で `intent-cli` を実行し、質問や結果を返します。1 台に collocate する team は
-`herdr-only` を最初の supported choice とします（PREVIEW は maturity note）。distributed team
-または既存の agmsg investment には `agmsg` + herdr を選びます。primary なのは transport
-ではなく 4 スレッドモデルです。
+最初に [自己完結した onboarding pattern](02a-getting-started-orchestration.md) を選びます。
+separate host repository / same-repository metadata branch と、brand-new / existing project を
+掛け合わせます。各 pattern には貼り付け可能な initial prompt が 2 つあります。1 台に
+collocate する team は `herdr-only` を最初の supported choice とします（PREVIEW は maturity
+note）。distributed team または既存の agmsg investment には `agmsg` + herdr を選びます。
+primary なのは transport ではなく 4 スレッドモデルです。
 
 ## ページ一覧
 
 1. [インストール](01-install.md)
 2. [プロジェクト開始](02-project-start.md)
 2a. [はじめに: 最初の packet までの道のり](02a-getting-started-orchestration.md) — minimal start と primary な 4 スレッドモデル。collocate する `herdr-only` は supported（PREVIEW は maturity note）
+   - [Separate host × brand-new](02b-separate-host-brand-new.md)
+   - [Separate host × existing](02c-separate-host-existing.md)
+   - [Same repo × brand-new](02d-same-repo-brand-new.md)
+   - [Same repo × existing](02e-same-repo-existing.md)
 3. [Intent Storming と intent の整理](03-intents.md)
 4. [packet 作成と issue 公開](04-packets-issues.md)
 4a. [GitHub ワークフローラベルで見る現在地](04a-workflow-labels.md) — ラベルの意味と読み方

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -6,18 +6,24 @@
 
 `intent-cli` は、AI agent に Intent System の正規手順を確認させながら Intent-Driven Development を進めるための **決定論的なサポートツール** です。
 
-`intent-cli` をインストールしたら、AI agent のデザインスレッドで次のように依頼します:
+新しい project では implementation repository と intents host repository を作り、host だけを
+checkout します。そこで AI agent を開き、次を貼り付けます:
 
-> `<owner>/<repo>` で intent-cli を使い始めたいです。
-> intent-cli に現在のフェーズと次に決断すべきことを聞いてください。
+> target implementation repository `<owner>/<implementation-repo>` 用に intent-cli を
+> 設定します。空の intents host repository を開いています。まずインストール済みの
+> guidance で intent-cli を理解し、それから初期化を案内してください。1 回に 1 つずつ
+> decision を聞いてください。
 
-agent が内部で `intent-cli` を実行し、質問や結果を返します。コマンドを覚える必要はありません。
+agent が内部で `intent-cli` を実行し、質問や結果を返します。1 台に collocate する team は
+`herdr-only` を最初の supported choice とします（PREVIEW は maturity note）。distributed team
+または既存の agmsg investment には `agmsg` + herdr を選びます。primary なのは transport
+ではなく 4 スレッドモデルです。
 
 ## ページ一覧
 
 1. [インストール](01-install.md)
 2. [プロジェクト開始](02-project-start.md)
-2a. [はじめに: 最初の packet までの道のり](02a-getting-started-orchestration.md) — **primary model** の onboarding。collocate する `herdr-only` は **PREVIEW transport**
+2a. [はじめに: 最初の packet までの道のり](02a-getting-started-orchestration.md) — minimal start と primary な 4 スレッドモデル。collocate する `herdr-only` は supported（PREVIEW は maturity note）
 3. [Intent Storming と intent の整理](03-intents.md)
 4. [packet 作成と issue 公開](04-packets-issues.md)
 4a. [GitHub ワークフローラベルで見る現在地](04a-workflow-labels.md) — ラベルの意味と読み方

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -149,7 +149,7 @@ internal static class GuideCommandsListCommand
             Classification = ClassificationSupport,
             Mutability = MutabilityMixed,
             RecommendedCaller = CallerOperator,
-            Purpose = "Session-layer transport and delivery topology (G570/G592/G604): `intent-cli session-layer show` reads the team transport and `session-layer set --mode agmsg|herdr-only` selects it, while `session-layer topology record|show|validate --domain <d> --team <t>` canonically writes and checks machine-local `.intent-cli/topology/<domain>/<team>.json` with directory-local CLI-owned ignore and internal identity. Topology record is dry-run by default, idempotent on an exact match, and refuses conflicts; show/validate are read-only and never query herdr or send. `agmsg` remains PRIMARY; `herdr-only` is PREVIEW only for the TRANSPORT, never to the four-thread model."
+            Purpose = "Session-layer transport and delivery topology (G570/G592/G604): `intent-cli session-layer show` reads the team transport and `session-layer set --mode agmsg|herdr-only` records the supported choice — `herdr-only` first for a collocated single-machine team (PREVIEW is a transport maturity note), or `agmsg` + herdr for a distributed team or existing agmsg investment. The PRIMARY four-thread model is unchanged in either transport. `session-layer topology record|show|validate --domain <d> --team <t>` canonically writes and checks machine-local `.intent-cli/topology/<domain>/<team>.json` with directory-local CLI-owned ignore and internal identity. Topology record is dry-run by default, idempotent on an exact match, and refuses conflicts; show/validate are read-only and never query herdr or send."
         },
         new CommandGroupEntry
         {

--- a/src/IntentSystem.Cli/Commands/GuideModelCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideModelCommand.cs
@@ -171,17 +171,18 @@ internal static class GuideModelCommand
             + "same four threads, the same authority boundaries, the same wake contract in either mode.",
         Modes = new[]
         {
-            "agmsg (PRIMARY) — the practiced, maintained transport: threads register as agmsg roles and exchange "
-                + "delegation / progress / completion / blocker messages. Use this unless you have a specific reason "
-                + "not to; every field-proven behaviour (wake contract, stalled-work, heartbeat) was built here.",
-            "herdr-only (PREVIEW) — a single-machine alternative in which herdr is the terminal controller and no "
-                + "separate message bridge runs. " + SessionLayerMode.PreviewScopingSentence,
+            "herdr-only (PREVIEW maturity) — the supported first choice when every agent in the team is "
+                + "herdr-resident on ONE machine: herdr is the terminal controller and no separate message bridge runs. "
+                + SessionLayerMode.PreviewScopingSentence,
+            "agmsg + herdr — the supported choice when team members are distributed across machines or the team "
+                + "already invests in agmsg: threads register as agmsg roles and exchange delegation / progress / "
+                + "completion / blocker messages.",
         },
         WhenToChooseHerdrOnly =
-            "Consider herdr-only when every agent in the team is herdr-resident on ONE machine and you want fewer "
+            "Choose herdr-only when every agent in the team is herdr-resident on ONE machine and you want fewer "
             + "moving parts: no message-bridge process to keep alive, and the terminal controller you already run "
-            + "carries the delegations. Stay on agmsg when threads live on different machines or when you want the "
-            + "most exercised path.",
+            + "carries the delegations. Choose agmsg + herdr when threads live on different machines or the team "
+            + "already invests in agmsg. Both are supported choices.",
         Exclusivity = SessionLayerMode.ExclusivitySentence,
         Selection =
             "`intent-cli session-layer show --domain <d> [--team <t>]` reports the mode in force; "

--- a/src/IntentSystem.Cli/Commands/GuideOnboardingCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOnboardingCommand.cs
@@ -85,7 +85,7 @@ internal static class GuideOnboardingCommand
                 {
                     Order = 3,
                     Command = "intent-cli session-layer show --domain <domain> [--team <team>] --format json",
-                    Purpose = "G570: learn which SESSION LAYER this team runs — `agmsg` (PRIMARY, the practiced transport) or `herdr-only` (PREVIEW, single-machine, herdr as terminal controller). "
+                    Purpose = "G570: learn which SESSION LAYER this team runs — choose supported `herdr-only` first for a collocated single-machine team (PREVIEW is a maturity note), or supported `agmsg` + herdr for a distributed team or an existing agmsg investment. "
                         + SessionLayerMode.PreviewScopingSentence
                         + " Absent a record the mode is `agmsg`. The recorded mode selects which operating sections `guide orchestrator-thread` renders, so read it before following any transport-specific setup. Change it with `intent-cli session-layer set --domain <domain> --mode agmsg|herdr-only --write` — reversible in both directions.",
                     NoMutation = "Pure read; `show` never writes. Only `session-layer set --write` records a mode."

--- a/tests/IntentSystem.Cli.Tests/GettingStartedOrchestrationDocsG607Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GettingStartedOrchestrationDocsG607Tests.cs
@@ -87,9 +87,10 @@ public sealed class GettingStartedOrchestrationDocsG607Tests
     {
         var root = File.ReadAllText(Path.Combine(RepoVersionPolicySource.RepoRoot(), "README.md"));
 
-        Assert.Contains("Start a collocated four-thread herdr-only team", root, StringComparison.Ordinal);
-        Assert.Contains("PREVIEW transport", root, StringComparison.Ordinal);
-        Assert.Contains("Start an implementation loop (timer-loop alternative)", root, StringComparison.Ordinal);
+        Assert.Contains("Check out **only the host repository**", root, StringComparison.Ordinal);
+        Assert.Contains("Start with an AI agent", root, StringComparison.Ordinal);
+        Assert.Contains("PREVIEW** label is a maturity note", root, StringComparison.Ordinal);
+        Assert.Contains("Timer-loop alternative", root, StringComparison.Ordinal);
     }
 
     private static string ReadDoc(string language, string path) =>

--- a/tests/IntentSystem.Cli.Tests/GettingStartedOrchestrationDocsG607Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GettingStartedOrchestrationDocsG607Tests.cs
@@ -71,7 +71,9 @@ public sealed class GettingStartedOrchestrationDocsG607Tests
         var index = ReadDoc(language, "README.md");
 
         var projectStart = index.IndexOf("02-project-start.md", StringComparison.Ordinal);
-        var gettingStarted = index.IndexOf(GettingStartedPath, StringComparison.Ordinal);
+        // The updated G608 front-door paragraph links 02a before the numbered
+        // list. The list ordering is the contract this G607 guard protects.
+        var gettingStarted = index.LastIndexOf(GettingStartedPath, StringComparison.Ordinal);
         var intents = index.IndexOf("03-intents.md", StringComparison.Ordinal);
         var packets = index.IndexOf("04-packets-issues.md", StringComparison.Ordinal);
         var contract = index.IndexOf("12-agent-message-orchestration.md", StringComparison.Ordinal);
@@ -87,8 +89,9 @@ public sealed class GettingStartedOrchestrationDocsG607Tests
     {
         var root = File.ReadAllText(Path.Combine(RepoVersionPolicySource.RepoRoot(), "README.md"));
 
-        Assert.Contains("Check out **only the host repository**", root, StringComparison.Ordinal);
-        Assert.Contains("Start with an AI agent", root, StringComparison.Ordinal);
+        Assert.Contains("Choose your onboarding pattern", root, StringComparison.Ordinal);
+        Assert.Contains("Separate host × brand-new", root, StringComparison.Ordinal);
+        Assert.Contains("Same repo × existing", root, StringComparison.Ordinal);
         Assert.Contains("PREVIEW** label is a maturity note", root, StringComparison.Ordinal);
         Assert.Contains("Timer-loop alternative", root, StringComparison.Ordinal);
     }

--- a/tests/IntentSystem.Cli.Tests/GuideCommandsListCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideCommandsListCommandTests.cs
@@ -69,6 +69,11 @@ public sealed class GuideCommandsListCommandTests
         Assert.Contains("guide prompt-matrix", byName.Keys);
         Assert.Equal("design", byName["guide prompt-matrix"].GetProperty("role").GetString());
         Assert.Equal("support", byName["guide prompt-matrix"].GetProperty("classification").GetString());
+
+        var sessionLayerPurpose = byName["session-layer"].GetProperty("purpose").GetString()!;
+        Assert.Contains("supported choice", sessionLayerPurpose, StringComparison.Ordinal);
+        Assert.Contains("`herdr-only` first", sessionLayerPurpose, StringComparison.Ordinal);
+        Assert.DoesNotContain("`agmsg` remains PRIMARY", sessionLayerPurpose, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/GuideModelCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideModelCommandTests.cs
@@ -104,6 +104,20 @@ public sealed class GuideModelCommandTests
         Assert.Contains("PRIMARY and unqualified in both modes", output, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void Execute_Markdown_PresentsBothTransportsAsConditionalChoices_G608()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideModelCommand.Execute(CreateContext(), [], writer));
+        var output = writer.ToString();
+
+        Assert.Contains("herdr-only (PREVIEW maturity)", output, StringComparison.Ordinal);
+        Assert.Contains("agmsg + herdr", output, StringComparison.Ordinal);
+        Assert.Contains("Both are supported choices.", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("agmsg (PRIMARY)", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Use this unless", output, StringComparison.Ordinal);
+    }
+
     private static string SectionBetween(string output, string startHeading, string endHeading)
     {
         var start = output.IndexOf(startHeading, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/GuideOnboardingCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOnboardingCommandTests.cs
@@ -90,6 +90,13 @@ public sealed class GuideOnboardingCommandTests
         var modelStep = steps.Single(s => s.GetProperty("command").GetString()!
             .StartsWith("intent-cli guide model", StringComparison.Ordinal));
         Assert.Contains("PRIMARY execution orchestration model", modelStep.GetProperty("purpose").GetString(), StringComparison.Ordinal);
+
+        var sessionStep = steps.Single(s => s.GetProperty("command").GetString()!
+            .StartsWith("intent-cli session-layer show", StringComparison.Ordinal));
+        var sessionPurpose = sessionStep.GetProperty("purpose").GetString()!;
+        Assert.Contains("supported `herdr-only` first", sessionPurpose, StringComparison.Ordinal);
+        Assert.Contains("supported `agmsg` + herdr", sessionPurpose, StringComparison.Ordinal);
+        Assert.DoesNotContain("agmsg` (PRIMARY", sessionPurpose, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/OnboardingTransportPresentationG608Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/OnboardingTransportPresentationG608Tests.cs
@@ -1,0 +1,117 @@
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G608 keeps the field-tested minimal start visible without turning document
+/// 02a into a replacement transport contract. It also makes the default
+/// reading trail mechanically observable in each language.
+/// </summary>
+public sealed class OnboardingTransportPresentationG608Tests
+{
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void MinimalStart_UsesOneHostCheckoutOnePromptAndFourHumanDecisions_G608(string language)
+    {
+        var root = language == "en"
+            ? File.ReadAllText(Path.Combine(RepoVersionPolicySource.RepoRoot(), "README.md"))
+            : ReadDoc(language, "README.md");
+        var gettingStarted = ReadDoc(language, "02a-getting-started-orchestration.md");
+
+        foreach (var text in new[]
+                 {
+                     "<owner>/<implementation-repo>",
+                     "guide onboarding",
+                     "intent-cli --version",
+                     "intent init",
+                     "--write",
+                     language == "en" ? "nine files" : "9 files",
+                     "session-layer set",
+                 })
+        {
+            Assert.Contains(text, root + gettingStarted, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("repository topology", gettingStarted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("base-branch", gettingStarted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("transport", gettingStarted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("agent kind", gettingStarted, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DefaultHeaderAndNextTrail_ReachesDocument12WithoutTimerLoop_G608(string language)
+    {
+        var trail = new[]
+        {
+            ("01-install.md", "02-project-start.md"),
+            ("02-project-start.md", "02a-getting-started-orchestration.md"),
+            ("02a-getting-started-orchestration.md", "03-intents.md"),
+            ("03-intents.md", "04-packets-issues.md"),
+            ("04-packets-issues.md", "12-agent-message-orchestration.md"),
+        };
+
+        foreach (var (page, next) in trail)
+        {
+            var doc = ReadDoc(language, page);
+            var header = string.Join('\n', doc.Split('\n').Take(5));
+            var nextHeading = language == "en" ? "## Next" : "## 次へ";
+            var footerStart = doc.LastIndexOf(nextHeading, StringComparison.Ordinal);
+
+            Assert.Contains($"]({next})", header, StringComparison.Ordinal);
+            Assert.True(footerStart >= 0, $"{language}/{page} must retain its Next footer.");
+            Assert.Contains($"]({next})", doc[footerStart..], StringComparison.Ordinal);
+        }
+
+        var terminalHeader = string.Join('\n', ReadDoc(language, "12-agent-message-orchestration.md").Split('\n').Take(5));
+        Assert.Contains("](04-packets-issues.md)", terminalHeader, StringComparison.Ordinal);
+        var defaultLinks = string.Join('\n', trail.Select(step =>
+        {
+            var doc = ReadDoc(language, step.Item1);
+            var header = string.Join('\n', doc.Split('\n').Take(5));
+            var nextHeading = language == "en" ? "## Next" : "## 次へ";
+            return header + "\n" + doc[doc.LastIndexOf(nextHeading, StringComparison.Ordinal)..];
+        }));
+        Assert.DoesNotContain("05-implementation-loop.md", defaultLinks, StringComparison.Ordinal);
+        Assert.DoesNotContain("06-review-next-slice-loop.md", defaultLinks, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en", "visible-generated-mode-markers", "#### Visible, generated mode markers")]
+    [InlineData("ja", "可視な生成済み-mode-marker", "#### 可視な生成済み mode marker")]
+    public void LanguageSpecificMarkerAnchor_ResolvesWithinItsOwnDocument_G608(
+        string language,
+        string anchor,
+        string heading)
+    {
+        Assert.Contains(
+            $"12-agent-message-orchestration.md#{anchor}",
+            ReadDoc(language, "02a-getting-started-orchestration.md"),
+            StringComparison.Ordinal);
+        Assert.Contains(heading, ReadDoc(language, "12-agent-message-orchestration.md"), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void TransportChooser_IsConditionalAndPrimaryBelongsToTheModel_G608(string language)
+    {
+        var presentation = string.Join('\n', new[]
+        {
+            ReadDoc(language, "README.md"),
+            ReadDoc(language, "02a-getting-started-orchestration.md"),
+            ReadDoc(language, "12-agent-message-orchestration.md").Split("## Canonical notify workflow", StringSplitOptions.None)[0],
+        });
+
+        Assert.Contains("herdr-only", presentation, StringComparison.Ordinal);
+        Assert.Contains("agmsg", presentation, StringComparison.Ordinal);
+        Assert.Contains("PREVIEW", presentation, StringComparison.Ordinal);
+        Assert.DoesNotContain("agmsg (PRIMARY)", presentation, StringComparison.Ordinal);
+        Assert.DoesNotContain("primary transport", presentation, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ReadDoc(string language, string path) =>
+        File.ReadAllText(Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, path));
+}

--- a/tests/IntentSystem.Cli.Tests/OnboardingTransportPresentationG608Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/OnboardingTransportPresentationG608Tests.cs
@@ -122,6 +122,13 @@ public sealed class OnboardingTransportPresentationG608Tests
         {
             ReadDoc(language, "README.md"),
             ReadDoc(language, "02a-getting-started-orchestration.md"),
+            ReadDoc(language, "02b-separate-host-brand-new.md"),
+            ReadDoc(language, "02c-separate-host-existing.md"),
+            ReadDoc(language, "02d-same-repo-brand-new.md"),
+            ReadDoc(language, "02e-same-repo-existing.md"),
+            ReadDoc(language, "09-developer-reference.md").Split(language == "en"
+                ? "Semantics:"
+                : "セマンティクス:", StringSplitOptions.None)[0],
             ReadDoc(language, "12-agent-message-orchestration.md").Split("## Canonical notify workflow", StringSplitOptions.None)[0],
         });
 
@@ -129,7 +136,28 @@ public sealed class OnboardingTransportPresentationG608Tests
         Assert.Contains("agmsg", presentation, StringComparison.Ordinal);
         Assert.Contains("PREVIEW", presentation, StringComparison.Ordinal);
         Assert.DoesNotContain("agmsg (PRIMARY)", presentation, StringComparison.Ordinal);
+        Assert.DoesNotContain("`agmsg` is PRIMARY", presentation, StringComparison.Ordinal);
+        Assert.DoesNotContain("`agmsg` が PRIMARY", presentation, StringComparison.Ordinal);
         Assert.DoesNotContain("primary transport", presentation, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void LiveDocumentation_DoesNotLabelAnyTransportPrimary_G608(string language)
+    {
+        var docsDirectory = Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language);
+        var liveDocs = Directory.GetFiles(docsDirectory, "*.md")
+            .Where(path => !Path.GetFileName(path).StartsWith("release-notes-", StringComparison.Ordinal))
+            .Select(File.ReadAllText);
+
+        foreach (var doc in liveDocs)
+        {
+            Assert.DoesNotContain("agmsg (PRIMARY)", doc, StringComparison.Ordinal);
+            Assert.DoesNotContain("`agmsg` is PRIMARY", doc, StringComparison.Ordinal);
+            Assert.DoesNotContain("`agmsg` が PRIMARY", doc, StringComparison.Ordinal);
+            Assert.DoesNotContain("primary transport", doc, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     private static string ReadDoc(string language, string path) =>

--- a/tests/IntentSystem.Cli.Tests/OnboardingTransportPresentationG608Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/OnboardingTransportPresentationG608Tests.cs
@@ -12,31 +12,51 @@ public sealed class OnboardingTransportPresentationG608Tests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void MinimalStart_UsesOneHostCheckoutOnePromptAndFourHumanDecisions_G608(string language)
+    public void PatternChooser_IsTheFirstOnboardingDecision_G608(string language)
     {
         var root = language == "en"
             ? File.ReadAllText(Path.Combine(RepoVersionPolicySource.RepoRoot(), "README.md"))
             : ReadDoc(language, "README.md");
         var gettingStarted = ReadDoc(language, "02a-getting-started-orchestration.md");
 
-        foreach (var text in new[]
-                 {
-                     "<owner>/<implementation-repo>",
-                     "guide onboarding",
-                     "intent-cli --version",
-                     "intent init",
-                     "--write",
-                     language == "en" ? "nine files" : "9 files",
-                     "session-layer set",
-                 })
+        foreach (var path in PatternPaths)
         {
-            Assert.Contains(text, root + gettingStarted, StringComparison.Ordinal);
+            Assert.Contains($"]({path})", root + gettingStarted, StringComparison.Ordinal);
         }
 
-        Assert.Contains("repository topology", gettingStarted, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("base-branch", gettingStarted, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("transport", gettingStarted, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("agent kind", gettingStarted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Separate host", gettingStarted, StringComparison.Ordinal);
+        Assert.Contains("Same repo", gettingStarted, StringComparison.Ordinal);
+        Assert.Contains("brand-new", gettingStarted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("existing", gettingStarted, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void EveryPattern_IsSelfContainedAndHasExactlyTwoInitialPrompts_G608(string language)
+    {
+        foreach (var path in PatternPaths)
+        {
+            var doc = ReadDoc(language, path);
+
+            Assert.Contains("<owner>/<implementation-repo>", doc, StringComparison.Ordinal);
+            Assert.Contains("guide onboarding", doc, StringComparison.Ordinal);
+            Assert.Contains("guide model", doc, StringComparison.Ordinal);
+            Assert.Contains("intent init", doc, StringComparison.Ordinal);
+            Assert.Contains("--write", doc, StringComparison.Ordinal);
+            Assert.Contains(language == "en" ? "nine files" : "9 files", doc, StringComparison.Ordinal);
+            Assert.Contains("base-branch", doc, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("agent kind", doc, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("herdr-only", doc, StringComparison.Ordinal);
+            Assert.Contains("agmsg", doc, StringComparison.Ordinal);
+            Assert.Equal(2, CountOccurrences(doc, "### "));
+            Assert.Equal(2, CountOccurrences(doc, "\n> "));
+            Assert.Contains("](02a-getting-started-orchestration.md)", doc, StringComparison.Ordinal);
+        }
+
+        var fieldTestPattern = ReadDoc(language, "02b-separate-host-brand-new.md");
+        Assert.Contains(language == "en" ? "two empty repositories" : "空の", fieldTestPattern, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "only the empty host repository" : "host repository だけ", fieldTestPattern, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -114,4 +134,25 @@ public sealed class OnboardingTransportPresentationG608Tests
 
     private static string ReadDoc(string language, string path) =>
         File.ReadAllText(Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, path));
+
+    private static int CountOccurrences(string value, string needle)
+    {
+        var count = 0;
+        var offset = 0;
+        while ((offset = value.IndexOf(needle, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += needle.Length;
+        }
+
+        return count;
+    }
+
+    private static readonly string[] PatternPaths =
+    [
+        "02b-separate-host-brand-new.md",
+        "02c-separate-host-existing.md",
+        "02d-same-repo-brand-new.md",
+        "02e-same-repo-existing.md",
+    ];
 }

--- a/tests/IntentSystem.Cli.Tests/SessionLayerModeG570Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerModeG570Tests.cs
@@ -1853,15 +1853,16 @@ public sealed class SessionLayerModeG570Tests : IDisposable
     }
 
     [Fact]
-    public void BothModesAreDescribed_WithAgmsgPrimary_G570()
+    public void BothModesAreDescribed_AsConditionalSupportedChoices_G608()
     {
         var model = workspace.Render(["guide", "model"]);
 
         Assert.Contains("## Session layer (transport for the four threads)", model, StringComparison.Ordinal);
-        Assert.Contains("agmsg (PRIMARY)", model, StringComparison.Ordinal);
-        Assert.Contains("herdr-only (PREVIEW)", model, StringComparison.Ordinal);
-        // The positioning paragraph the packet asks for: when herdr-only is the
-        // right call.
+        Assert.Contains("herdr-only (PREVIEW maturity)", model, StringComparison.Ordinal);
+        Assert.Contains("agmsg + herdr", model, StringComparison.Ordinal);
+        Assert.DoesNotContain("agmsg (PRIMARY)", model, StringComparison.Ordinal);
+        Assert.Contains("Both are supported choices.", model, StringComparison.Ordinal);
+        // The positioning paragraph says when herdr-only is the right call.
         Assert.Contains("herdr-resident on ONE machine", model, StringComparison.Ordinal);
         Assert.Contains(SessionLayerMode.ExclusivitySentence, model, StringComparison.Ordinal);
     }
@@ -1889,7 +1890,7 @@ public sealed class SessionLayerModeG570Tests : IDisposable
         var purpose = group.GetProperty("purpose").GetString()!;
         Assert.Contains("session-layer show", purpose, StringComparison.Ordinal);
         Assert.Contains("agmsg|herdr-only", purpose, StringComparison.Ordinal);
-        Assert.Contains("never to the four-thread model", purpose, StringComparison.Ordinal);
+        Assert.Contains("PRIMARY four-thread model is unchanged", purpose, StringComparison.Ordinal);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #1319

## Summary
- Replace the single onboarding story with a first-decision 2×2 chooser: separate host/same-repository metadata branch × brand-new/existing project.
- Add four self-contained EN and four matching JA pattern pages; every page has exactly two paste-ready initial prompts, herdr-only and agmsg + herdr.
- Retain the rewired default trail, conditional transport presentation, PREVIEW maturity wording, and primary-on-model guide alignment.

## Verification
- Scratch host: shipped v0.11.0 dry-run, init --write (nine files), host-check ok, session-layer record/show, guide onboarding/model.
- Focused G608/G607/G570 guide and documentation guards: 186 passed.
- Full: dotnet test --no-restore.
- git diff --check.