### PR TITLE
G609: prepare v0.11.1 release notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2623,12 +2623,14 @@ to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
 ### Next release readiness (v0.11.1)
 
-**`v0.11.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.11.1`. Its scope and bump rationale are deliberately unassigned until the
-`v0.11.1` release-prep packet replaces the
-[DRAFT notes](release-notes-v0.11.1.md). See
-[release-notes-v0.11.0.md](release-notes-v0.11.0.md) for the preceding shipped
-scope.
+**`v0.11.0` shipped** (GitHub Release + NuGet), and the prepared patch line is
+`0.11.1`. Its scope is exactly G607 / [PR #1318](https://github.com/J-Tech-Japan/intent-system/pull/1318)
+merge `764905194ee1` and G608 / [PR #1320](https://github.com/J-Tech-Japan/intent-system/pull/1320)
+merge `a138e32b82a7`. It adds no command surface: the `src` delta is limited to
+presentation strings in the three guide commands named in the
+[v0.11.1 notes](release-notes-v0.11.1.md), aligning installed-guide transport
+presentation with the published docs chooser. See
+[release-notes-v0.11.0.md](release-notes-v0.11.0.md) for the preceding shipped scope.
 
 **Release-readiness verification (run before merging the `v0.11.1`
 release-preparation PR):**
@@ -2646,10 +2648,10 @@ dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
 ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.11.1.nupkg
 
-# 4. Confirm the G475 package/release guard and the release/version guards.
+# 4. Confirm G475, the v0.11.1 release-note check, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0111DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Run the complete Release suite.
 dotnet test IntentSystem.sln -c Release

--- a/docs/en/release-notes-v0.11.1.md
+++ b/docs/en/release-notes-v0.11.1.md
@@ -1,41 +1,56 @@
-# Release Notes — intent-cli v0.11.1 (DRAFT — UNRELEASED)
+# Release Notes — intent-cli v0.11.1
 
-> **⚠️ DRAFT / UNRELEASED.** This is a **stub**, not release notes. It exists
-> because `eng/version.json` names `0.11.1` as the release-to-be-cut, and the
-> G475 guard requires notes to exist for that version before it can be
-> published. **The v0.11.1 release-prep packet authors the real content**;
-> nothing here describes shipped behavior, and this file must not be treated as
-> a changelog.
+> Prepare-only: this PR creates no GitHub Release, tag, package publish,
+> workflow run, merge, or version roll. The operator creates the Release only
+> after the readiness gate below is satisfied.
 
-## Status
+## Scope
 
-Created by the post-release version roll (G554 rule as amended by G557) at the
-moment `nextVersion` became `0.11.1`. Until the release-prep packet fills it in:
+This patch release contains exactly these verified `main` merges:
 
-- **No slices are listed yet.** What ships in `v0.11.1` is decided by the
-  release-prep packet, not by this stub.
-- **No bump rationale yet** (patch vs minor is a release-prep decision).
-- **No readiness gate yet.** Do **not** publish a `v0.11.1` GitHub Release while
-  this file is still a draft — an unfilled stub means release-prep has not run.
+- G607 — [PR #1318](https://github.com/J-Tech-Japan/intent-system/pull/1318), merge `764905194ee1`.
+- G608 — [PR #1320](https://github.com/J-Tech-Japan/intent-system/pull/1320), merge `a138e32b82a7`.
 
-## What the release-prep packet must replace this with
+Both commits resolve on `main`; no other slice is included. See
+[v0.11.0](release-notes-v0.11.0.md) for the preceding release scope.
 
-Follow the shape of the previous notes
-([v0.11.0](release-notes-v0.11.0.md), [v0.10.0](release-notes-v0.10.0.md)):
+## Why PATCH
 
-- what shipped, grouped by theme, covering exactly the merged slices;
-- the bump rationale (patch vs minor) stated, not just labelled;
-- the prepare-only publishing section and the release-readiness gate;
-- an upgrade section separating additive surfaces from corrective behavior
-  changes;
-- the post-release roll reminder.
+This is a verified patch release: it adds no command surface and changes no
+behaviour. Since v0.11.0, the `src` delta is confined to presentation strings
+in `GuideModelCommand`, `GuideOnboardingCommand`, and
+`GuideCommandsListCommand`. The G608 review verified that the transport
+operating contracts remain byte-unchanged. Installing v0.11.1 therefore aligns
+the installed guide's transport presentation with the published docs chooser.
 
-## Install (placeholder — the version below is what the guard checks)
+## Operational purpose
+
+G607 added the orchestration-first 02a onboarding page and reordered the docs
+index. G608 completes that front door: the default reading trail reaches
+orchestration; the first decision is a 2×2 pattern chooser with four
+self-contained pages and dual initial prompts; and `herdr-only` and
+`agmsg` + herdr are conditionally recommended supported choices. The
+four-thread model is primary; PREVIEW is only a transport maturity note.
+
+## Install or upgrade
 
 ```bash
 dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.11.1
 ```
 
-Once published, the self-contained binaries will be attached to the
-[v0.11.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.11.1).
-Verify the `.sha256` sidecar before use.
+## Release-readiness gate
+
+- [ ] `eng/version.json` remains `stableVersion` `0.11.0` / `nextVersion` `0.11.1`.
+- [ ] These EN/JA notes name exactly G607 and G608 with the verified PRs and
+      merge commits above.
+- [ ] The patch comparison confirms no new command surface and only the three
+      named guide presentation-string files in `src`.
+- [ ] G475, focused release-note checks, full suite, diff check, and exact-head
+      CI are green.
+- [ ] The operator explicitly approves creating and publishing the v0.11.1 GitHub Release.
+
+## Publishing v0.11.1
+
+After this preparation is merged and every gate is green, the operator may
+create [the v0.11.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.11.1).
+This PR itself does not publish a package or create that Release.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2697,10 +2697,13 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 
 ### 次リリース準備(v0.11.1)
 
-**`v0.11.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.11.1` です。出荷範囲と bump 根拠は `v0.11.1` の release-prep packet が
-[DRAFT ノート](release-notes-v0.11.1.md)を置き換えるまで意図的に未確定です。
-直前の出荷範囲は [release-notes-v0.11.0.md](release-notes-v0.11.0.md) を参照してください。
+**`v0.11.0` は出荷済み**(GitHub Release + NuGet)で、準備済み patch line は `0.11.1` です。
+scope は G607 / [PR #1318](https://github.com/J-Tech-Japan/intent-system/pull/1318) merge
+`764905194ee1` と、G608 / [PR #1320](https://github.com/J-Tech-Japan/intent-system/pull/1320)
+merge `a138e32b82a7` だけです。新しい command surface はありません。`src` delta は
+[v0.11.1 notes](release-notes-v0.11.1.md) が名指しする三つの guide command の presentation
+string に限定され、installed-guide の transport presentation を published docs chooser と整合
+させます。直前の出荷範囲は [release-notes-v0.11.0.md](release-notes-v0.11.0.md) を参照してください。
 
 **リリース準備検証(`v0.11.1` release-preparation PR のマージ前に実行):**
 
@@ -2717,10 +2720,10 @@ dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
 ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.11.1.nupkg
 
-# 4. G475 package/release guard と release/version guard を確認。
+# 4. G475、v0.11.1 release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0111DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Release suite を完全実行。
 dotnet test IntentSystem.sln -c Release

--- a/docs/ja/release-notes-v0.11.1.md
+++ b/docs/ja/release-notes-v0.11.1.md
@@ -1,40 +1,51 @@
-# リリースノート — intent-cli v0.11.1（DRAFT — 未リリース）
+# リリースノート — intent-cli v0.11.1
 
-> **⚠️ DRAFT / 未リリース。** これはリリースノートではなく **stub** です。
-> `eng/version.json` が `0.11.1` を「これからカットするリリース」として指しており、
-> G475 のガードが publish 前にそのバージョンのノートの存在を要求するため置かれています。
-> **実際の内容は v0.11.1 の release-prep パケットが author します**。ここには出荷済みの
-> 挙動は一切書かれておらず、このファイルを changelog として扱ってはいけません。
+> prepare-only です。この PR は GitHub Release、tag、package publish、workflow 実行、
+> merge、version roll を作成しません。readiness gate 後の Release 作成は operator が行います。
 
-## ステータス
+## 対象範囲
 
-`nextVersion` が `0.11.1` になった時点で、リリース後の version roll（G554 のルール、
-G557 による改訂版）によって作成されました。release-prep パケットが埋めるまでは:
+この patch release に含まれる検証済み `main` merge は次の二つだけです。
 
-- **スライスは未記載です。** `v0.11.1` で何が出荷されるかを決めるのはこの stub ではなく
-  release-prep パケットです。
-- **バンプ根拠も未記載です**（patch か minor かは release-prep の判断です）。
-- **リリース準備ゲートも未記載です。** このファイルが draft のままの間は `v0.11.1` の
-  GitHub Release を publish **しないでください** — 埋まっていない stub は release-prep が
-  未実行であることを意味します。
+- G607 — [PR #1318](https://github.com/J-Tech-Japan/intent-system/pull/1318)、merge `764905194ee1`。
+- G608 — [PR #1320](https://github.com/J-Tech-Japan/intent-system/pull/1320)、merge `a138e32b82a7`。
 
-## release-prep パケットがこれを置き換える際に必要なもの
+両 commit は `main` 上で解決することを検証済みです。他の slice は含みません。直前の
+release scope は [v0.11.0](release-notes-v0.11.0.md) を参照してください。
 
-過去のノート（[v0.11.0](release-notes-v0.11.0.md)、[v0.10.0](release-notes-v0.10.0.md)）の
-形に従ってください:
+## PATCH の根拠
 
-- 出荷内容をテーマ別にグループ化し、マージされたスライスを正確にカバーする;
-- バンプ根拠（patch か minor か）をラベルだけでなく理由まで記述する;
-- prepare-only の publishing セクションとリリース準備ゲート;
-- 追加サーフェスと是正的な挙動変更を分離した upgrade セクション;
-- リリース後の roll のリマインド。
+これは検証済みの patch release です。新しい command surface は追加せず、挙動も変更しません。
+v0.11.0 以降の `src` delta は `GuideModelCommand`、`GuideOnboardingCommand`、
+`GuideCommandsListCommand` の presentation string に限定されます。G608 review は transport
+operating contract が byte-unchanged のままであることを検証しました。したがって v0.11.1 の
+install は、installed guide の transport presentation を published docs chooser と整合させます。
 
-## インストール（プレースホルダー — 下記バージョンがガードの検査対象です）
+## 運用上の目的
+
+G607 は orchestration-first の 02a onboarding page と docs index の並び替えを追加しました。
+G608 はこの front door を完成させます。default reading trail は orchestration に到達し、最初の
+decision は四つの self-contained page と dual initial prompt を持つ 2×2 pattern chooser です。
+`herdr-only` と `agmsg` + herdr は条件に応じた supported choice です。primary なのは
+4 スレッドモデルであり、PREVIEW は transport の maturity note に限られます。
+
+## インストールまたは更新
 
 ```bash
 dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.11.1
 ```
 
-publish 後、self-contained バイナリは
-[v0.11.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.11.1)
-に添付されます。使用前に `.sha256` サイドカーを検証してください。
+## リリース準備ゲート
+
+- [ ] `eng/version.json` は `stableVersion` `0.11.0` / `nextVersion` `0.11.1` のまま。
+- [ ] EN/JA notes は、上記の verified PR と merge commit を持つ G607/G608 だけを記載。
+- [ ] patch 比較で、新しい command surface が無く、`src` は上記三つの guide presentation-string
+      file だけであることを確認。
+- [ ] G475、focused release-note check、full suite、diff check、exact-head CI が green。
+- [ ] operator が v0.11.1 GitHub Release の作成・publish を明示承認。
+
+## v0.11.1 の publish
+
+この準備が merge され、すべての gate が green になった後に、operator は
+[v0.11.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.11.1) を作成できます。
+この PR 自体は package publish や Release 作成を行いません。

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0111DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0111DocsTests.cs
@@ -1,0 +1,67 @@
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G609: the 0.11.1 release-prep is documentation-only and must describe the
+/// exact post-0.11.0 pair without retargeting version policy.
+/// </summary>
+public sealed class ReleaseNotesV0111DocsTests
+{
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_CoverExactlyG607AndG608WithVerifiedMerges_G609(string language)
+    {
+        var notes = Read(language, "release-notes-v0.11.1.md");
+
+        foreach (var text in new[] { "G607", "#1318", "764905194ee1", "G608", "#1320", "a138e32b82a7" })
+        {
+            Assert.Contains(text, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("release-notes-v0.11.0.md", notes, StringComparison.Ordinal);
+        Assert.DoesNotContain("DRAFT", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("stub", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReleaseNotes_ExplainTheBehaviourNeutralPatchAndPrepareOnlyBoundary_G609(string language)
+    {
+        var notes = Read(language, "release-notes-v0.11.1.md");
+
+        foreach (var command in new[] { "GuideModelCommand", "GuideOnboardingCommand", "GuideCommandsListCommand" })
+        {
+            Assert.Contains(command, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("0.11.1", notes, StringComparison.Ordinal);
+        Assert.Contains("JTechJapan.IntentSystem.Cli --version 0.11.1", notes, StringComparison.Ordinal);
+        Assert.Contains("releases/tag/v0.11.1", notes, StringComparison.Ordinal);
+        Assert.Contains("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("command surface", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Readiness_TracksThePreparedPatchWithoutChangingVersionPolicy_G609()
+    {
+        var policy = RepoVersionPolicySource.Read();
+        Assert.Equal("0.11.0", policy.StableVersion);
+        Assert.Equal("0.11.1", policy.NextVersion);
+
+        foreach (var language in new[] { "en", "ja" })
+        {
+            var reference = Read(language, "09-developer-reference.md");
+            Assert.Contains("G607", reference, StringComparison.Ordinal);
+            Assert.Contains("G608", reference, StringComparison.Ordinal);
+            Assert.Contains("764905194ee1", reference, StringComparison.Ordinal);
+            Assert.Contains("a138e32b82a7", reference, StringComparison.Ordinal);
+            Assert.Contains("ReleaseNotesV0111DocsTests", reference, StringComparison.Ordinal);
+        }
+    }
+
+    private static string Read(string language, string path) =>
+        File.ReadAllText(Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, path));
+}


### PR DESCRIPTION
Closes #1321

## Summary
- Replace EN/JA v0.11.1 stubs with real G607/G608 patch notes.
- Refresh EN/JA readiness with exact main-merge evidence and prepare-only boundary.
- Keep version policy, source, workflows, and publishing surfaces unchanged.

## Verification
- Focused G475/release-note/version-policy guards: 13 passed.
- Full: `dotnet test --no-restore`.
- `git diff --check`.

Prepare-only: no Release, tag, package publish, workflow run, merge, or version roll.