### PR TITLE
G610: record design judgment waits in guides

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -871,7 +871,9 @@ evidence land in the artifact's `Reason` under `Recommended answer:` and
 `Evidence:` labels. All three flags are optional — omit them and the pre-G552
 packet-derived behavior is unchanged. **No clarification schema change.**
 
-**Design-judgment wait recording duty.** When progress blocks on a design
+### Design-judgment wait recording duty
+
+When progress blocks on a design
 judgment, opening an operator-attention record is a duty, not an option. At the
 start of that wait, record design as the owner; the record is queryable and
 surfaces in `heartbeat` / `stalled-work` instead of living in scrollback:

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -871,6 +871,32 @@ evidence land in the artifact's `Reason` under `Recommended answer:` and
 `Evidence:` labels. All three flags are optional — omit them and the pre-G552
 packet-derived behavior is unchanged. **No clarification schema change.**
 
+**Design-judgment wait recording duty.** When progress blocks on a design
+judgment, opening an operator-attention record is a duty, not an option. At the
+start of that wait, record design as the owner; the record is queryable and
+surfaces in `heartbeat` / `stalled-work` instead of living in scrollback:
+
+```bash
+intent-cli operator-attention open --record <design-wait-id> \
+  --domain <domain> --team <team> --owner design \
+  --blocking-reference <issue|pr|unit|release> \
+  --action-needed "<design judgment needed>" --evidence "<facts>" \
+  --write --format json
+intent-cli operator-attention query --domain <domain> --team <team> --format json
+```
+
+Whoever supplies the judgment **must resolve** that same record with the answer
+and evidence:
+
+```bash
+intent-cli operator-attention resolve --record <design-wait-id> \
+  --resolution-evidence "<answer and evidence>" --write --format json
+```
+
+An answered-but-open record is a lie: the existing lifecycle is not complete
+until its answerer resolves it. This records the design-owned wait without
+adding a helper or changing the clarification lifecycle above.
+
 **Reviewer hold rule (refined).** Technical checks green and the only pending
 item non-semantic and mechanically fact-checkable → resolve it under bounded
 default authority, log the verifying facts, and proceed. Anything else →
@@ -967,6 +993,12 @@ packet (or give an explicit instruction):
 ```json
 {"to":"design","type":"packet-needed","domain":"<domain>","need":"<what is needed>","reason":"<why the orchestrator cannot proceed>","blocking":"<the work that is waiting>"}
 ```
+
+This is a design-judgment wait, not an inbox-only state: when it starts, the
+orchestrator opens the operator-attention record with `--owner design`, queries
+the existing record while waiting, and whoever answers resolves it with
+evidence. The complete lifecycle is specified in
+[Design-judgment wait recording duty](#design-judgment-wait-recording-duty).
 
 **Release-prep is design-owned:** design decides the release version and scope
 and authors the release-prep packet; the orchestrator may publish and coordinate
@@ -1788,6 +1820,10 @@ coordinates through the orchestrator and only surfaces human-needed items.
    metadata — that is the orchestrator/receivers' job through intent-cli.
 5. Summarize **only** human-needed items to the human; keep routine progress
    internal.
+6. If progress is waiting on a design judgment, make that wait durable before
+   waiting: open operator-attention with `--owner design`, query the record, and
+   resolve it with evidence when you supply the answer. An answered-but-open
+   record is a lie, not a completed design handoff.
 
 **"Orchestrator appears idle" diagnostic** (before escalating): confirm the
 orchestrator is scheduled and on a fresh turn; confirm it received your last

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -795,7 +795,9 @@ intent-cli clarify open <execution-unit> \
 任意で、省略すれば G552 以前の packet 由来挙動のままです。**clarification の schema
 変更はありません。**
 
-**design 判断待ちの記録義務。** 進行が design の判断で止まるとき、operator-attention
+### design 判断待ちの記録義務
+
+進行が design の判断で止まるとき、operator-attention
 record を開くことは任意ではなく義務です。その待ちが始まった時点で design を owner として
 記録します。record は query でき、scrollback に埋もれず `heartbeat` / `stalled-work` に
 現れます:

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -795,6 +795,31 @@ intent-cli clarify open <execution-unit> \
 任意で、省略すれば G552 以前の packet 由来挙動のままです。**clarification の schema
 変更はありません。**
 
+**design 判断待ちの記録義務。** 進行が design の判断で止まるとき、operator-attention
+record を開くことは任意ではなく義務です。その待ちが始まった時点で design を owner として
+記録します。record は query でき、scrollback に埋もれず `heartbeat` / `stalled-work` に
+現れます:
+
+```bash
+intent-cli operator-attention open --record <design-wait-id> \
+  --domain <domain> --team <team> --owner design \
+  --blocking-reference <issue|pr|unit|release> \
+  --action-needed "<必要な design judgment>" --evidence "<事実>" \
+  --write --format json
+intent-cli operator-attention query --domain <domain> --team <team> --format json
+```
+
+判断を回答した人は、その回答と evidence を添えて同じ record を**必ず resolve**します:
+
+```bash
+intent-cli operator-attention resolve --record <design-wait-id> \
+  --resolution-evidence "<回答と evidence>" --write --format json
+```
+
+回答済みで open のままの record は嘘です。既存 lifecycle は回答者が resolve するまで完了
+しません。これは design 所有の待ちを記録するもので、helper を追加せず、上記 clarification
+lifecycle も変更しません。
+
 **reviewer hold ルール(refined)。** 技術チェックが green で、保留項目が
 非セマンティックかつ機械的に事実確認可能 → bounded default authority のもとで
 解決し、検証事実をログに残して先へ進みます。それ以外 → clarification を記録し、
@@ -883,6 +908,11 @@ packet を author/更新する（または明示的に指示する）のを **�
 ```json
 {"to":"design","type":"packet-needed","domain":"<domain>","need":"<what is needed>","reason":"<why the orchestrator cannot proceed>","blocking":"<the work that is waiting>"}
 ```
+
+これは inbox だけに置く state ではなく design judgment の待ちです。開始時に orchestrator は
+`--owner design` つきの operator-attention record を open し、待機中に既存 record を query し、
+回答者が evidence とともに resolve します。完全な lifecycle は
+[design 判断待ちの記録義務](#design-判断待ちの記録義務)を参照してください。
 
 **release-prep は design 所有:** design がリリースバージョンとスコープを決め、release-prep
 packet を author します。orchestrator はそれが存在し `issue-cut-ready` になった **後** にのみ
@@ -1632,6 +1662,10 @@ orchestrator を通じて調整し、人間が必要な項目だけを surface �
 4. implementation/review の作業・labels・host メタデータを直接 **変更しない** — それは
    orchestrator/receivers が intent-cli 経由で行う仕事。
 5. 人間が必要な項目 **だけ** を人間に要約する。ルーチンな進捗は内部に留める。
+6. design judgment を待つことで進行が止まるなら、待つ前にその待ちを durable にします:
+   `--owner design` つきで operator-attention を open し、record を query し、回答を出したら
+   evidence とともに resolve します。回答済みで open のままの record は嘘であり、design handoff
+   は完了していません。
 
 **「orchestrator が idle に見える」診断**（エスカレーション前）: orchestrator がスケジュールされ
 新しい turn にあるか確認。最後のメッセージを受信したか確認（`inbox.sh`）— pre-monitor の送信は

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -819,7 +819,16 @@ internal static class GuideOrchestratorThreadCommand
                     + "acceptance criteria / release scope, the orchestrator does NOT invent the packet. It sends a "
                     + "structured request to DESIGN describing what is needed and WAITS for design to author/update the "
                     + "packet (or give an explicit instruction). The orchestrator only publishes/coordinates a packet "
-                    + "that already exists and is `issue-cut-ready`.",
+                    + "that already exists and is `issue-cut-ready`. When progress blocks on that design judgment, "
+                    + "recording the wait is a DUTY, not an option: open "
+                    + "`intent-cli operator-attention open --record <design-wait-id> --domain <domain> --team <team> "
+                    + "--owner design --blocking-reference <issue|pr|unit|release> --action-needed <judgment-needed> "
+                    + "--evidence <facts> --write --format json`. Query it with `intent-cli operator-attention query "
+                    + "--domain <domain> --team <team> --format json`; whoever supplies the judgment MUST resolve it "
+                    + "with evidence using `intent-cli operator-attention resolve --record <design-wait-id> "
+                    + "--resolution-evidence <answer-and-evidence> --write --format json`. An answered-but-open record "
+                    + "is a lie: the lifecycle exists so the wait is queryable and surfaces in heartbeat/stalled-work, "
+                    + "not lost in scrollback.",
                 MissingPacketMessageTemplate = Apply(
                     "{\"to\":\"design\",\"type\":\"packet-needed\",\"domain\":\"<domain>\",\"need\":\"<what is needed: "
                     + "e.g. a release-prep packet for vX.Y.Z, or acceptance criteria for <topic>>\",\"reason\":\"<why the "
@@ -1608,6 +1617,7 @@ internal static class GuideOrchestratorThreadCommand
                     // design can discharge it.
                     IntentTreeCoEvolutionDuty.Duty,
                     IntentTreeCoEvolutionDuty.CloseoutCheck,
+                    "When progress blocks on a design judgment, record that wait before waiting: open operator-attention with `--owner design`, query the existing record, and whoever supplies the judgment MUST resolve it with evidence. An answered-but-open record is a lie, not a completed design handoff.",
                 },
                 IdleDiagnostic = new[]
                 {

--- a/src/IntentSystem.Cli/Commands/SessionLayerFragments.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerFragments.cs
@@ -780,6 +780,13 @@ internal static class SessionLayerFragments
             Operative("Until it is recorded, the unit stays visible as a `knowledge-writeback-pending` item in `automation stalled-work` / `automation heartbeat` — closing the PR does not clear it, and nothing here writes intent content on design's behalf.")),
         Fragment(
             S8,
+            Descriptive("8."),
+            Scaffold(" "),
+            Operative("When progress blocks on a design judgment, record that wait before waiting: open operator-attention with `--owner design`, query the existing record, and whoever supplies the judgment MUST resolve it with evidence."),
+            Scaffold(" "),
+            Operative("An answered-but-open record is a lie, not a completed design handoff.")),
+        Fragment(
+            S8,
             Descriptive("1."),
             Scaffold(" "),
             Operative("Confirm the orchestrator is actually scheduled and on a fresh turn (its `/loop` or Codex automation is running).")),
@@ -1619,6 +1626,11 @@ internal static class SessionLayerFragments
             Operative("Same-cadence write-back check: perform the packet's declared write-backs and RECORD them in the same closeout wake, with `intent-cli automation knowledge-writeback-record --execution-unit <unit> --commit <host-sha> --write`."),
             Scaffold(" "),
             Operative("Until it is recorded, the unit stays visible as a `knowledge-writeback-pending` item in `automation stalled-work` / `automation heartbeat` — closing the PR does not clear it, and nothing here writes intent content on design's behalf.")),
+        Fragment(
+            "design_traffic_controller",
+            Operative("When progress blocks on a design judgment, record that wait before waiting: open operator-attention with `--owner design`, query the existing record, and whoever supplies the judgment MUST resolve it with evidence."),
+            Scaffold(" "),
+            Operative("An answered-but-open record is a lie, not a completed design handoff.")),
         Fragment("design_traffic_controller", Operative("Confirm the orchestrator is actually scheduled and on a fresh turn (its `/loop` or Codex automation is running).")),
         Fragment("design_traffic_controller", Transport("Confirm it received your last message (`inbox.sh` on the orchestrator) — a pre-monitor send may be queued, not delivered live; resend after an ack.")),
         Fragment("design_traffic_controller", Operative("Confirm intent-cli actually reports an actionable item for THIS domain/repo (`worker next-action` / `intent status`) — idle may be correct (nothing to do).")),

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -299,6 +299,22 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("## design traffic-controller プレイブック", ja, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("en", "Design-judgment wait recording duty", "design-judgment-wait-recording-duty")]
+    [InlineData("ja", "design 判断待ちの記録義務", "design-判断待ちの記録義務")]
+    public void DesignJudgmentWaitCrossLink_TargetsItsOwnLanguageHeading_G610(string language, string heading, string anchor)
+    {
+        var doc = ReadDoc(language);
+
+        Assert.Contains($"### {heading}", doc, StringComparison.Ordinal);
+        Assert.Contains($"](#{anchor})", doc, StringComparison.Ordinal);
+
+        var otherLanguageAnchor = language == "en"
+            ? "#design-判断待ちの記録義務"
+            : "#design-judgment-wait-recording-duty";
+        Assert.DoesNotContain(otherLanguageAnchor, doc, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void BothDocs_BoundTheDefaultAuthority_AndKeepSemanticDecisionsWithDesign_G552()
     {

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -271,6 +271,35 @@ public sealed class AgentMessageOrchestrationDocsTests
     }
 
     [Fact]
+    public void BothDocs_RecordAndResolveDesignJudgmentWaits_G610()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        // Both design-boundary surfaces carry the duty and the shipped lifecycle.
+        foreach (var doc in new[] { en, ja })
+        {
+            Assert.Contains("operator-attention open", doc, StringComparison.Ordinal);
+            Assert.Contains("--owner design", doc, StringComparison.Ordinal);
+            Assert.Contains("operator-attention query", doc, StringComparison.Ordinal);
+            Assert.Contains("operator-attention resolve", doc, StringComparison.Ordinal);
+            Assert.Contains("<design-wait-id>", doc, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("opening an operator-attention record is a duty, not an option", en, StringComparison.Ordinal);
+        Assert.Contains("Whoever supplies the judgment **must resolve**", en, StringComparison.Ordinal);
+        Assert.Contains("An answered-but-open record is a lie", en, StringComparison.Ordinal);
+        Assert.Contains("operator-attention record を開くことは任意ではなく義務です", ja, StringComparison.Ordinal);
+        Assert.Contains("回答した人は、その回答と evidence を添えて同じ record を**必ず resolve**", ja, StringComparison.Ordinal);
+        Assert.Contains("回答済みで open のままの record は嘘です", ja, StringComparison.Ordinal);
+
+        Assert.Contains("## Role boundary — design authors, orchestrator coordinates", en, StringComparison.Ordinal);
+        Assert.Contains("## ロール境界 — design が authoring、orchestrator は coordinate", ja, StringComparison.Ordinal);
+        Assert.Contains("## Design traffic-controller playbook", en, StringComparison.Ordinal);
+        Assert.Contains("## design traffic-controller プレイブック", ja, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BothDocs_BoundTheDefaultAuthority_AndKeepSemanticDecisionsWithDesign_G552()
     {
         var en = ReadDoc("en");

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -1639,6 +1639,13 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("**missing packet**", output, StringComparison.Ordinal);
         Assert.Contains("does NOT invent the packet", output, StringComparison.Ordinal);
         Assert.Contains("\"type\":\"packet-needed\"", output, StringComparison.Ordinal);
+        // G610: a wait for design is a recorded, queryable lifecycle state.
+        Assert.Contains("operator-attention open", output, StringComparison.Ordinal);
+        Assert.Contains("--owner design", output, StringComparison.Ordinal);
+        Assert.Contains("operator-attention query", output, StringComparison.Ordinal);
+        Assert.Contains("operator-attention resolve", output, StringComparison.Ordinal);
+        Assert.Contains("whoever supplies the judgment MUST resolve it", output, StringComparison.Ordinal);
+        Assert.Contains("answered-but-open record is a lie", output, StringComparison.Ordinal);
         // Release-prep is design-owned.
         Assert.Contains("**release-prep**", output, StringComparison.Ordinal);
         Assert.Contains("Release-prep is design-owned", output, StringComparison.Ordinal);
@@ -1662,6 +1669,14 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("packet-needed", boundary.GetProperty("missing_packet_message_template").GetString()!, StringComparison.Ordinal);
         Assert.Contains("design-owned", boundary.GetProperty("release_prep_rule").GetString()!, StringComparison.Ordinal);
         Assert.Contains("does NOT invent the packet", boundary.GetProperty("missing_packet_response").GetString()!, StringComparison.Ordinal);
+        var designWait = boundary.GetProperty("missing_packet_response").GetString()!;
+        Assert.Contains("--owner design", designWait, StringComparison.Ordinal);
+        Assert.Contains("operator-attention query", designWait, StringComparison.Ordinal);
+        Assert.Contains("operator-attention resolve", designWait, StringComparison.Ordinal);
+
+        var trafficController = doc.RootElement.GetProperty("design_traffic_controller");
+        Assert.Contains(trafficController.GetProperty("playbook").EnumerateArray().Select(item => item.GetString()),
+            item => item is not null && item.Contains("answered-but-open record is a lie", StringComparison.Ordinal));
 
         // Existing orchestrator publish ability is preserved (not removed).
         var publication = doc.RootElement.GetProperty("next_slice_publication");

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -12,7 +12,7 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     private const string Domain = "intent-cli";
     private const string Team = "intent-cli-dev";
     private const string Repo = "J-Tech-Japan/intent-system";
-    private const string G594AgmsgBaselineSha256 = "b5e54295c8bdecfa2ee3ec16ce3d7c7e3bc173ab43b16edb5b51f41a7bc06d5f";
+    private const string G594AgmsgBaselineSha256 = "0e3bde8e3c73ef5478a93a2556817f6bcd959fac35025e5b051d1f5ef6137187";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -10,7 +10,7 @@ namespace IntentSystem.Cli.Tests;
 public sealed class HerdrWakeSourcesG581Tests : IDisposable
 {
     private const string G594AgmsgGuideSha256 =
-        "984EC1645C357940CC6D24345D0CB0B7618DA1A2B47BA3A21FA095EA95E8F38E";
+        "0F52D9B675AF55CB91438BB5CA901ACE2377C409E499368B887E97D026E027D5";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 


### PR DESCRIPTION
Closes #1323

## Summary
- Add the required design-judgment wait duty to the rendered orchestrator guide and EN/JA Doc 12 design boundaries.
- Name the shipped open/query/resolve lifecycle with `--owner design` and require the answerer to resolve with evidence.
- Keep operator-attention mechanics unchanged; declare the new guide sentence mode-independent and refresh render snapshots.

## Verification
- Focused guide/docs/session-layer render tests: 278 passed.
- Full: `dotnet test --no-restore`.
- `git diff --check`.

Words-only scope: no helper, command, flag, schema, lifecycle, heartbeat, or delivery change.