### PR TITLE
docs: correct Japanese data-truth terms (G615)

### DIFF
--- a/docs/ja/02a-getting-started-orchestration.md
+++ b/docs/ja/02a-getting-started-orchestration.md
@@ -23,9 +23,9 @@
 mode と現在のインストール済みガイドに従います。
 
 このページは最小開始から最初の公開 packet までの **orchestration-first** 経路です。
-[プロジェクト開始](02-project-start.md) はトポロジーの権限、[agent メッセージ
+[プロジェクト開始](02-project-start.md) はトポロジーの正本となる定義であり、[agent メッセージ
 オーケストレーション contract](12-agent-message-orchestration.md) はセッションレイヤーの意味の
-権限として残ります。
+正本となる定義として残ります。
 
 ## これから設定するもの
 


### PR DESCRIPTION
Closes #1331

## Scope
- Correct exactly the two data-truth occurrences in `docs/ja/02a-getting-started-orchestration.md`: both now use `正本となる定義`, not `権限`.
- Inspected every G613 manifest page: no other data-truth misuse was found.

## Boundaries
- G613 policy defining `権限`, rolling guard/manifest, EN docs, release notes, and staged `09`/`12` passes are untouched.
- Links and anchors remain unchanged.

## Verification
- `rg -n '権限|正本となる定義'` over the G613 manifest (only the policy’s actor-authority definition remains)\n- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --filter 'FullyQualifiedName~MarkdownLocalLinkGuardG611Tests|FullyQualifiedName~JapaneseTerminologyGuardG613Tests'` (6 passed)\n- `dotnet test --no-restore` (full suite passed)\n- `git diff --check`