### PR TITLE
docs: add G617 unattended launch recipes

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -180,6 +180,52 @@ than a per-invocation approval that re-prompts on the next wake.
 > If answering would grant access, widen a permission mode, or accept a security
 > warning, it is the operator's call.
 
+### 3a. Unattended-launch recipes (agent-neutral) (G617)
+
+An unattended-launch recipe is agent-neutral: it states the launch invocation,
+the bounded allowed roots derived from that role's actual work, the autonomous
+continuation bound, the startup gates the operator must answer, and the denial
+semantics. A later Cursor or opencode recipe adds an entry with those same
+fields; it does not restate or weaken the central rule below.
+
+> **Central autopilot supervision rule.** In an unattended autopilot seat, an
+> action outside the launch allowlist is silently auto-denied rather than
+> surfaced as a G550 supervision dialog. Derive and **record** the allowlist
+> from role needs. READY must prove an expected allowed action, reachability of
+> the role's canonical reporting surface, and an out-of-scope denial. Review
+> evidence must inspect command outputs and the transcript for denials; liveness
+> is not proof that a denied step ran. This changes supervision evidence only:
+> G556 liveness and notify/delivery semantics are unchanged.
+
+#### Copilot — measured first recipe
+
+```text
+herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model claude-opus-5 --mode autopilot --allow-all-tools --add-dir <role-work-root> [--add-dir <host-routing-root>] --max-autopilot-continues 10
+```
+
+- **Role-derived roots.** Give every role one bounded `--add-dir <role-work-root>`
+  for its checkout or worktree. A reviewer also needs `--add-dir
+  <host-routing-root>` because `intent-cli notify report` is its canonical
+  reporting surface. Do not add unrelated developer-machine roots.
+- **Continuation bound.** Keep `--max-autopilot-continues 10` explicit. Any
+  different bound is an operator decision recorded with the recipe.
+- **Startup gates.** Folder trust and autopilot-enable are operator provisioning
+  gates; launch flags bypass neither. The autopilot-enable dialog appears at the
+  **first task** even when launch used `--mode autopilot`. With
+  `--allow-all-tools` and bounded roots, choose `Continue with limited
+  permissions`; never choose `Enable all permissions`, which discards the
+  boundary.
+- **Prohibited blanket permissions.** `--yolo` and `--allow-all-paths` are
+  **prohibited** for unattended seats on developer machines. Use bounded
+  `--add-dir` roots instead.
+
+**Unattended READY branch.** Run the normal G556 liveness checks and prove all
+three additional facts: an expected action inside the recorded roots succeeds;
+the role reaches its canonical reporting surface (for review, `intent-cli notify
+report` through its host routing root); and a deliberately out-of-scope action
+is denied. Capture that denial for review. A live pane or a successful allowed
+action alone is **not** READY.
+
 **4. Role initialization.** Type the actas form matching the pane's CLI —
 `/agmsg actas <role>` for claude, `$agmsg actas <role>` for codex — then confirm
 readiness in **three layers that must not be collapsed**:

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -170,6 +170,47 @@ monitor bridge を arm する（G521）ため、canonical な実行ファイル�
 > 付与・permission mode の拡大・security 警告の受諾になるなら、それはオペレーターの
 > 判断です。
 
+### 3a. unattended 起動レシピ（agent-neutral）(G617)
+
+unattended 起動レシピは agent-neutral です。起動 invocation、各 role の実際の作業から
+導く境界付き許可 root、自律継続の上限、operator が回答する startup gate、そして denial
+semantics を記します。後から Cursor や opencode のレシピを追加する場合も、同じ field を
+持つ entry を追加するだけで、以下の central rule を再定義・弱化しません。
+
+> **central autopilot supervision rule。** unattended autopilot seat では、launch allowlist
+> の外にある action は G550 の supervision dialog として表示されず、静かに自動拒否されます。
+> allowlist は role need から導出して **記録** します。READY では、期待される許可済み action、
+> その role の canonical reporting surface への到達可能性、out-of-scope action の拒否を証明
+> しなければなりません。review evidence は command output と transcript で拒否を調べます。
+> liveness は拒否された step が実行された証拠ではありません。これは supervision evidence
+> だけを変えるものです。G556 の liveness と notify/delivery semantics は変わりません。
+
+#### Copilot — 実測済みの最初のレシピ
+
+```text
+herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model claude-opus-5 --mode autopilot --allow-all-tools --add-dir <role-work-root> [--add-dir <host-routing-root>] --max-autopilot-continues 10
+```
+
+- **role-derived root。** 各 role には checkout または worktree 用の境界付き
+  `--add-dir <role-work-root>` を 1 つ与えます。reviewer には canonical reporting surface
+  である `intent-cli notify report` のため、さらに `--add-dir <host-routing-root>` が必要です。
+  developer-machine の無関係な root は追加しません。
+- **継続上限。** `--max-autopilot-continues 10` を明示したままにします。別の上限は、レシピと
+  ともに記録する operator の判断です。
+- **startup gate。** folder trust と autopilot-enable は operator provisioning gate であり、
+  launch flag ではどちらも bypass できません。`--mode autopilot` を launch 時に渡しても、
+  autopilot-enable dialog は **最初の task** で現れます。`--allow-all-tools` と境界付き root
+  を使う場合は `Continue with limited permissions` を選びます。境界を捨てる
+  `Enable all permissions` は選びません。
+- **禁止する包括権限。** developer machine の unattended seat では `--yolo` と
+  `--allow-all-paths` は **禁止** です。代わりに境界付き `--add-dir` root を使います。
+
+**unattended READY branch。** 通常の G556 liveness check に加え、次の 3 点を証明します:
+記録済み root 内の期待される action が成功すること、role が canonical reporting surface
+（review なら host routing root 経由の `intent-cli notify report`）へ到達できること、意図的に
+out-of-scope にした action が拒否されることです。その拒否を review 用に記録します。live pane
+だけ、または許可済み action の成功だけでは **READY ではありません**。
+
 **4. ロール初期化。** pane の CLI に合った actas 形式をタイプします — claude は
 `/agmsg actas <role>`、codex は `$agmsg actas <role>`。その後 readiness を
 **混同してはいけない 3 つのレイヤー** で確認します:

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -2183,6 +2183,58 @@ internal static class GuideOrchestratorThreadCommand
                     + "the operator: if answering the dialog would grant access, widen a permission mode, or accept a "
                     + "security warning, it is the operator's call, not the design thread's.",
             },
+            UnattendedLaunchRecipes = new OrchestratorUnattendedLaunchRecipes
+            {
+                Summary =
+                    "Agent-neutral recipes make an unattended launch reviewable rather than broad by default. Every "
+                    + "recipe states the invocation, bounded `--add-dir` roots derived from that role's real work, "
+                    + "the continuation bound, the startup gates the operator must answer, and the denial semantics. "
+                    + "Later agent recipes inherit the central rule below; do not duplicate or weaken it per agent.",
+                RequiredRecipeFields = new[]
+                {
+                    "the launch invocation and agent kind",
+                    "bounded allowed roots derived from the logical role's actual needs (not a product-wide path)",
+                    "the maximum autonomous continuation bound",
+                    "startup trust and autopilot/permission gates the operator must answer",
+                    "the silent-denial semantics and the READY/review evidence that proves them",
+                },
+                CentralAutopilotSupervisionRule =
+                    "AUTHORITATIVE AUTOPILOT SUPERVISION RULE — in an unattended autopilot seat, an action outside "
+                    + "the launch allowlist is silently auto-denied rather than surfaced as a G550 supervision dialog. "
+                    + "Derive and RECORD the allowlist from role needs. READY must prove an expected allowed action, "
+                    + "reachability of that role's canonical reporting surface, and an out-of-scope denial. Review "
+                    + "evidence MUST inspect outputs and the transcript for denials; liveness is not evidence that a "
+                    + "denied step ran. This changes supervision evidence only — G556 liveness and notify/delivery "
+                    + "semantics are unchanged.",
+                CopilotRecipe = new OrchestratorCopilotUnattendedRecipe
+                {
+                    Invocation =
+                        "herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model claude-opus-5 "
+                        + "--mode autopilot --allow-all-tools --add-dir <role-work-root> [--add-dir <host-routing-root>] "
+                        + "--max-autopilot-continues 10",
+                    RoleDerivedRoots =
+                        "Use one bounded `--add-dir <role-work-root>` for the role's checkout/worktree. A review "
+                        + "role additionally receives `--add-dir <host-routing-root>` because `intent-cli notify report` "
+                        + "is its canonical reporting surface. Do not add unrelated developer-machine roots.",
+                    ContinuationBound =
+                        "Keep `--max-autopilot-continues 10` explicit; changing the bound is an operator decision "
+                        + "recorded with the recipe, not an agent default.",
+                    StartupGates =
+                        "Folder trust and autopilot-enable are operator provisioning gates; neither is bypassed by "
+                        + "launch flags. The autopilot-enable dialog appears at the FIRST TASK even when `--mode autopilot` "
+                        + "was passed at launch. With `--allow-all-tools` plus bounded roots, choose `Continue with limited "
+                        + "permissions`; NEVER choose `Enable all permissions`, which discards the boundary.",
+                    ProhibitedBlanket =
+                        "For unattended developer-machine seats, `--yolo` and `--allow-all-paths` are PROHIBITED. "
+                        + "They discard the role-derived boundary; bounded `--add-dir` roots are the required alternative.",
+                },
+                ReadyBranch =
+                    "For an unattended seat, run the normal G556 liveness checks AND prove all three recipe-specific "
+                    + "facts: an expected action inside the recorded roots succeeds, the role can reach its canonical "
+                    + "reporting surface (for review, `intent-cli notify report` through its host routing root), and a "
+                    + "deliberately out-of-scope action is denied. Capture the denied result for review; a live pane or "
+                    + "successful allowed action alone is NOT READY.",
+            },
             RoleInitialization = new OrchestratorProvisioningRoleInitialization
             {
                 Summary = Fill(
@@ -3429,6 +3481,34 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"> **Warning:** {provisioning.LaunchRules.CodexDirectSpawnWarning}");
         writer.WriteLine();
         writer.WriteLine($"> **Authority boundary:** {provisioning.LaunchRules.AuthorityBoundary}");
+        writer.WriteLine();
+
+        var unattended = provisioning.UnattendedLaunchRecipes;
+        writer.WriteLine("### 3a. Unattended-launch recipes (agent-neutral) (G617)");
+        writer.WriteLine();
+        writer.WriteLine(unattended.Summary);
+        writer.WriteLine();
+        writer.WriteLine("Every recipe must state:");
+        writer.WriteLine();
+        foreach (var field in unattended.RequiredRecipeFields)
+        {
+            writer.WriteLine($"- {field}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"> **Central rule:** {unattended.CentralAutopilotSupervisionRule}");
+        writer.WriteLine();
+        writer.WriteLine("#### Copilot (measured first recipe)");
+        writer.WriteLine();
+        writer.WriteLine("```text");
+        writer.WriteLine(unattended.CopilotRecipe.Invocation);
+        writer.WriteLine("```");
+        writer.WriteLine();
+        writer.WriteLine($"- **role-derived roots** — {unattended.CopilotRecipe.RoleDerivedRoots}");
+        writer.WriteLine($"- **continuation bound** — {unattended.CopilotRecipe.ContinuationBound}");
+        writer.WriteLine($"- **startup gates** — {unattended.CopilotRecipe.StartupGates}");
+        writer.WriteLine($"- **prohibited blanket permissions** — {unattended.CopilotRecipe.ProhibitedBlanket}");
+        writer.WriteLine();
+        writer.WriteLine($"> **Unattended READY branch:** {unattended.ReadyBranch}");
         writer.WriteLine();
 
         writer.WriteLine("### 4. Role initialization (actas and readiness)");
@@ -4938,6 +5018,9 @@ internal sealed record OrchestratorTerminalWorkspaceProvisioning
     [JsonPropertyName("launch_rules")]
     public required OrchestratorProvisioningLaunchRules LaunchRules { get; init; }
 
+    [JsonPropertyName("unattended_launch_recipes")]
+    public required OrchestratorUnattendedLaunchRecipes UnattendedLaunchRecipes { get; init; }
+
     [JsonPropertyName("role_initialization")]
     public required OrchestratorProvisioningRoleInitialization RoleInitialization { get; init; }
 
@@ -5384,6 +5467,47 @@ internal sealed record OrchestratorProvisioningLaunchRules
     /// </summary>
     [JsonPropertyName("authority_boundary")]
     public required string AuthorityBoundary { get; init; }
+}
+
+/// <summary>
+/// G617: agent-neutral unattended launch requirements plus the first measured
+/// Copilot recipe. This is guidance only: it adds no agent-specific delivery,
+/// liveness, or runtime branching.
+/// </summary>
+internal sealed record OrchestratorUnattendedLaunchRecipes
+{
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("required_recipe_fields")]
+    public required IReadOnlyList<string> RequiredRecipeFields { get; init; }
+
+    [JsonPropertyName("central_autopilot_supervision_rule")]
+    public required string CentralAutopilotSupervisionRule { get; init; }
+
+    [JsonPropertyName("copilot_recipe")]
+    public required OrchestratorCopilotUnattendedRecipe CopilotRecipe { get; init; }
+
+    [JsonPropertyName("ready_branch")]
+    public required string ReadyBranch { get; init; }
+}
+
+internal sealed record OrchestratorCopilotUnattendedRecipe
+{
+    [JsonPropertyName("invocation")]
+    public required string Invocation { get; init; }
+
+    [JsonPropertyName("role_derived_roots")]
+    public required string RoleDerivedRoots { get; init; }
+
+    [JsonPropertyName("continuation_bound")]
+    public required string ContinuationBound { get; init; }
+
+    [JsonPropertyName("startup_gates")]
+    public required string StartupGates { get; init; }
+
+    [JsonPropertyName("prohibited_blanket")]
+    public required string ProhibitedBlanket { get; init; }
 }
 
 internal sealed record OrchestratorProvisioningRoleInitialization

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -65,6 +65,39 @@ public sealed class AgentMessageOrchestrationDocsTests
     }
 
     [Fact]
+    public void BothDocs_CarryAgentNeutralUnattendedRecipes_AndDenialAwareReady_G617()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        Assert.Contains("### 3a. Unattended-launch recipes (agent-neutral) (G617)", en, StringComparison.Ordinal);
+        Assert.Contains("### 3a. unattended 起動レシピ（agent-neutral）(G617)", ja, StringComparison.Ordinal);
+
+        foreach (var doc in new[] { en, ja })
+        {
+            Assert.Contains("--kind copilot", doc, StringComparison.Ordinal);
+            Assert.Contains("--allow-all-tools", doc, StringComparison.Ordinal);
+            Assert.Contains("--add-dir <role-work-root>", doc, StringComparison.Ordinal);
+            Assert.Contains("--add-dir <host-routing-root>", doc, StringComparison.Ordinal);
+            Assert.Contains("intent-cli notify report", doc, StringComparison.Ordinal);
+            Assert.Contains("--max-autopilot-continues 10", doc, StringComparison.Ordinal);
+            Assert.Contains("--yolo", doc, StringComparison.Ordinal);
+            Assert.Contains("--allow-all-paths", doc, StringComparison.Ordinal);
+            Assert.Contains("Continue with limited permissions", doc, StringComparison.Ordinal);
+            Assert.Contains("Enable all permissions", doc, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("silently auto-denied", en, StringComparison.Ordinal);
+        Assert.Contains("静かに自動拒否", ja, StringComparison.Ordinal);
+        Assert.Contains("G556 liveness and notify/delivery semantics are unchanged", en, StringComparison.Ordinal);
+        Assert.Contains("G556 の liveness と notify/delivery semantics は変わりません", ja, StringComparison.Ordinal);
+        Assert.Contains("out-of-scope action is denied", en, StringComparison.Ordinal);
+        Assert.Contains("out-of-scope にした action が拒否", ja, StringComparison.Ordinal);
+        Assert.Contains("transcript for denials", en, StringComparison.Ordinal);
+        Assert.Contains("transcript で拒否を調べます", ja, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BothDocs_SeparateDeliveryConfigFromLiveAttachment_AndKeepPingAckSoleProof_G549()
     {
         var en = ReadDoc("en");

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -1990,6 +1990,31 @@ public sealed class GuideOrchestratorThreadCommandTests
     }
 
     [Fact]
+    public void Execute_Markdown_UnattendedLaunchRecipes_KeepBoundedCopilotAndDenialEvidence_G617()
+    {
+        var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
+
+        Assert.Contains("### 3a. Unattended-launch recipes (agent-neutral) (G617)", output, StringComparison.Ordinal);
+        Assert.Contains("AUTHORITATIVE AUTOPILOT SUPERVISION RULE", output, StringComparison.Ordinal);
+        Assert.Contains("silently auto-denied", output, StringComparison.Ordinal);
+        Assert.Contains("Derive and RECORD the allowlist from role needs", output, StringComparison.Ordinal);
+        Assert.Contains("outputs and the transcript for denials", output, StringComparison.Ordinal);
+
+        Assert.Contains("herdr agent start <logical-role> --kind copilot", output, StringComparison.Ordinal);
+        Assert.Contains("--allow-all-tools --add-dir <role-work-root> [--add-dir <host-routing-root>]", output, StringComparison.Ordinal);
+        Assert.Contains("intent-cli notify report", output, StringComparison.Ordinal);
+        Assert.Contains("--max-autopilot-continues 10", output, StringComparison.Ordinal);
+        Assert.Contains("FIRST TASK", output, StringComparison.Ordinal);
+        Assert.Contains("Continue with limited permissions", output, StringComparison.Ordinal);
+        Assert.Contains("NEVER choose `Enable all permissions`", output, StringComparison.Ordinal);
+        Assert.Contains("`--yolo` and `--allow-all-paths` are PROHIBITED", output, StringComparison.Ordinal);
+
+        Assert.Contains("normal G556 liveness checks AND prove all three", output, StringComparison.Ordinal);
+        Assert.Contains("deliberately out-of-scope action is denied", output, StringComparison.Ordinal);
+        Assert.Contains("successful allowed action alone is NOT READY", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_Markdown_Provisioning_NamesHerdrSurfaces_AndLinksOutInternals_G549()
     {
         var output = RunMarkdown(["--domain", "intent-cli", "--target-repo", "owner/repo", "--agent", "claude"]);
@@ -2048,6 +2073,14 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("NEVER answerable", authorityBoundary, StringComparison.Ordinal);
         Assert.Contains("ALWAYS ESCALATED to the operator", authorityBoundary, StringComparison.Ordinal);
         Assert.Contains("no authorization makes them answerable", authorityBoundary, StringComparison.Ordinal);
+
+        var unattended = provisioning.GetProperty("unattended_launch_recipes");
+        Assert.Equal(5, unattended.GetProperty("required_recipe_fields").GetArrayLength());
+        Assert.Contains("silently auto-denied", unattended.GetProperty("central_autopilot_supervision_rule").GetString(), StringComparison.Ordinal);
+        Assert.Contains("--add-dir <role-work-root>", unattended.GetProperty("copilot_recipe").GetProperty("invocation").GetString(), StringComparison.Ordinal);
+        Assert.Contains("intent-cli notify report", unattended.GetProperty("copilot_recipe").GetProperty("role_derived_roots").GetString(), StringComparison.Ordinal);
+        Assert.Contains("--yolo", unattended.GetProperty("copilot_recipe").GetProperty("prohibited_blanket").GetString(), StringComparison.Ordinal);
+        Assert.Contains("out-of-scope action is denied", unattended.GetProperty("ready_branch").GetString(), StringComparison.Ordinal);
 
         var roleInitialization = provisioning.GetProperty("role_initialization");
         Assert.NotEmpty(roleInitialization.GetProperty("actas_forms").EnumerateArray());

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -12,7 +12,7 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     private const string Domain = "intent-cli";
     private const string Team = "intent-cli-dev";
     private const string Repo = "J-Tech-Japan/intent-system";
-    private const string G594AgmsgBaselineSha256 = "f7993d32c4423c7880fb71f089867546a406a270eb93f41fa09ed053a9ffce5f";
+    private const string G594AgmsgBaselineSha256 = "2d8d004cfd829b788a22870c9025cde0b2772fcf069d3307b85e726372c434f1";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -10,7 +10,7 @@ namespace IntentSystem.Cli.Tests;
 public sealed class HerdrWakeSourcesG581Tests : IDisposable
 {
     private const string G594AgmsgGuideSha256 =
-        "B6E2F69C7840D359E833645056A5C10D42A450141C97169B8C0BB330A8F490F9";
+        "6CCD31391485C6205EEAF746750C40E360316CF296621AFCE138E88DEB19749E";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 


### PR DESCRIPTION
Closes #1337

## G617 evidence

- Adds the agent-neutral unattended-launch recipe framework to the rendered guide and EN/JA doc 12: invocation, role-derived bounded roots, continuation bound, operator startup gates, and denial semantics.
- Adds the measured Copilot first recipe using bounded `--add-dir <role-work-root>` plus optional reviewer `<host-routing-root>` for canonical `intent-cli notify report`; it prohibits `--yolo` and `--allow-all-paths` for unattended developer-machine seats.
- Central authoritative rule records the role-derived allowlist, treats out-of-allowlist work as silently auto-denied, requires READY proof of allowed action + reporting reachability + denial, and requires denial inspection in review evidence. G556 liveness and notify/delivery semantics remain unchanged.
- Pins the intentionally changed rendered agmsg guide hashes and adds EN/JA + guide JSON/markdown coverage.

## Verification

- Rendered `guide orchestrator-thread` from the built CLI and observed the bounded Copilot recipe, first-task dialog choice, prohibited flags, and denial-aware READY branch.
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter "FullyQualifiedName~GuideOrchestratorThreadCommandTests|FullyQualifiedName~AgentMessageOrchestrationDocsTests|FullyQualifiedName~HerdrWakeSourcesG581Tests|FullyQualifiedName~HerdrPaneTopologyG586Tests" --no-restore` (136 passed)
- `dotnet test IntentSystem.sln --no-restore` (all projects green)
- `git diff --check`