### PR TITLE
feat: add G618 reference-first dispatch advisory

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -213,6 +213,12 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   declares `inline_payload_warning_chars: 4096`. It is advisory only: a payload
   above it is likely pasted rather than typed, while a payload below it is not
   promised safe because the real limit is terminal- and agent-dependent.
+- **Reference-first limit.** Keep repeated review substance in committed
+  `review-context.md` and delegate a terse pointer, but do not present that
+  discipline as the paste remedy: a minimal canonical `notify delegate` envelope
+  still measures 842 characters over 14 lines and can itself be pasted. It
+  reduces duplication, not a paste-sensitive wedge; G619 owns the transport-layer
+  remedy.
 - **Startup gates.** Folder trust and autopilot-enable are operator provisioning
   gates; launch flags bypass neither. The autopilot-enable dialog appears at the
   **first task** even when launch used `--mode autopilot`. With
@@ -539,6 +545,11 @@ task block; do not hand-write `herdr agent prompt`.
 consideration outside the packet to `review-context.md`, push it, then reference
 it — do not inline the substance into a pane prompt. This is the packet structure
 working as intended, not a new packet meaning.
+
+The measured limit matters: a minimal canonical `notify delegate` envelope is
+842 characters over 14 lines and is itself a paste. Reference-first reduces
+duplicated substance; it does not prevent a paste-sensitive seat from wedging.
+G619 owns the transport-layer remedy.
 
 The recipient recipe's `inline_payload_warning_chars` profile is **advisory**,
 not a universal safe-paste limit. When a delegate's inline payload exceeds its

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -209,6 +209,10 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   reporting surface. Do not add unrelated developer-machine roots.
 - **Continuation bound.** Keep `--max-autopilot-continues 10` explicit. Any
   different bound is an operator decision recorded with the recipe.
+- **Inline-payload advisory.** Profile `copilot-autopilot-observed-paste-risk`
+  declares `inline_payload_warning_chars: 4096`. It is advisory only: a payload
+  above it is likely pasted rather than typed, while a payload below it is not
+  promised safe because the real limit is terminal- and agent-dependent.
 - **Startup gates.** Folder trust and autopilot-enable are operator provisioning
   gates; launch flags bypass neither. The autopilot-enable dialog appears at the
   **first task** even when launch used `--mode autopilot`. With
@@ -529,6 +533,21 @@ Use the [canonical notify workflow](#canonical-notify-workflow): run
 `intent-cli notify delegate ...` with the target logical role. The CLI resolves
 herdr-only internally, validates the role mapping, and generates the structured
 task block; do not hand-write `herdr agent prompt`.
+
+**Reference-first dispatch.** Review substance belongs in the committed canonical
+`review-context.md`; the delegate carries a terse pointer to that file. Add any
+consideration outside the packet to `review-context.md`, push it, then reference
+it — do not inline the substance into a pane prompt. This is the packet structure
+working as intended, not a new packet meaning.
+
+The recipient recipe's `inline_payload_warning_chars` profile is **advisory**,
+not a universal safe-paste limit. When a delegate's inline payload exceeds its
+resolved threshold, `notify` warns with the payload size, threshold, and the
+reference-first remedy in both human and machine output, but still delivers the
+same payload. It never refuses or truncates it. Observed on a peer team: a large
+paste can leave broken bracketed-paste state in a terminal and terminate some
+agent processes; recover with a fresh agent start. This is an observation, not a
+universal size limit or a claim about every terminal or agent.
 
 For a settled pane, notify first uses bounded `agent prompt --wait --until
 working` semantics, then a separate bounded `agent wait` for

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -197,6 +197,10 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   developer-machine の無関係な root は追加しません。
 - **継続上限。** `--max-autopilot-continues 10` を明示したままにします。別の上限は、レシピと
   ともに記録する operator の判断です。
+- **inline-payload の advisory。** `copilot-autopilot-observed-paste-risk` profile は
+  `inline_payload_warning_chars: 4096` を宣言します。これは advisory にすぎません。これを
+  超える payload は type ではなく paste されやすいという目安であり、下回れば安全という保証には
+  なりません。実際の限界は terminal と agent に依存します。
 - **startup gate。** folder trust と autopilot-enable は operator provisioning gate であり、
   launch flag ではどちらも bypass できません。`--mode autopilot` を launch 時に渡しても、
   autopilot-enable dialog は **最初の task** で現れます。`--allow-all-tools` と境界付き root
@@ -483,6 +487,19 @@ READY ではありません。herdr-only の role identity は検証済み logic
 `intent-cli notify delegate ...` を target logical role に対して実行します。CLI が
 herdr-only を内部解決し、role mapping を検証して structured task block を生成します。
 `herdr agent prompt` を手書きしてはいけません。
+
+**reference-first dispatch。** review の実体は committed canonical な `review-context.md` に
+置き、delegate にはその file への短い pointer だけを載せます。packet にない consideration は
+`review-context.md` に追加して push し、それを reference します。pane prompt に実体を inline
+してはいけません。これは packet structure を変えるものではなく、意図どおりに使う discipline です。
+
+recipient recipe の `inline_payload_warning_chars` profile は **advisory** であり、universal な
+safe-paste limit ではありません。delegate の inline payload が resolved threshold を超えると、
+`notify` は payload size、threshold、reference-first remedy を human と machine の両方に warning
+として出しますが、同じ payload の delivery は続行します。refuse も truncate もしません。別 team
+での観測では、大きな paste が terminal に broken bracketed-paste state を残し、一部の agent process
+を terminate することがあります。fresh agent start で recovery します。これは観測事実であり、
+すべての terminal や agent に universal な size limit があるという主張ではありません。
 
 settled pane では、notify は最初に bounded `agent prompt --wait --until working` を使い、続けて
 idle/done/blocked を待つ別の bounded `agent wait` を実行します。観測された unattended working

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -201,6 +201,11 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   `inline_payload_warning_chars: 4096` を宣言します。これは advisory にすぎません。これを
   超える payload は type ではなく paste されやすいという目安であり、下回れば安全という保証には
   なりません。実際の限界は terminal と agent に依存します。
+- **reference-first の限界。** 繰り返す review の実体は committed canonical な
+  `review-context.md` に置き、delegate には短い pointer だけを載せます。ただし、これを paste の
+  remedy として扱ってはいけません。最小の canonical `notify delegate` envelope でも 842 文字・14 行で、
+  これ自体が paste になります。これは重複を減らす discipline であり、paste-sensitive な wedge を防ぐ
+  ものではありません。transport-layer の remedy は G619 が担当します。
 - **startup gate。** folder trust と autopilot-enable は operator provisioning gate であり、
   launch flag ではどちらも bypass できません。`--mode autopilot` を launch 時に渡しても、
   autopilot-enable dialog は **最初の task** で現れます。`--allow-all-tools` と境界付き root
@@ -492,6 +497,10 @@ herdr-only を内部解決し、role mapping を検証して structured task blo
 置き、delegate にはその file への短い pointer だけを載せます。packet にない consideration は
 `review-context.md` に追加して push し、それを reference します。pane prompt に実体を inline
 してはいけません。これは packet structure を変えるものではなく、意図どおりに使う discipline です。
+
+測定済みの限界も重要です。最小の canonical `notify delegate` envelope でも 842 文字・14 行であり、
+これ自体が paste になります。reference-first は重複する実体を減らしますが、paste-sensitive な seat の
+wedge を防ぐものではありません。transport-layer の remedy は G619 が担当します。
 
 recipient recipe の `inline_payload_warning_chars` profile は **advisory** であり、universal な
 safe-paste limit ではありません。delegate の inline payload が resolved threshold を超えると、

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -2223,7 +2223,10 @@ internal static class GuideOrchestratorThreadCommand
                     InlinePayloadWarningProfile =
                         "Profile `copilot-autopilot-observed-paste-risk` declares `inline_payload_warning_chars: 4096`. "
                         + "It is ADVISORY only: a payload above it is likely pasted rather than typed, while a payload "
-                        + "below it is not promised safe because the real limit is terminal- and agent-dependent.",
+                        + "below it is not promised safe because the real limit is terminal- and agent-dependent. "
+                        + "Reference-first dispatch keeps repeated review substance in committed `review-context.md`, but a "
+                        + "minimal canonical `notify delegate` envelope still measures 842 characters over 14 lines and can "
+                        + "itself be pasted: it reduces duplication, not a paste-sensitive wedge. G619 owns the transport-layer remedy.",
                     StartupGates =
                         "Folder trust and autopilot-enable are operator provisioning gates; neither is bypassed by "
                         + "launch flags. The autopilot-enable dialog appears at the FIRST TASK even when `--mode autopilot` "

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -2196,6 +2196,7 @@ internal static class GuideOrchestratorThreadCommand
                     "bounded allowed roots derived from the logical role's actual needs (not a product-wide path)",
                     "the maximum autonomous continuation bound",
                     "startup trust and autopilot/permission gates the operator must answer",
+                    "a named advisory inline-payload warning profile and threshold, never a safe-paste guarantee",
                     "the silent-denial semantics and the READY/review evidence that proves them",
                 },
                 CentralAutopilotSupervisionRule =
@@ -2219,6 +2220,10 @@ internal static class GuideOrchestratorThreadCommand
                     ContinuationBound =
                         "Keep `--max-autopilot-continues 10` explicit; changing the bound is an operator decision "
                         + "recorded with the recipe, not an agent default.",
+                    InlinePayloadWarningProfile =
+                        "Profile `copilot-autopilot-observed-paste-risk` declares `inline_payload_warning_chars: 4096`. "
+                        + "It is ADVISORY only: a payload above it is likely pasted rather than typed, while a payload "
+                        + "below it is not promised safe because the real limit is terminal- and agent-dependent.",
                     StartupGates =
                         "Folder trust and autopilot-enable are operator provisioning gates; neither is bypassed by "
                         + "launch flags. The autopilot-enable dialog appears at the FIRST TASK even when `--mode autopilot` "
@@ -3505,6 +3510,7 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine();
         writer.WriteLine($"- **role-derived roots** — {unattended.CopilotRecipe.RoleDerivedRoots}");
         writer.WriteLine($"- **continuation bound** — {unattended.CopilotRecipe.ContinuationBound}");
+        writer.WriteLine($"- **inline-payload advisory** — {unattended.CopilotRecipe.InlinePayloadWarningProfile}");
         writer.WriteLine($"- **startup gates** — {unattended.CopilotRecipe.StartupGates}");
         writer.WriteLine($"- **prohibited blanket permissions** — {unattended.CopilotRecipe.ProhibitedBlanket}");
         writer.WriteLine();
@@ -5502,6 +5508,9 @@ internal sealed record OrchestratorCopilotUnattendedRecipe
 
     [JsonPropertyName("continuation_bound")]
     public required string ContinuationBound { get; init; }
+
+    [JsonPropertyName("inline_payload_warning_profile")]
+    public required string InlinePayloadWarningProfile { get; init; }
 
     [JsonPropertyName("startup_gates")]
     public required string StartupGates { get; init; }

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -15,6 +15,10 @@ internal static class NotifyCommand
     private const string EscalationEventKind = "escalation";
     private const string FormatJson = "json";
     private const string FormatMarkdown = "markdown";
+    private const string CopilotObservedPasteRiskProfile = "copilot-autopilot-observed-paste-risk";
+    private const int CopilotObservedPasteRiskWarningChars = 4096;
+    private const string ReferenceFirstRemedy =
+        "Use reference-first dispatch: put review substance in committed canonical review-context.md, push it, and delegate a terse pointer.";
 
     private const string DelegateUsage =
         "Usage: intent-cli notify delegate --domain <d> --team <t> --from <role> --to <role> --report-to <role> "
@@ -175,6 +179,9 @@ internal static class NotifyCommand
         var payload = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
             ? BuildDelegatePayload(options, reportCommand!)
             : BuildReportPayload(options);
+        var inlinePayloadWarning = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+            ? ResolveInlinePayloadWarning(options, payload)
+            : null;
 
         var runner = ProcessRunnerFactory?.Invoke() ?? new NotifyProcessRunner();
         var transport = string.Equals(resolution.Mode, SessionLayerMode.HerdrOnly, StringComparison.Ordinal)
@@ -219,7 +226,8 @@ internal static class NotifyCommand
                 receiverStateOutcome: delivery.ReceiverStateOutcome,
                 workingTransition: delivery.WorkingTransition,
                 settleOutcome: delivery.SettleOutcome,
-                resendPermitted: delivery.ResendPermitted));
+                resendPermitted: delivery.ResendPermitted,
+                inlinePayloadWarning: inlinePayloadWarning));
             return 1;
         }
 
@@ -243,7 +251,8 @@ internal static class NotifyCommand
                     payload,
                     reportCommand,
                     modeSource: resolution.Source == SessionLayerModeSource.Recorded ? "recorded" : "default",
-                    preflight: deliveryPreflight));
+                    preflight: deliveryPreflight,
+                    inlinePayloadWarning: inlinePayloadWarning));
                 return 1;
             }
         }
@@ -274,7 +283,8 @@ internal static class NotifyCommand
             receiverStateOutcome: delivery.ReceiverStateOutcome,
             workingTransition: delivery.WorkingTransition,
             settleOutcome: delivery.SettleOutcome,
-            resendPermitted: delivery.ResendPermitted));
+            resendPermitted: delivery.ResendPermitted,
+            inlinePayloadWarning: inlinePayloadWarning));
         return 0;
     }
 
@@ -421,6 +431,27 @@ internal static class NotifyCommand
         summary = NotifyEventWriter.NormalizeSummary(options.Summary!),
     });
 
+    private static NotifyInlinePayloadWarning? ResolveInlinePayloadWarning(NotifyOptions options, string payload)
+    {
+        var topology = NotifyRoleTopologyStore.Resolve(options.RoutingRoot!, options.Domain!, options.Team!);
+        if (!topology.Resolved
+            || topology.Topology is null
+            || !topology.Topology.Roles.TryGetValue(options.ToRole!, out var recipient)
+            || !string.Equals(recipient.Kind, "copilot", StringComparison.OrdinalIgnoreCase)
+            || payload.Length <= CopilotObservedPasteRiskWarningChars)
+        {
+            return null;
+        }
+
+        return new NotifyInlinePayloadWarning
+        {
+            Profile = CopilotObservedPasteRiskProfile,
+            PayloadChars = payload.Length,
+            ThresholdChars = CopilotObservedPasteRiskWarningChars,
+            Remedy = ReferenceFirstRemedy,
+        };
+    }
+
     private static NotifyResult SuccessResult(
         string operation,
         NotifyOptions options,
@@ -435,7 +466,8 @@ internal static class NotifyCommand
         string? receiverStateOutcome = null,
         string? workingTransition = null,
         string? settleOutcome = null,
-        bool? resendPermitted = null) => new()
+        bool? resendPermitted = null,
+        NotifyInlinePayloadWarning? inlinePayloadWarning = null) => new()
         {
             Operation = operation,
             RoutingRoot = options.RoutingRoot!,
@@ -457,6 +489,7 @@ internal static class NotifyCommand
             WorkingTransition = workingTransition,
             SettleOutcome = settleOutcome,
             ResendPermitted = resendPermitted,
+            InlinePayloadWarning = inlinePayloadWarning,
             Cause = null,
             Payload = payload,
             ReportCommand = reportCommand,
@@ -476,7 +509,8 @@ internal static class NotifyCommand
         string? receiverStateOutcome = null,
         string? workingTransition = null,
         string? settleOutcome = null,
-        bool? resendPermitted = null) => new()
+        bool? resendPermitted = null,
+        NotifyInlinePayloadWarning? inlinePayloadWarning = null) => new()
         {
             Operation = operation,
             RoutingRoot = options.RoutingRoot ?? string.Empty,
@@ -498,6 +532,7 @@ internal static class NotifyCommand
             WorkingTransition = workingTransition,
             SettleOutcome = settleOutcome,
             ResendPermitted = resendPermitted,
+            InlinePayloadWarning = inlinePayloadWarning,
             Cause = cause,
             Payload = payload,
             ReportCommand = reportCommand,
@@ -543,6 +578,11 @@ internal static class NotifyCommand
         if (result.ResendPermitted is not null)
         {
             writer.WriteLine($"- resend permitted: {result.ResendPermitted.Value.ToString().ToLowerInvariant()}");
+        }
+        if (result.InlinePayloadWarning is { } warning)
+        {
+            writer.WriteLine($"- inline payload warning: profile={warning.Profile}; size={warning.PayloadChars} chars; "
+                + $"threshold={warning.ThresholdChars} chars; remedy: {warning.Remedy}");
         }
         if (result.ReportCommand is not null)
         {
@@ -773,10 +813,19 @@ internal sealed record NotifyResult
     [JsonPropertyName("working_transition")] public string? WorkingTransition { get; init; }
     [JsonPropertyName("settle_outcome")] public string? SettleOutcome { get; init; }
     [JsonPropertyName("resend_permitted")] public bool? ResendPermitted { get; init; }
+    [JsonPropertyName("inline_payload_warning")] public NotifyInlinePayloadWarning? InlinePayloadWarning { get; init; }
     [JsonPropertyName("cause")] public string? Cause { get; init; }
     [JsonPropertyName("payload")] public string? Payload { get; init; }
     [JsonPropertyName("report_command")] public string? ReportCommand { get; init; }
     [JsonPropertyName("summary")] public required string Summary { get; init; }
+}
+
+internal sealed record NotifyInlinePayloadWarning
+{
+    [JsonPropertyName("profile")] public required string Profile { get; init; }
+    [JsonPropertyName("payload_chars")] public required int PayloadChars { get; init; }
+    [JsonPropertyName("threshold_chars")] public required int ThresholdChars { get; init; }
+    [JsonPropertyName("remedy")] public required string Remedy { get; init; }
 }
 
 internal static class NotifyEventWriter

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -100,10 +100,14 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("Reference-first dispatch", en, StringComparison.Ordinal);
         Assert.Contains("committed canonical", en, StringComparison.Ordinal);
         Assert.Contains("`review-context.md`", en, StringComparison.Ordinal);
+        Assert.Contains("842 characters over 14 lines", en, StringComparison.Ordinal);
+        Assert.Contains("G619 owns the transport-layer remedy", en, StringComparison.Ordinal);
         Assert.Contains("never refuses or truncates", en, StringComparison.Ordinal);
         Assert.Contains("broken bracketed-paste", en, StringComparison.Ordinal);
         Assert.Contains("reference-first dispatch", ja, StringComparison.Ordinal);
         Assert.Contains("committed canonical な `review-context.md`", ja, StringComparison.Ordinal);
+        Assert.Contains("842 文字・14 行", ja, StringComparison.Ordinal);
+        Assert.Contains("transport-layer の remedy は G619 が担当", ja, StringComparison.Ordinal);
         Assert.Contains("refuse も truncate もしません", ja, StringComparison.Ordinal);
         Assert.Contains("broken bracketed-paste state", ja, StringComparison.Ordinal);
     }

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -81,6 +81,7 @@ public sealed class AgentMessageOrchestrationDocsTests
             Assert.Contains("--add-dir <host-routing-root>", doc, StringComparison.Ordinal);
             Assert.Contains("intent-cli notify report", doc, StringComparison.Ordinal);
             Assert.Contains("--max-autopilot-continues 10", doc, StringComparison.Ordinal);
+            Assert.Contains("inline_payload_warning_chars: 4096", doc, StringComparison.Ordinal);
             Assert.Contains("--yolo", doc, StringComparison.Ordinal);
             Assert.Contains("--allow-all-paths", doc, StringComparison.Ordinal);
             Assert.Contains("Continue with limited permissions", doc, StringComparison.Ordinal);
@@ -95,6 +96,16 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("out-of-scope にした action が拒否", ja, StringComparison.Ordinal);
         Assert.Contains("transcript for denials", en, StringComparison.Ordinal);
         Assert.Contains("transcript で拒否を調べます", ja, StringComparison.Ordinal);
+
+        Assert.Contains("Reference-first dispatch", en, StringComparison.Ordinal);
+        Assert.Contains("committed canonical", en, StringComparison.Ordinal);
+        Assert.Contains("`review-context.md`", en, StringComparison.Ordinal);
+        Assert.Contains("never refuses or truncates", en, StringComparison.Ordinal);
+        Assert.Contains("broken bracketed-paste", en, StringComparison.Ordinal);
+        Assert.Contains("reference-first dispatch", ja, StringComparison.Ordinal);
+        Assert.Contains("committed canonical な `review-context.md`", ja, StringComparison.Ordinal);
+        Assert.Contains("refuse も truncate もしません", ja, StringComparison.Ordinal);
+        Assert.Contains("broken bracketed-paste state", ja, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2004,6 +2004,8 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("--allow-all-tools --add-dir <role-work-root> [--add-dir <host-routing-root>]", output, StringComparison.Ordinal);
         Assert.Contains("intent-cli notify report", output, StringComparison.Ordinal);
         Assert.Contains("--max-autopilot-continues 10", output, StringComparison.Ordinal);
+        Assert.Contains("inline_payload_warning_chars: 4096", output, StringComparison.Ordinal);
+        Assert.Contains("ADVISORY only", output, StringComparison.Ordinal);
         Assert.Contains("FIRST TASK", output, StringComparison.Ordinal);
         Assert.Contains("Continue with limited permissions", output, StringComparison.Ordinal);
         Assert.Contains("NEVER choose `Enable all permissions`", output, StringComparison.Ordinal);
@@ -2075,11 +2077,12 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("no authorization makes them answerable", authorityBoundary, StringComparison.Ordinal);
 
         var unattended = provisioning.GetProperty("unattended_launch_recipes");
-        Assert.Equal(5, unattended.GetProperty("required_recipe_fields").GetArrayLength());
+        Assert.Equal(6, unattended.GetProperty("required_recipe_fields").GetArrayLength());
         Assert.Contains("silently auto-denied", unattended.GetProperty("central_autopilot_supervision_rule").GetString(), StringComparison.Ordinal);
         Assert.Contains("--add-dir <role-work-root>", unattended.GetProperty("copilot_recipe").GetProperty("invocation").GetString(), StringComparison.Ordinal);
         Assert.Contains("intent-cli notify report", unattended.GetProperty("copilot_recipe").GetProperty("role_derived_roots").GetString(), StringComparison.Ordinal);
         Assert.Contains("--yolo", unattended.GetProperty("copilot_recipe").GetProperty("prohibited_blanket").GetString(), StringComparison.Ordinal);
+        Assert.Contains("inline_payload_warning_chars: 4096", unattended.GetProperty("copilot_recipe").GetProperty("inline_payload_warning_profile").GetString(), StringComparison.Ordinal);
         Assert.Contains("out-of-scope action is denied", unattended.GetProperty("ready_branch").GetString(), StringComparison.Ordinal);
 
         var roleInitialization = provisioning.GetProperty("role_initialization");

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2006,6 +2006,8 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("--max-autopilot-continues 10", output, StringComparison.Ordinal);
         Assert.Contains("inline_payload_warning_chars: 4096", output, StringComparison.Ordinal);
         Assert.Contains("ADVISORY only", output, StringComparison.Ordinal);
+        Assert.Contains("842 characters over 14 lines", output, StringComparison.Ordinal);
+        Assert.Contains("G619 owns the transport-layer remedy", output, StringComparison.Ordinal);
         Assert.Contains("FIRST TASK", output, StringComparison.Ordinal);
         Assert.Contains("Continue with limited permissions", output, StringComparison.Ordinal);
         Assert.Contains("NEVER choose `Enable all permissions`", output, StringComparison.Ordinal);
@@ -2083,6 +2085,8 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("intent-cli notify report", unattended.GetProperty("copilot_recipe").GetProperty("role_derived_roots").GetString(), StringComparison.Ordinal);
         Assert.Contains("--yolo", unattended.GetProperty("copilot_recipe").GetProperty("prohibited_blanket").GetString(), StringComparison.Ordinal);
         Assert.Contains("inline_payload_warning_chars: 4096", unattended.GetProperty("copilot_recipe").GetProperty("inline_payload_warning_profile").GetString(), StringComparison.Ordinal);
+        Assert.Contains("842 characters over 14 lines", unattended.GetProperty("copilot_recipe").GetProperty("inline_payload_warning_profile").GetString(), StringComparison.Ordinal);
+        Assert.Contains("G619 owns the transport-layer remedy", unattended.GetProperty("copilot_recipe").GetProperty("inline_payload_warning_profile").GetString(), StringComparison.Ordinal);
         Assert.Contains("out-of-scope action is denied", unattended.GetProperty("ready_branch").GetString(), StringComparison.Ordinal);
 
         var roleInitialization = provisioning.GetProperty("role_initialization");

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -12,7 +12,7 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     private const string Domain = "intent-cli";
     private const string Team = "intent-cli-dev";
     private const string Repo = "J-Tech-Japan/intent-system";
-    private const string G594AgmsgBaselineSha256 = "2d8d004cfd829b788a22870c9025cde0b2772fcf069d3307b85e726372c434f1";
+    private const string G594AgmsgBaselineSha256 = "7bd1e0ab22b28311b90a07d9718f1d3df59286950638d7d6037b0af6565fa35c";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -12,7 +12,7 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     private const string Domain = "intent-cli";
     private const string Team = "intent-cli-dev";
     private const string Repo = "J-Tech-Japan/intent-system";
-    private const string G594AgmsgBaselineSha256 = "7bd1e0ab22b28311b90a07d9718f1d3df59286950638d7d6037b0af6565fa35c";
+    private const string G594AgmsgBaselineSha256 = "4860759aacf56780abdb589355c527dccb190e8973a82a39c997cb242191dd12";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -10,7 +10,7 @@ namespace IntentSystem.Cli.Tests;
 public sealed class HerdrWakeSourcesG581Tests : IDisposable
 {
     private const string G594AgmsgGuideSha256 =
-        "B763AADD0D79CCF5037C88B6305D74666B5EC2106016A1F9D10CF06CB661DDAE";
+        "A39A302F1E6EF7704C225605225C8E14D5695DA425C0EE223F0883DDD964CA2A";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -10,7 +10,7 @@ namespace IntentSystem.Cli.Tests;
 public sealed class HerdrWakeSourcesG581Tests : IDisposable
 {
     private const string G594AgmsgGuideSha256 =
-        "6CCD31391485C6205EEAF746750C40E360316CF296621AFCE138E88DEB19749E";
+        "B763AADD0D79CCF5037C88B6305D74666B5EC2106016A1F9D10CF06CB661DDAE";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
@@ -62,6 +62,52 @@ public sealed class NotifyCommandG578Tests : IDisposable
     }
 
     [Fact]
+    public void Delegate_BelowCopilotInlinePayloadAdvisoryThreshold_HasNoWarning_G618()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        NotifyCommand.ProcessRunnerFactory = SuccessfulRunner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        Assert.False(result.TryGetProperty("inline_payload_warning", out _));
+    }
+
+    [Fact]
+    public void Delegate_AboveCopilotInlinePayloadAdvisoryThreshold_WarnsWithoutChangingDelivery_G618()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var args = DelegateArgs();
+        args[Array.IndexOf(args, "--objective") + 1] = new string('x', 5_000);
+
+        var (exitCode, result) = workspace.Run(args);
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        var warning = result.GetProperty("inline_payload_warning");
+        Assert.Equal("copilot-autopilot-observed-paste-risk", warning.GetProperty("profile").GetString());
+        Assert.Equal(result.GetProperty("payload").GetString()!.Length, warning.GetProperty("payload_chars").GetInt32());
+        Assert.Equal(4096, warning.GetProperty("threshold_chars").GetInt32());
+        Assert.Contains("review-context.md", warning.GetProperty("remedy").GetString(), StringComparison.Ordinal);
+        Assert.Contains(runner.Calls, call =>
+            call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "wH:p2"]));
+
+        var markdownArgs = DelegateArgs();
+        markdownArgs[Array.IndexOf(markdownArgs, "--objective") + 1] = new string('x', 5_000);
+        markdownArgs[^1] = "markdown";
+        var (markdownExitCode, markdown) = workspace.RunRaw(markdownArgs);
+
+        Assert.Equal(0, markdownExitCode);
+        Assert.Contains("inline payload warning", markdown, StringComparison.Ordinal);
+        Assert.Contains("size=", markdown, StringComparison.Ordinal);
+        Assert.Contains("threshold=4096", markdown, StringComparison.Ordinal);
+        Assert.Contains("remedy:", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void UnrecordedMode_IsConfigurationIncompleteBeforeDefaultAgmsgTransport_G594()
     {
         var runner = SuccessfulRunner();
@@ -479,6 +525,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
                     ["implementation"] = new
                     {
                         resident = "herdr",
+                        kind = "copilot",
                         workspace_id = "wH",
                         pane_id = "wH:p2",
                     },
@@ -519,9 +566,15 @@ public sealed class NotifyCommandG578Tests : IDisposable
 
         public (int ExitCode, JsonElement Result) Run(string[] args)
         {
+            var (exitCode, output) = RunRaw(args);
+            return (exitCode, JsonDocument.Parse(output).RootElement.Clone());
+        }
+
+        public (int ExitCode, string Output) RunRaw(string[] args)
+        {
             using var writer = new StringWriter();
             var exitCode = CommandRouter.Execute(args, Context, writer);
-            return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+            return (exitCode, writer.ToString());
         }
 
         public void Dispose()


### PR DESCRIPTION
Closes #1339

## G618 amendment evidence

- Reference-first dispatch keeps review substance in committed canonical review-context.md and delegates a terse pointer.
- It now states the measured limit in EN/JA herdr-only dispatch guidance and unattended recipe guidance: a minimal canonical notify delegate envelope is 842 characters over 14 lines and is itself a paste. Reference-first reduces duplicate substance but is not the paste-wedge remedy; G619 owns that transport-layer remedy.
- The copilot-autopilot-observed-paste-risk 4096-character profile remains advisory only. notify still warns in human and JSON output above threshold while delivering the same payload without refusal, truncation, identity, or settle changes.

## Verification

- focused CLI/docs/guide/pin suite: 158 passed
- dotnet test IntentSystem.sln --no-restore --no-build: passed
- git diff --check: passed