### PR TITLE
feat: add G619 file-backed task delivery

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -219,6 +219,11 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   still measures 842 characters over 14 lines and can itself be pasted. It
   reduces duplication, not a paste-sensitive wedge; G619 owns the transport-layer
   remedy.
+- **Task-envelope delivery method.** A paste-sensitive herdr seat declares
+  `delivery_method: file-backed`: `notify` writes the unchanged envelope under
+  host `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` before sending
+  the pane one line, `Read task envelope: <path>`. Declare `inline` explicitly
+  when desired; an absent declaration preserves existing inline delivery.
 - **Startup gates.** Folder trust and autopilot-enable are operator provisioning
   gates; launch flags bypass neither. The autopilot-enable dialog appears at the
   **first task** even when launch used `--mode autopilot`. With
@@ -550,6 +555,14 @@ The measured limit matters: a minimal canonical `notify delegate` envelope is
 842 characters over 14 lines and is itself a paste. Reference-first reduces
 duplicated substance; it does not prevent a paste-sensitive seat from wedging.
 G619 owns the transport-layer remedy.
+
+For a paste-sensitive herdr seat, declare `delivery_method: file-backed` in its
+recipe. `notify` writes the unchanged envelope to an addressable durable task
+file under `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` before it
+sends the pane the single-line `Read task envelope: <path>` pointer. The file is
+not deleted, so a restarted recipient can read the same task. Declare `inline`
+only to choose it explicitly: without a declaration, the established inline
+delivery remains byte-identical.
 
 The recipient recipe's `inline_payload_warning_chars` profile is **advisory**,
 not a universal safe-paste limit. When a delegate's inline payload exceeds its

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -206,6 +206,11 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   remedy として扱ってはいけません。最小の canonical `notify delegate` envelope でも 842 文字・14 行で、
   これ自体が paste になります。これは重複を減らす discipline であり、paste-sensitive な wedge を防ぐ
   ものではありません。transport-layer の remedy は G619 が担当します。
+- **task-envelope delivery method。** paste-sensitive な herdr seat には
+  `delivery_method: file-backed` を宣言します。`notify` は unchanged な envelope を host の
+  `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` に書いてから、pane には
+  `Read task envelope: <path>` という 1 行だけを送ります。明示的に選ぶなら `inline` を宣言します。
+  宣言がなければ既存の inline delivery をそのまま維持します。
 - **startup gate。** folder trust と autopilot-enable は operator provisioning gate であり、
   launch flag ではどちらも bypass できません。`--mode autopilot` を launch 時に渡しても、
   autopilot-enable dialog は **最初の task** で現れます。`--allow-all-tools` と境界付き root
@@ -501,6 +506,13 @@ herdr-only を内部解決し、role mapping を検証して structured task blo
 測定済みの限界も重要です。最小の canonical `notify delegate` envelope でも 842 文字・14 行であり、
 これ自体が paste になります。reference-first は重複する実体を減らしますが、paste-sensitive な seat の
 wedge を防ぐものではありません。transport-layer の remedy は G619 が担当します。
+
+paste-sensitive な herdr seat では、その recipe に `delivery_method: file-backed` を宣言します。
+`notify` は unchanged な envelope を addressable で durable な
+`.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` に書いてから、pane へ
+`Read task envelope: <path>` という 1 行の pointer を送ります。file は削除しないため、restart
+した recipient も同じ task を読み直せます。明示的に選ぶ場合だけ `inline` を宣言し、宣言がなければ
+確立済みの inline delivery は byte-identical のままです。
 
 recipient recipe の `inline_payload_warning_chars` profile は **advisory** であり、universal な
 safe-paste limit ではありません。delegate の inline payload が resolved threshold を超えると、

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -2197,6 +2197,7 @@ internal static class GuideOrchestratorThreadCommand
                     "the maximum autonomous continuation bound",
                     "startup trust and autopilot/permission gates the operator must answer",
                     "a named advisory inline-payload warning profile and threshold, never a safe-paste guarantee",
+                    "a declared task-envelope delivery_method (inline or file-backed; undeclared remains inline)",
                     "the silent-denial semantics and the READY/review evidence that proves them",
                 },
                 CentralAutopilotSupervisionRule =
@@ -2227,6 +2228,11 @@ internal static class GuideOrchestratorThreadCommand
                         + "Reference-first dispatch keeps repeated review substance in committed `review-context.md`, but a "
                         + "minimal canonical `notify delegate` envelope still measures 842 characters over 14 lines and can "
                         + "itself be pasted: it reduces duplication, not a paste-sensitive wedge. G619 owns the transport-layer remedy.",
+                    DeliveryMethod =
+                        "Declare `delivery_method: file-backed` for a paste-sensitive herdr seat. `notify` writes the "
+                        + "unchanged envelope to durable host `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` before "
+                        + "sending one line, `Read task envelope: <path>`. Declare `inline` to opt in explicitly; an absent "
+                        + "declaration preserves existing inline delivery.",
                     StartupGates =
                         "Folder trust and autopilot-enable are operator provisioning gates; neither is bypassed by "
                         + "launch flags. The autopilot-enable dialog appears at the FIRST TASK even when `--mode autopilot` "
@@ -3514,6 +3520,7 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"- **role-derived roots** — {unattended.CopilotRecipe.RoleDerivedRoots}");
         writer.WriteLine($"- **continuation bound** — {unattended.CopilotRecipe.ContinuationBound}");
         writer.WriteLine($"- **inline-payload advisory** — {unattended.CopilotRecipe.InlinePayloadWarningProfile}");
+        writer.WriteLine($"- **task-envelope delivery method** — {unattended.CopilotRecipe.DeliveryMethod}");
         writer.WriteLine($"- **startup gates** — {unattended.CopilotRecipe.StartupGates}");
         writer.WriteLine($"- **prohibited blanket permissions** — {unattended.CopilotRecipe.ProhibitedBlanket}");
         writer.WriteLine();
@@ -5514,6 +5521,9 @@ internal sealed record OrchestratorCopilotUnattendedRecipe
 
     [JsonPropertyName("inline_payload_warning_profile")]
     public required string InlinePayloadWarningProfile { get; init; }
+
+    [JsonPropertyName("delivery_method")]
+    public required string DeliveryMethod { get; init; }
 
     [JsonPropertyName("startup_gates")]
     public required string StartupGates { get; init; }

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -182,6 +182,51 @@ internal static class NotifyCommand
         var inlinePayloadWarning = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
             ? ResolveInlinePayloadWarning(options, payload)
             : null;
+        var envelopeDelivery = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
+            ? NotifyTaskEnvelopeDelivery.Resolve(options, payload)
+            : NotifyTaskEnvelopeDelivery.Inline(payload);
+        if (!envelopeDelivery.Resolved)
+        {
+            Emit(writer, options.Format, FailureResult(
+                operation,
+                options,
+                resolution.Mode,
+                envelopeDelivery.Cause!,
+                envelopeDelivery.Summary,
+                payload,
+                reportCommand,
+                modeSource: resolution.Source == SessionLayerModeSource.Recorded ? "recorded" : "default",
+                preflight: preflight,
+                inlinePayloadWarning: inlinePayloadWarning));
+            return 1;
+        }
+
+        if (envelopeDelivery.FileBacked && options.Write)
+        {
+            var write = NotifyTaskEnvelopeStore.Write(
+                options.RoutingRoot!, options.Domain!, options.Team!, options.TaskId!, options.ResultNonce!, payload);
+            if (!write.Written)
+            {
+                Emit(writer, options.Format, FailureResult(
+                    operation,
+                    options,
+                    resolution.Mode,
+                    "task-file-write-failed",
+                    $"Could not write the file-backed task envelope before notifying role '{options.ToRole}': {write.Error} "
+                    + "No pointer was sent; repair host task-file access and retry notify.",
+                    payload,
+                    reportCommand,
+                    modeSource: resolution.Source == SessionLayerModeSource.Recorded ? "recorded" : "default",
+                    preflight: preflight,
+                    inlinePayloadWarning: inlinePayloadWarning,
+                    deliveryMethod: NotifyTaskEnvelopeDelivery.FileBackedMethod,
+                    taskFile: write.Path,
+                    deliveryPointer: envelopeDelivery.Pointer));
+                return 1;
+            }
+
+            envelopeDelivery = envelopeDelivery with { TaskFile = write.Path };
+        }
 
         var runner = ProcessRunnerFactory?.Invoke() ?? new NotifyProcessRunner();
         var transport = string.Equals(resolution.Mode, SessionLayerMode.HerdrOnly, StringComparison.Ordinal)
@@ -201,7 +246,7 @@ internal static class NotifyCommand
             options.FromRole!,
             options.ToRole!,
             roles,
-            payload,
+            envelopeDelivery.TransportPayload,
             options.Write);
         var deliveryPreflight = delivery.ActivePhase is null
             ? preflight
@@ -227,7 +272,10 @@ internal static class NotifyCommand
                 workingTransition: delivery.WorkingTransition,
                 settleOutcome: delivery.SettleOutcome,
                 resendPermitted: delivery.ResendPermitted,
-                inlinePayloadWarning: inlinePayloadWarning));
+                inlinePayloadWarning: inlinePayloadWarning,
+                deliveryMethod: envelopeDelivery.ResultDeliveryMethod,
+                taskFile: envelopeDelivery.TaskFile,
+                deliveryPointer: envelopeDelivery.ResultPointer));
             return 1;
         }
 
@@ -252,7 +300,10 @@ internal static class NotifyCommand
                     reportCommand,
                     modeSource: resolution.Source == SessionLayerModeSource.Recorded ? "recorded" : "default",
                     preflight: deliveryPreflight,
-                    inlinePayloadWarning: inlinePayloadWarning));
+                    inlinePayloadWarning: inlinePayloadWarning,
+                    deliveryMethod: envelopeDelivery.ResultDeliveryMethod,
+                    taskFile: envelopeDelivery.TaskFile,
+                    deliveryPointer: envelopeDelivery.ResultPointer));
                 return 1;
             }
         }
@@ -284,7 +335,10 @@ internal static class NotifyCommand
             workingTransition: delivery.WorkingTransition,
             settleOutcome: delivery.SettleOutcome,
             resendPermitted: delivery.ResendPermitted,
-            inlinePayloadWarning: inlinePayloadWarning));
+            inlinePayloadWarning: inlinePayloadWarning,
+            deliveryMethod: envelopeDelivery.ResultDeliveryMethod,
+            taskFile: envelopeDelivery.TaskFile,
+            deliveryPointer: envelopeDelivery.ResultPointer));
         return 0;
     }
 
@@ -467,7 +521,10 @@ internal static class NotifyCommand
         string? workingTransition = null,
         string? settleOutcome = null,
         bool? resendPermitted = null,
-        NotifyInlinePayloadWarning? inlinePayloadWarning = null) => new()
+        NotifyInlinePayloadWarning? inlinePayloadWarning = null,
+        string? deliveryMethod = null,
+        string? taskFile = null,
+        string? deliveryPointer = null) => new()
         {
             Operation = operation,
             RoutingRoot = options.RoutingRoot!,
@@ -490,6 +547,9 @@ internal static class NotifyCommand
             SettleOutcome = settleOutcome,
             ResendPermitted = resendPermitted,
             InlinePayloadWarning = inlinePayloadWarning,
+            DeliveryMethod = deliveryMethod,
+            TaskFile = taskFile,
+            DeliveryPointer = deliveryPointer,
             Cause = null,
             Payload = payload,
             ReportCommand = reportCommand,
@@ -510,7 +570,10 @@ internal static class NotifyCommand
         string? workingTransition = null,
         string? settleOutcome = null,
         bool? resendPermitted = null,
-        NotifyInlinePayloadWarning? inlinePayloadWarning = null) => new()
+        NotifyInlinePayloadWarning? inlinePayloadWarning = null,
+        string? deliveryMethod = null,
+        string? taskFile = null,
+        string? deliveryPointer = null) => new()
         {
             Operation = operation,
             RoutingRoot = options.RoutingRoot ?? string.Empty,
@@ -533,6 +596,9 @@ internal static class NotifyCommand
             SettleOutcome = settleOutcome,
             ResendPermitted = resendPermitted,
             InlinePayloadWarning = inlinePayloadWarning,
+            DeliveryMethod = deliveryMethod,
+            TaskFile = taskFile,
+            DeliveryPointer = deliveryPointer,
             Cause = cause,
             Payload = payload,
             ReportCommand = reportCommand,
@@ -583,6 +649,12 @@ internal static class NotifyCommand
         {
             writer.WriteLine($"- inline payload warning: profile={warning.Profile}; size={warning.PayloadChars} chars; "
                 + $"threshold={warning.ThresholdChars} chars; remedy: {warning.Remedy}");
+        }
+        if (result.DeliveryMethod is not null)
+        {
+            writer.WriteLine($"- envelope delivery method: {result.DeliveryMethod}");
+            writer.WriteLine($"- task file: `{result.TaskFile}`");
+            writer.WriteLine($"- pane pointer: `{result.DeliveryPointer}`");
         }
         if (result.ReportCommand is not null)
         {
@@ -814,6 +886,9 @@ internal sealed record NotifyResult
     [JsonPropertyName("settle_outcome")] public string? SettleOutcome { get; init; }
     [JsonPropertyName("resend_permitted")] public bool? ResendPermitted { get; init; }
     [JsonPropertyName("inline_payload_warning")] public NotifyInlinePayloadWarning? InlinePayloadWarning { get; init; }
+    [JsonPropertyName("delivery_method")] public string? DeliveryMethod { get; init; }
+    [JsonPropertyName("task_file")] public string? TaskFile { get; init; }
+    [JsonPropertyName("delivery_pointer")] public string? DeliveryPointer { get; init; }
     [JsonPropertyName("cause")] public string? Cause { get; init; }
     [JsonPropertyName("payload")] public string? Payload { get; init; }
     [JsonPropertyName("report_command")] public string? ReportCommand { get; init; }

--- a/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
@@ -10,6 +10,7 @@ internal sealed record NotifyRecordedRole(
     string? Reader,
     string? Cwd,
     string? Kind,
+    string? DeliveryMethod,
     string? Frontend)
 {
     public const string HerdrResident = "herdr";
@@ -249,6 +250,7 @@ internal static class NotifyRoleTopologyStore
                     ReadString(property.Value, "reader"),
                     ReadString(property.Value, "cwd"),
                     ReadString(property.Value, "kind"),
+                    ReadString(property.Value, "delivery_method"),
                     ReadString(property.Value, "frontend")));
             }
 

--- a/src/IntentSystem.Cli/Commands/NotifyTaskEnvelopeStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyTaskEnvelopeStore.cs
@@ -1,0 +1,130 @@
+using System.Text;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record NotifyTaskEnvelopeWriteResult(bool Written, string Path, string? Error);
+
+internal static class NotifyTaskEnvelopeStore
+{
+    internal static Func<string, string, NotifyTaskEnvelopeWriteResult>? WriteOverride { get; set; }
+
+    public static NotifyTaskEnvelopeWriteResult Write(
+        string routingRoot,
+        string domain,
+        string team,
+        string taskId,
+        string nonce,
+        string envelope)
+    {
+        var path = ResolvePath(routingRoot, domain, team, taskId, nonce);
+        if (WriteOverride is { } writeOverride)
+        {
+            return writeOverride(path, envelope);
+        }
+
+        var directory = Path.GetDirectoryName(path)!;
+        var temporaryPath = Path.Combine(directory, $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(temporaryPath, envelope, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            File.Move(temporaryPath, path, overwrite: true);
+            return new NotifyTaskEnvelopeWriteResult(true, path, null);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return new NotifyTaskEnvelopeWriteResult(false, path, exception.Message);
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+            {
+                try
+                {
+                    File.Delete(temporaryPath);
+                }
+                catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+                {
+                    // The primary write result is already fail-closed; a failed
+                    // best-effort temporary cleanup must not turn it into a send.
+                }
+            }
+        }
+    }
+
+    public static string ResolvePath(string routingRoot, string domain, string team, string taskId, string nonce) =>
+        Path.GetFullPath(Path.Combine(
+            routingRoot,
+            ".intent-cli",
+            "tasks",
+            domain,
+            team,
+            $"{taskId}-{nonce}.md"));
+}
+
+internal sealed record NotifyTaskEnvelopeDelivery
+{
+    public const string InlineMethod = "inline";
+    public const string FileBackedMethod = "file-backed";
+
+    public required bool Resolved { get; init; }
+    public required bool FileBacked { get; init; }
+    public required string TransportPayload { get; init; }
+    public string? Pointer { get; init; }
+    public string? TaskFile { get; init; }
+    public string? Cause { get; init; }
+    public required string Summary { get; init; }
+    public string? ResultDeliveryMethod => FileBacked ? FileBackedMethod : null;
+    public string? ResultPointer => FileBacked ? Pointer : null;
+
+    public static NotifyTaskEnvelopeDelivery Inline(string payload) => new()
+    {
+        Resolved = true,
+        FileBacked = false,
+        TransportPayload = payload,
+        Summary = "Inline envelope delivery is selected.",
+    };
+
+    public static NotifyTaskEnvelopeDelivery Resolve(NotifyOptions options, string payload)
+    {
+        var topology = NotifyRoleTopologyStore.Resolve(options.RoutingRoot!, options.Domain!, options.Team!);
+        if (!topology.Resolved || topology.Topology is null
+            || !topology.Topology.Roles.TryGetValue(options.ToRole!, out var recipient)
+            || string.IsNullOrWhiteSpace(recipient.DeliveryMethod))
+        {
+            return Inline(payload);
+        }
+
+        if (string.Equals(recipient.DeliveryMethod, InlineMethod, StringComparison.Ordinal))
+        {
+            return Inline(payload);
+        }
+
+        if (!string.Equals(recipient.DeliveryMethod, FileBackedMethod, StringComparison.Ordinal)
+            || !string.Equals(recipient.Resident, NotifyRecordedRole.HerdrResident, StringComparison.Ordinal))
+        {
+            return new NotifyTaskEnvelopeDelivery
+            {
+                Resolved = false,
+                FileBacked = false,
+                TransportPayload = payload,
+                Cause = "delivery-method-invalid",
+                Summary = $"Recorded delivery_method '{recipient.DeliveryMethod}' for role '{options.ToRole}' is unsupported. "
+                    + "Use inline or file-backed for a herdr resident and retry notify.",
+            };
+        }
+
+        var taskFile = NotifyTaskEnvelopeStore.ResolvePath(
+            options.RoutingRoot!, options.Domain!, options.Team!, options.TaskId!, options.ResultNonce!);
+        var pointer = $"Read task envelope: {taskFile}";
+        return new NotifyTaskEnvelopeDelivery
+        {
+            Resolved = true,
+            FileBacked = true,
+            TransportPayload = pointer,
+            Pointer = pointer,
+            TaskFile = taskFile,
+            Summary = "File-backed envelope delivery is selected.",
+        };
+    }
+}

--- a/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
@@ -18,7 +18,7 @@ internal static class SessionLayerTopologyCommand
         "Usage: intent-cli session-layer topology record|show|validate|update-kind|retire-legacy [options]";
     private const string RecordUsage =
         "Usage: intent-cli session-layer topology record --domain <name> --team <name> --role <name> --resident herdr "
-        + "--workspace-id <id> --pane-id <id> --cwd <path> [--kind <kind>] [--dry-run|--write] "
+        + "--workspace-id <id> --pane-id <id> --cwd <path> [--kind <kind>] [--delivery-method inline|file-backed] [--dry-run|--write] "
         + "[--format markdown|json]\n"
         + "   or: intent-cli session-layer topology record --domain <name> --team <name> --role <name> --resident external "
         + "--reader <routing-root-relative-path> [--frontend <name>] [--dry-run|--write] "
@@ -377,6 +377,7 @@ internal static class SessionLayerTopologyCommand
         string? paneId = null;
         string? cwd = null;
         string? kind = null;
+        string? deliveryMethod = null;
         string? reader = null;
         string? frontend = null;
         var write = false;
@@ -410,6 +411,9 @@ internal static class SessionLayerTopologyCommand
                     break;
                 case "--kind":
                     if (!TryReadValue(args, ref index, option, out kind, out error)) return false;
+                    break;
+                case "--delivery-method":
+                    if (!TryReadValue(args, ref index, option, out deliveryMethod, out error)) return false;
                     break;
                 case "--reader":
                     if (!TryReadValue(args, ref index, option, out reader, out error)) return false;
@@ -469,6 +473,12 @@ internal static class SessionLayerTopologyCommand
                 return false;
             }
 
+            if (deliveryMethod is not null && deliveryMethod is not ("inline" or "file-backed"))
+            {
+                error = "--delivery-method must be inline or file-backed when supplied.";
+                return false;
+            }
+
             var paneWorkspace = WorkspaceFromPane(paneId);
             if (paneWorkspace is not null
                 && !string.Equals(paneWorkspace, workspaceId, StringComparison.Ordinal))
@@ -486,9 +496,9 @@ internal static class SessionLayerTopologyCommand
                 return false;
             }
 
-            if (workspaceId is not null || paneId is not null || cwd is not null || kind is not null)
+            if (workspaceId is not null || paneId is not null || cwd is not null || kind is not null || deliveryMethod is not null)
             {
-                error = "An external resident does not accept --workspace-id, --pane-id, --cwd, or --kind.";
+                error = "An external resident does not accept --workspace-id, --pane-id, --cwd, --kind, or --delivery-method.";
                 return false;
             }
         }
@@ -503,6 +513,7 @@ internal static class SessionLayerTopologyCommand
             PaneId = paneId,
             Cwd = cwd,
             Kind = kind,
+            DeliveryMethod = deliveryMethod,
             Reader = reader,
             Frontend = frontend,
             Write = write,
@@ -629,7 +640,7 @@ internal static class SessionLayerTopologyWriter
 
     private static readonly string[] KnownRoleFields =
     [
-        "resident", "workspace_id", "pane_id", "cwd", "kind", "reader", "frontend",
+        "resident", "workspace_id", "pane_id", "cwd", "kind", "delivery_method", "reader", "frontend",
     ];
 
     public static SessionLayerTopologyRecordResult Record(
@@ -957,6 +968,7 @@ internal static class SessionLayerTopologyWriter
         Add(role, "pane_id", request.PaneId);
         Add(role, "cwd", request.Cwd);
         Add(role, "kind", request.Kind);
+        Add(role, "delivery_method", request.DeliveryMethod);
         Add(role, "reader", request.Reader);
         Add(role, "frontend", request.Frontend);
         return role;
@@ -1079,6 +1091,7 @@ internal sealed record SessionLayerTopologyRecordRequest
     public string? PaneId { get; init; }
     public string? Cwd { get; init; }
     public string? Kind { get; init; }
+    public string? DeliveryMethod { get; init; }
     public string? Reader { get; init; }
     public string? Frontend { get; init; }
     public required bool Write { get; init; }

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -82,6 +82,7 @@ public sealed class AgentMessageOrchestrationDocsTests
             Assert.Contains("intent-cli notify report", doc, StringComparison.Ordinal);
             Assert.Contains("--max-autopilot-continues 10", doc, StringComparison.Ordinal);
             Assert.Contains("inline_payload_warning_chars: 4096", doc, StringComparison.Ordinal);
+            Assert.Contains("delivery_method: file-backed", doc, StringComparison.Ordinal);
             Assert.Contains("--yolo", doc, StringComparison.Ordinal);
             Assert.Contains("--allow-all-paths", doc, StringComparison.Ordinal);
             Assert.Contains("Continue with limited permissions", doc, StringComparison.Ordinal);
@@ -102,12 +103,16 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("`review-context.md`", en, StringComparison.Ordinal);
         Assert.Contains("842 characters over 14 lines", en, StringComparison.Ordinal);
         Assert.Contains("G619 owns the transport-layer remedy", en, StringComparison.Ordinal);
+        Assert.Contains("Read task envelope: <path>", en, StringComparison.Ordinal);
+        Assert.Contains("absent declaration preserves existing inline delivery", en, StringComparison.Ordinal);
         Assert.Contains("never refuses or truncates", en, StringComparison.Ordinal);
         Assert.Contains("broken bracketed-paste", en, StringComparison.Ordinal);
         Assert.Contains("reference-first dispatch", ja, StringComparison.Ordinal);
         Assert.Contains("committed canonical な `review-context.md`", ja, StringComparison.Ordinal);
         Assert.Contains("842 文字・14 行", ja, StringComparison.Ordinal);
         Assert.Contains("transport-layer の remedy は G619 が担当", ja, StringComparison.Ordinal);
+        Assert.Contains("Read task envelope: <path>", ja, StringComparison.Ordinal);
+        Assert.Contains("宣言がなければ既存の inline delivery をそのまま維持", ja, StringComparison.Ordinal);
         Assert.Contains("refuse も truncate もしません", ja, StringComparison.Ordinal);
         Assert.Contains("broken bracketed-paste state", ja, StringComparison.Ordinal);
     }

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2008,6 +2008,8 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("ADVISORY only", output, StringComparison.Ordinal);
         Assert.Contains("842 characters over 14 lines", output, StringComparison.Ordinal);
         Assert.Contains("G619 owns the transport-layer remedy", output, StringComparison.Ordinal);
+        Assert.Contains("delivery_method: file-backed", output, StringComparison.Ordinal);
+        Assert.Contains("Read task envelope: <path>", output, StringComparison.Ordinal);
         Assert.Contains("FIRST TASK", output, StringComparison.Ordinal);
         Assert.Contains("Continue with limited permissions", output, StringComparison.Ordinal);
         Assert.Contains("NEVER choose `Enable all permissions`", output, StringComparison.Ordinal);
@@ -2079,7 +2081,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("no authorization makes them answerable", authorityBoundary, StringComparison.Ordinal);
 
         var unattended = provisioning.GetProperty("unattended_launch_recipes");
-        Assert.Equal(6, unattended.GetProperty("required_recipe_fields").GetArrayLength());
+        Assert.Equal(7, unattended.GetProperty("required_recipe_fields").GetArrayLength());
         Assert.Contains("silently auto-denied", unattended.GetProperty("central_autopilot_supervision_rule").GetString(), StringComparison.Ordinal);
         Assert.Contains("--add-dir <role-work-root>", unattended.GetProperty("copilot_recipe").GetProperty("invocation").GetString(), StringComparison.Ordinal);
         Assert.Contains("intent-cli notify report", unattended.GetProperty("copilot_recipe").GetProperty("role_derived_roots").GetString(), StringComparison.Ordinal);
@@ -2087,6 +2089,8 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("inline_payload_warning_chars: 4096", unattended.GetProperty("copilot_recipe").GetProperty("inline_payload_warning_profile").GetString(), StringComparison.Ordinal);
         Assert.Contains("842 characters over 14 lines", unattended.GetProperty("copilot_recipe").GetProperty("inline_payload_warning_profile").GetString(), StringComparison.Ordinal);
         Assert.Contains("G619 owns the transport-layer remedy", unattended.GetProperty("copilot_recipe").GetProperty("inline_payload_warning_profile").GetString(), StringComparison.Ordinal);
+        Assert.Contains("delivery_method: file-backed", unattended.GetProperty("copilot_recipe").GetProperty("delivery_method").GetString(), StringComparison.Ordinal);
+        Assert.Contains("absent declaration preserves existing inline delivery", unattended.GetProperty("copilot_recipe").GetProperty("delivery_method").GetString(), StringComparison.Ordinal);
         Assert.Contains("out-of-scope action is denied", unattended.GetProperty("ready_branch").GetString(), StringComparison.Ordinal);
 
         var roleInitialization = provisioning.GetProperty("role_initialization");

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -12,7 +12,7 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     private const string Domain = "intent-cli";
     private const string Team = "intent-cli-dev";
     private const string Repo = "J-Tech-Japan/intent-system";
-    private const string G594AgmsgBaselineSha256 = "4860759aacf56780abdb589355c527dccb190e8973a82a39c997cb242191dd12";
+    private const string G594AgmsgBaselineSha256 = "933a7c390d2e595abd2ad9ad1e1714b9724c9383bade883c0f650ed4c0326d3a";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -10,7 +10,7 @@ namespace IntentSystem.Cli.Tests;
 public sealed class HerdrWakeSourcesG581Tests : IDisposable
 {
     private const string G594AgmsgGuideSha256 =
-        "A39A302F1E6EF7704C225605225C8E14D5695DA425C0EE223F0883DDD964CA2A";
+        "782AA2A0F80E3E21C8D7CFFE955BF5612217D1C79FA69BE3584D65ABB848DE11";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
@@ -24,6 +24,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
         NotifyCommand.AgmsgScriptsDirectoryFactory = null;
         NotifyCommand.HerdrExecutableFactory = null;
         NotifyCommand.UtcNowFactory = null;
+        NotifyTaskEnvelopeStore.WriteOverride = null;
         workspace.Dispose();
     }
 
@@ -105,6 +106,70 @@ public sealed class NotifyCommandG578Tests : IDisposable
         Assert.Contains("size=", markdown, StringComparison.Ordinal);
         Assert.Contains("threshold=4096", markdown, StringComparison.Ordinal);
         Assert.Contains("remedy:", markdown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Delegate_FileBackedRecipe_WritesTheUnchangedEnvelopeBeforeSendingOneLinePointer_G619()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        workspace.SetImplementationDeliveryMethod("file-backed");
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        Assert.Equal("file-backed", result.GetProperty("delivery_method").GetString());
+        var taskFile = result.GetProperty("task_file").GetString()!;
+        var pointer = result.GetProperty("delivery_pointer").GetString()!;
+        Assert.True(File.Exists(taskFile));
+        Assert.Equal(result.GetProperty("payload").GetString(), File.ReadAllText(taskFile));
+        Assert.Contains("G578-demo-demo-nonce.md", taskFile, StringComparison.Ordinal);
+        Assert.Contains("TASK G578-demo", File.ReadAllText(taskFile), StringComparison.Ordinal);
+        Assert.Contains("result-nonce: demo-nonce", File.ReadAllText(taskFile), StringComparison.Ordinal);
+        Assert.StartsWith("Read task envelope: ", pointer, StringComparison.Ordinal);
+        Assert.DoesNotContain('\n', pointer);
+        Assert.DoesNotContain('\r', pointer);
+        var prompt = Assert.Single(runner.Calls, call =>
+            call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "wH:p2"]));
+        Assert.Equal(pointer, prompt.Arguments[3]);
+        Assert.DoesNotContain("TASK G578-demo", prompt.Arguments[3], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Delegate_WithoutDeliveryMethod_PreservesInlineEnvelopeByteForByte_G619()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(0, exitCode);
+        Assert.False(result.TryGetProperty("delivery_method", out _));
+        Assert.False(result.TryGetProperty("task_file", out _));
+        var prompt = Assert.Single(runner.Calls, call =>
+            call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "wH:p2"]));
+        Assert.Equal(result.GetProperty("payload").GetString(), prompt.Arguments[3]);
+    }
+
+    [Fact]
+    public void Delegate_FileBackedRecipe_FailsClosedBeforeSendingPointerWhenTaskFileWriteFails_G619()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        workspace.SetImplementationDeliveryMethod("file-backed");
+        var runner = SuccessfulRunner();
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        NotifyTaskEnvelopeStore.WriteOverride = (path, _) => new NotifyTaskEnvelopeWriteResult(false, path, "fixture denies task file write");
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("task-file-write-failed", result.GetProperty("cause").GetString());
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+        Assert.Empty(runner.Calls);
+        Assert.False(File.Exists(result.GetProperty("task_file").GetString()!));
     }
 
     [Fact]
@@ -501,6 +566,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
         public string AgmsgScriptsPath { get; }
         public string EventPath => Path.Combine(RootPath, ".intent-cli", "events", $"{Team}.jsonl");
         public CliContext Context { get; }
+        private string? implementationDeliveryMethod;
 
         private void WriteTopology()
         {
@@ -522,13 +588,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
                         workspace_id = "wH",
                         pane_id = "wH:p1",
                     },
-                    ["implementation"] = new
-                    {
-                        resident = "herdr",
-                        kind = "copilot",
-                        workspace_id = "wH",
-                        pane_id = "wH:p2",
-                    },
+                    ["implementation"] = ImplementationRole(),
                     ["review"] = new
                     {
                         resident = "herdr",
@@ -540,6 +600,29 @@ public sealed class NotifyCommandG578Tests : IDisposable
             File.WriteAllText(
                 Path.Combine(RootPath, NotifyRoleTopologyStore.RelativePath.Replace('/', Path.DirectorySeparatorChar)),
                 JsonSerializer.Serialize(topology));
+        }
+
+        public void SetImplementationDeliveryMethod(string? deliveryMethod)
+        {
+            implementationDeliveryMethod = deliveryMethod;
+            WriteTopology();
+        }
+
+        private object ImplementationRole()
+        {
+            var role = new Dictionary<string, object>
+            {
+                ["resident"] = "herdr",
+                ["kind"] = "copilot",
+                ["workspace_id"] = "wH",
+                ["pane_id"] = "wH:p2",
+            };
+            if (implementationDeliveryMethod is not null)
+            {
+                role["delivery_method"] = implementationDeliveryMethod;
+            }
+
+            return role;
         }
 
         public void SetMode(string mode)

--- a/tests/IntentSystem.Cli.Tests/SessionLayerTopologyG604Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerTopologyG604Tests.cs
@@ -113,6 +113,26 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
     }
 
     [Fact]
+    public void Record_HerdrRecipeMayDeclareFileBackedEnvelopeDelivery_G619()
+    {
+        const string team = "intent-cli-dev";
+        var context = CreateContext(Domain);
+        using var writer = new StringWriter();
+
+        Assert.Equal(0, SessionLayerTopologyCommand.ExecuteRecord(context,
+            ["--domain", Domain, "--team", team, "--role", "implementation", "--resident", "herdr",
+                "--workspace-id", "w1", "--pane-id", "w1:p2", "--cwd", "/machine-local", "--kind", "copilot",
+                "--delivery-method", "file-backed", "--write", "--format", "json"], writer));
+
+        var resolution = NotifyRoleTopologyStore.Resolve(root, Domain, team);
+        Assert.True(resolution.Resolved);
+        Assert.Equal("file-backed", resolution.Topology!.Roles["implementation"].DeliveryMethod);
+        using var record = JsonDocument.Parse(File.ReadAllText(NotifyRoleTopologyStore.ResolvePath(root, Domain, team)));
+        Assert.Equal("file-backed", record.RootElement.GetProperty("roles").GetProperty("implementation")
+            .GetProperty("delivery_method").GetString());
+    }
+
+    [Fact]
     public void DualLocationConflict_BlocksValidatePreflightAndAutomationDoctor_G604()
     {
         const string team = "intent-cli-dev";


### PR DESCRIPTION
Closes #1341

## G619 acceptance evidence

- A herdr recipient with delivery_method file-backed receives exactly one pointer line while the unchanged full delegate envelope is atomically written first under host .intent-cli/tasks/domain/team/task-id-nonce.md and remains durable for restart recovery.
- Missing delivery_method preserves existing inline transport payload and JSON shape; explicit inline does the same.
- A task-file write failure fails closed before transport creation, so no pointer can reach the pane.
- The recipe field is exposed in the unattended guide and can be recorded canonically with session-layer topology record --delivery-method inline|file-backed. EN/JA guidance stays in parity.
- G618 advisory warning, recipient identity, delivered working-transition semantics, and resend/settle behavior are unchanged.

## Verification

- focused notify/guide/docs/topology/pin suite: 173 passed
- dotnet test IntentSystem.sln --no-restore --no-build: passed
- git diff --check: passed