### PR TITLE
feat: add registry-limited topology field update

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -219,8 +219,9 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   still measures 842 characters over 14 lines and can itself be pasted. It
   reduces duplication, not a paste-sensitive wedge; G619 owns the transport-layer
   remedy.
-- **Task-envelope delivery method.** A paste-sensitive herdr seat declares
-  `delivery_method: file-backed`: `notify` writes the unchanged envelope under
+- **Task-envelope delivery method.** A paste-sensitive herdr seat with an
+  existing record declares `delivery_method: file-backed` through the
+  registry-limited topology field update: `notify` writes the unchanged envelope under
   host `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` before sending
   the pane one line, `Read task envelope: <path>`. Declare `inline` explicitly
   when desired; an absent declaration preserves existing inline delivery.
@@ -410,6 +411,7 @@ by hand:
 intent-cli session-layer topology record --domain <domain> --team <team> --role <role> --resident herdr --workspace-id <workspace-id> --pane-id <pane-id> --cwd <role-cwd> [--kind <agent-kind>] --write
 intent-cli session-layer topology record --domain <domain> --team <team> --role <role> --resident external --reader <routing-root-relative-path> [--frontend <frontend>] --write
 intent-cli session-layer topology update-kind --domain <domain> --team <team> --role <role> --current-kind <kind> --new-kind <kind> --confirm-update-kind --write
+intent-cli session-layer topology update-field --domain <domain> --team <team> --role <role> --field delivery_method --current <absent|inline|file-backed> --new <inline|file-backed> --confirm-update-field --write
 intent-cli session-layer topology retire-legacy --domain <domain> --team <team> --evidence <named-fleet-migration-evidence> --confirm-retire-legacy --write
 intent-cli session-layer topology validate --domain <domain> --team <team> --format json
 intent-cli session-layer topology show --domain <domain> --team <team> --format json
@@ -418,8 +420,8 @@ intent-cli session-layer topology show --domain <domain> --team <team> --format 
 Agent kind is whatever herdr can start: Claude, Codex, Copilot, Cursor, OpenCode,
 and others are examples, not a supported-set restriction. Logical role defaults
 are `implementation`, `review`, `interview`, and `clarify`; existing explicit
-role mappings, including legacy product-named mappings, remain valid. Both new
-mutation commands emit JSON and support only `--format json`. For `update-kind`,
+role mappings, including legacy product-named mappings, remain valid. The three
+update/retire mutation commands emit JSON and support only `--format json`. For `update-kind`,
 an explicit `--dry-run` takes precedence over `--write` in either flag order and
 never writes.
 
@@ -443,6 +445,16 @@ the mapping exists or herdr-only requires it, and notify topology refusals point
 back to `topology validate` / `record` as the remedy. Invalid state always stays
 fail-closed; these commands add knowledge and a controlled writer, never a
 fallback.
+
+`update-field` is the narrow path for declaring a field that a recorded role
+never carried, or for changing its already recorded value. It requires the
+role, the field name, the stated current value, the new value, explicit
+confirmation, and `--dry-run` or `--write`; state `--current absent` only when
+the field is actually absent. A stale statement is refused in both directions.
+The registry initially permits only `delivery_method`, so an unknown or dotted
+name is refused rather than becoming an arbitrary JSON-path editor. The command
+changes only that field. It does not relax `record`: re-recording a different
+shape still refuses its conflict and has no force flag.
 
 #### Visible, generated mode markers
 
@@ -556,8 +568,10 @@ The measured limit matters: a minimal canonical `notify delegate` envelope is
 duplicated substance; it does not prevent a paste-sensitive seat from wedging.
 G619 owns the transport-layer remedy.
 
-For a paste-sensitive herdr seat, declare `delivery_method: file-backed` in its
-recipe. `notify` writes the unchanged envelope to an addressable durable task
+For a paste-sensitive herdr seat whose recorded role lacks `delivery_method`,
+use `topology update-field` with `--field delivery_method --current absent --new
+file-backed` and explicit confirmation; use the same path with the recorded
+current value for a later allowed change. `notify` writes the unchanged envelope to an addressable durable task
 file under `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` before it
 sends the pane the single-line `Read task envelope: <path>` pointer. The file is
 not deleted, so a restarted recipient can read the same task. Declare `inline`

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -206,8 +206,8 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   remedy として扱ってはいけません。最小の canonical `notify delegate` envelope でも 842 文字・14 行で、
   これ自体が paste になります。これは重複を減らす discipline であり、paste-sensitive な wedge を防ぐ
   ものではありません。transport-layer の remedy は G619 が担当します。
-- **task-envelope delivery method。** paste-sensitive な herdr seat には
-  `delivery_method: file-backed` を宣言します。`notify` は unchanged な envelope を host の
+- **task-envelope delivery method。** existing record を持つ paste-sensitive な herdr seat では、
+  registry-limited topology field update で `delivery_method: file-backed` を宣言します。`notify` は unchanged な envelope を host の
   `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` に書いてから、pane には
   `Read task envelope: <path>` という 1 行だけを送ります。明示的に選ぶなら `inline` を宣言します。
   宣言がなければ既存の inline delivery をそのまま維持します。
@@ -381,6 +381,7 @@ foreign-workspace-only name、ambiguous mapping は prompt / append なしで fa
 intent-cli session-layer topology record --domain <domain> --team <team> --role <role> --resident herdr --workspace-id <workspace-id> --pane-id <pane-id> --cwd <role-cwd> [--kind <agent-kind>] --write
 intent-cli session-layer topology record --domain <domain> --team <team> --role <role> --resident external --reader <routing-root-relative-path> [--frontend <frontend>] --write
 intent-cli session-layer topology update-kind --domain <domain> --team <team> --role <role> --current-kind <kind> --new-kind <kind> --confirm-update-kind --write
+intent-cli session-layer topology update-field --domain <domain> --team <team> --role <role> --field delivery_method --current <absent|inline|file-backed> --new <inline|file-backed> --confirm-update-field --write
 intent-cli session-layer topology retire-legacy --domain <domain> --team <team> --evidence <named-fleet-migration-evidence> --confirm-retire-legacy --write
 intent-cli session-layer topology validate --domain <domain> --team <team> --format json
 intent-cli session-layer topology show --domain <domain> --team <team> --format json
@@ -389,7 +390,7 @@ intent-cli session-layer topology show --domain <domain> --team <team> --format 
 agent kind は herdr が起動できる任意の kind です。Claude、Codex、Copilot、Cursor、OpenCode などは
 例であり、supported-set の制約ではありません。logical role の既定値は `implementation`、`review`、
 `interview`、`clarify` です。legacy の product 名を含め、既存の明示的な role mapping はそのまま
-有効です。新しい 2 つの mutation command は JSON を出力し、`--format json` だけをサポートします。
+有効です。3 つの update/retire mutation command は JSON を出力し、`--format json` だけをサポートします。
 `update-kind` では明示した `--dry-run` が flag の順序にかかわらず `--write` より優先され、決して
 書き込みません。
 
@@ -409,6 +410,14 @@ herdr query を行いません。mapping が存在するか herdr-only が必要
 もこの health を載せ、notify の topology refusal は remedy として `topology validate` / `record`
 を示します。不正状態は常に fail closed のままです。これらは knowledge と controlled writer を
 追加するものであり、fallback は追加しません。
+
+`update-field` は、recorded role が一度も持たなかった field を宣言する場合、または既に記録された値を
+変更する場合のための狭い経路です。role、field 名、stated current value、新しい値、explicit confirmation、
+`--dry-run` または `--write` が必要です。field が実際に absent の場合に限り `--current absent` と指定します。
+古い認識にもとづく指定は両方向で refuse されます。registry が最初に許可するのは `delivery_method` だけなので、
+unknown または dotted name は任意の JSON path を編集できないよう refuse されます。この command が
+変更するのはその field だけです。`record` の conflict refusal は緩和されず、異なる shape の re-record は
+引き続き refuse され、force flag もありません。
 
 #### 可視な生成済み mode marker
 
@@ -507,8 +516,10 @@ herdr-only を内部解決し、role mapping を検証して structured task blo
 これ自体が paste になります。reference-first は重複する実体を減らしますが、paste-sensitive な seat の
 wedge を防ぐものではありません。transport-layer の remedy は G619 が担当します。
 
-paste-sensitive な herdr seat では、その recipe に `delivery_method: file-backed` を宣言します。
-`notify` は unchanged な envelope を addressable で durable な
+paste-sensitive な herdr seat の recorded role に `delivery_method` がない場合は、
+`--field delivery_method --current absent --new file-backed` と explicit confirmation を付けて
+`topology update-field` を使います。後から許可された値を変更するときも、recorded current value を指定して
+同じ経路を使います。`notify` は unchanged な envelope を addressable で durable な
 `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` に書いてから、pane へ
 `Read task envelope: <path>` という 1 行の pointer を送ります。file は削除しないため、restart
 した recipient も同じ task を読み直せます。明示的に選ぶ場合だけ `inline` を宣言し、宣言がなければ

--- a/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
@@ -15,7 +15,7 @@ internal static class SessionLayerTopologyCommand
     private const string FormatMarkdown = "markdown";
 
     private const string Usage =
-        "Usage: intent-cli session-layer topology record|show|validate|update-kind|retire-legacy [options]";
+        "Usage: intent-cli session-layer topology record|show|validate|update-kind|update-field|retire-legacy [options]";
     private const string RecordUsage =
         "Usage: intent-cli session-layer topology record --domain <name> --team <name> --role <name> --resident herdr "
         + "--workspace-id <id> --pane-id <id> --cwd <path> [--kind <kind>] [--delivery-method inline|file-backed] [--dry-run|--write] "
@@ -30,6 +30,10 @@ internal static class SessionLayerTopologyCommand
     private const string UpdateKindUsage =
         "Usage: intent-cli session-layer topology update-kind --domain <name> --team <name> --role <name> "
         + "--current-kind <kind> --new-kind <kind> --confirm-update-kind [--dry-run|--write] [--format json]";
+    private const string UpdateFieldUsage =
+        "Usage: intent-cli session-layer topology update-field --domain <name> --team <name> --role <name> "
+        + "--field delivery_method --current <value|absent> --new <value> --confirm-update-field "
+        + "[--dry-run|--write] [--format json]";
     private const string RetireLegacyUsage =
         "Usage: intent-cli session-layer topology retire-legacy --domain <name> --team <name> "
         + "--evidence <named-fleet-migration-evidence> --confirm-retire-legacy --write [--format json]";
@@ -54,6 +58,7 @@ internal static class SessionLayerTopologyCommand
             writer.WriteLine(ShowUsage);
             writer.WriteLine(ValidateUsage);
             writer.WriteLine(UpdateKindUsage);
+            writer.WriteLine(UpdateFieldUsage);
             writer.WriteLine(RetireLegacyUsage);
             return args.Length == 0 ? 1 : 0;
         }
@@ -64,6 +69,7 @@ internal static class SessionLayerTopologyCommand
             "show" => ExecuteShow(context, args[1..], writer),
             "validate" => ExecuteValidate(context, args[1..], writer),
             "update-kind" => ExecuteUpdateKind(context, args[1..], writer),
+            "update-field" => ExecuteUpdateField(context, args[1..], writer),
             "retire-legacy" => ExecuteRetireLegacy(context, args[1..], writer),
             _ => UnknownSubcommand(args[0], writer),
         };
@@ -246,6 +252,17 @@ internal static class SessionLayerTopologyCommand
         return result.Conflict ? 1 : 0;
     }
 
+    internal static int ExecuteUpdateField(CliContext context, string[] args, TextWriter writer)
+    {
+        if (!TryParseUpdateFieldArguments(args, out var request, out var error))
+        {
+            writer.WriteLine(error); writer.WriteLine(UpdateFieldUsage); return 1;
+        }
+        var result = SessionLayerTopologyWriter.UpdateField(context.RepoRoot, request!);
+        WriteJson(writer, result);
+        return result.Conflict ? 1 : 0;
+    }
+
     internal static int ExecuteRetireLegacy(CliContext context, string[] args, TextWriter writer)
     {
         if (!TryParseRetireLegacyArguments(args, out var request, out var error))
@@ -282,6 +299,34 @@ internal static class SessionLayerTopologyCommand
         // A dry-run is an explicit non-mutating request, irrespective of flag order.
         var write = requestedWrite && !requestedDryRun;
         request = new(values["--domain"], values["--team"], values["--role"], values["--current-kind"], values["--new-kind"], write);
+        return true;
+    }
+
+    private static bool TryParseUpdateFieldArguments(string[] args, out SessionLayerTopologyFieldUpdateRequest? request, out string error)
+    {
+        request = null; error = string.Empty;
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        var confirm = false; var requestedWrite = false; var requestedDryRun = false;
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i] == "--confirm-update-field") { confirm = true; continue; }
+            if (args[i] == "--write") { requestedWrite = true; continue; }
+            if (args[i] == "--dry-run") { requestedDryRun = true; continue; }
+            if (args[i] == "--format")
+            {
+                if (++i >= args.Length || !string.Equals(args[i], FormatJson, StringComparison.Ordinal))
+                { error = "update-field supports only '--format json'."; return false; }
+                continue;
+            }
+            if (args[i] is not ("--domain" or "--team" or "--role" or "--field" or "--current" or "--new") || i + 1 >= args.Length)
+            { error = $"Unknown or incomplete argument '{args[i]}'."; return false; }
+            values[args[i]] = args[++i];
+        }
+        if (!confirm || (!requestedWrite && !requestedDryRun) || values.Keys.Count != 6 || values.Values.Any(string.IsNullOrWhiteSpace))
+        { error = "--domain, --team, --role, --field, --current, --new, --confirm-update-field, and either --write or --dry-run are required."; return false; }
+        // A dry-run is an explicit non-mutating request, irrespective of flag order.
+        var write = requestedWrite && !requestedDryRun;
+        request = new(values["--domain"], values["--team"], values["--role"], values["--field"], values["--current"], values["--new"], write);
         return true;
     }
 
@@ -815,6 +860,56 @@ internal static class SessionLayerTopologyWriter
         }
     }
 
+    public static SessionLayerTopologyFieldUpdateResult UpdateField(string routingRoot, SessionLayerTopologyFieldUpdateRequest request)
+    {
+        var mode = request.Write ? "write" : "dry-run";
+        if (!string.Equals(request.Field, "delivery_method", StringComparison.Ordinal))
+            return new(request.Team, request.Role, request.Field, request.CurrentValue, request.NewValue, mode, false, false, true,
+                $"Field '{request.Field}' is not in the topology update registry. Only 'delivery_method' is allowed.");
+        if (request.NewValue is not ("inline" or "file-backed"))
+            return new(request.Team, request.Role, request.Field, request.CurrentValue, request.NewValue, mode, false, false, true,
+                $"Field 'delivery_method' must be 'inline' or 'file-backed', not '{request.NewValue}'.");
+
+        var path = NotifyRoleTopologyStore.ResolvePath(routingRoot, request.Domain, request.Team);
+        var validation = NotifyRoleTopologyStore.Validate(routingRoot, request.Domain, request.Team);
+        if (!validation.Valid)
+            return new(request.Team, request.Role, request.Field, request.CurrentValue, request.NewValue, mode, false, false, true,
+                $"Topology record is invalid; refusing update-field. {string.Join(" ", validation.Findings.Select(f => f.Message))}");
+        try
+        {
+            var root = JsonNode.Parse(File.ReadAllText(path)) as JsonObject ?? throw new JsonException("the root is not an object");
+            if (!TrySelectTeamForWrite(root, request.Team, out var team, out var error)
+                || !TrySelectRolesForWrite(team!, out var roles, out error)
+                || !roles!.TryGetPropertyValue(request.Role, out var roleNode) || roleNode is not JsonObject role)
+                return new(request.Team, request.Role, request.Field, request.CurrentValue, request.NewValue, mode, false, false, true,
+                    $"Role '{request.Role}' is not a valid recorded role. {error}");
+
+            var hasField = role.TryGetPropertyValue(request.Field, out var fieldNode);
+            var actual = hasField ? fieldNode?.GetValue<string>() : null;
+            var matches = string.Equals(request.CurrentValue, "absent", StringComparison.Ordinal)
+                ? !hasField
+                : hasField && string.Equals(actual, request.CurrentValue, StringComparison.Ordinal);
+            if (!matches)
+            {
+                var recorded = hasField ? actual ?? "invalid" : "absent";
+                return new(request.Team, request.Role, request.Field, request.CurrentValue, request.NewValue, mode, false, false, true,
+                    $"Role '{request.Role}' records {request.Field} '{recorded}', not stated current value '{request.CurrentValue}'. Refusing update-field.");
+            }
+
+            role[request.Field] = request.NewValue;
+            if (request.Write) WriteAtomically(path, root.ToJsonString(FileJsonOptions) + Environment.NewLine);
+            return new(request.Team, request.Role, request.Field, request.CurrentValue, request.NewValue, mode, request.Write, true, false,
+                request.Write
+                    ? $"Updated only {request.Field} for role '{request.Role}' in team '{request.Team}'."
+                    : $"Dry-run: would update only {request.Field} for role '{request.Role}'.");
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return new(request.Team, request.Role, request.Field, request.CurrentValue, request.NewValue, mode, false, false, true,
+                $"Topology file '{path}' could not be updated: {exception.Message}");
+        }
+    }
+
     public static SessionLayerTopologyLegacyRetireResult RetireLegacy(string routingRoot, SessionLayerTopologyLegacyRetireRequest request)
     {
         var legacyPath = NotifyRoleTopologyStore.ResolvePath(routingRoot);
@@ -1114,6 +1209,8 @@ internal sealed record SessionLayerTopologyRecordResult
 
 internal sealed record SessionLayerTopologyKindUpdateRequest(string Domain, string Team, string Role, string CurrentKind, string NewKind, bool Write);
 internal sealed record SessionLayerTopologyKindUpdateResult(string Team, string Role, string CurrentKind, string NewKind, string Mode, bool Applied, bool Changed, bool Conflict, string Summary);
+internal sealed record SessionLayerTopologyFieldUpdateRequest(string Domain, string Team, string Role, string Field, string CurrentValue, string NewValue, bool Write);
+internal sealed record SessionLayerTopologyFieldUpdateResult(string Team, string Role, string Field, string CurrentValue, string NewValue, string Mode, bool Applied, bool Changed, bool Conflict, string Summary);
 internal sealed record SessionLayerTopologyLegacyRetireRequest(string Domain, string Team, string Evidence);
 internal sealed record SessionLayerTopologyLegacyRetireResult(string Team, bool Retired, bool Conflict, string Summary);
 

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -118,6 +118,29 @@ public sealed class AgentMessageOrchestrationDocsTests
     }
 
     [Fact]
+    public void BothDocs_DescribeTheRegistryLimitedAbsentFieldUpdate_G620()
+    {
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+
+        foreach (var doc in new[] { en, ja })
+        {
+            Assert.Contains("topology update-field", doc, StringComparison.Ordinal);
+            Assert.Contains("--field delivery_method", doc, StringComparison.Ordinal);
+            Assert.Contains("--current absent", doc, StringComparison.Ordinal);
+            Assert.Contains("--confirm-update-field", doc, StringComparison.Ordinal);
+            Assert.Contains("force flag", doc, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("registry initially permits only `delivery_method`", en, StringComparison.Ordinal);
+        Assert.Contains("registry が最初に許可するのは `delivery_method` だけ", ja, StringComparison.Ordinal);
+        Assert.Contains("arbitrary JSON-path editor", en, StringComparison.Ordinal);
+        Assert.Contains("任意の JSON path を編集できない", ja, StringComparison.Ordinal);
+        Assert.Contains("stale statement is refused in both directions", en, StringComparison.Ordinal);
+        Assert.Contains("古い認識にもとづく指定は両方向で refuse", ja, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void BothDocs_SeparateDeliveryConfigFromLiveAttachment_AndKeepPingAckSoleProof_G549()
     {
         var en = ReadDoc("en");

--- a/tests/IntentSystem.Cli.Tests/SessionLayerTopologyG604Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerTopologyG604Tests.cs
@@ -206,6 +206,107 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
         Assert.Equal(beforeJson.RootElement.GetProperty("roles").GetProperty("review").GetProperty("cwd").GetString(), afterJson.RootElement.GetProperty("roles").GetProperty("review").GetProperty("cwd").GetString());
     }
 
+    [Fact]
+    public void UpdateField_DeclaresOnlyAllowedAbsentDeliveryMethodAndPreservesSiblingBytes_G620()
+    {
+        const string team = "intent-cli-dev";
+        Assert.True(Record(team, "review", "w1:p1").Applied);
+        var context = CreateContext(Domain);
+        var path = NotifyRoleTopologyStore.ResolvePath(root, Domain, team);
+        var before = File.ReadAllText(path);
+
+        using var missingConfirmation = new StringWriter();
+        Assert.Equal(1, SessionLayerTopologyCommand.ExecuteUpdateField(context,
+            ["--domain", Domain, "--team", team, "--role", "review", "--field", "delivery_method", "--current", "absent", "--new", "file-backed", "--write"], missingConfirmation));
+        Assert.Equal(before, File.ReadAllText(path));
+
+        using var output = new StringWriter();
+        Assert.Equal(0, SessionLayerTopologyCommand.ExecuteUpdateField(context,
+            ["--domain", Domain, "--team", team, "--role", "review", "--field", "delivery_method", "--current", "absent", "--new", "file-backed", "--confirm-update-field", "--write"], output));
+
+        using var beforeJson = JsonDocument.Parse(before);
+        using var afterJson = JsonDocument.Parse(File.ReadAllText(path));
+        var beforeRole = beforeJson.RootElement.GetProperty("roles").GetProperty("review");
+        var afterRole = afterJson.RootElement.GetProperty("roles").GetProperty("review");
+        Assert.Equal("file-backed", afterRole.GetProperty("delivery_method").GetString());
+        foreach (var sibling in beforeRole.EnumerateObject())
+            Assert.Equal(sibling.Value.GetRawText(), afterRole.GetProperty(sibling.Name).GetRawText());
+
+        using var result = JsonDocument.Parse(output.ToString());
+        Assert.Equal("delivery_method", result.RootElement.GetProperty("field").GetString());
+        Assert.True(result.RootElement.GetProperty("applied").GetBoolean());
+        Assert.False(result.RootElement.GetProperty("conflict").GetBoolean());
+
+        var strictRecord = SessionLayerTopologyWriter.Record(root, new SessionLayerTopologyRecordRequest
+        {
+            Domain = Domain, Team = team, Role = "review", Resident = NotifyRecordedRole.HerdrResident,
+            WorkspaceId = "w1", PaneId = "w1:p1", Cwd = "/machine-local", Kind = "codex",
+            DeliveryMethod = "inline", Write = true, Format = "json",
+        });
+        Assert.True(strictRecord.Conflict);
+        Assert.Contains("conflict", strictRecord.Summary, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UpdateField_RefusesBothStaleCurrentDirectionsAndUnregisteredNames_G620()
+    {
+        const string team = "intent-cli-dev";
+        Assert.True(Record(team, "review", "w1:p1").Applied);
+        var context = CreateContext(Domain);
+        var path = NotifyRoleTopologyStore.ResolvePath(root, Domain, team);
+        var before = File.ReadAllText(path);
+
+        using var valueWhenAbsent = new StringWriter();
+        Assert.Equal(1, SessionLayerTopologyCommand.ExecuteUpdateField(context,
+            ["--domain", Domain, "--team", team, "--role", "review", "--field", "delivery_method", "--current", "inline", "--new", "file-backed", "--confirm-update-field", "--write"], valueWhenAbsent));
+        Assert.Contains("absent", valueWhenAbsent.ToString(), StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllText(path));
+
+        using var declare = new StringWriter();
+        Assert.Equal(0, SessionLayerTopologyCommand.ExecuteUpdateField(context,
+            ["--domain", Domain, "--team", team, "--role", "review", "--field", "delivery_method", "--current", "absent", "--new", "inline", "--confirm-update-field", "--write"], declare));
+        var withDeclaredValue = File.ReadAllText(path);
+
+        using var absentWhenValue = new StringWriter();
+        Assert.Equal(1, SessionLayerTopologyCommand.ExecuteUpdateField(context,
+            ["--domain", Domain, "--team", team, "--role", "review", "--field", "delivery_method", "--current", "absent", "--new", "file-backed", "--confirm-update-field", "--write"], absentWhenValue));
+        Assert.Contains("inline", absentWhenValue.ToString(), StringComparison.Ordinal);
+        Assert.Equal(withDeclaredValue, File.ReadAllText(path));
+
+        foreach (var field in new[] { "kind", "roles.review.delivery_method" })
+        {
+            using var unregistered = new StringWriter();
+            Assert.Equal(1, SessionLayerTopologyCommand.ExecuteUpdateField(context,
+                ["--domain", Domain, "--team", team, "--role", "review", "--field", field, "--current", "absent", "--new", "file-backed", "--confirm-update-field", "--write"], unregistered));
+            using var refusal = JsonDocument.Parse(unregistered.ToString());
+            Assert.Equal(field, refusal.RootElement.GetProperty("field").GetString());
+            Assert.Contains("registry", refusal.RootElement.GetProperty("summary").GetString(), StringComparison.Ordinal);
+            Assert.Equal(withDeclaredValue, File.ReadAllText(path));
+        }
+    }
+
+    [Theory]
+    [InlineData("--dry-run", "--write")]
+    [InlineData("--write", "--dry-run")]
+    public void UpdateField_DryRunAlwaysWinsAndUsesTheSameAbsentComparison_G620(string firstModeFlag, string secondModeFlag)
+    {
+        const string team = "intent-cli-dev";
+        Assert.True(Record(team, "review", "w1:p1").Applied);
+        var context = CreateContext(Domain);
+        var path = NotifyRoleTopologyStore.ResolvePath(root, Domain, team);
+        var before = File.ReadAllText(path);
+
+        using var output = new StringWriter();
+        Assert.Equal(0, SessionLayerTopologyCommand.ExecuteUpdateField(context,
+            ["--domain", Domain, "--team", team, "--role", "review", "--field", "delivery_method", "--current", "absent", "--new", "file-backed", "--confirm-update-field", firstModeFlag, secondModeFlag], output));
+
+        Assert.Equal(before, File.ReadAllText(path));
+        using var result = JsonDocument.Parse(output.ToString());
+        Assert.Equal("dry-run", result.RootElement.GetProperty("mode").GetString());
+        Assert.False(result.RootElement.GetProperty("applied").GetBoolean());
+        Assert.True(result.RootElement.GetProperty("changed").GetBoolean());
+    }
+
     [Theory]
     [InlineData("--dry-run", "--write")]
     [InlineData("--write", "--dry-run")]
@@ -241,6 +342,12 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
         Assert.Equal(1, SessionLayerTopologyCommand.ExecuteUpdateKind(context,
             ["--domain", Domain, "--team", team, "--role", "review", "--current-kind", "codex", "--new-kind", "copilot", "--confirm-update-kind", "--dry-run", "--format", "markdown"], updateMarkdown));
         Assert.Contains("only '--format json'", updateMarkdown.ToString(), StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllText(path));
+
+        using var updateFieldMarkdown = new StringWriter();
+        Assert.Equal(1, SessionLayerTopologyCommand.ExecuteUpdateField(context,
+            ["--domain", Domain, "--team", team, "--role", "review", "--field", "delivery_method", "--current", "absent", "--new", "file-backed", "--confirm-update-field", "--dry-run", "--format", "markdown"], updateFieldMarkdown));
+        Assert.Contains("only '--format json'", updateFieldMarkdown.ToString(), StringComparison.Ordinal);
         Assert.Equal(before, File.ReadAllText(path));
 
         using var retireMarkdown = new StringWriter();


### PR DESCRIPTION
Closes #1343

## G620 contract
- Adds session-layer topology update-field, requiring domain, team, role, registry field, stated current value (including absent), new value, explicit confirmation, and dry-run or write.
- The registry admits only delivery_method; unknown and dotted names are refused. The field accepts only inline or file-backed and preserves every sibling field raw JSON value.
- Stale current values refuse in both directions. Dry-run wins over write in either flag order.
- record was not changed and remains strict/idempotent; update-kind, recipient identity, and delivery semantics are unchanged.
- EN/JA doc 12 explains the absent-field declaration path, why the registry exists, and why record conflict refusal remains.

## Verification
- Focused SessionLayerTopologyG604Tests and AgentMessageOrchestrationDocsTests: 37 passed.
- Full: dotnet test IntentSystem.sln --no-restore --verbosity quiet passed.
- git diff --check clean.

## Post-merge adoption
The issue requires the existing Copilot review seat to declare delivery_method file-backed after this command is merged. This child PR intentionally does not inspect or mutate host machine-local topology before merge. The required operator verification is: update the recorded role with current=absent and new=file-backed, then use canonical notify to measure the one-line pane pointer and confirm the durable task file exists before that pointer is sent. Existing G619 coverage pins file-before-pointer delivery; G620 coverage pins the new declaration path.