### PR TITLE
G625: report only resolved workflow state

### DIFF
--- a/docs/en/04-packets-issues.md
+++ b/docs/en/04-packets-issues.md
@@ -48,6 +48,9 @@ intent-cli packet draft --execution-unit <id> --target-repo <owner>/<repo> --for
 # Enforce the Standalone Child Issue Contract, then publish
 intent-cli issue validate-body ...
 intent-cli issue publish-flow <id> --repo <owner>/<repo> --write --format json
+# Apply intent-target by either the recorded unit or its issue number
+intent-cli automation issue-publish --execution-unit <id> --write --format json
+# Equivalent alternate when the issue number is already known:
 intent-cli automation issue-publish --issue <n> --write --format json
 ```
 

--- a/docs/ja/04-packets-issues.md
+++ b/docs/ja/04-packets-issues.md
@@ -48,6 +48,9 @@ intent-cli packet draft --execution-unit <id> --target-repo <owner>/<repo> --for
 # Standalone Child Issue Contract を検証してから公開
 intent-cli issue validate-body ...
 intent-cli issue publish-flow <id> --repo <owner>/<repo> --write --format json
+# 記録済み unit または issue 番号で intent-target を付与
+intent-cli automation issue-publish --execution-unit <id> --write --format json
+# issue 番号が既知の場合の同等な代替:
 intent-cli automation issue-publish --issue <n> --write --format json
 ```
 

--- a/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssuePublishCommand.cs
@@ -52,6 +52,7 @@ internal static class AutomationIssuePublishCommand
                 out var repo,
                 out var workdir,
                 out var issue,
+                out var executionUnit,
                 out var mode,
                 out var format,
                 out var allowHostOnlyOverride,
@@ -62,6 +63,24 @@ internal static class AutomationIssuePublishCommand
         }
 
         var resolvedWorkdir = WorkdirResolver.Resolve(context, workdir);
+        if (!string.IsNullOrWhiteSpace(executionUnit))
+        {
+            if (!TryResolveIssueFromExecutionUnit(resolvedWorkdir, executionUnit, out var resolvedIssue, out error))
+            {
+                writer.WriteLine(error);
+                return 1;
+            }
+
+            if (issue.HasValue && issue.Value != resolvedIssue)
+            {
+                writer.WriteLine($"--issue {issue.Value} disagrees with --execution-unit '{executionUnit}': "
+                    + $"publish.yaml records created_issue_number {resolvedIssue}.");
+                return 1;
+            }
+
+            issue = resolvedIssue;
+        }
+
         if (string.IsNullOrWhiteSpace(repo)
             && !AutomationCheckCommand.TryInferGitHubRepo(resolvedWorkdir, out repo, out error))
         {
@@ -211,6 +230,7 @@ internal static class AutomationIssuePublishCommand
         out string? repo,
         out string? workdir,
         out int? issue,
+        out string? executionUnit,
         out string mode,
         out string format,
         out bool allowHostOnlyOverride,
@@ -219,6 +239,7 @@ internal static class AutomationIssuePublishCommand
         repo = null;
         workdir = null;
         issue = null;
+        executionUnit = null;
         mode = WorkerClaimCompleteConstants.Modes.DryRun;
         format = FormatText;
         allowHostOnlyOverride = false;
@@ -258,6 +279,16 @@ internal static class AutomationIssuePublishCommand
                     index++;
                     break;
 
+                case "--execution-unit":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--execution-unit requires a value.";
+                        return false;
+                    }
+                    executionUnit = args[index + 1].Trim();
+                    index++;
+                    break;
+
                 case "--write":
                     mode = WorkerClaimCompleteConstants.Modes.Write;
                     break;
@@ -292,17 +323,66 @@ internal static class AutomationIssuePublishCommand
                     return false;
 
                 default:
-                    error = $"Unknown argument '{argument}'. Supported: [--repo <owner/repo>] [--workdir <path>] --issue <n> [--write] [--dry-run] [--format text|json].";
+                    error = $"Unknown argument '{argument}'. Supported: [--repo <owner/repo>] [--workdir <path>] (--issue <n>|--execution-unit <id>) [--write] [--dry-run] [--format text|json].";
                     return false;
             }
         }
 
-        if (issue is null)
+        if (issue is null && string.IsNullOrWhiteSpace(executionUnit))
         {
-            error = "--issue is required.";
+            error = "--issue or --execution-unit is required.";
             return false;
         }
 
+        return true;
+    }
+
+    private static bool TryResolveIssueFromExecutionUnit(
+        string workdir,
+        string executionUnit,
+        out int issue,
+        out string error)
+    {
+        issue = 0;
+        if (!KnowledgeWriteBackRecord.TryValidateExecutionUnit(executionUnit, out error))
+        {
+            return false;
+        }
+
+        var relativeArtifactPath = IssuePublishArtifactPathResolver.Resolve(executionUnit);
+        var artifactPath = Path.Combine(workdir, relativeArtifactPath.Replace('/', Path.DirectorySeparatorChar));
+        if (!File.Exists(artifactPath))
+        {
+            error = $"--execution-unit '{executionUnit}' has no publish.yaml at '{relativeArtifactPath}'.";
+            return false;
+        }
+
+        IssuePublishArtifact artifact;
+        try
+        {
+            artifact = IssuePublishArtifactYaml.Deserialize(File.ReadAllText(artifactPath));
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or ArgumentException)
+        {
+            error = $"--execution-unit '{executionUnit}' publish.yaml could not be read: {exception.Message}";
+            return false;
+        }
+
+        if (!string.Equals(artifact.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+        {
+            error = $"--execution-unit '{executionUnit}' does not match publish.yaml execution_unit "
+                + $"'{artifact.ExecutionUnit}'.";
+            return false;
+        }
+
+        if (!artifact.CreatedIssueNumber.HasValue || artifact.CreatedIssueNumber.Value <= 0)
+        {
+            error = $"--execution-unit '{executionUnit}' publish.yaml is missing created_issue_number.";
+            return false;
+        }
+
+        issue = artifact.CreatedIssueNumber.Value;
+        error = string.Empty;
         return true;
     }
 
@@ -347,7 +427,7 @@ internal static class AutomationIssuePublishCommand
     private static void WriteHelp(TextWriter writer)
     {
         writer.WriteLine("automation issue-publish");
-        writer.WriteLine("Usage: intent-cli automation issue-publish --repo <owner/repo> --issue <n> [--write] [--dry-run] [--format text|json]");
+        writer.WriteLine("Usage: intent-cli automation issue-publish --repo <owner/repo> (--issue <n>|--execution-unit <id>) [--write] [--dry-run] [--format text|json]");
         writer.WriteLine("Publishes a child issue by applying the host-owned intent-target transition.");
     }
 }

--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -307,8 +307,15 @@ internal static class CloseoutPrCommand
             nextSteps.Add("Confirm and close the linked issue if one exists (linked_issue not set in queue state).");
         }
 
-        nextSteps.Add($"Sync the parent submodule pointer for {repo} to the merge commit (manual step: git -C submodules/<child> fetch && git -C submodules/<child> reset --hard <merge-sha>; git add submodules/<child>).");
-        nextSteps.Add("Commit and push the parent durable state (queue-state, runs, submodule pointer).");
+        if (HasConfiguredSubmodules(context.RepoRoot))
+        {
+            nextSteps.Add($"Sync the parent submodule pointer for {repo} to the merge commit (manual step: git -C submodules/<child> fetch && git -C submodules/<child> reset --hard <merge-sha>; git add submodules/<child>).");
+            nextSteps.Add("Commit and push the parent durable state (queue-state, runs, submodule pointer).");
+        }
+        else
+        {
+            nextSteps.Add("Commit and push the parent durable state (queue-state, runs).");
+        }
 
         var result = new CloseoutPrResult
         {
@@ -335,6 +342,27 @@ internal static class CloseoutPrCommand
 
         EmitResult(writer, result, format);
         return 0;
+    }
+
+    private static bool HasConfiguredSubmodules(string repoRoot)
+    {
+        var gitmodulesPath = Path.Combine(repoRoot, ".gitmodules");
+        if (!File.Exists(gitmodulesPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            return File.ReadLines(gitmodulesPath)
+                .Any(line => line.TrimStart().StartsWith("[submodule ", StringComparison.Ordinal));
+        }
+        catch (IOException)
+        {
+            // A closeout plan must not claim a submodule sync step it could not
+            // establish from the host layout.
+            return false;
+        }
     }
 
     private static bool MatchesLinkedPr(QueueItem item, string repo, string prToken)

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -94,10 +94,10 @@ internal static class GuideOrchestratorThreadCommand
         var requestedDomain = string.Equals(values["<domain>"], "<domain>", StringComparison.Ordinal)
             ? null
             : values["<domain>"];
-        var preflight = SessionLayerPreflight.Analyze(
-            context.RepoRoot,
-            requestedDomain,
-            requestedTeam);
+        var modeResolved = requestedDomain is not null;
+        var preflight = modeResolved
+            ? SessionLayerPreflight.Analyze(context.RepoRoot, requestedDomain, requestedTeam)
+            : SessionLayerPreflight.AnonymousUnjudged();
         if (string.Equals(preflight.Verdict, SessionLayerPreflight.CannotDetermine, StringComparison.Ordinal))
         {
             writer.WriteLine($"session-layer-mode-unreadable: {preflight.Summary}");
@@ -110,7 +110,18 @@ internal static class GuideOrchestratorThreadCommand
         }
 
         SessionLayerModeResolution sessionLayer;
-        if (requestedTeam is not null)
+        if (!modeResolved)
+        {
+            // The generic document remains useful for non-transport duties,
+            // but a missing scope must not be represented as a resolved
+            // default or as the host's recorded mode.
+            sessionLayer = new SessionLayerModeResolution
+            {
+                Mode = SessionLayerMode.Default,
+                Source = SessionLayerModeSource.Default,
+            };
+        }
+        else if (requestedTeam is not null)
         {
             sessionLayer = preflight.Scopes.Single().Resolution!;
         }
@@ -123,7 +134,8 @@ internal static class GuideOrchestratorThreadCommand
             BuildGuide(values, sessionLayer.IsHerdrOnly),
             sessionLayer,
             values,
-            preflight);
+            preflight,
+            modeResolved);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {
@@ -160,7 +172,8 @@ internal static class GuideOrchestratorThreadCommand
         OrchestratorThreadGuide guide,
         SessionLayerModeResolution sessionLayer,
         IReadOnlyDictionary<string, string> values,
-        SessionLayerPreflightResult? preflight = null)
+        SessionLayerPreflightResult? preflight = null,
+        bool modeResolved = true)
     {
         preflight ??= SessionLayerPreflight.AnonymousUnjudged();
         var teamOmission = SessionLayerTeamOmissionDisclosure.Create(
@@ -171,9 +184,14 @@ internal static class GuideOrchestratorThreadCommand
                 + $"--target-repo {values["<owner/repo>"]} --agent {values["<agent>"]} --team {entry.Team}");
         var block = new OrchestratorSessionLayer
         {
-            Mode = sessionLayer.Mode,
-            Source = sessionLayer.Source == SessionLayerModeSource.Recorded ? "recorded" : "default",
-            Summary = teamOmission is not null
+            Mode = modeResolved ? sessionLayer.Mode : "not-resolved",
+            Source = modeResolved
+                ? sessionLayer.Source == SessionLayerModeSource.Recorded ? "recorded" : "default"
+                : "not-resolved",
+            Summary = !modeResolved
+                ? "Session layer: not resolved — no `--domain` was supplied, so this guide did not consult a recorded "
+                    + "mode or assert a default. Pass `--domain <name>` to render transport-specific guidance."
+                : teamOmission is not null
                 ? $"Session layer: {SessionLayerMode.Describe(sessionLayer.Mode)} — in force for this invocation "
                     + "because no team scope was supplied; team-scoped records are disclosed below."
                 : sessionLayer.Source == SessionLayerModeSource.Recorded
@@ -194,7 +212,10 @@ internal static class GuideOrchestratorThreadCommand
                 + " --mode agmsg|herdr-only --write` changes it, "
                 + "reversibly, in both directions.",
             Preflight = preflight,
-            ResidualAgmsgMechanics = sessionLayer.IsHerdrOnly
+            ResidualAgmsgMechanics = !modeResolved
+                ? "UNRESOLVED SESSION LAYER: do not treat any transport-specific section in this unscoped guide as "
+                    + "operative. Re-run with `--domain <name>` before following a session-layer procedure."
+                : sessionLayer.IsHerdrOnly
                 ? "HERDR-ONLY: the agmsg-only sections of this guide are REPLACED, whole, by the concrete herdr-only "
                     + "operating sections below. Retained sections carry mode-independent duties, but transport-specific "
                     + "examples in them govern only their named transport; the concrete herdr-only counterparts below "

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -224,7 +224,10 @@ internal static class GuideOrchestratorThreadCommand
             TeamOmission = teamOmission,
         };
 
-        var intakeNote = teamOmission is not null
+        var intakeNote = !modeResolved
+            ? "Session layer: not resolved — no `--domain` was supplied, so this guide did not consult a recorded "
+                + "mode or assert a default. Pass `--domain <name>` before following a session-layer procedure."
+            : teamOmission is not null
             ? teamOmission.Summary + " " + string.Join(
                 " ",
                 teamOmission.CorrectiveCommands.Select(correction => $"`{correction.Command}`"))
@@ -256,7 +259,7 @@ internal static class GuideOrchestratorThreadCommand
             SessionLayer = block,
             SetupIntake = setupIntake with
             {
-                SessionLayerMode = sessionLayer.Mode,
+                SessionLayerMode = modeResolved ? sessionLayer.Mode : "not-resolved",
                 SessionLayerNote = intakeNote,
             },
         };

--- a/src/IntentSystem.Cli/Commands/PreparedPacketCommitReadyAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/PreparedPacketCommitReadyAnalyzer.cs
@@ -154,7 +154,8 @@ internal static class PreparedPacketCommitReadyAnalyzer
             Refuse(
                 ReasonMissingCanonicalFile,
                 "missing canonical file(s): " + string.Join(", ", missing),
-                "Author every missing canonical file, preserving the four-file packet contract: "
+                "Run `intent-cli packet draft --execution-unit <id> --target-repo <owner/repo> --format json` to author "
+                    + "the missing canonical files, preserving the four-file packet contract: "
                     + string.Join(", ", missing) + ".");
         }
 

--- a/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
@@ -243,6 +243,12 @@ internal static class SessionLayerTopologyCommand
 
     internal static int ExecuteUpdateKind(CliContext context, string[] args, TextWriter writer)
     {
+        if (IsHelp(args))
+        {
+            writer.WriteLine(UpdateKindUsage);
+            return 0;
+        }
+
         if (!TryParseUpdateKindArguments(args, out var request, out var error))
         {
             writer.WriteLine(error); writer.WriteLine(UpdateKindUsage); return 1;
@@ -254,6 +260,12 @@ internal static class SessionLayerTopologyCommand
 
     internal static int ExecuteUpdateField(CliContext context, string[] args, TextWriter writer)
     {
+        if (IsHelp(args))
+        {
+            writer.WriteLine(UpdateFieldUsage);
+            return 0;
+        }
+
         if (!TryParseUpdateFieldArguments(args, out var request, out var error))
         {
             writer.WriteLine(error); writer.WriteLine(UpdateFieldUsage); return 1;
@@ -265,6 +277,12 @@ internal static class SessionLayerTopologyCommand
 
     internal static int ExecuteRetireLegacy(CliContext context, string[] args, TextWriter writer)
     {
+        if (IsHelp(args))
+        {
+            writer.WriteLine(RetireLegacyUsage);
+            return 0;
+        }
+
         if (!TryParseRetireLegacyArguments(args, out var request, out var error))
         {
             writer.WriteLine(error); writer.WriteLine(RetireLegacyUsage); return 1;

--- a/tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationIssuePublishCommandTests.cs
@@ -186,7 +186,65 @@ public sealed class AutomationIssuePublishCommandTests : IDisposable
             writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("--issue is required", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--issue or --execution-unit is required", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ExecutionUnitResolvesRecordedIssueNumber_G625()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+        workspace.WritePublishArtifact("G625", 557);
+        var mutator = new FakeMutator();
+        AutomationIssuePublishCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--execution-unit", "G625", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<AutomationIssuePublishResult>(writer.ToString())!;
+        Assert.Equal(557, result.Issue);
+        Assert.Equal(557, Assert.Single(mutator.AppliedTransitions).Number);
+    }
+
+    [Fact]
+    public void Execute_ExecutionUnitAndIssueDisagreementFailsClosed_G625()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+        workspace.WritePublishArtifact("G625", 557);
+        var mutator = new FakeMutator();
+        AutomationIssuePublishCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--execution-unit", "G625", "--issue", "558"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--issue 558", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--execution-unit 'G625'", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("created_issue_number 557", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_ExecutionUnitWithoutRecordedIssueRefusesNamingMissingField_G625()
+    {
+        using var workspace = new AutomationIssuePublishWorkspace();
+        workspace.WritePublishArtifact("G625", null);
+
+        using var writer = new StringWriter();
+        var exitCode = AutomationIssuePublishCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--execution-unit", "G625"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("G625", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("created_issue_number", writer.ToString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -355,6 +413,22 @@ public sealed class AutomationIssuePublishCommandTests : IDisposable
                 [remote "origin"]
                     url = {remoteUrl}
                 """);
+        }
+
+        public void WritePublishArtifact(string executionUnit, int? createdIssueNumber)
+        {
+            var directory = Path.Combine(RootPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, "publish.yaml"), IssuePublishArtifactYaml.Serialize(new IssuePublishArtifact
+            {
+                ExecutionUnit = executionUnit,
+                PublishStatus = "issue-created",
+                PacketPath = $".intent-cli/issues/{executionUnit}/packet.yaml",
+                IssueBodyPath = $".intent-cli/issues/{executionUnit}/github-body.md",
+                CreatedIssueNumber = createdIssueNumber,
+                CreatedIssueUrl = createdIssueNumber is null ? null : $"https://github.com/J-Tech-Japan/intent-system/issues/{createdIssueNumber}",
+                PublishedLabelName = null,
+            }));
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/AutomationQueueSeedFromPacketCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationQueueSeedFromPacketCommandTests.cs
@@ -248,6 +248,10 @@ public sealed class AutomationQueueSeedFromPacketCommandTests : IDisposable
         Assert.Equal(
             PreparedPacketCommitReadyAnalyzer.ReasonMissingCanonicalFile,
             doc.RootElement.GetProperty("unsafe_reason").GetString());
+        Assert.Contains(
+            "intent-cli packet draft --execution-unit <id>",
+            string.Join(' ', doc.RootElement.GetProperty("recommended_actions").EnumerateArray().Select(action => action.GetString())),
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
@@ -550,6 +550,42 @@ public sealed class CloseoutPrCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_WithoutSubmodules_OmitsSubmoduleSteps_G625()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G625", "review", linkedIssueNumber: 639));
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "640", "--issue", "639", "--dry-run", "--format", "json"],
+            writer));
+
+        var nextSteps = JsonDocument.Parse(writer.ToString()).RootElement.GetProperty("next_steps")
+            .EnumerateArray().Select(element => element.GetString()!).ToArray();
+        Assert.DoesNotContain(nextSteps, step => step.Contains("submodule", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(nextSteps, step => step.Contains("queue-state, runs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_WithSubmodules_IncludesSubmoduleSteps_G625()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueStateWithLinkedIssue("G625", "review", linkedIssueNumber: 639));
+        File.WriteAllText(Path.Combine(workspace.Context.RepoRoot, ".gitmodules"), "[submodule \"child\"]\n\tpath = submodules/child\n");
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "640", "--issue", "639", "--dry-run", "--format", "json"],
+            writer));
+
+        var nextSteps = JsonDocument.Parse(writer.ToString()).RootElement.GetProperty("next_steps")
+            .EnumerateArray().Select(element => element.GetString()!).ToArray();
+        Assert.Contains(nextSteps, step => step.Contains("Sync the parent submodule pointer", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Execute_GivenIssueFlagWithBothLinkedPrAndIssuePresent_PrefersLinkedPrMatch()
     {
         using var workspace = new CloseoutPrWorkspace();

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2710,16 +2710,36 @@ public sealed class GuideOrchestratorThreadCommandTests
     [Fact]
     public void Execute_WithoutDomainReportsSessionLayerNotResolved_G625()
     {
-        using var workspace = new RecordedGuideWorkspace("intent-cli", "intent-cli-dev");
+        using var workspace = new RecordedGuideWorkspace("intent-cli", "intent-cli-dev", SessionLayerMode.HerdrOnly);
 
         var output = RunMarkdown(workspace.Context,
             ["--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
         var sessionLayer = SectionFrom(output, "## Session layer");
+        var setupIntake = SectionFrom(output, "## Setup intake");
 
         Assert.Contains("Session layer: not resolved", sessionLayer, StringComparison.Ordinal);
         Assert.Contains("--domain <name>", sessionLayer, StringComparison.Ordinal);
         Assert.DoesNotContain("no selection recorded, so the default is in force", sessionLayer, StringComparison.Ordinal);
         Assert.DoesNotContain("recorded for this domain/team", sessionLayer, StringComparison.Ordinal);
+        Assert.Contains("Session layer: not resolved", setupIntake, StringComparison.Ordinal);
+        Assert.Contains("--domain <name>", setupIntake, StringComparison.Ordinal);
+        Assert.DoesNotContain("Recorded session layer for this setup", setupIntake, StringComparison.Ordinal);
+        Assert.DoesNotContain("default — nothing recorded yet", setupIntake, StringComparison.Ordinal);
+
+        using var writer = new StringWriter();
+        var exitCode = GuideOrchestratorThreadCommand.Execute(
+            workspace.Context,
+            ["--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude", "--format", "json"],
+            writer);
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var intake = document.RootElement.GetProperty("setup_intake");
+        Assert.Equal("not-resolved", intake.GetProperty("session_layer_mode").GetString());
+        var intakeNote = intake.GetProperty("session_layer_note").GetString()!;
+        Assert.Contains("Session layer: not resolved", intakeNote, StringComparison.Ordinal);
+        Assert.Contains("--domain <name>", intakeNote, StringComparison.Ordinal);
+        Assert.DoesNotContain("Recorded session layer for this setup", intakeNote, StringComparison.Ordinal);
+        Assert.DoesNotContain("default — nothing recorded yet", intakeNote, StringComparison.Ordinal);
     }
 
     private static string RunMarkdown(CliContext context, string[] args)
@@ -2733,7 +2753,7 @@ public sealed class GuideOrchestratorThreadCommandTests
 
     private sealed class RecordedGuideWorkspace : IDisposable
     {
-        public RecordedGuideWorkspace(string domain, string team)
+        public RecordedGuideWorkspace(string domain, string team, string mode = SessionLayerMode.Agmsg)
         {
             RootPath = Directory.CreateTempSubdirectory("guide-recorded-session-g594-").FullName;
             Context = new CliContext
@@ -2752,7 +2772,7 @@ public sealed class GuideOrchestratorThreadCommandTests
             using var writer = new StringWriter();
             var exitCode = SessionLayerCommand.ExecuteSet(
                 Context,
-                ["--domain", domain, "--team", team, "--mode", SessionLayerMode.Agmsg, "--write", "--format", "json"],
+                ["--domain", domain, "--team", team, "--mode", mode, "--write", "--format", "json"],
                 writer);
             Assert.True(exitCode == 0, writer.ToString());
         }

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2707,6 +2707,21 @@ public sealed class GuideOrchestratorThreadCommandTests
     private static string RunMarkdown(string[] args)
         => RunMarkdown(CreateContext(), args);
 
+    [Fact]
+    public void Execute_WithoutDomainReportsSessionLayerNotResolved_G625()
+    {
+        using var workspace = new RecordedGuideWorkspace("intent-cli", "intent-cli-dev");
+
+        var output = RunMarkdown(workspace.Context,
+            ["--target-repo", "J-Tech-Japan/intent-system", "--agent", "claude"]);
+        var sessionLayer = SectionFrom(output, "## Session layer");
+
+        Assert.Contains("Session layer: not resolved", sessionLayer, StringComparison.Ordinal);
+        Assert.Contains("--domain <name>", sessionLayer, StringComparison.Ordinal);
+        Assert.DoesNotContain("no selection recorded, so the default is in force", sessionLayer, StringComparison.Ordinal);
+        Assert.DoesNotContain("recorded for this domain/team", sessionLayer, StringComparison.Ordinal);
+    }
+
     private static string RunMarkdown(CliContext context, string[] args)
     {
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/SessionLayerTopologyG604Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerTopologyG604Tests.cs
@@ -356,6 +356,24 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
         Assert.Contains("only '--format json'", retireMarkdown.ToString(), StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("record", "Usage: intent-cli session-layer topology record")]
+    [InlineData("show", "Usage: intent-cli session-layer topology show")]
+    [InlineData("validate", "Usage: intent-cli session-layer topology validate")]
+    [InlineData("update-kind", "Usage: intent-cli session-layer topology update-kind")]
+    [InlineData("update-field", "Usage: intent-cli session-layer topology update-field")]
+    [InlineData("retire-legacy", "Usage: intent-cli session-layer topology retire-legacy")]
+    public void TopologySubcommands_AcceptHelpWithoutError_G625(string subcommand, string usage)
+    {
+        using var writer = new StringWriter();
+
+        var exitCode = SessionLayerTopologyCommand.Execute(CreateContext(Domain), [subcommand, "--help"], writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains(usage, writer.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("Unknown", writer.ToString(), StringComparison.Ordinal);
+    }
+
     [Fact]
     public void G614_DocumentationAndRenderedGuideKeepAgentKindsNeutral_G614()
     {


### PR DESCRIPTION
Closes #1353

## G625
- Accept `automation issue-publish --execution-unit` and resolve the recorded `created_issue_number`, with fail-closed disagreement and missing-number errors.
- Make an unscoped orchestrator guide report its session layer as not resolved; add topology subcommand help and packet-draft repair guidance.
- Emit closeout submodule sync steps only for a host with configured submodules.

## Verification
- Focused CLI suites: 201 passed.
- `dotnet test IntentSystem.sln --no-restore --verbosity quiet`
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore`
- `git diff --check`