### PR TITLE
G627: retire legacy topology compatibility read

### DIFF
--- a/docs/en/1.0-compatibility-ledger.md
+++ b/docs/en/1.0-compatibility-ledger.md
@@ -197,7 +197,7 @@ Every `cause` value actually emitted in a machine-consumed JSON payload is cover
 | per-team topology record | Canonical team topology record and its identity/path validation | `stable-at-1.0` | Record-first; no inferred mode change. |
 | judgment-wait record | `.intent-cli/operator-attention.json`; `open` → `resolved` or `superseded` | `stable-at-1.0` | G623 names the general durable record; its on-disk format and identifiers remain unchanged. |
 | operator-attention command alias | Alias for `judgment-wait`; no record schema or identifier change | `deprecate-with-alias` | Structured `deprecation_warning` names the replacement; alias is retained through 1.x and removal is only next MAJOR. |
-| role-pane-mapping compatibility read | Legacy fixed-file read when the current per-team record is absent | `retain-through-1.x` | G604 migration/re-record evidence is required before any retirement is eligible. |
+| role-pane-mapping compatibility read | Removed legacy fixed-file read; legacy-only hosts fail closed with record/retire recovery commands | `retire-before-1.0` | Retirement evidence: `legacy-topology-retirements.jsonl` entry one (Zero4Racer); all four measured hosts are legacy-free. |
 | runtime-state shapes | Runtime JSON state consumed by automation | `retain-through-1.x` | Inventory only; no automatic removal. |
 | packet-schema variants | Supported packet YAML/schema variants and state linkage | `retain-through-1.x` | A future `retire-before-1.0` row must name migration evidence. |
 | field aliases | Documented compatibility field aliases | `retain-through-1.x` | Inventory only; no inference or removal. |

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -426,7 +426,11 @@ update/retire mutation commands emit JSON and support only `--format json`. For 
 an explicit `--dry-run` takes precedence over `--write` in either flag order and
 never writes.
 
-After a successful `retire-legacy`, the CLI appends one fleet-citable entry to
+The legacy fixed `role-pane-mapping.json` compatibility read is removed. If a
+host still has that file but lacks its per-team record, readers fail closed and
+name `topology record --domain <domain> --team <team> ... --write` and
+`topology retire-legacy --domain <domain> --team <team> --evidence <evidence>
+--confirm-retire-legacy --write`; no reader auto-migrates it. After a successful `retire-legacy`, the CLI appends one fleet-citable entry to
 `<host-repo>/.intent-cli/legacy-topology-retirements.jsonl`, outside the ignored
 machine-local topology directory. Its defined fields are `timestamp_utc`, `host`,
 `domain`, `team`, `retired_path`, and named `evidence`, so a later ledger decision

--- a/docs/ja/1.0-compatibility-ledger.md
+++ b/docs/ja/1.0-compatibility-ledger.md
@@ -198,7 +198,7 @@ machine-consumed JSON payload で実際に emit されるすべての `cause` va
 | per-team topology record | canonical team topology record と identity/path validation | `stable-at-1.0` | record-first; inferred mode change はしない。 |
 | judgment-wait record | `.intent-cli/operator-attention.json`; `open` → `resolved` または `superseded` | `stable-at-1.0` | G623 が general な durable record を命名し、on-disk format と identifier は変えない。 |
 | operator-attention command alias | `judgment-wait` の alias。record schema と identifier は変更しない。 | `deprecate-with-alias` | structured `deprecation_warning` が replacement を示し、alias は 1.x を通じて残り removal は next MAJOR のみ。 |
-| role-pane-mapping compatibility read | current per-team record が absent の場合の legacy fixed-file read | `retain-through-1.x` | G604 migration/re-record evidence がなければ retirement は eligible ではない。 |
+| role-pane-mapping compatibility read | removed になった legacy fixed-file read。legacy-only host は record/retire recovery command を示して fail-closed する | `retire-before-1.0` | retirement evidence: Zero4Racer の `legacy-topology-retirements.jsonl` entry one と、legacy-free を確認した 4 host。 |
 | runtime-state shape | automation が consume する runtime JSON state | `retain-through-1.x` | inventory のみ。automatic removal ではない。 |
 | packet-schema variant | supported packet YAML/schema variant と state linkage | `retain-through-1.x` | future `retire-before-1.0` row は migration evidence を名指しする。 |
 | field alias | documented compatibility field alias | `retain-through-1.x` | inventory のみ。inference や removal はしない。 |

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -394,7 +394,7 @@ agent kind は herdr が起動できる任意の kind です。Claude、Codex、
 `update-kind` では明示した `--dry-run` が flag の順序にかかわらず `--write` より優先され、決して
 書き込みません。
 
-`retire-legacy` が成功すると、CLI は ignored な machine-local topology directory の外にある
+legacy fixed `role-pane-mapping.json` の compatibility read は削除済みです。この file が残り per-team record がない host では reader は安全側に停止し、`topology record --domain <domain> --team <team> ... --write` と `topology retire-legacy --domain <domain> --team <team> --evidence <evidence> --confirm-retire-legacy --write` を示します。reader は自動移行しません。`retire-legacy` が成功すると、CLI は ignored な machine-local topology directory の外にある
 `<host-repo>/.intent-cli/legacy-topology-retirements.jsonl` へ fleet-wide decision から引用可能な
 entry を 1 件追記します。定義済みの field は `timestamp_utc`、`host`、`domain`、`team`、
 `retired_path`、名前付きの `evidence` です。これにより、現在の legacy reader disposition を

--- a/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
@@ -364,40 +364,22 @@ internal static class NotifyRoleTopologyStore
                 path = matches[0];
             }
         }
-        if (!File.Exists(path) && !string.IsNullOrWhiteSpace(domain) && File.Exists(ResolvePath(routingRoot)))
+        if (!File.Exists(path) && !string.IsNullOrWhiteSpace(domain))
         {
-            path = ResolvePath(routingRoot);
-        }
-
-        if (!string.IsNullOrWhiteSpace(domain)
-            && File.Exists(ResolvePath(routingRoot, domain, team))
-            && File.Exists(ResolvePath(routingRoot)))
-        {
-            var dualLocation = Resolve(routingRoot, domain, team);
-            if (!dualLocation.Resolved
-                && string.Equals(dualLocation.Cause, "topology-location-conflict", StringComparison.Ordinal))
+            var legacyPath = ResolvePath(routingRoot);
+            if (File.Exists(legacyPath))
             {
-                findings.Add(Finding("<topology>", "location", dualLocation.Cause!, dualLocation.Summary));
+                var compatibility = LegacyCompatibilityReadRemoved(legacyPath, domain, team);
+                findings.Add(Finding("<topology>", "file", compatibility.Cause!, compatibility.Summary));
                 return Validation(team, path, findings);
             }
         }
-
-        var warnings = !string.IsNullOrWhiteSpace(domain)
-            && string.Equals(path, ResolvePath(routingRoot), StringComparison.Ordinal)
-            && File.Exists(path)
-                ? new[]
-                {
-                    $"Deprecated topology compatibility read from '{path}'; run "
-                    + $"`intent-cli session-layer topology record --domain {domain} --team {team} ... --write` to re-record this "
-                    + "machine's topology at its per-team local path.",
-                }
-                : [];
 
         if (!File.Exists(path))
         {
             var resolution = Resolve(routingRoot, domain, team);
             findings.Add(Finding("<topology>", "file", resolution.Cause!, resolution.Summary));
-            return Validation(team, path, findings, warnings);
+            return Validation(team, path, findings);
         }
 
         if (!string.IsNullOrWhiteSpace(domain) && !string.Equals(path, ResolvePath(routingRoot), StringComparison.Ordinal))
@@ -414,7 +396,7 @@ internal static class NotifyRoleTopologyStore
                         $"Topology file '{path}' identifies domain '{recordedDomain ?? "missing"}' team "
                         + $"'{recordedTeam ?? "missing"}', but its path was requested for domain '{domain}' "
                         + $"team '{team}'. Refusing the copied or misplaced machine record."));
-                    return Validation(team, path, findings, warnings);
+                    return Validation(team, path, findings);
                 }
             }
             catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException)
@@ -430,7 +412,7 @@ internal static class NotifyRoleTopologyStore
             {
                 findings.Add(Finding("<topology>", "team", "topology-team-missing",
                     $"Topology file '{path}' {teamError}"));
-                return Validation(team, path, findings, warnings);
+                return Validation(team, path, findings);
             }
 
             var rolesElement = teamElement.TryGetProperty("roles", out var nestedRoles)
@@ -440,7 +422,7 @@ internal static class NotifyRoleTopologyStore
             {
                 findings.Add(Finding("<topology>", "roles", "topology-invalid",
                     $"Team '{team}' has no object-valued roles field."));
-                return Validation(team, path, findings, warnings);
+                return Validation(team, path, findings);
             }
 
             var teamWorkspaceId = ReadString(teamElement, "workspace_id")
@@ -528,7 +510,7 @@ internal static class NotifyRoleTopologyStore
                 $"Topology file '{path}' is unreadable: {exception.Message}"));
         }
 
-        return Validation(team, path, findings, warnings);
+        return Validation(team, path, findings);
     }
 
     public static bool TryResolveReaderPath(

--- a/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
@@ -95,6 +95,15 @@ internal static class NotifyRoleTopologyStore
         $"Run `intent-cli session-layer topology validate --domain <domain> --team {team} --format json`, then use "
         + "`session-layer topology record --domain <domain> ... --write` to record the operator-supplied correction.";
 
+    private static NotifyTopologyResolution LegacyCompatibilityReadRemoved(string legacyPath, string? domain, string team) =>
+        Failure(
+            "legacy-topology-compatibility-removed",
+            $"Legacy topology file '{legacyPath}' was found for team '{team}', but the compatibility read has been removed. "
+            + $"Run `intent-cli session-layer topology record --domain {domain ?? "<domain>"} --team {team} ... --write` "
+            + "to declare the current shape, or run "
+            + $"`intent-cli session-layer topology retire-legacy --domain {domain ?? "<domain>"} --team {team} "
+            + "--evidence <evidence> --confirm-retire-legacy --write` to retire the legacy file with evidence.");
+
     public static NotifyTopologyResolution Resolve(string routingRoot, string team) =>
         Resolve(routingRoot, domain: null, team);
 
@@ -103,15 +112,12 @@ internal static class NotifyRoleTopologyStore
         if (string.IsNullOrWhiteSpace(domain))
         {
             var legacyOnlyPath = ResolvePath(routingRoot);
-            if (File.Exists(legacyOnlyPath))
-            {
-                return ResolveFromPath(legacyOnlyPath, null, team, requireIdentity: false);
-            }
-
             var matches = FindNewTopologyPaths(routingRoot, team).ToArray();
             return matches.Length == 1
                 ? ResolveFromPath(matches[0], expectedDomain: null, team, requireIdentity: false)
-                : ResolveFromPath(legacyOnlyPath, null, team, requireIdentity: false);
+                : File.Exists(legacyOnlyPath)
+                    ? LegacyCompatibilityReadRemoved(legacyOnlyPath, null, team)
+                    : ResolveFromPath(legacyOnlyPath, null, team, requireIdentity: false);
         }
 
         string newPath;
@@ -124,49 +130,22 @@ internal static class NotifyRoleTopologyStore
             return Failure("topology-invalid", exception.Message);
         }
 
-        var legacyPath = ResolvePath(routingRoot);
         if (!File.Exists(newPath))
         {
-            var legacy = ResolveFromPath(legacyPath, null, team, requireIdentity: false);
-            if (!legacy.Resolved)
+            var legacyPath = ResolvePath(routingRoot);
+            if (File.Exists(legacyPath))
             {
-                return Failure(
-                    "topology-missing",
-                    $"Recorded role topology for domain '{domain}' team '{team}' was not found at '{newPath}'. "
-                    + $"Provision and record the team's workspace, roles, residences, panes/readers, then retry "
-                    + $"notify. {TopologyRemedy(team)}");
+                return LegacyCompatibilityReadRemoved(legacyPath, domain, team);
             }
 
-            return legacy with
-            {
-                Warnings =
-                [
-                    $"Deprecated topology compatibility read from '{legacyPath}'; run "
-                    + $"`intent-cli session-layer topology record --domain {domain} --team {team} ... --write` to record this "
-                    + "machine's topology at its per-team local path.",
-                ],
-                Summary = legacy.Summary + " Deprecated legacy topology compatibility read; re-record with "
-                    + $"`intent-cli session-layer topology record --domain {domain} --team {team} ... --write`.",
-            };
-        }
-
-        var current = ResolveFromPath(newPath, domain, team, requireIdentity: true);
-        if (!current.Resolved || !File.Exists(legacyPath))
-        {
-            return current;
-        }
-
-        var legacyForComparison = ResolveFromPath(legacyPath, null, team, requireIdentity: false);
-        if (!legacyForComparison.Resolved || !Equivalent(current.Topology!, legacyForComparison.Topology!))
-        {
             return Failure(
-                "topology-location-conflict",
-                $"Topology records for domain '{domain}' team '{team}' disagree between new path '{newPath}' and "
-                + $"legacy path '{legacyPath}'. Refusing to prefer either machine topology. "
-                + TopologyRemedy(team));
+                "topology-missing",
+                $"Recorded role topology for domain '{domain}' team '{team}' was not found at '{newPath}'. "
+                + $"Provision and record the team's workspace, roles, residences, panes/readers, then retry "
+                + $"notify. {TopologyRemedy(team)}");
         }
 
-        return current;
+        return ResolveFromPath(newPath, domain, team, requireIdentity: true);
     }
 
     private static NotifyTopologyResolution ResolveFromPath(

--- a/tests/IntentSystem.Cli.Tests/AutomationHeartbeatDecisionG597Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHeartbeatDecisionG597Tests.cs
@@ -309,10 +309,11 @@ public sealed class AutomationHeartbeatDecisionG597Tests : IDisposable
 
         public void WriteTopology()
         {
-            var path = NotifyRoleTopologyStore.ResolvePath(RootPath);
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath, "intent-cli", "intent-cli-dev");
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             File.WriteAllText(path, JsonSerializer.Serialize(new
             {
+                domain = "intent-cli",
                 team = "intent-cli-dev",
                 workspace_id = "wH",
                 roles = new Dictionary<string, object>

--- a/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
@@ -572,6 +572,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
         {
             var topology = new
             {
+                domain = Domain,
                 team = Team,
                 workspace_id = "wH",
                 roles = new Dictionary<string, object>
@@ -597,9 +598,9 @@ public sealed class NotifyCommandG578Tests : IDisposable
                     },
                 },
             };
-            File.WriteAllText(
-                Path.Combine(RootPath, NotifyRoleTopologyStore.RelativePath.Replace('/', Path.DirectorySeparatorChar)),
-                JsonSerializer.Serialize(topology));
+            var topologyPath = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, Team);
+            Directory.CreateDirectory(Path.GetDirectoryName(topologyPath)!);
+            File.WriteAllText(topologyPath, JsonSerializer.Serialize(topology));
         }
 
         public void SetImplementationDeliveryMethod(string? deliveryMethod)
@@ -627,9 +628,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
 
         public void SetMode(string mode)
         {
-            var topologyPath = Path.Combine(
-                RootPath,
-                NotifyRoleTopologyStore.RelativePath.Replace('/', Path.DirectorySeparatorChar));
+            var topologyPath = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, Team);
             if (string.Equals(mode, SessionLayerMode.Agmsg, StringComparison.Ordinal))
             {
                 File.Delete(topologyPath);

--- a/tests/IntentSystem.Cli.Tests/NotifyRecordedRolesG588Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyRecordedRolesG588Tests.cs
@@ -194,7 +194,10 @@ public sealed class NotifyRecordedRolesG588Tests : IDisposable
         Assert.Equal(1, exitCode);
         Assert.Equal("unknown-role", result.GetProperty("cause").GetString());
         var summary = result.GetProperty("summary").GetString()!;
-        Assert.Contains(NotifyRoleTopologyStore.RelativePath, summary, StringComparison.Ordinal);
+        Assert.Contains(
+            NotifyRoleTopologyStore.ResolvePath(workspace.RootPath, Workspace.Domain, Workspace.Team),
+            summary,
+            StringComparison.Ordinal);
         Assert.Contains("team 'intent-cli-dev' workspace 'wH'", summary, StringComparison.Ordinal);
         Assert.Contains(
             "found in that team scope: design, implementation, orchestration, review",
@@ -394,10 +397,11 @@ public sealed class NotifyRecordedRolesG588Tests : IDisposable
 
         public void WriteTopology(string? externalReader)
         {
-            File.WriteAllText(
-                Path.Combine(RootPath, NotifyRoleTopologyStore.RelativePath.Replace('/', Path.DirectorySeparatorChar)),
-                JsonSerializer.Serialize(new
+            var topologyPath = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, Team);
+            Directory.CreateDirectory(Path.GetDirectoryName(topologyPath)!);
+            File.WriteAllText(topologyPath, JsonSerializer.Serialize(new
                 {
+                    domain = Domain,
                     team = Team,
                     workspace_id = "wH",
                     roles = new Dictionary<string, object>

--- a/tests/IntentSystem.Cli.Tests/OperatorAttentionG596Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/OperatorAttentionG596Tests.cs
@@ -447,10 +447,11 @@ public sealed class OperatorAttentionG596Tests : IDisposable
 
         public void WriteTopology()
         {
-            var path = NotifyRoleTopologyStore.ResolvePath(RootPath);
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath, "intent-cli", "intent-cli-dev");
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             File.WriteAllText(path, JsonSerializer.Serialize(new
             {
+                domain = "intent-cli",
                 team = "intent-cli-dev", workspace_id = "workspace", roles = new Dictionary<string, object>
                 {
                     ["design"] = new { resident = "herdr", workspace_id = "workspace", pane_id = "workspace:p1" },

--- a/tests/IntentSystem.Cli.Tests/SessionLayerMarkerG601Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerMarkerG601Tests.cs
@@ -82,7 +82,7 @@ public sealed class SessionLayerMarkerG601Tests : IDisposable
         var file = workspace.WriteStartup(Placeholder("alpha") + "\n");
         Assert.Equal(0, workspace.Generate("alpha", file).ExitCode);
         workspace.Record("alpha", SessionLayerMode.Agmsg);
-        File.Delete(NotifyRoleTopologyStore.ResolvePath(workspace.RootPath));
+        File.Delete(NotifyRoleTopologyStore.ResolvePath(workspace.RootPath, MarkerWorkspace.Domain, "alpha"));
 
         var result = SessionLayerPreflight.Analyze(workspace.RootPath, MarkerWorkspace.Domain, "alpha");
 
@@ -283,10 +283,11 @@ public sealed class SessionLayerMarkerG601Tests : IDisposable
 
         public void WriteTopology(string team)
         {
-            var path = NotifyRoleTopologyStore.ResolvePath(RootPath);
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, team);
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             File.WriteAllText(path, JsonSerializer.Serialize(new
             {
+                domain = Domain,
                 team,
                 workspace_id = "w",
                 roles = new

--- a/tests/IntentSystem.Cli.Tests/SessionLayerMigrationG602Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerMigrationG602Tests.cs
@@ -175,10 +175,11 @@ public sealed class SessionLayerMigrationG602Tests : IDisposable
 
         public void WriteTopology()
         {
-            var path = NotifyRoleTopologyStore.ResolvePath(RootPath);
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, Team);
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             File.WriteAllText(path, JsonSerializer.Serialize(new
             {
+                domain = Domain,
                 team = Team,
                 workspace_id = "w",
                 roles = new

--- a/tests/IntentSystem.Cli.Tests/SessionLayerModeG570Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerModeG570Tests.cs
@@ -2068,10 +2068,11 @@ public sealed class SessionLayerModeG570Tests : IDisposable
 
         private void WriteSetupTopology()
         {
-            var path = NotifyRoleTopologyStore.ResolvePath(RootPath);
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, "demo-team");
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             File.WriteAllText(path, JsonSerializer.Serialize(new
             {
+                domain = Domain,
                 team = "demo-team",
                 workspace_id = "w-demo",
                 roles = new Dictionary<string, object>

--- a/tests/IntentSystem.Cli.Tests/SessionLayerPreflightG594Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerPreflightG594Tests.cs
@@ -558,10 +558,11 @@ public sealed class SessionLayerPreflightG594Tests : IDisposable
                 writer);
             Assert.True(exitCode == 0, writer.ToString());
 
-            var topologyPath = NotifyRoleTopologyStore.ResolvePath(RootPath);
+            var topologyPath = NotifyRoleTopologyStore.ResolvePath(RootPath, Workspace.Domain, team);
             Directory.CreateDirectory(Path.GetDirectoryName(topologyPath)!);
             File.WriteAllText(topologyPath, JsonSerializer.Serialize(new
             {
+                domain = Workspace.Domain,
                 team,
                 workspace_id = workspaceId,
                 roles = new Dictionary<string, object>
@@ -670,10 +671,11 @@ public sealed class SessionLayerPreflightG594Tests : IDisposable
 
         public void WriteTopology()
         {
-            var path = NotifyRoleTopologyStore.ResolvePath(RootPath);
+            var path = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, Team);
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             File.WriteAllText(path, JsonSerializer.Serialize(new
             {
+                domain = Domain,
                 team = Team,
                 workspace_id = "wH",
                 roles = new Dictionary<string, object>

--- a/tests/IntentSystem.Cli.Tests/SessionLayerTopologyG604Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerTopologyG604Tests.cs
@@ -33,7 +33,7 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
     }
 
     [Fact]
-    public void Resolve_CopiedNewRecordAndDualLocationConflictFailClosed_G604()
+    public void Resolve_CopiedNewRecordFailsIdentityAndIgnoresLegacyFile_G627()
     {
         Assert.True(Record("intent-cli-dev", "orchestration", "w1:p1").Applied);
         var source = NotifyRoleTopologyStore.ResolvePath(root, Domain, "intent-cli-dev");
@@ -54,15 +54,12 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
                 "orchestration": { "resident": "herdr", "workspace_id": "other", "pane_id": "other:p1" }
             }}
             """);
-        var conflict = NotifyRoleTopologyStore.Resolve(root, Domain, "intent-cli-dev");
-        Assert.False(conflict.Resolved);
-        Assert.Equal("topology-location-conflict", conflict.Cause);
-        Assert.Contains(NotifyRoleTopologyStore.ResolvePath(root, Domain, "intent-cli-dev"), conflict.Summary, StringComparison.Ordinal);
-        Assert.Contains(NotifyRoleTopologyStore.ResolvePath(root), conflict.Summary, StringComparison.Ordinal);
+        var current = NotifyRoleTopologyStore.Resolve(root, Domain, "intent-cli-dev");
+        Assert.True(current.Resolved);
     }
 
     [Fact]
-    public void Resolve_LegacyOnlyWarnsAndModeOnlyPreflightIsConfigurationIncomplete_G604()
+    public void Resolve_LegacyOnlyFailsClosedAndNeitherRemainsConfigurationIncomplete_G627()
     {
         var legacyPath = NotifyRoleTopologyStore.ResolvePath(root);
         Directory.CreateDirectory(Path.GetDirectoryName(legacyPath)!);
@@ -73,8 +70,11 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
             }}
             """);
         var compatibility = NotifyRoleTopologyStore.Resolve(root, Domain, "intent-cli-dev");
-        Assert.True(compatibility.Resolved);
-        Assert.Contains(compatibility.Warnings, warning => warning.Contains("topology record", StringComparison.Ordinal));
+        Assert.False(compatibility.Resolved);
+        Assert.Equal("legacy-topology-compatibility-removed", compatibility.Cause);
+        Assert.Contains(legacyPath, compatibility.Summary, StringComparison.Ordinal);
+        Assert.Contains("topology record", compatibility.Summary, StringComparison.Ordinal);
+        Assert.Contains("retire-legacy", compatibility.Summary, StringComparison.Ordinal);
 
         File.Delete(legacyPath);
         using var writer = new StringWriter();
@@ -133,7 +133,7 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
     }
 
     [Fact]
-    public void DualLocationConflict_BlocksValidatePreflightAndAutomationDoctor_G604()
+    public void LegacyAlongsideCurrentRecord_DoesNotAffectReaders_G627()
     {
         const string team = "intent-cli-dev";
         Assert.True(Record(team, "orchestration", "w1:p1").Applied);
@@ -151,17 +151,15 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
         Assert.Equal(0, SessionLayerCommand.ExecuteSet(context,
             ["--domain", Domain, "--team", team, "--mode", "herdr-only", "--write", "--format", "json"], modeWriter));
         using var validateWriter = new StringWriter();
-        Assert.Equal(1, SessionLayerTopologyCommand.ExecuteValidate(context,
+        Assert.Equal(0, SessionLayerTopologyCommand.ExecuteValidate(context,
             ["--domain", Domain, "--team", team, "--format", "json"], validateWriter));
         using (var validate = JsonDocument.Parse(validateWriter.ToString()))
         {
-            Assert.Contains(validate.RootElement.GetProperty("findings").EnumerateArray(), finding =>
-                finding.GetProperty("cause").GetString() == "topology-location-conflict");
+            Assert.True(validate.RootElement.GetProperty("valid").GetBoolean());
         }
 
         var preflight = SessionLayerPreflight.Analyze(root, Domain, team);
-        Assert.False(preflight.Ready);
-        Assert.Contains(preflight.Scopes.Single().Findings, finding => finding.Cause == "topology-location-conflict");
+        Assert.True(preflight.Ready);
 
         AutomationInstalledCliSurfaceProbe.PathResolver = _ => null;
         try
@@ -171,7 +169,7 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
             using var doctor = JsonDocument.Parse(doctorWriter.ToString());
             var findings = doctor.RootElement.GetProperty("topology_health").GetProperty("teams")[0]
                 .GetProperty("findings").EnumerateArray();
-            Assert.Contains(findings, finding => finding.GetProperty("cause").GetString() == "topology-location-conflict");
+            Assert.DoesNotContain(findings, finding => finding.GetProperty("cause").GetString() == "topology-location-conflict");
         }
         finally
         {

--- a/tests/IntentSystem.Cli.Tests/SessionLayerTopologyG604Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerTopologyG604Tests.cs
@@ -92,6 +92,42 @@ public sealed class SessionLayerTopologyG604Tests : IDisposable
     }
 
     [Fact]
+    public void ValidateAndPreflight_LegacyOnlyFailClosed_G627()
+    {
+        const string team = "intent-cli-dev";
+        var context = CreateContext(Domain);
+        using var modeWriter = new StringWriter();
+        Assert.Equal(0, SessionLayerCommand.ExecuteSet(context,
+            ["--domain", Domain, "--team", team, "--mode", "herdr-only", "--write", "--format", "json"], modeWriter));
+
+        var legacyPath = NotifyRoleTopologyStore.ResolvePath(root);
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyPath)!);
+        File.WriteAllText(legacyPath,
+            """
+            { "team": "intent-cli-dev", "workspace_id": "w1", "roles": {
+                "orchestration": { "resident": "herdr", "workspace_id": "w1", "pane_id": "w1:p1" }
+            }}
+            """);
+
+        using var validateWriter = new StringWriter();
+        Assert.Equal(1, SessionLayerTopologyCommand.ExecuteValidate(context,
+            ["--domain", Domain, "--team", team, "--format", "json"], validateWriter));
+        using var validation = JsonDocument.Parse(validateWriter.ToString());
+        Assert.False(validation.RootElement.GetProperty("valid").GetBoolean());
+        var finding = Assert.Single(validation.RootElement.GetProperty("findings").EnumerateArray());
+        Assert.Equal("legacy-topology-compatibility-removed", finding.GetProperty("cause").GetString());
+        Assert.Contains("topology record", finding.GetProperty("message").GetString(), StringComparison.Ordinal);
+        Assert.Contains("retire-legacy", finding.GetProperty("message").GetString(), StringComparison.Ordinal);
+
+        var preflight = SessionLayerPreflight.Analyze(root, Domain, team);
+        Assert.Equal(SessionLayerPreflight.ConfigurationIncomplete, preflight.Verdict);
+        var preflightFinding = Assert.Single(preflight.Scopes.Single().Findings,
+            item => item.Cause == "legacy-topology-compatibility-removed");
+        Assert.Contains("topology record", preflightFinding.Message, StringComparison.Ordinal);
+        Assert.Contains("retire-legacy", preflightFinding.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void TopologyCommands_RequireExplicitNonDefaultDomainForRecordAndValidate_G604()
     {
         var context = CreateContext("sekiban-as-a-service");


### PR DESCRIPTION
Closes #1357

Removes legacy role-pane-mapping fallback, fails closed with record/retire recovery commands, and updates EN/JA ledger guidance.

Verification: focused topology/preflight/JA guards; full suite; git diff --check.