### PR TITLE
G628: freeze the 1.0 feature set and define preview

### DIFF
--- a/docs/en/1.0-compatibility-ledger.md
+++ b/docs/en/1.0-compatibility-ledger.md
@@ -191,6 +191,11 @@ Every `cause` value actually emitted in a machine-consumed JSON payload is cover
 
 ## Durable schemas and legacy inventory
 
+Post-freeze surfaces are not omitted from this ledger. A preview surface is
+enumerated with `preview-through-1.x`; the same completeness guard that
+requires every registered command to have a row also keeps preview surfaces
+discoverable.
+
 | Surface | Machine-consumed shape / states | Disposition | Evidence or rule |
 | --- | --- | --- | --- |
 | session-layer mode record | `.intent-cli/session-layer-mode.json`; recorded mode and transition history | `stable-at-1.0` | State transition semantics are covered. |
@@ -202,6 +207,7 @@ Every `cause` value actually emitted in a machine-consumed JSON payload is cover
 | packet-schema variants | Supported packet YAML/schema variants and state linkage | `retain-through-1.x` | A future `retire-before-1.0` row must name migration evidence. |
 | field aliases | Documented compatibility field aliases | `retain-through-1.x` | Inventory only; no inference or removal. |
 | future eligible legacy retirement | A named legacy entry with its consumer migration proof | `retire-before-1.0` | This disposition is invalid without named migration evidence in its row. |
+| post-freeze preview surface | A documented surface added after the v0.12.0 freeze and explicitly marked preview | `preview-through-1.x` | Outside the 1.0 promise; may change or be withdrawn in 1.x; formalise at a later MAJOR. |
 
 ## Guard
 

--- a/docs/en/1.0-compatibility-promise.md
+++ b/docs/en/1.0-compatibility-promise.md
@@ -39,6 +39,22 @@ Every `cause` value actually emitted in a machine-consumed JSON payload is
 covered, whether or not prose currently documents that value. Coverage follows
 machine emission, not the current state of human-facing documentation.
 
+## Freeze and preview lane
+
+The 1.0 feature set is frozen at **v0.12.0 (2026-08-05)**. This means the
+surfaces recorded in the covered-surface inventory at that freeze are the
+surfaces the 1.0 promise covers; a surface shipped later in the 1.x line is
+not covered merely because it was released. Decision owner: the product
+owner/operator (tomohisa).
+
+A surface added after the freeze must be documented as **preview**, recorded in
+the ledger with the `preview-through-1.x` disposition, and explicitly marked
+preview wherever it is described. Preview is outside the 1.0 compatibility
+promise: it may change or be withdrawn during 1.x and is formalised only by a
+later MAJOR release (2.0 or later). To tell which kind of surface you are
+reading, check its documentation marker and its ledger entry: `stable-at-1.0`
+is covered, while `preview-through-1.x` is preview and not covered.
+
 ## Deprecation rule
 
 A covered surface can change only when all of the following are present:

--- a/docs/en/release-notes-v0.12.0.md
+++ b/docs/en/release-notes-v0.12.0.md
@@ -58,6 +58,12 @@ hand-editing topology, avoids wedging a paste-sensitive agent, makes the
 Japanese documentation read as Japanese, and publishes the 1.0 compatibility
 promise with its ledger.
 
+## Compatibility promise policy
+
+The v0.12.0 freeze and the post-freeze preview lane are defined in the
+[1.0 compatibility promise](1.0-compatibility-promise.md). Use that promise
+and its ledger to tell whether a 1.x surface is covered or preview.
+
 ## Install or upgrade
 
 ```bash

--- a/docs/ja/1.0-compatibility-ledger.md
+++ b/docs/ja/1.0-compatibility-ledger.md
@@ -192,6 +192,10 @@ machine-consumed JSON payload で実際に emit されるすべての `cause` va
 
 ## Durable schema と legacy inventory
 
+freeze 後の surface を ledger から省略してはいけません。preview surface は
+`preview-through-1.x` で列挙します。registered command ごとの row を要求する同じ completeness
+guard により、preview も発見可能なままになります。
+
 | Surface | Machine-consumed shape / state | Disposition | Evidence / rule |
 | --- | --- | --- | --- |
 | session-layer mode record | `.intent-cli/session-layer-mode.json`; recorded mode と transition history | `stable-at-1.0` | state transition semantics は covered。 |
@@ -203,6 +207,8 @@ machine-consumed JSON payload で実際に emit されるすべての `cause` va
 | packet-schema variant | supported packet YAML/schema variant と state linkage | `retain-through-1.x` | future `retire-before-1.0` row は migration evidence を名指しする。 |
 | field alias | documented compatibility field alias | `retain-through-1.x` | inventory のみ。inference や removal はしない。 |
 | future eligible legacy retirement | consumer migration proof を持つ named legacy entry | `retire-before-1.0` | row に named migration evidence がなければこの disposition は無効。 |
+
+| post-freeze preview surface | v0.12.0 freeze 後に追加し、preview と明記した documented surface | `preview-through-1.x` | 1.0 promise の対象外。1.x で変更・撤回でき、後続 MAJOR で formalise する。 |
 
 ## Guard
 

--- a/docs/ja/1.0-compatibility-ledger.md
+++ b/docs/ja/1.0-compatibility-ledger.md
@@ -207,7 +207,6 @@ guard により、preview も発見可能なままになります。
 | packet-schema variant | supported packet YAML/schema variant と state linkage | `retain-through-1.x` | future `retire-before-1.0` row は migration evidence を名指しする。 |
 | field alias | documented compatibility field alias | `retain-through-1.x` | inventory のみ。inference や removal はしない。 |
 | future eligible legacy retirement | consumer migration proof を持つ named legacy entry | `retire-before-1.0` | row に named migration evidence がなければこの disposition は無効。 |
-
 | post-freeze preview surface | v0.12.0 freeze 後に追加し、preview と明記した documented surface | `preview-through-1.x` | 1.0 promise の対象外。1.x で変更・撤回でき、後続 MAJOR で formalise する。 |
 
 ## Guard

--- a/docs/ja/1.0-compatibility-promise.md
+++ b/docs/ja/1.0-compatibility-promise.md
@@ -37,6 +37,20 @@ machine-consumed JSON payload で実際に emit されるすべての `cause` va
 その value を現在 documented しているかにかかわらず covered です。coverage は
 human-facing documentation の状態ではなく machine emission に従います。
 
+## Freeze と preview lane
+
+1.0 の feature set は **v0.12.0（2026-08-05）** で freeze します。つまり、その時点で
+covered-surface inventory に記録されている surface が 1.0 promise の対象です。1.x line の
+途中で出荷された surface は、出荷されたというだけで covered にはなりません。決定 owner は
+product owner/operator（tomohisa）です。
+
+freeze 後に追加する surface は **preview** と明記し、ledger に
+`preview-through-1.x` disposition で記録し、description にも preview marker を付けます。
+preview は 1.0 compatibility promise の対象外です。1.x の間に変更または撤回される可能性が
+あり、正式化は後続の MAJOR release（2.0 以降）でのみ行います。読む側は documentation の
+marker と ledger entry を確認します。`stable-at-1.0` は covered、`preview-through-1.x` は
+preview であり covered ではありません。
+
 ## Deprecation rule
 
 covered surface の変更には、次のすべてが必要です。

--- a/docs/ja/release-notes-v0.12.0.md
+++ b/docs/ja/release-notes-v0.12.0.md
@@ -54,6 +54,12 @@ v0.12.0 では、team が topology を手編集せずに seat の担当者と宣
 変更でき、paste-sensitive な agent の wedge を避けられます。Japanese documentation は自然な
 日本語として読め、1.0 compatibility promise とその ledger が公開された contract になります。
 
+## Compatibility promise policy
+
+v0.12.0 の freeze と freeze 後の preview lane は [1.0 compatibility promise](1.0-compatibility-promise.md)
+で定義しています。1.x の surface が covered か preview かを判断するときは、この promise と
+ledger を参照してください。
+
 ## インストールまたは更新
 
 ```bash

--- a/tests/IntentSystem.Cli.Tests/CompatibilityPromiseG612Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/CompatibilityPromiseG612Tests.cs
@@ -40,6 +40,29 @@ public sealed class CompatibilityPromiseG612Tests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
+    public void Promise_RecordsTheV012FreezeAndPreviewReaderTest_G628(string language)
+    {
+        var promise = Read(language, "1.0-compatibility-promise.md");
+
+        Assert.Contains("v0.12.0", promise, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("2026-08-05", promise, StringComparison.Ordinal);
+        Assert.Contains("tomohisa", promise, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preview", promise, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("preview-through-1.x", promise, StringComparison.Ordinal);
+        var outsideAndWithdrawn = language == "en"
+            ? new[] { "outside", "withdraw" }
+            : new[] { "対象外", "撤回" };
+        foreach (var term in outsideAndWithdrawn)
+        {
+            Assert.Contains(term, promise, StringComparison.OrdinalIgnoreCase);
+        }
+        Assert.Contains("2.0", promise, StringComparison.Ordinal);
+        Assert.Contains("stable-at-1.0", promise, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
     public void Ledger_ContainsEveryRegisteredCommandAndRequiredLegacyDispositions_G612(string language)
     {
         var ledger = Read(language, "1.0-compatibility-ledger.md");
@@ -62,6 +85,28 @@ public sealed class CompatibilityPromiseG612Tests
         Assert.Contains("runtime-state", ledger, StringComparison.Ordinal);
         Assert.Contains("packet-schema", ledger, StringComparison.Ordinal);
         Assert.Contains("field alias", ledger, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void Ledger_EnumeratesThePreviewDispositionAlongsideTheCompletenessGuard_G628(string language)
+    {
+        var ledger = Read(language, "1.0-compatibility-ledger.md");
+
+        var previewRows = ledger.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Where(line => line.StartsWith("| post-freeze preview surface |", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Single(previewRows);
+        Assert.Contains("`preview-through-1.x`", previewRows[0], StringComparison.Ordinal);
+        Assert.Contains("preview", previewRows[0], StringComparison.OrdinalIgnoreCase);
+
+        // Keep the existing registered-command completeness guard exercised in
+        // the same fixture: preview rows are additive and cannot replace it.
+        foreach (var command in RegisteredCommands().Concat(TopLevelAliases))
+        {
+            Assert.Contains($"`{command}`", ledger, StringComparison.Ordinal);
+        }
     }
 
     [Theory]


### PR DESCRIPTION
Closes #1359. Records the v0.12.0 freeze with date and owner; defines the documented and ledgered preview-through-1.x lane and reader test; keeps EN/JA guidance in parity; adds compatibility tests for preview enumeration and command completeness. Validation: focused CompatibilityPromiseG612 tests, full dotnet test IntentSystem.sln -c Release, git diff --check.