### PR TITLE
G633: expand v0.12.0 notes through G628

### DIFF
--- a/docs/en/release-notes-v0.12.0.md
+++ b/docs/en/release-notes-v0.12.0.md
@@ -20,8 +20,17 @@ This minor release contains exactly these verified `main` merges:
 - G619 — [PR #1342](https://github.com/J-Tech-Japan/intent-system/pull/1342), merge `36b89ac9fbfc`.
 - G620 — [PR #1344](https://github.com/J-Tech-Japan/intent-system/pull/1344), merge `72878b63ff97`.
 - G621 — [PR #1346](https://github.com/J-Tech-Japan/intent-system/pull/1346), merge `a1886218f56c`.
+- G623 — [PR #1350](https://github.com/J-Tech-Japan/intent-system/pull/1350), merge `c04e137`.
+- G624 — [PR #1352](https://github.com/J-Tech-Japan/intent-system/pull/1352), merge `ccd4f29`.
+- G625 — [PR #1354](https://github.com/J-Tech-Japan/intent-system/pull/1354), merge `06f1a71`.
+- G626 — [PR #1356](https://github.com/J-Tech-Japan/intent-system/pull/1356), merge `2bb20d3`.
+- G627 — [PR #1358](https://github.com/J-Tech-Japan/intent-system/pull/1358), merge `5b86977`.
+- G628 — [PR #1360](https://github.com/J-Tech-Japan/intent-system/pull/1360), merge `f464a04`.
 
-Each commit resolves on `main`; no other slice is included. See
+These eighteen units were enumerated by running `git log v0.11.1..main`, not
+by hand. Every commit in that range is accounted for as one of these eighteen
+unit merges, G622's prepare-only notes authoring commit (excluded as the
+prepare-only slice), or the residual version roll and guard-fix commits. See
 [v0.11.1](release-notes-v0.11.1.md) and [v0.11.0](release-notes-v0.11.0.md)
 for the preceding shipped scopes.
 
@@ -29,7 +38,8 @@ for the preceding shipped scopes.
 
 This is a verifiable minor bump. Compared with `v0.11.1`, the command surfaces
 `session-layer topology update-kind`, `session-layer topology retire-legacy`,
-and `session-layer topology update-field` are new, and a recipe can newly
+`session-layer topology update-field`, `judgment-wait`, and
+`automation issue-publish --execution-unit` are new, and a recipe can newly
 declare `delivery_method: file-backed`. None of those surfaces exists at
 `v0.11.1`; the version policy reserves a minor bump for new command surface.
 
@@ -50,6 +60,37 @@ declare `delivery_method: file-backed`. None of those surfaces exists at
    success.
 4. **Documentation guards.** The repository-wide Markdown link/anchor guard
    and rolling Japanese terminology guard now fail CI on regressions.
+
+## Further behaviour changes in G623–G628
+
+5. **Judgment vocabulary (G623).** `judgment-wait` replaces
+   `operator-attention`. The old command remains a `deprecate-with-alias`
+   compatibility alias through 1.x; its machine output carries a
+   `deprecation_warning` naming `judgment-wait`, and removal is only allowed in
+   the next MAJOR release.
+6. **Transport graduation (G624).** `herdr-only` is no longer preview and is
+   preferred because it has fewer dependencies. `agmsg + herdr` remains
+   supported and explicitly is not retired; neither transport is called
+   primary.
+7. **Dispatch outcome vocabulary (G625–G626).** `issue-publish` accepts
+   `--execution-unit`, and unresolved work is reported as unresolved. A
+   delivery that reaches an observed working transition now reports a
+   successful non-terminal state instead of `working-did-not-settle` or
+   `not-observed-within-bound`. A caller matching either old name will
+   **silently stop matching**; update it to match the machine's
+   `working_transition` field.
+
+### Breaking change: legacy fixed-path topology read removed (G627)
+
+Hosts that have only the legacy `role-pane-mapping.json` and no per-team
+record now fail closed. The diagnostic names `topology record` and
+`topology retire-legacy` as recovery commands; no automatic migration occurs.
+This is a breaking change for that legacy-only host population.
+
+8. **Versioning policy (G628).** The 1.0 feature set is frozen at v0.12.0.
+   A surface added after the freeze ships as `preview`, is recorded in the
+   ledger as `preview-through-1.x`, sits outside the 1.0 compatibility promise,
+   and is formalised at a later MAJOR release.
 
 ## Operational purpose
 
@@ -73,10 +114,15 @@ dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.12.0
 ## Release-readiness gate
 
 - [ ] `eng/version.json` is `stableVersion` `0.11.1` / `nextVersion` `0.12.0`.
-- [ ] These EN/JA notes name exactly G610–G621 with the verified PRs and merge
-      commits above.
-- [ ] The minor comparison confirms the three topology subcommands and declared
-      `delivery_method` are absent from `v0.11.1`.
+- [ ] These EN/JA notes name exactly the eighteen units G610–G621 and G623–G628,
+      with the verified PRs and merge commits above; the enumeration comes from
+      `git log v0.11.1..main`.
+- [ ] The minor comparison confirms `judgment-wait`,
+      `automation issue-publish --execution-unit`, the three topology
+      subcommands, and declared `delivery_method` are absent from `v0.11.1`.
+- [ ] Verify the G627 breaking change is understood: legacy-only hosts fail
+      closed and must use `topology record` or `topology retire-legacy`; verify
+      the v0.12.0 freeze and preview policy before creating the Release.
 - [ ] G475, focused release-note checks, full suite, diff check, and exact-head
       CI are green.
 - [ ] The operator explicitly approves creating and publishing the v0.12.0 GitHub Release.

--- a/docs/ja/release-notes-v0.12.0.md
+++ b/docs/ja/release-notes-v0.12.0.md
@@ -20,8 +20,16 @@
 - G619 — [PR #1342](https://github.com/J-Tech-Japan/intent-system/pull/1342)、merge `36b89ac9fbfc`。
 - G620 — [PR #1344](https://github.com/J-Tech-Japan/intent-system/pull/1344)、merge `72878b63ff97`。
 - G621 — [PR #1346](https://github.com/J-Tech-Japan/intent-system/pull/1346)、merge `a1886218f56c`。
+- G623 — [PR #1350](https://github.com/J-Tech-Japan/intent-system/pull/1350)、merge `c04e137`。
+- G624 — [PR #1352](https://github.com/J-Tech-Japan/intent-system/pull/1352)、merge `ccd4f29`。
+- G625 — [PR #1354](https://github.com/J-Tech-Japan/intent-system/pull/1354)、merge `06f1a71`。
+- G626 — [PR #1356](https://github.com/J-Tech-Japan/intent-system/pull/1356)、merge `2bb20d3`。
+- G627 — [PR #1358](https://github.com/J-Tech-Japan/intent-system/pull/1358)、merge `5b86977`。
+- G628 — [PR #1360](https://github.com/J-Tech-Japan/intent-system/pull/1360)、merge `f464a04`。
 
-各 commit は `main` 上で解決します。他の slice は含みません。直前の出荷範囲は
+この十八件は手作業ではなく `git log v0.11.1..main` を実行して列挙しました。この範囲の
+commit は、十八件の unit merge、prepare-only の notes authoring である G622（prepare-only
+slice として除外）、または残った version roll と guard-fix のいずれかとして説明できます。直前の出荷範囲は
 [v0.11.1](release-notes-v0.11.1.md) と [v0.11.0](release-notes-v0.11.0.md) を
 参照してください。
 
@@ -29,7 +37,8 @@
 
 これは検証可能な minor bump です。`v0.11.1` と比較して、
 `session-layer topology update-kind`、`session-layer topology retire-legacy`、
-`session-layer topology update-field` が新しい command surface であり、recipe は新たに
+`session-layer topology update-field`、`judgment-wait`、
+`automation issue-publish --execution-unit` が新しい command surface であり、recipe は新たに
 `delivery_method: file-backed` を宣言できます。これらの surface は `v0.11.1` には無く、
 version policy は新しい command surface を minor bump に割り当てます。
 
@@ -47,6 +56,31 @@ version policy は新しい command surface を minor bump に割り当てます
    liveness を成功とみなさず denial を確認します。
 4. **documentation guard。** repository-wide の Markdown link/anchor guard と rolling Japanese
    terminology guard は regression があれば CI を失敗させます。
+
+## G623–G628 の追加の挙動変更
+
+5. **judgment の vocabulary（G623）。** `judgment-wait` が `operator-attention` に代わります。
+   旧 command は 1.x を通じて `deprecate-with-alias` compatibility alias として残り、machine
+   output は replacement の `judgment-wait` を示す `deprecation_warning` を持ちます。削除は
+   次の MAJOR release でのみ可能です。
+6. **transport の graduation（G624）。** `herdr-only` は preview ではなくなり、依存関係が少ない
+   ため preferred です。`agmsg + herdr` は supported で、明示的に retired ではありません。
+   どちらの transport も primary とは呼びません。
+7. **dispatch outcome vocabulary（G625–G626）。** `issue-publish` は `--execution-unit` を受け付け、
+   unresolved work は unresolved として報告します。observed working transition に到達した delivery は
+   `working-did-not-settle` や `not-observed-within-bound` ではなく、successful な non-terminal state を
+   報告します。旧名に match していた caller は **silent に match しなくなります**。machine の
+   `working_transition` field に match するよう更新してください。
+
+### Breaking change: legacy fixed-path topology read の削除（G627）
+
+legacy `role-pane-mapping.json` だけがあり per-team record がない host は fail closed になります。
+diagnostic は recovery command として `topology record` と `topology retire-legacy` を示し、自動
+ migration は行いません。これは legacy-only host population に対する breaking change です。
+
+8. **versioning policy（G628）。** 1.0 feature set は v0.12.0 で freeze します。freeze 後に追加された
+   surface は `preview` として出荷し、ledger には `preview-through-1.x` として記録し、1.0
+   compatibility promise の対象外とし、後続の MAJOR release で formalise します。
 
 ## 運用上の目的
 
@@ -69,9 +103,13 @@ dotnet tool install -g JTechJapan.IntentSystem.Cli --version 0.12.0
 ## リリース準備ゲート
 
 - [ ] `eng/version.json` は `stableVersion` `0.11.1` / `nextVersion` `0.12.0`。
-- [ ] EN/JA notes は上記の verified PR と merge commit を持つ G610–G621 だけを記載。
-- [ ] minor 比較で、三つの topology subcommand と宣言済み `delivery_method` が `v0.11.1` に
-      無いことを確認。
+- [ ] EN/JA notes は verified PR と merge commit を持つ十八件の unit、G610–G621 と G623–G628 を
+      記載し、`git log v0.11.1..main` からの列挙であることを確認。
+- [ ] minor 比較で、`judgment-wait`、`automation issue-publish --execution-unit`、三つの topology
+      subcommand、宣言済み `delivery_method` が `v0.11.1` に無いことを確認。
+- [ ] G627 の breaking change を理解していることを確認する。legacy-only host は fail closed となり、
+      `topology record` または `topology retire-legacy` が必要。Release 作成前に v0.12.0 freeze と
+      preview policy も確認する。
 - [ ] G475、focused release-note check、full suite、diff check、exact-head CI が green。
 - [ ] operator が v0.12.0 GitHub Release の作成・publish を明示承認。
 

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0120DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0120DocsTests.cs
@@ -4,8 +4,8 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G622 keeps the v0.12.0 prepare-only notes complete, bilingual, and bounded
-/// to the twelve merges selected for this minor release.
+/// G633 keeps the v0.12.0 prepare-only notes complete, bilingual, and bounded
+/// to the eighteen merged units selected for this minor release.
 /// </summary>
 public sealed class ReleaseNotesV0120DocsTests
 {
@@ -23,12 +23,18 @@ public sealed class ReleaseNotesV0120DocsTests
         ("G619", "#1342", "36b89ac9fbfc"),
         ("G620", "#1344", "72878b63ff97"),
         ("G621", "#1346", "a1886218f56c"),
+        ("G623", "#1350", "c04e137"),
+        ("G624", "#1352", "ccd4f29"),
+        ("G625", "#1354", "06f1a71"),
+        ("G626", "#1356", "2bb20d3"),
+        ("G627", "#1358", "5b86977"),
+        ("G628", "#1360", "f464a04"),
     ];
 
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void ReleaseNotes_CoverExactlyG610ThroughG621_WithVerifiedMerges_G622(string language)
+    public void ReleaseNotes_CoverExactlyEighteenUnits_WithVerifiedMerges_G633(string language)
     {
         var notes = Read(language);
         var listedUnits = Regex.Matches(notes, @"(?m)^- (G\d+) —")
@@ -36,7 +42,7 @@ public sealed class ReleaseNotesV0120DocsTests
             .ToArray();
 
         Assert.Equal(ReleasedUnits.Select(unit => unit.Unit), listedUnits);
-        Assert.Equal(12, listedUnits.Length);
+        Assert.Equal(18, listedUnits.Length);
         foreach (var unit in ReleasedUnits)
         {
             Assert.Contains(unit.Pr, notes, StringComparison.Ordinal);
@@ -73,6 +79,18 @@ public sealed class ReleaseNotesV0120DocsTests
         Assert.Contains("Release", notes, StringComparison.Ordinal);
         Assert.Contains("tag", notes, StringComparison.Ordinal);
         Assert.Contains("publish", notes, StringComparison.Ordinal);
+        foreach (var surface in new[] { "judgment-wait", "execution-unit", "preview-through-1.x" })
+        {
+            Assert.Contains(surface, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("working-did-not-settle", notes, StringComparison.Ordinal);
+        Assert.Contains("not-observed-within-bound", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "silently" : "silent", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("working_transition", notes, StringComparison.Ordinal);
+        Assert.Contains("breaking", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("topology record", notes, StringComparison.Ordinal);
+        Assert.Contains("topology retire-legacy", notes, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #1361. Extends EN/JA v0.12.0 notes from twelve to eighteen units using git log v0.11.1..main anchors; discloses G623-G628 alias, transport, outcome, breaking topology, and freeze/preview changes; refreshes rationale and readiness; updates release-note coverage tests. Validation: focused ReleaseNotesV0120DocsTests, full dotnet test IntentSystem.sln -c Release, git diff --check.