### PR TITLE
G632: classify issue targets from declarations

### DIFF
--- a/docs/en/07-recovery.md
+++ b/docs/en/07-recovery.md
@@ -123,6 +123,13 @@ intent-cli worker pr-comment-preflight --repo <owner>/<repo> --pr    <n> --forma
 intent-cli automation doctor --format json
 ```
 
+`worker issue-preflight` derives target-mismatch from the issue's declared
+`Repository:` and `Target paths:` fields. A declared child-repository target
+remains actionable even when explanatory prose mentions a host or `submodules/`;
+those mentions are advisory notes only. A declared submodule target still
+blocks when the workdir is outside that submodule, and a missing `Target paths:`
+declaration fails closed instead of guessing from prose.
+
 | Result | Action |
 |--------|--------|
 | `safe_repair_category: child-selector-label-gap` | Apply the one repair `intent-cli` marks safe; retry once |

--- a/docs/ja/07-recovery.md
+++ b/docs/ja/07-recovery.md
@@ -119,6 +119,8 @@ intent-cli worker pr-comment-preflight --repo <owner>/<repo> --pr    <n> --forma
 intent-cli automation doctor --format json
 ```
 
+`worker issue-preflight` の target-mismatch 判定は、本文の推測的な文字列検索ではなく、Issue に宣言された `Repository:` と `Target paths:` を根拠にします。子リポジトリを宣言した Issue は、説明文に host や `submodules/` が現れても actionable のままで、その言及は advisory note として出力されます。宣言された対象が submodule 内で workdir が外側なら従来どおりブロックし、`Target paths:` 宣言がない場合は本文から推測せず fail closed します。
+
 | 結果 | 対応 |
 |------|------|
 | `safe_repair_category: child-selector-label-gap` | `intent-cli` が安全と判断した修復を 1 回適用し、リトライ |

--- a/src/IntentSystem.Cli/Commands/WorkerIssuePreflightAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerIssuePreflightAnalyzer.cs
@@ -138,8 +138,19 @@ internal static class WorkerIssuePreflightAnalyzer
                 WorkerIssuePreflightConstants.RecommendedActions.ReleaseFromTarget);
         }
 
+        var declaredPaths = HostOnlyPacketClassifier.ExtractTargetPaths(body);
+        if (declaredPaths.Count == 0)
+        {
+            return Build(
+                lookup, repo, issueNumber, title, state, labels,
+                WorkerIssuePreflightConstants.Classifications.MissingTargetDeclaration,
+                ["declaration-derived: missing `Target paths:` declaration; cannot classify the issue from prose"],
+                actionable: false,
+                WorkerIssuePreflightConstants.RecommendedActions.WaitForClarification);
+        }
+
         // Step 5: target-mismatch.
-        var mismatchReasons = DetectTargetMismatch(body, repo, workdir);
+        var mismatchReasons = DetectTargetMismatch(body, repo, workdir, declaredPaths);
         if (mismatchReasons.Count > 0)
         {
             return Build(
@@ -154,6 +165,8 @@ internal static class WorkerIssuePreflightAnalyzer
                 actionable: false,
                 WorkerIssuePreflightConstants.RecommendedActions.SwitchRepo);
         }
+
+        var advisories = DetectAdvisories(body, declaredPaths);
 
         // Step 6: contract-incomplete (reuse G183 validator).
         var sourcePath = $"github://{repo}/issues/{issueNumber}";
@@ -198,10 +211,11 @@ internal static class WorkerIssuePreflightAnalyzer
             WorkerIssuePreflightConstants.Classifications.ReadyToImplement,
             Array.Empty<string>(),
             actionable: true,
-            WorkerIssuePreflightConstants.RecommendedActions.Implement);
+            WorkerIssuePreflightConstants.RecommendedActions.Implement,
+            advisories);
     }
 
-    private static IReadOnlyList<string> DetectTargetMismatch(string body, string repo, string workdir)
+    private static IReadOnlyList<string> DetectTargetMismatch(string body, string repo, string workdir, IReadOnlyList<string> declaredPaths)
     {
         var reasons = new List<string>();
         if (string.IsNullOrEmpty(body))
@@ -222,32 +236,34 @@ internal static class WorkerIssuePreflightAnalyzer
             }
         }
 
-        // Heuristic 2: body mentions a `submodules/...` path while --workdir is
-        // not under a `submodules/` location.
-        if (body.Contains("submodules/", StringComparison.OrdinalIgnoreCase))
+        // Declaration-derived: a target inside a submodule must run in that
+        // submodule worktree. Prose mentions are advisory only.
+        if (declaredPaths.Any(p => p.Replace('\\', '/').TrimStart('/').StartsWith("submodules/", StringComparison.OrdinalIgnoreCase)))
         {
             var workdirNormalized = workdir.Replace('\\', '/');
             if (workdirNormalized.IndexOf("submodules/", StringComparison.OrdinalIgnoreCase) < 0)
             {
                 reasons.Add(
-                    "issue body references a submodules/ path but --workdir does not point inside a submodules/ tree");
+                    "declaration-derived: declared target paths are inside submodules/ but --workdir is outside a submodules/ tree");
             }
         }
 
-        // Heuristic 3: body literally mentions parent-host markers while --repo
-        // is a child-style owner/repo (i.e. not the parent host repo). We treat
-        // any --repo value as child-side here because the parent-host repo is
-        // not named in the precedence rules; mention of `parent-host` or
-        // `MyIntentHost` in a child-issue body is itself a mismatch signal.
-        var mentionsParentHost = body.Contains("parent-host", StringComparison.OrdinalIgnoreCase)
-            || body.Contains("MyIntentHost", StringComparison.Ordinal);
-        if (mentionsParentHost)
-        {
-            reasons.Add(
-                $"issue body references parent-host/MyIntentHost execution path which conflicts with child --repo {repo}");
-        }
-
         return reasons;
+    }
+
+    private static IReadOnlyList<string> DetectAdvisories(string body, IReadOnlyList<string> declaredPaths)
+    {
+        var advisories = new List<string>();
+        var declaredChild = declaredPaths.Any(p => !p.Replace('\\', '/').TrimStart('/').StartsWith("submodules/", StringComparison.OrdinalIgnoreCase));
+        if (declaredChild && body.Contains("submodules/", StringComparison.OrdinalIgnoreCase))
+        {
+            advisories.Add("advisory-derived: prose mentions a submodules/ path, but the declared target is the child repository");
+        }
+        if (declaredChild && (body.Contains("parent-host", StringComparison.OrdinalIgnoreCase) || body.Contains("MyIntentHost", StringComparison.Ordinal)))
+        {
+            advisories.Add("advisory-derived: prose mentions parent-host/MyIntentHost, but the declared target is the child repository");
+        }
+        return advisories;
     }
 
     private static WorkerIssuePreflightResult Build(
@@ -260,7 +276,8 @@ internal static class WorkerIssuePreflightAnalyzer
         string classification,
         IReadOnlyList<string> reasons,
         bool actionable,
-        string recommendedAction)
+        string recommendedAction,
+        IReadOnlyList<string>? advisories = null)
     {
         _ = lookup;
         var summaryLine =
@@ -276,6 +293,7 @@ internal static class WorkerIssuePreflightAnalyzer
             IssueState = state,
             Labels = labels,
             Reasons = reasons,
+            Advisories = advisories ?? Array.Empty<string>(),
             RecommendedAction = recommendedAction,
             SummaryLine = summaryLine
         };

--- a/src/IntentSystem.Cli/Commands/WorkerIssuePreflightAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerIssuePreflightAnalyzer.cs
@@ -232,7 +232,7 @@ internal static class WorkerIssuePreflightAnalyzer
             if (!string.Equals(declared, repo, StringComparison.OrdinalIgnoreCase))
             {
                 reasons.Add(
-                    $"issue body declares Repository: {declared} which does not match --repo {repo}");
+                    $"declaration-derived: declared Repository: {declared} which does not match --repo {repo}");
             }
         }
 
@@ -280,6 +280,8 @@ internal static class WorkerIssuePreflightAnalyzer
         IReadOnlyList<string>? advisories = null)
     {
         _ = lookup;
+        var derivedAdvisories = advisories
+            ?? DetectAdvisories(lookup.Body ?? string.Empty, HostOnlyPacketClassifier.ExtractTargetPaths(lookup.Body));
         var summaryLine =
             $"Worker issue-preflight for {repo}#{issueNumber} — classification={classification}, actionable={actionable.ToString().ToLowerInvariant()}.";
 
@@ -293,7 +295,7 @@ internal static class WorkerIssuePreflightAnalyzer
             IssueState = state,
             Labels = labels,
             Reasons = reasons,
-            Advisories = advisories ?? Array.Empty<string>(),
+            Advisories = derivedAdvisories,
             RecommendedAction = recommendedAction,
             SummaryLine = summaryLine
         };

--- a/src/IntentSystem.Cli/Commands/WorkerIssuePreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerIssuePreflightCommand.cs
@@ -153,6 +153,20 @@ internal static class WorkerIssuePreflightCommand
         }
         writer.WriteLine();
 
+        writer.WriteLine("## Advisories");
+        if (result.Advisories.Count == 0)
+        {
+            writer.WriteLine("- (none)");
+        }
+        else
+        {
+            foreach (var advisory in result.Advisories)
+            {
+                writer.WriteLine($"- {advisory}");
+            }
+        }
+        writer.WriteLine();
+
         writer.WriteLine(result.SummaryLine);
     }
 

--- a/src/IntentSystem.Cli/Commands/WorkerIssuePreflightResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerIssuePreflightResult.cs
@@ -34,6 +34,9 @@ internal sealed record WorkerIssuePreflightResult
     [JsonPropertyName("reasons")]
     public required IReadOnlyList<string> Reasons { get; init; }
 
+    [JsonPropertyName("advisories")]
+    public required IReadOnlyList<string> Advisories { get; init; }
+
     [JsonPropertyName("recommended_action")]
     public required string RecommendedAction { get; init; }
 
@@ -69,6 +72,7 @@ internal static class WorkerIssuePreflightConstants
         public const string MissingTargetLabel = "missing-target-label";
         public const string ContractIncomplete = "contract-incomplete";
         public const string TargetMismatch = "target-mismatch";
+        public const string MissingTargetDeclaration = "missing-target-declaration";
         public const string NonActionable = "non-actionable";
 
         /// <summary>

--- a/tests/IntentSystem.Cli.Tests/WorkerIssuePreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerIssuePreflightCommandTests.cs
@@ -130,6 +130,7 @@ public sealed class WorkerIssuePreflightCommandTests : IDisposable
         // reported as ready-to-implement.
         using var workspace = new WorkerIssuePreflightWorkspace();
         var hostOnlyBody = ValidBody("J-Tech-Japan/intent-system")
+            .Replace("Target paths: `src/Foo`, `tests/IntentSystem.Cli.Tests`\n", string.Empty, StringComparison.Ordinal)
             + "\n\nTarget paths: `intents/intent-cli/intent-tree/purpose/04-product-goal.md`, `intents/intent-cli/intent-tree/00-map.md`, `.intent-cli/issues/G458`\n";
         WorkerIssuePreflightCommand.IssueLookupFactory = () => new FakeLookup(BuildIssue(
             number: 1018,
@@ -262,8 +263,42 @@ public sealed class WorkerIssuePreflightCommandTests : IDisposable
 
         Assert.Equal(0, exitCode);
         var result = JsonSerializer.Deserialize<WorkerIssuePreflightResult>(writer.ToString())!;
+        Assert.Equal(WorkerIssuePreflightConstants.Classifications.ReadyToImplement, result.Classification);
+        Assert.True(result.Actionable);
+        Assert.Contains(result.Advisories, r => r.Contains("submodules", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenDeclaredSubmoduleTargetOutsideWorkdir_BlocksFromDeclaration()
+    {
+        using var workspace = new WorkerIssuePreflightWorkspace();
+        var body = ValidBody("J-Tech-Japan/intent-system")
+            .Replace("Target paths: `src/Foo`, `tests/IntentSystem.Cli.Tests`", "Target paths: `submodules/child/src/Foo`", StringComparison.Ordinal);
+        WorkerIssuePreflightCommand.IssueLookupFactory = () => new FakeLookup(BuildIssue(601, "OPEN", "submodule", body, new[] { "intent-target" }));
+        using var writer = new StringWriter();
+        var exitCode = WorkerIssuePreflightCommand.Execute(workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--issue", "601", "--workdir", "/tmp/host", "--format", "json" }, writer);
+        var result = JsonSerializer.Deserialize<WorkerIssuePreflightResult>(writer.ToString())!;
+        Assert.Equal(0, exitCode);
+        Assert.False(result.Actionable);
         Assert.Equal(WorkerIssuePreflightConstants.Classifications.TargetMismatch, result.Classification);
-        Assert.Contains(result.Reasons, r => r.Contains("submodules", StringComparison.Ordinal));
+        Assert.Contains(result.Reasons, r => r.StartsWith("declaration-derived:", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenMissingTargetDeclaration_RefusesToGuess()
+    {
+        using var workspace = new WorkerIssuePreflightWorkspace();
+        var body = ValidBody("J-Tech-Japan/intent-system").Replace("Target paths: `src/Foo`, `tests/IntentSystem.Cli.Tests`\n", string.Empty, StringComparison.Ordinal);
+        WorkerIssuePreflightCommand.IssueLookupFactory = () => new FakeLookup(BuildIssue(602, "OPEN", "missing", body, new[] { "intent-target" }));
+        using var writer = new StringWriter();
+        var exitCode = WorkerIssuePreflightCommand.Execute(workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--issue", "602", "--format", "json" }, writer);
+        var result = JsonSerializer.Deserialize<WorkerIssuePreflightResult>(writer.ToString())!;
+        Assert.Equal(0, exitCode);
+        Assert.False(result.Actionable);
+        Assert.Equal(WorkerIssuePreflightConstants.Classifications.MissingTargetDeclaration, result.Classification);
+        Assert.Contains(result.Reasons, r => r.Contains("Target paths", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -725,7 +760,7 @@ public sealed class WorkerIssuePreflightCommandTests : IDisposable
 
             ## Target Repo / Path / Part
             Repository: {repository}
-            Primary path: src/Foo
+            Target paths: `src/Foo`, `tests/IntentSystem.Cli.Tests`
 
             ## In Scope
             - in scope item

--- a/tests/IntentSystem.Cli.Tests/WorkerIssuePreflightCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerIssuePreflightCommandTests.cs
@@ -269,6 +269,40 @@ public sealed class WorkerIssuePreflightCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenG625SentenceWithChildDeclaration_IsActionableWithAdvisory()
+    {
+        using var workspace = new WorkerIssuePreflightWorkspace();
+        var body = ValidBody("J-Tech-Japan/intent-system")
+            + "\nreported from a host with no `.gitmodules` and no `submodules/`\n";
+        WorkerIssuePreflightCommand.IssueLookupFactory = () => new FakeLookup(BuildIssue(603, "OPEN", "G625 sentence", body, new[] { "intent-target" }));
+        using var writer = new StringWriter();
+        var exitCode = WorkerIssuePreflightCommand.Execute(workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--issue", "603", "--format", "json" }, writer);
+        var result = JsonSerializer.Deserialize<WorkerIssuePreflightResult>(writer.ToString())!;
+        Assert.Equal(0, exitCode);
+        Assert.Equal(WorkerIssuePreflightConstants.Classifications.ReadyToImplement, result.Classification);
+        Assert.True(result.Actionable);
+        Assert.Contains(result.Advisories, r => r.Contains("submodules/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Execute_GivenG627SentenceWithChildDeclaration_IsActionableWithAdvisory()
+    {
+        using var workspace = new WorkerIssuePreflightWorkspace();
+        var body = ValidBody("J-Tech-Japan/intent-system")
+            + "\nnaming this machine's host directory as retirement evidence; the parent-host execution path was measured.\n";
+        WorkerIssuePreflightCommand.IssueLookupFactory = () => new FakeLookup(BuildIssue(604, "OPEN", "G627 sentence", body, new[] { "intent-target" }));
+        using var writer = new StringWriter();
+        var exitCode = WorkerIssuePreflightCommand.Execute(workspace.Context,
+            new[] { "--repo", "J-Tech-Japan/intent-system", "--issue", "604", "--format", "json" }, writer);
+        var result = JsonSerializer.Deserialize<WorkerIssuePreflightResult>(writer.ToString())!;
+        Assert.Equal(0, exitCode);
+        Assert.Equal(WorkerIssuePreflightConstants.Classifications.ReadyToImplement, result.Classification);
+        Assert.True(result.Actionable);
+        Assert.Contains(result.Advisories, r => r.Contains("parent-host", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Execute_GivenDeclaredSubmoduleTargetOutsideWorkdir_BlocksFromDeclaration()
     {
         using var workspace = new WorkerIssuePreflightWorkspace();


### PR DESCRIPTION
Closes #1366

Derive worker issue-preflight target mismatch from declared Repository/Target paths. Prose mismatches are advisory, missing declarations fail closed, and EN/JA recovery guidance plus regression tests are included.

Focused: dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --filter FullyQualifiedName~WorkerIssuePreflightCommandTests
Full: dotnet test IntentSystem.sln --no-restore -c Release