### PR TITLE
G631: pin encoding for every child process stream

### DIFF
--- a/docs/en/07-recovery.md
+++ b/docs/en/07-recovery.md
@@ -130,6 +130,14 @@ those mentions are advisory notes only. A declared submodule target still
 blocks when the workdir is outside that submodule, and a missing `Target paths:`
 declaration fails closed instead of guessing from prose.
 
+On Japanese Windows, a redirected child-process decoding failure can appear as
+an intermittent, environment-triggered total stall: ambient non-ASCII bytes
+(for example, a pane title in an unrelated workspace) can stop every transport
+operation at once. Child streams are now pinned to UTF-8, so no workaround that
+avoids non-ASCII text is required after upgrading. On macOS/Linux the Windows
+code-page failure is structurally unreachable; verification is by construction
+and by the source guard.
+
 | Result | Action |
 |--------|--------|
 | `safe_repair_category: child-selector-label-gap` | Apply the one repair `intent-cli` marks safe; retry once |

--- a/docs/ja/07-recovery.md
+++ b/docs/ja/07-recovery.md
@@ -121,6 +121,8 @@ intent-cli automation doctor --format json
 
 `worker issue-preflight` の target-mismatch 判定は、本文の推測的な文字列検索ではなく、Issue に宣言された `Repository:` と `Target paths:` を根拠にします。子リポジトリを宣言した Issue は、説明文に host や `submodules/` が現れても actionable のままで、その言及は advisory note として出力されます。宣言された対象が submodule 内で workdir が外側なら従来どおりブロックし、`Target paths:` 宣言がない場合は本文から推測せず fail closed します。
 
+日本語 Windows では、子プロセスのリダイレクト出力のデコード不良が、間欠的・環境依存の「全 transport が同時に止まる」ストールとして現れることがあります。別 workspace の pane title など、周囲の非 ASCII バイトがきっかけになります。子プロセスの stream は UTF-8 に固定されたため、更新後に非 ASCII を避ける回避策は不要です。macOS/Linux では Windows の code page 起因の失敗は構造上発生せず、構築結果と source guard で検証します。
+
 | 結果 | 対応 |
 |------|------|
 | `safe_repair_category: child-selector-label-gap` | `intent-cli` が安全と判断した修復を 1 回適用し、リトライ |

--- a/src/IntentSystem.Cli/Commands/AutomationDurableStatePreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationDurableStatePreflightCommand.cs
@@ -675,6 +675,8 @@ internal static class AutomationDurableStatePreflightCommand
         process.StartInfo.WorkingDirectory = workingDirectory;
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom;
+        process.StartInfo.StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom;
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.CreateNoWindow = true;
         process.Start();

--- a/src/IntentSystem.Cli/Commands/AutomationHostSyncPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHostSyncPreflightCommand.cs
@@ -332,6 +332,8 @@ internal static class AutomationHostSyncPreflightCommand
         process.StartInfo.WorkingDirectory = workingDirectory;
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom;
+        process.StartInfo.StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom;
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.CreateNoWindow = true;
         process.Start();

--- a/src/IntentSystem.Cli/Commands/AutomationInstalledCliSurfaceProbe.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationInstalledCliSurfaceProbe.cs
@@ -154,6 +154,8 @@ internal static class AutomationInstalledCliSurfaceProbe
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
         };
         startInfo.Environment["INTENT_CLI_SURFACE_PROBE"] = "1";
 

--- a/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationIssueRetireCommand.cs
@@ -942,8 +942,8 @@ internal sealed class GhCliGitHubIssueRetirementMutator : IGitHubIssueRetirement
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/AutomationPublishLifecycleRepairCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationPublishLifecycleRepairCommand.cs
@@ -406,8 +406,8 @@ internal sealed class GhCliGitHubAutomationIssueLookup : IGitHubAutomationIssueL
             FileName = "gh",
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/AutomationSameRepoMetadataPreflightCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationSameRepoMetadataPreflightCommand.cs
@@ -308,6 +308,8 @@ internal static class AutomationSameRepoMetadataPreflightCommand
         process.StartInfo.WorkingDirectory = repoRoot;
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom;
+        process.StartInfo.StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom;
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.CreateNoWindow = true;
         try

--- a/src/IntentSystem.Cli/Commands/AutomationWorkspaceGuardCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationWorkspaceGuardCommand.cs
@@ -843,6 +843,8 @@ internal sealed class ShellGitRunner : IGitRunner
         process.StartInfo.WorkingDirectory = workingDirectory;
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.RedirectStandardError = true;
+        process.StartInfo.StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom;
+        process.StartInfo.StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom;
         process.StartInfo.UseShellExecute = false;
         process.StartInfo.CreateNoWindow = true;
         process.Start();

--- a/src/IntentSystem.Cli/Commands/GhIssueCreator.cs
+++ b/src/IntentSystem.Cli/Commands/GhIssueCreator.cs
@@ -24,8 +24,8 @@ internal sealed class GhIssueCreator : IGhIssueCreator
             UseShellExecute = false,
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom
         };
 
         startInfo.ArgumentList.Add("issue");

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -312,8 +312,8 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
             FileName = "gh",
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubIssueClosingPrLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubIssueClosingPrLookup.cs
@@ -57,8 +57,8 @@ internal sealed class GhCliGitHubIssueClosingPrLookup : IGitHubIssueClosingPrLoo
             FileName = "gh",
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubIssueLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubIssueLookup.cs
@@ -43,8 +43,8 @@ internal sealed class GhCliGitHubIssueLookup : IGitHubIssueLookup
             FileName = "gh",
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelLister.cs
@@ -49,8 +49,8 @@ internal sealed class GhCliGitHubLabelLister : IGitHubLabelLister
             FileName = "gh",
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelMutator.cs
@@ -638,8 +638,8 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator, IGitHubLabe
         var startInfo = new ProcessStartInfo
         {
             FileName = "gh",
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             RedirectStandardInput = true,
@@ -718,8 +718,8 @@ internal sealed class GhCliGitHubLabelMutator : IGitHubLabelMutator, IGitHubLabe
             FileName = "gh",
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubLabelPaletteMutator.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubLabelPaletteMutator.cs
@@ -76,8 +76,8 @@ internal sealed class GhCliGitHubLabelPaletteMutator : IGitHubLabelPaletteMutato
             FileName = "gh",
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubPrCommentsLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubPrCommentsLookup.cs
@@ -155,8 +155,8 @@ internal sealed class GhCliGitHubPrCommentsLookup : IGitHubPrCommentsLookup
             FileName = "gh",
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubPrLookup.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubPrLookup.cs
@@ -87,8 +87,8 @@ internal sealed class GhCliGitHubPrLookup : IGitHubPrLookup
             FileName = "gh",
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/src/IntentSystem.Cli/Commands/IGitHubSignalGateway.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubSignalGateway.cs
@@ -136,8 +136,8 @@ internal sealed class GhCliGitHubSignalGateway : IGitHubSignalGateway
             FileName = "gh",
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             RedirectStandardInput = standardInput is not null,

--- a/src/IntentSystem.Cli/Commands/IntentHostCheckCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentHostCheckCommand.cs
@@ -156,6 +156,8 @@ internal static class IntentHostCheckCommand
             process.StartInfo.WorkingDirectory = repoRoot;
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom;
+            process.StartInfo.StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom;
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.CreateNoWindow = true;
             process.Start();

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -1638,8 +1638,8 @@ internal sealed class GhCliExistingIssueChecker : IGitHubExistingIssueChecker
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom
         };
         foreach (var argument in arguments)
         {
@@ -1740,8 +1740,8 @@ internal sealed class GhCliIssueCreator : IIssueCreator
             UseShellExecute = false,
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom
         };
         startInfo.ArgumentList.Add("issue");
         startInfo.ArgumentList.Add("create");

--- a/src/IntentSystem.Cli/Commands/NotifyTransport.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyTransport.cs
@@ -20,6 +20,8 @@ internal sealed class NotifyProcessRunner : INotifyProcessRunner
             FileName = fileName,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             UseShellExecute = false,
             CreateNoWindow = true,
         };

--- a/src/IntentSystem.Cli/GhCommandRunner.cs
+++ b/src/IntentSystem.Cli/GhCommandRunner.cs
@@ -16,8 +16,8 @@ internal sealed class GhCommandRunner : IGitHubCommandRunner
             UseShellExecute = false,
             // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient
             // console code page (Windows cp932) so Japanese payloads stay valid.
-            StandardOutputEncoding = GitHubCliProcessEncoding.Utf8NoBom,
-            StandardErrorEncoding = GitHubCliProcessEncoding.Utf8NoBom
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom
         };
 
         foreach (var argument in arguments)

--- a/src/IntentSystem.Cli/GitCommandRunner.cs
+++ b/src/IntentSystem.Cli/GitCommandRunner.cs
@@ -15,6 +15,8 @@ internal sealed class GitRemoteCommandRunner : IGitRemoteCommandRunner
             WorkingDirectory = workingDirectory,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             UseShellExecute = false
         };
 

--- a/src/IntentSystem.Cli/ProcessOutputEncoding.cs
+++ b/src/IntentSystem.Cli/ProcessOutputEncoding.cs
@@ -4,7 +4,7 @@ namespace IntentSystem.Cli;
 
 /// <summary>
 /// G631: shared decoding contract for redirected child-process output.
-/// always emits UTF-8 (JSON and error text), but when a redirected
+/// Child processes in this codebase emit UTF-8 (JSON and error text), but when a redirected
 /// <see cref="System.Diagnostics.ProcessStartInfo"/> does not pin
 /// <c>StandardOutputEncoding</c> / <c>StandardErrorEncoding</c>, .NET decodes
 /// the streams with <see cref="System.Console.OutputEncoding"/> — which on a
@@ -12,18 +12,19 @@ namespace IntentSystem.Cli;
 /// UTF-8 sequences in Japanese issue titles/bodies and corrupts otherwise-valid
 /// <c>gh</c> JSON, breaking <c>worker next-action</c> / preflight selection.
 ///
-/// Every <c>gh</c> invocation pins both stream encodings to
-/// <see cref="Utf8NoBom"/> so decoding is UTF-8 regardless of the ambient
-/// console code page, Git Bash, or PowerShell host encoding. This is identical
-/// to existing behavior on macOS/Linux (whose console is already UTF-8), so the
-/// fix is a no-op there and only repairs the Windows cp932 path.
+/// Every redirected child stream pins both encodings to <see cref="Utf8NoBom"/>
+/// so decoding is UTF-8 regardless of the ambient console code page, Git Bash,
+/// or PowerShell host encoding. The <c>gh</c> path motivated this contract, but
+/// it applies equally to git, herdr, and every other child process. This is
+/// identical to existing behavior on macOS/Linux (whose console is already
+/// UTF-8), so the fix is a no-op there and only repairs the Windows cp932 path.
 /// </summary>
 internal static class ProcessOutputEncoding
 {
     /// <summary>
     /// UTF-8 without a byte-order mark. Used as both
     /// <c>StandardOutputEncoding</c> and <c>StandardErrorEncoding</c> for every
-    /// <c>gh</c> subprocess so JSON and diagnostics decode as UTF-8.
+    /// redirected child subprocess so JSON and diagnostics decode as UTF-8.
     /// </summary>
     public static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 }

--- a/src/IntentSystem.Cli/ProcessOutputEncoding.cs
+++ b/src/IntentSystem.Cli/ProcessOutputEncoding.cs
@@ -3,7 +3,7 @@ using System.Text;
 namespace IntentSystem.Cli;
 
 /// <summary>
-/// G484: shared decoding contract for <c>gh</c> subprocess output. GitHub CLI
+/// G631: shared decoding contract for redirected child-process output.
 /// always emits UTF-8 (JSON and error text), but when a redirected
 /// <see cref="System.Diagnostics.ProcessStartInfo"/> does not pin
 /// <c>StandardOutputEncoding</c> / <c>StandardErrorEncoding</c>, .NET decodes
@@ -18,7 +18,7 @@ namespace IntentSystem.Cli;
 /// to existing behavior on macOS/Linux (whose console is already UTF-8), so the
 /// fix is a no-op there and only repairs the Windows cp932 path.
 /// </summary>
-internal static class GitHubCliProcessEncoding
+internal static class ProcessOutputEncoding
 {
     /// <summary>
     /// UTF-8 without a byte-order mark. Used as both

--- a/src/IntentSystem.Review/GhReviewCommandRunner.cs
+++ b/src/IntentSystem.Review/GhReviewCommandRunner.cs
@@ -1,14 +1,9 @@
 using System.Diagnostics;
-using System.Text;
 
 namespace IntentSystem.Review;
 
 public sealed class GhReviewCommandRunner : IReviewCommandRunner
 {
-    // G484: decode gh stdout/stderr as UTF-8 regardless of the ambient console
-    // code page (Windows cp932) so Japanese payloads stay valid JSON/text.
-    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-
     public ReviewCommandResult Run(IReadOnlyList<string> arguments)
     {
         ArgumentNullException.ThrowIfNull(arguments);
@@ -19,8 +14,8 @@ public sealed class GhReviewCommandRunner : IReviewCommandRunner
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
-            StandardOutputEncoding = Utf8NoBom,
-            StandardErrorEncoding = Utf8NoBom
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom
         };
 
         foreach (var argument in arguments)

--- a/src/IntentSystem.Review/GitCommandRunner.cs
+++ b/src/IntentSystem.Review/GitCommandRunner.cs
@@ -15,6 +15,8 @@ public sealed class GitCommandRunner : IGitCommandRunner
             WorkingDirectory = workingDirectory,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
+            StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
             UseShellExecute = false
         };
 

--- a/src/IntentSystem.Review/ProcessOutputEncoding.cs
+++ b/src/IntentSystem.Review/ProcessOutputEncoding.cs
@@ -1,0 +1,8 @@
+using System.Text;
+
+namespace IntentSystem.Review;
+
+internal static class ProcessOutputEncoding
+{
+    public static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+}

--- a/tests/IntentSystem.Cli.Tests/ChildProcessEncodingGuardTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ChildProcessEncodingGuardTests.cs
@@ -11,6 +11,15 @@ public sealed class ChildProcessEncodingGuardTests
         {
             var lines = File.ReadAllLines(file);
             var source = File.ReadAllText(file);
+            var outputRedirects = lines.Count(line => line.Contains("RedirectStandardOutput =", StringComparison.Ordinal));
+            var outputEncodings = lines.Count(line => line.Contains("StandardOutputEncoding =", StringComparison.Ordinal));
+            var errorRedirects = lines.Count(line => line.Contains("RedirectStandardError =", StringComparison.Ordinal));
+            var errorEncodings = lines.Count(line => line.Contains("StandardErrorEncoding =", StringComparison.Ordinal));
+            if (outputRedirects != outputEncodings || errorRedirects != errorEncodings)
+            {
+                offenders.Add($"{Path.GetRelativePath(root, file)}:redirect/encoding counts {outputRedirects}/{outputEncodings}, {errorRedirects}/{errorEncodings}");
+            }
+
             for (var i = 0; i < lines.Length; i++)
             {
                 if (!lines[i].Contains("process.StartInfo.RedirectStandard", StringComparison.Ordinal))

--- a/tests/IntentSystem.Cli.Tests/ChildProcessEncodingGuardTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ChildProcessEncodingGuardTests.cs
@@ -7,31 +7,69 @@ public sealed class ChildProcessEncodingGuardTests
     {
         var root = FindRepositoryRoot();
         var offenders = new List<string>();
-        foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
-                     .Where(path =>
-                     {
-                         var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
-                         return relative.StartsWith("src/IntentSystem.Cli/", StringComparison.Ordinal)
-                             || relative.StartsWith("src/IntentSystem.Review/", StringComparison.Ordinal);
-                     }))
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(root, "src"), "*.cs", SearchOption.AllDirectories))
         {
             var lines = File.ReadAllLines(file);
+            var source = File.ReadAllText(file);
             for (var i = 0; i < lines.Length; i++)
             {
-                if (!lines[i].Contains("RedirectStandardOutput", StringComparison.Ordinal)
-                    && !lines[i].Contains("RedirectStandardError", StringComparison.Ordinal))
+                if (!lines[i].Contains("process.StartInfo.RedirectStandard", StringComparison.Ordinal))
                 {
                     continue;
                 }
 
-                var start = Math.Max(0, i - 12);
-                var end = Math.Min(lines.Length, i + 13);
+                var start = Math.Max(0, i - 3);
+                var end = Math.Min(lines.Length, i + 4);
                 var window = string.Join('\n', lines[start..end]);
                 if (!window.Contains("StandardOutputEncoding", StringComparison.Ordinal)
                     || !window.Contains("StandardErrorEncoding", StringComparison.Ordinal))
                 {
                     offenders.Add($"{Path.GetRelativePath(root, file)}:{i + 1}");
                 }
+            }
+
+            for (var search = 0; ;)
+            {
+                var marker = source.IndexOf("new ProcessStartInfo", search, StringComparison.Ordinal);
+                if (marker < 0)
+                {
+                    break;
+                }
+
+                var open = source.IndexOf('{', marker);
+                if (open < 0)
+                {
+                    break;
+                }
+
+                var depth = 0;
+                var close = -1;
+                for (var index = open; index < source.Length; index++)
+                {
+                    if (source[index] == '{') depth++;
+                    if (source[index] == '}' && --depth == 0)
+                    {
+                        close = index;
+                        break;
+                    }
+                }
+
+                if (close < 0)
+                {
+                    break;
+                }
+
+                var initializer = source[(open + 1)..close];
+                if ((initializer.Contains("RedirectStandardOutput", StringComparison.Ordinal)
+                        || initializer.Contains("RedirectStandardError", StringComparison.Ordinal))
+                    && (!initializer.Contains("StandardOutputEncoding", StringComparison.Ordinal)
+                        || !initializer.Contains("StandardErrorEncoding", StringComparison.Ordinal)))
+                {
+                    var line = source[..marker].Count(c => c == '\n') + 1;
+                    offenders.Add($"{Path.GetRelativePath(root, file)}:{line}");
+                }
+
+                search = close + 1;
             }
         }
 

--- a/tests/IntentSystem.Cli.Tests/ChildProcessEncodingGuardTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ChildProcessEncodingGuardTests.cs
@@ -1,0 +1,56 @@
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ChildProcessEncodingGuardTests
+{
+    [Fact]
+    public void EveryRedirectedChildStreamDeclaresUtf8Encoding()
+    {
+        var root = FindRepositoryRoot();
+        var offenders = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+                     .Where(path =>
+                     {
+                         var relative = Path.GetRelativePath(root, path).Replace('\\', '/');
+                         return relative.StartsWith("src/IntentSystem.Cli/", StringComparison.Ordinal)
+                             || relative.StartsWith("src/IntentSystem.Review/", StringComparison.Ordinal);
+                     }))
+        {
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (!lines[i].Contains("RedirectStandardOutput", StringComparison.Ordinal)
+                    && !lines[i].Contains("RedirectStandardError", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var start = Math.Max(0, i - 12);
+                var end = Math.Min(lines.Length, i + 13);
+                var window = string.Join('\n', lines[start..end]);
+                if (!window.Contains("StandardOutputEncoding", StringComparison.Ordinal)
+                    || !window.Contains("StandardErrorEncoding", StringComparison.Ordinal))
+                {
+                    offenders.Add($"{Path.GetRelativePath(root, file)}:{i + 1}");
+                }
+            }
+        }
+
+        Assert.Empty(offenders);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (Directory.Exists(Path.Combine(directory.FullName, "src", "IntentSystem.Cli")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root.");
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GitHubCliProcessEncodingTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GitHubCliProcessEncodingTests.cs
@@ -14,7 +14,7 @@ namespace IntentSystem.Cli.Tests;
 /// the same bytes with a non-UTF-8 code page corrupts them — proving the
 /// encoding choice is what fixes the bug.
 /// </summary>
-public sealed class GitHubCliProcessEncodingTests
+public sealed class ProcessOutputEncodingTests
 {
     // gh issue list --json number,title,labels,url shape, with a Japanese title.
     private const string JapaneseTitle = "G484 日本語タイトルのテスト（cp932 回帰）";
@@ -25,9 +25,9 @@ public sealed class GitHubCliProcessEncodingTests
     [Fact]
     public void Utf8NoBom_IsUtf8WithoutPreamble()
     {
-        Assert.Equal("Unicode (UTF-8)", GitHubCliProcessEncoding.Utf8NoBom.EncodingName);
+        Assert.Equal("Unicode (UTF-8)", ProcessOutputEncoding.Utf8NoBom.EncodingName);
         // No BOM: gh JSON must not be prefixed with a byte-order mark on write.
-        Assert.Empty(GitHubCliProcessEncoding.Utf8NoBom.GetPreamble());
+        Assert.Empty(ProcessOutputEncoding.Utf8NoBom.GetPreamble());
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public sealed class GitHubCliProcessEncodingTests
         var ghStdoutBytes = Encoding.UTF8.GetBytes(JapaneseIssueListJson);
 
         // What the runner does (post-G484): decode with the pinned UTF-8 encoding.
-        var decoded = GitHubCliProcessEncoding.Utf8NoBom.GetString(ghStdoutBytes);
+        var decoded = ProcessOutputEncoding.Utf8NoBom.GetString(ghStdoutBytes);
 
         var extraction = GitHubCliJsonBoundary.ExtractJsonArray(decoded, "`gh issue list` for J-Tech-Japan/intent-system");
         Assert.True(extraction.Succeeded);
@@ -76,7 +76,7 @@ public sealed class GitHubCliProcessEncodingTests
             "[{\"number\":1,\"title\":\"ASCII only title\",\"labels\":[],\"url\":\"https://example/1\"}]";
         var bytes = Encoding.UTF8.GetBytes(asciiJson);
 
-        var decoded = GitHubCliProcessEncoding.Utf8NoBom.GetString(bytes);
+        var decoded = ProcessOutputEncoding.Utf8NoBom.GetString(bytes);
         Assert.Equal(asciiJson, decoded);
 
         var extraction = GitHubCliJsonBoundary.ExtractJsonArray(decoded, "`gh issue list` for owner/repo");


### PR DESCRIPTION
Closes #1365

Pin UTF-8/no-BOM decoding on every redirected child-process stream, rename the helper to a callee-neutral ProcessOutputEncoding, and add a source guard that catches omissions. EN/JA recovery guidance records the intermittent total Windows stall and the no-workaround outcome.

Focused guard: dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --filter FullyQualifiedName~ChildProcessEncodingGuardTests
Full: dotnet test IntentSystem.sln --no-restore -c Release

The Windows runtime failure was not reproduced on this macOS host; verification is by construction and the guard.