### PR TITLE
G635: prepare v0.12.1 notes for G631 and G632

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2628,8 +2628,8 @@ to keep in sync, and it goes stale on exactly the roll nobody is watching.
 ### Next release readiness (v0.12.1)
 
 **`v0.12.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.12.1`. [The v0.12.1 notes stub](release-notes-v0.12.1.md) is the required
-prepare-only placeholder. See [release-notes-v0.12.0.md](release-notes-v0.12.0.md)
+`0.12.1`. [The prepared v0.12.1 notes](release-notes-v0.12.1.md) cover exactly
+G631 and G632 and remain prepare-only. See [release-notes-v0.12.0.md](release-notes-v0.12.0.md)
 for the preceding shipped scope.
 
 **Release-readiness verification (run before merging the `v0.12.1`
@@ -2652,6 +2652,10 @@ ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.12.1.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
   "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0120DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+
+# 4a. Confirm the v0.12.1 bilingual notes and G634 count guard.
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --filter \
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0120DocsTests|FullyQualifiedName~ReleaseNotesV0121DocsTests"
 
 # 5. Run the complete Release suite.
 dotnet test IntentSystem.sln -c Release

--- a/docs/en/release-notes-v0.12.1.md
+++ b/docs/en/release-notes-v0.12.1.md
@@ -1,9 +1,64 @@
 # Release Notes — intent-cli v0.12.1
 
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
+> **Prepare-only / UNRELEASED.** These notes are ready for operator review.
+> This PR creates no GitHub Release, tag, package, or version-state change.
 
 Install verification: `JTechJapan.IntentSystem.Cli --version 0.12.1`.
-The eventual release will be published at
+When approved, the release will be published at
 https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.12.1.
+See the [v0.12.0 notes](release-notes-v0.12.0.md) for the preceding release;
+that content is linked, not repeated here.
+
+## v0.12.1 patch scope
+
+The unit list below was derived by running `git log v0.12.0..main`. The eight
+commits in that range are fully accounted for: the G631 repair series, the G632
+repair series, and the post-release version roll `e209d03`.
+
+- G631 — PR #1368, merge commit `4c4ef22` (resolves on `main`): every redirected
+  child-process stream is decoded as UTF-8; the helper is `ProcessOutputEncoding`,
+  and a guard fails the suite when a spawn site omits the declaration.
+- G632 — PR #1367, merge commit `77a57f2` (resolves on `main`): `worker
+  issue-preflight` derives target classification from declared `Repository:` and
+  `Target paths:`; prose mentions are advisory notes.
+
+This is a patch rather than a minor release: neither unit adds a command or a
+flag. G631 declares encoding at existing spawn sites and renames an internal
+helper; G632 changes how an existing classification is derived. Both claims
+are verifiable in the linked merge commits and the `git log` enumeration.
+
+### Operator impact: Windows child-stream decoding (G631)
+
+On a console whose code page is not UTF-8, non-ASCII child output could corrupt
+JSON and make every transport operation fail together. The symptom was an
+intermittent, environment-triggered total loop stall; ambient bytes such as a
+pane title in an unrelated workspace could trigger it. The workaround announced
+with v0.12.0—avoiding non-ASCII text in pane titles and paths—is no longer
+needed. A source guard now fails the test suite when a future spawn site omits
+the UTF-8 declaration.
+
+### Author impact: declaration-based preflight (G632)
+
+An issue that declares the child repository as its target remains actionable
+regardless of what its prose mentions; those mentions appear as advisory notes.
+A declared submodule target with a working directory outside that submodule
+still blocks, and an unreadable target declaration fails closed rather than
+guessing from prose.
+
+## Release-readiness gate
+
+Before creating the v0.12.1 Release, the operator must verify:
+
+- `eng/version.json` remains stable `0.12.0` / next `0.12.1`.
+- PRs #1368 and #1367 resolve on `main` at merge commits `4c4ef22` and
+  `77a57f2`, and `git log v0.12.0..main` accounts for all eight commits.
+- The bilingual release-notes guard and G634 count guard pass, followed by the
+  full Release suite and exact-head CI.
+- This remains prepare-only: do not create a Release, tag, or package publish
+  until the operator explicitly approves it.
+
+## Publishing v0.12.1
+
+After the readiness gate passes and the operator approves, a maintainer may
+create the GitHub Release and publish the package. This preparation PR does not
+perform that step.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2701,8 +2701,8 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 ### 次リリース準備(v0.12.1)
 
 **`v0.12.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.12.1` です。[v0.12.1 notes stub](release-notes-v0.12.1.md) は必須の
-prepare-only placeholder です。直前の出荷範囲は
+`0.12.1` です。[準備済み v0.12.1 notes](release-notes-v0.12.1.md) は G631 と G632 のみを
+扱う prepare-only の内容です。直前の出荷範囲は
 [release-notes-v0.12.0.md](release-notes-v0.12.0.md) を参照してください。
 
 **リリース準備検証(`v0.12.1` release-preparation PR のマージ前に実行):**
@@ -2724,6 +2724,10 @@ ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.12.1.nupkg
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
   "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0120DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+
+# 4a. v0.12.1 の bilingual notes と G634 count guard を確認。
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release --filter \
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0120DocsTests|FullyQualifiedName~ReleaseNotesV0121DocsTests"
 
 # 5. Release suite を完全実行。
 dotnet test IntentSystem.sln -c Release

--- a/docs/ja/release-notes-v0.12.1.md
+++ b/docs/ja/release-notes-v0.12.1.md
@@ -1,8 +1,56 @@
 # リリースノート — intent-cli v0.12.1
 
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。実際の内容はその packet が準備します。このファイルを changelog として扱ってはいけません。次の packet が準備できるまで内容はありません。
+> **prepare-only / 未リリース。** このノートは operator review 用に準備されたものです。
+> この PR は GitHub Release、tag、package、version state を作成・変更しません。
 
 Install verification: `JTechJapan.IntentSystem.Cli --version 0.12.1`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.12.1 に
-publish されます。
+承認後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.12.1 に公開されます。
+直前のリリース内容は [v0.12.0 notes](release-notes-v0.12.0.md) を参照し、ここでは重複記載しません。
+
+## v0.12.1 patch scope
+
+下記の unit 一覧は `git log v0.12.0..main` を実行して導出しました。この範囲の
+8 commit は、G631 の修正系列、G632 の修正系列、post-release version roll
+`e209d03` としてすべて説明できます。
+
+- G631 — PR #1368、merge commit `4c4ef22`（`main` に存在）: すべての redirected
+  child-process stream を UTF-8 で decode し、helper を `ProcessOutputEncoding` に変更しました。
+  spawn site が declaration を省略すると suite を fail させる guard もあります。
+- G632 — PR #1367、merge commit `77a57f2`（`main` に存在）: `worker issue-preflight` の
+  target classification を宣言された `Repository:` と `Target paths:` から導出し、
+  prose の言及は advisory note にしました。
+
+これは minor ではなく patch です。どちらも command や flag を追加していません。G631 は
+既存 spawn site に encoding を宣言して internal helper を rename し、G632 は既存 classification
+の導出方法を変更しました。両方とも merge commit と `git log` の列挙から検証できます。
+
+### operator impact: Windows child-stream decoding（G631）
+
+UTF-8 ではない code page の console で child output に非 ASCII が含まれると JSON が壊れ、
+すべての transport operation が同時に失敗することがありました。症状は間欠的・環境依存の
+total loop stall で、別 workspace の pane title などの ambient bytes が trigger になり得ます。
+v0.12.0 で案内した pane title や path の非 ASCII 回避 workaround は、現在は不要です。
+将来の spawn site が UTF-8 declaration を省略すると test suite を fail させる source guard もあります。
+
+### author impact: declaration-based preflight（G632）
+
+child repository を target として宣言した Issue は、prose に何が書かれていても actionable のままです。
+その言及は advisory note として表示されます。submodule 内を宣言した target を外側の working
+directory で実行する場合は引き続き block し、読めない target declaration は prose から推測せず
+fail closed します。
+
+## リリース準備ゲート (Release-readiness gate)
+
+v0.12.1 Release を作成する前に operator が確認します。
+
+- `eng/version.json` が stable `0.12.0` / next `0.12.1` のままであること。
+- PR #1368 と #1367 が `main` の merge commit `4c4ef22` と `77a57f2` に解決し、
+  `git log v0.12.0..main` の8 commit がすべて説明されること。
+- bilingual release-notes guard と G634 count guard、full Release suite、exact-head CI が green であること。
+- prepare-only の境界を守り、operator が明示承認するまで Release、tag、package publish を作成しないこと。
+
+## v0.12.1 の publish
+
+ゲートが green になり operator が承認した後にのみ maintainer が GitHub Release と package を
+publish できます。この prepare PR 自体はその操作を行いません。

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0121DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0121DocsTests.cs
@@ -1,0 +1,58 @@
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ReleaseNotesV0121DocsTests
+{
+    private static readonly (string Unit, string Pr, string Merge)[] Units =
+    [
+        ("G631", "#1368", "4c4ef22"),
+        ("G632", "#1367", "77a57f2"),
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyG631AndG632WithVerifiedMerges(string language)
+    {
+        var notes = Read(language);
+        var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+        Assert.Equal(Units.Select(unit => unit.Unit), listed);
+        Assert.Equal(2, listed.Length);
+        foreach (var unit in Units)
+        {
+            Assert.Contains(unit.Pr, notes, StringComparison.Ordinal);
+            Assert.Contains(unit.Merge, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("git log v0.12.0..main", notes, StringComparison.Ordinal);
+        Assert.Contains("0.12.0", notes, StringComparison.Ordinal);
+        Assert.Contains("0.12.1", notes, StringComparison.Ordinal);
+        Assert.Contains("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Release", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("tag", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("publish", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesContainBothPatchRationalesAndOperatorBoundaries(string language)
+    {
+        var notes = Read(language);
+        Assert.Contains("command", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("flag", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("advisory", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("submodule", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "fails closed" : "fail closed", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "non-ASCII" : "非 ASCII", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("pane", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("guard", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Read(string language) =>
+        File.ReadAllText(Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.12.1.md"));
+}


### PR DESCRIPTION
Closes #1369

Prepare-only EN/JA v0.12.1 notes covering exactly G631 and G632, with verified merge anchors, patch rationale, operator impact, and refreshed readiness. eng/version.json remains stable 0.12.0 / next 0.12.1; no Release, tag, or package publish is created.

Focused: dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --filter FullyQualifiedName~ReleaseNotesV0121DocsTests
Full: dotnet test IntentSystem.sln --no-restore -c Release
Diff check: clean