### PR TITLE
G636: record post-start interactions in unattended recipes

### DIFF
--- a/docs/en/1.0-compatibility-ledger.md
+++ b/docs/en/1.0-compatibility-ledger.md
@@ -207,6 +207,7 @@ discoverable.
 | packet-schema variants | Supported packet YAML/schema variants and state linkage | `retain-through-1.x` | A future `retire-before-1.0` row must name migration evidence. |
 | field aliases | Documented compatibility field aliases | `retain-through-1.x` | Inventory only; no inference or removal. |
 | future eligible legacy retirement | A named legacy entry with its consumer migration proof | `retire-before-1.0` | This disposition is invalid without named migration evidence in its row. |
+| unattended-launch post-start interaction | `guide orchestrator-thread --format json` recipe field recording the agent prompt, envelope-preserving answer, and `default_is_safe` flag | `preview-through-1.x` | G636; added after the v0.12.0 freeze, outside the 1.0 promise until a later MAJOR formalises it. |
 | post-freeze preview surface | A documented surface added after the v0.12.0 freeze and explicitly marked preview | `preview-through-1.x` | Outside the 1.0 promise; may change or be withdrawn in 1.x; formalise at a later MAJOR. |
 
 ## Guard

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -240,7 +240,8 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   `2. Continue with limited permissions` / `3. Cancel`, with the cursor on
   option 1. Answer `Continue with limited permissions` to preserve the bounded
   `--add-dir` envelope. The default `Enable all permissions` answer is unsafe;
-  accepting it on restart is a supervision failure, not a shortcut.
+  the recipe records `default_is_safe: false`, and accepting it on restart is a
+  supervision failure, not a shortcut.
 - **Startup gates.** Folder trust and autopilot-enable are operator provisioning
   gates; launch flags bypass neither. The autopilot-enable dialog appears at the
   **first task** even when launch used `--mode autopilot`. With

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -184,9 +184,19 @@ than a per-invocation approval that re-prompts on the next wake.
 
 An unattended-launch recipe is agent-neutral: it states the launch invocation,
 the bounded allowed roots derived from that role's actual work, the autonomous
-continuation bound, the startup gates the operator must answer, and the denial
-semantics. A later Cursor or opencode recipe adds an entry with those same
-fields; it does not restate or weaken the central rule below.
+continuation bound, the startup gates the operator must answer, the post-start
+interaction (what the agent presents, the answer that preserves the declared
+envelope, and whether the default answer is safe), and the denial semantics. A
+recipe that stops at the command line is incomplete: an agent can negotiate
+authority after launch even when the invocation is correct. A later Cursor or
+opencode recipe adds an entry with those same fields; it does not restate or
+weaken the central rule below.
+
+> **Preview through 1.x (G636).** The post-start interaction field is a
+> post-v0.12.0-freeze preview surface. It is outside the 1.0 compatibility
+> promise, may change or be withdrawn during 1.x, and is formalised only by a
+> later MAJOR release. See the [compatibility ledger](1.0-compatibility-ledger.md)
+> entry for this preview surface.
 
 > **Central autopilot supervision rule.** In an unattended autopilot seat, an
 > action outside the launch allowlist is silently auto-denied rather than
@@ -225,6 +235,12 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   host `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` before sending
   the pane one line, `Read task envelope: <path>`. Declare `inline` explicitly
   when desired; an absent declaration preserves existing inline delivery.
+- **Post-start interaction (G636, preview-through-1.x).** At the first task,
+  Copilot 1.0.78 presents `1. Enable all permissions (recommended)` /
+  `2. Continue with limited permissions` / `3. Cancel`, with the cursor on
+  option 1. Answer `Continue with limited permissions` to preserve the bounded
+  `--add-dir` envelope. The default `Enable all permissions` answer is unsafe;
+  accepting it on restart is a supervision failure, not a shortcut.
 - **Startup gates.** Folder trust and autopilot-enable are operator provisioning
   gates; launch flags bypass neither. The autopilot-enable dialog appears at the
   **first task** even when launch used `--mode autopilot`. With
@@ -240,7 +256,9 @@ three additional facts: an expected action inside the recorded roots succeeds;
 the role reaches its canonical reporting surface (for review, `intent-cli notify
 report` through its host routing root); and a deliberately out-of-scope action
 is denied. Capture that denial for review. A live pane or a successful allowed
-action alone is **not** READY.
+action alone is **not** READY. If a denial probe unexpectedly succeeds, first
+check whether the post-start interaction was answered with its default; an
+unsafe default can discard the declared boundary.
 
 **4. Role initialization.** Type the actas form matching the pane's CLI —
 `/agmsg actas <role>` for claude, `$agmsg actas <role>` for codex — then confirm

--- a/docs/ja/1.0-compatibility-ledger.md
+++ b/docs/ja/1.0-compatibility-ledger.md
@@ -207,6 +207,7 @@ guard により、preview も発見可能なままになります。
 | packet-schema variant | supported packet YAML/schema variant と state linkage | `retain-through-1.x` | future `retire-before-1.0` row は migration evidence を名指しする。 |
 | field alias | documented compatibility field alias | `retain-through-1.x` | inventory のみ。inference や removal はしない。 |
 | future eligible legacy retirement | consumer migration proof を持つ named legacy entry | `retire-before-1.0` | row に named migration evidence がなければこの disposition は無効。 |
+| unattended-launch post-start interaction | `guide orchestrator-thread --format json` の recipe field（agent prompt、境界を維持する回答、`default_is_safe` flag） | `preview-through-1.x` | G636。v0.12.0 freeze 後に追加されたため 1.0 promise の対象外であり、後続 MAJOR で formalise する。 |
 | post-freeze preview surface | v0.12.0 freeze 後に追加し、preview と明記した documented surface | `preview-through-1.x` | 1.0 promise の対象外。1.x で変更・撤回でき、後続 MAJOR で formalise する。 |
 
 ## Guard

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -223,7 +223,8 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   `1. Enable all permissions (recommended)` / `2. Continue with limited permissions` /
   `3. Cancel` を表示し、cursor は option 1 にあります。宣言した `--add-dir` 境界を維持するには
   `Continue with limited permissions` を選びます。default の `Enable all permissions` は unsafe です。
-  restart でこれを受け入れるのは shortcut ではなく supervision failure です。
+  recipe には `default_is_safe: false` と記録し、restart でこれを受け入れるのは shortcut ではなく
+  supervision failure です。
 - **startup gate。** folder trust と autopilot-enable は operator provisioning gate であり、
   launch flag ではどちらも bypass できません。`--mode autopilot` を launch 時に渡しても、
   autopilot-enable dialog は **最初の task** で現れます。`--allow-all-tools` と境界付き root

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -174,8 +174,16 @@ monitor bridge を arm する（G521）ため、canonical な実行ファイル�
 
 unattended 起動レシピは agent-neutral です。起動 invocation、各 role の実際の作業から
 導く境界付き許可 root、自律継続の上限、operator が回答する startup gate、そして denial
-semantics を記します。後から Cursor や opencode のレシピを追加する場合も、同じ field を
-持つ entry を追加するだけで、以下の central rule を再定義・弱化しません。
+semantics に加えて、起動後に agent が提示する post-start interaction、宣言した境界を
+維持するための回答、default answer が安全かどうかを記録します。command line が正しくても
+起動後に agent が権限を交渉できるため、command line で止まるレシピは不完全です。
+後から Cursor や opencode のレシピを追加する場合も、同じ field を持つ entry を追加するだけで、
+以下の central rule を再定義・弱化しません。
+
+> **1.x を通じた preview (G636)。** post-start interaction field は v0.12.0 freeze 後に追加された
+> preview surface です。1.0 compatibility promise の対象外であり、1.x の間に変更・撤回される
+> 可能性があり、正式化は後続 MAJOR release でのみ行います。詳細は
+> [compatibility ledger](1.0-compatibility-ledger.md) の preview row を参照してください。
 
 > **central autopilot supervision rule。** unattended autopilot seat では、launch allowlist
 > の外にある action は G550 の supervision dialog として表示されず、静かに自動拒否されます。
@@ -211,6 +219,11 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
   `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` に書いてから、pane には
   `Read task envelope: <path>` という 1 行だけを送ります。明示的に選ぶなら `inline` を宣言します。
   宣言がなければ既存の inline delivery をそのまま維持します。
+- **post-start interaction (G636, preview-through-1.x)。** 最初の task で Copilot 1.0.78 は
+  `1. Enable all permissions (recommended)` / `2. Continue with limited permissions` /
+  `3. Cancel` を表示し、cursor は option 1 にあります。宣言した `--add-dir` 境界を維持するには
+  `Continue with limited permissions` を選びます。default の `Enable all permissions` は unsafe です。
+  restart でこれを受け入れるのは shortcut ではなく supervision failure です。
 - **startup gate。** folder trust と autopilot-enable は operator provisioning gate であり、
   launch flag ではどちらも bypass できません。`--mode autopilot` を launch 時に渡しても、
   autopilot-enable dialog は **最初の task** で現れます。`--allow-all-tools` と境界付き root
@@ -223,7 +236,9 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --model clau
 記録済み root 内の期待される action が成功すること、role が canonical reporting surface
 （review なら host routing root 経由の `intent-cli notify report`）へ到達できること、意図的に
 out-of-scope にした action が拒否されることです。その拒否を review 用に記録します。live pane
-だけ、または許可済み action の成功だけでは **READY ではありません**。
+だけ、または許可済み action の成功だけでは **READY ではありません**。denial probe が予想に反して
+成功した場合は、まず post-start interaction が default で回答されていないか確認します。unsafe な
+default は宣言した境界を捨てます。
 
 **4. ロール初期化。** pane の CLI に合った actas 形式をタイプします — claude は
 `/agmsg actas <role>`、codex は `$agmsg actas <role>`。その後 readiness を

--- a/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOrchestratorThreadCommand.cs
@@ -2213,7 +2213,11 @@ internal static class GuideOrchestratorThreadCommand
                 Summary =
                     "Agent-neutral recipes make an unattended launch reviewable rather than broad by default. Every "
                     + "recipe states the invocation, bounded `--add-dir` roots derived from that role's real work, "
-                    + "the continuation bound, the startup gates the operator must answer, and the denial semantics. "
+                    + "the continuation bound, the startup gates the operator must answer, the post-start interaction "
+                    + "and answer that preserve the declared envelope, whether the default is safe, and the denial "
+                    + "semantics. A recipe that stops at the command line is incomplete because an agent can negotiate "
+                    + "authority after launch. The post-start interaction field is a G636 preview-through-1.x surface "
+                    + "added after the v0.12.0 freeze and outside the 1.0 compatibility promise. "
                     + "Later agent recipes inherit the central rule below; do not duplicate or weaken it per agent.",
                 RequiredRecipeFields = new[]
                 {
@@ -2221,6 +2225,7 @@ internal static class GuideOrchestratorThreadCommand
                     "bounded allowed roots derived from the logical role's actual needs (not a product-wide path)",
                     "the maximum autonomous continuation bound",
                     "startup trust and autopilot/permission gates the operator must answer",
+                    "a declared post-start interaction: what the agent presents, the envelope-preserving answer, and whether the default is safe",
                     "a named advisory inline-payload warning profile and threshold, never a safe-paste guarantee",
                     "a declared task-envelope delivery_method (inline or file-backed; undeclared remains inline)",
                     "the silent-denial semantics and the READY/review evidence that proves them",
@@ -2258,6 +2263,16 @@ internal static class GuideOrchestratorThreadCommand
                         + "unchanged envelope to durable host `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` before "
                         + "sending one line, `Read task envelope: <path>`. Declare `inline` to opt in explicitly; an absent "
                         + "declaration preserves existing inline delivery.",
+                    PostStartInteraction = new OrchestratorPostStartInteraction
+                    {
+                        Prompt =
+                            "At the first task, Copilot 1.0.78 presents `1. Enable all permissions (recommended)` / "
+                            + "`2. Continue with limited permissions` / `3. Cancel`, with the cursor on option 1.",
+                        Answer =
+                            "Choose `Continue with limited permissions` to preserve the bounded `--add-dir` envelope; "
+                            + "the default `Enable all permissions` answer is unsafe.",
+                        DefaultIsSafe = false,
+                    },
                     StartupGates =
                         "Folder trust and autopilot-enable are operator provisioning gates; neither is bypassed by "
                         + "launch flags. The autopilot-enable dialog appears at the FIRST TASK even when `--mode autopilot` "
@@ -2272,7 +2287,9 @@ internal static class GuideOrchestratorThreadCommand
                     + "facts: an expected action inside the recorded roots succeeds, the role can reach its canonical "
                     + "reporting surface (for review, `intent-cli notify report` through its host routing root), and a "
                     + "deliberately out-of-scope action is denied. Capture the denied result for review; a live pane or "
-                    + "successful allowed action alone is NOT READY.",
+                    + "successful allowed action alone is NOT READY. If a denial probe unexpectedly succeeds, first check "
+                    + "whether the post-start interaction was answered with its default; accepting an unsafe default is a "
+                    + "supervision failure, not a shortcut.",
             },
             RoleInitialization = new OrchestratorProvisioningRoleInitialization
             {
@@ -3527,6 +3544,8 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine();
         writer.WriteLine(unattended.Summary);
         writer.WriteLine();
+        writer.WriteLine("> **Preview through 1.x (G636).** The post-start interaction field was added after the v0.12.0 freeze; it is outside the 1.0 compatibility promise and may change or be withdrawn during 1.x.");
+        writer.WriteLine();
         writer.WriteLine("Every recipe must state:");
         writer.WriteLine();
         foreach (var field in unattended.RequiredRecipeFields)
@@ -3546,6 +3565,7 @@ internal static class GuideOrchestratorThreadCommand
         writer.WriteLine($"- **continuation bound** — {unattended.CopilotRecipe.ContinuationBound}");
         writer.WriteLine($"- **inline-payload advisory** — {unattended.CopilotRecipe.InlinePayloadWarningProfile}");
         writer.WriteLine($"- **task-envelope delivery method** — {unattended.CopilotRecipe.DeliveryMethod}");
+        writer.WriteLine($"- **post-start interaction** — {unattended.CopilotRecipe.PostStartInteraction.Prompt} Answer: {unattended.CopilotRecipe.PostStartInteraction.Answer} Default safe: {unattended.CopilotRecipe.PostStartInteraction.DefaultIsSafe.ToString().ToLowerInvariant()}.");
         writer.WriteLine($"- **startup gates** — {unattended.CopilotRecipe.StartupGates}");
         writer.WriteLine($"- **prohibited blanket permissions** — {unattended.CopilotRecipe.ProhibitedBlanket}");
         writer.WriteLine();
@@ -5511,9 +5531,9 @@ internal sealed record OrchestratorProvisioningLaunchRules
 }
 
 /// <summary>
-/// G617: agent-neutral unattended launch requirements plus the first measured
-/// Copilot recipe. This is guidance only: it adds no agent-specific delivery,
-/// liveness, or runtime branching.
+/// G617/G636: agent-neutral unattended launch requirements plus the first
+/// measured Copilot recipe. This is guidance only: it adds no agent-specific
+/// delivery, liveness, runtime branching, or dialog automation.
 /// </summary>
 internal sealed record OrchestratorUnattendedLaunchRecipes
 {
@@ -5550,11 +5570,32 @@ internal sealed record OrchestratorCopilotUnattendedRecipe
     [JsonPropertyName("delivery_method")]
     public required string DeliveryMethod { get; init; }
 
+    [JsonPropertyName("post_start_interaction")]
+    public required OrchestratorPostStartInteraction PostStartInteraction { get; init; }
+
     [JsonPropertyName("startup_gates")]
     public required string StartupGates { get; init; }
 
     [JsonPropertyName("prohibited_blanket")]
     public required string ProhibitedBlanket { get; init; }
+}
+
+/// <summary>
+/// G636: an unattended recipe records the interaction an agent may present
+/// after launch, the answer that preserves the declared envelope, and whether
+/// accepting the default is safe. It records guidance only; it never drives a
+/// dialog or sends keystrokes.
+/// </summary>
+internal sealed record OrchestratorPostStartInteraction
+{
+    [JsonPropertyName("prompt")]
+    public required string Prompt { get; init; }
+
+    [JsonPropertyName("answer")]
+    public required string Answer { get; init; }
+
+    [JsonPropertyName("default_is_safe")]
+    public required bool DefaultIsSafe { get; init; }
 }
 
 internal sealed record OrchestratorProvisioningRoleInitialization

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -96,7 +96,9 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("recipe that stops at the command line is incomplete", en, StringComparison.Ordinal);
         Assert.Contains("command line で止まるレシピは不完全", ja, StringComparison.Ordinal);
         Assert.Contains("default `Enable all permissions` answer is unsafe", en, StringComparison.Ordinal);
+        Assert.Contains("`default_is_safe: false`", en, StringComparison.Ordinal);
         Assert.Contains("default の `Enable all permissions` は unsafe", ja, StringComparison.Ordinal);
+        Assert.Contains("`default_is_safe: false`", ja, StringComparison.Ordinal);
         Assert.Contains("supervision failure, not a shortcut", en, StringComparison.Ordinal);
         Assert.Contains("supervision failure です", ja, StringComparison.Ordinal);
         Assert.Contains("G556 liveness and notify/delivery semantics are unchanged", en, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -87,14 +87,24 @@ public sealed class AgentMessageOrchestrationDocsTests
             Assert.Contains("--allow-all-paths", doc, StringComparison.Ordinal);
             Assert.Contains("Continue with limited permissions", doc, StringComparison.Ordinal);
             Assert.Contains("Enable all permissions", doc, StringComparison.Ordinal);
+            Assert.Contains("preview-through-1.x", doc, StringComparison.Ordinal);
+            Assert.Contains("post-start interaction", doc, StringComparison.Ordinal);
         }
 
         Assert.Contains("silently auto-denied", en, StringComparison.Ordinal);
         Assert.Contains("静かに自動拒否", ja, StringComparison.Ordinal);
+        Assert.Contains("recipe that stops at the command line is incomplete", en, StringComparison.Ordinal);
+        Assert.Contains("command line で止まるレシピは不完全", ja, StringComparison.Ordinal);
+        Assert.Contains("default `Enable all permissions` answer is unsafe", en, StringComparison.Ordinal);
+        Assert.Contains("default の `Enable all permissions` は unsafe", ja, StringComparison.Ordinal);
+        Assert.Contains("supervision failure, not a shortcut", en, StringComparison.Ordinal);
+        Assert.Contains("supervision failure です", ja, StringComparison.Ordinal);
         Assert.Contains("G556 liveness and notify/delivery semantics are unchanged", en, StringComparison.Ordinal);
         Assert.Contains("G556 の liveness と notify/delivery semantics は変わりません", ja, StringComparison.Ordinal);
         Assert.Contains("out-of-scope action is denied", en, StringComparison.Ordinal);
         Assert.Contains("out-of-scope にした action が拒否", ja, StringComparison.Ordinal);
+        Assert.Contains("denial probe unexpectedly succeeds", en, StringComparison.Ordinal);
+        Assert.Contains("denial probe が予想に反して", ja, StringComparison.Ordinal);
         Assert.Contains("transcript for denials", en, StringComparison.Ordinal);
         Assert.Contains("transcript で拒否を調べます", ja, StringComparison.Ordinal);
 

--- a/tests/IntentSystem.Cli.Tests/CompatibilityPromiseG612Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/CompatibilityPromiseG612Tests.cs
@@ -110,6 +110,23 @@ public sealed class CompatibilityPromiseG612Tests
     }
 
     [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void Ledger_RecordsTheG636PostStartInteractionPreviewSurface(string language)
+    {
+        var ledger = Read(language, "1.0-compatibility-ledger.md");
+
+        var rows = ledger.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Where(line => line.StartsWith("| unattended-launch post-start interaction |", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.Single(rows);
+        Assert.Contains("`preview-through-1.x`", rows[0], StringComparison.Ordinal);
+        Assert.Contains("`default_is_safe`", rows[0], StringComparison.Ordinal);
+        Assert.Contains("G636", rows[0], StringComparison.Ordinal);
+    }
+
+    [Theory]
     [InlineData("en", "all machine-emitted `cause` values", "Every `cause` value actually emitted")]
     [InlineData("ja", "machine-consumed JSON payload で実際に emit されるすべての `cause` value", "実際に emit されるすべての `cause` value")]
     public void PromiseAndLedger_CoverEveryMachineEmittedCauseValue_G612(

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2006,6 +2006,11 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("G619 owns the transport-layer remedy", output, StringComparison.Ordinal);
         Assert.Contains("delivery_method: file-backed", output, StringComparison.Ordinal);
         Assert.Contains("Read task envelope: <path>", output, StringComparison.Ordinal);
+        Assert.Contains("Preview through 1.x (G636)", output, StringComparison.Ordinal);
+        Assert.Contains("post-start interaction", output, StringComparison.Ordinal);
+        Assert.Contains("Copilot 1.0.78 presents", output, StringComparison.Ordinal);
+        Assert.Contains("default `Enable all permissions` answer is unsafe", output, StringComparison.Ordinal);
+        Assert.Contains("supervision failure, not a shortcut", output, StringComparison.Ordinal);
         Assert.Contains("FIRST TASK", output, StringComparison.Ordinal);
         Assert.Contains("Continue with limited permissions", output, StringComparison.Ordinal);
         Assert.Contains("NEVER choose `Enable all permissions`", output, StringComparison.Ordinal);
@@ -2014,6 +2019,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("normal G556 liveness checks AND prove all three", output, StringComparison.Ordinal);
         Assert.Contains("deliberately out-of-scope action is denied", output, StringComparison.Ordinal);
         Assert.Contains("successful allowed action alone is NOT READY", output, StringComparison.Ordinal);
+        Assert.Contains("denial probe unexpectedly succeeds", output, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -2077,7 +2083,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("no authorization makes them answerable", authorityBoundary, StringComparison.Ordinal);
 
         var unattended = provisioning.GetProperty("unattended_launch_recipes");
-        Assert.Equal(7, unattended.GetProperty("required_recipe_fields").GetArrayLength());
+        Assert.Equal(8, unattended.GetProperty("required_recipe_fields").GetArrayLength());
         Assert.Contains("silently auto-denied", unattended.GetProperty("central_autopilot_supervision_rule").GetString(), StringComparison.Ordinal);
         Assert.Contains("--add-dir <role-work-root>", unattended.GetProperty("copilot_recipe").GetProperty("invocation").GetString(), StringComparison.Ordinal);
         Assert.Contains("intent-cli notify report", unattended.GetProperty("copilot_recipe").GetProperty("role_derived_roots").GetString(), StringComparison.Ordinal);
@@ -2087,7 +2093,12 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("G619 owns the transport-layer remedy", unattended.GetProperty("copilot_recipe").GetProperty("inline_payload_warning_profile").GetString(), StringComparison.Ordinal);
         Assert.Contains("delivery_method: file-backed", unattended.GetProperty("copilot_recipe").GetProperty("delivery_method").GetString(), StringComparison.Ordinal);
         Assert.Contains("absent declaration preserves existing inline delivery", unattended.GetProperty("copilot_recipe").GetProperty("delivery_method").GetString(), StringComparison.Ordinal);
+        var postStart = unattended.GetProperty("copilot_recipe").GetProperty("post_start_interaction");
+        Assert.Contains("Copilot 1.0.78 presents", postStart.GetProperty("prompt").GetString(), StringComparison.Ordinal);
+        Assert.Contains("Continue with limited permissions", postStart.GetProperty("answer").GetString(), StringComparison.Ordinal);
+        Assert.False(postStart.GetProperty("default_is_safe").GetBoolean());
         Assert.Contains("out-of-scope action is denied", unattended.GetProperty("ready_branch").GetString(), StringComparison.Ordinal);
+        Assert.Contains("denial probe unexpectedly succeeds", unattended.GetProperty("ready_branch").GetString(), StringComparison.Ordinal);
 
         var roleInitialization = provisioning.GetProperty("role_initialization");
         Assert.NotEmpty(roleInitialization.GetProperty("actas_forms").EnumerateArray());
@@ -2114,6 +2125,27 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Equal("herdr", referenceManager.GetProperty("name").GetString());
         Assert.NotEmpty(referenceManager.GetProperty("surfaces").EnumerateArray());
         Assert.True(referenceManager.GetProperty("substitution_rule").GetString()!.Length > 0);
+    }
+
+    [Fact]
+    public void PostStartInteraction_RepresentsSafeAndUnsafeDefaults_G636()
+    {
+        var safe = new OrchestratorPostStartInteraction
+        {
+            Prompt = "The agent presents a bounded confirmation.",
+            Answer = "Keep the bounded permissions.",
+            DefaultIsSafe = true,
+        };
+        var unsafeDefault = new OrchestratorPostStartInteraction
+        {
+            Prompt = "The agent presents an all-permissions confirmation.",
+            Answer = "Continue with limited permissions.",
+            DefaultIsSafe = false,
+        };
+
+        Assert.True(safe.DefaultIsSafe);
+        Assert.False(unsafeDefault.DefaultIsSafe);
+        Assert.NotEqual(safe.DefaultIsSafe, unsafeDefault.DefaultIsSafe);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -12,7 +12,9 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     private const string Domain = "intent-cli";
     private const string Team = "intent-cli-dev";
     private const string Repo = "J-Tech-Japan/intent-system";
-    private const string G594AgmsgBaselineSha256 = "70865772d11641f82400ef99888022939ae4eda4963c3ec5563f1398646cfea3";
+    // G636 extends the shared guide; keep the deterministic baseline aligned
+    // with the rendered guidance while preserving the hash guard.
+    private const string G594AgmsgBaselineSha256 = "eb137cc1bf5a287aec11c35bbdd2ae404aae71a67fc016aa116d25b2020272b3";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -10,7 +10,7 @@ namespace IntentSystem.Cli.Tests;
 public sealed class HerdrWakeSourcesG581Tests : IDisposable
 {
     private const string G594AgmsgGuideSha256 =
-        "B8297E45CA1957438682D057CB8B95031E4512FC692CC3DAC1673F25F0A1D1A3";
+        "E2F3CE8103303C9DC5EACDCA4513201CBF85C4F40C7540E45D9A8ED4FB6B187E";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 


### PR DESCRIPTION
Closes #1371

## Summary
- Extend unattended-launch recipes with a post-start prompt, envelope-preserving answer, and explicit default-safety flag.
- Record the measured Copilot 1.0.78 dialog and unsafe default; add EN/JA preview guidance, ledger rows, and readiness diagnostics.
- Preserve the no-dialog-automation boundary and G617 readiness rule.

## Validation
- Focused: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --filter 'FullyQualifiedName~GuideOrchestratorThreadCommandTests|FullyQualifiedName~AgentMessageOrchestrationDocsTests|FullyQualifiedName~CompatibilityPromiseG612Tests'` (148 passed initially; 164 after hash/terminology guard updates)
- Full: `dotnet test IntentSystem.sln --no-restore` (4515 passed, 1 skipped)
- `git diff --check` clean
