### PR TITLE
G637: standardize team workspace layout guide

### DIFF
--- a/docs/en/02a-getting-started-orchestration.md
+++ b/docs/en/02a-getting-started-orchestration.md
@@ -26,6 +26,13 @@ first published packet. [Start a project](02-project-start.md) remains
 authoritative for topology, and the [agent-message orchestration contract](12-agent-message-orchestration.md)
 remains authoritative for session-layer semantics.
 
+Before arranging panes, use the [team workspace layout convention (G637,
+preview)](12-agent-message-orchestration.md#team-workspace-layout-convention-g637--preview-through-1x).
+After the real workspace and pane IDs are known, run
+`intent-cli guide workspace-layout` with the operator-observed shape so the same label vocabulary
+and 40% / 60%-even arrangement are visible during onboarding. The guide emits
+commands only; it does not drive herdr.
+
 ## What you are setting up
 
 The four-thread model is the **primary** model: design authors intent,

--- a/docs/en/1.0-compatibility-ledger.md
+++ b/docs/en/1.0-compatibility-ledger.md
@@ -211,6 +211,7 @@ discoverable.
 | field aliases | Documented compatibility field aliases | `retain-through-1.x` | Inventory only; no inference or removal. |
 | future eligible legacy retirement | A named legacy entry with its consumer migration proof | `retire-before-1.0` | This disposition is invalid without named migration evidence in its row. |
 | unattended-launch post-start interaction | `guide orchestrator-thread --format json` recipe field recording the agent prompt, envelope-preserving answer, and `default_is_safe` flag | `preview-through-1.x` | G636; added after the v0.12.0 freeze, outside the 1.0 promise until a later MAJOR formalises it. |
+| workspace-layout guide | `guide workspace-layout` renders operator-supplied workspace IDs, the canonical 40%/60%-even slot convention, pane rename/resize commands, and a temporary-tab round trip; it executes no herdr command | `preview-through-1.x` | G637; added after the v0.12.0 freeze, outside the 1.0 promise until a later MAJOR formalises it. |
 | post-freeze preview surface | A documented surface added after the v0.12.0 freeze and explicitly marked preview | `preview-through-1.x` | Outside the 1.0 promise; may change or be withdrawn in 1.x; formalise at a later MAJOR. |
 
 ## Guard

--- a/docs/en/1.0-compatibility-promise.md
+++ b/docs/en/1.0-compatibility-promise.md
@@ -55,6 +55,10 @@ later MAJOR release (2.0 or later). To tell which kind of surface you are
 reading, check its documentation marker and its ledger entry: `stable-at-1.0`
 is covered, while `preview-through-1.x` is preview and not covered.
 
+The G637 `guide workspace-layout` surface is one such preview: its emitted
+herdr command text, workspace-shape inputs, and layout prose may evolve during
+1.x.
+
 ## Deprecation rule
 
 A covered surface can change only when all of the following are present:

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -400,6 +400,48 @@ provided the same rules hold: one dedicated folder per role as the pane cwd,
 shim-safe typed launch, attended first-run prompts, actas + readiness before the
 ping test, and one holder per role with a graceful drop on handover.
 
+## Team workspace layout convention (G637 — preview-through-1.x)
+
+> **Preview through 1.x.** This workspace-layout guide was added after the
+> v0.12.0 freeze. It is outside the 1.0 compatibility promise, may change or
+> be withdrawn during 1.x, and is formalised only by a later MAJOR release.
+> See the [compatibility ledger](1.0-compatibility-ledger.md) preview entry.
+
+Every team workspace uses one visible three-seat shape: `orchestration` owns
+the left pane at 40% width and full height; `implementation` is the top-right
+pane; and `review` is the bottom-right pane. The two right panes therefore
+split the remaining 60% evenly (30% each). Labels use the recorded topology
+role vocabulary: `orchestration`, `implementation`, and `review`. If the
+third seat is genuinely a design seat, label that pane `design`; the slot
+convention does not change the seat's identity.
+
+The guide consumes an operator-observed shape and explicit IDs. It never lists
+or queries a live workspace and never executes herdr:
+
+```text
+intent-cli guide workspace-layout --workspace-id <workspace-id> --tab-id <tab-id> \
+  --shape canonical|three-column|mirrored|unknown \
+  --orchestration-pane <orchestration-pane> --implementation-pane <implementation-pane> \
+  --review-pane <review-pane> --temporary-tab-id <temporary-tab-id> --format markdown
+```
+
+For a conforming workspace with canonical labels, the command reports that no
+change is needed. For a different shape it prints, in order, a temporary-tab
+round trip (`herdr pane move` to the temporary tab and back targeting the pane
+it should sit under), pane renames, and the resize calls that establish the
+40% / 60%-even split. Supply the observed ratios when known so the resize
+amounts are minimal directional deltas. Resolve every explicit ID immediately
+before running a printed command; the guide is a plan, not an executor.
+
+Same-tab `herdr pane move` is a no-op returning `changed: false` on the measured
+herdr 0.8.0 on macOS baseline. The temporary-tab round trip was also measured
+on herdr 0.8.0 on macOS: the pane was reparented rather than recreated and all
+seventeen running agent processes survived. Verify that round trip on a scratch
+tab first, confirm every agent is still present, then apply it to a workspace
+holding working agents and confirm presence again. These are measured facts,
+not claims about unmeasured herdr versions or platforms. A single-pane
+workspace has no arrangement to standardise and is outside this convention.
+
 ## Herdr-only operating procedure (preferred — fewer dependencies)
 
 This section is operative only when the team has recorded `herdr-only`. It is

--- a/docs/ja/02a-getting-started-orchestration.md
+++ b/docs/ja/02a-getting-started-orchestration.md
@@ -27,6 +27,11 @@ mode と現在のインストール済みガイドに従います。
 オーケストレーション contract](12-agent-message-orchestration.md) はセッションレイヤーの意味の
 正本となる定義として残ります。
 
+pane を配置する前に、[チームのワークスペース配置（G637、preview）](12-agent-message-orchestration.md)
+を読んでください。実際の workspace と pane ID が分かったら、operator が観測した shape を
+`intent-cli guide workspace-layout` に渡します。同じ label vocabulary と 40% / 60% 均等分割を
+導入時から確認できます。この guide は command を表示するだけで、herdr を駆動しません。
+
 ## これから設定するもの
 
 4 スレッドモデルが **primary** です。design は intent を作成し、orchestration は

--- a/docs/ja/1.0-compatibility-ledger.md
+++ b/docs/ja/1.0-compatibility-ledger.md
@@ -211,6 +211,7 @@ guard により、preview も発見可能なままになります。
 | field alias | documented compatibility field alias | `retain-through-1.x` | inventory のみ。inference や removal はしない。 |
 | future eligible legacy retirement | consumer migration proof を持つ named legacy entry | `retire-before-1.0` | row に named migration evidence がなければこの disposition は無効。 |
 | unattended-launch post-start interaction | `guide orchestrator-thread --format json` の recipe field（agent prompt、境界を維持する回答、`default_is_safe` flag） | `preview-through-1.x` | G636。v0.12.0 freeze 後に追加されたため 1.0 promise の対象外であり、後続 MAJOR で formalise する。 |
+| workspace-layout guide | `guide workspace-layout` が operator の明示した workspace ID と 40% / 60% 均等の slot 規約、pane rename / resize command、一時 tab 往復を表示する。herdr command は実行しない | `preview-through-1.x` | G637。v0.12.0 freeze 後の追加であり、1.0 promise の対象外。後続 MAJOR で formalise する。 |
 | post-freeze preview surface | v0.12.0 freeze 後に追加し、preview と明記した documented surface | `preview-through-1.x` | 1.0 promise の対象外。1.x で変更・撤回でき、後続 MAJOR で formalise する。 |
 
 ## Guard

--- a/docs/ja/1.0-compatibility-promise.md
+++ b/docs/ja/1.0-compatibility-promise.md
@@ -51,6 +51,9 @@ preview は 1.0 compatibility promise の対象外です。1.x の間に変更�
 marker と ledger entry を確認します。`stable-at-1.0` は covered、`preview-through-1.x` は
 preview であり covered ではありません。
 
+G637 の `guide workspace-layout` はこの preview の 1 つです。表示する herdr command、workspace shape
+の入力、layout の prose は 1.x の間に変わる可能性があります。
+
 ## Deprecation rule
 
 covered surface の変更には、次のすべてが必要です。

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -367,6 +367,42 @@ agmsg internals と同じくリンクアウトし、herdr 自身のドキュメ�
 立ち会う、ping テスト前の actas + readiness、1 ロール 1 保持者と handover 時の graceful
 drop）が満たされるなら、**任意の** 同等なワークスペースマネージャーで置き換えられます。
 
+## チームのワークスペース配置（G637、preview-through-1.x）
+
+> **1.x を通じた preview。** このワークスペース配置ガイドは v0.12.0 の freeze 後に追加されました。
+> 1.0 compatibility promise の対象外であり、1.x の間に変更または撤回される可能性があります。
+> 正式化は後続 MAJOR release で行います。[compatibility ledger](1.0-compatibility-ledger.md) の
+> preview entry を参照してください。
+
+各 team workspace は、3 席を見渡せる 1 つの形にそろえます。
+`orchestration` は左側で幅 40%、高さ全体を占めます。`implementation` は右上、`review` は右下です。
+右側に残る 60% は上下で均等に分かれ、各 pane は 30% になります。label は記録済み topology の
+role 名である `orchestration`、`implementation`、`review` を使います。3 席目が実際に design の席なら
+その pane の label は `design` とします。slot の規約は seat の identity を変更しません。
+
+この guide は operator が観測した shape と明示的な ID を入力にします。live workspace を一覧・照会
+せず、herdr を実行もしません。
+
+```text
+intent-cli guide workspace-layout --workspace-id <workspace-id> --tab-id <tab-id> \
+  --shape canonical|three-column|mirrored|unknown \
+  --orchestration-pane <orchestration-pane> --implementation-pane <implementation-pane> \
+  --review-pane <review-pane> --temporary-tab-id <temporary-tab-id> --format markdown
+```
+
+canonical shape と canonical label の workspace では、変更不要であることを表示します。別の shape なら、
+一時 tab へ `herdr pane move` してから、本来その下に置く pane を target にして戻す往復、pane rename、
+40% / 60%-均等分割を作る resize の呼び出しをこの順番で表示します。ratio が分かる場合は渡して、
+resize amount を必要最小限の方向差分にします。表示された command を実行する直前に、明示的な ID を
+record から解決してください。この guide は plan であり executor ではありません。
+
+実測した herdr 0.8.0 on macOS では、同じ tab 内の `herdr pane move` は `changed: false` を返す no-op です。
+一時 tab に移してから destination pane を target にして戻す往復も同じ herdr 0.8.0 on macOS で実測し、
+pane は再作成ではなく付け替えられ、稼働中の 17 agent process がすべて残りました。まず scratch tab で
+この往復を検証し、すべての agent が残っていることを確認してから、稼働中 agent を持つ workspace に適用し、
+もう一度存在を確認します。これは測定した事実であり、未測定の herdr version や platform への主張では
+ありません。single-pane workspace は標準化する配置を持たないため、この規約の対象外です。
+
 ## herdr-only の運用手順（preferred — fewer dependencies）
 
 この節はチームが `herdr-only` を記録している場合だけ operative です。agmsg の

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -338,6 +338,8 @@ internal static class CommandRouter
                 ["artifact-intake"] = GuideArtifactIntakeCommand.Execute,
                 // G487: optional agmsg-backed orchestrator-thread guide surface.
                 ["orchestrator-thread"] = GuideOrchestratorThreadCommand.Execute,
+                // G637: read-only canonical team workspace layout plan.
+                ["workspace-layout"] = GuideWorkspaceLayoutCommand.Execute,
                 // G488: thin, portable agent skill pack bootstrap (ADR-013 / spec-27).
                 ["skill-pack"] = GuideSkillPackCommand.Execute
             },

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -279,6 +279,15 @@ internal static class GuideCommandsListCommand
         },
         new CommandGroupEntry
         {
+            Name = "guide workspace-layout",
+            Role = RoleDesign,
+            Classification = ClassificationSupport,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerOperator,
+            Purpose = "G637 preview-through-1.x layout convention: `intent-cli guide workspace-layout` consumes an operator-supplied workspace snapshot and renders explicit herdr pane rename/resize commands plus the temporary-tab round trip for non-conforming shapes. It never queries or executes herdr."
+        },
+        new CommandGroupEntry
+        {
             Name = "guide workflow task implementation-loop",
             Role = RoleChildImplementation,
             Classification = ClassificationSupport,

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -290,6 +290,13 @@ internal static class GuideHelpCommand
             Purpose = "G487/G540 paste-ready prompts for the PRIMARY four-thread orchestrator model (design/orchestrator/implementation/review) over its selected session transport, plus the implementation/review threads it delegates to. agmsg is a message/progress/completion signal layer only; intent-cli and GitHub stay authoritative. Distinguishes the primary orchestrator-message model from the simpler timer-loop alternative (no mixed-mode timer races), pins the structured reply contract, the design-orchestrator double-check rule, an orchestrator first-wake, and safety boundaries. Timer-loop mode remains fully supported, not replaced.",
             Example = "intent-cli guide orchestrator-thread --domain <name> --target-repo <owner/repo> --agent <agent> --format markdown"
         },
+        // G637: preview workspace convention; render-only and host-state-free.
+        new GuideSubcommandEntry
+        {
+            Name = "workspace-layout",
+            Purpose = "G637 preview-through-1.x team workspace convention: consume an operator-observed shape and explicit workspace/tab/pane IDs, then render the 40% orchestration-left / 60%-even implementation-review layout, topology-role labels, and the temporary-tab round trip for non-conforming shapes. Never queries or executes herdr.",
+            Example = "intent-cli guide workspace-layout --workspace-id <workspace-id> --tab-id <tab-id> --shape three-column --format markdown"
+        },
         // G563: G488's renderer is retired to a pointer — `intent-cli skill`
         // ships and installs the one artifact named `intent-cli`.
         new GuideSubcommandEntry

--- a/src/IntentSystem.Cli/Commands/GuideWorkspaceLayoutCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkspaceLayoutCommand.cs
@@ -1,0 +1,584 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G637: read-only workspace-layout convention guidance.
+///
+/// The command consumes operator-supplied workspace/pane identifiers and an
+/// observed shape. It renders the herdr commands an operator may run; it never
+/// starts herdr, asks herdr for state, or mutates the recorded topology. This
+/// keeps layout repair in the session layer while leaving identity, delivery,
+/// and settle semantics unchanged.
+///
+/// The surface is deliberately preview-through-1.x: it was added after the
+/// v0.12.0 compatibility freeze and its command/prose shape may evolve.
+/// </summary>
+internal static class GuideWorkspaceLayoutCommand
+{
+    internal const string CommandName = "workspace-layout";
+
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+    private const string ShapeCanonical = "canonical";
+    private const string ShapeThreeColumn = "three-column";
+    private const string ShapeMirrored = "mirrored";
+    private const string ShapeUnknown = "unknown";
+    private const string SeatReview = "review";
+    private const string SeatDesign = "design";
+    private const decimal TargetLeftRatio = 0.4m;
+    private const decimal TargetRightSplitRatio = 0.5m;
+    private const decimal RatioTolerance = 0.0005m;
+
+    private const string UsageLine =
+        "Usage: intent-cli guide workspace-layout [--workspace-id <id>] [--tab-id <id>] "
+        + "[--shape canonical|three-column|mirrored|unknown] "
+        + "[--orchestration-pane <id>] [--implementation-pane <id>] [--review-pane <id>] "
+        + "[--orchestration-label <label>] [--implementation-label <label>] [--review-label <label>] "
+        + "[--third-seat-role review|design] [--temporary-tab-id <id>] "
+        + "[--round-trip-pane <id>] [--target-pane <id>] "
+        + "[--actual-left-ratio <0..1>] [--actual-top-right-ratio <0..1>] "
+        + "[--format markdown|json]";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var request, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var plan = Build(request);
+        if (string.Equals(request.Format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(plan, JsonOptions));
+            return 0;
+        }
+
+        WriteMarkdown(writer, plan);
+        return 0;
+    }
+
+    /// <summary>
+    /// Builds a deterministic plan from explicit operator input. This method
+    /// has no filesystem, process, network, or host-state access so tests can
+    /// prove that the guide is render-only.
+    /// </summary>
+    internal static WorkspaceLayoutPlan Build(WorkspaceLayoutRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var expectedReviewLabel = string.Equals(request.ThirdSeatRole, SeatDesign, StringComparison.Ordinal)
+            ? SeatDesign
+            : SeatReview;
+        var shapeDiffers = !string.Equals(request.Shape, ShapeCanonical, StringComparison.Ordinal);
+
+        var scratchCommands = new List<string>();
+        if (shapeDiffers)
+        {
+            // A temporary tab is intentional: herdr's same-tab move is a
+            // measured no-op. The second move targets the pane that should be
+            // above the moved pane, preserving the running process.
+            scratchCommands.Add(
+                $"herdr tab create --workspace {request.WorkspaceId} --label g637-layout-scratch --no-focus");
+            scratchCommands.Add(
+                $"herdr pane move {request.RoundTripPaneId} --tab {request.TemporaryTabId} --no-focus");
+            scratchCommands.Add(
+                $"herdr pane move {request.RoundTripPaneId} --tab {request.SourceTabId} "
+                + $"--target-pane {request.TargetPaneId} --split down --ratio {TargetRightSplitRatio.ToString(CultureInfo.InvariantCulture)} --no-focus");
+        }
+
+        var renameCommands = new List<string>();
+        AddRenameIfNeeded(
+            renameCommands,
+            request.OrchestrationPaneId,
+            request.OrchestrationLabel,
+            "orchestration");
+        AddRenameIfNeeded(
+            renameCommands,
+            request.ImplementationPaneId,
+            request.ImplementationLabel,
+            "implementation");
+        AddRenameIfNeeded(
+            renameCommands,
+            request.ReviewPaneId,
+            request.ReviewLabel,
+            expectedReviewLabel);
+
+        var resizeCommands = new List<string>();
+        AddResizeCommand(
+            resizeCommands,
+            request.OrchestrationPaneId,
+            request.ActualLeftRatio,
+            TargetLeftRatio,
+            vertical: false);
+        AddResizeCommand(
+            resizeCommands,
+            request.ImplementationPaneId,
+            request.ActualTopRightRatio,
+            TargetRightSplitRatio,
+            vertical: true);
+
+        // When a caller only knows that the shape is non-conforming, retain a
+        // runnable correction rather than silently omitting the two canonical
+        // resize calls. Supplying actual ratios turns these into minimal
+        // directional deltas; otherwise the operator can inspect the emitted
+        // layout first and use the documented target amounts.
+        if (shapeDiffers && request.ActualLeftRatio is null)
+        {
+            resizeCommands.Add(
+                $"herdr pane resize --pane {request.OrchestrationPaneId} --direction right "
+                + $"--amount {TargetLeftRatio.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        if (shapeDiffers && request.ActualTopRightRatio is null)
+        {
+            resizeCommands.Add(
+                $"herdr pane resize --pane {request.ImplementationPaneId} --direction down "
+                + $"--amount {TargetRightSplitRatio.ToString(CultureInfo.InvariantCulture)}");
+        }
+
+        var commands = scratchCommands
+            .Concat(renameCommands)
+            .Concat(resizeCommands)
+            .ToArray();
+
+        return new WorkspaceLayoutPlan
+        {
+            Preview = true,
+            WorkspaceId = request.WorkspaceId,
+            SourceTabId = request.SourceTabId,
+            ObservedShape = request.Shape,
+            StructureDiffers = shapeDiffers,
+            Convention = new WorkspaceLayoutConvention
+            {
+                LeftRole = "orchestration",
+                LeftWidth = 0.4m,
+                TopRightRole = "implementation",
+                BottomRightRole = expectedReviewLabel,
+                RightWidth = 0.6m,
+                RightSplit = 0.5m,
+                LabelVocabulary = expectedReviewLabel == SeatDesign
+                    ? new[] { "orchestration", "implementation", "design" }
+                    : new[] { "orchestration", "implementation", "review" },
+            },
+            ScratchTabCommands = scratchCommands,
+            RenameCommands = renameCommands,
+            ResizeCommands = resizeCommands,
+            Commands = commands,
+            MeasuredFacts = MeasuredFacts,
+            SafeOrder = SafeOrder,
+            Boundaries = Boundaries,
+        };
+    }
+
+    private static readonly IReadOnlyList<string> MeasuredFacts =
+    [
+        "On herdr 0.8.0 on macOS, `herdr pane move` within the same tab returned `changed: false`; that measured no-op is not a claim about other herdr versions or platforms.",
+        "On herdr 0.8.0 on macOS, moving a pane to a temporary tab and back while targeting its destination pane reparented the pane rather than recreating it; all seventeen running agent processes survived the measured round trip.",
+    ];
+
+    private static readonly IReadOnlyList<string> SafeOrder =
+    [
+        "Run the temporary-tab round trip on a scratch tab first and inspect the returned pane/tab identifiers.",
+        "Before applying the plan to a workspace holding working agents, confirm the scratch process and every expected agent are still present.",
+        "Only then run the rendered rename and resize commands, resolving explicit identifiers immediately before each command.",
+        "After the layout change, confirm every agent is still present; intent-cli does not perform this check for you.",
+    ];
+
+    private static readonly IReadOnlyList<string> Boundaries =
+    [
+        "This command prints text only; it never executes herdr or any other process.",
+        "Seat identity, topology records, delivery semantics, and the settle contract are unchanged.",
+        "The convention does not prescribe an arrangement for a single-pane workspace.",
+        "The measured facts are scoped to herdr 0.8.0 on macOS; do not generalize them to an unmeasured version or platform.",
+    ];
+
+    private static void AddRenameIfNeeded(
+        ICollection<string> commands,
+        string paneId,
+        string currentLabel,
+        string expectedLabel)
+    {
+        if (!string.Equals(currentLabel, expectedLabel, StringComparison.Ordinal))
+        {
+            commands.Add($"herdr pane rename {paneId} {expectedLabel}");
+        }
+    }
+
+    private static void AddResizeCommand(
+        ICollection<string> commands,
+        string paneId,
+        decimal? actual,
+        decimal target,
+        bool vertical)
+    {
+        if (actual is null || Math.Abs(actual.Value - target) <= RatioTolerance)
+        {
+            return;
+        }
+
+        var delta = target - actual.Value;
+        var direction = vertical
+            ? delta > 0 ? "down" : "up"
+            : delta > 0 ? "right" : "left";
+
+        commands.Add(
+            $"herdr pane resize --pane {paneId} --direction {direction} "
+            + $"--amount {Math.Abs(delta).ToString(CultureInfo.InvariantCulture)}");
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out WorkspaceLayoutRequest request,
+        out string error)
+    {
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        var format = FormatMarkdown;
+        var shape = ShapeCanonical;
+        var thirdSeatRole = SeatReview;
+        decimal? actualLeftRatio = null;
+        decimal? actualTopRightRatio = null;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            if (string.Equals(argument, "--conforming", StringComparison.Ordinal))
+            {
+                shape = ShapeCanonical;
+                continue;
+            }
+
+            if (string.Equals(argument, "--nonconforming", StringComparison.Ordinal))
+            {
+                shape = ShapeUnknown;
+                continue;
+            }
+
+            if (!RequiresValue(argument))
+            {
+                request = new WorkspaceLayoutRequest();
+                error = $"Unknown argument '{argument}'.";
+                return false;
+            }
+
+            if (++index >= args.Length)
+            {
+                request = new WorkspaceLayoutRequest();
+                error = $"{argument} requires a value.";
+                return false;
+            }
+
+            var value = args[index];
+            switch (argument)
+            {
+                case "--format":
+                    format = value;
+                    break;
+                case "--shape":
+                case "--actual-shape":
+                    shape = NormalizeShape(value);
+                    break;
+                case "--third-seat-role":
+                    thirdSeatRole = value;
+                    break;
+                case "--actual-left-ratio":
+                    if (!TryParseRatio(value, out actualLeftRatio, out error))
+                    {
+                        request = new WorkspaceLayoutRequest();
+                        return false;
+                    }
+
+                    break;
+                case "--actual-top-right-ratio":
+                    if (!TryParseRatio(value, out actualTopRightRatio, out error))
+                    {
+                        request = new WorkspaceLayoutRequest();
+                        return false;
+                    }
+
+                    break;
+                default:
+                    values[argument] = value;
+                    break;
+            }
+        }
+
+        if (!string.Equals(format, FormatMarkdown, StringComparison.Ordinal)
+            && !string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            request = new WorkspaceLayoutRequest();
+            error = $"Unknown --format '{format}'. Supported: markdown, json.";
+            return false;
+        }
+
+        if (!string.Equals(thirdSeatRole, SeatReview, StringComparison.Ordinal)
+            && !string.Equals(thirdSeatRole, SeatDesign, StringComparison.Ordinal))
+        {
+            request = new WorkspaceLayoutRequest();
+            error = $"Unsupported --third-seat-role '{thirdSeatRole}'. Supported: review, design.";
+            return false;
+        }
+
+        var orchestrationPaneId = Get(values, "--orchestration-pane", "<orchestration-pane>");
+        var implementationPaneId = Get(values, "--implementation-pane", "<implementation-pane>");
+        var reviewPaneId = Get(values, "--review-pane", "<review-pane>");
+        request = new WorkspaceLayoutRequest
+        {
+            Format = format,
+            Shape = shape,
+            ThirdSeatRole = thirdSeatRole,
+            WorkspaceId = Get(values, "--workspace-id", "--workspace", "<workspace-id>"),
+            SourceTabId = Get(values, "--tab-id", "--source-tab-id", "<tab-id>"),
+            TemporaryTabId = Get(values, "--temporary-tab-id", "<temporary-tab-id>"),
+            OrchestrationPaneId = orchestrationPaneId,
+            ImplementationPaneId = implementationPaneId,
+            ReviewPaneId = reviewPaneId,
+            OrchestrationLabel = Get(values, "--orchestration-label", "orchestration"),
+            ImplementationLabel = Get(values, "--implementation-label", "implementation"),
+            ReviewLabel = Get(values, "--review-label", thirdSeatRole == SeatDesign ? "design" : "review"),
+            RoundTripPaneId = values.TryGetValue("--round-trip-pane", out var roundTripPane)
+                ? roundTripPane
+                : values.TryGetValue("--move-pane", out var movePane) ? movePane : reviewPaneId,
+            TargetPaneId = values.TryGetValue("--target-pane", out var targetPane)
+                ? targetPane
+                : implementationPaneId,
+            ActualLeftRatio = actualLeftRatio,
+            ActualTopRightRatio = actualTopRightRatio,
+        };
+        error = string.Empty;
+        return true;
+    }
+
+    private static string Get(
+        IReadOnlyDictionary<string, string> values,
+        string key,
+        string fallback) => values.TryGetValue(key, out var value) ? value : fallback;
+
+    private static string Get(
+        IReadOnlyDictionary<string, string> values,
+        string key,
+        string alias,
+        string fallback) => values.TryGetValue(key, out var value)
+        ? value
+        : values.TryGetValue(alias, out var aliasValue) ? aliasValue : fallback;
+
+    private static bool TryParseRatio(string value, out decimal? ratio, out string error)
+    {
+        if (!decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            || parsed < 0m
+            || parsed > 1m)
+        {
+            ratio = null;
+            error = $"Ratio '{value}' must be a number between 0 and 1.";
+            return false;
+        }
+
+        ratio = parsed;
+        error = string.Empty;
+        return true;
+    }
+
+    private static string NormalizeShape(string value) => value switch
+    {
+        "canonical" => ShapeCanonical,
+        "left-40-right-split" => ShapeCanonical,
+        "left-60-right-split" => ShapeThreeColumn,
+        "left-split" => ShapeMirrored,
+        "three-columns" => ShapeThreeColumn,
+        "three-column" => ShapeThreeColumn,
+        "mirrored" => ShapeMirrored,
+        "unknown" => ShapeUnknown,
+        _ => value,
+    };
+
+    private static bool RequiresValue(string argument) =>
+        argument is "--format"
+            or "--shape"
+            or "--actual-shape"
+            or "--third-seat-role"
+            or "--actual-left-ratio"
+            or "--actual-top-right-ratio"
+            or "--workspace-id"
+            or "--workspace"
+            or "--tab-id"
+            or "--source-tab-id"
+            or "--temporary-tab-id"
+            or "--orchestration-pane"
+            or "--implementation-pane"
+            or "--review-pane"
+            or "--orchestration-label"
+            or "--implementation-label"
+            or "--review-label"
+            or "--round-trip-pane"
+            or "--move-pane"
+            or "--target-pane";
+
+    private static void WriteMarkdown(TextWriter writer, WorkspaceLayoutPlan plan)
+    {
+        writer.WriteLine("# Team workspace layout guide (G637 — preview-through-1.x)");
+        writer.WriteLine();
+        writer.WriteLine("This is a render-only plan. `intent-cli` does not execute any command below or query a live workspace.");
+        writer.WriteLine();
+        writer.WriteLine($"- Workspace: `{plan.WorkspaceId}`");
+        writer.WriteLine($"- Observed shape: `{plan.ObservedShape}`");
+        writer.WriteLine($"- Structure differs: `{plan.StructureDiffers.ToString().ToLowerInvariant()}`");
+        writer.WriteLine();
+        writer.WriteLine("## Convention");
+        writer.WriteLine();
+        writer.WriteLine("| slot | role label | width |");
+        writer.WriteLine("| --- | --- | --- |");
+        writer.WriteLine($"| left, full height | `{plan.Convention.LeftRole}` | 40% |");
+        writer.WriteLine($"| top-right | `{plan.Convention.TopRightRole}` | 30% |");
+        writer.WriteLine($"| bottom-right | `{plan.Convention.BottomRightRole}` | 30% |");
+        writer.WriteLine();
+        writer.WriteLine("The right column is 60% of the workspace and is split evenly between the two right-hand seats.");
+        writer.WriteLine();
+        writer.WriteLine("The label is the recorded topology role. A genuinely design third seat uses `design`; the slot convention does not rename the seat's identity.");
+        writer.WriteLine();
+        writer.WriteLine("## Commands (run in the listed order after the safe-order checks)");
+        writer.WriteLine();
+        if (plan.Commands.Count == 0)
+        {
+            writer.WriteLine("The supplied workspace is already canonical and its labels match; no layout command is needed.");
+        }
+        else
+        {
+            for (var index = 0; index < plan.Commands.Count; index++)
+            {
+                writer.WriteLine($"{index + 1}. `{plan.Commands[index]}`");
+            }
+        }
+
+        WriteListSection(writer, "## Safe order", plan.SafeOrder);
+        WriteListSection(writer, "## Measured facts (herdr 0.8.0 on macOS)", plan.MeasuredFacts);
+        WriteListSection(writer, "## Boundaries", plan.Boundaries);
+    }
+
+    private static void WriteListSection(TextWriter writer, string heading, IEnumerable<string> entries)
+    {
+        writer.WriteLine();
+        writer.WriteLine(heading);
+        writer.WriteLine();
+        foreach (var entry in entries)
+        {
+            writer.WriteLine($"- {entry}");
+        }
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide workspace-layout (G637 — preview-through-1.x)");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("Supply the operator-observed shape and explicit workspace/tab/pane identifiers.");
+        writer.WriteLine("`canonical` emits little or nothing when labels and ratios already match.");
+        writer.WriteLine("Non-canonical shapes emit a temporary-tab round trip before rename/resize commands.");
+        writer.WriteLine("The command is read-only and never invokes herdr.");
+    }
+}
+
+internal sealed record WorkspaceLayoutRequest
+{
+    public string Format { get; init; } = "markdown";
+    public string Shape { get; init; } = "canonical";
+    public string ThirdSeatRole { get; init; } = "review";
+    public string WorkspaceId { get; init; } = "<workspace-id>";
+    public string SourceTabId { get; init; } = "<tab-id>";
+    public string TemporaryTabId { get; init; } = "<temporary-tab-id>";
+    public string OrchestrationPaneId { get; init; } = "<orchestration-pane>";
+    public string ImplementationPaneId { get; init; } = "<implementation-pane>";
+    public string ReviewPaneId { get; init; } = "<review-pane>";
+    public string OrchestrationLabel { get; init; } = "orchestration";
+    public string ImplementationLabel { get; init; } = "implementation";
+    public string ReviewLabel { get; init; } = "review";
+    public string RoundTripPaneId { get; init; } = "<review-pane>";
+    public string TargetPaneId { get; init; } = "<implementation-pane>";
+    public decimal? ActualLeftRatio { get; init; }
+    public decimal? ActualTopRightRatio { get; init; }
+}
+
+internal sealed record WorkspaceLayoutPlan
+{
+    [JsonPropertyName("preview")]
+    public required bool Preview { get; init; }
+
+    [JsonPropertyName("workspace_id")]
+    public required string WorkspaceId { get; init; }
+
+    [JsonPropertyName("source_tab_id")]
+    public required string SourceTabId { get; init; }
+
+    [JsonPropertyName("observed_shape")]
+    public required string ObservedShape { get; init; }
+
+    [JsonPropertyName("structure_differs")]
+    public required bool StructureDiffers { get; init; }
+
+    [JsonPropertyName("convention")]
+    public required WorkspaceLayoutConvention Convention { get; init; }
+
+    [JsonPropertyName("scratch_tab_commands")]
+    public required IReadOnlyList<string> ScratchTabCommands { get; init; }
+
+    [JsonPropertyName("rename_commands")]
+    public required IReadOnlyList<string> RenameCommands { get; init; }
+
+    [JsonPropertyName("resize_commands")]
+    public required IReadOnlyList<string> ResizeCommands { get; init; }
+
+    [JsonPropertyName("commands")]
+    public required IReadOnlyList<string> Commands { get; init; }
+
+    [JsonPropertyName("measured_facts")]
+    public required IReadOnlyList<string> MeasuredFacts { get; init; }
+
+    [JsonPropertyName("safe_order")]
+    public required IReadOnlyList<string> SafeOrder { get; init; }
+
+    [JsonPropertyName("boundaries")]
+    public required IReadOnlyList<string> Boundaries { get; init; }
+}
+
+internal sealed record WorkspaceLayoutConvention
+{
+    [JsonPropertyName("left_role")]
+    public required string LeftRole { get; init; }
+
+    [JsonPropertyName("left_width")]
+    public required decimal LeftWidth { get; init; }
+
+    [JsonPropertyName("top_right_role")]
+    public required string TopRightRole { get; init; }
+
+    [JsonPropertyName("bottom_right_role")]
+    public required string BottomRightRole { get; init; }
+
+    [JsonPropertyName("right_width")]
+    public required decimal RightWidth { get; init; }
+
+    [JsonPropertyName("right_split")]
+    public required decimal RightSplit { get; init; }
+
+    [JsonPropertyName("label_vocabulary")]
+    public required IReadOnlyList<string> LabelVocabulary { get; init; }
+}

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -206,6 +206,8 @@ internal static class Program
                 || string.Equals(args[1], "artifact-intake", StringComparison.Ordinal)
                 // G487: optional agmsg-backed orchestrator-thread guidance — read-only, no host state required.
                 || string.Equals(args[1], "orchestrator-thread", StringComparison.Ordinal)
+                // G637: read-only workspace-layout guidance — no host state required.
+                || string.Equals(args[1], "workspace-layout", StringComparison.Ordinal)
                 // G488: thin agent skill pack bootstrap — read-only, no host state required.
                 || string.Equals(args[1], "skill-pack", StringComparison.Ordinal));
     }

--- a/tests/IntentSystem.Cli.Tests/WorkspaceLayoutGuideG637Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkspaceLayoutGuideG637Tests.cs
@@ -1,0 +1,124 @@
+using System.Text.Json;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G637: the workspace convention is a render-only plan. These tests keep the
+/// canonical no-op, the non-conforming temporary-tab order, and the EN/JA
+/// onboarding/preview markers executable.
+/// </summary>
+public sealed class WorkspaceLayoutGuideG637Tests
+{
+    [Fact]
+    public void CanonicalWorkspace_WithCanonicalLabels_IsAReadOnlyNoOp()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkspaceLayoutCommand.Execute(
+            CreateContext(),
+            [
+                "--workspace-id", "w1", "--tab-id", "w1:t1", "--shape", "canonical",
+                "--orchestration-pane", "w1:p1", "--implementation-pane", "w1:p2", "--review-pane", "w1:p3",
+                "--actual-left-ratio", "0.4", "--actual-top-right-ratio", "0.5", "--format", "json"
+            ],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("preview").GetBoolean());
+        Assert.False(root.GetProperty("structure_differs").GetBoolean());
+        Assert.Empty(root.GetProperty("commands").EnumerateArray());
+        Assert.Equal(0.4m, root.GetProperty("convention").GetProperty("left_width").GetDecimal());
+        Assert.Equal(0.5m, root.GetProperty("convention").GetProperty("right_split").GetDecimal());
+    }
+
+    [Fact]
+    public void NonConformingWorkspace_EmitsTemporaryRoundTripBeforeRenameAndResize()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkspaceLayoutCommand.Execute(
+            CreateContext(),
+            [
+                "--workspace-id", "w1", "--tab-id", "w1:t1", "--temporary-tab-id", "w1:t-scratch",
+                "--shape", "three-column", "--orchestration-pane", "w1:p1", "--implementation-pane", "w1:p2",
+                "--review-pane", "w1:p3", "--orchestration-label", "orchestrator", "--implementation-label", "implement",
+                "--review-label", "reviewer", "--actual-left-ratio", "0.6", "--actual-top-right-ratio", "0.4",
+                "--format", "json"
+            ],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var root = document.RootElement;
+        Assert.True(root.GetProperty("structure_differs").GetBoolean());
+        var commands = root.GetProperty("commands").EnumerateArray().Select(value => value.GetString()!).ToArray();
+        Assert.Equal("herdr tab create --workspace w1 --label g637-layout-scratch --no-focus", commands[0]);
+        Assert.Equal("herdr pane move w1:p3 --tab w1:t-scratch --no-focus", commands[1]);
+        Assert.Contains("--target-pane w1:p2", commands[2], StringComparison.Ordinal);
+        Assert.Contains("herdr pane rename w1:p1 orchestration", commands);
+        Assert.Contains("herdr pane rename w1:p2 implementation", commands);
+        Assert.Contains("herdr pane rename w1:p3 review", commands);
+        Assert.Contains("--direction left --amount 0.2", commands.Single(command => command.Contains("w1:p1", StringComparison.Ordinal) && command.Contains("resize", StringComparison.Ordinal)), StringComparison.Ordinal);
+        Assert.Contains("--direction down --amount 0.1", commands.Single(command => command.Contains("w1:p2", StringComparison.Ordinal) && command.Contains("resize", StringComparison.Ordinal)), StringComparison.Ordinal);
+        Assert.DoesNotContain(commands, command => command.Contains("Process.Start", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Markdown_StatesMeasuredScopeSafetyAndPreviewBoundaries()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkspaceLayoutCommand.Execute(
+            CreateContext(),
+            ["--shape", "mirrored", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("G637 — preview-through-1.x", output, StringComparison.Ordinal);
+        Assert.Contains("40%", output, StringComparison.Ordinal);
+        Assert.Contains("60%", output, StringComparison.Ordinal);
+        Assert.Contains("herdr 0.8.0 on macOS", output, StringComparison.Ordinal);
+        Assert.Contains("changed: false", output, StringComparison.Ordinal);
+        Assert.Contains("scratch tab first", output, StringComparison.Ordinal);
+        Assert.Contains("never executes herdr", output, StringComparison.Ordinal);
+        Assert.Contains("single-pane", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Documentation_AndLedger_ExposeTheSamePreviewSurfaceInEnglishAndJapanese()
+    {
+        foreach (var language in new[] { "en", "ja" })
+        {
+            var root = RepoVersionPolicySource.RepoRoot();
+            var orchestration = File.ReadAllText(Path.Combine(root, "docs", language, "12-agent-message-orchestration.md"));
+            var onboarding = File.ReadAllText(Path.Combine(root, "docs", language, "02a-getting-started-orchestration.md"));
+            var ledger = File.ReadAllText(Path.Combine(root, "docs", language, "1.0-compatibility-ledger.md"));
+            var promise = File.ReadAllText(Path.Combine(root, "docs", language, "1.0-compatibility-promise.md"));
+
+            Assert.Contains("G637", orchestration, StringComparison.Ordinal);
+            Assert.Contains("workspace-layout", orchestration, StringComparison.Ordinal);
+            Assert.Contains("40%", orchestration, StringComparison.Ordinal);
+            Assert.Contains("60%", orchestration, StringComparison.Ordinal);
+            Assert.Contains("guide workspace-layout", onboarding, StringComparison.Ordinal);
+            Assert.Contains("workspace-layout guide", ledger, StringComparison.Ordinal);
+            Assert.Contains("preview-through-1.x", ledger, StringComparison.Ordinal);
+            Assert.Contains("G637", promise, StringComparison.Ordinal);
+        }
+    }
+
+    private static CliContext CreateContext() => new()
+    {
+        RepoRoot = Path.GetTempPath(),
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+}


### PR DESCRIPTION
Closes #1377

## Summary
- add the read-only intent-cli guide workspace-layout preview surface with canonical 40% orchestration-left and 60%-even implementation/review commands
- render the temporary-tab round trip, topology-role labels, scoped herdr 0.8.0/macOS measurements, and safe-order checks without invoking herdr
- document the EN/JA convention and onboarding pointer, with preview compatibility-ledger entries

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --filter WorkspaceLayoutGuideG637Tests,CompatibilityPromiseG612Tests,JapaneseTerminologyGuardG613Tests,AgentMessageOrchestrationDocsTests,OnboardingTransportPresentationG608Tests,GuideCommandsListCommandTests,CommandRouterTests
- dotnet test IntentSystem.sln --no-restore
- git diff --check