### PR TITLE
G639: Prepare v0.13.0 release notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2532,7 +2532,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0122)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0130)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2625,28 +2625,29 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.12.2)
+### Next release readiness (v0.13.0)
 
 **`v0.12.1` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.12.2`. [The v0.12.2 notes stub](release-notes-v0.12.2.md) is the required
-prepare-only placeholder. See [release-notes-v0.12.1.md](release-notes-v0.12.1.md)
-for the preceding shipped scope.
+`0.13.0`. [The v0.13.0 notes](release-notes-v0.13.0.md) are the required
+prepare-only preparation. See [release-notes-v0.12.1.md](release-notes-v0.12.1.md)
+for the preceding shipped scope and [release-notes-v0.12.0.md](release-notes-v0.12.0.md)
+for the prior minor scope.
 
-**Release-readiness verification (run before merging the `v0.12.2`
+**Release-readiness verification (run before merging the `v0.13.0`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.12.1 (published), nextVersion 0.12.2 (to release)
+cat eng/version.json   # stableVersion 0.12.1 (published), nextVersion 0.13.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.12.2-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.13.0-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.12.2.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.13.0.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2660,10 +2661,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.12.2`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.13.0`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.12.2`, `nextVersion → 0.12.3` — carrying, per **steps 4–6** of the
+`stableVersion → 0.13.0`, `nextVersion → 0.13.1` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.12.2.md
+++ b/docs/en/release-notes-v0.12.2.md
@@ -1,9 +1,0 @@
-# Release Notes — intent-cli v0.12.2
-
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.12.2`.
-The eventual release will be published at
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.12.2.

--- a/docs/en/release-notes-v0.13.0.md
+++ b/docs/en/release-notes-v0.13.0.md
@@ -1,0 +1,87 @@
+# Release Notes — intent-cli v0.13.0
+
+> **Prepare-only / UNRELEASED.** This preparation changes version state and
+> documentation only. It creates no GitHub Release, tag, package publish, or
+> release workflow run; Release creation remains the operator's step.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.13.0`.
+When approved, the release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.13.0.
+See the [v0.12.1 notes](release-notes-v0.12.1.md) and the
+[v0.12.0 notes](release-notes-v0.12.0.md) for the preceding scopes; those
+notes are linked, not repeated here.
+
+## Preview lane — read before the feature list
+
+Every surface in v0.13.0 is `preview-through-1.x`: it is outside the
+[1.0 compatibility promise](1.0-compatibility-promise.md), may change or be
+withdrawn during the 1.x line, and is not a 1.0 compatibility commitment.
+This is the first release after the freeze where that preview lane applies to
+shipped surfaces.
+
+## What's in v0.13.0
+
+This minor release covers exactly five units: G636, G629, G630, G637, and
+G638. The list was derived by running `git log v0.12.1..main`; the sixteen
+commits in that range are all accounted for. The post-release roll is
+`ca24b94`. The G636 sequence is `75e7a3a`, `8b4d0c1`, `d7cc4a5`, `844e3e7`,
+`c58aa9b`, and merge `861f1978`; G629 is `140b520` and merge `98e8805`; G630
+is `8ee090d` and merge `fa39c857`; G637 is `aa86ba8` and merge `26c2b465`;
+G638 is `2bd744a`, `1d0f81e`, and merge `b45f675`.
+
+- G636 — PR #1372, merge commit `861f1978` (resolves on `main`): the launch recipe records a post-start interaction, including the Copilot permission dialog whose default is the unbounded answer.
+- G629 — PR #1374, merge commit `98e8805` (resolves on `main`): a dispatch becomes durable state, with a pending record and `notify status` returning live, settled, or lost.
+- G630 — PR #1376, merge commit `fa39c857` (resolves on `main`): `notify supervise` stays silent while seats are healthy, verifies recovery and loss, and makes re-dispatch opt-in.
+- G637 — PR #1378, merge commit `26c2b465` (resolves on `main`): the workspace layout convention and `guide workspace-layout` make the recorded topology reproducible.
+- G638 — PR #1380, merge commit `b45f675` (resolves on `main`): `automation ci-wait`, the `ci-all-green-not-transitioned` stall class, and a recipient warning make exact-head waits durable.
+
+## Why this is a minor release
+
+The minor bump is verifiable rather than assumed. `notify status`, `notify
+supervise`, `automation ci-wait`, and `guide workspace-layout` were absent at
+v0.12.1 and first ship in this line. Every one of those surfaces remains in
+the preview lane described above.
+
+## What the new surfaces deliberately do not do
+
+- `notify status` reads durable delegation state and never acts on a process.
+- `notify supervise` stays silent on healthy seats and keeps re-dispatch off by
+  default; it does not invent a recovery action from silence alone.
+- `automation ci-wait` records an exact-head wait and starts no polling or
+  background timer.
+- `guide workspace-layout` prints the commands and conventions needed to
+  reproduce the layout and executes none of them.
+
+## Operational purpose and operator disclosure
+
+On 2026-08-06 this team's loop stopped silently three times, with different
+causes: a recipient process died mid-task, a CI run finished with nobody to
+wake, and a completion report reached a sleeping seat. The five units make
+those states visible, and the durable delegation, supervision, CI-wait, and
+report paths make the relevant recovery states explicit; two of the observed
+stalls are now recoverable through the recorded workflow.
+
+G636 carries an authority disclosure that must not be inferred away: a seat
+launched with a correct command line can still hold authority the operator
+never granted, because the agent's startup dialog defaults to enabling all
+permissions. The launch recipe now records the answer that preserves the
+declared envelope.
+
+## Release-readiness gate
+
+Before creating the v0.13.0 Release, the operator must verify:
+
+- `eng/version.json` records stable `0.12.1` and next `0.13.0`.
+- PRs #1372, #1374, #1376, #1378, and #1380 resolve on `main` at merge
+  commits `861f1978`, `98e8805`, `fa39c857`, `26c2b465`, and `b45f675`; the
+  sixteen commits in `git log v0.12.1..main` remain fully accounted for.
+- The bilingual release-notes guard and G634 count guard pass, followed by
+  the full Release suite and exact-head CI.
+- Prepare-only remains in force: do not create the GitHub Release, tag, or
+  package publish until the operator explicitly approves it.
+
+## Publishing v0.13.0
+
+After the readiness gate passes and the operator approves, a maintainer may
+create the GitHub Release and publish the package. This preparation PR does
+not perform that step.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2698,27 +2698,28 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.12.2)
+### 次リリース準備(v0.13.0)
 
 **`v0.12.1` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.12.2` です。[v0.12.2 notes stub](release-notes-v0.12.2.md) は必須の
-prepare-only placeholder です。直前の出荷範囲は
-[release-notes-v0.12.1.md](release-notes-v0.12.1.md) を参照してください。
+`0.13.0` です。[v0.13.0 notes](release-notes-v0.13.0.md) が必須の
+prepare-only preparation です。直前の出荷範囲は
+[release-notes-v0.12.1.md](release-notes-v0.12.1.md) を、直前の minor scope は
+[release-notes-v0.12.0.md](release-notes-v0.12.0.md) を参照してください。
 
-**リリース準備検証(`v0.12.2` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.13.0` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.12.1 (published), nextVersion 0.12.2 (to release)
+cat eng/version.json   # stableVersion 0.12.1 (published), nextVersion 0.13.0 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.12.2-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.13.0-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.12.2.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.13.0.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2731,10 +2732,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.12.2` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.13.0` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.12.2`、`nextVersion → 0.12.3` —
+`stableVersion → 0.13.0`、`nextVersion → 0.13.1` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.12.2.md
+++ b/docs/ja/release-notes-v0.12.2.md
@@ -1,9 +1,0 @@
-# リリースノート — intent-cli v0.12.2
-
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
-> このファイルを changelog として扱ってはいけません。
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.12.2`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.12.2 に
-publish されます。

--- a/docs/ja/release-notes-v0.13.0.md
+++ b/docs/ja/release-notes-v0.13.0.md
@@ -1,0 +1,72 @@
+# リリースノート — intent-cli v0.13.0
+
+> **prepare-only / 未リリース。** この準備では version state と documentation だけを
+> 変更します。GitHub Release、tag、package publish、release workflow は作成・実行せず、
+> Release 作成は operator の手順として残します。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.13.0`。
+承認後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.13.0 に公開されます。
+直前の範囲は [v0.12.1 notes](release-notes-v0.12.1.md) と
+[v0.12.0 notes](release-notes-v0.12.0.md) を参照し、ここでは重複記載しません。
+
+## feature list の前に読む preview lane
+
+v0.13.0 のすべての surface は `preview-through-1.x` です。
+[1.0 compatibility promise](1.0-compatibility-promise.md) の対象外であり、1.x の間に
+変更または撤回される可能性があり、1.0 の compatibility commitment ではありません。
+freeze 後にこの preview lane が実際の surface に適用される最初の Release です。
+
+## v0.13.0 の内容
+
+この minor release は G636、G629、G630、G637、G638 の正確に五件の unit を対象にします。
+一覧は `git log v0.12.1..main` を実行して導出し、その範囲の 16 commit をすべて説明しています。
+post-release roll は `ca24b94` です。G636 の系列は `75e7a3a`、`8b4d0c1`、`d7cc4a5`、
+`844e3e7`、`c58aa9b`、merge `861f1978`、G629 は `140b520` と merge `98e8805`、G630 は
+`8ee090d` と merge `fa39c857`、G637 は `aa86ba8` と merge `26c2b465`、G638 は `2bd744a`、
+`1d0f81e`、merge `b45f675` です。
+
+- G636 — PR #1372、merge commit `861f1978`（`main` に存在）: launch recipe が post-start interaction を記録し、Copilot permission dialog の既定値が unbounded answer であることを扱います。
+- G629 — PR #1374、merge commit `98e8805`（`main` に存在）: dispatch を永続状態にし、pending record と `notify status` の live / settled / lost を提供します。
+- G630 — PR #1376、merge commit `fa39c857`（`main` に存在）: `notify supervise` が healthy seat では黙り、recovery と loss を確認し、re-dispatch を opt-in にします。
+- G637 — PR #1378、merge commit `26c2b465`（`main` に存在）: workspace layout convention と `guide workspace-layout` で記録済み topology を再現できます。
+- G638 — PR #1380、merge commit `b45f675`（`main` に存在）: `automation ci-wait`、`ci-all-green-not-transitioned` stall class、recipient warning で exact-head wait を永続化します。
+
+## minor bump の根拠
+
+minor bump は推測ではなく検証できます。`notify status`、`notify supervise`、
+`automation ci-wait`、`guide workspace-layout` は v0.12.1 には存在せず、この line で初めて
+追加されました。これらの surface はすべて上記の preview lane に属します。
+
+## 新しい surface が意図的にしないこと
+
+- `notify status` は永続化された delegation state を読むだけで、process には作用しません。
+- `notify supervise` は healthy seat では黙り、re-dispatch を既定で off にします。沈黙だけから recovery action を作りません。
+- `automation ci-wait` は exact-head wait を記録しますが、polling や background timer を開始しません。
+- `guide workspace-layout` は必要な command と convention を表示するだけで、command を実行しません。
+
+## 運用上の目的と operator への開示
+
+2026-08-06、このチームの loop は異なる原因で三回 silent に停止しました。recipient process が task の途中で終了し、
+CI run が wake する相手のいないまま完了し、completion report が sleeping seat に届いたためです。五件の unit はこれらの
+state を可視化し、delegation、supervision、CI-wait、report の記録済み経路で recovery state を明示します。観測された
+stall のうち二つは、記録された workflow から recovery できるようになりました。
+
+G636 には、見落としてはいけない authority disclosure があります。正しい command line で seat を起動しても、operator
+が許可していない authority を保持する可能性があります。agent の startup dialog は既定で全 permissions を有効にするためです。
+launch recipe は、宣言した envelope を保つ回答を記録するようになりました。
+
+## リリース準備ゲート (Release-readiness gate)
+
+v0.13.0 Release を作成する前に operator が確認します。
+
+- `eng/version.json` が stable `0.12.1` / next `0.13.0` を記録していること。
+- PR #1372、#1374、#1376、#1378、#1380 が `main` の merge commit `861f1978`、`98e8805`、
+  `fa39c857`、`26c2b465`、`b45f675` に解決し、`git log v0.12.1..main` の 16 commit がすべて説明されること。
+- bilingual release-notes guard と G634 count guard、full Release suite、exact-head CI が green であること。
+- prepare-only の境界を守り、operator が明示承認するまで GitHub Release、tag、package publish を作成しないこと。
+
+## v0.13.0 の publish
+
+ゲートが green になり operator が承認した後にのみ maintainer が GitHub Release と package を publish できます。
+この preparation PR 自体はその操作を行いません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
   "stableVersion": "0.12.1",
-  "nextVersion": "0.12.2"
+  "nextVersion": "0.13.0"
 }


### PR DESCRIPTION
Closes #1381

Prepare-only v0.13.0 release readiness: retargets eng/version.json, replaces the superseded 0.12.2 stubs with bilingual v0.13.0 notes covering G636/G629/G630/G637/G638, and refreshes EN/JA developer-reference readiness. No Release, tag, or package publish is created.

Focused verification: release/version guards, local-link and terminology guards, range/merge-anchor enumeration, surface-absence check, and git diff --check. Full suite and exact-head CI are required.