### PR TITLE
G640: deliver unmatched reports with advisory

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -54,15 +54,25 @@ intent-cli notify status --task-id <task-id> [--domain <domain> --team <team>] \
 `<routing-root>/.intent-cli/notify/<domain>/<team>/pending.jsonl`. The snapshot
 contains the task id, recorded recipient identity, expected artifact, and
 dispatch timestamp. If that write fails, no pane prompt or external reader
-event is attempted. A matching `notify report` appends the resolution; an
-unknown or already-settled task id is refused and the supplied id plus known
-open ids are named. `notify status` reads the same recorded identity and
+event is attempted. A matching `notify report` appends the resolution. An
+unmatched task id still delivers the report and emits an advisory in both
+human-readable and machine output naming the supplied id and stating that no
+open pending delegation matched; it creates or resolves no pending record. An
+already-settled task id, or a lookup whose identifiers conflict across team
+stores, remains refused and names the supplied id plus the known open ids.
+`notify status` reads the same recorded identity and
 liveness judgment as delegate: herdr uses the exact `agent_running` flag at
 the recorded workspace/pane (never the status string), while agmsg uses its
 recorded roster. It reports `live` for a running recipient with no report,
 `settled` after the matching report regardless of current liveness, and
 `lost` only when the recipient is not running and no report arrived. Elapsed
 time never changes the verdict.
+
+A report is a message rather than a bookkeeping entry: fail-closed protection
+belongs on pending-state mutation, not on carrying the message. Refusing an
+unrecognised identifier would silence unsolicited reports and answers to
+escalations—the messages whose information the recipient did not know to
+request.
 
 > **Preview through 1.x (G629).** Pending-delegation records and `notify
 > status` were added after the v0.12.0 freeze. They are outside the 1.0

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -52,13 +52,22 @@ intent-cli notify status --task-id <task-id> [--domain <domain> --team <team>] \
 `<routing-root>/.intent-cli/notify/<domain>/<team>/pending.jsonl` へ追記します。
 snapshot は task id、recorded recipient identity、expected artifact、dispatch timestamp を
 持ちます。write に失敗した場合は pane prompt や external reader event を試みません。
-一致する `notify report` は resolution を追記し、unknown または既に settled の task id は
-拒否して supplied id と known open ids の両方を示します。`notify status` は delegate と同じ
+一致する `notify report` は resolution を追記します。open な pending delegation に一致しない
+task id でも report は配信し、human-readable と machine output の両方に supplied id と
+「open な pending delegation に一致しなかった」ことを示す advisory を出します。この場合は
+pending record を作成も解決もしません。既に settled の task id、または team store 間で
+identifier が衝突する lookup は従来どおり拒否し、supplied id と known open ids を示します。
+`notify status` は delegate と同じ
 recorded identity / liveness judgment を読みます。herdr では recorded workspace/pane の
 正確な `agent_running` flag を使い、status string は使いません。agmsg では recorded roster を
 使います。report がなく recipient が running なら `live`、一致する report 後は現在の liveness
 によらず `settled`、recipient が not running かつ report がない場合だけ `lost` です。経過時間
 だけで verdict を変えることはありません。
+
+report は bookkeeping entry ではなく message です。fail-closed の保護は message を運ぶことではなく
+pending state の mutation に置きます。認識されない identifier を理由に配信を拒否すると、recipient が
+依頼したことを知らなかった unsolicited report や escalation への回答という、情報を運ぶ message を
+黙らせてしまいます。
 
 > **1.x を通じた preview (G629)。** pending-delegation record と `notify status` は
 > v0.12.0 freeze 後に追加されました。1.0 compatibility promise の対象外であり、1.x の間に

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -167,6 +167,7 @@ internal static class NotifyCommand
                 return 1;
             }
 
+            string? reportAdvisory = null;
             if (string.Equals(operation, OperationReport, StringComparison.Ordinal))
             {
                 var pending = NotifyPendingDelegationStore.Find(
@@ -174,7 +175,11 @@ internal static class NotifyCommand
                     options.Domain,
                     options.Team,
                     options.TaskId!);
-                if (!pending.Resolved || pending.Record is null || pending.Record.ReportArrived)
+                var unmatched = !pending.Resolved
+                    && pending.Record is null
+                    && pending.Error is null;
+                if (!unmatched
+                    && (!pending.Resolved || pending.Record is null || pending.Record.ReportArrived))
                 {
                     var known = FormatKnownTaskIds(pending.KnownTaskIds);
                     Emit(writer, options.Format, FailureResult(
@@ -189,9 +194,16 @@ internal static class NotifyCommand
                         preflight: preflight));
                     return 1;
                 }
+
+                if (unmatched)
+                {
+                    reportAdvisory = BuildUnmatchedReportAdvisory(
+                        options.TaskId!,
+                        pending.KnownTaskIds);
+                }
             }
 
-            return ExecuteDelivery(writer, operation, options, resolution, preflight);
+            return ExecuteDelivery(writer, operation, options, resolution, preflight, reportAdvisory);
         }
 
         SessionLayerModeResolution escalationResolution;
@@ -372,6 +384,12 @@ internal static class NotifyCommand
     private static string FormatKnownTaskIds(IReadOnlyList<string> knownTaskIds) =>
         knownTaskIds.Count == 0 ? "<none>" : string.Join(", ", knownTaskIds);
 
+    private static string BuildUnmatchedReportAdvisory(
+        string taskId,
+        IReadOnlyList<string> knownTaskIds) =>
+        $"No open pending delegation matched supplied report task id '{taskId}'; the report was delivered "
+        + $"without creating or resolving a pending record. Known open task ids: {FormatKnownTaskIds(knownTaskIds)}.";
+
     internal static void EmitSupervision(
         TextWriter writer,
         NotifySupervisorPass pass,
@@ -445,7 +463,8 @@ internal static class NotifyCommand
         string operation,
         NotifyOptions options,
         SessionLayerModeResolution resolution,
-        SessionLayerPreflightResult preflight)
+        SessionLayerPreflightResult preflight,
+        string? reportAdvisory = null)
     {
         var reportCommand = string.Equals(operation, OperationDelegate, StringComparison.Ordinal)
             ? BuildReportCommand(options)
@@ -691,7 +710,8 @@ internal static class NotifyCommand
             deliveryMethod: envelopeDelivery.ResultDeliveryMethod,
             taskFile: envelopeDelivery.TaskFile,
             deliveryPointer: envelopeDelivery.ResultPointer,
-            pendingRecordPath: pendingRecordPath));
+            pendingRecordPath: pendingRecordPath,
+            advisory: reportAdvisory));
         return 0;
     }
 
@@ -939,7 +959,8 @@ internal static class NotifyCommand
         string? deliveryMethod = null,
         string? taskFile = null,
         string? deliveryPointer = null,
-        string? pendingRecordPath = null) => new()
+        string? pendingRecordPath = null,
+        string? advisory = null) => new()
         {
             Operation = operation,
             RoutingRoot = options.RoutingRoot!,
@@ -963,7 +984,8 @@ internal static class NotifyCommand
             ResendPermitted = resendPermitted,
             InlinePayloadWarning = inlinePayloadWarning,
             RecipientWarning = recipientWarning,
-            Warnings = recipientWarning is null ? null : [recipientWarning.Message],
+            Advisory = advisory,
+            Warnings = BuildWarnings(advisory, recipientWarning),
             DeliveryMethod = deliveryMethod,
             TaskFile = taskFile,
             DeliveryPointer = deliveryPointer,
@@ -993,7 +1015,8 @@ internal static class NotifyCommand
         string? deliveryMethod = null,
         string? taskFile = null,
         string? deliveryPointer = null,
-        string? pendingRecordPath = null) => new()
+        string? pendingRecordPath = null,
+        string? advisory = null) => new()
         {
             Operation = operation,
             RoutingRoot = options.RoutingRoot ?? string.Empty,
@@ -1017,7 +1040,8 @@ internal static class NotifyCommand
             ResendPermitted = resendPermitted,
             InlinePayloadWarning = inlinePayloadWarning,
             RecipientWarning = recipientWarning,
-            Warnings = recipientWarning is null ? null : [recipientWarning.Message],
+            Advisory = advisory,
+            Warnings = BuildWarnings(advisory, recipientWarning),
             DeliveryMethod = deliveryMethod,
             TaskFile = taskFile,
             DeliveryPointer = deliveryPointer,
@@ -1027,6 +1051,24 @@ internal static class NotifyCommand
             ReportCommand = reportCommand,
             Summary = summary,
         };
+
+    private static IReadOnlyList<string>? BuildWarnings(
+        string? advisory,
+        NotifyRecipientWarning? recipientWarning)
+    {
+        var warnings = new List<string>();
+        if (recipientWarning is not null)
+        {
+            warnings.Add(recipientWarning.Message);
+        }
+
+        if (!string.IsNullOrWhiteSpace(advisory))
+        {
+            warnings.Add(advisory);
+        }
+
+        return warnings.Count == 0 ? null : warnings;
+    }
 
     private static void Emit(TextWriter writer, string format, NotifyResult result)
     {
@@ -1076,6 +1118,10 @@ internal static class NotifyCommand
         if (result.RecipientWarning is { } recipientWarning)
         {
             writer.WriteLine($"- recipient warning: role={recipientWarning.Role}; liveness={recipientWarning.ObservedLiveness}; {recipientWarning.Message}");
+        }
+        if (result.Advisory is not null)
+        {
+            writer.WriteLine($"- advisory: {result.Advisory}");
         }
         if (result.DeliveryMethod is not null)
         {
@@ -1370,6 +1416,7 @@ internal sealed record NotifyResult
     [JsonPropertyName("resend_permitted")] public bool? ResendPermitted { get; init; }
     [JsonPropertyName("inline_payload_warning")] public NotifyInlinePayloadWarning? InlinePayloadWarning { get; init; }
     [JsonPropertyName("recipient_warning")] public NotifyRecipientWarning? RecipientWarning { get; init; }
+    [JsonPropertyName("advisory")] public string? Advisory { get; init; }
     [JsonPropertyName("warnings")] public IReadOnlyList<string>? Warnings { get; init; }
     [JsonPropertyName("delivery_method")] public string? DeliveryMethod { get; init; }
     [JsonPropertyName("task_file")] public string? TaskFile { get; init; }

--- a/tests/IntentSystem.Cli.Tests/NotifyPendingDelegationG629Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyPendingDelegationG629Tests.cs
@@ -122,6 +122,29 @@ public sealed class NotifyPendingDelegationG629Tests : IDisposable
     }
 
     [Fact]
+    public void CorruptPendingStoreRefusesReportWithoutDelivery_G640()
+    {
+        var runner = new FakeRunner(() => workspace.HerdrAgents(implementationRunning: true));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        var pendingPath = NotifyPendingDelegationStore.ResolvePath(
+            workspace.RootPath,
+            Workspace.Domain,
+            Workspace.Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(pendingPath)!);
+        File.WriteAllText(pendingPath, "{ not valid pending json");
+
+        var (exitCode, result) = workspace.Run(ReportArgs(taskId: "G640-corrupt"));
+
+        Assert.Equal(1, exitCode);
+        Assert.False(result.GetProperty("delivered").GetBoolean());
+        Assert.Equal("unknown-task-id", result.GetProperty("cause").GetString());
+        var summary = result.GetProperty("summary").GetString()!;
+        Assert.Contains("G640-corrupt", summary, StringComparison.Ordinal);
+        Assert.Contains("could not be read", summary, StringComparison.Ordinal);
+        Assert.Empty(runner.Calls);
+    }
+
+    [Fact]
     public void PendingRecordWriteFailureHappensBeforeAnyPaneDelivery_G629()
     {
         var runner = new FakeRunner(() => workspace.HerdrAgents(implementationRunning: true));

--- a/tests/IntentSystem.Cli.Tests/NotifyPendingDelegationG629Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyPendingDelegationG629Tests.cs
@@ -89,21 +89,36 @@ public sealed class NotifyPendingDelegationG629Tests : IDisposable
     }
 
     [Fact]
-    public void UnknownReportNamesSuppliedAndKnownTaskIdsAndDoesNotDeliver_G629()
+    public void UnmatchedReportDeliversWithAdvisoryAndLeavesPendingRecordUnchanged_G640()
     {
         var runner = new FakeRunner(() => workspace.HerdrAgents(implementationRunning: true));
         NotifyCommand.ProcessRunnerFactory = () => runner;
-        Assert.Equal(0, workspace.Run(DelegateArgs()).ExitCode);
+        var (_, delegated) = workspace.Run(DelegateArgs());
+        var pendingPath = delegated.GetProperty("pending_record_path").GetString()!;
+        var pendingBefore = File.ReadAllText(pendingPath);
         runner.Calls.Clear();
 
         var (exitCode, result) = workspace.Run(ReportArgs(taskId: "G629-unknown"));
 
-        Assert.Equal(1, exitCode);
-        Assert.Equal("unknown-task-id", result.GetProperty("cause").GetString());
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("delivered").GetBoolean());
+        var advisory = result.GetProperty("advisory").GetString()!;
+        Assert.Contains("G629-unknown", advisory, StringComparison.Ordinal);
+        Assert.Contains("No open pending delegation matched", advisory, StringComparison.Ordinal);
+        Assert.Contains("G629-demo", advisory, StringComparison.Ordinal);
+        Assert.Contains(result.GetProperty("warnings").EnumerateArray(), warning =>
+            warning.GetString()!.Contains("G629-unknown", StringComparison.Ordinal));
         var summary = result.GetProperty("summary").GetString()!;
-        Assert.Contains("G629-unknown", summary, StringComparison.Ordinal);
-        Assert.Contains("G629-demo", summary, StringComparison.Ordinal);
-        Assert.Empty(runner.Calls);
+        Assert.Contains("Delivered notification", summary, StringComparison.Ordinal);
+        Assert.Contains(runner.Calls, call => call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "wH:p1"]));
+        Assert.Equal(pendingBefore, File.ReadAllText(pendingPath));
+
+        var (humanExit, humanOutput) = workspace.RunText(ReportArgs(taskId: "G629-human", format: "markdown"));
+        Assert.Equal(0, humanExit);
+        Assert.Contains("- advisory:", humanOutput, StringComparison.Ordinal);
+        Assert.Contains("G629-human", humanOutput, StringComparison.Ordinal);
+        Assert.Contains("No open pending delegation matched", humanOutput, StringComparison.Ordinal);
+        Assert.Equal(pendingBefore, File.ReadAllText(pendingPath));
     }
 
     [Fact]
@@ -131,12 +146,12 @@ public sealed class NotifyPendingDelegationG629Tests : IDisposable
         "--write", "--format", "json",
     ];
 
-    private static string[] ReportArgs(string taskId = "G629-demo") =>
+    private static string[] ReportArgs(string taskId = "G629-demo", string format = "json") =>
     [
         "notify", "report", "--domain", Workspace.Domain, "--team", Workspace.Team,
         "--from", "implementation", "--to", "orchestration", "--task-id", taskId,
         "--status", "completed", "--artifact", "https://example.test/pr/1373",
-        "--summary", "pending state implemented", "--write", "--format", "json",
+        "--summary", "pending state implemented", "--write", "--format", format,
     ];
 
     private static string[] StatusArgs() =>
@@ -198,6 +213,13 @@ public sealed class NotifyPendingDelegationG629Tests : IDisposable
             using var writer = new StringWriter();
             var exitCode = CommandRouter.Execute(args, Context, writer);
             return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
+        }
+
+        public (int ExitCode, string Output) RunText(string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = CommandRouter.Execute(args, Context, writer);
+            return (exitCode, writer.ToString());
         }
 
         public string HerdrAgents(


### PR DESCRIPTION
Closes #1383

## Summary
- deliver reports whose task id has no open pending delegation
- emit an advisory naming the unmatched id without creating or resolving pending state
- preserve matched resolution and ambiguous/settled refusal, with EN/JA guidance

## Verification
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~NotifyPendingDelegationG629Tests --no-restore
- dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore
- git diff --check