### PR TITLE
G642: prepare v0.13.1 release notes

### DIFF
--- a/docs/en/release-notes-v0.13.1.md
+++ b/docs/en/release-notes-v0.13.1.md
@@ -1,9 +1,70 @@
 # Release Notes — intent-cli v0.13.1
 
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
+> **Prepare-only / UNRELEASED.** These notes replace the post-release stub
+> with the v0.13.1 preparation. This PR creates no GitHub Release, tag,
+> package publish, or release workflow run; Release creation remains the
+> operator's step.
 
 Install verification: `JTechJapan.IntentSystem.Cli --version 0.13.1`.
-The eventual release will be published at
+When approved, the release will be published at
 https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.13.1.
+See the [v0.13.0 notes](release-notes-v0.13.0.md) for the preceding release;
+that content is linked, not repeated here.
+
+## What's in v0.13.1
+
+This patch release covers exactly one merged unit: **G640**. The list was
+derived by running `git log v0.13.0..main`; all four commits in that range are
+accounted for as G640's two implementation commits `a69430f` and `3d9b793`,
+its merge commit `b206075`, and the post-release version roll `9d1705d`.
+
+- G640 — PR #1384, merge commit `b206075` (resolves on `main`): a report whose
+  task id matches no open pending delegation is delivered with an advisory
+  instead of being refused.
+
+## What v0.13.0 broke
+
+In v0.13.0, a report whose task id did not match an open pending delegation was
+refused with `delivered: false` and `cause: unknown-task-id`. The failure looked
+like silence to the person waiting for the report rather than a visible error.
+A role that answers escalations rather than delegations—on this host, the
+design thread—never holds a pending record, so its reporting channel was closed
+entirely. The same refusal also lost unsolicited reports, corrections, and
+out-of-band answers from any role: precisely the messages carrying news the
+recipient did not know to request.
+
+## What is preserved
+
+- An unmatched report is delivered with an advisory, but it creates or resolves
+  no pending record.
+- The refusal for two conflicting identifiers describing the same work still
+  fires.
+- A matching task id still resolves its pending record exactly as before.
+
+This is a patch rather than a new command surface: **no command and no flag are
+added**. The change narrows one existing report-path refusal while keeping the
+state-mutation protections intact.
+
+## Upgrade advice
+
+Anyone running v0.13.0 should upgrade to v0.13.1. Until upgrading, send blocked
+reports through the existing `intent-cli notify escalate` path so they reach
+the design boundary instead of relying on the refused report path.
+
+## Release-readiness gate
+
+Before creating the v0.13.1 Release, the operator must verify:
+
+- `eng/version.json` remains stable `0.13.0` / next `0.13.1`.
+- PR #1384 resolves on `main` at merge commit `b206075`, and the four commits
+  in `git log v0.13.0..main` remain fully accounted for.
+- The bilingual release-notes guard and count guard pass, followed by the full
+  Release suite and exact-head CI.
+- Prepare-only remains in force: do not create the GitHub Release, tag, or
+  package publish until the operator explicitly approves it.
+
+## Publishing v0.13.1
+
+After the readiness gate passes and the operator approves, a maintainer may
+create the GitHub Release and publish the package. This preparation PR does not
+perform that step.

--- a/docs/ja/release-notes-v0.13.1.md
+++ b/docs/ja/release-notes-v0.13.1.md
@@ -1,9 +1,63 @@
 # リリースノート — intent-cli v0.13.1
 
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
-> このファイルを changelog として扱ってはいけません。
+> **prepare-only / 未リリース。** post-release の stub を v0.13.1 の
+> 準備内容に置き換えます。この PR は GitHub Release、tag、package publish、
+> release workflow を作成・実行せず、Release 作成は operator の手順として残します。
 
 Install verification: `JTechJapan.IntentSystem.Cli --version 0.13.1`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.13.1 に
-publish されます。
+承認後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.13.1 に公開されます。
+直前のリリースは [v0.13.0 notes](release-notes-v0.13.0.md) を参照し、ここでは
+重複記載しません。
+
+## v0.13.1 の内容
+
+この patch release は **G640 の正確に一件の merged unit** だけを対象にします。
+一覧は `git log v0.13.0..main` を実行して導出し、その範囲の 4 commit はすべて、
+G640 の実装 commit `a69430f` と `3d9b793`、merge commit `b206075`、post-release
+version roll `9d1705d` として説明できます。
+
+- G640 — PR #1384、merge commit `b206075`（`main` に存在）: open な pending delegation
+  に一致しない task id の report を拒否せず advisory とともに配信します。
+
+## v0.13.0 で壊れたこと
+
+v0.13.0 では、task id が open な pending delegation に一致しない report を
+`delivered: false`、`cause: unknown-task-id` で拒否していました。待っている人には
+visible error ではなく沈黙として見えました。delegation ではなく escalation に回答する
+role（この host では design thread）は pending record を持たないため、その reporting
+channel が完全に閉じていました。同じ拒否は unsolicited report、correction、out-of-band
+answer も失わせました。これは recipient が依頼を知らなかった情報を運ぶ message でした。
+
+## 保持されること
+
+- unmatched report は advisory とともに配信しますが、pending record を create も resolve
+  もしません。
+- 同じ work を指す二つの conflicting identifier に対する refusal は引き続き発火します。
+- matching task id は従来どおり pending record を resolve します。
+
+これは新しい command surface ではなく patch です。**command も flag も追加しません**。
+既存の report path の一つの拒否を狭めつつ、state mutation の保護は維持します。
+
+## upgrade advice
+
+v0.13.0 を使用している場合は v0.13.1 に upgrade してください。upgrade までの間に
+blocked report を送る場合は、既存の `intent-cli notify escalate` path を使い、拒否される
+report path に頼らず design boundary へ届けてください。
+
+## リリース準備ゲート (Release-readiness gate)
+
+v0.13.1 Release を作成する前に operator が確認します。
+
+- `eng/version.json` が stable `0.13.0` / next `0.13.1` のままであること。
+- PR #1384 が merge commit `b206075` で `main` に解決し、
+  `git log v0.13.0..main` の 4 commit がすべて説明されること。
+- bilingual release-notes guard と count guard、full Release suite、exact-head CI が
+  green であること。
+- prepare-only の境界を守り、operator が明示承認するまで GitHub Release、tag、package
+  publish を作成しないこと。
+
+## v0.13.1 の publish
+
+ゲートが green になり operator が承認した後にのみ maintainer が GitHub Release と package
+を publish できます。この preparation PR 自体はその操作を行いません。


### PR DESCRIPTION
Closes #1385

## Summary
- replace the EN/JA v0.13.1 stubs with prepare-only notes for exactly G640
- document the v0.13.0 reporting regression, preserved behavior, upgrade advice, and readiness gate
- preserve eng/version.json stable 0.13.0 / next 0.13.1

## Verification
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~ReleasePackageMetadataTests --no-restore` (5 passed)
- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore` (4540 passed, 1 skipped)
- `git diff --check`