### PR TITLE
G643: Prepare v0.14.0 (prepare-only)

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2532,7 +2532,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0132)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0140)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2625,28 +2625,29 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.13.2)
+### Next release readiness (v0.14.0)
 
 **`v0.13.1` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.13.2`. [The v0.13.2 notes stub](release-notes-v0.13.2.md) is the required
-prepare-only placeholder. See [release-notes-v0.13.1.md](release-notes-v0.13.1.md)
-for the preceding shipped scope.
+`0.14.0`. [The v0.14.0 notes](release-notes-v0.14.0.md) are the required
+prepare-only release scope. See [release-notes-v0.13.1.md](release-notes-v0.13.1.md)
+and [release-notes-v0.13.0.md](release-notes-v0.13.0.md) for the preceding shipped
+scopes; those notes are linked, not restated here.
 
-**Release-readiness verification (run before merging the `v0.13.2`
+**Release-readiness verification (run before merging the `v0.14.0`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.13.1 (published), nextVersion 0.13.2 (to release)
+cat eng/version.json   # stableVersion 0.13.1 (published), nextVersion 0.14.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.13.2-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.14.0-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.13.2.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.14.0.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2660,10 +2661,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.13.2`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.14.0`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.13.2`, `nextVersion → 0.13.3` — carrying, per **steps 4–6** of the
+`stableVersion → 0.14.0`, `nextVersion → 0.14.1` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.13.2.md
+++ b/docs/en/release-notes-v0.13.2.md
@@ -1,9 +1,0 @@
-# Release Notes — intent-cli v0.13.2
-
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.13.2`.
-The eventual release will be published at
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.13.2.

--- a/docs/en/release-notes-v0.14.0.md
+++ b/docs/en/release-notes-v0.14.0.md
@@ -1,0 +1,84 @@
+# Release Notes — intent-cli v0.14.0
+
+> **Prepare-only / UNRELEASED.** This preparation changes version state and
+> documentation only. It creates no GitHub Release, tag, package publish, or
+> release workflow run; Release creation remains the operator's step.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.14.0`.
+When approved, the release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.14.0.
+See the [v0.13.1 notes](release-notes-v0.13.1.md) and the
+[v0.13.0 notes](release-notes-v0.13.0.md) for the preceding scopes; those
+notes are linked, not repeated here.
+
+## Preview lane — read before the feature list
+
+The v0.14.0 measured recovery supervision surface is
+`preview-through-1.x`: it is outside the [1.0 compatibility promise](1.0-compatibility-promise.md),
+may change or be withdrawn during the 1.x line, and is not a 1.0 compatibility
+commitment.
+
+## What's in v0.14.0
+
+This minor release covers exactly one merged unit: **G641**. The list was
+derived by running `git log v0.13.1..main`; all five commits in that range are
+accounted for as the post-release roll `e08a6a7`, G641's implementation
+`3330ec0`, blocker repair `de0a142`, cadence/headroom repair `5cc8a2e`, and
+the merge `7524c305`. G641 is PR #1388, merge commit `7524c305` (verified to
+resolve on `main`).
+
+- G641 — PR #1388, merge commit `7524c305`: one measured supervision pass over
+  every known stall class, a declared detection bound that the loop checks
+  itself against, and a per-stall record of when a condition became
+  detectable, was surfaced, and was cleared.
+
+## Why this is a minor release
+
+The minor bump is verifiable rather than assumed. `notify supervise` gains
+declared-bound and duration-record behaviour together with new options; this
+is added surface on an existing command, not only a fix to existing behaviour.
+
+## What the release addresses
+
+On 2026-08-06 and 07 this team's loop stopped silently four times, with four
+distinct causes: a recipient dying mid-task, checks finishing with nobody to
+wake, a completion reaching a sleeping seat, and an escalation recorded
+durably that woke no one. The measured worst gap was about two hours fifteen
+minutes. G641 makes the detection interval a declared, self-checked property
+and makes each stall's duration a number that can be read back.
+
+## Honesty and boundaries
+
+- An unknown start is recorded as unknown rather than being started at first
+  observation; an unknown start never receives an invented duration.
+- The supervisor reports its own absence since the last recorded cycle rather
+  than presenting a missing cycle as healthy.
+- The loop wakes the owning role through its recorded transport and records
+  recovery evidence; it never takes an owed transition and hard-codes no agent
+  kind.
+
+Bounded recovery time is what makes supporting more agent kinds practical: a
+wedged Copilot or other seat can cost minutes without silently becoming an
+unbounded human investigation.
+
+## Release-readiness gate
+
+Before creating the v0.14.0 Release, the operator must verify:
+
+- `eng/version.json` records stable `0.13.1` and next `0.14.0`.
+- PR #1388 resolves on `main` at merge commit `7524c305`, and the five commits
+  in `git log v0.13.1..main` remain fully accounted for as the three G641
+  commits, its merge, and the post-release roll.
+- The bilingual release-notes guard and count guard pass, followed by the full
+  Release suite and exact-head CI.
+- The [v0.13.1 notes](release-notes-v0.13.1.md) and
+  [v0.13.0 notes](release-notes-v0.13.0.md) remain the linked preceding scopes;
+  this note does not restate them.
+- Prepare-only remains in force: do not create the GitHub Release, tag, or
+  package publish until the operator explicitly approves it.
+
+## Publishing v0.14.0
+
+After the readiness gate passes and the operator approves, a maintainer may
+create the GitHub Release and publish the package. This preparation PR does
+not perform that step.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2698,27 +2698,28 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.13.2)
+### 次リリース準備(v0.14.0)
 
 **`v0.13.1` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.13.2` です。[v0.13.2 notes stub](release-notes-v0.13.2.md) が必須の
-prepare-only placeholder です。直前の出荷範囲は
-[release-notes-v0.13.1.md](release-notes-v0.13.1.md) を参照してください。
+`0.14.0` です。[v0.14.0 notes](release-notes-v0.14.0.md) が必須の
+prepare-only release scope です。直前の出荷範囲は
+[release-notes-v0.13.1.md](release-notes-v0.13.1.md) と
+[release-notes-v0.13.0.md](release-notes-v0.13.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.13.2` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.14.0` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.13.1 (published), nextVersion 0.13.2 (to release)
+cat eng/version.json   # stableVersion 0.13.1 (published), nextVersion 0.14.0 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.13.2-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.14.0-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.13.2.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.14.0.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2731,10 +2732,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.13.2` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.14.0` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.13.2`、`nextVersion → 0.13.3` —
+`stableVersion → 0.14.0`、`nextVersion → 0.14.1` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.13.2.md
+++ b/docs/ja/release-notes-v0.13.2.md
@@ -1,9 +1,0 @@
-# リリースノート — intent-cli v0.13.2
-
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
-> このファイルを changelog として扱ってはいけません。
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.13.2`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.13.2 に
-publish されます。

--- a/docs/ja/release-notes-v0.14.0.md
+++ b/docs/ja/release-notes-v0.14.0.md
@@ -1,0 +1,74 @@
+# リリースノート — intent-cli v0.14.0
+
+> **prepare-only / 未リリース。** この準備では version state と documentation だけを
+> 変更します。GitHub Release、tag、package publish、release workflow は作成・実行せず、
+> Release 作成は operator の手順として残します。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.14.0`。
+承認後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.14.0 に公開されます。
+直前の範囲は [v0.13.1 notes](release-notes-v0.13.1.md) と
+[v0.13.0 notes](release-notes-v0.13.0.md) を参照し、ここでは重複記載しません。
+
+## feature list の前に読む preview lane
+
+v0.14.0 の measured recovery supervision surface は `preview-through-1.x` です。
+[1.0 compatibility promise](1.0-compatibility-promise.md) の対象外であり、1.x の間に
+変更または撤回される可能性があり、1.0 の compatibility commitment ではありません。
+
+## v0.14.0 の内容
+
+この minor release は **G641 の正確に一件の merged unit** を対象にします。一覧は
+`git log v0.13.1..main` を実行して導出し、その範囲の 5 commit はすべて、post-release
+roll `e08a6a7`、G641 の implementation `3330ec0`、blocker repair `de0a142`、
+cadence/headroom repair `5cc8a2e`、merge `7524c305` として説明できます。G641 は PR #1388、
+merge commit `7524c305` であり、`main` に解決することを確認しています。
+
+- G641 — PR #1388、merge commit `7524c305`: 既知の stall class を一回の measured
+  supervision pass で確認し、loop 自身が declared detection bound を検査し、各 stall の
+  detectable / surfaced / cleared 時刻を per-stall record として残します。
+
+## minor bump の根拠
+
+minor bump は推測ではなく検証できます。`notify supervise` は declared-bound と
+duration-record behaviour、新しい option を得ます。これは既存 command の単なる修正ではなく、
+追加された surface です。
+
+## この release が扱う問題
+
+2026-08-06 と 07、この team の loop は異なる四つの原因で四回 silent に停止しました。
+recipient が task の途中で終了し、check が wake する相手のいないまま完了し、completion が
+sleeping seat に届き、durable に記録された escalation が誰も wake しなかったためです。
+測定した最長 gap は約2時間15分でした。G641 は detection interval を declared かつ self-checked
+な property にし、各 stall の duration を読み返せる数値にします。
+
+## honesty と boundary
+
+- unknown start は first observation から開始したことにせず unknown として記録します。unknown
+  start に都合のよい duration は作りません。
+- supervisor は直前に記録された cycle 以後の自分の absence を報告し、cycle がないことを
+  healthy と表示しません。
+- loop は記録済み transport で owning role を wake し、recovery evidence を record しますが、
+  owed transition は取りません。agent kind も固定しません。
+
+bounded recovery time があるからこそ、より多くの agent kind を現実的に support できます。
+Copilot などの seat が停止しても、silent な無期限の human investigation にはしません。
+
+## リリース準備ゲート (Release-readiness gate)
+
+v0.14.0 Release を作成する前に operator が確認します。
+
+- `eng/version.json` が stable `0.13.1` / next `0.14.0` を記録していること。
+- PR #1388 が merge commit `7524c305` で `main` に解決し、`git log v0.13.1..main` の 5 commit
+  が G641 の三つの commit、merge、post-release roll としてすべて説明されること。
+- bilingual release-notes guard と count guard、full Release suite、exact-head CI が green で
+  あること。
+- 直前の scope は [v0.13.1 notes](release-notes-v0.13.1.md) と
+  [v0.13.0 notes](release-notes-v0.13.0.md) をリンクして参照し、ここでは重複記載しないこと。
+- prepare-only の境界を守り、operator が明示承認するまで GitHub Release、tag、package publish
+  を作成しないこと。
+
+## v0.14.0 の publish
+
+ゲートが green になり operator が承認した後にのみ maintainer が GitHub Release と package を
+publish できます。この preparation PR 自体はその操作を行いません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
   "stableVersion": "0.13.1",
-  "nextVersion": "0.13.2"
+  "nextVersion": "0.14.0"
 }


### PR DESCRIPTION
## Summary

- Retargets eng/version.json to stable 0.13.1 / next 0.14.0.
- Replaces the superseded v0.13.2 EN/JA stubs with bilingual v0.14.0 G641 notes.
- Refreshes EN/JA release-readiness guidance while keeping Release, tag, and package publication operator-only.

## Verification

- Focused release/readiness/terminology guards: 25 passed.
- Full CLI suite: 4546 passed, 1 skipped.
- git diff --check clean.

Closes #1389