### PR TITLE
G646: prepare v0.15.0 notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2688,7 +2688,7 @@ maintainer/operator (or authorized external release automation) create and
 publish the GitHub Release for `v0.15.0`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.15.0`, `nextVersion → 0.16.0` — carrying, per **steps 4–6** of the
+`stableVersion → 0.15.0`, `nextVersion → 0.15.1` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2556,7 +2556,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0141)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0150)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2649,28 +2649,29 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.14.1)
+### Next release readiness (v0.15.0)
 
 **`v0.14.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.14.1`. [The v0.14.1 notes stub](release-notes-v0.14.1.md) is the required
-prepare-only placeholder. See [release-notes-v0.14.0.md](release-notes-v0.14.0.md)
-for the preceding shipped scope.
+`0.15.0`. [The v0.15.0 notes](release-notes-v0.15.0.md) are the required
+prepare-only preparation. See [release-notes-v0.14.0.md](release-notes-v0.14.0.md)
+and [release-notes-v0.13.1.md](release-notes-v0.13.1.md) for the preceding
+scopes; those notes are linked, not repeated here.
 
-**Release-readiness verification (run before merging the `v0.14.1`
+**Release-readiness verification (run before merging the `v0.15.0`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.14.0 (published), nextVersion 0.14.1 (to release)
+cat eng/version.json   # stableVersion 0.14.0 (published), nextVersion 0.15.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.14.1-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.15.0-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.14.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.15.0.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2684,10 +2685,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.14.1`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.15.0`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.14.1`, `nextVersion → 0.14.2` — carrying, per **steps 4–6** of the
+`stableVersion → 0.15.0`, `nextVersion → 0.16.0` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.14.1.md
+++ b/docs/en/release-notes-v0.14.1.md
@@ -1,9 +1,0 @@
-# Release Notes — intent-cli v0.14.1
-
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.14.1`.
-The eventual release will be published at
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.14.1.

--- a/docs/en/release-notes-v0.15.0.md
+++ b/docs/en/release-notes-v0.15.0.md
@@ -1,0 +1,104 @@
+# Release Notes — intent-cli v0.15.0
+
+> **Prepare-only / UNRELEASED.** This preparation changes version state and
+> documentation only. It creates no GitHub Release, tag, package publish, or
+> release workflow run; Release creation remains the operator's step.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.15.0`.
+When approved, the release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.15.0.
+See the [v0.14.0 notes](release-notes-v0.14.0.md) and the
+[v0.13.1 notes](release-notes-v0.13.1.md) for the preceding scopes; those
+notes are linked, not repeated here.
+
+## Preview lane — read before the feature list
+
+G644 supervision setup discoverability and G645 guide reachability are
+`preview-through-1.x`: they are outside the [1.0 compatibility
+promise](1.0-compatibility-promise.md), may change or be withdrawn during the
+1.x line, and are not 1.0 compatibility commitments.
+
+## What's in v0.15.0
+
+This minor release covers exactly two merged units: **G644 and G645**. The
+list was derived by running `git log v0.14.0..main`; all six commits in that
+range are accounted for as the post-release roll `96ab9947`, G644's
+implementation `605f377a`, G644's repair `9aa377a1`, G644's merge `0031bfb1`,
+G645's implementation `d6b64785`, and G645's merge `5ee849a8`. Both merge
+commits are verified to resolve on `main`.
+
+- G644 — PR #1392, merge commit `0031bfb1` (verified on `main`): the guides a
+  role reads now name the supervision setup, and a team with no recorded
+  supervision cycle is told to set it up.
+- G645 — PR #1394, merge commit `5ee849a8` (verified on `main`): each packet
+  declares which guide routes which role to every role-facing surface it adds,
+  and an unsatisfied declaration is reported as
+  `guide-reachability-pending` debt.
+
+## Why this is a minor release
+
+The minor bump is verifiable rather than assumed. G645 adds the packet
+guide-reachability declaration and the `guide-reachability-pending` stall
+class; neither existed at v0.14.0. This is a new packet and closeout surface,
+not a patch-only correction to an existing contract.
+
+## What these units make testable
+
+intent-cli exists so that keeping the whole intent in view while adding one
+feature is a mechanism inside the process, rather than something people must
+remember to do. Guidance lives in the guide, not for a human to read as a
+reference after the fact: the intended path is that a thread handed a keyword
+converses with the guide, understands the surface, and acts. Writing something
+in a reference is not completion. G644 routes the supervision setup through
+the guides a role reads; G645 makes every future slice declare its guide route
+and reports an omitted recording as debt.
+
+## What was measured, and what remains guidance
+
+The measurement that forced this work is concrete: immediately after the
+supervision loop shipped, the installed v0.14.0 build's
+`review-next-slice-loop`, `implementation-loop`, `init-host`, and `guide next`
+guides mentioned `supervise` **zero times**. That is an observed discoverability
+gap, not a claim about whether a deployment process was running.
+
+G644's deployment facts are guidance: `guide next` can recommend
+`supervision-setup` when no cycle is recorded, and the host-init/design-side
+guides explain the deployment step, while `next` remains read-only and never
+starts or manages a background process. The notes therefore do not present a
+recorded cycle or a running deployment as measured merely because the guidance
+exists; the operator must verify those facts at readiness.
+
+## Boundaries and deliberate non-behaviour
+
+- G644 surfaces a missing recorded cycle and points to setup; it does not start
+  or supervise a background process.
+- G645 never infers a route from a filename, keyword, or guide wording, and it
+  never judges whether a guide is good.
+- `guide-reachability-pending` is closeout debt, not a merge or closeout gate;
+  an explicit no-role-facing-surface declaration is silent.
+
+## Release-readiness gate
+
+Before creating the v0.15.0 Release, the operator must verify:
+
+- `eng/version.json` records stable `0.14.0` and next `0.15.0`.
+- PR #1392 resolves on `main` at merge `0031bfb1` and PR #1394 resolves on
+  `main` at merge `5ee849a8`; the six commits in `git log v0.14.0..main`
+  remain fully accounted for above.
+- The preview statement appears before the feature description, and the
+  [1.0 compatibility promise](1.0-compatibility-promise.md) remains linked
+  rather than restated.
+- The bilingual release-notes guard and count guard pass, followed by the full
+  Release suite and exact-head CI. Verify the measured-versus-guidance
+  distinction before treating supervision deployment as ready.
+- The [v0.14.0 notes](release-notes-v0.14.0.md) and
+  [v0.13.1 notes](release-notes-v0.13.1.md) remain linked preceding scopes;
+  this note does not restate them.
+- Prepare-only remains in force: do not create the GitHub Release, tag, or
+  package publish until the operator explicitly approves it.
+
+## Publishing v0.15.0
+
+After the readiness gate passes and the operator approves, a maintainer may
+create the GitHub Release and publish the package. This preparation PR does
+not perform that step.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2754,7 +2754,7 @@ dotnet test IntentSystem.sln -c Release
 外部リリース自動化)が `v0.15.0` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.15.0`、`nextVersion → 0.16.0` —
+`stableVersion → 0.15.0`、`nextVersion → 0.15.1` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2717,27 +2717,28 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.14.1)
+### 次リリース準備(v0.15.0)
 
 **`v0.14.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.14.1` です。[v0.14.1 notes stub](release-notes-v0.14.1.md) が必須の
-prepare-only placeholder です。直前の出荷範囲は
-[release-notes-v0.14.0.md](release-notes-v0.14.0.md) を参照してください。
+`0.15.0` です。[v0.15.0 notes](release-notes-v0.15.0.md) が必須の
+prepare-only preparation です。直前の scope は
+[release-notes-v0.14.0.md](release-notes-v0.14.0.md) と
+[release-notes-v0.13.1.md](release-notes-v0.13.1.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.14.1` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.15.0` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.14.0 (published), nextVersion 0.14.1 (to release)
+cat eng/version.json   # stableVersion 0.14.0 (published), nextVersion 0.15.0 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.14.1-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.15.0-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.14.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.15.0.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2750,10 +2751,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.14.1` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.15.0` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.14.1`、`nextVersion → 0.14.2` —
+`stableVersion → 0.15.0`、`nextVersion → 0.16.0` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.14.1.md
+++ b/docs/ja/release-notes-v0.14.1.md
@@ -1,9 +1,0 @@
-# リリースノート — intent-cli v0.14.1
-
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
-> このファイルを changelog として扱ってはいけません。
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.14.1`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.14.1 に
-publish されます。

--- a/docs/ja/release-notes-v0.15.0.md
+++ b/docs/ja/release-notes-v0.15.0.md
@@ -1,0 +1,84 @@
+# リリースノート — intent-cli v0.15.0
+
+> **prepare-only / 未リリース。** この準備では version state と documentation だけを
+> 変更します。GitHub Release、tag、package publish、release workflow は作成・実行せず、
+> Release 作成は operator の手順として残します。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.15.0`。
+承認後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.15.0 に公開されます。
+直前の scope は [v0.14.0 notes](release-notes-v0.14.0.md) と
+[v0.13.1 notes](release-notes-v0.13.1.md) を参照し、ここでは重複記載しません。
+
+## feature list の前に読む preview lane
+
+G644 の supervision setup discoverability と G645 の guide reachability は
+`preview-through-1.x` です。[1.0 compatibility promise](1.0-compatibility-promise.md) の対象外であり、
+1.x の間に変更または撤回される可能性があり、1.0 の compatibility commitment ではありません。
+
+## v0.15.0 の内容
+
+この minor release は **G644 と G645 の正確に二件の merged unit** を対象にします。一覧は
+`git log v0.14.0..main` を実行して導出し、その範囲の 6 commit はすべて、post-release roll
+`96ab9947`、G644 implementation `605f377a`、G644 repair `9aa377a1`、G644 merge `0031bfb1`、
+G645 implementation `d6b64785`、G645 merge `5ee849a8` として説明できます。両方の merge commit が
+`main` に解決することを確認しています。
+
+- G644 — PR #1392、merge commit `0031bfb1`（`main` で確認）: role が読む guide が supervision setup を
+  名指しし、supervision cycle の記録がない team には setup を行うよう伝えます。
+- G645 — PR #1394、merge commit `5ee849a8`（`main` で確認）: packet が追加する role-facing surface ごとに、
+  どの guide がどの role を route するかを宣言し、未記録の declaration を
+  `guide-reachability-pending` debt として報告します。
+
+## minor release の根拠
+
+minor bump は推測ではなく検証できます。G645 は packet の guide-reachability declaration と
+`guide-reachability-pending` stall class を追加しました。どちらも v0.14.0 には存在しません。
+これは既存 contract の patch-only 修正ではなく、新しい packet と closeout の surface です。
+
+## この二件が testable にするもの
+
+intent-cli は、feature を一つ追加するときにも intent 全体を視野に置くことを、人が覚えておくものではなく
+process 内の mechanism にします。guidance は人が後から読む reference のためだけにあるのではありません。
+keyword を渡された thread が guide と対話し、surface を理解し、action することが意図された path です。
+reference に何かを書くだけでは completion ではありません。G644 は role が読む guide に supervision setup の
+route を置き、G645 は今後の各 slice に guide route を宣言させ、未記録を debt として報告します。
+
+## 測定したことと guidance の区別
+
+この作業を強制した測定は具体的です。supervision loop が ship された直後、installed v0.14.0 build の
+`review-next-slice-loop`、`implementation-loop`、`init-host`、`guide next` の四つの guide は
+`supervise` を **0 回**しか mention しませんでした。これは discoverability gap の observed evidence であり、
+deployment process が実行中だったかどうかの主張ではありません。
+
+G644 の deployment facts は guidance です。`guide next` は cycle が記録されていないときに
+`supervision-setup` を recommend でき、host-init と design-side loop の guide は deployment step を説明します。
+一方で `next` は read-only のままで、background process を start・manage しません。したがって notes は guidance が
+存在するだけで recorded cycle や running deployment が測定済みだとは扱いません。readiness で operator がその事実を確認します。
+
+## boundary と意図した non-behaviour
+
+- G644 は recorded cycle がないことを surface して setup を示しますが、background process を start・supervise しません。
+- G645 は filename、keyword、guide wording から route を推測せず、guide が良いかどうかも判定しません。
+- `guide-reachability-pending` は closeout debt であり merge または closeout gate ではありません。明示的な
+  no-role-facing-surface declaration は silent です。
+
+## リリース準備ゲート (Release-readiness gate)
+
+v0.15.0 Release を作成する前に operator が確認します。
+
+- `eng/version.json` が stable `0.14.0` / next `0.15.0` を記録していること。
+- PR #1392 が merge `0031bfb1` で `main` に、PR #1394 が merge `5ee849a8` で `main` に解決し、
+  `git log v0.14.0..main` の 6 commit が上記の通りすべて説明されること。
+- preview statement が feature description より前にあり、[1.0 compatibility promise](1.0-compatibility-promise.md) は
+  重複記載せず link されていること。
+- bilingual release-notes guard と count guard、full Release suite、exact-head CI が green であること。
+  supervision deployment を ready と扱う前に measured-versus-guidance の区別も確認すること。
+- [v0.14.0 notes](release-notes-v0.14.0.md) と [v0.13.1 notes](release-notes-v0.13.1.md) は preceding scope として
+  link され、ここでは重複記載しないこと。
+- prepare-only の境界を守り、operator が明示承認するまで GitHub Release、tag、package publish を作成しないこと。
+
+## v0.15.0 の publish
+
+ゲートが green になり operator が承認した後にのみ maintainer が GitHub Release と package を publish できます。
+この preparation PR 自体はその操作を行いません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
   "stableVersion": "0.14.0",
-  "nextVersion": "0.14.1"
+  "nextVersion": "0.15.0"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0150DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0150DocsTests.cs
@@ -1,0 +1,28 @@
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G646 pins the operator-approved post-release transition for v0.15.0. The
+/// preparation line is minor, but its immediate follow-up is the next patch,
+/// not a skipped 0.16.0 line.
+/// </summary>
+public sealed class ReleaseNotesV0150DocsTests
+{
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DeveloperReference_PostReleaseRollTargetsImmediatePatchAfterV0150_G646(string language)
+    {
+        var path = Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md");
+        var reference = File.ReadAllText(path);
+
+        Assert.Contains(
+            language == "en" ? "### Next release readiness (v0.15.0)" : "### 次リリース準備(v0.15.0)",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains("stableVersion → 0.15.0", reference, StringComparison.Ordinal);
+        Assert.Contains("nextVersion → 0.15.1", reference, StringComparison.Ordinal);
+        Assert.DoesNotContain("nextVersion → 0.16.0", reference, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes #1395

Prepare-only v0.15.0 release readiness for G644 and G645. Retargets eng/version.json to stable 0.14.0 / next 0.15.0, replaces the superseded v0.14.1 EN/JA stubs with bilingual notes, refreshes both readiness mirrors, accounts for all six post-v0.14.0 commits, and carries the measured-versus-guidance distinction plus G645 non-behaviour boundaries. No Release, tag, package publish, code, or runtime behaviour change is performed.

Verification:
- exact commit/merge-anchor and preview-order checks
- focused release/version/link/Japanese guards
- full IntentSystem.Cli.Tests suite
- git diff --check