### PR TITLE
G649: prepare v0.16.0 release notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2556,7 +2556,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0151)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0160)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2649,33 +2649,34 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.15.1)
+### Next release readiness (v0.16.0)
 
 **`v0.15.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.15.1`. [The v0.15.1 notes stub](release-notes-v0.15.1.md) is the required
-prepare-only placeholder. See [release-notes-v0.15.0.md](release-notes-v0.15.0.md)
-for the preceding shipped scope.
+`0.16.0`. [The v0.16.0 notes](release-notes-v0.16.0.md) are the required
+prepare-only release body. See [release-notes-v0.15.0.md](release-notes-v0.15.0.md)
+and [release-notes-v0.14.0.md](release-notes-v0.14.0.md) for the preceding shipped
+scopes.
 
-**Release-readiness verification (run before merging the `v0.15.1`
+**Release-readiness verification (run before merging the `v0.16.0`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.15.0 (published), nextVersion 0.15.1 (to release)
+cat eng/version.json   # stableVersion 0.15.0 (published), nextVersion 0.16.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.15.1-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.16.0-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.15.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.16.0.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0120DocsTests|FullyQualifiedName~ReleaseNotesV0121DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0150DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Run the complete Release suite.
 dotnet test IntentSystem.sln -c Release
@@ -2684,10 +2685,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.15.1`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.16.0`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.15.1`, `nextVersion → 0.15.2` — carrying, per **steps 4–6** of the
+`stableVersion → 0.16.0`, `nextVersion → 0.16.1` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.15.1.md
+++ b/docs/en/release-notes-v0.15.1.md
@@ -1,9 +1,0 @@
-# Release Notes — intent-cli v0.15.1
-
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.15.1`.
-The eventual release will be published at
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.15.1.

--- a/docs/en/release-notes-v0.16.0.md
+++ b/docs/en/release-notes-v0.16.0.md
@@ -1,0 +1,106 @@
+# Release Notes — intent-cli v0.16.0
+
+> **Prepare-only / UNRELEASED.** This preparation changes version state and
+> documentation only. It creates no GitHub Release, tag, package publish, or
+> release workflow run; Release creation remains the operator's step.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.16.0`.
+When approved, the release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.16.0.
+See the [v0.15.0 notes](release-notes-v0.15.0.md) and the
+[v0.14.0 notes](release-notes-v0.14.0.md) for the preceding scopes; those
+notes are linked, not repeated here.
+
+## Preview lane — read before the feature list
+
+The G647 per-kind launch-recipe registry and G648 registration-loss
+corroboration are `preview-through-1.x`: they are outside the
+[1.0 compatibility promise](1.0-compatibility-promise.md), may change or be
+withdrawn during the 1.x line, and are not 1.0 compatibility commitments.
+
+## What's in v0.16.0
+
+This minor release covers exactly two merged units: **G647 and G648**. The
+list was derived by running `git log v0.15.0..main`; all three commits in that
+range are accounted for as the post-release roll `e3c2e432`, G647's merge
+`532b01b9`, and G648's merge `e3200aeb`. Both merge commits are verified to
+resolve on `main`.
+
+- G647 — PR #1398, merge commit `532b01b9` (verified on `main`): the recorded
+  seat kind is the human's current wish, a requested kind switch takes one
+  step, and recovery never changes kind unattended. The per-kind registry
+  surfaces the measured target launch recipe or an explicit absent notice;
+  `topology update-kind` therefore cannot silently guess a command or model.
+- G648 — PR #1400, merge commit `e3200aeb` (verified on `main`): liveness,
+  supervision, and delivery distinguish `registration-lost-process-present`
+  from genuine `lost`, return `resend_permitted: true` for the corroborated
+  state, and emit at most one finding per recorded pane per cycle. No kill,
+  restart, or automatic re-registration is performed.
+
+## Why this is a minor release
+
+G647 adds the per-kind recipe/update-kind surface and the measured Codex
+recipe registry that were absent at v0.15.0. G648 adds the distinct
+registration-loss/process-presence state and its delivery/supervision
+corroboration. These are new preview surfaces, not patch-only corrections to
+an existing v0.15.0 contract.
+
+## Operator principle
+
+The recorded seat kind is the human operator's current wish. A human-requested
+switch moves one step and records the target recipe; if the target is unknown,
+the operator is asked rather than given an invented default. Recovery never
+switches a kind unattended.
+
+## What was measured, and what remains guidance
+
+The Codex recipe is a measured observation, not a universal claim. On
+**MyIntentHost** on **2026-08-07**, Codex **v0.144.1 / macOS** was observed with
+this bounded invocation:
+
+```text
+herdr agent start <logical-role> --kind codex --pane <pane-id> -- --sandbox workspace-write --ask-for-approval never --add-dir <role-work-root> [--add-dir <host-routing-root>]
+```
+
+The observed envelope fact was asymmetric: a write outside the declared root
+was rejected while a read outside it was not. That is measured evidence for
+this host and date, not a promise that every platform or version behaves the
+same way. An unmeasured target kind remains explicitly absent; its flags and
+post-start answers are never inferred.
+
+## G648 incident and fail-closed boundary
+
+During the G648 incident, a healthy orchestrator reported `lost` six times
+while a herdr registration flickered. The old-process stop stayed held
+**fail-closed**: process corroboration prevented a kill or restart, and no
+automatic re-registration was attempted. Genuine absence remains `lost` only
+when both the registration and the recorded-pane process are absent. A
+registration loss with a foreground process is the named
+`registration-lost-process-present` state, is reported once per pane per cycle,
+and keeps `resend_permitted: true` so the operator can re-register the pane.
+
+## Release-readiness gate
+
+Before creating the v0.16.0 Release, the operator must verify:
+
+- `eng/version.json` records stable `0.15.0` and next `0.16.0`.
+- PR #1398 resolves on `main` at merge `532b01b9` and PR #1400 resolves on
+  `main` at merge `e3200aeb`; the three commits in `git log v0.15.0..main`
+  remain fully accounted for above.
+- The preview statement appears before the feature description, and the
+  [1.0 compatibility promise](1.0-compatibility-promise.md) remains linked
+  rather than restated.
+- The bilingual release-notes guard and count guard pass, followed by the full
+  Release suite and exact-head CI. Verify measured attribution for Codex and
+  the G648 fail-closed incident boundary before treating the line as ready.
+- The [v0.15.0 notes](release-notes-v0.15.0.md) and
+  [v0.14.0 notes](release-notes-v0.14.0.md) remain linked preceding scopes;
+  this note does not restate them.
+- Prepare-only remains in force: do not create the GitHub Release, tag, or
+  package publish until the operator explicitly approves it.
+
+## Publishing v0.16.0
+
+After the readiness gate passes and the operator approves, a maintainer may
+create the GitHub Release and publish the package. This preparation PR does
+not perform that step.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2717,32 +2717,33 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.15.1)
+### 次リリース準備(v0.16.0)
 
 **`v0.15.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.15.1` です。[v0.15.1 notes stub](release-notes-v0.15.1.md) が必須の
-prepare-only placeholder です。直前の出荷範囲は
-[release-notes-v0.15.0.md](release-notes-v0.15.0.md) を参照してください。
+`0.16.0` です。[v0.16.0 notes](release-notes-v0.16.0.md) が必須の
+prepare-only release body です。直前の出荷範囲は
+[release-notes-v0.15.0.md](release-notes-v0.15.0.md) と
+[release-notes-v0.14.0.md](release-notes-v0.14.0.md) を参照してください。
 
-**リリース準備検証(`v0.15.1` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.16.0` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.15.0 (published), nextVersion 0.15.1 (to release)
+cat eng/version.json   # stableVersion 0.15.0 (published), nextVersion 0.16.0 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.15.1-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.16.0-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.15.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.16.0.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0120DocsTests|FullyQualifiedName~ReleaseNotesV0121DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0150DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Release suite を完全実行。
 dotnet test IntentSystem.sln -c Release
@@ -2750,10 +2751,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.15.1` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.16.0` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.15.1`、`nextVersion → 0.15.2` —
+`stableVersion → 0.16.0`、`nextVersion → 0.16.1` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.15.1.md
+++ b/docs/ja/release-notes-v0.15.1.md
@@ -1,9 +1,0 @@
-# リリースノート — intent-cli v0.15.1
-
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
-> このファイルを changelog として扱ってはいけません。
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.15.1`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.15.1 に
-publish されます。

--- a/docs/ja/release-notes-v0.16.0.md
+++ b/docs/ja/release-notes-v0.16.0.md
@@ -1,0 +1,85 @@
+# リリースノート — intent-cli v0.16.0
+
+> **prepare-only / 未リリース。** この準備では version state と documentation だけを
+> 変更します。GitHub Release、tag、package publish、release workflow は作成・実行せず、
+> Release 作成は operator の手順として残します。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.16.0`。
+承認後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.16.0 に公開されます。
+直前の scope は [v0.15.0 notes](release-notes-v0.15.0.md) と
+[v0.14.0 notes](release-notes-v0.14.0.md) を参照し、ここでは重複記載しません。
+
+## feature list の前に読む preview lane
+
+G647 の per-kind launch-recipe registry と G648 の registration-loss
+corroboration は `preview-through-1.x` です。[1.0 compatibility promise](1.0-compatibility-promise.md)
+の対象外であり、1.x の間に変更または撤回される可能性があり、1.0 の compatibility commitment ではありません。
+
+## v0.16.0 の内容
+
+この minor release は **G647 と G648 の正確に二件の merged unit** を対象にします。一覧は
+`git log v0.15.0..main` を実行して導出し、その範囲の 3 commit はすべて post-release roll
+`e3c2e432`、G647 merge `532b01b9`、G648 merge `e3200aeb` として説明できます。両方の merge commit が
+`main` に解決することを確認しています。
+
+- G647 — PR #1398、merge commit `532b01b9`（`main` で確認）: recorded seat kind は human の現在の wish で、
+  human が要求した kind switch は one step、recovery は unattended に kind を変更しません。per-kind registry は
+  実測済み target launch recipe または明示的な absent notice を表示し、`topology update-kind` が command や model を
+  silently 推測しないようにします。
+- G648 — PR #1400、merge commit `e3200aeb`（`main` で確認）: liveness、supervision、delivery は
+  `registration-lost-process-present` と genuine `lost` を区別し、corroborated state では
+  `resend_permitted: true` を返し、recorded pane ごと cycle ごとに最大一件の finding を返します。kill、restart、
+  automatic re-registration は行いません。
+
+## minor release の根拠
+
+G647 は v0.15.0 に存在しなかった per-kind recipe/update-kind surface と実測 Codex recipe registry を追加します。
+G648 は registration-loss と process-presence の distinct state、および delivery/supervision の corroboration を追加します。
+これは既存 v0.15.0 contract の patch-only 修正ではなく、新しい preview surface です。
+
+## Operator principle
+
+記録された seat kind は human operator の現在の wish です。human が要求した switch は one step で target recipe を記録し、
+target が unknown なら invented default を与えず operator に尋ねます。recovery は unattended に kind を変更しません。
+
+## 測定したことと guidance の区別
+
+Codex recipe は universal claim ではなく実測値です。**MyIntentHost** で **2026-08-07** に
+Codex **v0.144.1 / macOS** を次の bounded invocation で観測しました。
+
+```text
+herdr agent start <logical-role> --kind codex --pane <pane-id> -- --sandbox workspace-write --ask-for-approval never --add-dir <role-work-root> [--add-dir <host-routing-root>]
+```
+
+観測した envelope fact は asymmetric でした。宣言した root の外への write は拒否されましたが、外への read は拒否されませんでした。
+これはこの host と date の measured evidence であり、すべての platform/version に同じ挙動を約束するものではありません。
+未実測の target kind は明示的に absent のままにし、flags や post-start answer を推測しません。
+
+## G648 incident と fail-closed boundary
+
+G648 incident では、herdr registration が flicker したため、healthy orchestrator が `lost` を 6 回報告しました。
+old-process stop は **fail-closed** のまま保持され、process corroboration が kill/restart を防ぎ、automatic re-registration も行いませんでした。
+registration と recorded-pane process の両方が absent の場合だけ genuine absence を `lost` とします。foreground process が残る
+registration loss は `registration-lost-process-present` と命名し、pane ごと cycle ごとに一件だけ報告し、operator が pane を再登録できるよう
+`resend_permitted: true` を維持します。
+
+## リリース準備ゲート (Release-readiness gate)
+
+v0.16.0 Release を作成する前に operator が確認します。
+
+- `eng/version.json` が stable `0.15.0` / next `0.16.0` を記録していること。
+- PR #1398 が merge `532b01b9` で `main` に、PR #1400 が merge `e3200aeb` で `main` に解決し、
+  `git log v0.15.0..main` の 3 commit が上記の通りすべて説明されること。
+- preview statement が feature description より前にあり、[1.0 compatibility promise](1.0-compatibility-promise.md) は
+  重複記載せず link されていること。
+- bilingual release-notes guard と count guard、full Release suite、exact-head CI が green であること。Codex の measured attribution と
+  G648 fail-closed incident boundary も確認すること。
+- [v0.15.0 notes](release-notes-v0.15.0.md) と [v0.14.0 notes](release-notes-v0.14.0.md) は preceding scope として
+  link され、ここでは重複記載しないこと。
+- prepare-only の境界を守り、operator が明示承認するまで GitHub Release、tag、package publish を作成しないこと。
+
+## v0.16.0 の publish
+
+ゲートが green になり operator が承認した後にのみ maintainer が GitHub Release と package を publish できます。
+この preparation PR 自体はその操作を行いません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
   "stableVersion": "0.15.0",
-  "nextVersion": "0.15.1"
+  "nextVersion": "0.16.0"
 }


### PR DESCRIPTION
Closes #1401

Prepare-only v0.16.0 release metadata and bilingual notes covering exactly G647 and G648. Retargets eng/version.json to stable 0.15.0 / next 0.16.0, replaces the 0.15.1 stubs, refreshes EN/JA readiness, preserves measured Codex attribution and the G648 fail-closed incident boundary, and creates no Release/tag/package.