### PR TITLE
G651: prepare v0.16.1 notes for G650

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2652,9 +2652,10 @@ to keep in sync, and it goes stale on exactly the roll nobody is watching.
 ### Next release readiness (v0.16.1)
 
 **`v0.16.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.16.1`. [The v0.16.1 notes stub](release-notes-v0.16.1.md) is the required
-prepare-only placeholder. See [release-notes-v0.16.0.md](release-notes-v0.16.0.md)
-for the preceding shipped scope.
+`0.16.1`. [The v0.16.1 notes](release-notes-v0.16.1.md) now contain the
+operator-review content for exactly G650 and are the required prepare-only
+artifact. See [release-notes-v0.16.0.md](release-notes-v0.16.0.md) for the
+preceding shipped scope; it is linked, not restated.
 
 **Release-readiness verification (run before merging the `v0.16.1`
 release-preparation PR):**
@@ -2675,7 +2676,7 @@ ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.16.1.nupkg
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0150DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0161DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Run the complete Release suite.
 dotnet test IntentSystem.sln -c Release

--- a/docs/en/release-notes-v0.16.1.md
+++ b/docs/en/release-notes-v0.16.1.md
@@ -1,9 +1,67 @@
 # Release Notes — intent-cli v0.16.1
 
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
+> **Prepare-only / UNRELEASED.** These notes replace the post-release
+> placeholder with the operator-review content for this patch. This preparation creates
+> no GitHub Release, tag, package publish, or version-state change; Release
+> creation remains the operator's step.
 
 Install verification: `JTechJapan.IntentSystem.Cli --version 0.16.1`.
-The eventual release will be published at
+When approved, the release will be published at
 https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.16.1.
+See the [v0.16.0 notes](release-notes-v0.16.0.md) for the preceding release;
+that content is linked, not repeated here.
+
+## v0.16.1 patch scope
+
+This patch release covers exactly one merged unit: **G650**. The list was
+derived by running `git log v0.16.0..main`; the two commits in that range are
+fully accounted for as the post-release roll `428eea70` and G650's merge
+`53ee440e`. The G650 merge commit is verified to resolve on `main`.
+
+- G650 — PR #1405, merge commit `53ee440e` (verified to resolve on `main`):
+  the team-scoped `guide orchestrator-thread` renders again because its
+  undeclared Setup-intake fragment is declared, and a guard renders every guide
+  under every session-layer mode with and without `--team`, failing on any
+  undeclared fragment.
+
+## What v0.16.0 broke
+
+On v0.16.0, `guide orchestrator-thread --domain <d> --team <t>` exited 1 with
+an undeclared-fragment error while the same invocation without `--team`
+rendered successfully. The failing shape is a herdr-only team's normal
+invocation, so the setup sentences v0.16.0 announced (asking which CLI and
+model each seat runs) were unreachable for the readers they were written for.
+
+## What this patch preserves
+
+- The fragment-typing rule that produced the error is correct and was not
+  weakened: G650 declares the fragment rather than bypassing the rule.
+- **Source presence is not reachability.** A guide is verified by rendering it
+  on the shipped build, not merely by finding its source fragment.
+- The guard renders every guide × every session-layer mode × with and without
+  `--team`, and fails closed on any undeclared fragment.
+
+This is a patch rather than a new command surface: **no command and no flag are
+added**. The fix restores the guide that v0.16.0 could not render for the
+configuration it was written for.
+
+## Release-readiness gate
+
+Before creating the v0.16.1 Release, the operator must verify:
+
+- `eng/version.json` remains stable `0.16.0` / next `0.16.1`.
+- The two commits in `git log v0.16.0..main` remain fully accounted for above,
+  and PR #1405 resolves on `main` at merge `53ee440e`.
+- The bilingual release-notes guard and count guard pass, followed by the full
+  Release suite and exact-head CI. EN and JA remain in parity under the G613
+  terminology policy.
+- The [v0.16.0 notes](release-notes-v0.16.0.md) remain linked as the preceding
+  scope; this patch note does not restate them.
+- Prepare-only remains in force: do not create the GitHub Release, tag, or
+  package publish until the operator explicitly approves it.
+
+## Publishing v0.16.1
+
+After the readiness gate passes and the operator approves, a maintainer may
+create the GitHub Release and publish the package. This preparation PR does not
+perform that step.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2720,9 +2720,9 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 ### 次リリース準備(v0.16.1)
 
 **`v0.16.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.16.1` です。[v0.16.1 notes stub](release-notes-v0.16.1.md) が必須の
-prepare-only placeholder です。直前の出荷範囲は
-[release-notes-v0.16.0.md](release-notes-v0.16.0.md) を参照してください。
+`0.16.1` です。[v0.16.1 notes](release-notes-v0.16.1.md) に G650 だけを対象とする
+operator review 用の内容が入り、必須の prepare-only artifact になっています。直前の
+出荷範囲は [release-notes-v0.16.0.md](release-notes-v0.16.0.md) を参照し、ここでは重複記載しません。
 
 **リリース準備検証(`v0.16.1` release-preparation PR のマージ前に実行):**
 
@@ -2742,7 +2742,7 @@ ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.16.1.nupkg
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0150DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0161DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Release suite を完全実行。
 dotnet test IntentSystem.sln -c Release

--- a/docs/ja/release-notes-v0.16.1.md
+++ b/docs/ja/release-notes-v0.16.1.md
@@ -1,9 +1,59 @@
 # リリースノート — intent-cli v0.16.1
 
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
-> このファイルを changelog として扱ってはいけません。
+> **prepare-only / 未リリース。** post-release の placeholder を、この patch の
+> operator review 用の内容に置き換えます。この preparation は GitHub Release、tag、
+> package publish、version state の変更を作成せず、Release 作成は operator の手順として残します。
 
 Install verification: `JTechJapan.IntentSystem.Cli --version 0.16.1`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.16.1 に
-publish されます。
+承認後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.16.1 に公開されます。
+直前のリリース内容は [v0.16.0 notes](release-notes-v0.16.0.md) を参照し、ここでは
+重複記載しません。
+
+## v0.16.1 patch scope
+
+この patch release は **G650 の正確に一件の merged unit** を対象にします。一覧は
+`git log v0.16.0..main` を実行して導出しました。その範囲の 2 commit は post-release roll
+`428eea70` と G650 の merge `53ee440e` としてすべて説明できます。G650 の merge commit が
+`main` に解決することを確認しています。
+
+- G650 — PR #1405、merge commit `53ee440e`（`main` に解決）: team-scoped の
+  `guide orchestrator-thread` が再び render されます。undeclared な Setup-intake fragment を
+  declare し、every guide を every session-layer mode で `--team` の有無両方について render する
+  guard が undeclared fragment を見つけると fail closed します。
+
+## v0.16.0 で壊れていたこと
+
+v0.16.0 では `guide orchestrator-thread --domain <d> --team <t>` が undeclared-fragment error で
+exit 1 になりましたが、`--team` なしの同じ invocation は正常に render しました。この失敗形は
+herdr-only team の通常の invocation です。そのため v0.16.0 が案内した setup sentence（各 seat が
+どの CLI と model を実行するかを尋ねる内容）が、想定した読者には到達不能でした。
+
+## この patch が維持すること
+
+- エラーを生んだ fragment-typing rule は正しく、弱めていません。G650 は rule を bypass せず fragment
+  を declare して修正します。
+- **source presence is not reachability**。source fragment があるだけでは不十分で、shipped build 上で
+  guide を render して検証します。
+- guard は every guide × every session-layer mode × `--team` の有無を render し、undeclared fragment が
+  あれば fail closed します。
+
+これは新しい command surface ではなく patch です。**command も flag も追加していません**。v0.16.0 が
+書かれた configuration では render できなかった guide を復元します。
+
+## リリース準備ゲート (Release-readiness gate)
+
+v0.16.1 Release を作成する前に operator が確認します。
+
+- `eng/version.json` が stable `0.16.0` / next `0.16.1` のままであること。
+- `git log v0.16.0..main` の 2 commit が上記の通りすべて説明され、PR #1405 が merge
+  `53ee440e` で `main` に解決すること。
+- bilingual release-notes guard と count guard、full Release suite、exact-head CI が green であること。
+  EN/JA の parity は G613 terminology policy に従うこと。
+- 直前の scope として [v0.16.0 notes](release-notes-v0.16.0.md) を link し、ここでは重複記載しないこと。
+- prepare-only の境界を守り、operator が明示承認するまで GitHub Release、tag、package publish を作成しないこと。
+
+## v0.16.1 の publish
+
+ゲートが green になり operator が承認した後にのみ maintainer が GitHub Release と package を publish できます。
+この preparation PR 自体はその操作を行いません。

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0161DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0161DocsTests.cs
@@ -1,0 +1,168 @@
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G651 keeps the v0.16.1 preparation bilingual, bounded to the one merged
+/// repair in the version range, and visibly distinct from the post-roll stub.
+/// </summary>
+public sealed class ReleaseNotesV0161DocsTests
+{
+    private static readonly (string Unit, string Pr, string Merge)[] Units =
+    [
+        ("G650", "#1405", "53ee440e"),
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyG650WithTheVerifiedMerge(string language)
+    {
+        var notes = Read(language);
+        var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(Units.Select(unit => unit.Unit), listed);
+        Assert.Single(listed);
+        foreach (var unit in Units)
+        {
+            Assert.Contains(unit.Pr, notes, StringComparison.Ordinal);
+            Assert.Contains(unit.Merge, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("git log v0.16.0..main", notes, StringComparison.Ordinal);
+        Assert.Contains("428eea70", notes, StringComparison.Ordinal);
+        Assert.Contains("0.16.0", notes, StringComparison.Ordinal);
+        Assert.Contains("0.16.1", notes, StringComparison.Ordinal);
+        Assert.Contains("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Release", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("tag", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("package", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("DRAFT /", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCarryTheUserRegressionAndPreservedBoundaries(string language)
+    {
+        var notes = Read(language);
+
+        foreach (var term in new[]
+                 {
+                     "G650", "guide orchestrator-thread", "--team", "herdr-only",
+                     "undeclared-fragment", "source presence is not reachability",
+                     "guard",
+                 })
+        {
+            Assert.Contains(term, notes, StringComparison.OrdinalIgnoreCase);
+        }
+
+        Assert.Contains(language == "en" ? "fails closed" : "fail closed", notes, StringComparison.OrdinalIgnoreCase);
+
+        if (language == "en")
+        {
+            Assert.Contains("no command", notes, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("no flag", notes, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Contains("command", notes, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("flag", notes, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("追加していません", notes, StringComparison.Ordinal);
+        }
+        Assert.Contains("every session-layer mode", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void Notes_CountGuardMatchesTheListedUnit_AndRejectsAStatedMismatch(string language)
+    {
+        var notes = Read(language);
+        Assert.Empty(CountMismatches(notes, language));
+
+        var wrong = language == "en"
+            ? notes.Replace("exactly one merged unit", "exactly two merged units", StringComparison.Ordinal)
+            : notes.Replace("正確に一件の merged unit", "正確に二件の merged units", StringComparison.Ordinal);
+
+        Assert.NotEmpty(CountMismatches(wrong, language));
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReadinessMirrorNamesTheAuthoredNotesGuard(string language)
+    {
+        var path = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md");
+        var reference = File.ReadAllText(path);
+
+        Assert.Contains("release-notes-v0.16.1.md", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleaseNotesV0161DocsTests", reference, StringComparison.Ordinal);
+        Assert.DoesNotContain("release-notes-v0.16.1.md) is the required prepare-only placeholder", reference, StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyList<string> CountMismatches(string notes, string language)
+    {
+        var listedCount = Regex.Matches(notes, @"(?m)^- (G\d+) —").Count;
+        var statedCounts = language == "en"
+            ? Regex.Matches(notes, @"\b(?<count>one|two|three|four|five|six|seven|eight|nine|ten)\s+merged units?\b", RegexOptions.IgnoreCase)
+                .Select(match => EnglishCount(match.Groups["count"].Value))
+            : Regex.Matches(notes, @"(?<count>[一二三四五六七八九十百〇零]+)件")
+                .Select(match => JapaneseCount(match.Groups["count"].Value));
+
+        return statedCounts
+            .Where(count => count != listedCount)
+            .Select(count => $"{language} stated {count} units, but lists {listedCount}.")
+            .ToArray();
+    }
+
+    private static int EnglishCount(string text) => text.ToLowerInvariant() switch
+    {
+        "one" => 1,
+        "two" => 2,
+        "three" => 3,
+        "four" => 4,
+        "five" => 5,
+        "six" => 6,
+        "seven" => 7,
+        "eight" => 8,
+        "nine" => 9,
+        "ten" => 10,
+        _ => throw new ArgumentOutOfRangeException(nameof(text), text, "unsupported count")
+    };
+
+    private static int JapaneseCount(string text)
+    {
+        var values = new Dictionary<char, int>
+        {
+            ['〇'] = 0, ['零'] = 0, ['一'] = 1, ['二'] = 2, ['三'] = 3, ['四'] = 4,
+            ['五'] = 5, ['六'] = 6, ['七'] = 7, ['八'] = 8, ['九'] = 9, ['十'] = 10,
+            ['百'] = 100,
+        };
+        var total = 0;
+        var pending = 0;
+        foreach (var character in text)
+        {
+            var value = values[character];
+            if (value is 10 or 100)
+            {
+                total += (pending == 0 ? 1 : pending) * value;
+                pending = 0;
+            }
+            else
+            {
+                pending = value;
+            }
+        }
+
+        return total + pending;
+    }
+
+    private static string Read(string language) =>
+        File.ReadAllText(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.16.1.md"));
+}


### PR DESCRIPTION
Closes #1406

## Summary

- Replace the v0.16.1 EN/JA post-roll placeholders with real prepare-only notes covering exactly G650.
- Record the exact v0.16.0..main inventory (post-release roll 428eea70 and G650 merge 53ee440e), PR #1405, and merge 53ee440e.
- Document the team-scoped/no-team regression, the preserved fragment typing rule, source-presence versus reachability, and the every-guide/every-mode/team matrix guard.
- Refresh the mirrored EN/JA readiness sections without changing eng/version.json or creating a Release, tag, package, or roll.
- Add a bilingual notes/count guard for the authored v0.16.1 artifact.

## Verification

- Focused release/readiness filter: 16 passed.
- Full Release suite: 4,580 passed, 1 skipped, 4,581 total.
- git log v0.16.0..main: both expected commits accounted for.
- G650 merge ancestry check: 53ee440e is an ancestor of main.
- git diff --check: clean.
- eng/version.json remains stable 0.16.0 / next 0.16.1.