### PR TITLE
Roll post-release version to 0.16.2

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2556,7 +2556,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0161)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0162)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2649,34 +2649,33 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.16.1)
+### Next release readiness (v0.16.2)
 
-**`v0.16.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.16.1`. [The v0.16.1 notes](release-notes-v0.16.1.md) now contain the
-operator-review content for exactly G650 and are the required prepare-only
-artifact. See [release-notes-v0.16.0.md](release-notes-v0.16.0.md) for the
-preceding shipped scope; it is linked, not restated.
+**`v0.16.1` shipped** (GitHub Release + NuGet), and the next prepared line is
+`0.16.2`. [The v0.16.2 notes stub](release-notes-v0.16.2.md) is the required
+prepare-only placeholder. See [release-notes-v0.16.1.md](release-notes-v0.16.1.md)
+for the preceding shipped scope.
 
-**Release-readiness verification (run before merging the `v0.16.1`
+**Release-readiness verification (run before merging the `v0.16.2`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.16.0 (published), nextVersion 0.16.1 (to release)
+cat eng/version.json   # stableVersion 0.16.1 (published), nextVersion 0.16.2 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.16.1-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.16.2-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.16.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.16.2.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0161DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0162DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Run the complete Release suite.
 dotnet test IntentSystem.sln -c Release
@@ -2685,10 +2684,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.16.1`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.16.2`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.16.1`, `nextVersion → 0.16.2` — carrying, per **steps 4–6** of the
+`stableVersion → 0.16.2`, `nextVersion → 0.16.3` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.16.2.md
+++ b/docs/en/release-notes-v0.16.2.md
@@ -1,0 +1,9 @@
+# Release Notes — intent-cli v0.16.2
+
+> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
+> roll. The release-prep packet authors the real content; this file must not be
+> treated as a changelog until that packet replaces it.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.16.2`.
+The eventual release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.16.2.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2717,32 +2717,32 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.16.1)
+### 次リリース準備(v0.16.2)
 
-**`v0.16.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.16.1` です。[v0.16.1 notes](release-notes-v0.16.1.md) に G650 だけを対象とする
-operator review 用の内容が入り、必須の prepare-only artifact になっています。直前の
-出荷範囲は [release-notes-v0.16.0.md](release-notes-v0.16.0.md) を参照し、ここでは重複記載しません。
+**`v0.16.1` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
+`0.16.2` です。[v0.16.2 notes stub](release-notes-v0.16.2.md) が必須の
+prepare-only placeholder です。直前の出荷範囲は
+[release-notes-v0.16.1.md](release-notes-v0.16.1.md) を参照してください。
 
-**リリース準備検証(`v0.16.1` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.16.2` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.16.0 (published), nextVersion 0.16.1 (to release)
+cat eng/version.json   # stableVersion 0.16.1 (published), nextVersion 0.16.2 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.16.1-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.16.2-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.16.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.16.2.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0161DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0162DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Release suite を完全実行。
 dotnet test IntentSystem.sln -c Release
@@ -2750,10 +2750,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.16.1` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.16.2` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.16.1`、`nextVersion → 0.16.2` —
+`stableVersion → 0.16.2`、`nextVersion → 0.16.3` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.16.2.md
+++ b/docs/ja/release-notes-v0.16.2.md
@@ -1,0 +1,9 @@
+# リリースノート — intent-cli v0.16.2
+
+> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
+> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
+> このファイルを changelog として扱ってはいけません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.16.2`。
+将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.16.2 に
+publish されます。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.16.0",
-  "nextVersion": "0.16.1"
+  "stableVersion": "0.16.1",
+  "nextVersion": "0.16.2"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0161DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0161DocsTests.cs
@@ -94,14 +94,13 @@ public sealed class ReleaseNotesV0161DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void ReadinessMirrorNamesTheAuthoredNotesGuard(string language)
+    public void ReadinessMirrorLinksTheShippedNotes(string language)
     {
         var path = Path.Combine(
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md");
         var reference = File.ReadAllText(path);
 
         Assert.Contains("release-notes-v0.16.1.md", reference, StringComparison.Ordinal);
-        Assert.Contains("ReleaseNotesV0161DocsTests", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("release-notes-v0.16.1.md) is the required prepare-only placeholder", reference, StringComparison.Ordinal);
     }
 


### PR DESCRIPTION
Roll the release policy immediately after published v0.16.1.

- v0.16.1 Release: https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.16.1
- release workflow: 31244689658, all four jobs green, eight assets attached
- stableVersion: 0.16.1
- nextVersion: 0.16.2
- add EN/JA v0.16.2 DRAFT note stubs
- refresh EN/JA next-release readiness mirrors
- preserve the frozen v0.16.1 notes guard while allowing readiness to advance to v0.16.2

Focused guards: 16 passed. Full Release suite: 4580 passed, 1 skipped, 4581 total. git diff --check clean.