### PR TITLE
feat(notify): supervise live activity evidence

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -71,6 +71,16 @@ registration but a process remains, status reports the distinct
 `registration-lost-process-present` state and directs an operator to repair the
 registration; it does not infer process loss.
 
+**Activity evidence (G652 — preview-through-1.x).** A running process is not
+evidence of work. For herdr, status also names `agent_status`,
+`state_change_seq`, and the last state-change time: `working` requires a
+working agent with advancing activity; otherwise a present process is
+`live-idle`. Supervision records those observations, surfaces an unchanged
+live-idle recipient with no report once and names terminal inspection as the
+remedy; it never reads terminal content or enters recovery for that finding.
+A declared bound below the configured interval is a structural false-alarm
+warning, not a value the CLI silently corrects.
+
 A report is a message rather than a bookkeeping entry: fail-closed protection
 belongs on pending-state mutation, not on carrying the message. Refusing an
 unrecognised identifier would silence unsolicited reports and answers to

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -74,12 +74,15 @@ registration; it does not infer process loss.
 **Activity evidence (G652 — preview-through-1.x).** A running process is not
 evidence of work. For herdr, status also names `agent_status`,
 `state_change_seq`, and the last state-change time: `working` requires a
-working agent with advancing activity; otherwise a present process is
-`live-idle`. Supervision records those observations, surfaces an unchanged
-live-idle recipient with no report once and names terminal inspection as the
-remedy; it never reads terminal content or enters recovery for that finding.
-A declared bound below the configured interval is a structural false-alarm
-warning, not a value the CLI silently corrects.
+working agent with advancing activity. Before a sequence baseline exists,
+status reports `activity-unknown` rather than asserting `live-idle`; a
+state-change time after dispatch is sufficient cold-start evidence for
+`working`. Supervision records the first baseline without a live-idle finding,
+then surfaces an unchanged live-idle recipient with no report once and names
+terminal inspection as the remedy; it never reads terminal content or enters
+recovery for that finding. A declared bound below the configured interval is a
+structural false-alarm warning, emitted at supervise start and on each cycle,
+not a value the CLI silently corrects.
 
 A report is a message rather than a bookkeeping entry: fail-closed protection
 belongs on pending-state mutation, not on carrying the message. Refusing an

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -66,7 +66,7 @@ process の corroboration がない場合だけ `lost` です。herdr の regist
 process が残っている場合は `registration-lost-process-present` という別の state を返し、
 process が消えたとは推測しません。経過時間だけで verdict を変えることはありません。
 
-**活動証拠 (G652 — 1.x を通じた preview)。** 実行中 process は作業の証拠ではありません。herdr では status が `agent_status`、`state_change_seq`、最後の状態変更時刻も示します。`working` には working agent と進行する活動が必要で、それ以外の present process は `live-idle` です。supervision はこれらの observation を記録し、変化しない live-idle recipient に report がなければ一度だけ表示して terminal の確認を remedy として示します。この finding のために terminal content を読んだり recovery に入ったりしません。declared bound が configured interval より小さい場合は、CLI が黙って補正する値ではなく structural false alarm warning です。
+**活動証拠 (G652 — 1.x を通じた preview)。** 実行中 process は作業の証拠ではありません。herdr では status が `agent_status`、`state_change_seq`、最後の状態変更時刻も示します。`working` には working agent と進行する活動が必要です。sequence baseline がまだない場合、status は `live-idle` を断定せず `activity-unknown` を返します。dispatch 後の状態変更時刻は cold-start の `working` の十分な証拠です。supervision は最初の baseline を live-idle finding なしで記録し、その後に変化しない live-idle recipient に report がなければ一度だけ表示して terminal の確認を remedy として示します。この finding のために terminal content を読んだり recovery に入ったりしません。declared bound が configured interval より小さい場合は、supervise start と各 cycle で structural false alarm warning を出し、CLI が黙って補正する値ではありません。
 
 report は bookkeeping entry ではなく message です。fail-closed の保護は message を運ぶことではなく
 pending state の mutation に置きます。認識されない identifier を理由に配信を拒否すると、recipient が

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -66,6 +66,8 @@ process の corroboration がない場合だけ `lost` です。herdr の regist
 process が残っている場合は `registration-lost-process-present` という別の state を返し、
 process が消えたとは推測しません。経過時間だけで verdict を変えることはありません。
 
+**活動証拠 (G652 — 1.x を通じた preview)。** 実行中 process は作業の証拠ではありません。herdr では status が `agent_status`、`state_change_seq`、最後の状態変更時刻も示します。`working` には working agent と進行する活動が必要で、それ以外の present process は `live-idle` です。supervision はこれらの observation を記録し、変化しない live-idle recipient に report がなければ一度だけ表示して terminal の確認を remedy として示します。この finding のために terminal content を読んだり recovery に入ったりしません。declared bound が configured interval より小さい場合は、CLI が黙って補正する値ではなく structural false alarm warning です。
+
 report は bookkeeping entry ではなく message です。fail-closed の保護は message を運ぶことではなく
 pending state の mutation に置きます。認識されない identifier を理由に配信を拒否すると、recipient が
 依頼したことを知らなかった unsolicited report や escalation への回答という、情報を運ぶ message を

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -127,7 +127,7 @@ internal static class NotifyCommand
 
         if (string.Equals(operation, OperationStatus, StringComparison.Ordinal))
         {
-            return ExecuteStatus(writer, options, routingRoot);
+            return ExecuteStatus(context, writer, options, routingRoot);
         }
 
         if (string.Equals(operation, OperationSupervise, StringComparison.Ordinal))
@@ -232,7 +232,7 @@ internal static class NotifyCommand
         string.Equals(finding.Cause, "marker-not-generated", StringComparison.Ordinal)
         || string.Equals(finding.Cause, SessionLayerMigration.ResidueCause, StringComparison.Ordinal);
 
-    private static int ExecuteStatus(TextWriter writer, NotifyOptions options, string routingRoot)
+    private static int ExecuteStatus(CliContext context, TextWriter writer, NotifyOptions options, string routingRoot)
     {
         var lookup = NotifyPendingDelegationStore.Find(
             routingRoot,
@@ -305,6 +305,23 @@ internal static class NotifyCommand
                 : liveness.Running.Value
                     ? "live"
                     : "lost";
+        var activityKey = record.WorkspaceId is not null && record.PaneId is not null
+            ? $"activity:{record.WorkspaceId}:{record.PaneId}"
+            : $"activity:{record.RecipientIdentity}";
+        var supervision = NotifySupervisionStore.Read(
+            context.ResolveSupervisionArtifactRootPath(),
+            record.Domain,
+            record.Team);
+        var activityAdvancing = liveness.StateChangeSequence is { } sequence
+            && supervision.LastCycle?.LastObservedStateChangeSequences.TryGetValue(activityKey, out var priorSequence) == true
+            && sequence > priorSequence;
+        var hasHerdrActivity = liveness.StateChangeSequence.HasValue
+            || liveness.LastStateChangeAt.HasValue
+            || liveness.AgentStatus is not null;
+        var activityVerdict = liveness.Running == true && hasHerdrActivity
+            ? string.Equals(liveness.AgentStatus, "working", StringComparison.Ordinal)
+                && activityAdvancing ? "working" : "live-idle"
+            : null;
         EmitStatus(writer, options.Format, new NotifyStatusResult
         {
             Operation = NotifyCommand.OperationStatus,
@@ -321,6 +338,13 @@ internal static class NotifyCommand
             ProcessPresent = liveness.ProcessPresent,
             ResendPermitted = liveness.ResendPermitted,
             LivenessSource = liveness.Source,
+            AgentStatus = liveness.AgentStatus,
+            StateChangeSequence = liveness.StateChangeSequence,
+            LastStateChangeAt = liveness.LastStateChangeAt,
+            ActivityVerdict = activityVerdict,
+            ActivityInputs = liveness.Running == true
+                ? $"agent_status={liveness.AgentStatus ?? "<unknown>"}; state_change_seq={liveness.StateChangeSequence?.ToString(CultureInfo.InvariantCulture) ?? "<unknown>"}; last_state_change_at={liveness.LastStateChangeAt?.ToString("O") ?? "<unknown>"}; advancing_since_last_observation={activityAdvancing.ToString().ToLowerInvariant()}"
+                : null,
             ReportArrived = record.ReportArrived,
             ReportStatus = record.ReportStatus,
             ReportArtifact = record.ReportArtifact,
@@ -476,6 +500,11 @@ internal static class NotifyCommand
         writer.WriteLine($"- process present: {result.ProcessPresent?.ToString().ToLowerInvariant() ?? "<unknown>"}");
         writer.WriteLine($"- resend permitted: {result.ResendPermitted?.ToString().ToLowerInvariant() ?? "<unknown>"}");
         writer.WriteLine($"- liveness source: {result.LivenessSource ?? "<unknown>"}");
+        writer.WriteLine($"- agent status: {result.AgentStatus ?? "<unknown>"}");
+        writer.WriteLine($"- state change sequence: {result.StateChangeSequence?.ToString(CultureInfo.InvariantCulture) ?? "<unknown>"}");
+        writer.WriteLine($"- last state change at: {result.LastStateChangeAt?.ToString("O") ?? "<unknown>"}");
+        writer.WriteLine($"- activity verdict: {result.ActivityVerdict ?? "<unknown>"}");
+        writer.WriteLine($"- activity inputs: {result.ActivityInputs ?? "<unknown>"}");
         writer.WriteLine($"- report arrived: {result.ReportArrived?.ToString().ToLowerInvariant() ?? "<unknown>"}");
         writer.WriteLine($"- verdict: {result.Verdict ?? "<unknown>"}");
         if (result.Cause is not null)
@@ -1584,6 +1613,11 @@ internal sealed record NotifyStatusResult
     [JsonPropertyName("process_present")] public bool? ProcessPresent { get; init; }
     [JsonPropertyName("resend_permitted")] public bool? ResendPermitted { get; init; }
     [JsonPropertyName("liveness_source")] public string? LivenessSource { get; init; }
+    [JsonPropertyName("agent_status")] public string? AgentStatus { get; init; }
+    [JsonPropertyName("state_change_seq")] public long? StateChangeSequence { get; init; }
+    [JsonPropertyName("last_state_change_at")] public DateTimeOffset? LastStateChangeAt { get; init; }
+    [JsonPropertyName("activity_verdict")] public string? ActivityVerdict { get; init; }
+    [JsonPropertyName("activity_inputs")] public string? ActivityInputs { get; init; }
     [JsonPropertyName("report_arrived")] public bool? ReportArrived { get; init; }
     [JsonPropertyName("report_status")] public string? ReportStatus { get; init; }
     [JsonPropertyName("report_artifact")] public string? ReportArtifact { get; init; }

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -312,15 +312,36 @@ internal static class NotifyCommand
             context.ResolveSupervisionArtifactRootPath(),
             record.Domain,
             record.Team);
+        long? priorStateChangeSequence = null;
+        if (supervision.LastCycle?.LastObservedStateChangeSequences.TryGetValue(activityKey, out var observedSequence) == true)
+        {
+            priorStateChangeSequence = observedSequence;
+        }
+
+        var hasPriorActivityObservation = liveness.StateChangeSequence.HasValue && priorStateChangeSequence.HasValue;
         var activityAdvancing = liveness.StateChangeSequence is { } sequence
-            && supervision.LastCycle?.LastObservedStateChangeSequences.TryGetValue(activityKey, out var priorSequence) == true
+            && priorStateChangeSequence is { } priorSequence
             && sequence > priorSequence;
+        var stateChangedAfterDispatch = liveness.LastStateChangeAt is { } lastStateChangeAt
+            && lastStateChangeAt > record.DispatchedAt;
+        var activityEvidence = activityAdvancing
+            ? "observed-sequence-advance"
+            : !hasPriorActivityObservation && stateChangedAfterDispatch
+                ? "state-change-after-dispatch"
+                : hasPriorActivityObservation
+                    ? "observed-sequence-unchanged"
+                    : "baseline-missing";
         var hasHerdrActivity = liveness.StateChangeSequence.HasValue
             || liveness.LastStateChangeAt.HasValue
             || liveness.AgentStatus is not null;
         var activityVerdict = liveness.Running == true && hasHerdrActivity
-            ? string.Equals(liveness.AgentStatus, "working", StringComparison.Ordinal)
-                && activityAdvancing ? "working" : "live-idle"
+            ? !hasPriorActivityObservation
+                ? string.Equals(liveness.AgentStatus, "working", StringComparison.Ordinal) && stateChangedAfterDispatch
+                    ? "working"
+                    : "activity-unknown"
+                : string.Equals(liveness.AgentStatus, "working", StringComparison.Ordinal) && activityAdvancing
+                    ? "working"
+                    : "live-idle"
             : null;
         EmitStatus(writer, options.Format, new NotifyStatusResult
         {
@@ -343,7 +364,7 @@ internal static class NotifyCommand
             LastStateChangeAt = liveness.LastStateChangeAt,
             ActivityVerdict = activityVerdict,
             ActivityInputs = liveness.Running == true
-                ? $"agent_status={liveness.AgentStatus ?? "<unknown>"}; state_change_seq={liveness.StateChangeSequence?.ToString(CultureInfo.InvariantCulture) ?? "<unknown>"}; last_state_change_at={liveness.LastStateChangeAt?.ToString("O") ?? "<unknown>"}; advancing_since_last_observation={activityAdvancing.ToString().ToLowerInvariant()}"
+                ? $"agent_status={liveness.AgentStatus ?? "<unknown>"}; state_change_seq={liveness.StateChangeSequence?.ToString(CultureInfo.InvariantCulture) ?? "<unknown>"}; last_state_change_at={liveness.LastStateChangeAt?.ToString("O") ?? "<unknown>"}; activity_evidence={activityEvidence}; advancing_since_last_observation={activityAdvancing.ToString().ToLowerInvariant()}"
                 : null,
             ReportArrived = record.ReportArrived,
             ReportStatus = record.ReportStatus,

--- a/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
@@ -201,9 +201,22 @@ internal sealed class NotifyMeasuredSupervisor
                 observedTimes[paneKey] = changedAt;
             }
 
-            var advanced = previousCycle?.LastObservedStateChangeSequences.TryGetValue(paneKey, out var priorSequence) == true
-                && sequence > priorSequence;
-            var idle = !string.Equals(activity.AgentStatus, "working", StringComparison.Ordinal) || !advanced;
+            long? priorStateChangeSequence = null;
+            if (previousCycle?.LastObservedStateChangeSequences.TryGetValue(paneKey, out var observedSequence) == true)
+            {
+                priorStateChangeSequence = observedSequence;
+            }
+
+            var hasPriorActivityObservation = priorStateChangeSequence.HasValue;
+            var advanced = priorStateChangeSequence is { } priorSequence && sequence > priorSequence;
+            var stateChangedAfterDispatch = activity.LastStateChangeAt is { } lastStateChangeAt
+                && lastStateChangeAt > pending.DispatchedAt;
+            var working = string.Equals(activity.AgentStatus, "working", StringComparison.Ordinal)
+                && (advanced || (!hasPriorActivityObservation && stateChangedAfterDispatch));
+            // A first observation establishes a durable baseline but is never
+            // proof that no activity occurred. Only a later observation can
+            // classify an unchanged/non-working recipient as live-idle.
+            var idle = hasPriorActivityObservation && !working;
             var beyondThreshold = declaredBoundSeconds.HasValue
                 && now - pending.DispatchedAt > TimeSpan.FromSeconds(declaredBoundSeconds.Value);
             if (!pending.ReportArrived && idle && beyondThreshold)

--- a/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
@@ -142,6 +142,11 @@ internal sealed class NotifyMeasuredSupervisor
         var observations = new List<NotifySupervisionObservation>();
         var actions = new List<NotifySupervisorAction>();
         var warnings = new List<string>();
+        var boundBelowInterval = declaredBoundSeconds.HasValue && declaredBoundSeconds.Value < intervalSeconds;
+        if (boundBelowInterval)
+        {
+            warnings.Add($"declared bound {declaredBoundSeconds!.Value}s is smaller than configured interval {intervalSeconds}s; normal cadence will structurally exceed the bound and the value was not corrected.");
+        }
 
         var openBefore = NotifyPendingDelegationStore.ReadOpen(routingRoot, domain, team, out var pendingError);
         if (pendingError is not null)
@@ -174,6 +179,47 @@ internal sealed class NotifyMeasuredSupervisor
         }
 
         var openByTask = openBefore.ToDictionary(item => item.TaskId, StringComparer.Ordinal);
+        var observedSequences = new Dictionary<string, long>(StringComparer.Ordinal);
+        var observedTimes = new Dictionary<string, DateTimeOffset>(StringComparer.Ordinal);
+        foreach (var pending in openBefore)
+        {
+            var transportMode = string.IsNullOrWhiteSpace(pending.TransportMode)
+                ? SessionLayerMode.Agmsg
+                : pending.TransportMode!;
+            var activity = NotifyPendingLiveness.Probe(routingRoot, pending, transportMode, runner, herdrExecutable, agmsgScriptsDirectory);
+            if (!activity.Resolved || activity.Running != true || activity.StateChangeSequence is not { } sequence)
+            {
+                continue;
+            }
+
+            var paneKey = pending.WorkspaceId is not null && pending.PaneId is not null
+                ? $"activity:{pending.WorkspaceId}:{pending.PaneId}"
+                : $"activity:{pending.RecipientIdentity}";
+            observedSequences[paneKey] = sequence;
+            if (activity.LastStateChangeAt is { } changedAt)
+            {
+                observedTimes[paneKey] = changedAt;
+            }
+
+            var advanced = previousCycle?.LastObservedStateChangeSequences.TryGetValue(paneKey, out var priorSequence) == true
+                && sequence > priorSequence;
+            var idle = !string.Equals(activity.AgentStatus, "working", StringComparison.Ordinal) || !advanced;
+            var beyondThreshold = declaredBoundSeconds.HasValue
+                && now - pending.DispatchedAt > TimeSpan.FromSeconds(declaredBoundSeconds.Value);
+            if (!pending.ReportArrived && idle && beyondThreshold)
+            {
+                observations.Add(new NotifySupervisionObservation
+                {
+                    Key = $"live-idle:{paneKey}",
+                    Kind = "live-idle-no-report",
+                    OwnerRole = pending.DelegatingRole ?? ownerRole,
+                    Source = "herdr.activity",
+                    Summary = $"Recipient '{pending.RecipientRole}' is live-idle with no report beyond the declared {declaredBoundSeconds!.Value}s threshold; inspect the recorded terminal pane. No recovery sequence was entered.",
+                    DetectableAt = pending.DispatchedAt.AddSeconds(declaredBoundSeconds!.Value),
+                    WakeSuppressed = true,
+                });
+            }
+        }
         foreach (var action in legacy.Actions)
         {
             var record = openByTask.GetValueOrDefault(action.TaskId);
@@ -281,6 +327,16 @@ internal sealed class NotifyMeasuredSupervisor
             .Select(group => group.First()))
         {
             var existing = state.ActiveStalls.GetValueOrDefault(observation.Key);
+            if (existing is not null && observation.WakeSuppressed)
+            {
+                // Activity-backed live-idle is an informational, once-only
+                // finding. Keep its durable record active, but do not emit a
+                // duplicate result on unchanged cycles and never wake or enter
+                // the G630 recovery path for it.
+                records.Add(existing with { Summary = observation.Summary });
+                continue;
+            }
+
             if (existing is not null && existing.WakeDelivered)
             {
                 records.Add(existing with { Summary = observation.Summary });
@@ -288,7 +344,9 @@ internal sealed class NotifyMeasuredSupervisor
                 continue;
             }
 
-            var wake = observation.WakeAlreadyAttempted && existing is null
+            var wake = observation.WakeSuppressed
+                ? new NotifySupervisionWakeResult { Attempted = false, Delivered = false, Summary = "Finding is informational; inspect the terminal and do not enter recovery." }
+                : observation.WakeAlreadyAttempted && existing is null
                 ? new NotifySupervisionWakeResult
                 {
                     Attempted = true,
@@ -392,6 +450,9 @@ internal sealed class NotifyMeasuredSupervisor
             AbsenceThresholdKind = absenceThresholdKind,
             AbsentSinceLastCycle = absentSinceLastCycle,
             GapSeconds = gapSeconds,
+            BoundBelowInterval = boundBelowInterval,
+            LastObservedStateChangeSequences = observedSequences,
+            LastObservedStateChangeTimes = observedTimes,
         };
         var cycleWrite = NotifySupervisionStore.RecordCycle(
             NotifySupervisionStore.ResolveCyclePath(
@@ -793,6 +854,7 @@ internal sealed record NotifySupervisionObservation
     public bool WakeAlreadyAttempted { get; init; }
     public bool WakeAlreadyDelivered { get; init; }
     public string? WakeCause { get; init; }
+    public bool WakeSuppressed { get; init; }
 }
 
 internal sealed record NotifySupervisionWakeResult

--- a/src/IntentSystem.Cli/Commands/NotifyPendingLiveness.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyPendingLiveness.cs
@@ -9,6 +9,9 @@ internal sealed record NotifyPendingLivenessResult
     public string State { get; init; } = "unavailable";
     public bool? ProcessPresent { get; init; }
     public bool? ResendPermitted { get; init; }
+    public string? AgentStatus { get; init; }
+    public long? StateChangeSequence { get; init; }
+    public DateTimeOffset? LastStateChangeAt { get; init; }
     public required string Source { get; init; }
     public required string Summary { get; init; }
     public string? Cause { get; init; }
@@ -99,6 +102,7 @@ internal static class NotifyPendingLiveness
 
         if (running.Length == 1)
         {
+            var agent = running[0];
             return new NotifyPendingLivenessResult
             {
                 Resolved = true,
@@ -106,6 +110,9 @@ internal static class NotifyPendingLiveness
                 State = "live",
                 ProcessPresent = null,
                 Source = "herdr.agent_running",
+                AgentStatus = agent.AgentStatus,
+                StateChangeSequence = agent.StateChangeSequence,
+                LastStateChangeAt = agent.LastStateChangeAt,
                 Summary = $"The recorded recipient identity '{record.RecipientIdentity}' has one agent with running=true.",
             };
         }

--- a/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
@@ -322,6 +322,9 @@ internal sealed record NotifySupervisionCycle
     [JsonPropertyName("absence_threshold_kind")] public string? AbsenceThresholdKind { get; init; }
     [JsonPropertyName("absent_since_last_cycle")] public bool AbsentSinceLastCycle { get; init; }
     [JsonPropertyName("gap_seconds")] public long? GapSeconds { get; init; }
+    [JsonPropertyName("bound_below_interval")] public bool BoundBelowInterval { get; init; }
+    [JsonPropertyName("last_observed_state_change_sequences")] public IReadOnlyDictionary<string, long> LastObservedStateChangeSequences { get; init; } = new Dictionary<string, long>(StringComparer.Ordinal);
+    [JsonPropertyName("last_observed_state_change_times")] public IReadOnlyDictionary<string, DateTimeOffset> LastObservedStateChangeTimes { get; init; } = new Dictionary<string, DateTimeOffset>(StringComparer.Ordinal);
 }
 
 internal sealed record NotifySupervisionStallRecord

--- a/src/IntentSystem.Cli/Commands/NotifySupervisor.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySupervisor.cs
@@ -30,7 +30,7 @@ internal sealed record NotifySupervisorPass
     public NotifySupervisionLiveness? Liveness { get; init; }
     public IReadOnlyList<string> Warnings { get; init; } = [];
     public string? Error { get; init; }
-    public bool Silent => Actions.Count == 0 && Findings.Count == 0 && Error is null;
+    public bool Silent => Actions.Count == 0 && Findings.Count == 0 && Warnings.Count == 0 && Error is null;
     public int ExitCode => Error is null
         && Actions.All(action => action.Cause is null)
         && Findings.All(finding => finding.Cause is null)

--- a/src/IntentSystem.Cli/Commands/NotifyTransport.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyTransport.cs
@@ -723,6 +723,8 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
                 var agentWorkspaceId = ReadString(agent, "workspace_id") ?? WorkspaceFromPane(paneId);
                 var agentKind = ReadString(agent, "agent");
                 var status = ReadString(agent, "agent_status");
+                var stateChangeSequence = ReadInt64(agent, "state_change_seq");
+                var lastStateChangeAt = ReadDateTimeOffset(agent, "last_state_change_at");
                 var cwd = ReadString(agent, "cwd") ?? ReadString(agent, "foreground_cwd");
                 var explicitlyNotReady = agent.TryGetProperty("interactive_ready", out var ready)
                     && ready.ValueKind == JsonValueKind.False;
@@ -733,7 +735,7 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
                     && !explicitlyNotReady
                     && !string.Equals(status, "unknown", StringComparison.Ordinal);
 
-                parsed.Add(new HerdrAgentState(name, agentWorkspaceId, paneId, running, status, cwd));
+                parsed.Add(new HerdrAgentState(name, agentWorkspaceId, paneId, running, status, cwd, stateChangeSequence, lastStateChangeAt));
             }
 
             return parsed;
@@ -750,6 +752,16 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
         element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
             ? value.GetString()
             : null;
+
+    private static long? ReadInt64(JsonElement element, string property) =>
+        element.TryGetProperty(property, out var value)
+        && value.ValueKind == JsonValueKind.Number
+        && value.TryGetInt64(out var parsed) ? parsed : null;
+
+    private static DateTimeOffset? ReadDateTimeOffset(JsonElement element, string property) =>
+        element.TryGetProperty(property, out var value)
+        && value.ValueKind == JsonValueKind.String
+        && DateTimeOffset.TryParse(value.GetString(), out var parsed) ? parsed : null;
 
     private static string? WorkspaceFromPane(string? paneId)
     {
@@ -874,7 +886,9 @@ internal sealed record HerdrAgentState(
     string? PaneId,
     bool AgentRunning,
     string? AgentStatus,
-    string? Cwd = null);
+    string? Cwd = null,
+    long? StateChangeSequence = null,
+    DateTimeOffset? LastStateChangeAt = null);
 
 internal static class NotifyTransportPaths
 {

--- a/tests/IntentSystem.Cli.Tests/NotifyPendingDelegationG629Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyPendingDelegationG629Tests.cs
@@ -49,6 +49,62 @@ public sealed class NotifyPendingDelegationG629Tests : IDisposable
     }
 
     [Fact]
+    public void StatusNamesHerdrActivityEvidenceAndDistinguishesWorkingFromLiveIdle_G652()
+    {
+        var runner = new FakeRunner(() => workspace.HerdrAgents(
+            implementationRunning: true,
+            implementationStatus: "working",
+            stateChangeSequence: 7,
+            lastStateChangeAt: FixedNow.AddMinutes(1)));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        Assert.Equal(0, workspace.Run(DelegateArgs()).ExitCode);
+
+        var supervisionRoot = workspace.Context.ResolveSupervisionArtifactRootPath();
+        Assert.True(NotifySupervisionStore.RecordCycle(
+            NotifySupervisionStore.ResolveCyclePath(supervisionRoot, Workspace.Domain, Workspace.Team),
+            new NotifySupervisionCycle
+            {
+                CycleId = "G652-baseline",
+                StartedAt = FixedNow,
+                CompletedAt = FixedNow,
+                IntervalSeconds = 300,
+                LastObservedStateChangeSequences = new Dictionary<string, long>
+                {
+                    ["activity:wH:wH:p2"] = 6,
+                },
+                LastObservedStateChangeTimes = new Dictionary<string, DateTimeOffset>
+                {
+                    ["activity:wH:wH:p2"] = FixedNow,
+                },
+            },
+            write: true).Applied);
+
+        var (_, working) = workspace.Run(StatusArgs());
+        Assert.Equal("working", working.GetProperty("activity_verdict").GetString());
+        Assert.Equal("working", working.GetProperty("agent_status").GetString());
+        Assert.Equal(7, working.GetProperty("state_change_seq").GetInt64());
+
+        Assert.True(NotifySupervisionStore.RecordCycle(
+            NotifySupervisionStore.ResolveCyclePath(supervisionRoot, Workspace.Domain, Workspace.Team),
+            new NotifySupervisionCycle
+            {
+                CycleId = "G652-current-observation",
+                StartedAt = FixedNow.AddMinutes(1),
+                CompletedAt = FixedNow.AddMinutes(1),
+                IntervalSeconds = 300,
+                LastObservedStateChangeSequences = new Dictionary<string, long>
+                {
+                    ["activity:wH:wH:p2"] = 7,
+                },
+            },
+            write: true).Applied);
+        runner.AgentResponse = workspace.HerdrAgents(implementationRunning: true, implementationStatus: "working", stateChangeSequence: 7);
+        var (_, idle) = workspace.Run(StatusArgs());
+        Assert.Equal("live-idle", idle.GetProperty("activity_verdict").GetString());
+        Assert.Contains("advancing_since_last_observation=false", idle.GetProperty("activity_inputs").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void StatusUsesRunningFlagNotIdleStatusStringAndReportsLost_G629()
     {
         var runner = new FakeRunner(() => workspace.HerdrAgents(implementationRunning: true));
@@ -256,7 +312,9 @@ public sealed class NotifyPendingDelegationG629Tests : IDisposable
         public string HerdrAgents(
             bool implementationRunning,
             string implementationStatus = "idle",
-            bool includeImplementationSession = true)
+            bool includeImplementationSession = true,
+            long? stateChangeSequence = null,
+            DateTimeOffset? lastStateChangeAt = null)
         {
             object HerdrAgent(string name, string paneId, bool running, string status) => new
             {
@@ -269,6 +327,8 @@ public sealed class NotifyPendingDelegationG629Tests : IDisposable
                     : null,
                 agent_status = status,
                 interactive_ready = running,
+                state_change_seq = name == "implementation" ? stateChangeSequence : null,
+                last_state_change_at = name == "implementation" ? lastStateChangeAt?.ToString("O") : null,
             };
 
             return JsonSerializer.Serialize(new

--- a/tests/IntentSystem.Cli.Tests/NotifyPendingDelegationG629Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyPendingDelegationG629Tests.cs
@@ -105,6 +105,45 @@ public sealed class NotifyPendingDelegationG629Tests : IDisposable
     }
 
     [Fact]
+    public void StatusTreatsColdStartStateChangesAsWorkingAndKeepsUnknownDistinctFromLiveIdle_G652()
+    {
+        var runner = new FakeRunner(() => workspace.HerdrAgents(
+            implementationRunning: true,
+            implementationStatus: "working",
+            stateChangeSequence: 7,
+            lastStateChangeAt: FixedNow.AddMinutes(1)));
+        NotifyCommand.ProcessRunnerFactory = () => runner;
+        Assert.Equal(0, workspace.Run(DelegateArgs()).ExitCode);
+
+        var (_, first) = workspace.Run(StatusArgs());
+        Assert.Equal("working", first.GetProperty("activity_verdict").GetString());
+        Assert.Contains("activity_evidence=state-change-after-dispatch", first.GetProperty("activity_inputs").GetString(), StringComparison.Ordinal);
+
+        runner.AgentResponse = workspace.HerdrAgents(
+            implementationRunning: true,
+            implementationStatus: "working",
+            stateChangeSequence: 8,
+            lastStateChangeAt: FixedNow.AddMinutes(2));
+        var (_, second) = workspace.Run(StatusArgs());
+        Assert.Equal("working", second.GetProperty("activity_verdict").GetString());
+
+        runner.AgentResponse = workspace.HerdrAgents(
+            implementationRunning: true,
+            implementationStatus: "working",
+            stateChangeSequence: 9,
+            lastStateChangeAt: FixedNow.AddMinutes(3));
+        var (_, third) = workspace.Run(StatusArgs());
+        Assert.Equal("working", third.GetProperty("activity_verdict").GetString());
+
+        runner.AgentResponse = workspace.HerdrAgents(
+            implementationRunning: true,
+            implementationStatus: "working",
+            stateChangeSequence: 9);
+        var (_, unknown) = workspace.Run(StatusArgs());
+        Assert.Equal("activity-unknown", unknown.GetProperty("activity_verdict").GetString());
+    }
+
+    [Fact]
     public void StatusUsesRunningFlagNotIdleStatusStringAndReportsLost_G629()
     {
         var runner = new FakeRunner(() => workspace.HerdrAgents(implementationRunning: true));

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionG641Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionG641Tests.cs
@@ -223,7 +223,7 @@ public sealed class NotifySupervisionG641Tests : IDisposable
     }
 
     [Fact]
-    public void LiveIdleIsSurfacedOnceWhileAdvancingWorkingActivityStaysHealthy_G652()
+    public void ColdStartWorkingActivityEstablishesBaselineBeforeLiveIdleIsSurfacedOnce_G652()
     {
         var context = CreateContext();
         RecordMode(context, SessionLayerMode.HerdrOnly);
@@ -251,9 +251,7 @@ public sealed class NotifySupervisionG641Tests : IDisposable
 
         var first = supervisor.RunOnce();
 
-        var idle = Assert.Single(first.Findings, finding => finding.Kind == "live-idle-no-report");
-        Assert.Equal("herdr.activity", idle.Source);
-        Assert.False(idle.WakeAttempted);
+        Assert.DoesNotContain(first.Findings, finding => finding.Kind == "live-idle-no-report");
         Assert.Contains("not corrected", Assert.Single(first.Warnings), StringComparison.Ordinal);
         Assert.Equal(120, first.Bound!.BoundSeconds);
         var recordedFirst = NotifySupervisionStore.Read(context.ResolveSupervisionArtifactRootPath(), Domain, Team);
@@ -263,10 +261,17 @@ public sealed class NotifySupervisionG641Tests : IDisposable
         now = firstNow.AddSeconds(1);
         var unchanged = supervisor.RunOnce();
 
-        Assert.DoesNotContain(unchanged.Findings, finding => finding.Kind == "live-idle-no-report");
+        var idle = Assert.Single(unchanged.Findings, finding => finding.Kind == "live-idle-no-report");
+        Assert.Equal("herdr.activity", idle.Source);
+        Assert.False(idle.WakeAttempted);
         Assert.Contains("not corrected", Assert.Single(unchanged.Warnings), StringComparison.Ordinal);
 
         now = firstNow.AddSeconds(2);
+        var unchangedAgain = supervisor.RunOnce();
+
+        Assert.DoesNotContain(unchangedAgain.Findings, finding => finding.Kind == "live-idle-no-report");
+
+        now = firstNow.AddSeconds(3);
         runner.AgentsJson = HerdrAgentsJson(stateChangeSequence: 8);
         var advancing = supervisor.RunOnce();
 
@@ -274,6 +279,30 @@ public sealed class NotifySupervisionG641Tests : IDisposable
         var recordedAdvancing = NotifySupervisionStore.Read(context.ResolveSupervisionArtifactRootPath(), Domain, Team);
         Assert.Equal(8, recordedAdvancing.LastCycle!.LastObservedStateChangeSequences["activity:wG641:wG641:p2"]);
         Assert.DoesNotContain(runner.Calls, call => call.Arguments.Contains("send-text"));
+    }
+
+    [Fact]
+    public void ContinuousSupervisionEmitsBoundBelowIntervalWarningAtStart_G652()
+    {
+        var context = CreateContext();
+        var supervisor = CreateSupervisor(
+            context,
+            "unused-agmsg",
+            new FakeRunner(),
+            write: true,
+            boundSeconds: 120,
+            intervalSeconds: 600);
+        using var cancellation = new CancellationTokenSource();
+        NotifySupervisor.Delay = _ => cancellation.Cancel();
+        using var writer = new StringWriter();
+
+        var exitCode = supervisor.RunLoop(writer, cancellation.Token, once: false);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.False(document.RootElement.GetProperty("silent").GetBoolean());
+        Assert.Contains("not corrected", document.RootElement.GetProperty("warnings")[0].GetString(), StringComparison.Ordinal);
+        Assert.True(document.RootElement.GetProperty("bound").GetProperty("recorded").GetBoolean());
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionG641Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionG641Tests.cs
@@ -223,6 +223,60 @@ public sealed class NotifySupervisionG641Tests : IDisposable
     }
 
     [Fact]
+    public void LiveIdleIsSurfacedOnceWhileAdvancingWorkingActivityStaysHealthy_G652()
+    {
+        var context = CreateContext();
+        RecordMode(context, SessionLayerMode.HerdrOnly);
+        WriteTopology();
+        Assert.True(NotifyPendingDelegationStore.WriteDispatch(root, new NotifyPendingDelegation
+        {
+            Domain = Domain,
+            Team = Team,
+            TaskId = "G652-live-activity",
+            DelegatingRole = "orchestration",
+            RecipientRole = "implementation",
+            RecipientIdentity = "implementation",
+            ExpectedArtifact = "draft-pr",
+            DispatchedAt = firstNow.AddSeconds(-121),
+            TransportMode = SessionLayerMode.HerdrOnly,
+            Resident = NotifyRecordedRole.HerdrResident,
+            WorkspaceId = "wG641",
+            PaneId = "wG641:p2",
+        }).Written);
+        var runner = new FakeRunner
+        {
+            AgentsJson = HerdrAgentsJson(stateChangeSequence: 7),
+        };
+        var supervisor = CreateSupervisor(context, "unused-agmsg", runner, write: true, boundSeconds: 120, intervalSeconds: 600);
+
+        var first = supervisor.RunOnce();
+
+        var idle = Assert.Single(first.Findings, finding => finding.Kind == "live-idle-no-report");
+        Assert.Equal("herdr.activity", idle.Source);
+        Assert.False(idle.WakeAttempted);
+        Assert.Contains("not corrected", Assert.Single(first.Warnings), StringComparison.Ordinal);
+        Assert.Equal(120, first.Bound!.BoundSeconds);
+        var recordedFirst = NotifySupervisionStore.Read(context.ResolveSupervisionArtifactRootPath(), Domain, Team);
+        Assert.True(recordedFirst.LastCycle!.BoundBelowInterval);
+        Assert.Equal(7, recordedFirst.LastCycle.LastObservedStateChangeSequences["activity:wG641:wG641:p2"]);
+
+        now = firstNow.AddSeconds(1);
+        var unchanged = supervisor.RunOnce();
+
+        Assert.DoesNotContain(unchanged.Findings, finding => finding.Kind == "live-idle-no-report");
+        Assert.Contains("not corrected", Assert.Single(unchanged.Warnings), StringComparison.Ordinal);
+
+        now = firstNow.AddSeconds(2);
+        runner.AgentsJson = HerdrAgentsJson(stateChangeSequence: 8);
+        var advancing = supervisor.RunOnce();
+
+        Assert.DoesNotContain(advancing.Findings, finding => finding.Kind == "live-idle-no-report");
+        var recordedAdvancing = NotifySupervisionStore.Read(context.ResolveSupervisionArtifactRootPath(), Domain, Team);
+        Assert.Equal(8, recordedAdvancing.LastCycle!.LastObservedStateChangeSequences["activity:wG641:wG641:p2"]);
+        Assert.DoesNotContain(runner.Calls, call => call.Arguments.Contains("send-text"));
+    }
+
+    [Fact]
     public void EnglishAndJapaneseGuidanceNameTheMeasuredPreviewContract_G641()
     {
         var rootPath = RepoVersionPolicySource.RepoRoot();
@@ -234,10 +288,13 @@ public sealed class NotifySupervisionG641Tests : IDisposable
         foreach (var document in new[] { english, japanese })
         {
             Assert.Contains("G641", document, StringComparison.Ordinal);
+            Assert.Contains("G652", document, StringComparison.Ordinal);
             Assert.Contains("--bound", document, StringComparison.Ordinal);
             Assert.Contains("undelivered-escalation", document, StringComparison.Ordinal);
             Assert.Contains("detectable_at", document, StringComparison.Ordinal);
             Assert.Contains("absent_since_last_cycle", document, StringComparison.Ordinal);
+            Assert.Contains("state_change_seq", document, StringComparison.Ordinal);
+            Assert.Contains("live-idle", document, StringComparison.Ordinal);
             Assert.Contains("preview-through-1.x", document, StringComparison.Ordinal);
         }
 
@@ -250,14 +307,15 @@ public sealed class NotifySupervisionG641Tests : IDisposable
         string scripts,
         FakeRunner runner,
         bool write,
-        int? boundSeconds) => new(
+        int? boundSeconds,
+        int intervalSeconds = 300) => new(
         context,
         root,
         Domain,
         Team,
         repo: null,
         ownerRole: "orchestration",
-        intervalSeconds: 300,
+        intervalSeconds: intervalSeconds,
         declaredBoundSeconds: boundSeconds,
         staleMinutes: 45,
         claimedSilentMinutes: 720,
@@ -269,6 +327,28 @@ public sealed class NotifySupervisionG641Tests : IDisposable
         runner,
         herdrExecutable: "fake-herdr",
         agmsgScriptsDirectory: scripts);
+
+    private static string HerdrAgentsJson(long stateChangeSequence) => JsonSerializer.Serialize(new
+    {
+        result = new
+        {
+            agents = new[]
+            {
+                new
+                {
+                    name = "orchestration", workspace_id = "wG641", pane_id = "wG641:p1", agent = "fixture",
+                    agent_session = new { id = "orchestration" }, agent_status = "working", interactive_ready = true,
+                    state_change_seq = 1L, last_state_change_at = (string?)null,
+                },
+                new
+                {
+                    name = "implementation", workspace_id = "wG641", pane_id = "wG641:p2", agent = "fixture",
+                    agent_session = new { id = "implementation" }, agent_status = "working", interactive_ready = true,
+                    state_change_seq = stateChangeSequence, last_state_change_at = (string?)"2026-08-07T12:00:00.0000000+00:00",
+                },
+            },
+        },
+    });
 
     private CliContext CreateContext() => new()
     {
@@ -315,7 +395,7 @@ public sealed class NotifySupervisionG641Tests : IDisposable
     private sealed class FakeRunner : INotifyProcessRunner
     {
         public List<(string FileName, IReadOnlyList<string> Arguments)> Calls { get; } = [];
-        public string AgentsJson { get; init; } = "{\"result\":{\"agents\":[]}}";
+        public string AgentsJson { get; set; } = "{\"result\":{\"agents\":[]}}";
 
         public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
         {


### PR DESCRIPTION
## Summary

- add herdr activity evidence to notify status and supervision cycles
- distinguish advancing working activity from live-idle without terminal parsing or recovery
- document the preview contract in English and Japanese

Closes #1411

## Validation

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --no-restore --filter "FullyQualifiedName~NotifyPendingDelegationG629Tests|FullyQualifiedName~NotifySupervisionG641Tests|FullyQualifiedName~JapaneseTerminologyGuardG613Tests"`
- `dotnet test IntentSystem.sln --no-restore`
- `git diff --check`