### PR TITLE
G661: Fix host-state honesty and scaffolding frictions

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -68,6 +68,61 @@ apply. A kind with an inbound app monitor may use that external reader. This is
 a deployment rule, not a recommendation; it does not assign stall recovery to
 design or add a model-backed monitoring role.
 
+## Host-state honesty and complete scaffolds (G661 — preview-through-1.x)
+
+Five host-side edges share one rule: a surface must not claim more than its
+evidence. `automation knowledge-writeback-record --write` creates the local
+record but always states that other checkouts cannot observe it until the path
+is committed and pushed; intent-cli never commits it. `automation stalled-work`
+therefore distinguishes an absent record (`knowledge-writeback-pending`) from a
+local recorded path (`knowledge-writeback-recorded-uncommitted`) and names the
+exact path that still needs commit and push.
+
+`packet retire --reactivate --evidence <text> --write` is the only reactivation
+edge. It requires evidence, writes `lifecycle: ready` plus the prior lifecycle,
+evidence, and timestamp, and appends `packet-reactivated`. Closeout never infers
+this transition: if shipped work still has a non-publishable lifecycle, closeout
+emits `shipped-while-retired-contradiction` and leaves the sidecar unchanged.
+
+Issue-cut readiness consumes the existing publish validator's verdict. A TODO
+scaffold, including placeholder-only Related Links, is visible as not ready with
+the validator's reason and is never offered as `issue-cut-ready`. `packet draft`
+also leaves guide reachability commented until the author chooses one of these
+accepted forms; a missing-declaration warning prints both fragments verbatim:
+
+```yaml
+guide_reachability:
+  no_role_facing_surface: false
+  routes:
+    - guide_surface: guide workflow task implementation-loop
+      role: implementation
+      target_surface: <role-facing-surface>
+```
+
+```yaml
+guide_reachability:
+  no_role_facing_surface: true
+  routes: []
+```
+
+On a fresh host, `intent init --write` appends these repository defaults while
+preserving existing file content:
+
+```gitattributes
+.intent-cli/runs.jsonl merge=union
+.intent-cli/**/*.jsonl merge=union
+```
+
+```gitignore
+.intent-cli/supervision/**/cycles.jsonl
+.intent-cli/supervision/**/stalls.jsonl
+```
+
+The first pair gives append-only JSONL stores union-merge behaviour; the second
+keeps per-team supervision telemetry out of git. For an already initialised
+host, `intent init` prints these exact lines as guidance and changes neither
+`.gitattributes` nor `.gitignore`; migration is always an explicit operator act.
+
 ## Canonical notify workflow
 
 All role-to-role workflow messages use `intent-cli notify`; agents never choose

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -57,6 +57,58 @@ herdr seat にし、persistent AGENTS rule を適用します。inbound app moni
 を利用できます。これは recommendation ではなく deployment rule であり、stall recovery を design に
 移したり、model-backed monitoring role を追加したりしません。
 
+## host state の誠実さと不足のない scaffold (G661 — 1.x を通じた preview)
+
+host 側の 5 つの境界には「surface は evidence より強い完了を主張しない」という同じ規則を
+適用します。`automation knowledge-writeback-record --write` はローカル record を作りますが、
+その path をコミットしてプッシュするまで別 checkout からは観測できないことを常に表示します。
+intent-cli 自身が自動でコミットすることはありません。このため `automation stalled-work` は record の不在
+(`knowledge-writeback-pending`)と、ローカルだけに記録済みの path
+(`knowledge-writeback-recorded-uncommitted`)を区別し、commit と push が必要な正確な path を示します。
+
+reactivation の経路は `packet retire --reactivate --evidence <text> --write` だけです。evidence を
+必須とし、`lifecycle: ready` と変更前の lifecycle、evidence、timestamp を書き、
+`packet-reactivated` を追記します。closeout はこの transition を推測しません。出荷済みの work に
+non-publishable な lifecycle が残っていれば `shipped-while-retired-contradiction` を出し、sidecar は
+変更しません。
+
+issue-cut readiness は既存の publish validator の判定をそのまま使います。placeholder だけの
+Related Links を含む TODO scaffold は validator の理由付きで not ready と表示され、
+`issue-cut-ready` として提示されません。`packet draft` の guide reachability も、作者が次の accepted
+form のどちらかを選ぶまで comment のままです。declaration 欠落 warning は両 fragment をそのまま表示します。
+
+```yaml
+guide_reachability:
+  no_role_facing_surface: false
+  routes:
+    - guide_surface: guide workflow task implementation-loop
+      role: implementation
+      target_surface: <role-facing-surface>
+```
+
+```yaml
+guide_reachability:
+  no_role_facing_surface: true
+  routes: []
+```
+
+新規 host では `intent init --write` が既存内容を保持したまま、次の repository default を追記します。
+
+```gitattributes
+.intent-cli/runs.jsonl merge=union
+.intent-cli/**/*.jsonl merge=union
+```
+
+```gitignore
+.intent-cli/supervision/**/cycles.jsonl
+.intent-cli/supervision/**/stalls.jsonl
+```
+
+前者は append-only JSONL store に union merge を適用し、後者は team ごとの supervision telemetry を
+git の対象外にします。初期化済みの host に対して `intent init` はこの正確な行を guidance として
+表示するだけで、`.gitattributes` と `.gitignore` を変更しません。migration は常に operator が明示的に
+行います。
+
 ## canonical notify workflow
 
 role 間の workflow message はすべて `intent-cli notify` を使い、agent 自身は

--- a/src/IntentSystem.Cli/Commands/AutomationKnowledgeWriteBackRecordCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationKnowledgeWriteBackRecordCommand.cs
@@ -187,6 +187,8 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
             DeclaredFacets = declaration.RequiredFacets,
             DeclarationRequired = declaration.IsRequired,
             Note = record.Note,
+            CommitPushRequiredForOtherCheckouts = true,
+            DurabilityGuidance = BuildDurabilityGuidance(KnowledgeWriteBackRecord.ResolveRelativePath(executionUnit!)),
             Warnings = warnings,
             Error = null,
         };
@@ -211,6 +213,8 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
             DeclaredFacets = Array.Empty<string>(),
             DeclarationRequired = false,
             Note = null,
+            CommitPushRequiredForOtherCheckouts = true,
+            DurabilityGuidance = BuildDurabilityGuidance(KnowledgeWriteBackRecord.ResolveRelativePath(executionUnit)),
             Warnings = Array.Empty<string>(),
             Error = error,
         };
@@ -238,6 +242,8 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
         {
             writer.WriteLine($"- host_commit: `{result.HostCommit}`");
         }
+        writer.WriteLine($"- commit_push_required_for_other_checkouts: {(result.CommitPushRequiredForOtherCheckouts ? "true" : "false")}");
+        writer.WriteLine($"- durability_guidance: {result.DurabilityGuidance}");
         if (result.Targets.Count > 0)
         {
             writer.WriteLine($"- targets: {string.Join(", ", result.Targets)}");
@@ -268,6 +274,10 @@ internal static class AutomationKnowledgeWriteBackRecordCommand
             }
         }
     }
+
+    private static string BuildDurabilityGuidance(string recordPath) =>
+        $"The record at `{recordPath}` exists only in this checkout until it is committed and pushed; "
+        + "other checkouts cannot observe or rely on it before both steps complete. intent-cli never auto-commits.";
 
     private static bool TryParseArguments(
         string[] args,
@@ -448,6 +458,12 @@ internal sealed record KnowledgeWriteBackRecordResult
 
     [JsonPropertyName("note")]
     public required string? Note { get; init; }
+
+    [JsonPropertyName("commit_push_required_for_other_checkouts")]
+    public required bool CommitPushRequiredForOtherCheckouts { get; init; }
+
+    [JsonPropertyName("durability_guidance")]
+    public required string DurabilityGuidance { get; init; }
 
     [JsonPropertyName("warnings")]
     public required IReadOnlyList<string> Warnings { get; init; }

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Clarify.Models;
@@ -392,6 +394,15 @@ internal static class AutomationStalledWorkCommand
     /// commits) but nothing said "done", so nothing could say "not done".
     /// </summary>
     public const string KindKnowledgeWritebackPending = "knowledge-writeback-pending";
+
+    /// <summary>
+    /// G661: the record exists locally but git still reports its exact path as
+    /// untracked, ignored, staged, or modified. This is distinct from an
+    /// absent record: the write-back was recorded, but another checkout cannot
+    /// observe it until the operator commits and pushes it.
+    /// </summary>
+    public const string KindKnowledgeWritebackRecordedUncommitted =
+        "knowledge-writeback-recorded-uncommitted";
 
     /// <summary>
     /// G645: a closed-out unit whose packet declared guide routes but whose
@@ -2544,8 +2555,29 @@ internal static class AutomationStalledWorkCommand
                     // host_commit that is not a commit — discharge this unit's
                     // obligation.
                     _ = KnowledgeWriteBackRecord.Deserialize(File.ReadAllText(recordPath), executionUnit);
-                    // Recorded: the obligation is discharged. This is the
-                    // clearing path — no item, no exclusion.
+                    var relativeRecordPath = KnowledgeWriteBackRecord.ResolveRelativePath(executionUnit);
+                    if (IsGitPathUncommitted(context.RepoRoot, relativeRecordPath))
+                    {
+                        items.Add(new StalledWorkItem
+                        {
+                            Kind = KindKnowledgeWritebackRecordedUncommitted,
+                            ExecutionUnit = executionUnit,
+                            Issue = null,
+                            Pr = null,
+                            AgeMinutes = ComputeAgeMinutesFromInstant(ClampToNow(closedAt, now), now),
+                            IsInformational = false,
+                            DeclaredWriteBackTargets = declaration.DeclaredTargets,
+                            RecordPath = relativeRecordPath,
+                            RecommendedAction =
+                                $"commit and push `{relativeRecordPath}` in the host repo, then re-run stalled-work. "
+                                + "The record exists only in this checkout until both steps complete; intent-cli never auto-commits.",
+                        });
+                    }
+
+                    // A committed record discharges the obligation. If git
+                    // status cannot be established (legacy/non-git fixture),
+                    // preserve the pre-G661 clearing behavior rather than
+                    // manufacturing a dirty finding without evidence.
                     continue;
                 }
                 catch (Exception exception) when (exception is IOException or InvalidOperationException)
@@ -2577,6 +2609,50 @@ internal static class AutomationStalledWorkCommand
                 DeclaredWriteBackTargets = declaration.DeclaredTargets,
                 RecommendedAction = BuildKnowledgeWritebackPendingAction(executionUnit, declaration),
             });
+        }
+    }
+
+    private static bool IsGitPathUncommitted(string repoRoot, string relativePath)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo("git")
+                {
+                    WorkingDirectory = repoRoot,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    StandardOutputEncoding = Encoding.UTF8,
+                    StandardErrorEncoding = Encoding.UTF8,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                },
+            };
+            process.StartInfo.ArgumentList.Add("status");
+            process.StartInfo.ArgumentList.Add("--porcelain=v1");
+            process.StartInfo.ArgumentList.Add("--untracked-files=all");
+            process.StartInfo.ArgumentList.Add("--ignored=matching");
+            process.StartInfo.ArgumentList.Add("--");
+            process.StartInfo.ArgumentList.Add(relativePath);
+            if (!process.Start())
+            {
+                return false;
+            }
+
+            var output = process.StandardOutput.ReadToEnd();
+            _ = process.StandardError.ReadToEnd();
+            if (!process.WaitForExit(5000))
+            {
+                process.Kill(entireProcessTree: true);
+                return false;
+            }
+
+            return process.ExitCode == 0 && !string.IsNullOrWhiteSpace(output);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or IOException or System.ComponentModel.Win32Exception)
+        {
+            return false;
         }
     }
 
@@ -2743,7 +2819,11 @@ internal static class AutomationStalledWorkCommand
                 warnings.Add(
                     $"'{executionUnit}': packet '{packetYamlPath}' has no guide_reachability declaration; "
                     + "absence is distinct from explicit no_role_facing_surface: true and should be repaired "
-                    + "before a role-facing surface is shipped.");
+                    + "before a role-facing surface is shipped. Paste exactly one accepted YAML form:\n\n"
+                    + "Route form:\n"
+                    + GuideReachabilityDeclaration.RouteYaml
+                    + "\n\nExplicit no-surface form:\n"
+                    + GuideReachabilityDeclaration.NoSurfaceYaml);
                 continue;
             }
 
@@ -3546,6 +3626,10 @@ internal static class AutomationStalledWorkCommand
                 {
                     writer.WriteLine($"- declared_write_back_targets: {string.Join(", ", declaredTargets)}");
                 }
+                if (item.RecordPath is { } recordPath)
+                {
+                    writer.WriteLine($"- record_path: {recordPath}");
+                }
                 if (item.DeclaredGuideSurfaces is { Count: > 0 } declaredGuides)
                 {
                     writer.WriteLine($"- declared_guide_surfaces: {string.Join(", ", declaredGuides)}");
@@ -3738,6 +3822,11 @@ internal sealed record StalledWorkItem
     /// </summary>
     [JsonPropertyName("declared_write_back_targets")]
     public IReadOnlyList<string>? DeclaredWriteBackTargets { get; init; }
+
+    /// <summary>G661: exact locally recorded but not-yet-committed path.</summary>
+    [JsonPropertyName("record_path")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RecordPath { get; init; }
 
     /// <summary>
     /// G645: guide surfaces the packet declared for a role-facing addition.

--- a/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/CloseoutPrCommand.cs
@@ -238,6 +238,28 @@ internal static class CloseoutPrCommand
         var executionUnit = matchedItem.ExecutionUnit;
         var nowTs = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
 
+        // G661 / RH-030A: shipped work does not erase contradictory packet
+        // history. Report the still-retired sidecar and leave it byte-identical;
+        // only an explicit, evidenced reactivation may change lifecycle.
+        var closeoutFindings = new List<CloseoutPrFinding>();
+        var packetDirectory = Path.Combine(context.RepoRoot, ".intent-cli", "issues", executionUnit);
+        var lifecycle = PacketLifecycle.ReadState(packetDirectory);
+        if (lifecycle.State == PacketLifecycleState.ValidRetired)
+        {
+            closeoutFindings.Add(new CloseoutPrFinding
+            {
+                Kind = "shipped-while-retired-contradiction",
+                Path = lifecycle.SidecarPath,
+                Summary =
+                    $"Execution unit '{executionUnit}' is being closed out as shipped while lifecycle.yaml still "
+                    + $"declares '{lifecycle.Metadata?.Lifecycle}'. The lifecycle record was not changed.",
+                RecommendedAction =
+                    $"Inspect the history, then run `intent-cli packet retire --execution-unit {executionUnit} "
+                    + "--reactivate --evidence <why-the-prior-retirement-is-no-longer-valid> --write --format json` "
+                    + "if reactivation is correct. Never silently unretire a shipped unit.",
+            });
+        }
+
         var runsEvents = new List<string>
         {
             BuildRunsEvent(executionUnit, "pr-merged", repo!, pr.Value, nowTs),
@@ -337,7 +359,8 @@ internal static class CloseoutPrCommand
             RecoverableMissingLinkedPr = recoverableMissingLinkedPr,
             InferredIssue = inferredIssue,
             RecoverySource = recoverySource,
-            RecoveryAction = recoveryAction
+            RecoveryAction = recoveryAction,
+            Findings = closeoutFindings,
         };
 
         EmitResult(writer, result, format);
@@ -459,7 +482,8 @@ internal static class CloseoutPrCommand
             ContinuationHint = null,
             NextSteps = Array.Empty<string>(),
             Error = error,
-            StateLayout = stateLayout
+            StateLayout = stateLayout,
+            Findings = Array.Empty<CloseoutPrFinding>(),
         };
     }
 
@@ -501,6 +525,22 @@ internal static class CloseoutPrCommand
             writer.WriteLine($"- {result.Error}");
             return;
         }
+
+        writer.WriteLine("## Findings");
+        if (result.Findings.Count == 0)
+        {
+            writer.WriteLine("- none");
+        }
+        else
+        {
+            foreach (var finding in result.Findings)
+            {
+                writer.WriteLine($"- {finding.Kind}: {finding.Summary}");
+                writer.WriteLine($"  - path: {finding.Path}");
+                writer.WriteLine($"  - recommended_action: {finding.RecommendedAction}");
+            }
+        }
+        writer.WriteLine();
 
         writer.WriteLine("## Queue transition");
         writer.WriteLine($"- before: {result.QueueStateBeforeState}");
@@ -821,4 +861,22 @@ internal sealed record CloseoutPrResult
     /// </summary>
     [JsonPropertyName("recovery_action")]
     public string? RecoveryAction { get; init; }
+
+    [JsonPropertyName("findings")]
+    public required IReadOnlyList<CloseoutPrFinding> Findings { get; init; }
+}
+
+internal sealed record CloseoutPrFinding
+{
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    [JsonPropertyName("path")]
+    public required string Path { get; init; }
+
+    [JsonPropertyName("summary")]
+    public required string Summary { get; init; }
+
+    [JsonPropertyName("recommended_action")]
+    public required string RecommendedAction { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/GuideReachabilityDeclaration.cs
+++ b/src/IntentSystem.Cli/Commands/GuideReachabilityDeclaration.cs
@@ -19,6 +19,26 @@ internal sealed record GuideReachabilityRoute
 
 internal sealed record GuideReachabilityDeclaration
 {
+    /// <summary>
+    /// G661: canonical accepted YAML fragments. The missing-declaration
+    /// warning and packet scaffold both render these exact spellings so an
+    /// author can paste either form without reverse-engineering the parser.
+    /// </summary>
+    public const string RouteYaml = """
+        guide_reachability:
+          no_role_facing_surface: false
+          routes:
+            - guide_surface: guide workflow task implementation-loop
+              role: implementation
+              target_surface: <role-facing-surface>
+        """;
+
+    public const string NoSurfaceYaml = """
+        guide_reachability:
+          no_role_facing_surface: true
+          routes: []
+        """;
+
     public required bool IsDeclared { get; init; }
 
     public required bool NoRoleFacingSurface { get; init; }

--- a/src/IntentSystem.Cli/Commands/IntentInitCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentInitCommand.cs
@@ -28,6 +28,18 @@ internal static class IntentInitCommand
     private const string UsageLine =
         "Usage: intent-cli intent init --domain <name> [--target-repo <owner/repo>] [--host-repo <owner/repo>] [--base-branch-policy direct-main|main-ai] [--write] [--format markdown|json]";
 
+    internal static readonly IReadOnlyList<string> AppendOnlyGitAttributesLines =
+    [
+        ".intent-cli/runs.jsonl merge=union",
+        ".intent-cli/**/*.jsonl merge=union",
+    ];
+
+    internal static readonly IReadOnlyList<string> SupervisionTelemetryGitIgnoreLines =
+    [
+        ".intent-cli/supervision/**/cycles.jsonl",
+        ".intent-cli/supervision/**/stalls.jsonl",
+    ];
+
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -67,6 +79,11 @@ internal static class IntentInitCommand
 
         EnsureNotChildWorktree(hostRepoRoot);
 
+        var configPath = ResolveHostPath(
+            hostRepoRoot,
+            $"{CliRuntimeContracts.IntentCliDirectoryName}/{CliRuntimeContracts.ConfigFileName}");
+        var freshHost = !File.Exists(configPath);
+
         // G301: extend the new-host bootstrap to also write the canonical
         // host policy files (`AGENTS.md`, `CLAUDE.md`) and the host-binding
         // record so wrong-host operation can be detected later. The
@@ -89,6 +106,11 @@ internal static class IntentInitCommand
             $"intents/{request.Domain}/clarifications/open.md",
             $"intents/{request.Domain}/intent-tree/00-map.md"
         };
+        if (freshHost)
+        {
+            planned.Add(".gitattributes");
+            planned.Add(".gitignore");
+        }
 
         var written = new List<string>();
         var existing = new List<string>();
@@ -96,6 +118,27 @@ internal static class IntentInitCommand
         foreach (var relativePath in planned)
         {
             var absolutePath = ResolveHostPath(hostRepoRoot, relativePath);
+            if (freshHost && relativePath is ".gitattributes" or ".gitignore")
+            {
+                var requiredLines = relativePath == ".gitattributes"
+                    ? AppendOnlyGitAttributesLines
+                    : SupervisionTelemetryGitIgnoreLines;
+                if (!request.Write)
+                {
+                    continue;
+                }
+
+                if (AppendMissingLines(absolutePath, requiredLines))
+                {
+                    written.Add(relativePath);
+                }
+                else
+                {
+                    existing.Add(relativePath);
+                }
+                continue;
+            }
+
             if (File.Exists(absolutePath))
             {
                 existing.Add(relativePath);
@@ -124,8 +167,37 @@ internal static class IntentInitCommand
             PlannedPaths = planned,
             WrittenPaths = written,
             ExistingPaths = existing,
-            NextSteps = BuildNextSteps(request, written.Count, existing.Count)
+            NextSteps = BuildNextSteps(request, written.Count, existing.Count, freshHost),
+            FreshHost = freshHost,
+            GitAttributesLines = AppendOnlyGitAttributesLines,
+            GitIgnoreLines = SupervisionTelemetryGitIgnoreLines,
+            ExistingHostGuidance =
+                "Existing hosts are never auto-migrated. Add the exact .gitattributes and .gitignore lines "
+                + "reported by this command deliberately, then commit and push them if adopted.",
         };
+    }
+
+    private static bool AppendMissingLines(string path, IReadOnlyList<string> requiredLines)
+    {
+        var existingText = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+        var existingLines = existingText.Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Trim())
+            .ToHashSet(StringComparer.Ordinal);
+        var missing = requiredLines.Where(line => !existingLines.Contains(line)).ToArray();
+        if (missing.Length == 0)
+        {
+            return false;
+        }
+
+        var prefix = existingText.Length == 0 || existingText.EndsWith('\n') ? string.Empty : Environment.NewLine;
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+        File.AppendAllText(path, prefix + string.Join(Environment.NewLine, missing) + Environment.NewLine);
+        return true;
     }
 
     private static void EnsureNotChildWorktree(string hostRepoRoot)
@@ -148,7 +220,8 @@ internal static class IntentInitCommand
     private static IReadOnlyList<string> BuildNextSteps(
         IntentInitRequest request,
         int writtenCount,
-        int existingCount)
+        int existingCount,
+        bool freshHost)
     {
         var domain = request.Domain;
         var verb = request.Write
@@ -168,6 +241,9 @@ internal static class IntentInitCommand
         steps.Add($"Open `intents/{domain}/intent-tree/00-map.md` and capture the initial domain shape.");
         steps.Add($"Use `intent-cli interview record-answer --write` (chat-first) to durably record durable Q/A for '{domain}'.");
         steps.Add($"Use `intent-cli intent next-slice --domain {domain} --dry-run` to plan the first publishable slice.");
+        steps.Add(freshHost
+            ? "Fresh-host git defaults include merge=union for append-only .intent-cli JSONL stores and ignores for supervision cycles/stalls telemetry. Commit and push those repo policy files with the host scaffold."
+            : "Existing host detected: no .gitattributes or .gitignore migration was performed. Apply the exact reported lines manually if desired; intent-cli never auto-migrates them.");
         steps.Add("Run this command from the parent host repository, never inside `.intent-cli/worktrees/**`.");
 
         return steps;

--- a/src/IntentSystem.Cli/Commands/IntentInitRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IntentInitRenderer.cs
@@ -26,6 +26,21 @@ internal static class IntentInitRenderer
         WriteList(writer, result.ExistingPaths);
 
         writer.WriteLine();
+        writer.WriteLine("## Multi-checkout git defaults (G661)");
+        writer.WriteLine($"- host classification: {(result.FreshHost ? "fresh" : "existing")}");
+        writer.WriteLine("- `.gitattributes` exact lines:");
+        foreach (var line in result.GitAttributesLines)
+        {
+            writer.WriteLine($"  - `{line}`");
+        }
+        writer.WriteLine("- `.gitignore` exact lines:");
+        foreach (var line in result.GitIgnoreLines)
+        {
+            writer.WriteLine($"  - `{line}`");
+        }
+        writer.WriteLine($"- existing-host rule: {result.ExistingHostGuidance}");
+
+        writer.WriteLine();
         writer.WriteLine("## Next steps");
         foreach (var step in result.NextSteps)
         {

--- a/src/IntentSystem.Cli/Commands/IntentInitResult.cs
+++ b/src/IntentSystem.Cli/Commands/IntentInitResult.cs
@@ -17,4 +17,12 @@ internal sealed record IntentInitResult
     public required IReadOnlyList<string> ExistingPaths { get; init; }
 
     public required IReadOnlyList<string> NextSteps { get; init; }
+
+    public required bool FreshHost { get; init; }
+
+    public required IReadOnlyList<string> GitAttributesLines { get; init; }
+
+    public required IReadOnlyList<string> GitIgnoreLines { get; init; }
+
+    public required string ExistingHostGuidance { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IntentNextSliceCommand.cs
@@ -654,16 +654,20 @@ internal static class IntentNextSliceCommand
         var githubBodyPath = Path.Combine(directory, "github-body.md");
         var githubBodyPresent = File.Exists(githubBodyPath);
         var missing = new List<string>();
+        IssueValidateBodyResult? publishGate = null;
 
         if (githubBodyPresent)
         {
             var content = File.ReadAllText(githubBodyPath);
-            foreach (var section in RequiredContractSections)
+            // G661: reuse the publish gate's own judgment. In particular, a
+            // freshly scaffolded `- TODO` Related Links section is present but
+            // not valid, so it remains visibly not-ready instead of being
+            // surfaced as work the publish path will refuse.
+            publishGate = IssueValidateBodyValidator.Validate(githubBodyPath, content);
+            missing.AddRange(publishGate.MissingHeadings);
+            if (publishGate.RelatedLinksInvalid)
             {
-                if (!ContainsSectionHeading(content, section))
-                {
-                    missing.Add(section);
-                }
+                missing.Add("Related Links");
             }
         }
         else
@@ -690,31 +694,15 @@ internal static class IntentNextSliceCommand
             ExecutionUnit = executionUnit,
             PacketDirectory = directory,
             GithubBodyPresent = githubBodyPresent,
-            MissingContractSections = missing,
+            MissingContractSections = missing.Distinct(StringComparer.Ordinal).ToArray(),
+            PublishGateReady = publishGate?.IsValid == true,
+            NotReadyReason = publishGate?.IsValid == false
+                ? publishGate.RelatedLinksReason
+                    ?? $"publish gate rejected missing section(s): {string.Join(", ", publishGate.MissingHeadings)}"
+                : githubBodyPresent ? null : "github-body.md is missing.",
             GapAnalysis = gapAnalysis,
             Provenance = provenance
         };
-    }
-
-    private static bool ContainsSectionHeading(string content, string section)
-    {
-        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
-        foreach (var rawLine in lines)
-        {
-            var line = rawLine.Trim();
-            if (!line.StartsWith("##", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var heading = line.TrimStart('#').Trim();
-            if (string.Equals(heading, section, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private static string ComputeRecommendedOutcome(
@@ -1052,6 +1040,11 @@ internal static class IntentNextSliceCommand
             writer.WriteLine($"- execution unit: {result.Candidate.ExecutionUnit}");
             writer.WriteLine($"- packet directory: {result.Candidate.PacketDirectory}");
             writer.WriteLine($"- github-body.md present: {(result.Candidate.GithubBodyPresent ? "yes" : "no")}");
+            writer.WriteLine($"- publish gate ready: {(result.Candidate.PublishGateReady ? "yes" : "no")}");
+            if (!string.IsNullOrWhiteSpace(result.Candidate.NotReadyReason))
+            {
+                writer.WriteLine($"- not-ready reason: {result.Candidate.NotReadyReason}");
+            }
             if (result.Candidate.MissingContractSections.Count == 0)
             {
                 writer.WriteLine("- missing contract sections: none");
@@ -1264,6 +1257,15 @@ internal sealed record IntentNextSliceCandidate
 
     [JsonPropertyName("missing_contract_sections")]
     public required IReadOnlyList<string> MissingContractSections { get; init; }
+
+    /// <summary>G661: the existing issue publish gate's own verdict.</summary>
+    [JsonPropertyName("publish_gate_ready")]
+    public required bool PublishGateReady { get; init; }
+
+    /// <summary>G661: visible reason a present scaffold is not issue-cut-ready.</summary>
+    [JsonPropertyName("not_ready_reason")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? NotReadyReason { get; init; }
 
     /// <summary>
     /// G354: per-section gap classification and repair guidance.

--- a/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssuePublishFlowCommand.cs
@@ -121,11 +121,16 @@ internal static class IssuePublishFlowCommand
         }
 
         var githubBodyPresent = File.Exists(githubBodyPath);
-        IReadOnlyList<string> missing = githubBodyPresent
+        var githubBody = githubBodyPresent ? File.ReadAllText(githubBodyPath) : null;
+        var validation = githubBody is null
+            ? null
+            : IssueValidateBodyValidator.Validate(githubBodyPath, githubBody);
+        IReadOnlyList<string> missing = validation is null
             ? PacketDraftCommand.RequiredContractSections
-                .Where(section => !ContainsSectionHeading(File.ReadAllText(githubBodyPath), section))
-                .ToArray()
-            : PacketDraftCommand.RequiredContractSections;
+            : validation.MissingHeadings
+                .Concat(validation.RelatedLinksInvalid ? ["Related Links"] : Array.Empty<string>())
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
 
         // G290: prefer `packet.yaml` `title:` over the body H1 fallback so a
         // packet with valid metadata never publishes as `<id> (untitled)`.
@@ -150,7 +155,7 @@ internal static class IssuePublishFlowCommand
         // exactly one that next-slice / packet-draft / diagnostics will not
         // report issue-cut-ready. ContractComplete requires the body present AND
         // no missing required sections.
-        var contractComplete = githubBodyPresent && missing.Count == 0;
+        var contractComplete = githubBodyPresent && validation?.IsValid == true;
         if (!NextSliceReadinessEvaluator.IsPublishable(executionUnit!, contractComplete))
         {
             var validationResult = NewResult(executionUnit!, domain, repo!, packetDirectory, githubBodyPath, publishYamlPath, write,
@@ -167,7 +172,7 @@ internal static class IssuePublishFlowCommand
                 publishYamlPatched: false,
                 runsAppended: false,
                 error: githubBodyPresent
-                    ? "Child Issue Contract is incomplete; required sections are missing."
+                    ? "Child Issue Contract is incomplete; the existing publish gate rejected headings or placeholder-only Related Links."
                     : "github-body.md is missing in the packet directory.",
                 titleSource: titleSource);
             EmitResult(writer, validationResult, format);
@@ -1108,27 +1113,6 @@ internal static class IssuePublishFlowCommand
                 writer.WriteLine($"- {step}");
             }
         }
-    }
-
-    private static bool ContainsSectionHeading(string content, string section)
-    {
-        var lines = content.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
-        foreach (var rawLine in lines)
-        {
-            var line = rawLine.Trim();
-            if (!line.StartsWith("##", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            var heading = line.TrimStart('#').Trim();
-            if (string.Equals(heading, section, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -297,13 +297,23 @@ internal static class PacketDraftCommand
               expected: ""
               write_back_required: false
               write_back_targets: []
-            # G645: guide reachability is explicit and checked at closeout.
-            # Set this to false and name one route per role-facing surface,
-            # or keep the explicit no-surface answer when this slice adds no
-            # role-facing surface. A blank declaration is not a decision.
-            guide_reachability:
-              no_role_facing_surface: true
-              routes: []
+            # G645/G661: guide reachability is explicit and checked at closeout.
+            # Uncomment and complete EXACTLY ONE accepted form. Leaving this
+            # commented is visibly undeclared; the scaffold never guesses that
+            # a new slice has no role-facing surface.
+            #
+            # Route form:
+            # guide_reachability:
+            #   no_role_facing_surface: false
+            #   routes:
+            #     - guide_surface: guide workflow task implementation-loop
+            #       role: implementation
+            #       target_surface: <role-facing-surface>
+            #
+            # Explicit no-surface form:
+            # guide_reachability:
+            #   no_role_facing_surface: true
+            #   routes: []
             """;
     }
 

--- a/src/IntentSystem.Cli/Commands/PacketLifecycle.cs
+++ b/src/IntentSystem.Cli/Commands/PacketLifecycle.cs
@@ -74,7 +74,10 @@ internal static class PacketLifecycle
             AbsorbedBy = fields.GetValueOrDefault("absorbed_by"),
             SupersededBy = fields.GetValueOrDefault("superseded_by"),
             RetiredReason = fields.GetValueOrDefault("retired_reason"),
-            RetiredAt = fields.GetValueOrDefault("retired_at")
+            RetiredAt = fields.GetValueOrDefault("retired_at"),
+            ReactivatedFrom = fields.GetValueOrDefault("reactivated_from"),
+            ReactivationEvidence = fields.GetValueOrDefault("reactivation_evidence"),
+            ReactivatedAt = fields.GetValueOrDefault("reactivated_at")
         };
     }
 
@@ -184,7 +187,10 @@ internal static class PacketLifecycle
             AbsorbedBy = fields.GetValueOrDefault("absorbed_by"),
             SupersededBy = fields.GetValueOrDefault("superseded_by"),
             RetiredReason = fields.GetValueOrDefault("retired_reason"),
-            RetiredAt = fields.GetValueOrDefault("retired_at")
+            RetiredAt = fields.GetValueOrDefault("retired_at"),
+            ReactivatedFrom = fields.GetValueOrDefault("reactivated_from"),
+            ReactivationEvidence = fields.GetValueOrDefault("reactivation_evidence"),
+            ReactivatedAt = fields.GetValueOrDefault("reactivated_at")
         };
 
         if (trimmedLifecycle == LifecycleReady)
@@ -272,6 +278,9 @@ internal static class PacketLifecycle
         AppendOptional(builder, "superseded_by", metadata.SupersededBy);
         AppendOptional(builder, "retired_reason", metadata.RetiredReason);
         AppendOptional(builder, "retired_at", metadata.RetiredAt);
+        AppendOptional(builder, "reactivated_from", metadata.ReactivatedFrom);
+        AppendOptional(builder, "reactivation_evidence", metadata.ReactivationEvidence);
+        AppendOptional(builder, "reactivated_at", metadata.ReactivatedAt);
         return builder.ToString();
     }
 
@@ -352,6 +361,12 @@ internal sealed record PacketLifecycleMetadata
     public string? RetiredReason { get; init; }
 
     public string? RetiredAt { get; init; }
+
+    public string? ReactivatedFrom { get; init; }
+
+    public string? ReactivationEvidence { get; init; }
+
+    public string? ReactivatedAt { get; init; }
 }
 
 /// <summary>

--- a/src/IntentSystem.Cli/Commands/PacketRetireCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketRetireCommand.cs
@@ -28,12 +28,15 @@ internal static class PacketRetireCommand
     private const string StatusRetired = "retired";
     private const string StatusAlreadyRetired = "already-retired";
     private const string StatusPlanned = "planned";
+    private const string StatusReactivated = "reactivated";
+    private const string StatusAlreadyReactivated = "already-reactivated";
 
     private const string RetireActor = "intent-cli";
     private const string RunEventName = "packet-retired";
+    private const string ReactivateRunEventName = "packet-reactivated";
 
     private const string UsageLine =
-        "Usage: intent-cli packet retire --execution-unit <id> (--absorbed-by <unit> | --superseded-by <unit> | --retired) --reason <text> [--write] [--format markdown|json]";
+        "Usage: intent-cli packet retire --execution-unit <id> ((--absorbed-by <unit> | --superseded-by <unit> | --retired) --reason <text> | --reactivate --evidence <text>) [--write] [--format markdown|json]";
 
     private static readonly Regex ExecutionUnitPattern = new(
         @"^[A-Za-z][A-Za-z0-9-]*$",
@@ -68,7 +71,9 @@ internal static class PacketRetireCommand
             out var absorbedBy,
             out var supersededBy,
             out var retired,
+            out var reactivate,
             out var reason,
+            out var evidence,
             out var write,
             out var format,
             out var error))
@@ -93,14 +98,29 @@ internal static class PacketRetireCommand
             return 1;
         }
 
-        var lifecycle = absorbedBy is not null
+        var lifecycle = reactivate
+            ? PacketLifecycle.LifecycleReady
+            : absorbedBy is not null
             ? PacketLifecycle.LifecycleAbsorbed
             : supersededBy is not null
                 ? PacketLifecycle.LifecycleSuperseded
                 : PacketLifecycle.LifecycleRetired;
 
         var existing = PacketLifecycle.TryRead(packetDirectory);
-        var alreadyRetired = existing is not null
+        if (reactivate && existing is null)
+        {
+            writer.WriteLine($"Cannot reactivate '{executionUnit}': no lifecycle metadata exists to prove a prior retirement.");
+            return 1;
+        }
+        if (reactivate && existing is not null
+            && existing.Lifecycle != PacketLifecycle.LifecycleReady
+            && !PacketLifecycle.IsNonPublishable(existing))
+        {
+            writer.WriteLine($"Cannot reactivate '{executionUnit}': lifecycle '{existing.Lifecycle}' is not a recognized retired state.");
+            return 1;
+        }
+
+        var alreadyRetired = !reactivate && existing is not null
             && string.Equals(existing.Lifecycle, lifecycle, StringComparison.Ordinal)
             && string.Equals(existing.AbsorbedBy, absorbedBy, StringComparison.Ordinal)
             && string.Equals(existing.SupersededBy, supersededBy, StringComparison.Ordinal)
@@ -110,8 +130,28 @@ internal static class PacketRetireCommand
         string mode;
         string status;
         string? retiredAt = existing?.RetiredAt;
+        string? reactivatedAt = existing?.ReactivatedAt;
+        string? reactivatedFrom = existing?.ReactivatedFrom;
+        if (reactivate && existing is not null && PacketLifecycle.IsNonPublishable(existing))
+        {
+            reactivatedFrom ??= existing.Lifecycle;
+        }
+        var alreadyReactivated = reactivate
+            && existing is not null
+            && string.Equals(existing.Lifecycle, PacketLifecycle.LifecycleReady, StringComparison.Ordinal)
+            && string.Equals(existing.ReactivationEvidence, evidence, StringComparison.Ordinal);
 
-        if (alreadyRetired)
+        if (alreadyReactivated)
+        {
+            mode = write ? ModeWrite : ModeDryRun;
+            status = StatusAlreadyReactivated;
+        }
+        else if (reactivate && existing?.Lifecycle == PacketLifecycle.LifecycleReady)
+        {
+            writer.WriteLine($"'{executionUnit}' is already active with different reactivation evidence; refusing to replace the recorded transition.");
+            return 1;
+        }
+        else if (alreadyRetired)
         {
             // Idempotent: same retirement already recorded. Do not rewrite the
             // sidecar or append a duplicate run event.
@@ -120,31 +160,54 @@ internal static class PacketRetireCommand
         }
         else if (write)
         {
-            retiredAt = TimestampFactory().ToString("O");
-            var metadata = new PacketLifecycleMetadata
+            var transitionAt = TimestampFactory();
+            PacketLifecycleMetadata metadata;
+            string runEvent;
+            string runReason;
+            if (reactivate)
             {
-                Lifecycle = lifecycle,
-                AbsorbedBy = absorbedBy,
-                SupersededBy = supersededBy,
-                RetiredReason = reason,
-                RetiredAt = retiredAt
-            };
+                reactivatedAt = transitionAt.ToString("O");
+                reactivatedFrom = existing!.Lifecycle;
+                metadata = new PacketLifecycleMetadata
+                {
+                    Lifecycle = PacketLifecycle.LifecycleReady,
+                    ReactivatedFrom = reactivatedFrom,
+                    ReactivationEvidence = evidence,
+                    ReactivatedAt = reactivatedAt,
+                };
+                runEvent = ReactivateRunEventName;
+                runReason = evidence!;
+            }
+            else
+            {
+                retiredAt = transitionAt.ToString("O");
+                metadata = new PacketLifecycleMetadata
+                {
+                    Lifecycle = lifecycle,
+                    AbsorbedBy = absorbedBy,
+                    SupersededBy = supersededBy,
+                    RetiredReason = reason,
+                    RetiredAt = retiredAt
+                };
+                runEvent = RunEventName;
+                runReason = reason!;
+            }
 
             File.WriteAllText(sidecarPath, PacketLifecycle.Render(metadata));
             AppendRunEvent(
                 context,
                 new RunEvent
                 {
-                    Ts = TimestampFactory(),
+                    Ts = transitionAt,
                     ExecutionUnit = executionUnit!,
-                    Event = RunEventName,
+                    Event = runEvent,
                     By = RetireActor,
-                    Reason = reason,
+                    Reason = runReason,
                     PacketRef = sidecarPath
                 });
 
             mode = ModeWrite;
-            status = StatusRetired;
+            status = reactivate ? StatusReactivated : StatusRetired;
         }
         else
         {
@@ -163,7 +226,10 @@ internal static class PacketRetireCommand
             AbsorbedBy = absorbedBy,
             SupersededBy = supersededBy,
             RetiredReason = reason,
-            RetiredAt = retiredAt
+            RetiredAt = retiredAt,
+            ReactivationEvidence = evidence,
+            ReactivatedFrom = reactivatedFrom,
+            ReactivatedAt = reactivatedAt,
         };
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
@@ -185,7 +251,9 @@ internal static class PacketRetireCommand
         out string? absorbedBy,
         out string? supersededBy,
         out bool retired,
+        out bool reactivate,
         out string? reason,
+        out string? evidence,
         out bool write,
         out string format,
         out string error)
@@ -194,7 +262,9 @@ internal static class PacketRetireCommand
         absorbedBy = null;
         supersededBy = null;
         retired = false;
+        reactivate = false;
         reason = null;
+        evidence = null;
         write = false;
         format = FormatMarkdown;
         error = string.Empty;
@@ -231,10 +301,21 @@ internal static class PacketRetireCommand
                 case "--retired":
                     retired = true;
                     break;
+                case "--reactivate":
+                    reactivate = true;
+                    break;
                 case "--reason":
                     if (!TryTakeValue(args, ref index, out reason))
                     {
                         error = "--reason requires a value.";
+                        return false;
+                    }
+
+                    break;
+                case "--evidence":
+                    if (!TryTakeValue(args, ref index, out evidence))
+                    {
+                        error = "--evidence requires a value.";
                         return false;
                     }
 
@@ -273,20 +354,27 @@ internal static class PacketRetireCommand
 
         var relationshipCount = (absorbedBy is not null ? 1 : 0)
             + (supersededBy is not null ? 1 : 0)
-            + (retired ? 1 : 0);
+            + (retired ? 1 : 0)
+            + (reactivate ? 1 : 0);
         if (relationshipCount == 0)
         {
-            error = "Exactly one of --absorbed-by, --superseded-by, or --retired is required.";
+            error = "Exactly one of --absorbed-by, --superseded-by, --retired, or --reactivate is required.";
             return false;
         }
 
         if (relationshipCount > 1)
         {
-            error = "--absorbed-by, --superseded-by, and --retired are mutually exclusive.";
+            error = "--absorbed-by, --superseded-by, --retired, and --reactivate are mutually exclusive.";
             return false;
         }
 
-        if (string.IsNullOrWhiteSpace(reason))
+        if (reactivate && string.IsNullOrWhiteSpace(evidence))
+        {
+            error = "--reactivate requires --evidence <text>; reactivation must preserve why the prior retirement is no longer valid.";
+            return false;
+        }
+
+        if (!reactivate && string.IsNullOrWhiteSpace(reason))
         {
             error = "--reason is required; retirement must record a deterministic reason.";
             return false;
@@ -340,6 +428,12 @@ internal static class PacketRetireCommand
         {
             writer.WriteLine($"- retired_at: {result.RetiredAt}");
         }
+        if (result.ReactivationEvidence is not null)
+        {
+            writer.WriteLine($"- reactivated_from: {result.ReactivatedFrom}");
+            writer.WriteLine($"- reactivation_evidence: {result.ReactivationEvidence}");
+            writer.WriteLine($"- reactivated_at: {result.ReactivatedAt}");
+        }
 
         writer.WriteLine($"- sidecar: {result.SidecarPath}");
         writer.WriteLine();
@@ -347,13 +441,15 @@ internal static class PacketRetireCommand
         {
             writer.WriteLine("Dry-run: re-run with --write to record the retirement and preserve packet files.");
         }
-        else if (result.Status == StatusAlreadyRetired)
+        else if (result.Status is StatusAlreadyRetired or StatusAlreadyReactivated)
         {
-            writer.WriteLine("Already retired with the same metadata; no changes written (idempotent).");
+            writer.WriteLine("Lifecycle transition already carries the same evidence; no changes written (idempotent).");
         }
         else
         {
-            writer.WriteLine("Packet files preserved; excluded from next-slice issue-cut-ready candidates.");
+            writer.WriteLine(result.Status == StatusReactivated
+                ? "Packet reactivated with durable evidence; packet files and the prior mistake remain visible in git history."
+                : "Packet files preserved; excluded from next-slice issue-cut-ready candidates.");
         }
     }
 
@@ -366,6 +462,7 @@ internal static class PacketRetireCommand
         writer.WriteLine("Marks an absorbed / superseded / retired packet so next-slice excludes it");
         writer.WriteLine("from issue-cut-ready candidates, while preserving the packet files in git history.");
         writer.WriteLine("Writes a lifecycle.yaml sidecar and appends a packet-retired run event. Idempotent.");
+        writer.WriteLine("--reactivate requires --evidence, records packet-reactivated, and never silently clears retirement.");
     }
 
     internal sealed record PacketRetireResult
@@ -399,5 +496,14 @@ internal static class PacketRetireCommand
 
         [JsonPropertyName("retired_at")]
         public string? RetiredAt { get; init; }
+
+        [JsonPropertyName("reactivation_evidence")]
+        public string? ReactivationEvidence { get; init; }
+
+        [JsonPropertyName("reactivated_from")]
+        public string? ReactivatedFrom { get; init; }
+
+        [JsonPropertyName("reactivated_at")]
+        public string? ReactivatedAt { get; init; }
     }
 }

--- a/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/CloseoutPrCommandTests.cs
@@ -166,6 +166,49 @@ public sealed class CloseoutPrCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_Rh030AShape_ReportsShippedWhileRetiredWithoutUnretiring_G661()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueState("RH-030A", "review", linkedPr: "98"));
+        var packetDirectory = Path.Combine(workspace.Context.RepoRoot, ".intent-cli", "issues", "RH-030A");
+        Directory.CreateDirectory(packetDirectory);
+        var sidecarPath = Path.Combine(packetDirectory, PacketLifecycle.SidecarFileName);
+        const string retired = "lifecycle: retired\nretired_reason: empty scaffold\n";
+        File.WriteAllText(sidecarPath, retired);
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "98", "--pr-merged", "true", "--write", "--format", "json"],
+            writer));
+
+        using var result = JsonDocument.Parse(writer.ToString());
+        var finding = Assert.Single(result.RootElement.GetProperty("findings").EnumerateArray());
+        Assert.Equal("shipped-while-retired-contradiction", finding.GetProperty("kind").GetString());
+        Assert.Contains("--reactivate --evidence", finding.GetProperty("recommended_action").GetString()!, StringComparison.Ordinal);
+        Assert.Equal(retired, File.ReadAllText(sidecarPath));
+    }
+
+    [Fact]
+    public void Execute_EvidencedReactivationThenCloseout_HasNoContradiction_G661()
+    {
+        using var workspace = new CloseoutPrWorkspace();
+        workspace.WriteQueueState(BuildQueueState("RH-030A", "review", linkedPr: "98"));
+        var packetDirectory = Path.Combine(workspace.Context.RepoRoot, ".intent-cli", "issues", "RH-030A");
+        Directory.CreateDirectory(packetDirectory);
+        File.WriteAllText(Path.Combine(packetDirectory, PacketLifecycle.SidecarFileName),
+            "lifecycle: ready\nreactivated_from: retired\nreactivation_evidence: real defect\n");
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, CloseoutPrCommand.Execute(
+            workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--pr", "98", "--pr-merged", "true", "--dry-run", "--format", "json"],
+            writer));
+        using var result = JsonDocument.Parse(writer.ToString());
+        Assert.Empty(result.RootElement.GetProperty("findings").EnumerateArray());
+    }
+
+    [Fact]
     public void Execute_GivenDryRun_DoesNotMutateAnyFile()
     {
         using var workspace = new CloseoutPrWorkspace();

--- a/tests/IntentSystem.Cli.Tests/G661DocumentationParityTests.cs
+++ b/tests/IntentSystem.Cli.Tests/G661DocumentationParityTests.cs
@@ -1,0 +1,31 @@
+namespace IntentSystem.Cli.Tests;
+
+public sealed class G661DocumentationParityTests
+{
+    [Fact]
+    public void OrchestrationReference_CarriesFiveFixesInEnglishAndJapanese_G661()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var required = new[]
+        {
+            "knowledge-writeback-record",
+            "knowledge-writeback-recorded-uncommitted",
+            "--reactivate --evidence",
+            "shipped-while-retired-contradiction",
+            "publish validator",
+            "guide_reachability:",
+            ".intent-cli/runs.jsonl merge=union",
+            ".intent-cli/**/*.jsonl merge=union",
+            ".intent-cli/supervision/**/cycles.jsonl",
+            ".intent-cli/supervision/**/stalls.jsonl",
+        };
+
+        foreach (var language in new[] { "en", "ja" })
+        {
+            var content = File.ReadAllText(Path.Combine(root, "docs", language, "12-agent-message-orchestration.md"));
+            Assert.Contains("G661", content, StringComparison.Ordinal);
+            Assert.Contains("preview", content, StringComparison.OrdinalIgnoreCase);
+            Assert.All(required, item => Assert.Contains(item, content, StringComparison.Ordinal));
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/GuideReachabilityG645Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideReachabilityG645Tests.cs
@@ -105,7 +105,10 @@ public sealed class GuideReachabilityG645Tests : IDisposable
                 StringComparison.Ordinal));
         Assert.Contains(
             result.GetProperty("warnings").EnumerateArray().Select(warning => warning.GetString()),
-            warning => warning is not null && warning.Contains("no guide_reachability declaration", StringComparison.Ordinal));
+            warning => warning is not null
+                && warning.Contains("no guide_reachability declaration", StringComparison.Ordinal)
+                && warning.Contains(GuideReachabilityDeclaration.RouteYaml, StringComparison.Ordinal)
+                && warning.Contains(GuideReachabilityDeclaration.NoSurfaceYaml, StringComparison.Ordinal));
 
         var recorded = workspace.RunRecord(["--execution-unit", "G645", "--commit", HostCommit, "--format", "json"]);
         Assert.Equal(1, recorded.ExitCode);
@@ -123,11 +126,44 @@ public sealed class GuideReachabilityG645Tests : IDisposable
             writer));
 
         var packet = File.ReadAllText(Path.Combine(workspace.RootPath, ".intent-cli", "issues", "G645", "packet.yaml"));
-        Assert.Contains("guide_reachability:", packet, StringComparison.Ordinal);
-        Assert.Contains("no_role_facing_surface: true", packet, StringComparison.Ordinal);
+        Assert.Contains("# guide_reachability:", packet, StringComparison.Ordinal);
+        Assert.Contains("#   no_role_facing_surface: true", packet, StringComparison.Ordinal);
+        Assert.False(GuideReachabilityDeclaration.Read(packet).IsDeclared);
         var guide = CommandRouterOutput("guide", "workflow", "task", "packet-draft");
         Assert.Contains("guide-reachability", guide, StringComparison.Ordinal);
         Assert.Contains("keyword-to-guide", guide, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void WarningYamlPastedVerbatim_IsAcceptedAndSilencesWarning_G661(bool routeForm)
+    {
+        using var workspace = new ReachabilityWorkspace();
+        var declaration = routeForm
+            ? GuideReachabilityDeclaration.RouteYaml.Replace("<role-facing-surface>", "notify supervise", StringComparison.Ordinal)
+            : GuideReachabilityDeclaration.NoSurfaceYaml;
+        workspace.WritePacket("G661", $"""
+            implementation_issue_packet:
+              source_execution_unit: G661
+              domain: intent-cli
+            {declaration}
+            """);
+        workspace.WriteCloseout("G661", FixedNow.AddMinutes(-180));
+
+        var result = workspace.RunStalledWorkResult();
+        Assert.DoesNotContain(
+            result.GetProperty("warnings").EnumerateArray(),
+            warning => warning.GetString()!.Contains("no guide_reachability declaration", StringComparison.Ordinal));
+        if (routeForm)
+        {
+            Assert.Contains(result.GetProperty("items").EnumerateArray(),
+                item => item.GetProperty("kind").GetString() == AutomationStalledWorkCommand.KindGuideReachabilityPending);
+        }
+        else
+        {
+            Assert.Empty(result.GetProperty("items").EnumerateArray());
+        }
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IntentInitCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentInitCommandTests.cs
@@ -391,6 +391,64 @@ public sealed class IntentInitCommandTests
         Assert.Equal(existing, File.ReadAllText(queueStatePath));
     }
 
+    [Fact]
+    public void Execute_FreshHostWritesUnionAttributesAndTelemetryIgnores_G661()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        File.WriteAllText(Path.Combine(hostRoot, ".gitattributes"), "*.md text\n");
+        File.WriteAllText(Path.Combine(hostRoot, ".gitignore"), ".DS_Store\n");
+        using var writer = new StringWriter();
+
+        Assert.Equal(0, IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "demo", "--write", "--format", "json"],
+            writer));
+
+        var attributes = File.ReadAllText(Path.Combine(hostRoot, ".gitattributes"));
+        var ignores = File.ReadAllText(Path.Combine(hostRoot, ".gitignore"));
+        Assert.Contains("*.md text", attributes, StringComparison.Ordinal);
+        Assert.All(IntentInitCommand.AppendOnlyGitAttributesLines,
+            line => Assert.Contains(line, attributes, StringComparison.Ordinal));
+        Assert.Contains(".DS_Store", ignores, StringComparison.Ordinal);
+        Assert.All(IntentInitCommand.SupervisionTelemetryGitIgnoreLines,
+            line => Assert.Contains(line, ignores, StringComparison.Ordinal));
+
+        using var result = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        Assert.True(result.RootElement.GetProperty("fresh_host").GetBoolean());
+        Assert.Contains("merge=union", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("never auto-migrated", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ExistingHostOnlyReportsExactGuidanceAndDoesNotMigrate_G661()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var hostRoot = tempDirectory.CreateDirectory("host");
+        Directory.CreateDirectory(Path.Combine(hostRoot, ".intent-cli"));
+        File.WriteAllText(Path.Combine(hostRoot, ".intent-cli", "config.toml"), "[project]\ndomain=\"demo\"\n");
+        File.WriteAllText(Path.Combine(hostRoot, ".gitattributes"), "*.md text\n");
+        File.WriteAllText(Path.Combine(hostRoot, ".gitignore"), ".DS_Store\n");
+        var attributesBefore = File.ReadAllText(Path.Combine(hostRoot, ".gitattributes"));
+        var ignoresBefore = File.ReadAllText(Path.Combine(hostRoot, ".gitignore"));
+        using var writer = new StringWriter();
+
+        Assert.Equal(0, IntentInitCommand.Execute(
+            CreateContext(hostRoot),
+            ["--domain", "demo", "--write", "--format", "json"],
+            writer));
+
+        Assert.Equal(attributesBefore, File.ReadAllText(Path.Combine(hostRoot, ".gitattributes")));
+        Assert.Equal(ignoresBefore, File.ReadAllText(Path.Combine(hostRoot, ".gitignore")));
+        using var result = System.Text.Json.JsonDocument.Parse(writer.ToString());
+        Assert.False(result.RootElement.GetProperty("fresh_host").GetBoolean());
+        Assert.Contains("never auto-migrated", result.RootElement.GetProperty("existing_host_guidance").GetString()!, StringComparison.Ordinal);
+        Assert.All(IntentInitCommand.AppendOnlyGitAttributesLines,
+            line => Assert.Contains(line, writer.ToString(), StringComparison.Ordinal));
+        Assert.All(IntentInitCommand.SupervisionTelemetryGitIgnoreLines,
+            line => Assert.Contains(line, writer.ToString(), StringComparison.Ordinal));
+    }
+
     private static CliContext CreateContext(string repoRoot)
     {
         return new CliContext

--- a/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IntentNextSliceCommandTests.cs
@@ -2795,7 +2795,7 @@ public sealed class IntentNextSliceCommandTests
 
             ## Related Links
 
-            - (none)
+            - G354 verification evidence
 
             ## Base Branch Policy
 
@@ -2851,7 +2851,7 @@ public sealed class IntentNextSliceCommandTests
 
             ## Related Links
 
-            - (none)
+            - G354 product-gap evidence
             """);
 
         using var writer = new StringWriter();
@@ -3749,6 +3749,46 @@ public sealed class IntentNextSliceCommandTests
         var root = document.RootElement;
         Assert.Equal("issue-cut-ready", root.GetProperty("recommended_outcome").GetString());
         Assert.Equal(0, root.GetProperty("candidate").GetProperty("missing_contract_sections").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_TodoScaffoldUsesPublishGateAndIsVisiblyNotReady_G661()
+    {
+        using var workspace = new IntentNextSliceWorkspace();
+        Assert.Equal(0, PacketDraftCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "G661", "--target-repo", "J-Tech-Japan/intent-system"],
+            TextWriter.Null));
+        workspace.WriteQueueState(
+            """
+            {
+              "schema_version": "1",
+              "updated_at": "2026-08-10T00:00:00Z",
+              "items": [
+                {
+                  "execution_unit": "G661",
+                  "title": "TODO short title",
+                  "state": "queued",
+                  "dependencies": [],
+                  "blocked_by": [],
+                  "clarification_return_path": "intents/intent-cli/clarifications/open.md",
+                  "packet_paths": {"implementation": "a", "review_context": "b", "yaml": "c"},
+                  "worker_role": "coder",
+                  "review_role": "reviewer",
+                  "priority": "normal"
+                }
+              ]
+            }
+            """);
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, IntentNextSliceCommand.Execute(workspace.Context, ["--dry-run"], writer));
+        using var result = JsonDocument.Parse(writer.ToString());
+        Assert.NotEqual("issue-cut-ready", result.RootElement.GetProperty("recommended_outcome").GetString());
+        var candidate = result.RootElement.GetProperty("candidate");
+        Assert.False(candidate.GetProperty("publish_gate_ready").GetBoolean());
+        Assert.Contains("Related Links", candidate.GetProperty("not_ready_reason").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("Related Links", candidate.GetProperty("missing_contract_sections").EnumerateArray().Select(item => item.GetString()));
     }
 
     private sealed class IntentNextSliceWorkspace : IDisposable

--- a/tests/IntentSystem.Cli.Tests/KnowledgeWriteBackG564Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/KnowledgeWriteBackG564Tests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
@@ -90,6 +91,29 @@ public sealed class KnowledgeWriteBackG564Tests : IDisposable
         Assert.False(record.Json.GetProperty("already_recorded").GetBoolean());
         Assert.True(File.Exists(workspace.RecordPath("G564")));
 
+        Assert.Equal(0, workspace.RunStalledWork().GetArrayLength());
+    }
+
+    [Fact]
+    public void RecordedButUncommitted_IsDistinctAndNamesThePath_G661()
+    {
+        using var workspace = new WriteBackWorkspace();
+        workspace.InitializeGit();
+        workspace.WriteDeclaringPacket("G661", requiredIntentTree: true, targets: ["intents/node-02.md"]);
+        workspace.WriteCloseout("G661", FixedNow.AddMinutes(-45));
+        workspace.CommitAll("baseline closeout");
+
+        var record = workspace.RunRecord(["--execution-unit", "G661", "--commit", HostCommit, "--write", "--format", "json"]);
+        Assert.True(record.Json.GetProperty("commit_push_required_for_other_checkouts").GetBoolean());
+        Assert.Contains("committed and pushed", record.Json.GetProperty("durability_guidance").GetString()!, StringComparison.Ordinal);
+
+        var item = Assert.Single(workspace.RunStalledWork().EnumerateArray());
+        Assert.Equal(AutomationStalledWorkCommand.KindKnowledgeWritebackRecordedUncommitted, item.GetProperty("kind").GetString());
+        Assert.Equal(".intent-cli/knowledge-writebacks/G661/record.json", item.GetProperty("record_path").GetString());
+        Assert.Contains("commit and push", item.GetProperty("recommended_action").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("knowledge-writebacks", workspace.GitStatus(), StringComparison.Ordinal);
+
+        workspace.CommitAll("commit writeback record");
         Assert.Equal(0, workspace.RunStalledWork().GetArrayLength());
     }
 
@@ -846,6 +870,45 @@ public sealed class KnowledgeWriteBackG564Tests : IDisposable
             var document = JsonDocument.Parse(writer.ToString());
             _documents.Add(document);
             return new RecordRun(exit, document.RootElement);
+        }
+
+        public void InitializeGit()
+        {
+            RunGit("init", "-q");
+            RunGit("config", "user.email", "tests@example.com");
+            RunGit("config", "user.name", "Intent CLI Tests");
+        }
+
+        public void CommitAll(string message)
+        {
+            RunGit("add", ".");
+            RunGit("commit", "-q", "-m", message);
+        }
+
+        public string GitStatus() => RunGit("status", "--short");
+
+        private string RunGit(params string[] args)
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo("git")
+                {
+                    WorkingDirectory = RootPath,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                },
+            };
+            foreach (var arg in args)
+            {
+                process.StartInfo.ArgumentList.Add(arg);
+            }
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            Assert.True(process.ExitCode == 0, $"git {string.Join(' ', args)} failed: {error}");
+            return output;
         }
 
         public void Dispose()

--- a/tests/IntentSystem.Cli.Tests/PacketRetireCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketRetireCommandTests.cs
@@ -117,6 +117,40 @@ public sealed class PacketRetireCommandTests
     }
 
     [Fact]
+    public void Execute_ReactivateRequiresAndRecordsEvidence_G661()
+    {
+        using var workspace = new PacketRetireWorkspace();
+        workspace.CreatePacket("RH-030A");
+        Assert.Equal(0, PacketRetireCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "RH-030A", "--retired", "--reason", "empty scaffold", "--write", "--format", "json"],
+            TextWriter.Null));
+
+        using var missingEvidence = new StringWriter();
+        Assert.Equal(1, PacketRetireCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "RH-030A", "--reactivate", "--write"],
+            missingEvidence));
+        Assert.Contains("--evidence", missingEvidence.ToString(), StringComparison.Ordinal);
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, PacketRetireCommand.Execute(
+            workspace.Context,
+            ["--execution-unit", "RH-030A", "--reactivate", "--evidence", "real defect shipped in PR #98", "--write", "--format", "json"],
+            writer));
+        using var result = JsonDocument.Parse(writer.ToString());
+        Assert.Equal("reactivated", result.RootElement.GetProperty("status").GetString());
+        Assert.Equal("ready", result.RootElement.GetProperty("lifecycle").GetString());
+        Assert.Equal("retired", result.RootElement.GetProperty("reactivated_from").GetString());
+        Assert.Equal("real defect shipped in PR #98", result.RootElement.GetProperty("reactivation_evidence").GetString());
+
+        var sidecar = File.ReadAllText(Path.Combine(workspace.PacketDirectory("RH-030A"), "lifecycle.yaml"));
+        Assert.Contains("lifecycle: ready", sidecar, StringComparison.Ordinal);
+        Assert.Contains("reactivation_evidence: \"real defect shipped in PR #98\"", sidecar, StringComparison.Ordinal);
+        Assert.Contains("packet-reactivated", File.ReadAllText(workspace.Context.GetRunLogPath()), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_MissingPacketDirectory_Fails()
     {
         using var workspace = new PacketRetireWorkspace();


### PR DESCRIPTION
## Summary

- make knowledge writeback durability explicit and distinguish recorded-but-uncommitted records
- require evidenced packet reactivation and surface RH-030A shipped/retired contradictions
- reuse publish-gate readiness for TODO drafts and emit paste-ready guide reachability YAML
- scaffold fresh-host merge/ignore policy while keeping existing hosts guidance-only
- preserve EN/JA preview parity

## Validation

- focused G661 and compatibility matrix: 403 passed
- full Release solution: 4,983 passed, 1 skipped, 0 failed
- RH-030A retire/reactivate/closeout regressions green
- writeback, reachability, readiness, fresh/existing init, EN/JA, and G613 regressions green
- git diff --check: clean

Closes #1427