### PR TITLE
G663: prepare v0.17.0 release notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2556,7 +2556,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0162)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0170)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2649,33 +2649,34 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.16.2)
+### Next release readiness (v0.17.0)
 
 **`v0.16.1` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.16.2`. [The v0.16.2 notes stub](release-notes-v0.16.2.md) is the required
-prepare-only placeholder. See [release-notes-v0.16.1.md](release-notes-v0.16.1.md)
-for the preceding shipped scope.
+`0.17.0`. [The v0.17.0 notes](release-notes-v0.17.0.md) are a real prepare-only
+release candidate. See [release-notes-v0.16.1.md](release-notes-v0.16.1.md) and
+[release-notes-v0.16.0.md](release-notes-v0.16.0.md) for the preceding shipped
+scopes; they are linked rather than restated.
 
-**Release-readiness verification (run before merging the `v0.16.2`
+**Release-readiness verification (run before merging the `v0.17.0`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.16.1 (published), nextVersion 0.16.2 (to release)
+cat eng/version.json   # stableVersion 0.16.1 (published), nextVersion 0.17.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.16.2-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.17.0-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.16.2.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.17.0.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0162DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Run the complete Release suite.
 dotnet test IntentSystem.sln -c Release
@@ -2684,10 +2685,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.16.2`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.17.0`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.16.2`, `nextVersion → 0.16.3` — carrying, per **steps 4–6** of the
+`stableVersion → 0.17.0`, `nextVersion → 0.17.1` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.16.2.md
+++ b/docs/en/release-notes-v0.16.2.md
@@ -1,9 +1,0 @@
-# Release Notes — intent-cli v0.16.2
-
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.16.2`.
-The eventual release will be published at
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.16.2.

--- a/docs/en/release-notes-v0.17.0.md
+++ b/docs/en/release-notes-v0.17.0.md
@@ -1,0 +1,136 @@
+# Release Notes — intent-cli v0.17.0
+
+> **Prepare-only / UNRELEASED.** This preparation changes version state,
+> release notes, and readiness documentation only. It creates no GitHub
+> Release, tag, package publish, or release workflow run; Release creation
+> remains the operator's step.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.17.0`.
+When approved, the release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.17.0.
+See the [v0.16.1 notes](release-notes-v0.16.1.md) and the
+[v0.16.0 notes](release-notes-v0.16.0.md) for the preceding scopes; those
+notes are linked, not repeated here.
+
+## Preview lane — read before the feature description
+
+The surfaces described below are `preview-through-1.x`: they are outside the
+[1.0 compatibility promise](1.0-compatibility-promise.md), may change or be
+withdrawn during the 1.x line, and are not 1.0 compatibility commitments.
+
+## Operating contract for supervised teams
+
+Three teams ran Codex as the design seat and failed in the same week, not on
+model capability but on an unwritten operating contract. The three field
+reports and the 45-unit remote-herdr report are the measured basis for this
+release. G654 writes that contract; the surrounding units give the watcher
+durable activity and delivery evidence, an OS-owned lifetime, an escalation
+ladder, and a recency signal for coherence work.
+
+The organizing formula is: **each team has four judgment-bearing threads —
+design, orchestration, implementation, and review — plus one supervision
+process**. The supervision process is watcher infrastructure. It observes,
+records, and wakes the authorized thread; it does not own judgment or recovery.
+
+## What's in v0.17.0
+
+This minor release covers exactly eleven merged units, in contract order. The
+list was derived by running `git log v0.16.1..main`; all twenty commits in that
+range are accounted for below, and every named merge resolves on `main`.
+
+- G656 — PR #1410, merge commit `853b48ab` (verified on `main`): JSON guide
+  fragments are explicitly declared, and the rendering guard covers every
+  reachable missing-count headline in JSON and Markdown.
+- G652 — PR #1412, merge commit `542133f7` (verified on `main`): `notify status`
+  and supervision use durable activity sequence/time evidence to distinguish
+  `working` from `live-idle`; a bound below interval is warned, not rewritten.
+- G653 — PR #1414, merge commit `83c5feea` (verified on `main`): reports persist
+  to a generation-aware outbox before transport. An undelivered report is
+  recovered by `notify collect`, never by re-delegating the task.
+- G655 — PR #1416, merge commit `c06e16d3` (verified on `main`): orchestration
+  prepares workspace prerequisites before delegation and documents the
+  prepare-and-resume path for permission failures without making intent-cli run git.
+- G654 — PR #1418, merge commit `eae66f05` (verified on `main`): the
+  agent-kind-neutral design-thread guide defines four-outcome wakes, provenance
+  vocabulary, transaction-scoped approval, merge-authority comparison, and
+  monitoring separation.
+- G657 — PR #1420, merge commit `7ab3e297` (verified on `main`): the escalation
+  ladder gains the owner-role subject fallback, settled-red CI findings, and a
+  declared-label green fallback while preserving single-rung wakes.
+- G658 — PR #1422, merge commit `39d7cf42` (verified on `main`):
+  `notify supervise install` emits per-team launchd, Task Scheduler, or systemd
+  artifacts and their exact management commands. Install emits and never registers.
+- G659 — PR #1424, merge commit `5331ec11` (verified on `main`): opt-in event
+  mode holds recorded `herdr agent wait` calls in the one supervisor process,
+  re-arms failed waits, and wakes within seconds. Event mode keeps the interval floor.
+- G660 — PR #1426, merge commit `bdc5b5b1` (verified on `main`): one
+  residency-resolved delivery judgment is shared by status, escalate, and
+  supervise, so durable external-reader append and pane wake retain distinct bases.
+- G661 — PR #1428, merge commit `b06dac5d` (verified on `main`): five field
+  frictions are corrected across writeback commit clarity, retire reactivation,
+  placeholder exclusion, reachability scaffolding, and multi-checkout host defaults.
+- G662 — PR #1430, merge commit `f2e53c03` (verified on `main`): improve runs
+  become durable records, `guide next` uses realignment recency, and facet-check
+  states honestly that `no_facet_data: true` means the lexical check did not run.
+
+## Twenty-commit derivation
+
+The range contains the post-release roll, three squash merges, and eight
+direct-commit/merge pairs. This enumeration accounts for every commit returned
+by `git log v0.16.1..main`:
+
+| account | commits |
+|---|---|
+| post-release roll | `f3165a5c` |
+| G656 | `853b48ab` |
+| G652 | `542133f7` |
+| G653 | `83c5feea` |
+| G655 | `f6f2b6f0`, `c06e16d3` |
+| G654 | `d1ec27d8`, `eae66f05` |
+| G657 | `970eb671`, `7ab3e297` |
+| G658 | `f9b5ff96`, `39d7cf42` |
+| G659 | `30931bd2`, `5331ec11` |
+| G660 | `99f5f2b2`, `bdc5b5b1` |
+| G661 | `28a68cd0`, `b06dac5d` |
+| G662 | `234a7058`, `f2e53c03` |
+
+## Deliberate boundaries
+
+- `notify supervise install` emits an artifact and exact commands; it never
+  registers, unregisters, starts, or stops the OS scheduler.
+- Event mode adds seconds-scale evidence to the same supervisor process; the
+  independent interval cycle remains the safety floor.
+- Realignment-window recency recommends a paste-ready improve action; it never
+  schedules, runs, or grades realignment work.
+- The escalation ladder may wake design when owner-role is itself the subject;
+  design receives one escalation-class wake and gains no recovery authority.
+
+## Why this is a minor release
+
+`supervise install`, event mode, `packet retire --reactivate`, the design-thread
+guide surface, and the durable improve-run record were all absent at v0.16.1.
+They are new preview surfaces rather than patch-only corrections to an existing
+v0.16.1 contract.
+
+## Release-readiness gate
+
+Before creating the v0.17.0 Release, the operator must verify:
+
+- `eng/version.json` records stable `0.16.1` and next `0.17.0`.
+- Every one of the eleven PR merges above resolves on `main`, and all twenty
+  commits in `git log v0.16.1..main` remain accounted for by the table.
+- The preview statement precedes the feature description and links the
+  [1.0 compatibility promise](1.0-compatibility-promise.md).
+- The bilingual release-notes guard and count guard pass, followed by the full
+  Release suite, `git diff --check`, and exact-head CI.
+- The [v0.16.1 notes](release-notes-v0.16.1.md) and
+  [v0.16.0 notes](release-notes-v0.16.0.md) remain links to preceding scopes;
+  this note does not restate them.
+- Prepare-only remains in force: do not create a GitHub Release, tag, or package
+  publish until the operator explicitly performs that separate step.
+
+## Publishing v0.17.0
+
+After the readiness gate passes and the operator approves, a maintainer may
+create the GitHub Release and publish the package. This preparation PR does not
+perform that step.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2717,32 +2717,33 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.16.2)
+### 次リリース準備(v0.17.0)
 
 **`v0.16.1` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.16.2` です。[v0.16.2 notes stub](release-notes-v0.16.2.md) が必須の
-prepare-only placeholder です。直前の出荷範囲は
-[release-notes-v0.16.1.md](release-notes-v0.16.1.md) を参照してください。
+`0.17.0` です。[v0.17.0 notes](release-notes-v0.17.0.md) は実内容を持つ
+prepare-only release candidate です。直前の出荷範囲は
+[release-notes-v0.16.1.md](release-notes-v0.16.1.md) と
+[release-notes-v0.16.0.md](release-notes-v0.16.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.16.2` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.17.0` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.16.1 (published), nextVersion 0.16.2 (to release)
+cat eng/version.json   # stableVersion 0.16.1 (published), nextVersion 0.17.0 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.16.2-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.17.0-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.16.2.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.17.0.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0162DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Release suite を完全実行。
 dotnet test IntentSystem.sln -c Release
@@ -2750,10 +2751,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.16.2` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.17.0` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.16.2`、`nextVersion → 0.16.3` —
+`stableVersion → 0.17.0`、`nextVersion → 0.17.1` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.16.2.md
+++ b/docs/ja/release-notes-v0.16.2.md
@@ -1,9 +1,0 @@
-# リリースノート — intent-cli v0.16.2
-
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
-> このファイルを changelog として扱ってはいけません。
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.16.2`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.16.2 に
-publish されます。

--- a/docs/ja/release-notes-v0.17.0.md
+++ b/docs/ja/release-notes-v0.17.0.md
@@ -1,0 +1,126 @@
+# リリースノート — intent-cli v0.17.0
+
+> **prepare-only / 未リリース。** この準備では version state、release notes、
+> readiness documentation だけを変更します。GitHub Release、tag、package publish、
+> release workflow は作成・実行せず、Release 作成は operator の手順として残します。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.17.0`。
+承認後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.17.0 に公開されます。
+直前の scope は [v0.16.1 notes](release-notes-v0.16.1.md) と
+[v0.16.0 notes](release-notes-v0.16.0.md) を参照し、ここでは重複記載しません。
+
+## feature description の前に読む preview lane
+
+以下の surface は `preview-through-1.x` です。[1.0 compatibility promise](1.0-compatibility-promise.md)
+の対象外であり、1.x の間に変更または撤回される可能性があり、1.0 の compatibility commitment
+ではありません。
+
+## supervised team の operating contract
+
+三つの team が Codex を design seat として動かし、同じ週に失敗しました。原因は model capability
+ではなく、書かれていない operating contract でした。三件の field report と 45-unit remote-herdr
+report がこの release の measured basis です。G654 が contract を明文化し、周辺 unit が watcher に
+durable activity/delivery evidence、OS-owned lifetime、escalation ladder、coherence work の recency signal
+を与えます。
+
+中心となる formula は、**各 team = 四つの judgment-bearing thread — design、orchestration、
+implementation、review — + 一つの supervision process** です。supervision process は watcher
+infrastructure であり、観測、記録、authorized thread の wake は行いますが、judgment や recovery
+authority は持ちません。
+
+## v0.17.0 の内容
+
+この minor release は contract 順で正確に十一件の merged unit を対象にします。一覧は
+`git log v0.16.1..main` を実行して導出し、その範囲の全二十 commit を以下で説明しています。
+記載したすべての merge が `main` に解決することも確認しています。
+
+- G656 — PR #1410、merge commit `853b48ab`（`main` で確認）: JSON guide fragment を明示宣言し、
+  rendering guard が JSON と Markdown の到達可能な missing-count headline をすべて検証します。
+- G652 — PR #1412、merge commit `542133f7`（`main` で確認）: `notify status` と supervision が
+  durable activity sequence/time evidence を使って `working` と `live-idle` を区別し、interval 未満の
+  bound は書き換えず warning にします。
+- G653 — PR #1414、merge commit `83c5feea`（`main` で確認）: report は transport より前に
+  generation-aware outbox へ永続化されます。undelivered report は task の再 delegate ではなく
+  `notify collect` で回収します。
+- G655 — PR #1416、merge commit `c06e16d3`（`main` で確認）: orchestration が delegate 前に
+  workspace prerequisite を準備し、intent-cli に git を実行させず permission failure の
+  prepare-and-resume path を示します。
+- G654 — PR #1418、merge commit `eae66f05`（`main` で確認）: agent-kind-neutral な
+  design-thread guide が four-outcome wake、provenance vocabulary、transaction-scoped approval、
+  merge-authority comparison、monitoring separation を定義します。
+- G657 — PR #1420、merge commit `7ab3e297`（`main` で確認）: escalation ladder に owner-role
+  subject fallback、settled-red CI finding、declared-label green fallback を加え、single-rung wake を保ちます。
+- G658 — PR #1422、merge commit `39d7cf42`（`main` で確認）:
+  `notify supervise install` が team ごとの launchd、Task Scheduler、systemd artifact と正確な管理 command
+  を出力します。Install は emit するだけで、register は決して行いません。
+- G659 — PR #1424、merge commit `5331ec11`（`main` で確認）: opt-in event mode は一つの
+  supervisor process 内で recorded `herdr agent wait` を保持し、失敗した wait を re-arm して数秒で wake
+  します。Event mode は interval floor を維持します。
+- G660 — PR #1426、merge commit `bdc5b5b1`（`main` で確認）: status、escalate、supervise が
+  一つの residency-resolved delivery judgment を共有し、durable external-reader append と pane wake の
+  異なる basis を保ちます。
+- G661 — PR #1428、merge commit `b06dac5d`（`main` で確認）: writeback commit clarity、retire
+  reactivation、placeholder exclusion、reachability scaffolding、multi-checkout host defaults という五つの
+  field friction を修正します。
+- G662 — PR #1430、merge commit `f2e53c03`（`main` で確認）: improve run を durable record にし、
+  `guide next` が realignment recency を使い、facet-check の `no_facet_data: true` は lexical check が
+  実行されなかった意味だと正直に示します。
+
+## 二十 commit の derivation
+
+この範囲は post-release roll、三つの squash merge、八つの direct-commit/merge pair から成ります。
+次の一覧が `git log v0.16.1..main` のすべての commit を説明します。
+
+| account | commits |
+|---|---|
+| post-release roll | `f3165a5c` |
+| G656 | `853b48ab` |
+| G652 | `542133f7` |
+| G653 | `83c5feea` |
+| G655 | `f6f2b6f0`, `c06e16d3` |
+| G654 | `d1ec27d8`, `eae66f05` |
+| G657 | `970eb671`, `7ab3e297` |
+| G658 | `f9b5ff96`, `39d7cf42` |
+| G659 | `30931bd2`, `5331ec11` |
+| G660 | `99f5f2b2`, `bdc5b5b1` |
+| G661 | `28a68cd0`, `b06dac5d` |
+| G662 | `234a7058`, `f2e53c03` |
+
+## 意図的な boundary
+
+- `notify supervise install` は artifact と正確な command を emit しますが、OS scheduler の register、
+  unregister、start、stop は決して行いません。
+- Event mode は同じ supervisor process に秒単位の evidence を加えますが、独立した interval cycle は
+  safety floor として残ります。
+- Realignment-window recency は paste-ready な improve action を recommend しますが、realignment work を
+  schedule、実行、grade することは決してありません。
+- owner-role 自身が subject の場合、escalation ladder は design を wake できますが、design が受け取るのは
+  一件の escalation-class wake だけで、recovery authority は一切付与されません。
+
+## minor release の根拠
+
+`supervise install`、event mode、`packet retire --reactivate`、design-thread guide surface、durable
+improve-run record はすべて v0.16.1 には存在しませんでした。既存 v0.16.1 contract の patch-only
+修正ではなく、新しい preview surface です。
+
+## リリース準備ゲート (Release-readiness gate)
+
+v0.17.0 Release を作成する前に operator が確認します。
+
+- `eng/version.json` が stable `0.16.1` / next `0.17.0` を記録していること。
+- 上記十一件の PR merge がすべて `main` に解決し、`git log v0.16.1..main` の全二十 commit が表で
+  説明されていること。
+- preview statement が feature description より前にあり、
+  [1.0 compatibility promise](1.0-compatibility-promise.md) を link していること。
+- bilingual release-notes guard と count guard、full Release suite、`git diff --check`、exact-head CI が
+  green であること。
+- [v0.16.1 notes](release-notes-v0.16.1.md) と [v0.16.0 notes](release-notes-v0.16.0.md) は
+  preceding scope への link のままで、ここでは重複記載しないこと。
+- prepare-only の境界を守り、operator が別手順を明示的に実行するまで GitHub Release、tag、
+  package publish を作成しないこと。
+
+## v0.17.0 の publish
+
+ゲートが green になり operator が承認した後にのみ maintainer が GitHub Release と package を
+publish できます。この preparation PR 自体はその操作を行いません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
   "stableVersion": "0.16.1",
-  "nextVersion": "0.16.2"
+  "nextVersion": "0.17.0"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
@@ -1,0 +1,247 @@
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G663 keeps the v0.17.0 preparation bilingual, bounded to the eleven merged
+/// units in the twenty-commit range, and explicitly prepare-only.
+/// </summary>
+public sealed class ReleaseNotesV0170DocsTests
+{
+    private static readonly (string Unit, string Pr, string Merge)[] Units =
+    [
+        ("G656", "#1410", "853b48ab"),
+        ("G652", "#1412", "542133f7"),
+        ("G653", "#1414", "83c5feea"),
+        ("G655", "#1416", "c06e16d3"),
+        ("G654", "#1418", "eae66f05"),
+        ("G657", "#1420", "7ab3e297"),
+        ("G658", "#1422", "39d7cf42"),
+        ("G659", "#1424", "5331ec11"),
+        ("G660", "#1426", "bdc5b5b1"),
+        ("G661", "#1428", "b06dac5d"),
+        ("G662", "#1430", "f2e53c03"),
+    ];
+
+    private static readonly string[] RangeCommits =
+    [
+        "f3165a5c", "853b48ab", "542133f7", "83c5feea",
+        "f6f2b6f0", "c06e16d3", "d1ec27d8", "eae66f05",
+        "970eb671", "7ab3e297", "f9b5ff96", "39d7cf42",
+        "30931bd2", "5331ec11", "99f5f2b2", "bdc5b5b1",
+        "28a68cd0", "b06dac5d", "234a7058", "f2e53c03",
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyTheElevenUnitsWithVerifiedMerges(string language)
+    {
+        var notes = Read(language);
+        var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(Units.Select(unit => unit.Unit), listed);
+        Assert.Equal(11, listed.Length);
+        foreach (var unit in Units)
+        {
+            Assert.Contains(unit.Pr, notes, StringComparison.Ordinal);
+            Assert.Contains(unit.Merge, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("git log v0.16.1..main", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "twenty commits" : "二十 commit", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesAccountForEveryCommitInTheRange(string language)
+    {
+        var notes = Read(language);
+
+        Assert.Equal(20, RangeCommits.Length);
+        Assert.Equal(RangeCommits.Length, RangeCommits.Distinct(StringComparer.Ordinal).Count());
+        foreach (var commit in RangeCommits)
+        {
+            Assert.Contains(commit, notes, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void PreviewStatementPrecedesTheFeatureDescription(string language)
+    {
+        var notes = Read(language);
+        var preview = notes.IndexOf("preview-through-1.x", StringComparison.Ordinal);
+        var featureDescription = notes.IndexOf(
+            language == "en" ? "## Operating contract for supervised teams" : "## supervised team の operating contract",
+            StringComparison.Ordinal);
+
+        Assert.True(preview >= 0, "The preview statement must be present.");
+        Assert.True(featureDescription > preview, "The preview statement must precede the feature description.");
+        Assert.Contains("[1.0 compatibility promise](1.0-compatibility-promise.md)", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCarryTheOperatingContractAndDeliberateBoundaries(string language)
+    {
+        var notes = Read(language);
+        var compact = Regex.Replace(notes, @"\s+", " ");
+
+        foreach (var term in new[]
+                 {
+                     "Codex", "design", "orchestration", "implementation", "review",
+                     "supervision process", "watcher infrastructure", "45-unit remote-herdr",
+                     "supervise install", "event mode", "interval floor", "realignment", "recovery authority",
+                 })
+        {
+            Assert.Contains(term, compact, StringComparison.OrdinalIgnoreCase);
+        }
+
+        Assert.Contains(
+            language == "en" ? "four judgment-bearing threads" : "四つの judgment-bearing thread",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "one supervision process" : "一つの supervision process",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "three teams" : "三つの team", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "never registers" : "register は決して", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "never schedules" : "schedule、実行、grade することは決して", compact, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void MinorRationaleNamesSurfacesAbsentAtV0161(string language)
+    {
+        var notes = Read(language);
+
+        foreach (var term in new[]
+                 {
+                     "supervise install", "event mode", "packet retire --reactivate",
+                     "design-thread guide", "improve-run record", "v0.16.1",
+                 })
+        {
+            Assert.Contains(term, notes, StringComparison.OrdinalIgnoreCase);
+        }
+
+        Assert.Contains(language == "en" ? "absent at v0.16.1" : "v0.16.1 には存在しませんでした", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCountGuardMatchesAndRejectsAStatedMismatch(string language)
+    {
+        var notes = Read(language);
+        Assert.Empty(CountMismatches(notes, language));
+
+        var wrong = language == "en"
+            ? notes.Replace("exactly eleven merged units", "exactly ten merged units", StringComparison.Ordinal)
+            : notes.Replace("正確に十一件の merged unit", "正確に十件の merged unit", StringComparison.Ordinal);
+
+        Assert.NotEqual(notes, wrong);
+        Assert.NotEmpty(CountMismatches(wrong, language));
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void PreparationReplacesTheDraftAndRefreshesReadiness(string language)
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
+
+        Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.16.2.md")));
+        Assert.Contains("release-notes-v0.17.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.16.1.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.16.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleaseNotesV0170DocsTests", reference, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReleaseNotesV0162DocsTests", reference, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesRemainPrepareOnly(string language)
+    {
+        var notes = Read(language);
+
+        Assert.Contains("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "UNRELEASED" : "未リリース", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Release", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("tag", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("package publish", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("DRAFT /", notes, StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyList<string> CountMismatches(string notes, string language)
+    {
+        var listedCount = Regex.Matches(notes, @"(?m)^- (G\d+) —").Count;
+        var statedCounts = language == "en"
+            ? Regex.Matches(notes, @"\b(?<count>one|two|three|four|five|six|seven|eight|nine|ten|eleven)\s+merged units?\b", RegexOptions.IgnoreCase)
+                .Select(match => EnglishCount(match.Groups["count"].Value))
+            : Regex.Matches(notes, @"正確に(?<count>[一二三四五六七八九十百〇零]+)件の merged unit")
+                .Select(match => JapaneseCount(match.Groups["count"].Value));
+
+        return statedCounts
+            .Where(count => count != listedCount)
+            .Select(count => $"{language} stated {count} units, but lists {listedCount}.")
+            .ToArray();
+    }
+
+    private static int EnglishCount(string text) => text.ToLowerInvariant() switch
+    {
+        "one" => 1,
+        "two" => 2,
+        "three" => 3,
+        "four" => 4,
+        "five" => 5,
+        "six" => 6,
+        "seven" => 7,
+        "eight" => 8,
+        "nine" => 9,
+        "ten" => 10,
+        "eleven" => 11,
+        _ => throw new ArgumentOutOfRangeException(nameof(text), text, "unsupported count")
+    };
+
+    private static int JapaneseCount(string text)
+    {
+        var values = new Dictionary<char, int>
+        {
+            ['〇'] = 0, ['零'] = 0, ['一'] = 1, ['二'] = 2, ['三'] = 3, ['四'] = 4,
+            ['五'] = 5, ['六'] = 6, ['七'] = 7, ['八'] = 8, ['九'] = 9, ['十'] = 10,
+            ['百'] = 100,
+        };
+        var total = 0;
+        var pending = 0;
+        foreach (var character in text)
+        {
+            var value = values[character];
+            if (value is 10 or 100)
+            {
+                total += (pending == 0 ? 1 : pending) * value;
+                pending = 0;
+            }
+            else
+            {
+                pending = value;
+            }
+        }
+
+        return total + pending;
+    }
+
+    private static string Read(string language) =>
+        File.ReadAllText(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.17.0.md"));
+}


### PR DESCRIPTION
## Summary

- retarget stable/next policy to 0.16.1 / 0.17.0 and replace the superseded bilingual 0.16.2 draft stubs with real v0.17.0 notes
- account for all 20 commits in `git log v0.16.1..main` and cover exactly G656, G652, G653, G655, G654, G657, G658, G659, G660, G661, and G662 with verified PR/merge identities
- preserve preview, operating-contract, supervision formula, deliberate non-behavior, older-note linkage, and EN/JA parity in the notes and readiness mirrors
- add a bilingual release-notes/count/derivation regression guard

## Validation

- focused Release guards: 28 passed, 0 failed
- full `dotnet test IntentSystem.sln -c Release --no-restore`: 5,005 passed, 0 failed, 1 expected skip
- `git rev-list --count v0.16.1..origin/main`: 20
- all eleven named merge commits independently resolve on `origin/main` and match their merged PRs
- `git diff --check`: clean

## Release boundary

Prepare-only. This PR creates no GitHub Release, tag, package publish, or release workflow run.

Closes #1431