### PR TITLE
Roll post-release version to 0.17.1

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2556,7 +2556,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0170)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0171)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2649,29 +2649,28 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.17.0)
+### Next release readiness (v0.17.1)
 
-**`v0.16.1` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.17.0`. [The v0.17.0 notes](release-notes-v0.17.0.md) are a real prepare-only
-release candidate. See [release-notes-v0.16.1.md](release-notes-v0.16.1.md) and
-[release-notes-v0.16.0.md](release-notes-v0.16.0.md) for the preceding shipped
-scopes; they are linked rather than restated.
+**`v0.17.0` shipped** (GitHub Release + NuGet), and the next prepared line is
+`0.17.1`. [The v0.17.1 notes stub](release-notes-v0.17.1.md) is the required
+prepare-only placeholder. See [release-notes-v0.17.0.md](release-notes-v0.17.0.md)
+for the preceding shipped scope; it is linked, not restated.
 
-**Release-readiness verification (run before merging the `v0.17.0`
+**Release-readiness verification (run before merging the `v0.17.1`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.16.1 (published), nextVersion 0.17.0 (to release)
+cat eng/version.json   # stableVersion 0.17.0 (published), nextVersion 0.17.1 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.17.0-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.17.1-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.17.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.17.1.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2685,10 +2684,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.17.0`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.17.1`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.17.0`, `nextVersion → 0.17.1` — carrying, per **steps 4–6** of the
+`stableVersion → 0.17.1`, `nextVersion → 0.17.2` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.17.1.md
+++ b/docs/en/release-notes-v0.17.1.md
@@ -1,0 +1,9 @@
+# Release Notes — intent-cli v0.17.1
+
+> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
+> roll. The release-prep packet authors the real content; this file must not be
+> treated as a changelog until that packet replaces it.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.17.1`.
+The eventual release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.17.1.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2717,28 +2717,27 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.17.0)
+### 次リリース準備(v0.17.1)
 
-**`v0.16.1` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.17.0` です。[v0.17.0 notes](release-notes-v0.17.0.md) は実内容を持つ
-prepare-only release candidate です。直前の出荷範囲は
-[release-notes-v0.16.1.md](release-notes-v0.16.1.md) と
-[release-notes-v0.16.0.md](release-notes-v0.16.0.md) を参照し、ここでは重複記載しません。
+**`v0.17.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
+`0.17.1` です。[v0.17.1 notes stub](release-notes-v0.17.1.md) が必須の
+prepare-only placeholder です。直前の出荷範囲は
+[release-notes-v0.17.0.md](release-notes-v0.17.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.17.0` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.17.1` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.16.1 (published), nextVersion 0.17.0 (to release)
+cat eng/version.json   # stableVersion 0.17.0 (published), nextVersion 0.17.1 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.17.0-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.17.1-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.17.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.17.1.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2751,10 +2750,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.17.0` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.17.1` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.17.0`、`nextVersion → 0.17.1` —
+`stableVersion → 0.17.1`、`nextVersion → 0.17.2` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.17.1.md
+++ b/docs/ja/release-notes-v0.17.1.md
@@ -1,0 +1,9 @@
+# リリースノート — intent-cli v0.17.1
+
+> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
+> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
+> このファイルを changelog として扱ってはいけません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.17.1`。
+将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.17.1 に
+publish されます。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.16.1",
-  "nextVersion": "0.17.0"
+  "stableVersion": "0.17.0",
+  "nextVersion": "0.17.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0161DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0161DocsTests.cs
@@ -94,14 +94,14 @@ public sealed class ReleaseNotesV0161DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void ReadinessMirrorLinksTheShippedNotes(string language)
+    public void PublishedNotesLinkTheirPrecedingScope(string language)
     {
         var path = Path.Combine(
-            RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md");
-        var reference = File.ReadAllText(path);
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.16.1.md");
+        var notes = File.ReadAllText(path);
 
-        Assert.Contains("release-notes-v0.16.1.md", reference, StringComparison.Ordinal);
-        Assert.DoesNotContain("release-notes-v0.16.1.md) is the required prepare-only placeholder", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.16.0.md", notes, StringComparison.Ordinal);
+        Assert.DoesNotContain("DRAFT /", notes, StringComparison.Ordinal);
     }
 
     private static IReadOnlyList<string> CountMismatches(string notes, string language)

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
@@ -155,17 +155,16 @@ public sealed class ReleaseNotesV0170DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void PreparationReplacesTheDraftAndRefreshesReadiness(string language)
+    public void ReadinessAdvancesWhilePublishedNotesRemainGuarded(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
 
-        Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.16.2.md")));
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.17.1.md")));
+        Assert.Contains("release-notes-v0.17.1.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.17.0.md", reference, StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.16.1.md", reference, StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.16.0.md", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0170DocsTests", reference, StringComparison.Ordinal);
-        Assert.DoesNotContain("ReleaseNotesV0162DocsTests", reference, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReleaseNotesV0171DocsTests", reference, StringComparison.Ordinal);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

Roll the release policy immediately after published v0.17.0.

- v0.17.0 Release: https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.17.0
- release workflow: https://github.com/J-Tech-Japan/intent-system/actions/runs/31427013854, green at `d828b0054b007625fd15f7b408be848bbd48388a`, eight assets attached
- `stableVersion`: `0.17.0`
- `nextVersion`: `0.17.1`
- add EN/JA v0.17.1 DRAFT note stubs
- refresh EN/JA next-release readiness mirrors and examples
- preserve the exact frozen v0.17.0 release-note contract while allowing readiness to advance
- decouple the older v0.16.1 frozen-note guard from the moving readiness section

No product behavior changes are included.

## Validation

- focused release/version/docs guards: 36 passed, 0 failed
- full `dotnet test IntentSystem.sln -c Release --no-restore`: 5,005 passed, 0 failed, 1 expected skip
- `git diff --check`: clean
- frozen `docs/{en,ja}/release-notes-v0.17.0.md`: unchanged

## Boundary

Draft post-release roll only. Do not merge as part of this implementation task.
