### PR TITLE
G665: prepare v0.18.0 release notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2556,7 +2556,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0171)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0180)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2649,45 +2649,47 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.17.1)
+### Next release readiness (v0.18.0)
 
 **`v0.17.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.17.1`. [The v0.17.1 notes stub](release-notes-v0.17.1.md) is the required
-prepare-only placeholder. See [release-notes-v0.17.0.md](release-notes-v0.17.0.md)
-for the preceding shipped scope; it is linked, not restated.
+`0.18.0`. [The v0.18.0 notes](release-notes-v0.18.0.md) are the real
+prepare-only release candidate for exactly G664. See
+[release-notes-v0.17.0.md](release-notes-v0.17.0.md) for the preceding shipped
+scope; it is linked, not restated.
 
-**Release-readiness verification (run before merging the `v0.17.1`
+**Release-readiness verification (run before merging the `v0.18.0`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.17.0 (published), nextVersion 0.17.1 (to release)
+cat eng/version.json   # stableVersion 0.17.0 (published), nextVersion 0.18.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.17.1-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.18.0-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.17.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.18.0.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Run the complete Release suite.
 dotnet test IntentSystem.sln -c Release
 ```
 
 After the preparation merge lands on `main` and the readiness evidence holds,
-the operator must explicitly approve Release creation. Only then may a
-maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.17.1`; publishing it triggers `release.yml`
+this preparation PR stops. Conditional approval `v0180-preapproved-001` is
+already recorded for the separate operator/release-automation action once that
+condition holds. Only that separately authorized actor may create and publish
+the GitHub Release for `v0.18.0`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.17.1`, `nextVersion → 0.17.2` — carrying, per **steps 4–6** of the
+`stableVersion → 0.18.0`, `nextVersion → 0.18.1` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.17.1.md
+++ b/docs/en/release-notes-v0.17.1.md
@@ -1,9 +1,0 @@
-# Release Notes — intent-cli v0.17.1
-
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.17.1`.
-The eventual release will be published at
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.17.1.

--- a/docs/en/release-notes-v0.18.0.md
+++ b/docs/en/release-notes-v0.18.0.md
@@ -1,0 +1,136 @@
+# Release Notes — intent-cli v0.18.0
+
+> **prepare-only / UNRELEASED.** This change prepares version state, release
+> notes, and readiness documentation only. It does not create a GitHub Release
+> or tag, publish a package, run the release workflow, or perform the
+> post-release roll.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.18.0`.
+After the separate operator release action, the Release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.18.0.
+The preceding shipped scope remains in the
+[v0.17.0 notes](release-notes-v0.17.0.md); it is linked rather than restated.
+
+## Preview lane — read before the feature description
+
+`guide bootstrap` and the advisor's `bootstrap-resume` action are
+`preview-through-1.x`, outside the
+[1.0 compatibility promise](1.0-compatibility-promise.md). They may change or
+be withdrawn during 1.x and are not part of the 1.0 compatibility commitment.
+
+## The application conversation is the front door
+
+v0.18.0 contains exactly one merged unit. The list was independently derived
+with `git log v0.17.0..main`; every commit in that three-commit range is
+accounted for below, and the listed merge resolves on `main`.
+
+- G664 — PR #1435, merge commit `40081137` (verified on `main`): the
+  application-front-door bootstrap turns one request into a guided herdr-only
+  team genesis and delegates the first task to that team.
+
+Start the guide with either exact trigger phrase:
+
+- English: `Start this work in a herdr-only team.`
+- Japanese: `herdr-only で起動して。`
+
+The rendered pass keeps these six steps in order:
+
+1. Ask the human which CLI and model each design, orchestration,
+   implementation, and review seat should run. A missing answer is a named gap;
+   there are no defaults.
+2. Emit the herdr workspace, pane, and typed-seat commands from the installed
+   per-kind recipes and the linked G637 layout guide.
+3. Record operator-supplied topology through the canonical topology writer,
+   then validate and show the roster.
+4. Emit `notify supervise install` so the human can inspect and register the
+   scheduler artifact.
+5. Ask the human for the application agent kind and whether it has an inbound
+   app monitor, then apply the linked G654 design-seat placement rule. The CLI
+   never assumes either answer.
+6. Delegate the first task to orchestration with a fresh task id and result
+   nonce; do not run that task in the application conversation.
+
+The rendered output ends with the explicit statement:
+
+> **HANDOFF:** State which recorded thread is now the design seat. The
+> application conversation remains the operator's front door for new requests;
+> it is not a design, orchestration, implementation, review, or supervision
+> loop seat.
+
+Recorded topology selects the idempotent `join-and-delegate` path. The guide
+does not recreate the workspace or already recorded seats; it names partial
+state such as `topology-recorded-seats-missing` and
+`topology-recorded-supervision-and-handoff-missing`, then emits only missing
+steps. `guide next` recommends `bootstrap-resume` when topology is recorded but
+the supervision-cycle/front-door handoff is incomplete. Absent topology is
+silent because bootstrap has not started, and a completed cycle clears the
+recommendation.
+
+## Merged-tree design verification
+
+On merged head `40081137`, design built the CLI and rendered the guide against
+this host's real data in Markdown and JSON, with and without `--team`: eight
+consecutive renders exited 0. The rendered questions asked the human for the
+seat CLI/model and application kind, the join and named partial-state paths
+were present, the final output was the HANDOFF statement, and `guide next`
+showed and cleared `bootstrap-resume` along the recorded lifecycle. This
+verification used the merged tree and real host data, not a diff-only reading.
+It verifies the one-keyword claim on the shipped tree. A source audit also
+confirmed that the command's only `Process` occurrence is a string field name;
+there is no execution path behind the guide.
+
+## Three-commit derivation
+
+This table accounts for every commit returned by `git log v0.17.0..main`. The
+post-release roll is range context, not a release execution unit.
+
+| account | commit | release-unit treatment |
+|---|---|---|
+| post-release roll to 0.17.1 | `c2746f26` | accounted for; not a unit |
+| G664 implementation | `229e5522` | implementation commit for G664 |
+| G664 merge | `40081137` | the one merged execution unit |
+
+## Deliberate boundaries
+
+- This preparation changes version policy, notes, readiness documentation, and
+  release guards only; it makes no product-code or runtime-behavior change.
+- The guide emits questions and command text. intent-cli executes nothing: it
+  never invokes herdr, starts a provider or seat, or registers/unregisters an
+  OS scheduler artifact.
+- No application-side integration code is added. The application conversation
+  reads the guide and remains the operator's front door.
+- Existing per-kind recipes, G637 layout, G654 design placement, topology,
+  supervision-install, and delegation contracts are linked and composed; the
+  release does not restate or change those rules.
+- Join is idempotent, partial state is preserved, and no recorded team is
+  casually forked or recreated.
+
+## Why this is a minor release
+
+`guide bootstrap` and the advisor's `bootstrap-resume` lifecycle were absent at
+v0.17.0. They are new preview surfaces, not patch-only corrections to the
+frozen v0.17.0 contract.
+
+## Release-readiness gate
+
+Before the separate operator release action:
+
+- `eng/version.json` records stable `0.17.0` and next `0.18.0`.
+- PR #1435 / merge `40081137` resolves on `main`, and all three commits in
+  `git log v0.17.0..main` remain accounted for by the table.
+- The preview statement precedes the feature description and links the 1.0
+  compatibility promise.
+- The bilingual release-notes and count guards pass, followed by the full
+  Release suite, `git diff --check`, and exact-head CI.
+- The [v0.17.0 notes](release-notes-v0.17.0.md) remain a link to the preceding
+  shipped scope rather than content repeated here.
+- Prepare-only remains in force: this PR creates no Release or tag, performs no
+  package publish, and does no post-release roll.
+
+## Publishing v0.18.0
+
+Release creation remains a distinct operator action after this preparation is
+merged and its readiness evidence is green. Conditional approval
+`v0180-preapproved-001` is recorded for that separate action once its condition
+holds; it does not turn this preparation PR into a release action. This
+implementation PR does not perform that action.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2717,43 +2717,44 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.17.1)
+### 次リリース準備(v0.18.0)
 
 **`v0.17.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.17.1` です。[v0.17.1 notes stub](release-notes-v0.17.1.md) が必須の
-prepare-only placeholder です。直前の出荷範囲は
+`0.18.0` です。[v0.18.0 notes](release-notes-v0.18.0.md) は正確に G664 だけを
+対象にする実内容付き prepare-only release candidate です。直前の出荷範囲は
 [release-notes-v0.17.0.md](release-notes-v0.17.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.17.1` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.18.0` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.17.0 (published), nextVersion 0.17.1 (to release)
+cat eng/version.json   # stableVersion 0.17.0 (published), nextVersion 0.18.0 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.17.1-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.18.0-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.17.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.18.0.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Release suite を完全実行。
 dotnet test IntentSystem.sln -c Release
 ```
 
-準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
-明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.17.1` の GitHub Release を作成・公開できます。公開すると
+準備コミットが `main` に入り readiness の証跡が揃った時点で、この preparation PR は停止します。
+その condition が成立した後の別の operator / release-automation action には conditional approval
+`v0180-preapproved-001` が記録済みです。その別途 authorized された actor だけが `v0.18.0` の
+GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.17.1`、`nextVersion → 0.17.2` —
+`stableVersion → 0.18.0`、`nextVersion → 0.18.1` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.17.1.md
+++ b/docs/ja/release-notes-v0.17.1.md
@@ -1,9 +1,0 @@
-# リリースノート — intent-cli v0.17.1
-
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
-> このファイルを changelog として扱ってはいけません。
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.17.1`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.17.1 に
-publish されます。

--- a/docs/ja/release-notes-v0.18.0.md
+++ b/docs/ja/release-notes-v0.18.0.md
@@ -1,0 +1,129 @@
+# リリースノート — intent-cli v0.18.0
+
+> **prepare-only / 未リリース。** この変更は version state、release notes、
+> readiness documentation だけを準備します。GitHub Release や tag の作成、
+> package publish、release workflow の実行、post-release roll は行いません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.18.0`。
+operator が別手順を実行した後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.18.0 に公開されます。
+直前の出荷範囲は [v0.17.0 notes](release-notes-v0.17.0.md) を参照し、
+ここでは重複記載しません。
+
+## feature description より先に読む preview lane
+
+`guide bootstrap` と advisor の `bootstrap-resume` action は
+`preview-through-1.x` です。[1.0 compatibility promise](1.0-compatibility-promise.md)
+の対象外であり、1.x の間に変更または撤回される可能性があり、1.0 の
+compatibility commitment には含まれません。
+
+## application conversation は front door
+
+v0.18.0 は正確に一件の merged unit を含みます。一覧は
+`git log v0.17.0..main` を独立に実行して導出しました。その三 commit をすべて
+以下で説明し、記載した merge が `main` に解決することも確認しています。
+
+- G664 — PR #1435、merge commit `40081137`（`main` で確認）: application-front-door
+  bootstrap は一つの request を guided herdr-only team genesis に変え、最初の task を
+  その team へ委譲します。
+
+guide は次の exact trigger phrase のどちらでも開始できます。
+
+- English: `Start this work in a herdr-only team.`
+- Japanese: `herdr-only で起動して。`
+
+rendered pass は次の六 step をこの順序で保ちます。
+
+1. design、orchestration、implementation、review の各 seat が使う CLI と model を
+   人間へ質問します。回答がなければ named gap とし、default は置きません。
+2. installed per-kind recipe と link した G637 layout guide から herdr workspace、
+   pane、typed-seat command を出力します。
+3. operator-supplied topology を canonical topology writer で記録し、roster を
+   validate / show します。
+4. `notify supervise install` を出力し、人間が scheduler artifact を確認して
+   register できるようにします。
+5. application agent kind と inbound app monitor の有無を人間へ質問してから、
+   link した G654 design-seat placement rule を適用します。CLI はどちらの回答も
+   推測しません。
+6. fresh task id と result nonce で最初の task を orchestration へ委譲します。
+   application conversation 自身ではその task を実行しません。
+
+rendered output の末尾は次の explicit statement です。
+
+> **HANDOFF:** どの recorded thread が design seat になったかを明示します。
+> application conversation は新しい request を受ける operator's front door のままで、
+> design、orchestration、implementation、review、supervision の loop seat ではありません。
+
+recorded topology がある場合は idempotent な `join-and-delegate` path を選びます。
+workspace や記録済み seat を再作成せず、`topology-recorded-seats-missing`、
+`topology-recorded-supervision-and-handoff-missing` などの partial state を命名し、
+不足 step だけを出力します。`guide next` は topology が記録済みで supervision-cycle /
+front-door handoff が未完了なら `bootstrap-resume` を推奨します。topology がなければ
+bootstrap 未開始なので silent で、completed cycle は推奨を解除します。
+
+## merged tree での design verification
+
+merged head `40081137` で design は CLI を build し、この host の real data に対して
+Markdown / JSON、`--team` あり / なしの guide を render しました。連続八回が exit 0
+でした。rendered question は seat の CLI/model と application kind を人間へ尋ね、join
+path と named partial state が存在し、最終出力は HANDOFF statement でした。さらに
+`guide next` は recorded lifecycle に沿って `bootstrap-resume` を表示し、完了後に解除
+しました。この検証は diff の読解だけでなく merged tree と real host data を使いました。
+これにより shipped tree 上で one-keyword claim を検証しました。source audit でも、
+command 内の唯一の `Process` は string field name であり、guide の背後に execution path
+がないことを確認しました。
+
+## 三 commit の derivation
+
+次の表が `git log v0.17.0..main` の全 commit を説明します。post-release roll は
+range context であり、release execution unit ではありません。
+
+| account | commit | release-unit treatment |
+|---|---|---|
+| 0.17.1 への post-release roll | `c2746f26` | 説明済み。unit ではない |
+| G664 implementation | `229e5522` | G664 の implementation commit |
+| G664 merge | `40081137` | 一件の merged execution unit |
+
+## 意図的な boundary
+
+- この準備は version policy、notes、readiness documentation、release guard だけを
+  変更し、product code や runtime behavior は変更しません。
+- guide は question と command text を出力するだけです。intent-cli executes nothing:
+  herdr の呼び出し、provider / seat の起動、OS scheduler artifact の register /
+  unregister は行いません。
+- application-side integration code は追加しません。application conversation は guide を
+  読み、operator's front door のままです。
+- 既存 per-kind recipe、G637 layout、G654 design placement、topology、
+  supervision-install、delegation contract は link して compose し、ここで再定義や変更を
+  しません。
+- join は idempotent で partial state を保存し、recorded team を不用意に fork / recreate
+  しません。
+
+## minor release の根拠
+
+`guide bootstrap` と advisor の `bootstrap-resume` lifecycle は v0.17.0 には存在しません
+でした。frozen v0.17.0 contract の patch-only correction ではなく、新しい preview surface
+です。
+
+## リリース準備ゲート (Release-readiness gate)
+
+operator が別の Release 手順を実行する前に確認します。
+
+- `eng/version.json` が stable `0.17.0` / next `0.18.0` を記録していること。
+- PR #1435 / merge `40081137` が `main` に解決し、`git log v0.17.0..main` の全三 commit
+  が表で説明されていること。
+- preview statement が feature description より前にあり、1.0 compatibility promise を
+  link していること。
+- bilingual release-notes / count guard、full Release suite、`git diff --check`、
+  exact-head CI が green であること。
+- [v0.17.0 notes](release-notes-v0.17.0.md) は preceding shipped scope への link のままで、
+  内容をここに重複記載しないこと。
+- prepare-only を保ち、この PR が Release / tag を作成せず、package publish と
+  post-release roll を行わないこと。
+
+## v0.18.0 の publish
+
+Release 作成は、この準備が merge され readiness evidence が green になった後の別の
+operator action です。その condition 成立後の別 action には conditional approval
+`v0180-preapproved-001` が記録済みです。この approval が preparation PR を release action
+に変えることはなく、この implementation PR はその操作を行いません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
   "stableVersion": "0.17.0",
-  "nextVersion": "0.17.1"
+  "nextVersion": "0.18.0"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
@@ -155,14 +155,16 @@ public sealed class ReleaseNotesV0170DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void ReadinessAdvancesWhilePublishedNotesRemainGuarded(string language)
+    public void ReadinessAdvancesToV0180WhilePublishedNotesRemainGuarded(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
 
-        Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.17.1.md")));
-        Assert.Contains("release-notes-v0.17.1.md", reference, StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.17.1.md")));
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.18.0.md")));
+        Assert.Contains("release-notes-v0.18.0.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.17.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleaseNotesV0180DocsTests", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0170DocsTests", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("ReleaseNotesV0171DocsTests", reference, StringComparison.Ordinal);
     }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0180DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0180DocsTests.cs
@@ -1,0 +1,234 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G665 keeps the v0.18.0 preparation bilingual, bounded to G664 in the
+/// three-commit post-v0.17.0 range, and explicitly prepare-only.
+/// </summary>
+public sealed class ReleaseNotesV0180DocsTests
+{
+    private static readonly string[] RangeCommits = ["c2746f26", "229e5522", "40081137"];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyG664AndAccountForTheThreeCommitRange(string language)
+    {
+        var notes = Read(language);
+        var units = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(["G664"], units);
+        Assert.Single(units);
+        Assert.Contains("#1435", notes, StringComparison.Ordinal);
+        Assert.Contains("merge commit `40081137`", notes, StringComparison.Ordinal);
+        Assert.Contains("git log v0.17.0..main", notes, StringComparison.Ordinal);
+        foreach (var commit in RangeCommits) Assert.Contains(commit, notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "three-commit range" : "三 commit", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "not a release execution unit" : "release execution unit ではありません", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void PreviewStatementPrecedesTheFeatureAndLinksThePromise(string language)
+    {
+        var notes = Read(language);
+        var preview = notes.IndexOf("preview-through-1.x", StringComparison.Ordinal);
+        var feature = notes.IndexOf(
+            language == "en" ? "## The application conversation is the front door" : "## application conversation は front door",
+            StringComparison.Ordinal);
+
+        Assert.True(preview >= 0);
+        Assert.True(feature > preview);
+        Assert.Contains("[1.0 compatibility promise](1.0-compatibility-promise.md)", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesStateExactTriggersSixOrderedStepsAndExplicitHandoff(string language)
+    {
+        var notes = Read(language);
+        Assert.Contains("Start this work in a herdr-only team.", notes, StringComparison.Ordinal);
+        Assert.Contains("herdr-only で起動して。", notes, StringComparison.Ordinal);
+
+        var previous = -1;
+        for (var step = 1; step <= 6; step++)
+        {
+            var index = notes.IndexOf($"\n{step}. ", StringComparison.Ordinal);
+            Assert.True(index > previous, $"step {step} must follow step {step - 1}");
+            previous = index;
+        }
+
+        Assert.Contains("HANDOFF", notes, StringComparison.Ordinal);
+        Assert.Contains("operator's front door", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en"
+                ? "not a design, orchestration, implementation, review, or supervision"
+                : "design、orchestration、implementation、review、supervision の loop seat ではありません",
+            notes,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void HumanQuestionsNeverBecomeDefaults(string language)
+    {
+        var notes = Read(language);
+        var compact = Regex.Replace(notes, @"\s+", " ");
+
+        foreach (var term in new[] { language == "en" ? "human" : "人間", "CLI", "model", "application", "agent kind", "inbound app monitor" })
+            Assert.Contains(term, compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "there are no defaults" : "default は置きません", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "never assumes" : "推測しません", compact, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCarryJoinPartialAndAdvisorLifecycle(string language)
+    {
+        var notes = Read(language);
+        var compact = Regex.Replace(notes, @"\s+", " ");
+        foreach (var term in new[]
+                 {
+                     "join-and-delegate", "idempotent", "topology-recorded-seats-missing",
+                     "topology-recorded-supervision-and-handoff-missing", "bootstrap-resume",
+                 })
+        {
+            Assert.Contains(term, compact, StringComparison.OrdinalIgnoreCase);
+        }
+
+        Assert.Contains(language == "en" ? "Absent topology is silent" : "topology がなければ", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "completed cycle clears" : "completed cycle は推奨を解除", compact, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCarryNoExecutionNoIntegrationAndLinkedCompositionBoundaries(string language)
+    {
+        var notes = Read(language);
+        Assert.Contains("executes nothing", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("application-side integration code", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("G637", notes, StringComparison.Ordinal);
+        Assert.Contains("G654", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "linked and composed" : "link して compose", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "never invokes herdr" : "herdr の呼び出し", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("register", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("unregister", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesStateMergedTreeRealHostRenderingVerification(string language)
+    {
+        var notes = Read(language);
+        var compact = Regex.Replace(notes, @"\s+", " ");
+
+        foreach (var term in new[] { "merged head", "40081137", "real host data", "Markdown", "JSON", "--team", language == "en" ? "eight" : "八回" })
+            Assert.Contains(term, compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "not a diff-only reading" : "diff の読解だけでなく", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("one-keyword claim", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("string field name", compact, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void CountGuardMatchesExactlyOneUnitAndRejectsMismatch(string language)
+    {
+        var notes = Read(language);
+        Assert.Empty(CountMismatches(notes, language));
+
+        var wrong = language == "en"
+            ? notes.Replace("exactly one merged unit", "exactly two merged units", StringComparison.Ordinal)
+            : notes.Replace("正確に一件の merged unit", "正確に二件の merged unit", StringComparison.Ordinal);
+
+        Assert.NotEqual(notes, wrong);
+        Assert.NotEmpty(CountMismatches(wrong, language));
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void VersionReadinessMinorRationaleAndPrepareOnlyBoundariesStayAligned(string language)
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var notes = Read(language);
+        var compact = Regex.Replace(notes, @"\s+", " ");
+        var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
+        var policy = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, "eng", "version.json"))).RootElement;
+
+        Assert.Equal("0.17.0", policy.GetProperty("stableVersion").GetString());
+        Assert.Equal("0.18.0", policy.GetProperty("nextVersion").GetString());
+        Assert.Contains("guide bootstrap", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("bootstrap-resume", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "absent at v0.17.0" : "v0.17.0 には存在しません", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "UNRELEASED" : "未リリース", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Release", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("tag", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("package publish", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("post-release roll", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("v0180-preapproved-001", notes, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.18.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.17.0.md", reference, StringComparison.Ordinal);
+        Assert.DoesNotContain("release-notes-v0.17.1.md", reference, StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyList<string> CountMismatches(string notes, string language)
+    {
+        var listedCount = Regex.Matches(notes, @"(?m)^- (G\d+) —").Count;
+        var statedCounts = language == "en"
+            ? Regex.Matches(notes, @"\b(?<count>one|two|three|four|five|six|seven|eight|nine|ten)\s+merged units?\b", RegexOptions.IgnoreCase)
+                .Select(match => EnglishCount(match.Groups["count"].Value))
+            : Regex.Matches(notes, @"正確に(?<count>[一二三四五六七八九十百〇零]+)件の merged unit")
+                .Select(match => JapaneseCount(match.Groups["count"].Value));
+
+        return statedCounts.Where(count => count != listedCount).Select(count => $"stated {count}; listed {listedCount}").ToArray();
+    }
+
+    private static int EnglishCount(string text) => text.ToLowerInvariant() switch
+    {
+        "one" => 1, "two" => 2, "three" => 3, "four" => 4, "five" => 5,
+        "six" => 6, "seven" => 7, "eight" => 8, "nine" => 9, "ten" => 10,
+        _ => throw new ArgumentOutOfRangeException(nameof(text), text, "unsupported count"),
+    };
+
+    private static int JapaneseCount(string text)
+    {
+        var values = new Dictionary<char, int>
+        {
+            ['〇'] = 0, ['零'] = 0, ['一'] = 1, ['二'] = 2, ['三'] = 3, ['四'] = 4,
+            ['五'] = 5, ['六'] = 6, ['七'] = 7, ['八'] = 8, ['九'] = 9, ['十'] = 10,
+            ['百'] = 100,
+        };
+        var total = 0;
+        var pending = 0;
+        foreach (var character in text)
+        {
+            var value = values[character];
+            if (value is 10 or 100)
+            {
+                total += (pending == 0 ? 1 : pending) * value;
+                pending = 0;
+            }
+            else
+            {
+                pending = value;
+            }
+        }
+        return total + pending;
+    }
+
+    private static string Read(string language) => File.ReadAllText(Path.Combine(
+        RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.18.0.md"));
+}


### PR DESCRIPTION
## Summary
- keep stableVersion at 0.17.0 and retarget nextVersion to 0.18.0
- replace the EN/JA v0.17.1 draft stubs with real prepare-only v0.18.0 notes covering exactly G664
- account for the full v0.17.0..main range: c2746f26 post-roll context, 229e5522 implementation, and 40081137 merge
- document exact triggers, six ordered steps, front-door HANDOFF, human-question/no-default behavior, partial/join lifecycle, no-execution boundaries, and merged-tree real-host verification
- advance bilingual readiness and add v0.18.0 guards while retaining the frozen v0.17.0 guard

## Validation
- focused Release notes/version guards: 42 passed
- full Release solution: 5,034 passed, 1 existing skip
- git diff --check: clean
- merge 40081137 verified as an ancestor of origin/main

## Prepare-only boundary
This PR creates no tag or GitHub Release, publishes no package, runs no release workflow, performs no post-release roll, and changes no product/runtime behavior.

Exact head: aaa7b2e9b0c296e5d49e668994b0c8086d4a1187

Closes #1436