### PR TITLE
Roll post-release version to v0.18.1

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2556,7 +2556,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0180)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0181)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2649,29 +2649,28 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.18.0)
+### Next release readiness (v0.18.1)
 
-**`v0.17.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.18.0`. [The v0.18.0 notes](release-notes-v0.18.0.md) are the real
-prepare-only release candidate for exactly G664. See
-[release-notes-v0.17.0.md](release-notes-v0.17.0.md) for the preceding shipped
-scope; it is linked, not restated.
+**`v0.18.0` shipped** (GitHub Release + NuGet), and the next prepared line is
+`0.18.1`. [The v0.18.1 notes stub](release-notes-v0.18.1.md) is the required
+prepare-only placeholder. See [release-notes-v0.18.0.md](release-notes-v0.18.0.md)
+for the preceding shipped scope; it is linked, not restated.
 
-**Release-readiness verification (run before merging the `v0.18.0`
+**Release-readiness verification (run before merging the `v0.18.1`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.17.0 (published), nextVersion 0.18.0 (to release)
+cat eng/version.json   # stableVersion 0.18.0 (published), nextVersion 0.18.1 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.18.0-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.18.1-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.18.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.18.1.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2683,13 +2682,12 @@ dotnet test IntentSystem.sln -c Release
 ```
 
 After the preparation merge lands on `main` and the readiness evidence holds,
-this preparation PR stops. Conditional approval `v0180-preapproved-001` is
-already recorded for the separate operator/release-automation action once that
-condition holds. Only that separately authorized actor may create and publish
-the GitHub Release for `v0.18.0`; publishing it triggers `release.yml`
+the operator must explicitly approve Release creation. Only then may a
+maintainer/operator (or authorized external release automation) create and
+publish the GitHub Release for `v0.18.1`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.18.0`, `nextVersion → 0.18.1` — carrying, per **steps 4–6** of the
+`stableVersion → 0.18.1`, `nextVersion → 0.18.2` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.18.1.md
+++ b/docs/en/release-notes-v0.18.1.md
@@ -1,0 +1,9 @@
+# Release Notes — intent-cli v0.18.1
+
+> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
+> roll. The release-prep packet authors the real content; this file must not be
+> treated as a changelog until that packet replaces it.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.18.1`.
+The eventual release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.18.1.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2717,27 +2717,27 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.18.0)
+### 次リリース準備(v0.18.1)
 
-**`v0.17.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.18.0` です。[v0.18.0 notes](release-notes-v0.18.0.md) は正確に G664 だけを
-対象にする実内容付き prepare-only release candidate です。直前の出荷範囲は
-[release-notes-v0.17.0.md](release-notes-v0.17.0.md) を参照し、ここでは重複記載しません。
+**`v0.18.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
+`0.18.1` です。[v0.18.1 notes stub](release-notes-v0.18.1.md) が必須の
+prepare-only placeholder です。直前の出荷範囲は
+[release-notes-v0.18.0.md](release-notes-v0.18.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.18.0` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.18.1` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.17.0 (published), nextVersion 0.18.0 (to release)
+cat eng/version.json   # stableVersion 0.18.0 (published), nextVersion 0.18.1 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.18.0-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.18.1-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.18.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.18.1.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2748,13 +2748,12 @@ dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
 dotnet test IntentSystem.sln -c Release
 ```
 
-準備コミットが `main` に入り readiness の証跡が揃った時点で、この preparation PR は停止します。
-その condition が成立した後の別の operator / release-automation action には conditional approval
-`v0180-preapproved-001` が記録済みです。その別途 authorized された actor だけが `v0.18.0` の
-GitHub Release を作成・公開できます。公開すると
+準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
+明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
+外部リリース自動化)が `v0.18.1` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.18.0`、`nextVersion → 0.18.1` —
+`stableVersion → 0.18.1`、`nextVersion → 0.18.2` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.18.1.md
+++ b/docs/ja/release-notes-v0.18.1.md
@@ -1,0 +1,9 @@
+# リリースノート — intent-cli v0.18.1
+
+> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
+> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
+> このファイルを changelog として扱ってはいけません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.18.1`。
+将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.18.1 に
+publish されます。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.17.0",
-  "nextVersion": "0.18.0"
+  "stableVersion": "0.18.0",
+  "nextVersion": "0.18.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
@@ -155,15 +155,18 @@ public sealed class ReleaseNotesV0170DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void ReadinessAdvancesToV0180WhilePublishedNotesRemainGuarded(string language)
+    public void ReadinessAdvancesBeyondV0180WhilePublishedNotesRemainGuarded(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
+        var v0180Notes = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.18.0.md"));
 
         Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.17.1.md")));
         Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.18.0.md")));
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.18.1.md")));
+        Assert.Contains("release-notes-v0.18.1.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.18.0.md", reference, StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.17.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.17.0.md", v0180Notes, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0180DocsTests", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0170DocsTests", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("ReleaseNotesV0171DocsTests", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0180DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0180DocsTests.cs
@@ -159,16 +159,11 @@ public sealed class ReleaseNotesV0180DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void VersionReadinessMinorRationaleAndPrepareOnlyBoundariesStayAligned(string language)
+    public void PublishedNotesMinorRationaleAndPrepareOnlyBoundariesStayGuarded(string language)
     {
-        var root = RepoVersionPolicySource.RepoRoot();
         var notes = Read(language);
         var compact = Regex.Replace(notes, @"\s+", " ");
-        var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
-        var policy = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, "eng", "version.json"))).RootElement;
 
-        Assert.Equal("0.17.0", policy.GetProperty("stableVersion").GetString());
-        Assert.Equal("0.18.0", policy.GetProperty("nextVersion").GetString());
         Assert.Contains("guide bootstrap", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("bootstrap-resume", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(language == "en" ? "absent at v0.17.0" : "v0.17.0 には存在しません", compact, StringComparison.OrdinalIgnoreCase);
@@ -179,9 +174,39 @@ public sealed class ReleaseNotesV0180DocsTests
         Assert.Contains("package publish", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("post-release roll", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("v0180-preapproved-001", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void PostReleaseReadinessAdvancesToV0181WhileV0180NotesStayLinked(string language)
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
+        var policy = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, "eng", "version.json"))).RootElement;
+        var stubPath = Path.Combine(root, "docs", language, "release-notes-v0.18.1.md");
+
+        Assert.Equal("0.18.0", policy.GetProperty("stableVersion").GetString());
+        Assert.Equal("0.18.1", policy.GetProperty("nextVersion").GetString());
+        Assert.True(File.Exists(stubPath));
+        Assert.Contains(language == "en" ? "DRAFT / UNRELEASED" : "DRAFT / 未リリース", File.ReadAllText(stubPath), StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.18.1.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.18.0.md", reference, StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.17.0.md", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("release-notes-v0.17.1.md", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleaseNotesV0180DocsTests", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleaseNotesV0170DocsTests", reference, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReleaseNotesV0181DocsTests", reference, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en", "7bb2938af2c10b3f6907b5d7aae4e80707e1381aad766f3bf2b8a392203373ac")]
+    [InlineData("ja", "52256cd05666fb7ff514d2766878c87892afa28baf401450fc90e460267bc08f")]
+    public void PublishedV0180NotesRemainByteForByteFrozen(string language, string expectedSha256)
+    {
+        var bytes = File.ReadAllBytes(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.18.0.md"));
+
+        Assert.Equal(expectedSha256, Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(bytes)));
     }
 
     private static IReadOnlyList<string> CountMismatches(string notes, string language)


### PR DESCRIPTION
## Summary

- roll `eng/version.json` to stable `0.18.0` and next `0.18.1`
- add bilingual v0.18.1 DRAFT / UNRELEASED release-note stubs
- advance EN/JA release readiness, version examples, and package examples to v0.18.1
- keep the published v0.18.0 notes byte-for-byte frozen and add explicit SHA-256 regression guards

## Why

v0.18.0 is published from `b966cb5f06372eb96053fd892160091e9d2efea5`, so the repository needs the immediate post-release roll before new release preparation begins.

## Impact

Documentation, version policy, and release guards only. There are no product or runtime behavior changes. Promotion, merge, and host-wrapper refresh remain separate orchestration/review actions.

## Validation

- release workflow `31435035655`: success at `b966cb5f06372eb96053fd892160091e9d2efea5`, with eight published assets/checksums
- focused Release guards: 46 passed, 0 failed
- full Release solution: 5,038 passed, 1 existing skip, 0 failed
- `git diff --check`: clean
- published v0.18.0 notes unchanged from base:
  - EN SHA-256 `7bb2938af2c10b3f6907b5d7aae4e80707e1381aad766f3bf2b8a392203373ac`
  - JA SHA-256 `52256cd05666fb7ff514d2766878c87892afa28baf401450fc90e460267bc08f`
- exact head: `8e96261a9fc764b2c3fc9ba12116f1b85706568c`
