### PR TITLE
G667: honor configured packet draft base branch

### DIFF
--- a/docs/en/04-packets-issues.md
+++ b/docs/en/04-packets-issues.md
@@ -64,6 +64,21 @@ The current intent-cli domain is the measured example—it has no facet nodes—
 human/agent semantic alignment review remains necessary. Do not author facet
 nodes merely to manufacture a green result in this slice.
 
+## Effective PR base branch in a new packet draft
+
+`packet draft` fills the `Expected PR base branch` line in the new
+`github-body.md` through the same effective-branch judgment used by the
+automation surfaces:
+
+- when `[project] implementation_base_branch` is configured, that branch is
+  used;
+- when it is absent, the default branch of `base_branch_policy` is used
+  (`direct-main` → `main`, `main-ai` → `main-ai`).
+
+This behavior applies only to newly scaffolded packet bodies. `packet draft`
+does not rewrite existing packets or published issue bodies, and an absent
+`implementation_base_branch` keeps the prior scaffold output byte-for-byte.
+
 ## Alternative: timer-loop setup
 
 Use [Implementation loop setup](05-implementation-loop.md) and then

--- a/docs/ja/04-packets-issues.md
+++ b/docs/ja/04-packets-issues.md
@@ -64,6 +64,19 @@ facet check は publish 前に必須ですが、結果は正直に記述しま�
 alignment review が引き続き必要です。この slice で green result を作るためだけに facet node
 を author してはいけません。
 
+## 新しい packet draft での有効な PR base branch
+
+`packet draft` は、新しく作る `github-body.md` の `Expected PR base branch` を、
+automation の各サーフェスと同じ effective-branch の判定で埋めます:
+
+- `[project] implementation_base_branch` が設定されていれば、そのブランチを使う;
+- 設定されていなければ、`base_branch_policy` の default branch を使う
+  （`direct-main` → `main`、`main-ai` → `main-ai`）。
+
+この挙動は新しく scaffold する packet body にだけ適用されます。`packet draft` は既存の
+packet や公開済み issue 本文を書き換えず、`implementation_base_branch` が無い場合は従来の
+scaffold 出力を byte 単位で維持します。
+
 ## 代替: timer-loop のセットアップ
 
 timer-loop の alternative を選ぶときだけ、[実装ループの設定](05-implementation-loop.md)、続けて

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -139,9 +139,19 @@ internal static class PacketDraftCommand
         {
             baseBranchPolicy = CliRuntimeContracts.DefaultBaseBranchPolicy;
         }
-        var expectedBaseBranch = BaseBranchPolicyContract.IsKnownPolicy(baseBranchPolicy)
+        var policyDefaultBaseBranch = BaseBranchPolicyContract.IsKnownPolicy(baseBranchPolicy)
             ? BaseBranchPolicyContract.ResolveExpectedBaseBranch(baseBranchPolicy)
             : CliRuntimeContracts.DirectMainBaseBranch;
+        // G667: use the shared effective-branch judgment so a configured
+        // implementation_base_branch is carried into newly drafted issue
+        // bodies, while the policy default remains byte-identical when no
+        // implementation branch is configured.
+        var branchDecision = ImplementationBaseBranchResolver.Resolve(
+            explicitBranch: null,
+            configuredBranch: context.Config.Project.ImplementationBaseBranch,
+            sameRepoTopologyBranch: null,
+            policyDefaultBranch: policyDefaultBaseBranch);
+        var expectedBaseBranch = branchDecision.Branch;
 
         // G530: review-context.md's generated "Facet context" block scopes
         // to whatever `intent_references` an EXISTING packet.yaml on disk

--- a/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/PacketDraftCommandTests.cs
@@ -742,6 +742,92 @@ public sealed class PacketDraftCommandTests
     }
 
     [Fact]
+    public void Execute_G667_ConfiguredImplementationBaseBranch_UsesConfiguredBranch()
+    {
+        using var workspace = new PacketDraftWorkspace();
+        var context = workspace.Context with
+        {
+            Config = workspace.Context.Config with
+            {
+                Project = workspace.Context.Config.Project with
+                {
+                    BaseBranchPolicy = CliRuntimeContracts.DirectMainBaseBranchPolicy,
+                    ImplementationBaseBranch = "develop"
+                }
+            }
+        };
+        using var writer = new StringWriter();
+
+        var exitCode = PacketDraftCommand.Execute(
+            context,
+            ["--execution-unit", "G667", "--target-repo", "J-Tech-Japan/intent-system"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var githubBody = File.ReadAllText(
+            Path.Combine(workspace.RepoRoot, ".intent-cli", "issues", "G667", "github-body.md"));
+
+        Assert.Contains("Expected PR base branch: `develop`", githubBody, StringComparison.Ordinal);
+        Assert.Contains("Open all child PRs against `develop` directly.", githubBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("Expected PR base branch: `main`", githubBody, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(CliRuntimeContracts.DirectMainBaseBranchPolicy, "main")]
+    [InlineData(CliRuntimeContracts.MainAiBaseBranchPolicy, "main-ai")]
+    public void Execute_G667_AbsentImplementationBaseBranch_PreservesPolicyDefaultScaffold(
+        string policy,
+        string expectedBranch)
+    {
+        using var baselineWorkspace = new PacketDraftWorkspace();
+        using var explicitEmptyWorkspace = new PacketDraftWorkspace();
+        var baselineContext = baselineWorkspace.Context with
+        {
+            Config = baselineWorkspace.Context.Config with
+            {
+                Project = baselineWorkspace.Context.Config.Project with
+                {
+                    BaseBranchPolicy = policy
+                }
+            }
+        };
+        var explicitEmptyContext = explicitEmptyWorkspace.Context with
+        {
+            Config = explicitEmptyWorkspace.Context.Config with
+            {
+                Project = explicitEmptyWorkspace.Context.Config.Project with
+                {
+                    BaseBranchPolicy = policy,
+                    ImplementationBaseBranch = string.Empty
+                }
+            }
+        };
+        using var baselineWriter = new StringWriter();
+        using var explicitEmptyWriter = new StringWriter();
+
+        Assert.Equal(
+            0,
+            PacketDraftCommand.Execute(
+                baselineContext,
+                ["--execution-unit", "G667-default"],
+                baselineWriter));
+        Assert.Equal(
+            0,
+            PacketDraftCommand.Execute(
+                explicitEmptyContext,
+                ["--execution-unit", "G667-empty"],
+                explicitEmptyWriter));
+
+        var baselineBody = File.ReadAllText(
+            Path.Combine(baselineWorkspace.RepoRoot, ".intent-cli", "issues", "G667-default", "github-body.md"));
+        var explicitEmptyBody = File.ReadAllText(
+            Path.Combine(explicitEmptyWorkspace.RepoRoot, ".intent-cli", "issues", "G667-empty", "github-body.md"));
+
+        Assert.Equal(baselineBody, explicitEmptyBody);
+        Assert.Contains($"Expected PR base branch: `{expectedBranch}`", baselineBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GeneratesOptionalIntentMaintenanceMetadata_WithoutAddingRequiredSections()
     {
         // G461 AC: new generated packet templates include the optional intent


### PR DESCRIPTION
## Summary

- route packet draft through the shared implementation base branch resolver
- preserve policy-default scaffold output when no implementation base branch is configured
- document the behavior in English and Japanese guidance

## Verification

- targeted PacketDraftCommand, resolver, and G613 tests: 46 passed
- solution build: 0 warnings, 0 errors
- full solution test: 5,048 passed, 1 skipped; 2 packaged invocation smoke tests were environment-blocked because the bounded sandbox denied NuGet audit cache writes outside the workspace
- git diff --check: clean

Closes #1443