### PR TITLE
G677: prepare v0.19.0 release notes

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2628,7 +2628,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0181)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0190)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2721,33 +2721,34 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.18.1)
+### Next release readiness (v0.19.0)
 
 **`v0.18.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.18.1`. [The v0.18.1 notes stub](release-notes-v0.18.1.md) is the required
-prepare-only placeholder. See [release-notes-v0.18.0.md](release-notes-v0.18.0.md)
-for the preceding shipped scope; it is linked, not restated.
+`0.19.0`. [The v0.19.0 notes](release-notes-v0.19.0.md) are the real
+prepare-only release candidate for exactly G666–G676. See
+[release-notes-v0.18.0.md](release-notes-v0.18.0.md) for the preceding shipped
+scope; it is linked, not restated.
 
-**Release-readiness verification (run before merging the `v0.18.1`
+**Release-readiness verification (run before merging the `v0.19.0`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.18.0 (published), nextVersion 0.18.1 (to release)
+cat eng/version.json   # stableVersion 0.18.0 (published), nextVersion 0.19.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.18.1-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.19.0-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.18.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.19.0.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Run the complete Release suite.
 dotnet test IntentSystem.sln -c Release
@@ -2756,10 +2757,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.18.1`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.19.0`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.18.1`, `nextVersion → 0.18.2` — carrying, per **steps 4–6** of the
+`stableVersion → 0.19.0`, `nextVersion → 0.19.1` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.18.1.md
+++ b/docs/en/release-notes-v0.18.1.md
@@ -1,9 +1,0 @@
-# Release Notes — intent-cli v0.18.1
-
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.18.1`.
-The eventual release will be published at
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.18.1.

--- a/docs/en/release-notes-v0.19.0.md
+++ b/docs/en/release-notes-v0.19.0.md
@@ -1,0 +1,124 @@
+# Release Notes — intent-cli v0.19.0
+
+> **prepare-only / UNRELEASED.** This change prepares version state, release
+> notes, and readiness documentation only. It does not create a GitHub Release
+> or tag, publish a package, run the release workflow, or perform a post-release
+> roll.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.19.0`.
+After the separate operator release action, the Release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.19.0.
+The preceding shipped scope remains in the
+[v0.18.0 notes](release-notes-v0.18.0.md); it is linked rather than restated.
+
+## Preview lane — read before the feature description
+
+The G666–G676 surfaces are `preview-through-1.x`, outside the
+[1.0 compatibility promise](1.0-compatibility-promise.md). They may change or
+be withdrawn during 1.x and are not part of the 1.0 compatibility commitment.
+
+## The feedback loop closed at day scale
+
+v0.19.0 contains exactly eleven merged units, G666 through G676. The list was
+derived by running `git log v0.18.0..main --first-parent`; every commit in that
+range is accounted for below as the post-release roll or one of the eleven
+merge commits. Every PR below is MERGED and every full merge commit resolves on
+`main`.
+
+- G666 — PR #1440, merge commit `1b7f8b718d9c22cfe67707ee9ca23a9a9e6f0b7b` (verified on `main`): approval layers eliminate first by recipe, adjudicate recorded policy, and keep design from relaying.
+- G667 — PR #1444, merge commit `2c253a01ea3b7d3836ad044eb5e9ffac38d46f77` (verified on `main`): packet draft resolves the effective base branch through the shared judgment.
+- G668 — PR #1446, merge commit `e9d125ea45a163636323a7a0420476b7267cf94e` (verified on `main`): named branch lanes provide a registry, explicit membership, and an immutable routing snapshot.
+- G669 — PR #1448, merge commit `e1924405e6d0fcdfdccf8665abc7263dc9a0ee96` (verified on `main`): lane propose/confirm decision records distinguish the two routing stall classes.
+- G670 — PR #1450, merge commit `8a85262cd1e42f73d9ba1f438f783e394f8a3828` (verified on `main`): placeholder scaffolds leave the issue-cut-ready pool after the gate's judgment.
+- G671 — PR #1452, merge commit `c4f2d66af72c278d0de1d38b0c2c4ea508b1be5f` (verified on `main`): pending-delegation dispositions end the expectation while retaining the carriage.
+- G672 — PR #1454, merge commit `cc60fc7ae94ddba7746caf2acdef53ecb29becaf` (verified on `main`): the role contract is first in guide next, and event mode is explained at both offer and duty.
+- G673 — PR #1456, merge commit `e6762a5151dc8f489dd5ba108a63adca4ee8c0a6` (verified on `main`): GitHub API quota exhaustion is a named degraded state and doctor reports quota per resource.
+- G674 — PR #1458, merge commit `44c4a27befe458399777743ed5c8e16c0d5f3fe1` (verified on `main`): verified GitHub reads use REST with field equivalence, while unverified reads remain GraphQL-bound.
+- G675 — PR #1460, merge commit `1c7cace56fdf29a834ee2de61df768e3b083a796` (verified on `main`): scheduler artifacts carry their environment and transport start failure is degraded rather than lost.
+- G676 — PR #1462, merge commit `85a4d451d9a91daaf936e3997cf36f67b73766f1` (verified on `main`): duplicate supervisors are detected by writer identity, never elected.
+
+### Full first-parent range accounting
+
+The first-parent range has twelve commits. The eleven merge rows above account
+for the feature units; the remaining commit is the post-release context and is
+not a release execution unit.
+
+| account | full commit | treatment |
+| --- | --- | --- |
+| post-release roll to 0.18.1 | `478dd57b5de609e47dbe678c82f714fd0e463dd8` | accounted for; context, not a unit |
+| G666 merge | `1b7f8b718d9c22cfe67707ee9ca23a9a9e6f0b7b` | merged unit above |
+| G667 merge | `2c253a01ea3b7d3836ad044eb5e9ffac38d46f77` | merged unit above |
+| G668 merge | `e9d125ea45a163636323a7a0420476b7267cf94e` | merged unit above |
+| G669 merge | `e1924405e6d0fcdfdccf8665abc7263dc9a0ee96` | merged unit above |
+| G670 merge | `8a85262cd1e42f73d9ba1f438f783e394f8a3828` | merged unit above |
+| G671 merge | `c4f2d66af72c278d0de1d38b0c2c4ea508b1be5f` | merged unit above |
+| G672 merge | `cc60fc7ae94ddba7746caf2acdef53ecb29becaf` | merged unit above |
+| G673 merge | `e6762a5151dc8f489dd5ba108a63adca4ee8c0a6` | merged unit above |
+| G674 merge | `44c4a27befe458399777743ed5c8e16c0d5f3fe1` | merged unit above |
+| G675 merge | `1c7cace56fdf29a834ee2de61df768e3b083a796` | merged unit above |
+| G676 merge | `85a4d451d9a91daaf936e3997cf36f67b73766f1` | merged unit above |
+
+### Four attributed origins
+
+These units are one feedback loop closing at day scale, but their measured
+facts remain separately attributed under G625:
+
+- The operator's branch-lane request produced G667–G669. Those units are the
+  operator-request origin, not a measurement from the remote-herdr team.
+- Operator-filed feedback issue [#1441](https://github.com/J-Tech-Japan/intent-system/issues/1441)
+  produced G670–G672. It was reported by the remote-herdr design thread (Claude)
+  for the remote-herdr domain, with Tomohisa Takaoka as operator, over
+  2026-08-04–2026-08-11: 48 packets and 21 tier-2 E2E rounds. These measurements
+  belong to that reporting team and period.
+- Operator-filed feedback issue [#1442](https://github.com/J-Tech-Japan/intent-system/issues/1442)
+  produced G673–G674. The remote-herdr four-thread team measured the outage at
+  2026-08-12T02:05–02:08Z: GraphQL remaining 0 after 5,046 requests while REST
+  still had 4,948 remaining. That report's team and timestamp stay attached to
+  those facts; they are not this repository's measurements.
+- Same-day incidents on this host produced G675–G676. G675 measured the
+  scheduler exit-127 loop and then ten false losses on 2026-08-12; G676 measured
+  four concurrent supervisors for the Sekiban workers team in workspace `w2H`
+  on this machine on 2026-08-12. The host incidents and the sibling-team
+  observation remain distinguishable, including their teams and date.
+
+The minor bump is checkable: the branch-lane registry and routing snapshot, the
+pending-delegation disposition record, the named quota-degraded state and
+doctor quota report, and duplicate-supervisor detection were absent at
+v0.18.0. This is additive preview capability, not a patch-only correction.
+
+## Deliberate boundaries
+
+- This preparation changes version policy, release notes, readiness
+  documentation, and release guards only. It makes no code or runtime behavior
+  change.
+- Earlier release notes are linked rather than restated. The table above is
+  bounded exactly to G666–G676; it does not silently include an earlier unit.
+- Prepare-only remains in force: this PR creates no GitHub Release or tag,
+  publishes no package, and does not run release automation.
+
+## Release-readiness gate
+
+Before the separate operator release action:
+
+- `eng/version.json` records stable `0.18.0` and next `0.19.0`.
+- The eleven PRs and full merge commits above resolve on `main`, and every
+  commit in `git log v0.18.0..main --first-parent` is accounted for by the
+  range table.
+- The preview statement precedes the feature description and links the 1.0
+  compatibility promise.
+- The EN/JA notes remain in parity under the G613 terminology policy; the
+  release-notes count guard, version/readiness guards, full suite, and
+  `git diff --check` are green.
+- Prepare-only remains in force. Release creation, tagging, and package
+  publication are separate operator actions.
+
+## Publishing v0.19.0
+
+Release creation remains a distinct operator action after this preparation is
+merged and its readiness evidence is green. Only then may an authorized
+maintainer create and publish the GitHub Release for `v0.19.0`; publishing it
+triggers `release.yml` (`on: release: published`) to build and publish the
+NuGet package and platform artifacts. After that separate release, roll
+`eng/version.json` to stable `0.19.0` / next `0.19.1`, add the next DRAFT note
+stubs in the same commit, refresh both readiness mirrors, and verify child-main
+CI before calling the post-release roll complete.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2787,32 +2787,32 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.18.1)
+### 次リリース準備(v0.19.0)
 
 **`v0.18.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.18.1` です。[v0.18.1 notes stub](release-notes-v0.18.1.md) が必須の
-prepare-only placeholder です。直前の出荷範囲は
+`0.19.0` です。[v0.19.0 notes](release-notes-v0.19.0.md) は G666–G676 を
+正確に扱う実内容付き prepare-only release candidate です。直前の出荷範囲は
 [release-notes-v0.18.0.md](release-notes-v0.18.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.18.1` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.19.0` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.18.0 (published), nextVersion 0.18.1 (to release)
+cat eng/version.json   # stableVersion 0.18.0 (published), nextVersion 0.19.0 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.18.1-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.19.0-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.18.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.19.0.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Release suite を完全実行。
 dotnet test IntentSystem.sln -c Release
@@ -2820,10 +2820,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.18.1` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.19.0` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.18.1`、`nextVersion → 0.18.2` —
+`stableVersion → 0.19.0`、`nextVersion → 0.19.1` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.18.1.md
+++ b/docs/ja/release-notes-v0.18.1.md
@@ -1,9 +1,0 @@
-# リリースノート — intent-cli v0.18.1
-
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
-> このファイルを changelog として扱ってはいけません。
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.18.1`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.18.1 に
-publish されます。

--- a/docs/ja/release-notes-v0.19.0.md
+++ b/docs/ja/release-notes-v0.19.0.md
@@ -1,0 +1,114 @@
+# リリースノート — intent-cli v0.19.0
+
+> **prepare-only / 未リリース。** この変更は version state、release notes、
+> readiness documentation だけを準備します。GitHub Release や tag の作成、
+> package publish、release workflow の実行、post-release roll は行いません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.19.0`。
+operator が別手順を実行した後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.19.0 に公開されます。
+直前の出荷範囲は [v0.18.0 notes](release-notes-v0.18.0.md) を参照し、ここでは
+重複記載しません。
+
+## feature description より先に読む preview lane
+
+G666–G676 の surface は `preview-through-1.x` です。[1.0 compatibility promise](1.0-compatibility-promise.md)
+の対象外であり、1.x の間に変更または撤回される可能性があり、1.0 の compatibility
+commitment には含まれません。
+
+## day-scale で閉じた feedback loop
+
+v0.19.0 は G666 から G676 まで、正確に十一件の merged unit を含みます。一覧は
+`git log v0.18.0..main --first-parent` を実行して導出しました。その range の全 commit を
+post-release roll または十一件の merge commit として以下で説明しています。各 PR は
+MERGED であり、各 full merge commit が `main` に解決することを確認しています。
+
+- G666 — PR #1440、merge commit `1b7f8b718d9c22cfe67707ee9ca23a9a9e6f0b7b`（`main` で確認）: approval layer は recipe による eliminate-first、recorded policy の adjudication、design が relay しないことを実現します。
+- G667 — PR #1444、merge commit `2c253a01ea3b7d3836ad044eb5e9ffac38d46f77`（`main` で確認）: packet draft が shared judgment を通して effective base branch を解決します。
+- G668 — PR #1446、merge commit `e9d125ea45a163636323a7a0420476b7267cf94e`（`main` で確認）: named branch lane が registry、明示的 membership、immutable routing snapshot を持ちます。
+- G669 — PR #1448、merge commit `e1924405e6d0fcdfdccf8665abc7263dc9a0ee96`（`main` で確認）: lane propose/confirm decision record が二つの routing stall class を区別します。
+- G670 — PR #1450、merge commit `8a85262cd1e42f73d9ba1f438f783e394f8a3828`（`main` で確認）: placeholder scaffold は gate の judgment 後に issue-cut-ready pool から外れます。
+- G671 — PR #1452、merge commit `c4f2d66af72c278d0de1d38b0c2c4ea508b1be5f`（`main` で確認）: pending-delegation disposition は expectation を終え、carriage を保持します。
+- G672 — PR #1454、merge commit `cc60fc7ae94ddba7746caf2acdef53ecb29becaf`（`main` で確認）: role contract を guide next の先頭に置き、event mode を offer と duty の両方で説明します。
+- G673 — PR #1456、merge commit `e6762a5151dc8f489dd5ba108a63adca4ee8c0a6`（`main` で確認）: GitHub API quota exhaustion を named degraded state とし、doctor が resource ごとの quota を報告します。
+- G674 — PR #1458、merge commit `44c4a27befe458399777743ed5c8e16c0d5f3fe1`（`main` で確認）: field equivalence を確認した GitHub read に REST を使い、未確認の read は GraphQL-bound のままです。
+- G675 — PR #1460、merge commit `1c7cace56fdf29a834ee2de61df768e3b083a796`（`main` で確認）: scheduler artifact が environment を持ち、transport start failure を lost ではなく degraded とします。
+- G676 — PR #1462、merge commit `85a4d451d9a91daaf936e3997cf36f67b73766f1`（`main` で確認）: writer identity で duplicate supervisor を検出し、election は行いません。
+
+### full first-parent range の会計
+
+first-parent range は十二 commit です。上の十一 merge row が feature unit を説明し、残る
+一つは range の context であり、release execution unit ではありません。
+
+| account | full commit | treatment |
+| --- | --- | --- |
+| 0.18.1 への post-release roll | `478dd57b5de609e47dbe678c82f714fd0e463dd8` | 説明済み。context であり unit ではない |
+| G666 merge | `1b7f8b718d9c22cfe67707ee9ca23a9a9e6f0b7b` | 上記の merged unit |
+| G667 merge | `2c253a01ea3b7d3836ad044eb5e9ffac38d46f77` | 上記の merged unit |
+| G668 merge | `e9d125ea45a163636323a7a0420476b7267cf94e` | 上記の merged unit |
+| G669 merge | `e1924405e6d0fcdfdccf8665abc7263dc9a0ee96` | 上記の merged unit |
+| G670 merge | `8a85262cd1e42f73d9ba1f438f783e394f8a3828` | 上記の merged unit |
+| G671 merge | `c4f2d66af72c278d0de1d38b0c2c4ea508b1be5f` | 上記の merged unit |
+| G672 merge | `cc60fc7ae94ddba7746caf2acdef53ecb29becaf` | 上記の merged unit |
+| G673 merge | `e6762a5151dc8f489dd5ba108a63adca4ee8c0a6` | 上記の merged unit |
+| G674 merge | `44c4a27befe458399777743ed5c8e16c0d5f3fe1` | 上記の merged unit |
+| G675 merge | `1c7cace56fdf29a834ee2de61df768e3b083a796` | 上記の merged unit |
+| G676 merge | `85a4d451d9a91daaf936e3997cf36f67b73766f1` | 上記の merged unit |
+
+### 四つの attribution された origin
+
+この unit 群は day-scale で閉じる一つの feedback loop ですが、G625 に従い measured fact
+の attribution は分けて保持します。
+
+- operator の branch-lane request が G667–G669 を生みました。これは operator-request origin
+  であり、remote-herdr team の measurement ではありません。
+- operator-filed feedback issue [#1441](https://github.com/J-Tech-Japan/intent-system/issues/1441)
+  が G670–G672 を生みました。remote-herdr domain の design thread (Claude) が report し、
+  operator は Tomohisa Takaoka、期間は 2026-08-04–2026-08-11、48 packet、tier-2 E2E 21 round
+  です。これらの measurement はその reporting team と期間に属します。
+- operator-filed feedback issue [#1442](https://github.com/J-Tech-Japan/intent-system/issues/1442)
+  が G673–G674 を生みました。remote-herdr の four-thread team が 2026-08-12T02:05–02:08Z
+  に outage を測定し、GraphQL remaining 0（5,046 request 後）、REST remaining 4,948 を
+  記録しました。この report の team と timestamp を保持し、この repository 自身の measurement
+  と混ぜません。
+- same-day の host incident が G675–G676 を生みました。G675 は 2026-08-12 に scheduler の
+  exit-127 loop と一 cycle の ten false loss をこの host で測定し、G676 は同じ machine の
+  Sekiban workers team、workspace `w2H` で四つの concurrent supervisor を 2026-08-12 に
+  測定しました。host incident と sibling-team observation は team と date を含めて区別します。
+
+minor bump の根拠は検証可能です。branch-lane registry / routing snapshot、pending-delegation
+disposition record、named quota-degraded state / doctor quota report、duplicate-supervisor
+detection は v0.18.0 には存在しませんでした。これは additive な preview capability であり、
+patch-only correction ではありません。
+
+## 意図的な boundary
+
+- この準備が変更するのは version policy、release notes、readiness documentation、release
+  guard だけです。code と runtime behavior は変更しません。
+- earlier release notes は link し、重複記載しません。上の table は G666–G676 に正確に限定し、
+  earlier unit を追加しません。
+- prepare-only を保ち、この PR は GitHub Release / tag を作成せず、package publish も release
+  automation の実行も行いません。
+
+## リリース準備ゲート (Release-readiness gate)
+
+operator が別の Release 手順を実行する前に確認します。
+
+- `eng/version.json` が stable `0.18.0` / next `0.19.0` を記録していること。
+- 上記十一 PR と full merge commit が `main` に解決し、`git log v0.18.0..main --first-parent`
+  の全 commit が range table で説明されていること。
+- preview statement が feature description より前にあり、1.0 compatibility promise を link
+  していること。
+- EN/JA notes が G613 terminology policy の parity を保ち、release-notes count guard、
+  version/readiness guard、full suite、`git diff --check` が green であること。
+- prepare-only を保つこと。Release creation、tagging、package publication は operator の別 action
+  です。
+
+## v0.19.0 の publish
+
+この準備が merge され readiness evidence が green になった後も、Release 作成は別の operator
+action です。その後に限り authorized maintainer が `v0.19.0` の GitHub Release を作成・公開でき、
+`release.yml`（`on: release: published`）が NuGet package と platform artifact の build / publish
+を起動します。その別 Release 後に `eng/version.json` を stable `0.19.0` / next `0.19.1` へ roll し、
+同じ commit に次の DRAFT note stub を加え、両方の readiness mirror を更新し、post-release roll を
+完了とする前に child-main CI を確認します。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
   "stableVersion": "0.18.0",
-  "nextVersion": "0.18.1"
+  "nextVersion": "0.19.0"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
@@ -163,11 +163,12 @@ public sealed class ReleaseNotesV0170DocsTests
 
         Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.17.1.md")));
         Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.18.0.md")));
-        Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.18.1.md")));
-        Assert.Contains("release-notes-v0.18.1.md", reference, StringComparison.Ordinal);
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.19.0.md")));
+        Assert.Contains("release-notes-v0.19.0.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.18.0.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.17.0.md", v0180Notes, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0180DocsTests", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleaseNotesV0190DocsTests", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0170DocsTests", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("ReleaseNotesV0171DocsTests", reference, StringComparison.Ordinal);
     }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0180DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0180DocsTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using System.Text.RegularExpressions;
 using IntentSystem.Cli.Infrastructure;
 
@@ -179,23 +178,23 @@ public sealed class ReleaseNotesV0180DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void PostReleaseReadinessAdvancesToV0181WhileV0180NotesStayLinked(string language)
+    public void PostReleaseReadinessAdvancesToV0190WhileV0180NotesStayLinked(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
-        var policy = JsonDocument.Parse(File.ReadAllText(Path.Combine(root, "eng", "version.json"))).RootElement;
-        var stubPath = Path.Combine(root, "docs", language, "release-notes-v0.18.1.md");
+        var policy = RepoVersionPolicySource.Read();
+        var notesPath = Path.Combine(root, "docs", language, $"release-notes-v{policy.NextVersion}.md");
 
-        Assert.Equal("0.18.0", policy.GetProperty("stableVersion").GetString());
-        Assert.Equal("0.18.1", policy.GetProperty("nextVersion").GetString());
-        Assert.True(File.Exists(stubPath));
-        Assert.Contains(language == "en" ? "DRAFT / UNRELEASED" : "DRAFT / 未リリース", File.ReadAllText(stubPath), StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.18.1.md", reference, StringComparison.Ordinal);
+        Assert.Equal("0.18.0", policy.StableVersion);
+        Assert.Equal("0.19.0", policy.NextVersion);
+        Assert.True(File.Exists(notesPath));
+        Assert.DoesNotContain(language == "en" ? "DRAFT / UNRELEASED" : "DRAFT / 未リリース", File.ReadAllText(notesPath), StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.19.0.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.18.0.md", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("release-notes-v0.17.1.md", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0180DocsTests", reference, StringComparison.Ordinal);
+        Assert.Contains("ReleaseNotesV0190DocsTests", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0170DocsTests", reference, StringComparison.Ordinal);
-        Assert.DoesNotContain("ReleaseNotesV0181DocsTests", reference, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0190DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0190DocsTests.cs
@@ -1,0 +1,142 @@
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G677 keeps the v0.19.0 prepare-only notes bilingual, exactly bounded to
+/// G666-G676, and reconciled with the full v0.18.0..main first-parent range.
+/// </summary>
+public sealed class ReleaseNotesV0190DocsTests
+{
+    private static readonly (string Unit, string Pr, string Merge)[] Units =
+    [
+        ("G666", "#1440", "1b7f8b718d9c22cfe67707ee9ca23a9a9e6f0b7b"),
+        ("G667", "#1444", "2c253a01ea3b7d3836ad044eb5e9ffac38d46f77"),
+        ("G668", "#1446", "e9d125ea45a163636323a7a0420476b7267cf94e"),
+        ("G669", "#1448", "e1924405e6d0fcdfdccf8665abc7263dc9a0ee96"),
+        ("G670", "#1450", "8a85262cd1e42f73d9ba1f438f783e394f8a3828"),
+        ("G671", "#1452", "c4f2d66af72c278d0de1d38b0c2c4ea508b1be5f"),
+        ("G672", "#1454", "cc60fc7ae94ddba7746caf2acdef53ecb29becaf"),
+        ("G673", "#1456", "e6762a5151dc8f489dd5ba108a63adca4ee8c0a6"),
+        ("G674", "#1458", "44c4a27befe458399777743ed5c8e16c0d5f3fe1"),
+        ("G675", "#1460", "1c7cace56fdf29a834ee2de61df768e3b083a796"),
+        ("G676", "#1462", "85a4d451d9a91daaf936e3997cf36f67b73766f1"),
+    ];
+
+    private static readonly string[] RangeCommits =
+    [
+        "478dd57b5de609e47dbe678c82f714fd0e463dd8",
+        .. Units.Select(unit => unit.Merge),
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyG666ThroughG676WithVerifiedPrsAndMerges(string language)
+    {
+        var notes = Read(language);
+        var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(Units.Select(unit => unit.Unit), listed);
+        Assert.Equal(11, listed.Length);
+        foreach (var unit in Units)
+        {
+            Assert.Contains(unit.Pr, notes, StringComparison.Ordinal);
+            Assert.Contains($"merge commit `{unit.Merge}`", notes, StringComparison.Ordinal);
+            Assert.Contains($"`{unit.Merge}`", notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("git log v0.18.0..main --first-parent", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "eleven merged units" : "正確に十一件の merged unit", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "twelve commits" : "十二 commit", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesAccountForEveryFullFirstParentRangeCommit(string language)
+    {
+        var notes = Read(language);
+
+        Assert.Equal(12, RangeCommits.Length);
+        Assert.Equal(RangeCommits.Length, RangeCommits.Distinct(StringComparer.Ordinal).Count());
+        foreach (var commit in RangeCommits)
+        {
+            Assert.Contains(commit, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains(language == "en" ? "not a release execution unit" : "release execution unit ではありません", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void PreviewStatementPrecedesFeatureDescriptionAndLinksPromise(string language)
+    {
+        var notes = Read(language);
+        var preview = notes.IndexOf("preview-through-1.x", StringComparison.Ordinal);
+        var feature = notes.IndexOf(
+            language == "en" ? "## The feedback loop closed at day scale" : "## day-scale で閉じた feedback loop",
+            StringComparison.Ordinal);
+
+        Assert.True(preview >= 0);
+        Assert.True(feature > preview);
+        Assert.Contains("[1.0 compatibility promise](1.0-compatibility-promise.md)", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPreserveAttributedOriginsMinorRationaleAndPrepareOnly(string language)
+    {
+        var notes = Read(language);
+        var compact = Regex.Replace(notes, @"\s+", " ");
+
+        foreach (var term in new[] { "G625", "#1441", "#1442", "remote-herdr", "2026-08-12", "G675", "G676" })
+        {
+            Assert.Contains(term, compact, StringComparison.OrdinalIgnoreCase);
+        }
+
+        foreach (var term in new[]
+                 {
+                     "branch-lane registry", "routing snapshot", "pending-delegation", "quota-degraded",
+                     "duplicate-supervisor", "v0.18.0",
+                 })
+        {
+            Assert.Contains(term, compact, StringComparison.OrdinalIgnoreCase);
+        }
+
+        Assert.Contains("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "UNRELEASED" : "未リリース", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "no code or runtime behavior change" : "code と runtime behavior は変更しません", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "creates no GitHub Release or tag" : "GitHub Release / tag を作成せず", compact, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void CurrentPolicyAndReadinessPointAtRealV0190Notes(string language)
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var policy = RepoVersionPolicySource.Read();
+        var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
+        var notes = Read(language);
+
+        Assert.Equal("0.18.0", policy.StableVersion);
+        Assert.Equal("0.19.0", policy.NextVersion);
+        Assert.Contains("release-notes-v0.19.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "Next release readiness (v0.19.0)" : "次リリース準備(v0.19.0)",
+            reference,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("DRAFT /", notes, StringComparison.Ordinal);
+        Assert.Contains("Release-readiness gate", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "Publishing v0.19.0" : "v0.19.0 の publish", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Read(string language) => File.ReadAllText(Path.Combine(
+        RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.19.0.md"));
+}


### PR DESCRIPTION
Closes #1463

Prepare-only v0.19.0 release readiness:
- retargets eng/version.json to stable 0.18.0 / next 0.19.0;
- replaces the superseded EN/JA 0.18.1 draft stubs with real bilingual notes covering exactly G666-G676;
- records each verified PR and full merge commit, plus every commit in git log v0.18.0..main --first-parent;
- preserves G625 attribution and puts preview-through-1.x before the feature description;
- refreshes EN/JA readiness and updates the release-note/version guards.

No GitHub Release, tag, package publish, release workflow, or code/runtime behavior change is included.

Verification: targeted release/G613/version guards 68 passed; full IntentSystem.sln 4822 passed, 1 skipped; git diff --check clean; all range commits reachable from origin/main.