### PR TITLE
Roll post-release version to 0.19.1

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2628,7 +2628,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0190)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0191)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2721,34 +2721,33 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.19.0)
+### Next release readiness (v0.19.1)
 
-**`v0.18.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.19.0`. [The v0.19.0 notes](release-notes-v0.19.0.md) are the real
-prepare-only release candidate for exactly G666–G676. See
-[release-notes-v0.18.0.md](release-notes-v0.18.0.md) for the preceding shipped
-scope; it is linked, not restated.
+**`v0.19.0` shipped** (GitHub Release + NuGet), and the next prepared line is
+`0.19.1`. [The v0.19.1 notes stub](release-notes-v0.19.1.md) is the required
+prepare-only placeholder. See [release-notes-v0.19.0.md](release-notes-v0.19.0.md)
+for the preceding shipped scope; it is linked, not restated.
 
-**Release-readiness verification (run before merging the `v0.19.0`
+**Release-readiness verification (run before merging the `v0.19.1`
 release-preparation PR):**
 
 ```bash
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.18.0 (published), nextVersion 0.19.0 (to release)
+cat eng/version.json   # stableVersion 0.19.0 (published), nextVersion 0.19.1 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.19.0-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.19.1-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.19.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.19.1.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Run the complete Release suite.
 dotnet test IntentSystem.sln -c Release
@@ -2757,10 +2756,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.19.0`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.19.1`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.19.0`, `nextVersion → 0.19.1` — carrying, per **steps 4–6** of the
+`stableVersion → 0.19.1`, `nextVersion → 0.19.2` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.19.1.md
+++ b/docs/en/release-notes-v0.19.1.md
@@ -1,0 +1,9 @@
+# Release Notes — intent-cli v0.19.1
+
+> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
+> roll. The release-prep packet authors the real content; this file must not be
+> treated as a changelog until that packet replaces it.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.19.1`.
+The eventual release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.19.1.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2787,32 +2787,32 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.19.0)
+### 次リリース準備(v0.19.1)
 
-**`v0.18.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.19.0` です。[v0.19.0 notes](release-notes-v0.19.0.md) は G666–G676 を
-正確に扱う実内容付き prepare-only release candidate です。直前の出荷範囲は
-[release-notes-v0.18.0.md](release-notes-v0.18.0.md) を参照し、ここでは重複記載しません。
+**`v0.19.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
+`0.19.1` です。[v0.19.1 notes stub](release-notes-v0.19.1.md) が必須の
+prepare-only placeholder です。直前の出荷範囲は
+[release-notes-v0.19.0.md](release-notes-v0.19.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.19.0` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.19.1` release-preparation PR のマージ前に実行):**
 
 ```bash
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.18.0 (published), nextVersion 0.19.0 (to release)
+cat eng/version.json   # stableVersion 0.19.0 (published), nextVersion 0.19.1 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.19.0-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.19.1-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.19.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.19.1.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Release suite を完全実行。
 dotnet test IntentSystem.sln -c Release
@@ -2820,10 +2820,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.19.0` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.19.1` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.19.0`、`nextVersion → 0.19.1` —
+`stableVersion → 0.19.1`、`nextVersion → 0.19.2` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.19.1.md
+++ b/docs/ja/release-notes-v0.19.1.md
@@ -1,0 +1,9 @@
+# リリースノート — intent-cli v0.19.1
+
+> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
+> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
+> このファイルを changelog として扱ってはいけません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.19.1`。
+将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.19.1 に
+publish されます。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.18.0",
-  "nextVersion": "0.19.0"
+  "stableVersion": "0.19.0",
+  "nextVersion": "0.19.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0170DocsTests.cs
@@ -160,12 +160,13 @@ public sealed class ReleaseNotesV0170DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
         var v0180Notes = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.18.0.md"));
+        var policy = RepoVersionPolicySource.Read();
+        var currentNotes = $"release-notes-v{policy.NextVersion}.md";
 
         Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.17.1.md")));
         Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.18.0.md")));
-        Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.19.0.md")));
-        Assert.Contains("release-notes-v0.19.0.md", reference, StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.18.0.md", reference, StringComparison.Ordinal);
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
+        Assert.Contains(currentNotes, reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.17.0.md", v0180Notes, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0180DocsTests", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0190DocsTests", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0180DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0180DocsTests.cs
@@ -178,19 +178,17 @@ public sealed class ReleaseNotesV0180DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void PostReleaseReadinessAdvancesToV0190WhileV0180NotesStayLinked(string language)
+    public void PublishedV0180NotesStayGuardedWhileCurrentReadinessFollowsPolicy(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
         var policy = RepoVersionPolicySource.Read();
-        var notesPath = Path.Combine(root, "docs", language, $"release-notes-v{policy.NextVersion}.md");
+        var currentNotes = $"release-notes-v{policy.NextVersion}.md";
 
-        Assert.Equal("0.18.0", policy.StableVersion);
-        Assert.Equal("0.19.0", policy.NextVersion);
-        Assert.True(File.Exists(notesPath));
-        Assert.DoesNotContain(language == "en" ? "DRAFT / UNRELEASED" : "DRAFT / 未リリース", File.ReadAllText(notesPath), StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.19.0.md", reference, StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.18.0.md", reference, StringComparison.Ordinal);
+        RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.18.0.md")));
+        Assert.Contains(currentNotes, reference, StringComparison.Ordinal);
         Assert.DoesNotContain("release-notes-v0.17.1.md", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0180DocsTests", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0190DocsTests", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0190DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0190DocsTests.cs
@@ -118,23 +118,40 @@ public sealed class ReleaseNotesV0190DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void CurrentPolicyAndReadinessPointAtRealV0190Notes(string language)
+    public void CurrentPolicyAndReadinessFollowVersionPolicyWhileV0190NotesStayReal(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
         var notes = Read(language);
+        var currentNotes = $"release-notes-v{policy.NextVersion}.md";
+        var shippedNotes = $"release-notes-v{policy.StableVersion}.md";
 
-        Assert.Equal("0.18.0", policy.StableVersion);
-        Assert.Equal("0.19.0", policy.NextVersion);
-        Assert.Contains("release-notes-v0.19.0.md", reference, StringComparison.Ordinal);
+        RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, shippedNotes)));
+        Assert.Contains(currentNotes, reference, StringComparison.Ordinal);
+        Assert.Contains(shippedNotes, reference, StringComparison.Ordinal);
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.19.0)" : "次リリース準備(v0.19.0)",
+            language == "en"
+                ? $"Next release readiness (v{policy.NextVersion})"
+                : $"次リリース準備(v{policy.NextVersion})",
             reference,
             StringComparison.Ordinal);
         Assert.DoesNotContain("DRAFT /", notes, StringComparison.Ordinal);
         Assert.Contains("Release-readiness gate", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(language == "en" ? "Publishing v0.19.0" : "v0.19.0 の publish", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en", "11866387f4fe8017bfbc3b8e3dad089435dee9c1da426dadecdfd50ec2bc5221")]
+    [InlineData("ja", "2383b58cc3a21910469f2a78c899d2df50592d79c62ab0c0d832dbbfbe509702")]
+    public void PublishedV0190NotesRemainByteForByteFrozen(string language, string expectedSha256)
+    {
+        var bytes = File.ReadAllBytes(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.19.0.md"));
+
+        Assert.Equal(expectedSha256, Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(bytes)));
     }
 
     private static string Read(string language) => File.ReadAllText(Path.Combine(


### PR DESCRIPTION
## Summary

Immediate post-release roll after the operator-approved v0.19.0 transaction:

- rolls `eng/version.json` to stable `0.19.0` / next `0.19.1`;
- adds EN/JA `v0.19.1` DRAFT / UNRELEASED stubs in the same commit;
- refreshes both developer-reference readiness sections, version/package examples, and links v0.19.0 as the preceding shipped scope;
- keeps published v0.19.0 notes byte-for-byte frozen and keeps current-state guards derived from `eng/version.json`.

No Issue, host queue, packet, or metadata state is created or changed.

## Release evidence

- Release/tag target: `cd2d55c0f8239538d48e99d2e20a514f0616436d`
- Release: https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.19.0
- Release workflow: https://github.com/J-Tech-Japan/intent-system/actions/runs/31619023231 — SUCCESS at the same head
- Assets: 8 uploaded assets (3 platform archives + NuGet package, each with SHA-256 checksum)
- Public NuGet clean install: `JTechJapan.IntentSystem.Cli` 0.19.0 installed from NuGet.org; `intent-cli --version` returned `intent-cli 0.19.0-cd2d55c-G675`

## Verification

- Focused Release/version/G613 guards (`-c Release`): 104 passed, 0 failed
- Full `IntentSystem.sln -c Release`: 5154 passed, 1 skipped, 0 failed across 11 test projects
- `git diff --check`: clean
- Published v0.19.0 notes frozen hashes:
  - EN `11866387f4fe8017bfbc3b8e3dad089435dee9c1da426dadecdfd50ec2bc5221`
  - JA `2383b58cc3a21910469f2a78c899d2df50592d79c62ab0c0d832dbbfbe509702`
- Exact head: `16b1ce6646a860550a3a38f65e561c01c5a48452`