### PR TITLE
G687: Prepare v0.20.0 (prepare-only)

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2628,7 +2628,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0191)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0200)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2721,14 +2721,14 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.19.1)
+### Next release readiness (v0.20.0)
 
 **`v0.19.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.19.1`. [The v0.19.1 notes stub](release-notes-v0.19.1.md) is the required
-prepare-only placeholder. See [release-notes-v0.19.0.md](release-notes-v0.19.0.md)
+`0.20.0`. [The v0.20.0 release notes](release-notes-v0.20.0.md) carry the
+prepare-only scope. See [release-notes-v0.19.0.md](release-notes-v0.19.0.md)
 for the preceding shipped scope; it is linked, not restated.
 
-**Release-readiness verification (run before merging the `v0.19.1`
+**Release-readiness verification (run before merging the `v0.20.0`
 release-preparation PR):**
 
 On a claims-enabled host, acquire and verify the release scope before editing
@@ -2737,25 +2737,25 @@ no claims store preserves legacy single-team behavior.
 
 ```bash
 # 0. Acquire and verify release-prep ownership (preview-through-1.x).
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.19.1 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.19.1 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.20.0 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.20.0 --team <team> --format json
 
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.19.0 (published), nextVersion 0.19.1 (to release)
+cat eng/version.json   # stableVersion 0.19.0 (published), nextVersion 0.20.0 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.19.1-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.20.0-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.19.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.20.0.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0200DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Run the complete Release suite.
 dotnet test IntentSystem.sln -c Release
@@ -2764,10 +2764,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.19.1`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.20.0`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.19.1`, `nextVersion → 0.19.2` — carrying, per **steps 4–6** of the
+`stableVersion → 0.20.0`, `nextVersion → 0.20.1` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.19.1.md
+++ b/docs/en/release-notes-v0.19.1.md
@@ -1,9 +1,0 @@
-# Release Notes — intent-cli v0.19.1
-
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the post-release version
-> roll. The release-prep packet authors the real content; this file must not be
-> treated as a changelog until that packet replaces it.
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.19.1`.
-The eventual release will be published at
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.19.1.

--- a/docs/en/release-notes-v0.20.0.md
+++ b/docs/en/release-notes-v0.20.0.md
@@ -1,0 +1,119 @@
+# Release Notes — intent-cli v0.20.0
+
+> **prepare-only / UNRELEASED.** This PR prepares version state, release
+> notes, readiness documentation, and guards only. It does not create a GitHub
+> Release or tag, publish a package, run release automation, or perform a
+> post-release roll.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.20.0`.
+After a separate operator approval and release action, the Release will be
+published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.20.0.
+The preceding shipped scope remains in the
+[v0.19.0 notes](release-notes-v0.19.0.md); it is linked rather than restated.
+
+## Preview lane — read before the feature description
+
+The G678–G686 surfaces are `preview-through-1.x`, outside the
+[1.0 compatibility promise](1.0-compatibility-promise.md). They may change or
+be withdrawn during 1.x and are not part of the 1.0 compatibility commitment.
+
+## The day-scale feedback loop
+
+v0.20.0 contains exactly nine merged feature units, G678 through G686. This
+scope was derived by running `git log v0.19.0..main --first-parent`; every
+commit in that range is accounted for below as the post-release roll or one of
+the nine merge commits. Every PR below is MERGED, and every full merge commit
+resolves on `main`.
+
+- G678 — [PR #1468](https://github.com/J-Tech-Japan/intent-system/pull/1468), merge commit `3671ba062cd1a4e4b54d634e7160da381fdd3ceb` (verified on `main`): per-lane `operator-merge` landing authority is visible and patient, and no `intent-cli` path merges that lane.
+- G679 — [PR #1471](https://github.com/J-Tech-Japan/intent-system/pull/1471), merge commit `42789d6d8b1e4ac0d7133a277decd6ebcddeaf6b` (verified on `main`): git push-CAS claims provide multi-user work ownership for the shared claim verification surfaces.
+- G680 — [PR #1473](https://github.com/J-Tech-Japan/intent-system/pull/1473), merge commit `46836e83098c6dd1192beeffe7daf6a32c529d89` (verified on `main`): packet draft, queue seed, publish flow, worker next-action, and next-slice share claim verification, with claim-before-scaffold numbering.
+- G681 — [PR #1475](https://github.com/J-Tech-Japan/intent-system/pull/1475), merge commit `7540932f61ee34cb2941405d13964b5aa90affb1` (verified on `main`): event streams are scoped by domain and team while the legacy team-file fallback remains readable.
+- G682 — [PR #1477](https://github.com/J-Tech-Japan/intent-system/pull/1477), merge commit `bbcc360255ecc01fefbf30f4ea06687b763208e6` (verified on `main`): pre-approval and pre-escalation records loudly report inapplicability when no prompt-class producer exists and fail closed until coverage is real.
+- G683 — [PR #1479](https://github.com/J-Tech-Japan/intent-system/pull/1479), merge commit `358d8b83b3ea53ae62a5f8323a9b2a26db34235e` (verified on `main`): literal prompt classes come from kind recipes, matched answers are bounded and audited, and unknown or unmatched prompts remain escalate-only.
+- G684 — [PR #1481](https://github.com/J-Tech-Japan/intent-system/pull/1481), merge commit `23a90d36ec9907541b1b3aa6aec789cf3ea00df7` (verified on `main`): security-envelope recipe drift is detect-only, with observed and recorded shapes named while model and reasoning effort remain human-selected wish fields.
+- G685 — [PR #1483](https://github.com/J-Tech-Japan/intent-system/pull/1483), merge commit `5e6bf6b6f1ffa3e882c8445960881ed85cc415d7` (verified on `main`): grammar-only model and effort resolution uses host-local positive or negative evidence and a live same-kind argv fallback, never a shipped model list.
+- G686 — [PR #1485](https://github.com/J-Tech-Japan/intent-system/pull/1485), merge commit `e759bc04eeb4e4a56ac5334401b130fd749cb084` (verified on `main`): typed host-recorded envelope profiles have explicit precedence and invalid profile shapes fail closed before registry fallback.
+
+### Full first-parent range accounting
+
+The first-parent range has ten commits. The nine merge rows above account for
+the feature units; the remaining commit is the post-release context and is not
+a release execution unit.
+
+| account | full commit | treatment |
+| --- | --- | --- |
+| post-release roll to 0.19.1 | `32fefec52ae353dbbe10b827020047c57ddfa279` | accounted for; context, not a unit |
+| G678 merge | `3671ba062cd1a4e4b54d634e7160da381fdd3ceb` | merged unit above |
+| G679 merge | `42789d6d8b1e4ac0d7133a277decd6ebcddeaf6b` | merged unit above |
+| G680 merge | `46836e83098c6dd1192beeffe7daf6a32c529d89` | merged unit above |
+| G681 merge | `7540932f61ee34cb2941405d13964b5aa90affb1` | merged unit above |
+| G682 merge | `bbcc360255ecc01fefbf30f4ea06687b763208e6` | merged unit above |
+| G683 merge | `358d8b83b3ea53ae62a5f8323a9b2a26db34235e` | merged unit above |
+| G684 merge | `23a90d36ec9907541b1b3aa6aec789cf3ea00df7` | merged unit above |
+| G685 merge | `5e6bf6b6f1ffa3e882c8445960881ed85cc415d7` | merged unit above |
+| G686 merge | `e759bc04eeb4e4a56ac5334401b130fd749cb084` | merged unit above |
+
+### Four attributed origins
+
+These units form one day-scale feedback loop, but measured facts remain
+separately attributed under G625:
+
+- The operator's landing-authority and multi-user requests produced G678–G681.
+  These are operator-request origins, not measurements borrowed from another
+  team.
+- The operator-filed [#1469 audit](https://github.com/J-Tech-Japan/intent-system/issues/1469)
+  produced the configured-looking-but-inert policy and envelope observations
+  carried by G682–G684. Its audit attribution remains separate from this
+  host's later corroboration.
+- The neighboring-domain `--model sol` incident on 2026-08-12 produced the
+  G685 model-resolution evidence: a `btx-mvc` launch returned account-shaped
+  HTTP 400, and live same-kind argv supplied recovery evidence. That incident
+  belongs to the neighboring domain, not this team's measurement.
+- This team's own first-cycle drift finding on 2026-08-12 produced G686. It is
+  this host's envelope-profile observation and is not relabeled as the #1469
+  audit or the neighboring-domain incident.
+
+The minor bump is checkable: operator-controlled landing and work ownership,
+domain-scoped event streams, prompt-policy applicability and bounded audit,
+detect-only envelope drift, host-local model resolution, and typed envelope
+profiles were absent from the v0.19.0 line. This is additive preview
+capability, not a patch-only correction.
+
+## Deliberate boundaries
+
+- This preparation changes version policy, release notes, readiness
+  documentation, and release guards only. It makes no code or runtime behavior
+  change.
+- Earlier release notes are linked rather than restated. The feature list is
+  bounded exactly to G678–G686; it does not silently include G687 or an earlier
+  unit.
+- Prepare-only remains in force: this PR creates no GitHub Release or tag,
+  publishes no package, and does not run release automation.
+
+## Release-readiness gate
+
+Before the separate operator release action:
+
+- `eng/version.json` records stable `0.19.0` and next `0.20.0`.
+- The nine PRs and full merge commits above resolve on `main`, and every commit
+  in `git log v0.19.0..main --first-parent` is accounted for by the range table.
+- The preview statement precedes the feature description and links the 1.0
+  compatibility promise.
+- The EN/JA notes remain in parity under the G613 terminology policy; the
+  release-notes count guard, version/readiness guards, full suite, and
+  `git diff --check` are green.
+- Prepare-only remains in force. Release creation, tagging, and package
+  publication are separate operator actions.
+
+## Publishing v0.20.0
+
+Release creation remains a distinct operator action after this preparation is
+merged and its readiness evidence is green. Only then may an authorized
+maintainer create and publish the GitHub Release for `v0.20.0`; publishing it
+triggers `release.yml` (`on: release: published`) to build and publish the
+NuGet package and platform artifacts. After that separate release, roll
+`eng/version.json` to stable `0.20.0` / next `0.20.1`, add the next DRAFT note
+stubs in the same commit, refresh both readiness mirrors, and verify child-main
+CI before calling the post-release roll complete.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2787,14 +2787,14 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.19.1)
+### 次リリース準備(v0.20.0)
 
 **`v0.19.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.19.1` です。[v0.19.1 notes stub](release-notes-v0.19.1.md) が必須の
-prepare-only placeholder です。直前の出荷範囲は
+`0.20.0` です。[v0.20.0 release notes](release-notes-v0.20.0.md) が
+prepare-only の scope を持ちます。直前の出荷範囲は
 [release-notes-v0.19.0.md](release-notes-v0.19.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.19.1` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.20.0` release-preparation PR のマージ前に実行):**
 
 claims-enabled host では release artifact を編集する前に release scope を acquire / verify します。
 同じ shared verification が G680 の全 start surface を gate し、claims store が無ければ legacy
@@ -2802,25 +2802,25 @@ single-team behavior を維持します。
 
 ```bash
 # 0. release-prep ownership を acquire / verify (preview-through-1.x)。
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.19.1 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.19.1 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.20.0 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.20.0 --team <team> --format json
 
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.19.0 (published), nextVersion 0.19.1 (to release)
+cat eng/version.json   # stableVersion 0.19.0 (published), nextVersion 0.20.0 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.19.1-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.20.0-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.19.1.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.20.0.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
-  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  "FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0200DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 
 # 5. Release suite を完全実行。
 dotnet test IntentSystem.sln -c Release
@@ -2828,10 +2828,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.19.1` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.20.0` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.19.1`、`nextVersion → 0.19.2` —
+`stableVersion → 0.20.0`、`nextVersion → 0.20.1` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.19.1.md
+++ b/docs/ja/release-notes-v0.19.1.md
@@ -1,9 +1,0 @@
-# リリースノート — intent-cli v0.19.1
-
-> **⚠️ DRAFT / 未リリース。** この stub は post-release version roll で作成されました。
-> release-prep パケットが author します。その packet がこの stub を置き換えるまで、
-> このファイルを changelog として扱ってはいけません。
-
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.19.1`。
-将来の Release は https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.19.1 に
-publish されます。

--- a/docs/ja/release-notes-v0.20.0.md
+++ b/docs/ja/release-notes-v0.20.0.md
@@ -1,0 +1,105 @@
+# リリースノート — intent-cli v0.20.0
+
+> **prepare-only / 未リリース。** この PR は version state、release notes、readiness
+> documentation、guard だけを準備します。GitHub Release や tag の作成、package
+> publish、release automation の実行、post-release roll は行いません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.20.0`。
+operator が別途承認して release action を実行した後の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.20.0 に公開されます。
+直前の出荷範囲は [v0.19.0 notes](release-notes-v0.19.0.md) を参照し、ここでは重複記載しません。
+
+## feature description より先に読む preview lane
+
+G678–G686 の surface は `preview-through-1.x` です。[1.0 compatibility promise](1.0-compatibility-promise.md)
+の対象外であり、1.x の間に変更または撤回される可能性があり、1.0 の compatibility
+commitment には含まれません。
+
+## day-scale で閉じた feedback loop
+
+v0.20.0 は G678 から G686 まで、正確に九件の merged feature unit を含みます。この scope は
+`git log v0.19.0..main --first-parent` を実行して導出しました。その range の全 commit を
+post-release roll または九件の merge commit として以下で説明しています。各 PR は MERGED であり、
+各 full merge commit が `main` に解決することを確認しています。
+
+- G678 — [PR #1468](https://github.com/J-Tech-Japan/intent-system/pull/1468)、merge commit `3671ba062cd1a4e4b54d634e7160da381fdd3ceb`（`main` で確認）: per-lane `operator-merge` の landing authority を visible / patient にし、その lane を `intent-cli` の path が merge しません。
+- G679 — [PR #1471](https://github.com/J-Tech-Japan/intent-system/pull/1471)、merge commit `42789d6d8b1e4ac0d7133a277decd6ebcddeaf6b`（`main` で確認）: git push-CAS claim を shared claim verification の multi-user work ownership として使います。
+- G680 — [PR #1473](https://github.com/J-Tech-Japan/intent-system/pull/1473)、merge commit `46836e83098c6dd1192beeffe7daf6a32c529d89`（`main` で確認）: packet draft、queue seed、publish flow、worker next-action、next-slice が claim verification を共有し、claim-before-scaffold の numbering を行います。
+- G681 — [PR #1475](https://github.com/J-Tech-Japan/intent-system/pull/1475)、merge commit `7540932f61ee34cb2941405d13964b5aa90affb1`（`main` で確認）: event stream を domain と team で scope し、legacy team-file fallback を読み取り可能なまま保ちます。
+- G682 — [PR #1477](https://github.com/J-Tech-Japan/intent-system/pull/1477)、merge commit `bbcc360255ecc01fefbf30f4ea06687b763208e6`（`main` で確認）: prompt-class producer が無いとき pre-approval / pre-escalation record が inapplicability を明示し、coverage が実在するまで fail closed にします。
+- G683 — [PR #1479](https://github.com/J-Tech-Japan/intent-system/pull/1479)、merge commit `358d8b83b3ea53ae62a5f8323a9b2a26db34235e`（`main` で確認）: literal prompt class は kind recipe から来て、matched answer は bounded / audited にし、unknown / unmatched prompt は escalate-only のままです。
+- G684 — [PR #1481](https://github.com/J-Tech-Japan/intent-system/pull/1481)、merge commit `23a90d36ec9907541b1b3aa6aec789cf3ea00df7`（`main` で確認）: security-envelope recipe drift を detect-only とし、observed / recorded shape を示します。model と reasoning effort は human-selected wish field のままです。
+- G685 — [PR #1483](https://github.com/J-Tech-Japan/intent-system/pull/1483)、merge commit `5e6bf6b6f1ffa3e882c8445960881ed85cc415d7`（`main` で確認）: grammar-only model / effort resolution は host-local の positive / negative evidence と live same-kind argv を使い、shipped model list は持ちません。
+- G686 — [PR #1485](https://github.com/J-Tech-Japan/intent-system/pull/1485)、merge commit `e759bc04eeb4e4a56ac5334401b130fd749cb084`（`main` で確認）: typed host-recorded envelope profile に明示的 precedence を持たせ、invalid profile shape は registry fallback の前に fail closed にします。
+
+### full first-parent range の会計
+
+first-parent range は十 commit です。上の九 merge row が feature unit を説明し、残る一つは
+post-release context であり、release execution unit ではありません。
+
+| account | full commit | treatment |
+| --- | --- | --- |
+| 0.19.1 への post-release roll | `32fefec52ae353dbbe10b827020047c57ddfa279` | 説明済み。context であり unit ではない |
+| G678 merge | `3671ba062cd1a4e4b54d634e7160da381fdd3ceb` | 上記の merged unit |
+| G679 merge | `42789d6d8b1e4ac0d7133a277decd6ebcddeaf6b` | 上記の merged unit |
+| G680 merge | `46836e83098c6dd1192beeffe7daf6a32c529d89` | 上記の merged unit |
+| G681 merge | `7540932f61ee34cb2941405d13964b5aa90affb1` | 上記の merged unit |
+| G682 merge | `bbcc360255ecc01fefbf30f4ea06687b763208e6` | 上記の merged unit |
+| G683 merge | `358d8b83b3ea53ae62a5f8323a9b2a26db34235e` | 上記の merged unit |
+| G684 merge | `23a90d36ec9907541b1b3aa6aec789cf3ea00df7` | 上記の merged unit |
+| G685 merge | `5e6bf6b6f1ffa3e882c8445960881ed85cc415d7` | 上記の merged unit |
+| G686 merge | `e759bc04eeb4e4a56ac5334401b130fd749cb084` | 上記の merged unit |
+
+### 四つの attribution された origin
+
+この unit 群は一つの day-scale feedback loop ですが、G625 に従い measured fact の attribution は
+分けて保持します。
+
+- operator の landing-authority と multi-user request が G678–G681 を生みました。これは
+  operator-request origin であり、別 team の measurement を借りたものではありません。
+- operator-filed の [#1469 audit](https://github.com/J-Tech-Japan/intent-system/issues/1469) が
+  G682–G684 の configured-looking-but-inert policy / envelope observation を生みました。その
+  audit attribution は、この host の後続 corroboration とは別に保持します。
+- neighboring domain の `--model sol` incident（2026-08-12）が G685 の model-resolution evidence
+  を生みました。`btx-mvc` の launch は account-shaped HTTP 400 を返し、live same-kind argv が
+  recovery evidence になりました。この incident は neighboring domain に属し、この team の
+  measurement ではありません。
+- この team 自身の first-cycle drift finding（2026-08-12）が G686 を生みました。これはこの host
+  の envelope-profile observation であり、#1469 audit や neighboring-domain incident とは別です。
+
+minor bump の根拠は検証可能です。operator-controlled landing / work ownership、domain-scoped
+event stream、prompt-policy applicability と bounded audit、detect-only envelope drift、host-local
+model resolution、typed envelope profile は v0.19.0 line にはありませんでした。これは additive な
+preview capability であり、patch-only correction ではありません。
+
+## 意図的な boundary
+
+- この準備が変更するのは version policy、release notes、readiness documentation、release guard
+  だけです。code と runtime behavior は変更しません。
+- earlier release notes は link し、重複記載しません。feature list は G678–G686 に正確に限定し、
+  G687 や earlier unit を暗黙に追加しません。
+- prepare-only を保ち、この PR は GitHub Release / tag を作成せず、package publish も release
+  automation の実行も行いません。
+
+## リリース準備ゲート (Release-readiness gate)
+
+operator が別の Release 手順を実行する前に確認します。
+
+- `eng/version.json` が stable `0.19.0` / next `0.20.0` を記録していること。
+- 上記九 PR と full merge commit が `main` に解決し、`git log v0.19.0..main --first-parent` の全
+  commit が range table で説明されていること。
+- preview statement が feature description より前にあり、1.0 compatibility promise を link
+  していること。
+- EN/JA notes が G613 terminology policy の parity を保ち、release-notes count guard、
+  version/readiness guard、full suite、`git diff --check` が green であること。
+- prepare-only を保つこと。Release creation、tagging、package publication は operator の別 action
+  です。
+
+## v0.20.0 の publish
+
+この準備が merge され readiness evidence が green になった後も、Release 作成は別の operator action
+です。その後に限り authorized maintainer が `v0.20.0` の GitHub Release を作成・公開でき、
+`release.yml`（`on: release: published`）が NuGet package と platform artifact の build / publish
+を起動します。その別 Release 後に `eng/version.json` を stable `0.20.0` / next `0.20.1` へ roll し、
+同じ commit に次の DRAFT note stub を加え、両方の readiness mirror を更新し、post-release roll を
+完了とする前に child-main CI を確認します。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
   "stableVersion": "0.19.0",
-  "nextVersion": "0.19.1"
+  "nextVersion": "0.20.0"
 }

--- a/tests/IntentSystem.Cli.Tests/G680ClaimConsumerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/G680ClaimConsumerTests.cs
@@ -378,7 +378,7 @@ public sealed class G680ClaimConsumerTests : IDisposable
             var ledger = File.ReadAllText(Path.Combine(root, "docs", language, "1.0-compatibility-ledger.md"));
             Assert.Contains("claim-then-draft", packets, StringComparison.Ordinal);
             Assert.Contains("claim verify", loop, StringComparison.Ordinal);
-            Assert.Contains("release-prep:<owner/repo>:0.19.1", release, StringComparison.Ordinal);
+            Assert.Contains("release-prep:<owner/repo>:0.20.0", release, StringComparison.Ordinal);
             Assert.Contains("G680", ledger, StringComparison.Ordinal);
             Assert.Contains("preview-through-1.x", ledger, StringComparison.Ordinal);
         }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0200DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0200DocsTests.cs
@@ -1,0 +1,164 @@
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G687 keeps the v0.20.0 prepare-only notes bilingual, derived from the
+/// v0.19.0..main first-parent history, and bounded exactly to G678-G686.
+/// </summary>
+public sealed class ReleaseNotesV0200DocsTests
+{
+    private static readonly (string Unit, string Pr, string Merge)[] Units =
+    [
+        ("G678", "#1468", "3671ba062cd1a4e4b54d634e7160da381fdd3ceb"),
+        ("G679", "#1471", "42789d6d8b1e4ac0d7133a277decd6ebcddeaf6b"),
+        ("G680", "#1473", "46836e83098c6dd1192beeffe7daf6a32c529d89"),
+        ("G681", "#1475", "7540932f61ee34cb2941405d13964b5aa90affb1"),
+        ("G682", "#1477", "bbcc360255ecc01fefbf30f4ea06687b763208e6"),
+        ("G683", "#1479", "358d8b83b3ea53ae62a5f8323a9b2a26db34235e"),
+        ("G684", "#1481", "23a90d36ec9907541b1b3aa6aec789cf3ea00df7"),
+        ("G685", "#1483", "5e6bf6b6f1ffa3e882c8445960881ed85cc415d7"),
+        ("G686", "#1485", "e759bc04eeb4e4a56ac5334401b130fd749cb084"),
+    ];
+
+    private static readonly string[] RangeCommits =
+    [
+        "32fefec52ae353dbbe10b827020047c57ddfa279",
+        .. Units.Select(unit => unit.Merge),
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyG678ThroughG686WithVerifiedPrsAndMerges(string language)
+    {
+        var notes = Read(language);
+        var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(Units.Select(unit => unit.Unit), listed);
+        Assert.Equal(9, listed.Length);
+        foreach (var unit in Units)
+        {
+            Assert.Contains(unit.Pr, notes, StringComparison.Ordinal);
+            Assert.Contains($"merge commit `{unit.Merge}`", notes, StringComparison.Ordinal);
+            Assert.Contains($"`{unit.Merge}`", notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("git log v0.19.0..main --first-parent", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "exactly nine merged feature units" : "正確に九件の merged feature unit", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "ten commits" : "十 commit", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesAccountForEveryFullFirstParentRangeCommit(string language)
+    {
+        var notes = Read(language);
+        var compact = Regex.Replace(notes, @"\s+", " ");
+
+        Assert.Equal(10, RangeCommits.Length);
+        Assert.Equal(RangeCommits.Length, RangeCommits.Distinct(StringComparer.Ordinal).Count());
+        foreach (var commit in RangeCommits)
+        {
+            Assert.Contains(commit, notes, StringComparison.Ordinal);
+        }
+
+        Assert.Contains(language == "en" ? "not a release execution unit" : "release execution unit ではありません", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("post-release roll", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void PreviewStatementPrecedesFeatureDescriptionAndLinksPromise(string language)
+    {
+        var notes = Read(language);
+        var preview = notes.IndexOf("preview-through-1.x", StringComparison.Ordinal);
+        var feature = notes.IndexOf(
+            language == "en" ? "## The day-scale feedback loop" : "## day-scale で閉じた feedback loop",
+            StringComparison.Ordinal);
+
+        Assert.True(preview >= 0);
+        Assert.True(feature > preview);
+        Assert.Contains("[1.0 compatibility promise](1.0-compatibility-promise.md)", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesPreserveFourAttributedOriginsAndPrepareOnlyBoundaries(string language)
+    {
+        var notes = Read(language);
+        var compact = Regex.Replace(notes, @"\s+", " ");
+
+        foreach (var term in new[] { "G625", "landing-authority", "multi-user", "#1469", "--model sol", "2026-08-12", "first-cycle", "drift" })
+        {
+            Assert.Contains(term, compact, StringComparison.OrdinalIgnoreCase);
+        }
+
+        Assert.Contains("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "UNRELEASED" : "未リリース", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "no code or runtime behavior" : "code と runtime behavior は変更しません",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "no GitHub Release or tag" : "GitHub Release / tag を作成せず",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "Earlier release notes are linked" : "earlier release notes は link", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("G687 —", notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void CurrentPolicyAndReadinessFollowVersionPolicyAndOldStubsAreGone(string language)
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var policy = RepoVersionPolicySource.Read();
+        var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
+        var notes = Read(language);
+        var currentNotes = $"release-notes-v{policy.NextVersion}.md";
+        var shippedNotes = $"release-notes-v{policy.StableVersion}.md";
+
+        RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
+        Assert.True(File.Exists(Path.Combine(root, "docs", language, shippedNotes)));
+        Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.19.1.md")));
+        Assert.Contains(currentNotes, reference, StringComparison.Ordinal);
+        Assert.Contains(shippedNotes, reference, StringComparison.Ordinal);
+        Assert.DoesNotContain("release-notes-v0.19.1.md", reference, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en"
+                ? $"Next release readiness (v{policy.NextVersion})"
+                : $"次リリース準備(v{policy.NextVersion})",
+            reference,
+            StringComparison.Ordinal);
+        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", notes, StringComparison.Ordinal);
+        Assert.Contains($"releases/tag/v{policy.NextVersion}", notes, StringComparison.Ordinal);
+        Assert.DoesNotContain("DRAFT /", notes, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EnglishAndJapaneseNotesHaveTheSameUnitAndMergeInventory()
+    {
+        var english = Read("en");
+        var japanese = Read("ja");
+
+        foreach (var unit in Units)
+        {
+            Assert.Contains($"{unit.Unit} —", english, StringComparison.Ordinal);
+            Assert.Contains($"{unit.Unit} —", japanese, StringComparison.Ordinal);
+            Assert.Contains(unit.Merge, english, StringComparison.Ordinal);
+            Assert.Contains(unit.Merge, japanese, StringComparison.Ordinal);
+        }
+    }
+
+    private static string Read(string language) => File.ReadAllText(Path.Combine(
+        RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.20.0.md"));
+}


### PR DESCRIPTION
Closes #1486

## Summary

Prepare-only v0.20.0 release preparation derived from the full first-parent history from `v0.19.0..main`.

- Retargeted `eng/version.json` to stable `0.19.0` / next `0.20.0`.
- Replaced the EN/JA v0.19.1 DRAFT stubs with substantive v0.20.0 notes.
- Refreshed EN/JA developer-reference readiness, package/version examples, release-prep scope, and links to the preceding shipped v0.19.0 notes.
- Added a bilingual G687 release-note/history guard and updated the current G680 docs assertion to the new release-prep line.
- Kept `docs/{en,ja}/release-notes-v0.19.0.md` byte-for-byte unchanged.

## AC/source/test mapping

| Contract | Source and evidence |
| --- | --- |
| Version retarget | `eng/version.json`; `ReleasePackageMetadataTests`, `VersionSourcePolicyGuardTests`, `ReleaseNotesV0200DocsTests` |
| Exactly G678-G686 | `docs/{en,ja}/release-notes-v0.20.0.md` feature list and `ReleaseNotesV0200DocsTests.NotesCoverExactlyG678ThroughG686WithVerifiedPrsAndMerges` |
| History derivation and complete accounting | Notes state `git log v0.19.0..main --first-parent`; the range table accounts for post-release roll `32fefec52ae353dbbe10b827020047c57ddfa279` plus all nine full merge SHAs; `ReleaseNotesV0200DocsTests.NotesAccountForEveryFullFirstParentRangeCommit` |
| Verified PR/merge inventory | PRs #1468, #1471, #1473, #1475, #1477, #1479, #1481, #1483, #1485 and full merge commits `3671ba0`, `42789d6`, `46836e8`, `7540932`, `bbcc360`, `358d8b8`, `23a90d3`, `5e6bf6b`, `e759bc0` (full hashes are in both notes and were verified as `origin/main` ancestors) |
| Four separately attributed origins | Notes preserve operator landing-authority/multi-user requests, operator-filed #1469 audit, neighboring-domain 2026-08-12 `btx-mvc --model sol` HTTP 400/live-argv incident, and this team's own first-cycle drift finding; covered by `NotesPreserveFourAttributedOriginsAndPrepareOnlyBoundaries` |
| Preview and compatibility treatment | Preview statement precedes the feature list and links `1.0-compatibility-promise.md`; `PreviewStatementPrecedesFeatureDescriptionAndLinksPromise` |
| EN/JA readiness parity | `docs/{en,ja}/09-developer-reference.md`, bilingual notes, and `EnglishAndJapaneseNotesHaveTheSameUnitAndMergeInventory` |
| Prepare-only boundary | No code/runtime changes, no GitHub Release, tag, package publish, or release automation; notes and guard assert this boundary |

## Verification

- Exact head: `d6438dfc7af1d5ef3ae0cd27952f651464c29b48`
- Focused release/version/G680 guards: **40 passed, 0 failed**
- Full `IntentSystem.sln` Release suite: **4,932 passed, 1 existing skip, 0 failed**
- `git diff --check`: clean
- Published v0.19.0 notes SHA-256 unchanged: EN `11866387f4fe8017bfbc3b8e3dad089435dee9c1da426dadecdfd50ec2bc5221`; JA `2383b58cc3a21910469f2a78c899d2df50592d79c62ab0c0d832dbbfbe509702`
- No GitHub Release, tag, package publish, or provider launch was performed.
