### PR TITLE
Roll post-release version to 0.20.1

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2628,7 +2628,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0200)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0201)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2721,14 +2721,14 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.20.0)
+### Next release readiness (v0.20.1)
 
-**`v0.19.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.20.0`. [The v0.20.0 release notes](release-notes-v0.20.0.md) carry the
-prepare-only scope. See [release-notes-v0.19.0.md](release-notes-v0.19.0.md)
+**`v0.20.0` shipped** (GitHub Release + NuGet), and the next prepared line is
+`0.20.1`. [The v0.20.1 notes stub](release-notes-v0.20.1.md) is the required
+prepare-only placeholder. See [release-notes-v0.20.0.md](release-notes-v0.20.0.md)
 for the preceding shipped scope; it is linked, not restated.
 
-**Release-readiness verification (run before merging the `v0.20.0`
+**Release-readiness verification (run before merging the `v0.20.1`
 release-preparation PR):**
 
 On a claims-enabled host, acquire and verify the release scope before editing
@@ -2737,20 +2737,20 @@ no claims store preserves legacy single-team behavior.
 
 ```bash
 # 0. Acquire and verify release-prep ownership (preview-through-1.x).
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.20.0 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.20.0 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.20.1 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.20.1 --team <team> --format json
 
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.19.0 (published), nextVersion 0.20.0 (to release)
+cat eng/version.json   # stableVersion 0.20.0 (published), nextVersion 0.20.1 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.20.0-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.20.1-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.20.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.20.1.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2764,10 +2764,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.20.0`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.20.1`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.20.0`, `nextVersion → 0.20.1` — carrying, per **steps 4–6** of the
+`stableVersion → 0.20.1`, `nextVersion → 0.20.2` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.20.1.md
+++ b/docs/en/release-notes-v0.20.1.md
@@ -1,0 +1,15 @@
+# Release Notes — intent-cli v0.20.1
+
+> **⚠️ DRAFT / UNRELEASED.** This stub is created by the mandatory immediate
+> post-release version roll after v0.20.0. The release-prep packet authors the
+> real content; this must not be treated as a changelog until that packet
+> replaces it.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.20.1`.
+The eventual release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.20.1.
+
+## Release-readiness gate
+
+This DRAFT has no feature scope yet. The release-prep packet must replace it
+with substantive notes and record the full readiness evidence before release.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2787,14 +2787,14 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.20.0)
+### 次リリース準備(v0.20.1)
 
-**`v0.19.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.20.0` です。[v0.20.0 release notes](release-notes-v0.20.0.md) が
-prepare-only の scope を持ちます。直前の出荷範囲は
-[release-notes-v0.19.0.md](release-notes-v0.19.0.md) を参照し、ここでは重複記載しません。
+**`v0.20.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
+`0.20.1` です。[v0.20.1 notes stub](release-notes-v0.20.1.md) が必須の
+prepare-only placeholder です。直前の出荷範囲は
+[release-notes-v0.20.0.md](release-notes-v0.20.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.20.0` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.20.1` release-preparation PR のマージ前に実行):**
 
 claims-enabled host では release artifact を編集する前に release scope を acquire / verify します。
 同じ shared verification が G680 の全 start surface を gate し、claims store が無ければ legacy
@@ -2802,20 +2802,20 @@ single-team behavior を維持します。
 
 ```bash
 # 0. release-prep ownership を acquire / verify (preview-through-1.x)。
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.20.0 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.20.0 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.20.1 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.20.1 --team <team> --format json
 
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.19.0 (published), nextVersion 0.20.0 (to release)
+cat eng/version.json   # stableVersion 0.20.0 (published), nextVersion 0.20.1 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.20.0-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.20.1-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.20.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.20.1.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2828,10 +2828,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.20.0` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.20.1` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.20.0`、`nextVersion → 0.20.1` —
+`stableVersion → 0.20.1`、`nextVersion → 0.20.2` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.20.1.md
+++ b/docs/ja/release-notes-v0.20.1.md
@@ -1,0 +1,14 @@
+# リリースノート — intent-cli v0.20.1
+
+> **⚠️ DRAFT / 未リリース。** この stub は v0.20.0 後の mandatory immediate
+> post-release version roll で作成されました。release-prep パケットが author します。
+> そのパケットが置き換えるまで、このファイルを changelog として扱ってはいけません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.20.1`。
+将来の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.20.1 に publish されます。
+
+## リリース準備ゲート
+
+この DRAFT にはまだ feature scope がありません。release-prep パケットが substantive な
+notes と置き換え、Release 前に full readiness evidence を記録しなければなりません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.19.0",
-  "nextVersion": "0.20.0"
+  "stableVersion": "0.20.0",
+  "nextVersion": "0.20.1"
 }

--- a/tests/IntentSystem.Cli.Tests/G680ClaimConsumerTests.cs
+++ b/tests/IntentSystem.Cli.Tests/G680ClaimConsumerTests.cs
@@ -378,7 +378,7 @@ public sealed class G680ClaimConsumerTests : IDisposable
             var ledger = File.ReadAllText(Path.Combine(root, "docs", language, "1.0-compatibility-ledger.md"));
             Assert.Contains("claim-then-draft", packets, StringComparison.Ordinal);
             Assert.Contains("claim verify", loop, StringComparison.Ordinal);
-            Assert.Contains("release-prep:<owner/repo>:0.20.0", release, StringComparison.Ordinal);
+            Assert.Contains("release-prep:<owner/repo>:0.20.1", release, StringComparison.Ordinal);
             Assert.Contains("G680", ledger, StringComparison.Ordinal);
             Assert.Contains("preview-through-1.x", ledger, StringComparison.Ordinal);
         }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0200DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0200DocsTests.cs
@@ -4,8 +4,9 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G687 keeps the v0.20.0 prepare-only notes bilingual, derived from the
-/// v0.19.0..main first-parent history, and bounded exactly to G678-G686.
+/// G687 keeps the published v0.20.0 notes bilingual and frozen after the
+/// v0.19.0..main first-parent preparation, while the current next-version
+/// readiness points at the post-release v0.20.1 stub.
 /// </summary>
 public sealed class ReleaseNotesV0200DocsTests
 {
@@ -117,14 +118,15 @@ public sealed class ReleaseNotesV0200DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void CurrentPolicyAndReadinessFollowVersionPolicyAndOldStubsAreGone(string language)
+    public void CurrentPolicyAndReadinessFollowVersionPolicyAndPublishedNotesStayFrozen(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
-        var notes = Read(language);
         var currentNotes = $"release-notes-v{policy.NextVersion}.md";
         var shippedNotes = $"release-notes-v{policy.StableVersion}.md";
+        var notes = Read(language);
+        var currentStub = File.ReadAllText(Path.Combine(root, "docs", language, currentNotes));
 
         RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
         Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
@@ -139,8 +141,15 @@ public sealed class ReleaseNotesV0200DocsTests
                 : $"次リリース準備(v{policy.NextVersion})",
             reference,
             StringComparison.Ordinal);
-        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", notes, StringComparison.Ordinal);
-        Assert.Contains($"releases/tag/v{policy.NextVersion}", notes, StringComparison.Ordinal);
+        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.StableVersion}", notes, StringComparison.Ordinal);
+        Assert.Contains($"releases/tag/v{policy.StableVersion}", notes, StringComparison.Ordinal);
+        Assert.Contains("DRAFT /", currentStub, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "UNRELEASED" : "未リリース",
+            currentStub,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", currentStub, StringComparison.Ordinal);
+        Assert.Contains($"releases/tag/v{policy.NextVersion}", currentStub, StringComparison.Ordinal);
         Assert.DoesNotContain("DRAFT /", notes, StringComparison.Ordinal);
     }
 
@@ -157,6 +166,17 @@ public sealed class ReleaseNotesV0200DocsTests
             Assert.Contains(unit.Merge, english, StringComparison.Ordinal);
             Assert.Contains(unit.Merge, japanese, StringComparison.Ordinal);
         }
+    }
+
+    [Theory]
+    [InlineData("en", "f00b7326cb82b49b77c9c3e48d001aa8ba97a1ac24b46c5b84dfc682efeb3aeb")]
+    [InlineData("ja", "541a80688f3aea78d32f4c73dd60bb80d189ad44603ae53717261ba52a9db9b6")]
+    public void PublishedV0200NotesRemainByteForByteFrozen(string language, string expectedSha256)
+    {
+        var bytes = File.ReadAllBytes(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.20.0.md"));
+
+        Assert.Equal(expectedSha256, Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(bytes)));
     }
 
     private static string Read(string language) => File.ReadAllText(Path.Combine(


### PR DESCRIPTION
## Summary

Mandatory immediate post-release roll after the published v0.20.0 release.

- Set `eng/version.json` to `stableVersion=0.20.0` and `nextVersion=0.20.1`.
- Add the EN/JA `v0.20.1` DRAFT / UNRELEASED note stubs in the same commit.
- Refresh the EN/JA developer-reference readiness mirrors and the version-derived guard expectations to the 0.20.1 line.
- Keep the published v0.20.0 notes byte-for-byte frozen; the guard records their SHA-256 values.

## Release evidence

- Published release: https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.20.0
- Release target: `d860c336d1efa21ca3faa704edfb2909f52e1b46`
- Release workflow: https://github.com/J-Tech-Japan/intent-system/actions/runs/31681630662 (success)

## Verification

- Exact PR head: `2b04b15ff6fdc79c2e9cb66468ae030d70015b8e`.
- Exact-head CI: https://github.com/J-Tech-Japan/intent-system/actions/runs/31683188428 (success).
- Focused release/version guards: **42 passed, 0 failed**.
- Full `IntentSystem.sln` Release suite: **4,934 passed, 1 skipped, 0 failed**.
- `git diff --check`: **clean**.
- Frozen-note SHA-256 guard: EN `f00b7326cb82b49b77c9c3e48d001aa8ba97a1ac24b46c5b84dfc682efeb3aeb`; JA `541a80688f3aea78d32f4c73dd60bb80d189ad44603ae53717261ba52a9db9b6`.

No GitHub Release, tag, or package publish is created by this PR.
