### PR TITLE
G694: roll post-release version to 0.21.1

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2628,7 +2628,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0210)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0211)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2721,14 +2721,14 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.21.0)
+### Next release readiness (v0.21.1)
 
-**`v0.20.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.21.0`. [The v0.21.0 release notes](release-notes-v0.21.0.md) carry the
-prepare-only scope. See [release-notes-v0.20.0.md](release-notes-v0.20.0.md)
+**`v0.21.0` shipped** (GitHub Release + NuGet), and the next prepared line is
+`0.21.1`. [The v0.21.1 notes stub](release-notes-v0.21.1.md) is the required
+prepare-only placeholder. See [release-notes-v0.21.0.md](release-notes-v0.21.0.md)
 for the preceding shipped scope; it is linked, not restated.
 
-**Release-readiness verification (run before merging the `v0.21.0`
+**Release-readiness verification (run before merging the `v0.21.1`
 release-preparation PR):**
 
 On a claims-enabled host, acquire and verify the release scope before editing
@@ -2737,20 +2737,20 @@ no claims store preserves legacy single-team behavior.
 
 ```bash
 # 0. Acquire and verify release-prep ownership (preview-through-1.x).
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.21.0 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.21.0 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.21.1 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.21.1 --team <team> --format json
 
 # 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.20.0 (published), nextVersion 0.21.0 (to release)
+cat eng/version.json   # stableVersion 0.21.0 (published), nextVersion 0.21.1 (to release)
 
 # 2. Build and confirm the display version identity (version + git SHA + G-unit).
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   expected shape: intent-cli 0.21.0-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.21.1-<sha>-G<unit>   (NOT a stale literal)
 
 # 3. Pack and confirm the NuGet package version matches the policy.
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.21.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.21.1.nupkg
 
 # 4. Confirm G475, the shipped release-note checks, and the release/version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2764,10 +2764,10 @@ dotnet test IntentSystem.sln -c Release
 After the preparation merge lands on `main` and the readiness evidence holds,
 the operator must explicitly approve Release creation. Only then may a
 maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.21.0`; publishing it triggers `release.yml`
+publish the GitHub Release for `v0.21.1`; publishing it triggers `release.yml`
 (`on: release: published`) to build and publish the NuGet package and the
 per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.21.0`, `nextVersion → 0.21.1` — carrying, per **steps 4–6** of the
+`stableVersion → 0.21.1`, `nextVersion → 0.21.2` — carrying, per **steps 4–6** of the
 [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step

--- a/docs/en/release-notes-v0.21.0.md
+++ b/docs/en/release-notes-v0.21.0.md
@@ -1,18 +1,25 @@
 # Release Notes — intent-cli v0.21.0
 
-> **prepare-only / UNRELEASED.** This preparation changes version state,
-> release notes, readiness documentation, and release guards only. It creates
-> no GitHub Release or tag, publishes no package, runs no release automation,
-> and performs no post-release roll. It contains no code or runtime behaviour
-> change.
+> **Released / stable.** intent-cli v0.21.0 was published after the operator-
+> approved release transaction. The evidence below is frozen with this note;
+> this file is no longer a preparation stub.
 
 Install verification: `JTechJapan.IntentSystem.Cli --version 0.21.0`.
-After a separate operator approval and release action, the Release will be
-published at
+The clean install output is `intent-cli 0.21.0-c77c92f-G691`.
+The published Release is at
 https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.21.0.
 The preceding shipped scope remains in the
 [v0.20.0 notes](release-notes-v0.20.0.md); earlier release notes are linked
 rather than restated.
+
+## Publication evidence (frozen)
+
+- The `v0.21.0` tag and GitHub Release target commit
+  `c77c92fe8e5c9e62fc15b1ba96754b2acb35691c` (`c77c92fe`).
+- Release workflow run [31766364883](https://github.com/J-Tech-Japan/intent-system/actions/runs/31766364883) completed successfully with the `NuGet package`, `Self-contained linux-x64`, `Self-contained osx-arm64`, and `Self-contained win-x64` jobs.
+- All eight release assets are present: the linux-x64, osx-arm64, and win-x64 archives with their `.sha256` files, plus the NuGet package and its `.sha256` file. Four checksum verifications passed.
+- NuGet.org indexes `JTechJapan.IntentSystem.Cli` version `0.21.0`.
+- A clean install reports exactly `intent-cli 0.21.0-c77c92f-G691`.
 
 ## Preview lane — read before the feature description
 
@@ -61,20 +68,20 @@ v0.20.0. These are additive preview surfaces, not a patch-only correction.
 
 ## Deliberate boundaries
 
-- This preparation changes version policy, release notes, readiness
-  documentation, and release guards only. It makes no code or runtime
-  behaviour change.
+- This release records the version, notes, and release-readiness evidence. It
+  makes no code or runtime behaviour change.
 - The feature list is bounded exactly to G689–G692. It does not silently
   include G693 or restate earlier release notes.
-- Prepare-only remains in force: this child creates no GitHub Release or tag,
-  publishes no package, and performs no post-roll. Release creation is the
-  operator's separate action after readiness is green.
+- The operator release transaction recorded above is complete. This post-
+  release documentation roll creates no additional GitHub Release or tag,
+  republishes no package, and performs no second post-release transaction.
 
-## Release-readiness gate
+## Release evidence and compatibility boundary
 
-Before the separate operator release action:
+The published release satisfies the boundary that was checked before the
+operator release action:
 
-- `eng/version.json` records stable `0.20.0` and next `0.21.0`.
+- The release-to-be-cut was the additive v0.21.0 line after stable v0.20.0.
 - The four PRs and full merge commits above resolve on `main`, and every commit
   in `git log v0.20.0..main --first-parent` is accounted for by the range table.
 - The preview statement precedes the feature description and links the 1.0
@@ -82,13 +89,11 @@ Before the separate operator release action:
 - EN/JA notes remain in parity under the G613 terminology policy; the
   release-notes guard, bilingual count guard, version/readiness guards, full
   Release suite, and `git diff --check` are green.
-- Prepare-only remains in force. Release creation, tagging, package
-  publication, and post-release rolling are separate operator actions.
+- The release, tag, package index evidence, and four checksum results are
+  recorded in the frozen publication evidence above.
 
-## Publishing v0.21.0
+## Released v0.21.0
 
-After this preparation is merged and readiness evidence is green, the operator
-must explicitly approve Release creation. Only then may an authorized
-maintainer create and publish the GitHub Release for `v0.21.0`; its downstream
-release automation is outside this child PR. Any post-release version roll is
-a separate operator action and is not performed here.
+The operator-approved publication is complete and remains linked above. The
+post-release roll advances the development line to v0.21.1; it does not alter
+this released note or repeat the release transaction.

--- a/docs/en/release-notes-v0.21.1.md
+++ b/docs/en/release-notes-v0.21.1.md
@@ -1,0 +1,15 @@
+# Release Notes — intent-cli v0.21.1
+
+> **⚠️ DRAFT / UNRELEASED.** This stub is created by the mandatory immediate
+> post-release version roll after v0.21.0. The release-prep packet authors the
+> real content; this must not be treated as a changelog until that packet
+> replaces it.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.21.1`.
+The eventual release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.21.1.
+
+## Release-readiness gate
+
+This DRAFT has no feature scope yet. The release-prep packet must replace it
+with substantive notes and record the full readiness evidence before release.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2787,14 +2787,14 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.21.0)
+### 次リリース準備(v0.21.1)
 
-**`v0.20.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.21.0` です。[v0.21.0 release notes](release-notes-v0.21.0.md) が
-prepare-only の scope を持ちます。直前の出荷範囲は
-[release-notes-v0.20.0.md](release-notes-v0.20.0.md) を参照し、ここでは重複記載しません。
+**`v0.21.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
+`0.21.1` です。[v0.21.1 notes stub](release-notes-v0.21.1.md) が必須の
+prepare-only placeholder です。直前の出荷範囲は
+[release-notes-v0.21.0.md](release-notes-v0.21.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.21.0` release-preparation PR のマージ前に実行):**
+**リリース準備検証(`v0.21.1` release-preparation PR のマージ前に実行):**
 
 claims-enabled host では release artifact を編集する前に release scope を acquire / verify します。
 同じ shared verification が G680 の全 start surface を gate し、claims store が無ければ legacy
@@ -2802,20 +2802,20 @@ single-team behavior を維持します。
 
 ```bash
 # 0. release-prep ownership を acquire / verify (preview-through-1.x)。
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.21.0 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.21.0 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.21.1 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.21.1 --team <team> --format json
 
 # 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.20.0 (published), nextVersion 0.21.0 (to release)
+cat eng/version.json   # stableVersion 0.21.0 (published), nextVersion 0.21.1 (to release)
 
 # 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet run --project src/IntentSystem.Cli -c Release --no-build -- --version
-#   期待する形: intent-cli 0.21.0-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.21.1-<sha>-G<unit>   (古いリテラルではない)
 
 # 3. pack して NuGet package version が policy と一致することを確認。
 dotnet pack src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -o .artifacts/packages
-ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.21.0.nupkg
+ls .artifacts/packages/   # JTechJapan.IntentSystem.Cli.0.21.1.nupkg
 
 # 4. G475、出荷済み release-note check、release/version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
@@ -2828,10 +2828,10 @@ dotnet test IntentSystem.sln -c Release
 
 準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
 明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.21.0` の GitHub Release を作成・公開できます。公開すると
+外部リリース自動化)が `v0.21.1` の GitHub Release を作成・公開できます。公開すると
 `release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
 バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.21.0`、`nextVersion → 0.21.1` —
+`stableVersion → 0.21.1`、`nextVersion → 0.21.2` —
 [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、

--- a/docs/ja/release-notes-v0.21.0.md
+++ b/docs/ja/release-notes-v0.21.0.md
@@ -1,15 +1,23 @@
 # リリースノート — intent-cli v0.21.0
 
-> **prepare-only / 未リリース。** この準備が変更するのは version state、release
-> notes、readiness documentation、release guard だけです。GitHub Release や tag を
-> 作成せず、package を publish せず、release automation と post-release roll を実行しません。
-> code や runtime behaviour の変更もありません。
+> **Released / stable（公開済み）。** operator が承認した release transaction により
+> intent-cli v0.21.0 は公開済みです。下の evidence はこの notes とともに freeze され、
+> このファイルは preparation stub ではありません。
 
 Install verification: `JTechJapan.IntentSystem.Cli --version 0.21.0`。
-operator が別途承認して release action を実行した後の Release は
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.21.0 に公開されます。
+clean install の出力は `intent-cli 0.21.0-c77c92f-G691` です。公開済み Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.21.0 です。
 直前の出荷範囲は [v0.20.0 notes](release-notes-v0.20.0.md) を参照し、earlier release notes は
 link して、ここでは重複記載しません。
+
+## Publication evidence (frozen)
+
+- `v0.21.0` tag と GitHub Release は commit
+  `c77c92fe8e5c9e62fc15b1ba96754b2acb35691c`（`c77c92fe`）を target にします。
+- [31766364883](https://github.com/J-Tech-Japan/intent-system/actions/runs/31766364883) の release workflow は success で完了し、`NuGet package`、`Self-contained linux-x64`、`Self-contained osx-arm64`、`Self-contained win-x64` の4 job が成功しました。
+- 八つの release asset（linux-x64、osx-arm64、win-x64 の各 archive と `.sha256`、NuGet package とその `.sha256`）が存在し、四つの checksum verification が pass しました。
+- NuGet.org は `JTechJapan.IntentSystem.Cli` version `0.21.0` を index 済みです。
+- clean install は正確に `intent-cli 0.21.0-c77c92f-G691` を出力します。
 
 ## feature description より先に読む preview lane
 
@@ -58,29 +66,29 @@ registry と `prompt-class list/describe`、`answerable_by` と hard risk floor 
 
 ## 意図的な boundary
 
-- この準備が変更するのは version policy、release notes、readiness documentation、release guard
-  だけです。code と runtime behaviour は変更しません。
+- この release が記録するのは version、notes、release-readiness evidence です。code と runtime
+  behaviour は変更しません。
 - feature list は G689–G692 に正確に限定し、G693 を暗黙に含めず、earlier release notes を再掲しません。
-- prepare-only を保ち、この child は GitHub Release / tag を作成せず、package publish と post-roll を
-  行いません。readiness が green になった後の Release 作成は operator の別 action です。
+- 上に記録した operator release transaction は完了済みです。この post-release documentation roll
+  は追加の GitHub Release / tag を作成せず、package を再 publish せず、二度目の release transaction
+  を実行しません。
 
-## リリース準備ゲート (Release-readiness gate)
+## Publication evidence と compatibility boundary
 
-operator が別の Release 手順を実行する前に確認します。
+operator の Release action 前に確認した boundary は次のとおりです。
 
-- `eng/version.json` が stable `0.20.0` / next `0.21.0` を記録していること。
+- stable v0.20.0 の後の additive な v0.21.0 line を release-to-be-cut としました。
 - 上記四 PR と full merge commit が `main` に解決し、`git log v0.20.0..main --first-parent` の全
   commit が range table で説明されていること。
 - preview statement が feature description より前にあり、1.0 compatibility promise を link
   していること。
 - EN/JA notes が G613 terminology policy の parity を保ち、release-notes guard、bilingual count
   guard、version/readiness guard、full Release suite、`git diff --check` が green であること。
-- prepare-only を保つこと。Release creation、tagging、package publication、post-release rolling
-  は operator の別 action です。
+- Release、tag、package index evidence、四つの checksum result は上の frozen publication evidence
+  に記録されています。
 
-## v0.21.0 の publish
+## 公開済み v0.21.0
 
-この準備が merge され readiness evidence が green になった後、operator は Release 作成を明示的に
-承認しなければなりません。その後に限り authorized maintainer が `v0.21.0` の GitHub Release を
-作成・公開できます。downstream の release automation はこの child PR の範囲外で、post-release
-version roll もここでは実行しません。
+operator が承認した publication は完了しており、上の evidence から参照できます。post-release roll
+は development line を v0.21.1 に進めますが、この released note を変更せず、release transaction を
+繰り返しません。

--- a/docs/ja/release-notes-v0.21.1.md
+++ b/docs/ja/release-notes-v0.21.1.md
@@ -1,0 +1,14 @@
+# リリースノート — intent-cli v0.21.1
+
+> **⚠️ DRAFT / 未リリース。** この stub は v0.21.0 後の mandatory immediate
+> post-release version roll で作成されました。release-prep パケットが author します。
+> そのパケットが置き換えるまで、このファイルを changelog として扱ってはいけません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.21.1`。
+将来の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.21.1 に publish されます。
+
+## リリース準備ゲート
+
+この DRAFT にはまだ feature scope がありません。release-prep パケットが substantive な
+notes と置き換え、Release 前に full readiness evidence を記録しなければなりません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.20.0",
-  "nextVersion": "0.21.0"
+  "stableVersion": "0.21.0",
+  "nextVersion": "0.21.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
@@ -4,8 +4,8 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G693 keeps the v0.21.0 preparation bilingual, exactly bounded to G689-G692,
-/// and reconciled with the full v0.20.0..main first-parent range.
+/// G694 keeps the published v0.21.0 notes bilingual and frozen while the
+/// post-release readiness points at the v0.21.1 DRAFT stubs.
 /// </summary>
 public sealed class ReleaseNotesV0210DocsTests
 {
@@ -91,7 +91,7 @@ public sealed class ReleaseNotesV0210DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void NotesPreserveOriginsMinorRationaleAndPrepareOnlyBoundaries(string language)
+    public void NotesPreserveOriginsMinorRationaleAndPublishedBoundaries(string language)
     {
         var notes = Read(language);
         var compact = Regex.Replace(notes, @"\s+", " ");
@@ -106,23 +106,35 @@ public sealed class ReleaseNotesV0210DocsTests
             Assert.Contains(term, compact, StringComparison.OrdinalIgnoreCase);
         }
 
-        Assert.Contains("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(language == "en" ? "UNRELEASED" : "未リリース", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(language == "en" ? "UNRELEASED" : "未リリース", notes, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(
-            language == "en" ? "no code or runtime behaviour" : "code や runtime behaviour の変更もありません",
+            language == "en" ? "no code or runtime behaviour" : "code と runtime behaviour は変更しません",
             compact,
             StringComparison.OrdinalIgnoreCase);
         Assert.Contains(
-            language == "en" ? "no GitHub Release or tag" : "GitHub Release や tag を",
+            language == "en" ? "Released / stable" : "公開済み",
+            notes,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("31766364883", notes, StringComparison.Ordinal);
+        Assert.Contains("c77c92fe", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "eight release assets" : "八つの release asset",
             compact,
             StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "Four checksum verifications passed" : "四つの checksum verification が pass",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("NuGet.org", notes, StringComparison.Ordinal);
+        Assert.Contains("intent-cli 0.21.0-c77c92f-G691", notes, StringComparison.Ordinal);
         Assert.DoesNotContain("G693 —", notes, StringComparison.Ordinal);
     }
 
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void CurrentPolicyAndReadinessFollowVersionPolicyAndSupersededStubsAreGone(string language)
+    public void CurrentPolicyAndReadinessFollowVersionPolicyAndNextStubsAreDraft(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
@@ -134,20 +146,28 @@ public sealed class ReleaseNotesV0210DocsTests
         RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
         Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
         Assert.True(File.Exists(Path.Combine(root, "docs", language, shippedNotes)));
-        var supersededNotes = Path.Combine(root, "docs", language, "release-notes-v0.20." + "1.md");
-        Assert.False(File.Exists(supersededNotes));
         Assert.Contains(currentNotes, reference, StringComparison.Ordinal);
         Assert.Contains(shippedNotes, reference, StringComparison.Ordinal);
-        Assert.DoesNotContain("release-notes-v0.20." + "1.md", reference, StringComparison.Ordinal);
         Assert.Contains(
             language == "en"
                 ? $"Next release readiness (v{policy.NextVersion})"
                 : $"次リリース準備(v{policy.NextVersion})",
             reference,
             StringComparison.Ordinal);
-        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", notes, StringComparison.Ordinal);
-        Assert.Contains($"releases/tag/v{policy.NextVersion}", notes, StringComparison.Ordinal);
+        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.StableVersion}", notes, StringComparison.Ordinal);
+        Assert.Contains($"releases/tag/v{policy.StableVersion}", notes, StringComparison.Ordinal);
+        var currentStub = File.ReadAllText(Path.Combine(root, "docs", language, currentNotes));
+        Assert.Contains("DRAFT /", currentStub, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "UNRELEASED" : "未リリース",
+            currentStub,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", currentStub, StringComparison.Ordinal);
+        Assert.Contains($"releases/tag/v{policy.NextVersion}", currentStub, StringComparison.Ordinal);
         Assert.DoesNotContain("DRAFT /", notes, StringComparison.Ordinal);
+        Assert.DoesNotContain("UNRELEASED", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("未リリース", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]
@@ -188,6 +208,17 @@ public sealed class ReleaseNotesV0210DocsTests
     {
         var bytes = File.ReadAllBytes(Path.Combine(
             RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.20.0.md"));
+
+        Assert.Equal(expectedSha256, Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(bytes)));
+    }
+
+    [Theory]
+    [InlineData("en", "95b9f17459860f14665170d17dea2e4afbfe4fe5a547a359cd79442d10b488f7")]
+    [InlineData("ja", "448c9f34a899712e39b1fcbcd0be15c6012d9ac6b3dac63d7ca5a5549011bb25")]
+    public void PublishedV0210NotesRemainByteForByteFrozen(string language, string expectedSha256)
+    {
+        var bytes = File.ReadAllBytes(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.21.0.md"));
 
         Assert.Equal(expectedSha256, Convert.ToHexStringLower(System.Security.Cryptography.SHA256.HashData(bytes)));
     }


### PR DESCRIPTION
Closes #1501

Roll-only follow-through for the published v0.21.0 release. Rolls eng/version.json to stable 0.21.0 / next 0.21.1, adds bilingual v0.21.1 DRAFT stubs, freezes v0.21.0 notes with the c77c92fe / workflow 31766364883 / four-job / eight-asset / checksum / NuGet / clean-install evidence, and refreshes readiness and guards. No new Release, tag, package publish, or source/runtime behavior change.

Verification: focused release guards 109/109 passed; full Release suite 5311 passed, 1 skipped, 0 failed; Release build 0 warnings / 0 errors; git diff --check clean.