### PR TITLE
feat: distribute intent-cli through npm (#1519)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,83 @@ jobs:
           name: test-results
           path: .artifacts/test-results/
           retention-days: 7
+
+  npm-dry-run:
+    name: npm package dry-run (no publish)
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          dotnet-quality: preview
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Resolve CI package version from repository policy
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          NEXT_VERSION="$(python3 -c "import json; print(json.load(open('eng/version.json'))['nextVersion'])")"
+          VERSION="${NEXT_VERSION}-ci.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          echo "version=${VERSION}" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Publish the Linux smoke binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          dotnet publish src/IntentSystem.Cli/IntentSystem.Cli.csproj \
+            --configuration Release --runtime linux-x64 --self-contained true \
+            -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true \
+            -p:Version="${VERSION}" -o .artifacts/npm-binaries/linux-x64
+          cp .artifacts/npm-binaries/linux-x64/IntentSystem.Cli .artifacts/npm-binaries/linux-x64/intent-cli
+          chmod +x .artifacts/npm-binaries/linux-x64/intent-cli
+          .artifacts/npm-binaries/linux-x64/intent-cli --version > .artifacts/npm-version.txt
+
+      - name: Prepare all npm packages for a dry run
+        shell: bash
+        run: |
+          set -euo pipefail
+          node packaging/npm/scripts/prepare-packages.js \
+            --version "${{ steps.ver.outputs.version }}" \
+            --binary-root .artifacts/npm-binaries \
+            --output .artifacts/npm-packages \
+            --allow-missing-binaries
+
+      - name: Pack, verify, and exercise the packed npm entry point
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          mkdir -p .artifacts/npm-tarballs
+          for package in .artifacts/npm-packages/*; do
+            npm pack "${package}" --ignore-scripts --pack-destination .artifacts/npm-tarballs
+          done
+          node packaging/npm/scripts/verify-packages.js \
+            --packages-dir .artifacts/npm-packages \
+            --expected-version "${VERSION}" \
+            --version-output .artifacts/npm-version.txt
+          MAIN_TGZ="$(find .artifacts/npm-tarballs -maxdepth 1 -name 'intent-system-*.tgz' -print -quit)"
+          LINUX_TGZ="$(find .artifacts/npm-tarballs -maxdepth 1 -name '*intent-cli-linux-x64-*.tgz' -print -quit)"
+          test -n "${MAIN_TGZ}" -a -n "${LINUX_TGZ}"
+          node packaging/npm/scripts/smoke-packed.js \
+            --main "${MAIN_TGZ}" --platform "${LINUX_TGZ}" --expected-version "${VERSION}" \
+            --work-dir ".artifacts/npm-packed-smoke"
+
+      - name: Upload npm dry-run artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: intent-cli-npm-dry-run-${{ steps.ver.outputs.version }}
+          path: .artifacts/npm-tarballs/
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,12 @@
 #      osx-arm64, win-x64, and linux-x64 on matching runners, smoke-tests
 #      `intent-cli --version`, and archives each with a SHA-256 sidecar.
 #
-#   3. Attaches the .nupkg and the per-platform binary archives (plus
-#      checksums) to the triggering GitHub Release.
+#   3. Prepares the npm entry package plus its per-platform optional packages,
+#      verifies checksums/version identity, and publishes them only on the same
+#      real-release event and guarded secret path as NuGet.
+#
+#   4. Attaches the .nupkg, npm packages, and per-platform binary archives
+#      (plus checksums) to the triggering GitHub Release.
 #
 # Non-SDK users install by downloading a release binary; SDK users run
 # `dotnet tool install -g JTechJapan.IntentSystem.Cli`. See README.md "Install".
@@ -225,7 +229,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          "${{ steps.stage.outputs.bin }}" --version
+          VERSION="${{ steps.ver.outputs.version }}"
+          OUTPUT="$("${{ steps.stage.outputs.bin }}" --version)"
+          printf '%s\n' "${OUTPUT}"
+          FIRST_LINE="$(printf '%s\n' "${OUTPUT}" | sed -n '1p')"
+          case "${FIRST_LINE}" in
+            "intent-cli ${VERSION}"|"intent-cli ${VERSION}-"*|"intent-cli ${VERSION}+"*) ;;
+            *) echo "binary version '${FIRST_LINE}' does not match release version '${VERSION}'" >&2; exit 1 ;;
+          esac
 
       - name: Archive + checksum
         id: pack
@@ -272,3 +283,123 @@ jobs:
             "${{ steps.pack.outputs.asset }}" \
             "${{ steps.pack.outputs.asset }}.sha256" \
             --repo "${{ github.repository }}" --clobber
+
+  npm:
+    name: npm packages
+    needs: [nupkg, binaries]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js for release packaging
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Resolve the same tag-derived release version as NuGet and binaries
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            RAW="${{ github.event.release.tag_name }}"
+          else
+            RAW="${{ github.event.inputs.version }}"
+          fi
+          VERSION="${RAW#v}"
+          if [ -z "${VERSION}" ]; then
+            NEXT_VERSION="$(python3 -c "import json; data=json.load(open('eng/version.json')); print(data['nextVersion'])" 2>/dev/null || echo "0.3.0")"
+            VERSION="${NEXT_VERSION}-dryrun.${GITHUB_RUN_NUMBER}.${GITHUB_RUN_ATTEMPT}"
+          fi
+          echo "version=${VERSION}" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Download the exact binary artifacts produced by the release matrix
+        uses: actions/download-artifact@v4
+        with:
+          pattern: intent-cli-*
+          path: .artifacts/release-assets
+          merge-multiple: true
+
+      - name: Rebuild npm platform packages from release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          for RID in osx-arm64 linux-x64 win-x64; do
+            case "${RID}" in
+              osx-arm64) ARCHIVE="intent-cli-${VERSION}-osx-arm64.*"; BINARY="intent-cli" ;;
+              linux-x64) ARCHIVE="intent-cli-${VERSION}-linux-x64.*"; BINARY="intent-cli" ;;
+              win-x64) ARCHIVE="intent-cli-${VERSION}-win-x64.*"; BINARY="intent-cli.exe" ;;
+            esac
+            ASSET="$(find .artifacts/release-assets -type f -name "${ARCHIVE}" ! -name '*.sha256' -print -quit)"
+            test -n "${ASSET}"
+            EXTRACT=".artifacts/extract/${RID}"
+            mkdir -p "${EXTRACT}"
+            case "${ASSET}" in
+              *.tar.gz) tar -xzf "${ASSET}" -C "${EXTRACT}" ;;
+              *.zip) unzip -q "${ASSET}" -d "${EXTRACT}" ;;
+              *) echo "unsupported binary asset: ${ASSET}" >&2; exit 1 ;;
+            esac
+            mkdir -p ".artifacts/npm-binaries/${RID}"
+            cp "$(find "${EXTRACT}" -type f -name "${BINARY}" -print -quit)" ".artifacts/npm-binaries/${RID}/${BINARY}"
+            if [ "${BINARY}" != "intent-cli.exe" ]; then chmod +x ".artifacts/npm-binaries/${RID}/${BINARY}"; fi
+          done
+          .artifacts/npm-binaries/linux-x64/intent-cli --version > .artifacts/npm-version.txt
+          node packaging/npm/scripts/prepare-packages.js \
+            --version "${VERSION}" --binary-root .artifacts/npm-binaries --output .artifacts/npm-packages
+
+      - name: Pack and verify npm packages without publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ steps.ver.outputs.version }}"
+          mkdir -p .artifacts/npm-tarballs
+          for package in .artifacts/npm-packages/*; do
+            npm pack "${package}" --ignore-scripts --pack-destination .artifacts/npm-tarballs
+          done
+          node packaging/npm/scripts/verify-packages.js \
+            --packages-dir .artifacts/npm-packages --expected-version "${VERSION}" \
+            --version-output .artifacts/npm-version.txt --require-real-binaries
+          for file in .artifacts/npm-tarballs/*.tgz; do
+            sha256sum "${file}" > "${file}.sha256"
+          done
+
+      - name: Upload npm workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: intent-cli-npm-${{ steps.ver.outputs.version }}
+          path: .artifacts/npm-tarballs/*
+
+      - name: Attach npm packages to GitHub Release
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            .artifacts/npm-tarballs/* \
+            --repo "${{ github.repository }}" --clobber
+
+      - name: Publish npm packages (guarded; same release gate as NuGet)
+        if: ${{ github.event_name == 'release' }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN is not set (fork or missing secret); skipping npm publish."
+            echo "Packages were still packed, checksum-verified, and attached to the release."
+            exit 0
+          fi
+          for package in \
+            .artifacts/npm-tarballs/j-tech-japan-intent-cli-darwin-arm64-*.tgz \
+            .artifacts/npm-tarballs/j-tech-japan-intent-cli-linux-x64-*.tgz \
+            .artifacts/npm-tarballs/j-tech-japan-intent-cli-win32-x64-*.tgz \
+            .artifacts/npm-tarballs/intent-system-*.tgz; do
+            npm publish "${package}" --access public
+          done

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ dotnet tool install -g JTechJapan.IntentSystem.Cli
 If `intent-cli` is not found after install, add `~/.dotnet/tools` (macOS/Linux)
 or `%USERPROFILE%\.dotnet\tools` (Windows) to your `PATH`.
 
+No .NET SDK? The npm entry point provides the same self-contained release
+binary through the matching optional platform package:
+
+```bash
+npm install -g intent-system
+intent-cli --version
+npx intent-system guide onboarding
+```
+
+See the [npm distribution guide](docs/en/13-npm-distribution.md) for npx
+guidance, checksums, release gating, and coexistence with the .NET tool.
+
 > No .NET SDK? See **[Install without a .NET SDK](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/01-install.md#install-without-a-net-sdk)**
 > for self-contained binaries. Need the preview channel? See the
 > **[developer reference](https://github.com/J-Tech-Japan/intent-system/blob/main/docs/en/09-developer-reference.md#preview-install)**.

--- a/docs/en/01-install.md
+++ b/docs/en/01-install.md
@@ -38,6 +38,20 @@ intent-cli --version
 If `~/.dotnet/tools` (macOS/Linux) or `%USERPROFILE%\.dotnet\tools` (Windows) is
 not on your `PATH`, the install output prints the line to add.
 
+**npm entry point (no .NET SDK required):** install the self-contained
+platform package through npm, or run one command with npx:
+
+```bash
+npm install -g intent-system
+intent-cli --version
+npx intent-system guide onboarding
+```
+
+The npm shim never installs globally on your behalf. See the
+[npm distribution guide](13-npm-distribution.md) for the one-line npx guidance,
+checksums, release gating, and coexistence rules when the .NET tool is also on
+`PATH`.
+
 **No .NET SDK?** Download the self-contained binary for your platform from the
 [latest GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/latest);
 the runtime is bundled. Verify the `.sha256` sidecar before use. See the

--- a/docs/en/13-npm-distribution.md
+++ b/docs/en/13-npm-distribution.md
@@ -1,0 +1,58 @@
+# npm distribution
+
+← [docs index](README.md) | → [developer reference](09-developer-reference.md)
+
+G702 makes the npm distribution an installation interface for `intent-cli`.
+The unscoped `intent-system` package is a thin entry point; its optional
+platform dependency supplies a self-contained release binary for macOS Apple
+Silicon, Linux x64, or Windows x64.
+
+## Persistent and one-shot use
+
+For a persistent command, install globally and then invoke the command:
+
+```bash
+npm install -g intent-system
+intent-cli --version
+```
+
+For a one-shot command, use npx:
+
+```bash
+npx intent-system guide onboarding
+```
+
+The shim detects npx from the npm user agent and checks whether `intent-cli` is
+already on `PATH`. If both conditions say this is a one-shot invocation, it
+prints exactly one concise line after the command suggesting
+`npm install -g intent-system`, followed by the resulting `intent-cli` command.
+It never performs that installation itself. There is no `postinstall` hook and
+no package-install network download.
+
+## Release integrity
+
+The release workflow derives one version from the published Git tag and uses
+it for the NuGet package, every npm package, every self-contained binary, and
+the binary `--version` output. Each platform npm package records a SHA-256
+digest and includes a matching `.sha256` sidecar. Platform packages are
+published only as part of the same guarded operator release transaction as
+NuGet. Pull-request CI runs package preparation, `npm pack`, checksum/version
+verification, and a packed-install smoke test; it never publishes to npm and
+does not require npm organization credentials.
+
+## Coexisting with the .NET tool
+
+The npm route and the .NET global tool can coexist:
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli
+# or: npm install -g intent-system
+command -v intent-cli
+intent-cli --version
+```
+
+Both routes install a command named `intent-cli`. The first matching directory
+on `PATH` wins, so choose the intended channel by ordering
+`$HOME/.dotnet/tools` and the npm global bin directory, or use the package
+manager's update command for that channel. Do not mix a stale binary with a
+new package when diagnosing version differences.

--- a/docs/en/README.md
+++ b/docs/en/README.md
@@ -39,6 +39,7 @@ model, not either transport.
 8. [Command reference](08-command-reference.md) — agent-facing and power-user command surfaces
 9. [Developer reference](09-developer-reference.md) — packaged invocation, preview channel, version flow
 10. [1.0 compatibility promise](1.0-compatibility-promise.md) — covered machine surfaces, deprecation rule, and ledger
+13. [npm distribution](13-npm-distribution.md) — global/npx entry points, release integrity, and .NET tool coexistence
 
 ## What is Intent Storming?
 

--- a/docs/ja/01-install.md
+++ b/docs/ja/01-install.md
@@ -37,6 +37,19 @@ intent-cli --version
 `~/.dotnet/tools`（macOS/Linux）または `%USERPROFILE%\.dotnet\tools`（Windows）が
 `PATH` に無い場合、インストール出力に追加すべき行が表示されます。
 
+**npm エントリーポイント（.NET SDK 不要）:** npm からランタイム同梱のプラットフォーム
+パッケージをインストールするか、npx で一回だけ実行できます。
+
+```bash
+npm install -g intent-system
+intent-cli --version
+npx intent-system guide onboarding
+```
+
+npm shim が代わりにグローバルインストールを実行することはありません。npx の 1 行 guidance、
+checksum、release gate、.NET tool と同じ `PATH` で共存するルールは
+[npm 配布ガイド](13-npm-distribution.md)を参照してください。
+
 **.NET SDK が無い場合**は、各プラットフォーム向けの `self-contained`（ランタイム同梱）バイナリを
 [最新 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/latest)
 から取得（ランタイム同梱）。使用前に `.sha256` を検証する。手順は

--- a/docs/ja/13-npm-distribution.md
+++ b/docs/ja/13-npm-distribution.md
@@ -1,0 +1,54 @@
+# npm 配布
+
+← [ドキュメント索引](README.md) | → [開発者リファレンス](09-developer-reference.md)
+
+G702 では npm 配布を `intent-cli` のインストール用インターフェースとして扱います。
+非スコープの `intent-system` パッケージは薄いエントリーポイントで、optional dependency
+から macOS Apple Silicon、Linux x64、または Windows x64 向けのランタイム同梱 release
+バイナリを取得します。
+
+## 常用と一回限りの実行
+
+常用するコマンドはグローバルにインストールしてから実行します。
+
+```bash
+npm install -g intent-system
+intent-cli --version
+```
+
+一回限りのコマンドは npx で実行します。
+
+```bash
+npx intent-system guide onboarding
+```
+
+shim は npm user agent から npx を検出し、`PATH` に `intent-cli` があるかを確認します。
+両方の条件が一回限りの実行を示す場合だけ、実行完了後に
+`npm install -g intent-system` と、その結果使う `intent-cli` を案内する短い行を**正確に 1 行**表示します。
+shim 自身がインストールを実行することはありません。`postinstall` hook もパッケージインストール時の
+ネットワークダウンロードもありません。
+
+## リリースの整合性
+
+release workflow は公開された Git tag から 1 つのバージョンを導出し、NuGet パッケージ、すべての
+npm パッケージ、ランタイム同梱バイナリ、およびバイナリの `--version` 出力に同じ値を使います。
+各プラットフォーム npm パッケージには SHA-256 digest と一致する `.sha256` sidecar を含めます。
+プラットフォームパッケージの公開は NuGet と同じ保護された operator release transaction の一部だけで行います。
+Pull request CI は package preparation、`npm pack`、checksum/version 検証、packed-install smoke test
+までを実行します。npm への公開は行わず、npm 組織の credential も必要としません。
+
+## .NET tool との共存
+
+npm 経路と .NET global tool は共存できます。
+
+```bash
+dotnet tool install -g JTechJapan.IntentSystem.Cli
+# または: npm install -g intent-system
+command -v intent-cli
+intent-cli --version
+```
+
+両方の経路が `intent-cli` という同じコマンドをインストールします。`PATH` で先に見つかるディレクトリが
+使われるため、`$HOME/.dotnet/tools` と npm global bin directory の順序で使用する channel を選びます。
+バージョン差を調査するときは古いバイナリと新しいパッケージを混在させず、その channel の package manager の
+update command を使ってください。

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -39,6 +39,7 @@ agmsg 投資があるチームには、サポート対象で廃止されない `
 9. [開発者リファレンス](09-developer-reference.md) — パッケージ化された実行、preview チャンネル、バージョンフロー
 10. [1.0 互換性の約束](1.0-compatibility-promise.md) — 対象となる機械向けサーフェス、廃止規則、ledger
 11. [日本語ドキュメントの用語ポリシー](00-terminology-policy.md)
+13. [npm 配布](13-npm-distribution.md) — global/npx エントリーポイント、リリース整合性、.NET tool との共存
 
 ## Intent Storming とは
 

--- a/packaging/npm/README.md
+++ b/packaging/npm/README.md
@@ -1,0 +1,24 @@
+# intent-system
+
+`intent-system` is the npm distribution entry point for `intent-cli`. It
+installs the matching self-contained release binary through an npm optional
+dependency for macOS Apple Silicon, Linux x64, or Windows x64.
+
+For a persistent command:
+
+```bash
+npm install -g intent-system
+intent-cli --version
+```
+
+For a one-shot invocation:
+
+```bash
+npx intent-system guide onboarding
+```
+
+The thin shim never installs packages and has no `postinstall` download hook.
+When npx is used and no `intent-cli` is already on `PATH`, it prints one short
+line suggesting the global install after the command completes. The release
+pipeline writes a checksum for every platform package and verifies package,
+binary, and `--version` identity before publishing.

--- a/packaging/npm/bin/intent-cli.js
+++ b/packaging/npm/bin/intent-cli.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const platformPackage = new Map([
+  ['darwin:arm64', '@j-tech-japan/intent-cli-darwin-arm64'],
+  ['linux:x64', '@j-tech-japan/intent-cli-linux-x64'],
+  ['win32:x64', '@j-tech-japan/intent-cli-win32-x64'],
+]);
+
+function platformBinaryName() {
+  return process.platform === 'win32' ? 'intent-cli.exe' : 'intent-cli';
+}
+
+function findPlatformBinary() {
+  const key = `${process.platform}:${process.arch}`;
+  const packageName = platformPackage.get(key);
+  if (!packageName) {
+    throw new Error(
+      `intent-system does not ship a self-contained intent-cli binary for ${process.platform}/${process.arch}. ` +
+      'Install JTechJapan.IntentSystem.Cli with dotnet or use a supported release platform.',
+    );
+  }
+
+  const binaryName = platformBinaryName();
+  let packageBinary;
+  try {
+    packageBinary = require.resolve(`${packageName}/bin/${binaryName}`);
+  } catch {
+    throw new Error(
+      `The optional dependency ${packageName} is not installed for ${process.platform}/${process.arch}. ` +
+      'Reinstall intent-system with optional dependencies enabled.',
+    );
+  }
+
+  return packageBinary;
+}
+
+function pathHasIntentCli() {
+  const pathValue = process.env.PATH || '';
+  const names = process.platform === 'win32'
+    ? ['intent-cli.exe', 'intent-cli.cmd', 'intent-cli']
+    : ['intent-cli'];
+
+  return pathValue.split(path.delimiter).filter(Boolean).some((directory) =>
+    names.some((name) => {
+      const candidate = path.join(directory, name);
+      try {
+        fs.accessSync(candidate, fs.constants.X_OK);
+        return true;
+      } catch {
+        return false;
+      }
+    }),
+  );
+}
+
+function wasInvokedByNpx() {
+  const userAgent = process.env.npm_config_user_agent || process.env.NPM_CONFIG_USER_AGENT || '';
+  return /(?:^|\s|\/)npx(?:\/|\s|$)/i.test(userAgent) || /^npx(?:\/|\s|$)/i.test(userAgent);
+}
+
+function emitNpxGuidanceOnce() {
+  process.stderr.write(
+    'For a persistent install, run: npm install -g intent-system; then use intent-cli.\n',
+  );
+}
+
+function main() {
+  const binary = findPlatformBinary();
+  const result = spawnSync(binary, process.argv.slice(2), {
+    env: process.env,
+    stdio: 'inherit',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status === 0 && wasInvokedByNpx() && !pathHasIntentCli()) {
+    emitNpxGuidanceOnce();
+  }
+
+  process.exitCode = result.status ?? 1;
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+}

--- a/packaging/npm/package.json
+++ b/packaging/npm/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "intent-system",
+  "version": "0.0.0-dev",
+  "description": "The intent-cli command, distributed with self-contained platform binaries.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/J-Tech-Japan/intent-system.git"
+  },
+  "homepage": "https://github.com/J-Tech-Japan/intent-system",
+  "engines": {
+    "node": ">=18"
+  },
+  "bin": {
+    "intent-cli": "bin/intent-cli.js"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "optionalDependencies": {
+    "@j-tech-japan/intent-cli-darwin-arm64": "0.0.0-dev",
+    "@j-tech-japan/intent-cli-linux-x64": "0.0.0-dev",
+    "@j-tech-japan/intent-cli-win32-x64": "0.0.0-dev"
+  },
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  }
+}

--- a/packaging/npm/platforms/darwin-arm64/README.md
+++ b/packaging/npm/platforms/darwin-arm64/README.md
@@ -1,0 +1,4 @@
+# @j-tech-japan/intent-cli-darwin-arm64
+
+The self-contained `intent-cli` binary for macOS Apple Silicon. Install the
+`intent-system` package instead of this platform package directly.

--- a/packaging/npm/platforms/darwin-arm64/package.json
+++ b/packaging/npm/platforms/darwin-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@j-tech-japan/intent-cli-darwin-arm64",
+  "version": "0.0.0-dev",
+  "description": "Self-contained intent-cli binary for macOS Apple Silicon.",
+  "license": "Apache-2.0",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "intentCli": {
+    "platform": "osx-arm64",
+    "version": "0.0.0-dev",
+    "binary": "bin/intent-cli",
+    "binarySha256": "__BINARY_SHA256__",
+    "source": "self-contained GitHub Release asset"
+  }
+}

--- a/packaging/npm/platforms/linux-x64/README.md
+++ b/packaging/npm/platforms/linux-x64/README.md
@@ -1,0 +1,4 @@
+# @j-tech-japan/intent-cli-linux-x64
+
+The self-contained `intent-cli` binary for Linux x64. Install the
+`intent-system` package instead of this platform package directly.

--- a/packaging/npm/platforms/linux-x64/package.json
+++ b/packaging/npm/platforms/linux-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@j-tech-japan/intent-cli-linux-x64",
+  "version": "0.0.0-dev",
+  "description": "Self-contained intent-cli binary for Linux x64.",
+  "license": "Apache-2.0",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "intentCli": {
+    "platform": "linux-x64",
+    "version": "0.0.0-dev",
+    "binary": "bin/intent-cli",
+    "binarySha256": "__BINARY_SHA256__",
+    "source": "self-contained GitHub Release asset"
+  }
+}

--- a/packaging/npm/platforms/win32-x64/README.md
+++ b/packaging/npm/platforms/win32-x64/README.md
@@ -1,0 +1,4 @@
+# @j-tech-japan/intent-cli-win32-x64
+
+The self-contained `intent-cli` binary for Windows x64. Install the
+`intent-system` package instead of this platform package directly.

--- a/packaging/npm/platforms/win32-x64/package.json
+++ b/packaging/npm/platforms/win32-x64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@j-tech-japan/intent-cli-win32-x64",
+  "version": "0.0.0-dev",
+  "description": "Self-contained intent-cli binary for Windows x64.",
+  "license": "Apache-2.0",
+  "os": [
+    "win32"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "intentCli": {
+    "platform": "win-x64",
+    "version": "0.0.0-dev",
+    "binary": "bin/intent-cli.exe",
+    "binarySha256": "__BINARY_SHA256__",
+    "source": "self-contained GitHub Release asset"
+  }
+}

--- a/packaging/npm/scripts/prepare-packages.js
+++ b/packaging/npm/scripts/prepare-packages.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const packageRoot = path.resolve(__dirname, '..');
+const platforms = [
+  {
+    rid: 'osx-arm64',
+    directory: 'darwin-arm64',
+    template: 'platforms/darwin-arm64/package.json',
+    binary: 'intent-cli',
+    npmPackage: '@j-tech-japan/intent-cli-darwin-arm64',
+  },
+  {
+    rid: 'linux-x64',
+    directory: 'linux-x64',
+    template: 'platforms/linux-x64/package.json',
+    binary: 'intent-cli',
+    npmPackage: '@j-tech-japan/intent-cli-linux-x64',
+  },
+  {
+    rid: 'win-x64',
+    directory: 'win32-x64',
+    template: 'platforms/win32-x64/package.json',
+    binary: 'intent-cli.exe',
+    npmPackage: '@j-tech-japan/intent-cli-win32-x64',
+  },
+];
+
+function parseArguments(argv) {
+  const options = { allowMissingBinaries: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--allow-missing-binaries') {
+      options.allowMissingBinaries = true;
+      continue;
+    }
+    if (argument === '--version' || argument === '--binary-root' || argument === '--output') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${argument} requires a value`);
+      }
+      options[argument.slice(2).replace('-', '')] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${argument}`);
+  }
+
+  if (!options.version || !options.binaryroot || !options.output) {
+    throw new Error('usage: prepare-packages.js --version VERSION --binary-root DIR --output DIR [--allow-missing-binaries]');
+  }
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(options.version)) {
+    throw new Error(`invalid npm version: ${options.version}`);
+  }
+  return options;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function sha256(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function copyOrCreateBinary(source, destination, version, allowMissing, isWindows) {
+  if (fs.existsSync(source)) {
+    fs.copyFileSync(source, destination);
+    if (!isWindows) {
+      fs.chmodSync(destination, 0o755);
+    }
+    return 'release-asset';
+  }
+  if (!allowMissing) {
+    throw new Error(`missing release binary for ${source}; use --allow-missing-binaries only for CI dry-run packaging`);
+  }
+
+  if (isWindows) {
+    // A dry-run package is never published. Keep a deterministic placeholder
+    // so npm pack and metadata/checksum checks exercise every platform shape.
+    fs.writeFileSync(destination, `intent-cli ${version} (dry-run placeholder)\r\n`);
+  } else {
+    fs.writeFileSync(destination, `#!/bin/sh\nprintf 'intent-cli %s\\n' '${version}'\n`);
+    fs.chmodSync(destination, 0o755);
+  }
+  return 'dry-run-placeholder';
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const binaryRoot = path.resolve(options.binaryroot);
+  const outputRoot = path.resolve(options.output);
+  fs.mkdirSync(outputRoot, { recursive: true });
+
+  const mainPackage = readJson(path.join(packageRoot, 'package.json'));
+  mainPackage.version = options.version;
+  for (const platform of platforms) {
+    mainPackage.optionalDependencies[platform.npmPackage] = options.version;
+  }
+
+  const mainOutput = path.join(outputRoot, 'intent-system');
+  fs.mkdirSync(path.join(mainOutput, 'bin'), { recursive: true });
+  fs.copyFileSync(path.join(packageRoot, 'bin', 'intent-cli.js'), path.join(mainOutput, 'bin', 'intent-cli.js'));
+  fs.chmodSync(path.join(mainOutput, 'bin', 'intent-cli.js'), 0o755);
+  fs.copyFileSync(path.join(packageRoot, 'README.md'), path.join(mainOutput, 'README.md'));
+  writeJson(path.join(mainOutput, 'package.json'), mainPackage);
+
+  const manifest = [];
+  for (const platform of platforms) {
+    const platformOutput = path.join(outputRoot, platform.directory);
+    const binaryOutput = path.join(platformOutput, 'bin', platform.binary);
+    fs.mkdirSync(path.dirname(binaryOutput), { recursive: true });
+    const binarySource = path.join(binaryRoot, platform.rid, platform.binary);
+    const sourceKind = copyOrCreateBinary(
+      binarySource,
+      binaryOutput,
+      options.version,
+      options.allowMissingBinaries,
+      platform.binary.endsWith('.exe'),
+    );
+    const checksum = sha256(binaryOutput);
+    fs.writeFileSync(`${binaryOutput}.sha256`, `${checksum}  ${platform.binary}\n`);
+
+    const packageJson = readJson(path.join(packageRoot, platform.template));
+    packageJson.version = options.version;
+    packageJson.intentCli.version = options.version;
+    packageJson.intentCli.binarySha256 = checksum;
+    packageJson.intentCli.source = sourceKind === 'release-asset'
+      ? 'self-contained GitHub Release asset'
+      : 'CI-only dry-run placeholder; never publish';
+    fs.copyFileSync(
+      path.join(packageRoot, 'platforms', platform.directory, 'README.md'),
+      path.join(platformOutput, 'README.md'),
+    );
+    writeJson(path.join(platformOutput, 'package.json'), packageJson);
+    manifest.push({ package: platform.npmPackage, version: options.version, platform: platform.rid, source: sourceKind, sha256: checksum });
+  }
+
+  console.log(JSON.stringify({ main: 'intent-system', version: options.version, platforms: manifest }, null, 2));
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packaging/npm/scripts/smoke-packed.js
+++ b/packaging/npm/scripts/smoke-packed.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+function parseArguments(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--main' || argument === '--platform' || argument === '--expected-version' || argument === '--work-dir') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) throw new Error(`${argument} requires a value`);
+      options[argument.slice(2).replaceAll('-', '')] = value;
+      index += 1;
+    } else {
+      throw new Error(`unknown argument: ${argument}`);
+    }
+  }
+  if (!options.main || !options.platform || !options.expectedversion || !options.workdir) {
+    throw new Error('usage: smoke-packed.js --main MAIN_TGZ --platform PLATFORM_TGZ --expected-version VERSION --work-dir DIR');
+  }
+  return options;
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, { encoding: 'utf8', ...options });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed (${result.status})\n${result.stdout}\n${result.stderr}`);
+  }
+  return result;
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const root = path.resolve(options.workdir);
+  const emptyPath = path.join(root, 'empty-path');
+  fs.mkdirSync(emptyPath, { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: 'g702-packed-smoke', version: '0.0.0', private: true }) + '\n',
+  );
+  run('npm', [
+    'install', '--ignore-scripts', '--no-audit', '--no-fund', '--offline', '--omit=optional',
+    path.resolve(options.main), path.resolve(options.platform),
+  ], { cwd: root });
+  const shim = path.join(root, 'node_modules', 'intent-system', 'bin', 'intent-cli.js');
+  const result = run(process.execPath, [shim, '--version'], {
+    cwd: root,
+    env: {
+      ...process.env,
+      PATH: emptyPath,
+      npm_config_user_agent: `npx/ci node/${process.version.slice(1)}`,
+    },
+  });
+  const firstLine = result.stdout.trim().split(/\r?\n/, 1)[0];
+  if (!new RegExp(`^intent-cli ${options.expectedversion}(?:$|[-+])`).test(firstLine)) {
+    throw new Error(`packed shim returned '${firstLine}', expected ${options.expectedversion}`);
+  }
+  const guidance = result.stderr.trim().split(/\r?\n/).filter(Boolean);
+  if (guidance.length !== 1 || !guidance[0].includes('npm install -g intent-system') || !guidance[0].includes('intent-cli')) {
+    throw new Error(`packed npx invocation must emit exactly one guidance line; got ${JSON.stringify(guidance)}`);
+  }
+  console.log(`packed smoke passed: npx shim -> platform binary ${firstLine}; one guidance line`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packaging/npm/scripts/verify-packages.js
+++ b/packaging/npm/scripts/verify-packages.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const platforms = [
+  { directory: 'darwin-arm64', package: '@j-tech-japan/intent-cli-darwin-arm64', rid: 'osx-arm64', binary: 'intent-cli' },
+  { directory: 'linux-x64', package: '@j-tech-japan/intent-cli-linux-x64', rid: 'linux-x64', binary: 'intent-cli' },
+  { directory: 'win32-x64', package: '@j-tech-japan/intent-cli-win32-x64', rid: 'win-x64', binary: 'intent-cli.exe' },
+];
+
+function parseArguments(argv) {
+  const options = { requireRealBinaries: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--require-real-binaries') {
+      options.requireRealBinaries = true;
+      continue;
+    }
+    if (argument === '--packages-dir' || argument === '--expected-version' || argument === '--version-output') {
+      const value = argv[index + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`${argument} requires a value`);
+      }
+      options[argument.slice(2).replaceAll('-', '')] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${argument}`);
+  }
+  if (!options.packagesdir || !options.expectedversion) {
+    throw new Error('usage: verify-packages.js --packages-dir DIR --expected-version VERSION [--version-output FILE] [--require-real-binaries]');
+  }
+  return options;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function digest(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const root = path.resolve(options.packagesdir);
+  const mainPackagePath = path.join(root, 'intent-system', 'package.json');
+  const mainPackage = readJson(mainPackagePath);
+  assert(mainPackage.name === 'intent-system', 'main package name drifted');
+  assert(mainPackage.version === options.expectedversion, `main package version ${mainPackage.version} != ${options.expectedversion}`);
+  assert(mainPackage.bin?.['intent-cli'] === 'bin/intent-cli.js', 'main package must expose the intent-cli shim');
+  assert(!mainPackage.scripts?.postinstall, 'main package must not have a postinstall hook');
+
+  for (const platform of platforms) {
+    const directory = path.join(root, platform.directory);
+    const packageJson = readJson(path.join(directory, 'package.json'));
+    assert(packageJson.name === platform.package, `${platform.rid} package name drifted`);
+    assert(packageJson.version === options.expectedversion, `${platform.rid} package version drifted`);
+    assert(packageJson.intentCli?.version === options.expectedversion, `${platform.rid} recorded binary version drifted`);
+    assert(packageJson.intentCli?.platform === platform.rid, `${platform.rid} platform metadata drifted`);
+    assert(!packageJson.scripts?.postinstall, `${platform.rid} package must not have a postinstall hook`);
+    assert(mainPackage.optionalDependencies?.[platform.package] === options.expectedversion, `${platform.rid} optional dependency version drifted`);
+
+    const binary = path.join(directory, 'bin', platform.binary);
+    const sidecar = `${binary}.sha256`;
+    assert(fs.existsSync(binary), `${platform.rid} binary is missing`);
+    assert(fs.existsSync(sidecar), `${platform.rid} checksum sidecar is missing`);
+    const actual = digest(binary);
+    const declared = packageJson.intentCli.binarySha256;
+    assert(declared === actual, `${platform.rid} declared checksum does not match binary`);
+    assert(fs.readFileSync(sidecar, 'utf8').startsWith(`${actual}  ${platform.binary}`), `${platform.rid} sidecar checksum does not match binary`);
+    if (options.requireRealBinaries) {
+      assert(packageJson.intentCli.source === 'self-contained GitHub Release asset', `${platform.rid} is not a release binary`);
+    }
+  }
+
+  if (options.versionoutput) {
+    const firstLine = fs.readFileSync(options.versionoutput, 'utf8').split(/\r?\n/, 1)[0];
+    assert(new RegExp(`^intent-cli ${options.expectedversion}(?:$|[-+])`).test(firstLine), `binary version output '${firstLine}' does not match ${options.expectedversion}`);
+  }
+
+  console.log(`verified intent-system ${options.expectedversion}: main shim, ${platforms.length} platform packages, checksums, and version identity`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/packaging/npm/test/package-contract.test.js
+++ b/packaging/npm/test/package-contract.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const packageRoot = path.resolve(__dirname, '..');
+const platforms = [
+  { directory: 'darwin-arm64', name: '@j-tech-japan/intent-cli-darwin-arm64', os: 'darwin', cpu: 'arm64', rid: 'osx-arm64' },
+  { directory: 'linux-x64', name: '@j-tech-japan/intent-cli-linux-x64', os: 'linux', cpu: 'x64', rid: 'linux-x64' },
+  { directory: 'win32-x64', name: '@j-tech-japan/intent-cli-win32-x64', os: 'win32', cpu: 'x64', rid: 'win-x64' },
+];
+
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(packageRoot, relativePath), 'utf8'));
+}
+
+test('main package exposes exactly the supported optional platform packages', () => {
+  const main = readJson('package.json');
+  assert.equal(main.name, 'intent-system');
+  assert.equal(main.bin['intent-cli'], 'bin/intent-cli.js');
+  assert.deepEqual(Object.keys(main.optionalDependencies).sort(), platforms.map((item) => item.name).sort());
+  assert.equal(main.scripts?.postinstall, undefined);
+  for (const platform of platforms) {
+    assert.equal(main.optionalDependencies[platform.name], '0.0.0-dev');
+  }
+});
+
+test('platform templates declare npm selection, release RID, and checksum metadata', () => {
+  for (const platform of platforms) {
+    const manifest = readJson(`platforms/${platform.directory}/package.json`);
+    assert.equal(manifest.name, platform.name);
+    assert.deepEqual(manifest.os, [platform.os]);
+    assert.deepEqual(manifest.cpu, [platform.cpu]);
+    assert.equal(manifest.intentCli.platform, platform.rid);
+    assert.equal(manifest.intentCli.binarySha256, '__BINARY_SHA256__');
+    assert.equal(manifest.scripts?.postinstall, undefined);
+  }
+});
+
+test('package readme documents global, npx, no-postinstall, and checksum behavior', () => {
+  const readme = fs.readFileSync(path.join(packageRoot, 'README.md'), 'utf8');
+  assert.match(readme, /npm install -g intent-system/);
+  assert.match(readme, /npx intent-system/);
+  assert.match(readme, /no `postinstall`/);
+  assert.match(readme, /checksum/);
+});

--- a/packaging/npm/test/shim.test.js
+++ b/packaging/npm/test/shim.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const packageRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(packageRoot, '..', '..');
+
+function makeFixture() {
+  fs.mkdirSync(path.join(repoRoot, '.artifacts'), { recursive: true });
+  const root = fs.mkdtempSync(path.join(repoRoot, '.artifacts', 'g702-npm-shim-'));
+  const shimDirectory = path.join(root, 'node_modules', 'intent-system', 'bin');
+  const platformPackages = {
+    'darwin:arm64': ['intent-cli-darwin-arm64', 'intent-cli'],
+    'linux:x64': ['intent-cli-linux-x64', 'intent-cli'],
+    'win32:x64': ['intent-cli-win32-x64', 'intent-cli.exe'],
+  };
+  const platform = platformPackages[`${process.platform}:${process.arch}`];
+  if (!platform) {
+    throw new Error(`test host ${process.platform}/${process.arch} is outside the supported npm matrix`);
+  }
+  const binaryDirectory = path.join(root, 'node_modules', '@j-tech-japan', platform[0], 'bin');
+  const emptyPath = path.join(root, 'empty-path');
+  fs.mkdirSync(shimDirectory, { recursive: true });
+  fs.mkdirSync(binaryDirectory, { recursive: true });
+  fs.mkdirSync(emptyPath);
+  fs.copyFileSync(path.join(packageRoot, 'bin', 'intent-cli.js'), path.join(shimDirectory, 'intent-cli.js'));
+
+  const binary = path.join(binaryDirectory, platform[1]);
+  fs.writeFileSync(binary, '#!/bin/sh\nprintf "intent-cli 9.9.9\\n"\n');
+  if (!binary.endsWith('.exe')) fs.chmodSync(binary, 0o755);
+  return { root, shim: path.join(shimDirectory, 'intent-cli.js'), emptyPath };
+}
+
+function invoke(fixture, environment) {
+  return spawnSync(process.execPath, [fixture.shim, '--version'], {
+    cwd: fixture.root,
+    encoding: 'utf8',
+    env: { ...process.env, ...environment },
+  });
+}
+
+test('npx shim runs the optional platform binary and emits exactly one guidance line without PATH intent-cli', () => {
+  const fixture = makeFixture();
+  const result = invoke(fixture, {
+    PATH: fixture.emptyPath,
+    npm_config_user_agent: 'npx/10.9.2 node/v23.10.0 darwin arm64',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), 'intent-cli 9.9.9');
+  const lines = result.stderr.trim().split(/\r?\n/).filter(Boolean);
+  assert.equal(lines.length, 1);
+  assert.match(lines[0], /npm install -g intent-system/);
+  assert.match(lines[0], /intent-cli/);
+});
+
+test('npx shim does not repeat guidance when intent-cli is already on PATH', () => {
+  const fixture = makeFixture();
+  const pathDirectory = path.join(fixture.root, 'path-with-intent-cli');
+  fs.mkdirSync(pathDirectory);
+  const pathCommand = path.join(pathDirectory, 'intent-cli');
+  fs.writeFileSync(pathCommand, '#!/bin/sh\nexit 0\n');
+  fs.chmodSync(pathCommand, 0o755);
+  const result = invoke(fixture, {
+    PATH: pathDirectory,
+    npm_config_user_agent: 'npx/10.9.2 node/v23.10.0',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stderr.trim(), '');
+});
+
+test('non-npx invocations do not emit the npx guidance line', () => {
+  const fixture = makeFixture();
+  const result = invoke(fixture, {
+    PATH: fixture.emptyPath,
+    npm_config_user_agent: 'npm/10.9.2 node/v23.10.0',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stderr.trim(), '');
+});
+
+test('shim has no installation side effect or postinstall contract', () => {
+  const source = fs.readFileSync(path.join(packageRoot, 'bin', 'intent-cli.js'), 'utf8');
+  assert.doesNotMatch(source, /(?:spawn|exec)(?:Sync|File)?\([^)]*['"]npm['"]/s);
+  const packageJson = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8'));
+  assert.equal(packageJson.scripts?.postinstall, undefined);
+});

--- a/tests/IntentSystem.Cli.Tests/NpmDistributionG702Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NpmDistributionG702Tests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G702: the npm distribution is a product interface, not just a release
+/// implementation detail. These source-contract tests keep the package family,
+/// shim behavior, release gate, and bilingual operator documentation aligned.
+/// Packed-install behavior is exercised by packaging/npm/scripts/smoke-packed.js
+/// in CI; this class makes the contract visible to the normal .NET suite too.
+/// </summary>
+public sealed class NpmDistributionG702Tests
+{
+    private static readonly (string Directory, string Name, string Os, string Cpu, string Rid)[] Platforms =
+    [
+        ("darwin-arm64", "@j-tech-japan/intent-cli-darwin-arm64", "darwin", "arm64", "osx-arm64"),
+        ("linux-x64", "@j-tech-japan/intent-cli-linux-x64", "linux", "x64", "linux-x64"),
+        ("win32-x64", "@j-tech-japan/intent-cli-win32-x64", "win32", "x64", "win-x64"),
+    ];
+
+    [Fact]
+    public void PackageFamily_DeclaresThinMainShimAndExactlyThreeOptionalPlatformPackages()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        using var document = ReadJson(Path.Combine(root, "packaging", "npm", "package.json"));
+        var package = document.RootElement;
+
+        Assert.Equal("intent-system", package.GetProperty("name").GetString());
+        Assert.Equal("bin/intent-cli.js", package.GetProperty("bin").GetProperty("intent-cli").GetString());
+        Assert.False(HasScript(package, "postinstall"));
+
+        var dependencies = package.GetProperty("optionalDependencies");
+        Assert.Equal(Platforms.Length, dependencies.EnumerateObject().Count());
+        foreach (var platform in Platforms)
+        {
+            Assert.Equal("0.0.0-dev", dependencies.GetProperty(platform.Name).GetString());
+            var templatePath = Path.Combine(root, "packaging", "npm", "platforms", platform.Directory, "package.json");
+            using var template = ReadJson(templatePath);
+            Assert.Equal(platform.Name, template.RootElement.GetProperty("name").GetString());
+            Assert.Equal("0.0.0-dev", template.RootElement.GetProperty("version").GetString());
+            Assert.Equal(platform.Os, template.RootElement.GetProperty("os")[0].GetString());
+            Assert.Equal(platform.Cpu, template.RootElement.GetProperty("cpu")[0].GetString());
+            Assert.Equal(platform.Rid, template.RootElement.GetProperty("intentCli").GetProperty("platform").GetString());
+            Assert.Equal("0.0.0-dev", template.RootElement.GetProperty("intentCli").GetProperty("version").GetString());
+            Assert.Equal("__BINARY_SHA256__", template.RootElement.GetProperty("intentCli").GetProperty("binarySha256").GetString());
+            Assert.False(HasScript(template.RootElement, "postinstall"));
+        }
+    }
+
+    [Fact]
+    public void Shim_UsesNpmUserAgentAndPathAbsence_WithoutAnInstallSideEffect()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var shimPath = Path.Combine(root, "packaging", "npm", "bin", "intent-cli.js");
+        var shim = File.ReadAllText(shimPath);
+
+        Assert.Contains("npm_config_user_agent", shim, StringComparison.Ordinal);
+        Assert.Contains("process.env.PATH", shim, StringComparison.Ordinal);
+        Assert.Contains("npm install -g intent-system", shim, StringComparison.Ordinal);
+        Assert.Contains("intent-cli", shim, StringComparison.Ordinal);
+        Assert.DoesNotContain("npm install", shim.Replace("npm install -g intent-system", string.Empty, StringComparison.Ordinal), StringComparison.Ordinal);
+        Assert.DoesNotContain("postinstall", shim, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Ci_IsPackOnlyAndRelease_NpmPublishUsesTheSameTagReleaseGateAsNuGet()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var ci = File.ReadAllText(Path.Combine(root, ".github", "workflows", "ci.yml"));
+        var release = File.ReadAllText(Path.Combine(root, ".github", "workflows", "release.yml"));
+
+        Assert.Contains("npm-dry-run", ci, StringComparison.Ordinal);
+        Assert.Contains("npm pack", ci, StringComparison.Ordinal);
+        Assert.Contains("smoke-packed.js", ci, StringComparison.Ordinal);
+        Assert.Contains("verify-packages.js", ci, StringComparison.Ordinal);
+        Assert.DoesNotContain("npm publish", ci, StringComparison.Ordinal);
+        Assert.DoesNotContain("NPM_TOKEN", ci, StringComparison.Ordinal);
+
+        Assert.Contains("github.event.release.tag_name", release, StringComparison.Ordinal);
+        Assert.Contains("VERSION=\"${RAW#v}\"", release, StringComparison.Ordinal);
+        Assert.Contains("needs: [nupkg, binaries]", release, StringComparison.Ordinal);
+        Assert.Contains("NPM_TOKEN", release, StringComparison.Ordinal);
+        Assert.Contains("npm publish", release, StringComparison.Ordinal);
+        Assert.Contains("if: ${{ github.event_name == 'release' }}", release, StringComparison.Ordinal);
+        Assert.Contains("NUGET_API_KEY", release, StringComparison.Ordinal);
+        Assert.Contains("--require-real-binaries", release, StringComparison.Ordinal);
+        Assert.Contains("--version", release, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OperatorDocs_KeepEnglishJapaneseInstallAndCoexistenceParity()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var english = File.ReadAllText(Path.Combine(root, "docs", "en", "13-npm-distribution.md"));
+        var japanese = File.ReadAllText(Path.Combine(root, "docs", "ja", "13-npm-distribution.md"));
+
+        foreach (var document in new[] { english, japanese })
+        {
+            Assert.Contains("npm install -g intent-system", document, StringComparison.Ordinal);
+            Assert.Contains("npx intent-system", document, StringComparison.Ordinal);
+            Assert.Contains("intent-cli", document, StringComparison.Ordinal);
+            Assert.Contains("PATH", document, StringComparison.Ordinal);
+            Assert.Contains("postinstall", document, StringComparison.Ordinal);
+            Assert.Contains("JTechJapan.IntentSystem.Cli", document, StringComparison.Ordinal);
+            Assert.Contains("--version", document, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("checksum", english, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("SHA-256", japanese, StringComparison.Ordinal);
+        Assert.Contains("never publishes", english, StringComparison.Ordinal);
+        Assert.Contains("公開は行わず", japanese, StringComparison.Ordinal);
+    }
+
+    private static JsonDocument ReadJson(string path)
+    {
+        Assert.True(File.Exists(path), $"expected G702 contract file: {path}");
+        return JsonDocument.Parse(File.ReadAllText(path));
+    }
+
+    private static bool HasScript(JsonElement package, string scriptName) =>
+        package.TryGetProperty("scripts", out var scripts) && scripts.TryGetProperty(scriptName, out _);
+}


### PR DESCRIPTION
Closes #1519

## Summary
- add the unscoped intent-system npm entry package with a thin intent-cli shim and optional self-contained packages for darwin-arm64, linux-x64, and win-x64
- keep npx one-shot execution side-effect free; when the npm user agent indicates npx and PATH has no intent-cli, emit exactly one concise global-install guidance line
- prepare and verify package versions, platform metadata, binary checksums, sidecars, and --version identity without postinstall downloads
- add PR-only npm pack/dry-run CI and tag-derived release packaging/publish gated on the same published-release event and guarded secret path as NuGet
- document npm global/npx installation and coexistence/PATH ordering with dotnet tool, in English and Japanese

## Verification
- npm --prefix packaging/npm test — 7 passed
- focused G613 + G702 CLI tests — 10 passed
- dotnet test IntentSystem.sln --configuration Release --no-restore — 5,036 passed, 1 skipped
- unique-run package dry-run: npm pack main + all three platform packages, checksum/version verification, and packed install smoke; npx shim returned intent-cli 0.21.1-ci.local with exactly one guidance line
- Release-equivalent macOS self-contained binary package: intent-cli 0.21.1-ci.real-b95a2d7-G701, package/checksum/version verification and packed smoke passed
- git diff --cached --check — clean

PR validation never calls npm publish and requires no npm organization credentials. The only publish step is in the release workflow under the published-release gate with NPM_TOKEN.