### PR TITLE
G706: scope the design-thread negative invariants

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -3330,3 +3330,33 @@ G690 is distinct: its hard risk floor bounds what design may decide alone; it
 does not block execution of a human decision already recorded in conversation.
 The guide remains observation-only and preserves the no-provider and
 no-terminal-mutation boundaries.
+
+## Terminal observation and keystroke boundary (G706)
+
+`guide design-thread` makes the terminal boundary explicit. Terminal pane
+reading is permitted only for **operational liveness diagnosis** — determining
+whether a seat is alive or responding after an explicit operator or authorized
+orchestration diagnostic request. Terminal content is never parsed, promoted,
+or cited as **canonical workflow evidence**; canonical evidence remains
+intent-cli/GitHub state, recorded activity, and real artifacts. A liveness
+observation never transfers detection, classification, or authorized recovery
+ownership from orchestration to design.
+
+If orchestration cannot read panes, use the existing recorded observation
+route:
+
+```text
+intent-cli notify status --task-id <task-id> --domain <domain> --team <team> --routing-root <host-root> --format json
+```
+
+Then use the configured non-destructive `status-request`/canonical report
+route as applicable. Treat the returned liveness as observation only and
+escalate unresolved silence; do not infer workflow state or recovery ownership
+from it.
+
+Keystrokes follow the G701 `dialog-answering/v1` three-tier boundary, not a
+generic design relay: the provisioner answers self-provisioned gates; design
+may mechanically answer only an exact dialog/action match already approved by
+the human through the session layer, with the human as decision actor and no
+per-action class generalization; every unapproved, unknown-origin, uncertain,
+or mismatching dialog goes through design to the human with grounds.

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -2947,3 +2947,30 @@ setup と `guide design-thread` は `dialog-answering/v1` の exactly three tier
 G690 との違いも明示します。G690 の hard risk floor は design が **単独で決められること**
 だけを制限し、conversation に記録された human decision の実行を阻みません。guide は
 observation-only であり、provider launch と terminal mutation を追加しません。
+
+## terminal observation と keystroke の境界（G706）
+
+`guide design-thread` は terminal の境界を明示します。terminal pane の読み取りは、明示的な
+operator または authorized orchestration の diagnostic request の後に、seat が alive / responding
+かを確かめる **operational liveness diagnosis** に限って許可されます。terminal content は
+**canonical workflow evidence** として parse、promote、または引用してはいけません。canonical
+evidence は intent-cli/GitHub state、recorded activity、real artifacts のままです。liveness
+observation は detection、classification、authorized recovery の **recovery ownership** を
+orchestration から design に移しません。
+
+orchestration が pane を読めない場合は、既存の recorded observation route を使います:
+
+```text
+intent-cli notify status --task-id <task-id> --domain <domain> --team <team> --routing-root <host-root> --format json
+```
+
+必要に応じて configured な non-destructive `status-request` / canonical report route を続けます。
+返った liveness は observation としてだけ扱い、解決しない silence はエスカレーションします。そこから
+workflow state や recovery ownership を推論してはいけません。
+
+keystroke は generic な design relay ではなく、G701 `dialog-answering/v1` の three-tier boundary
+に従います。provisioner 自身が作った gate は provisioner が回答します。human が conversation で
+既に許可した action は、exact dialog/action match の場合だけ design が session layer を通じて
+mechanical に実行し、decision actor は human のままです。per-action approval を class に一般化
+しません。unapproved、unknown-origin、uncertain、または mismatch の dialog はすべて grounds を
+示して design 経由で human にエスカレーションします。

--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -5,8 +5,10 @@ namespace IntentSystem.Cli.Commands;
 
 /// <summary>
 /// G654: render-only, agent-kind-neutral design-thread operating contract.
-/// This guide does not inspect terminals, supervise work, mutate state, or
-/// launch a provider. It is deliberately identical across session layers.
+/// This guide does not use terminal content as workflow evidence, supervise
+/// work, mutate state, or launch a provider. Pane reads are scoped to
+/// operational liveness diagnosis and are deliberately identical across
+/// session layers.
 /// </summary>
 internal static class GuideDesignThreadCommand
 {
@@ -50,7 +52,7 @@ internal static class GuideDesignThreadCommand
         if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
         {
             writer.WriteLine(UsageLine);
-            writer.WriteLine("Read-only G654 design-thread operating contract. Preview-through-1.x; no provider launch, supervision, terminal parsing, or mutation.");
+            writer.WriteLine("Read-only G654 design-thread operating contract. Preview-through-1.x; no provider launch, supervision, canonical terminal parsing, or mutation. Pane reads are for operational liveness diagnosis only.");
             return 0;
         }
 
@@ -114,7 +116,7 @@ internal static class GuideDesignThreadCommand
                 {
                     "Interim in-contract path: eliminate each known dialog through agent-side allow configuration recorded in that kind's G636 unattended-launch recipe fields; never answer the dialog.",
                     "G683 supervision reads dialog-blocked seats and emits only exact recipe-registry classes; unmatched text is class unknown and escalate-only, never fuzzy-classified.",
-                    "G689 adds the shell-command class and extracts a payload without granting a bare answer; every compound AST segment needs project-test, owned-scratch-delete, or exact-command-once scope, with digest/dialog audit. G690 routes any declared authority through canonical `intent-cli notify adjudicate`: exact class/scope `answerable_by`, the hard risk floor, durable audit, and live pane/state-sequence/text-hash CAS must all permit the bounded answer. Design has no unscoped relay or direct `send-keys` path and never relays keystrokes.",
+                    "G689 adds the shell-command class and extracts a payload without granting a bare answer; every compound AST segment needs project-test, owned-scratch-delete, or exact-command-once scope, with digest/dialog audit. G690 routes any declared authority through canonical `intent-cli notify adjudicate`: exact class/scope `answerable_by`, the hard risk floor, durable audit, and live pane/state-sequence/text-hash CAS must all permit the bounded answer. Design has no unscoped relay or direct `send-keys` path; design never relays keystrokes as a generic action. Any exact-match execution allowed by `dialog-answering/v1` remains a session-layer mechanical answer, never a design-owned relay.",
                 },
                 NoPolicyRule = "Without an exact validated pre-approve match or matching shell scoped policy, residual prompts are escalate-only; unknown, unmatched, bare shell classes, pre-escalate prompts, capability-denied prompts, and hard-risk-floor prompts execute no answer. A permitted answer still goes only through `notify adjudicate` with declared `answerable_by` and live CAS; no unscoped relay is valid.",
                 Incident = "G666 measured the 2026-08-11 workspace wK Claude app safety relay refusal. Operator-filed #1469 then measured a 0.19.0 supervision cycle with 47 keys and no prompt/dialog/class/adjudication producer key, a review seat wedged three times in one day, and orchestration correctly refusing to fabricate a class. This is the same configured-looking-but-inert failure shape as #1465; the interim correction is agent-side allow configuration recorded in the G636 kind recipe fields, while G690 keeps residual adjudication scoped, audited, and CAS-bound.",
@@ -130,6 +132,14 @@ internal static class GuideDesignThreadCommand
             {
                 Layers = new[] { "canonical workflow status", "recorded session-layer agent state and G652 activity sub-verdicts", "real artifacts such as files, commits, and pull requests" },
                 Rule = "Verify all three layers. `running=true` alone never proves progress; terminal content is never parsed as workflow evidence.",
+            },
+            ObservationBoundary = new DesignThreadObservationBoundary
+            {
+                PaneReadRule = "Terminal pane reading is permitted only for operational liveness diagnosis: determine whether a seat is alive or responding after an explicit operator or authorized orchestration diagnostic request.",
+                CanonicalEvidenceRule = "Terminal content is never parsed, promoted, or cited as canonical workflow evidence. Canonical workflow evidence remains intent-cli/GitHub state, recorded activity, and real artifacts.",
+                RecoveryOwnershipRule = "A liveness observation never transfers detection, classification, or authorized recovery ownership from orchestration to design; design remains observation-only outside its declared escalation and approval boundaries.",
+                FallbackRoute = "If orchestration cannot read panes, use `intent-cli notify status --task-id <task-id> --domain <domain> --team <team> --routing-root <host-root> --format json` and the configured non-destructive `status-request`/canonical report route. Treat the returned liveness as observation only and escalate unresolved silence; do not infer workflow state or recovery ownership from it.",
+                KeystrokeBoundary = "Keystrokes are never a generic design relay: apply G701 `dialog-answering/v1` exactly. The provisioner answers self-provisioned gates; design may mechanically answer only an exact dialog/action match already approved by the human through the session layer, with the human as decision actor and no per-action class generalization; every unapproved, unknown-origin, uncertain, or mismatching dialog goes through design to the human with grounds.",
             },
             TeamAndDutySplit = new DesignThreadTeamAndDutySplit
             {
@@ -155,8 +165,9 @@ internal static class GuideDesignThreadCommand
             NegativeInvariants = new[]
             {
                 "No behavior change outside guide rendering and reachability surfaces.",
-                "No terminal parsing, provider launch, hidden fifth role, or design-owned stall recovery.",
-                "No design-thread approval-keystroke relay and no watcher restart, correction, dialog answer, or key send.",
+                "No terminal content parsed or promoted as canonical workflow evidence, no canonical state inferred from a pane, and no transfer of detection, classification, or recovery ownership from orchestration to design.",
+                "No provider launch, hidden fifth role, or design-owned stall recovery.",
+                "No generic design keystroke relay, watcher restart, correction, dialog answer, or key send outside the G701 exact-match session-layer rule.",
                 "No fuzzy prompt classification, unvalidated rule, unaudited answer, unscoped key relay, or unscoped design answer path.",
                 "No canonical identity inferred from prose, transport state, or an unaccepted candidate.",
                 "No publication, contract, priority, release, destructive, permission, security, or credential decision is silently broadened.",
@@ -207,6 +218,13 @@ internal static class GuideDesignThreadCommand
         foreach (var fact in result.MergeAuthority.Facts) writer.WriteLine($"- compare: {fact}");
         WriteList(writer, "## 5. Three-layer delegation verification", result.DelegationVerification.Layers);
         writer.WriteLine(result.DelegationVerification.Rule);
+        writer.WriteLine();
+        writer.WriteLine("## 5a. Terminal observation and keystroke boundary (G706)");
+        writer.WriteLine($"- **pane read:** {result.ObservationBoundary.PaneReadRule}");
+        writer.WriteLine($"- **canonical evidence:** {result.ObservationBoundary.CanonicalEvidenceRule}");
+        writer.WriteLine($"- **recovery ownership:** {result.ObservationBoundary.RecoveryOwnershipRule}");
+        writer.WriteLine($"- **fallback observation route:** {result.ObservationBoundary.FallbackRoute}");
+        writer.WriteLine($"- **keystroke/dialog boundary:** {result.ObservationBoundary.KeystrokeBoundary}");
         writer.WriteLine();
         writer.WriteLine("## 6. Team formula, duty split, and monitoring separation");
         writer.WriteLine($"- formula: **{result.TeamAndDutySplit.Formula}**");
@@ -295,6 +313,7 @@ internal sealed record DesignThreadGuideResult
     public required DesignThreadResidualApproval ResidualApproval { get; init; }
     public required DesignThreadMergeAuthority MergeAuthority { get; init; }
     public required DesignThreadDelegationVerification DelegationVerification { get; init; }
+    public required DesignThreadObservationBoundary ObservationBoundary { get; init; }
     public required DesignThreadTeamAndDutySplit TeamAndDutySplit { get; init; }
     public required DesignThreadMonitoring Monitoring { get; init; }
     public required DesignThreadReporting Reporting { get; init; }
@@ -308,6 +327,14 @@ internal sealed record DesignThreadApproval { public required string ReadOnlyRul
 internal sealed record DesignThreadResidualApproval { public required string PreviewStatus { get; init; } public required IReadOnlyList<string> Layers { get; init; } public required string NoPolicyRule { get; init; } public required string Incident { get; init; } public required string WatcherBoundary { get; init; } public required string Formula { get; init; } }
 internal sealed record DesignThreadMergeAuthority { public required string Rule { get; init; } public required IReadOnlyList<string> Facts { get; init; } }
 internal sealed record DesignThreadDelegationVerification { public required IReadOnlyList<string> Layers { get; init; } public required string Rule { get; init; } }
+internal sealed record DesignThreadObservationBoundary
+{
+    public required string PaneReadRule { get; init; }
+    public required string CanonicalEvidenceRule { get; init; }
+    public required string RecoveryOwnershipRule { get; init; }
+    public required string FallbackRoute { get; init; }
+    public required string KeystrokeBoundary { get; init; }
+}
 internal sealed record DesignThreadTeamAndDutySplit { public required string Formula { get; init; } public required string MonitoringRule { get; init; } public required string OrchestrationOwnership { get; init; } public required string DesignMode { get; init; } public required IReadOnlyList<string> DesignEscalations { get; init; } }
 internal sealed record DesignThreadMonitoring { public required string Separation { get; init; } public required string ResidualDesignCheck { get; init; } public required string BoundRule { get; init; } public required string GuideRefreshRule { get; init; } public required string DeploymentRule { get; init; } }
 internal sealed record DesignThreadReporting { public required string Rule { get; init; } public required string HumanActionRule { get; init; } }

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadG706Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadG706Tests.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideDesignThreadG706Tests
+{
+    [Fact]
+    public void MetadataFreeJson_ExposesScopedPaneObservationFallbackAndG701Boundary()
+    {
+        var context = BareContext();
+        Assert.False(File.Exists(Path.Combine(context.RepoRoot, ".intent-cli", "config.toml")));
+
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(context, ["--format", "json"], writer));
+
+        var output = writer.ToString();
+        Assert.DoesNotContain("No terminal parsing", output, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "No terminal parsing, provider launch, hidden fifth role, or design-owned stall recovery.",
+            output,
+            StringComparison.Ordinal);
+
+        using var document = JsonDocument.Parse(output);
+        var boundary = document.RootElement.GetProperty("observation_boundary");
+        Assert.Contains("operational liveness diagnosis", boundary.GetProperty("pane_read_rule").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("canonical workflow evidence", boundary.GetProperty("canonical_evidence_rule").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("never transfers", boundary.GetProperty("recovery_ownership_rule").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("intent-cli notify status", boundary.GetProperty("fallback_route").GetString()!, StringComparison.Ordinal);
+        Assert.Contains("status-request", boundary.GetProperty("fallback_route").GetString()!, StringComparison.Ordinal);
+
+        var keystrokeBoundary = boundary.GetProperty("keystroke_boundary").GetString()!;
+        Assert.Contains("G701", keystrokeBoundary, StringComparison.Ordinal);
+        Assert.Contains("dialog-answering/v1", keystrokeBoundary, StringComparison.Ordinal);
+        Assert.Contains("exact dialog/action match", keystrokeBoundary, StringComparison.Ordinal);
+        Assert.Contains("human as decision actor", keystrokeBoundary, StringComparison.Ordinal);
+        Assert.Contains("no per-action class generalization", keystrokeBoundary, StringComparison.Ordinal);
+        Assert.Contains("unknown-origin", keystrokeBoundary, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MetadataFreeMarkdown_StatesObservationIsNotEvidenceOrRecoveryOwnership()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(BareContext(), [], writer));
+        var output = writer.ToString();
+
+        Assert.Contains("Terminal observation and keystroke boundary (G706)", output, StringComparison.Ordinal);
+        Assert.Contains("**pane read:** Terminal pane reading is permitted only for operational liveness diagnosis", output, StringComparison.Ordinal);
+        Assert.Contains("**canonical evidence:** Terminal content is never parsed, promoted, or cited as canonical workflow evidence", output, StringComparison.Ordinal);
+        Assert.Contains("**fallback observation route:** If orchestration cannot read panes", output, StringComparison.Ordinal);
+        Assert.Contains("**keystroke/dialog boundary:** Keystrokes are never a generic design relay", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("No terminal parsing", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Help_ScopesPaneReadsToOperationalLiveness()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(BareContext(), ["--help"], writer));
+        var output = writer.ToString();
+
+        Assert.Contains("canonical terminal parsing", output, StringComparison.Ordinal);
+        Assert.Contains("Pane reads are for operational liveness diagnosis only", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("supervision, terminal parsing, or mutation", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EnglishAndJapaneseGuides_PreserveG706BoundaryAndRemoveUnqualifiedForm()
+    {
+        var repo = RepoVersionPolicySource.RepoRoot();
+        foreach (var language in new[] { "en", "ja" })
+        {
+            var document = File.ReadAllText(Path.Combine(repo, "docs", language, "12-agent-message-orchestration.md"));
+            Assert.Contains("G706", document, StringComparison.Ordinal);
+            Assert.Contains("operational liveness", document, StringComparison.Ordinal);
+            Assert.Contains("canonical workflow evidence", document, StringComparison.Ordinal);
+            Assert.Contains("intent-cli notify status", document, StringComparison.Ordinal);
+            Assert.Contains("status-request", document, StringComparison.Ordinal);
+            Assert.Contains("recovery ownership", document, StringComparison.Ordinal);
+            Assert.Contains("dialog-answering/v1", document, StringComparison.Ordinal);
+            Assert.DoesNotContain(
+                "No terminal parsing, provider launch, hidden fifth role, or design-owned stall recovery.",
+                document,
+                StringComparison.Ordinal);
+        }
+    }
+
+    private static CliContext BareContext() => new()
+    {
+        RepoRoot = AppContext.BaseDirectory,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+}


### PR DESCRIPTION
## Summary

- Add a structured G706 terminal-observation boundary to the built `guide design-thread` output.
- Permit pane reads only for operational liveness diagnosis; terminal content is never canonical workflow evidence and liveness never transfers recovery ownership from orchestration to design.
- Name the metadata-free-safe fallback observation route through `intent-cli notify status` and the configured non-destructive `status-request`/canonical report path.
- Align keystrokes with G701 `dialog-answering/v1`: exact dialog/action matches through the session layer only, with the human as decision actor; all other dialogs escalate with grounds.
- Add EN/JA documentation and negative regressions for the removed unqualified terminal prohibition.

Closes #1521

## Guide evidence

The Release-built CLI was executed from the bare metadata-free directory
`.artifacts/g706-guide-run-1746a6d0-r2/bare` (no `.intent-cli` directory/config):

```text
dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll guide design-thread --domain intent-cli --team intent-cli-dev --routing-root /Users/tomohisa/dev/GitHub/MyIntentHost --format markdown
dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll guide design-thread --domain intent-cli --team intent-cli-dev --routing-root /Users/tomohisa/dev/GitHub/MyIntentHost --format json
```

Both routes emitted the G706 observation boundary, fallback route, G701 dialog boundary, and no `No terminal parsing, ...` form.

## Verification

- `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --filter FullyQualifiedName~GuideDesignThreadG706Tests --no-restore` — 4 passed.
- G654/G701/G706 focused guide suites — 22 passed.
- G613 parity guard — 6 passed.
- G666 compatibility guard — 24 passed.
- `dotnet build IntentSystem.sln --configuration Release --no-restore` — succeeded, 0 warnings/errors.
- `dotnet test IntentSystem.sln --configuration Release --no-build --no-restore` — 5,040 passed, 1 skipped, 0 failed.
- `git diff --check` — clean.
