### PR TITLE
G703: add channel-aware intent-cli self-update

### DIFF
--- a/docs/en/13-npm-distribution.md
+++ b/docs/en/13-npm-distribution.md
@@ -29,6 +29,39 @@ prints exactly one concise line after the command suggesting
 It never performs that installation itself. There is no `postinstall` hook and
 no package-install network download.
 
+## Channel-aware update (G703)
+
+`intent-cli update` derives the channel from the fully resolved real path of the
+running executable on every invocation. It does not persist a channel marker.
+The detection line names both the channel and the path evidence before an
+update action starts:
+
+```bash
+intent-cli update
+```
+
+The supported actions are:
+
+- .NET global tool: `dotnet tool update -g JTechJapan.IntentSystem.Cli`.
+- npm global: `npm install -g intent-system@latest`.
+- npx cache: guidance only — rerun the command with `npx intent-system@latest`;
+  the CLI does not mutate the cache or install globally.
+- standalone binary: download the matching release archive, verify its
+  `.sha256` sidecar, then replace the binary through a same-volume temp+rename
+  swap. A checksum mismatch leaves the original binary byte-identical.
+
+Use the no-effect check from any metadata-free directory:
+
+```bash
+intent-cli update --check --format json
+intent-cli update --check --format markdown
+```
+
+The check reports the current version, latest release, and would-be action;
+`process_spawned=false` and `writes_performed=false` are part of the result.
+Unknown or ambiguous executable paths fail closed and print manual guidance for
+all four channels rather than guessing.
+
 ## Release integrity
 
 The release workflow derives one version from the published Git tag and uses

--- a/docs/ja/13-npm-distribution.md
+++ b/docs/ja/13-npm-distribution.md
@@ -28,6 +28,34 @@ shim は npm user agent から npx を検出し、`PATH` に `intent-cli` があ
 shim 自身がインストールを実行することはありません。`postinstall` hook もパッケージインストール時の
 ネットワークダウンロードもありません。
 
+## channel-aware update (G703)
+
+`intent-cli update` は、実行中 executable の symlink を解決した real path から毎回 channel を導出します。
+channel marker は保存しません。update action の前に channel と path evidence を表示します。
+
+```bash
+intent-cli update
+```
+
+対応する action は次のとおりです。
+
+- .NET global tool: `dotnet tool update -g JTechJapan.IntentSystem.Cli`。
+- npm global: `npm install -g intent-system@latest`。
+- npx cache: guidance のみ。`npx intent-system@latest` で再実行し、cache の変更や global install は行いません。
+- standalone binary: 対応する release archive を取得し、`.sha256` sidecar を検証してから、同一 volume の
+  temp+rename swap で binary を置き換えます。checksum mismatch の場合、元の binary は byte-identical のままです。
+
+metadata の無い directory から、書き込みのない check を実行できます。
+
+```bash
+intent-cli update --check --format json
+intent-cli update --check --format markdown
+```
+
+check は current version、latest release、would-be action を表示し、結果に
+`process_spawned=false` と `writes_performed=false` を含めます。unknown または ambiguous な executable path は推測せず
+fail closed し、4 channel すべての手動 guidance を表示します。
+
 ## リリースの整合性
 
 release workflow は公開された Git tag から 1 つのバージョンを導出し、NuGet パッケージ、すべての

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -30,6 +30,8 @@ internal static class CommandRouter
         "closeout",
         "migrate",
         "skill",
+        // G703: metadata-free channel-aware self-update.
+        "update",
         // G570: session-layer transport selection (agmsg | herdr-only).
         "session-layer",
         // G691: durable team shape (delivery | authoring-only), orthogonal to transport.
@@ -55,6 +57,7 @@ internal static class CommandRouter
     internal static readonly IReadOnlyList<string> PrimaryCommandGroups = new[]
     {
         "guide",
+        "update",
         "automation",
         "notify",
         "worker",
@@ -453,6 +456,15 @@ internal static class CommandRouter
             return 0;
         }
 
+        // G703: update is a metadata-free top-level command rather than a
+        // host-state command group. Keep this route available to direct
+        // CommandRouter callers as well as Program.Main's early bootstrap
+        // path.
+        if (args.Length > 0 && string.Equals(args[0], "update", StringComparison.Ordinal))
+        {
+            return UpdateCommand.Execute(args[1..], writer);
+        }
+
         if (args.Length == 0
             || (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal)))
         {
@@ -618,6 +630,17 @@ internal static class CommandRouter
     private static void WriteGroupHelp(string group, TextWriter writer)
     {
         writer.WriteLine($"intent-cli {group} — group help");
+
+        if (string.Equals(group, "update", StringComparison.Ordinal))
+        {
+            writer.WriteLine();
+            writer.WriteLine("Usage: intent-cli update [--check] [--format markdown|json]");
+            writer.WriteLine("Derives the install channel from the fully resolved executable path on every run.");
+            writer.WriteLine("`--check` reports current/latest/would-be action with no process spawn or writes.");
+            writer.WriteLine("See also: `intent-cli guide onboarding --format markdown` (metadata-free update route).");
+            return;
+        }
+
         writer.WriteLine($"Usage: intent-cli {group} <subcommand> [--help]");
         writer.WriteLine();
 
@@ -687,7 +710,8 @@ internal static class CommandRouter
             ["safety"] = "`intent-cli safety nested-provider-handoff` (artifact-only nested-provider handoffs).",
             ["projection"] = "`intent-cli projection generate` / `regenerate` (internal tooling).",
             ["project"] = "`intent-cli project status` (older surface; prefer `intent status`).",
-            ["skill"] = "`intent-cli skill list` / `install --target claude|codex|copilot|all [--scope user|repo] [--force]` / `diff` (installs the embedded SKILL.md into each platform's skill location)."
+            ["skill"] = "`intent-cli skill list` / `install --target claude|codex|copilot|all [--scope user|repo] [--force]` / `diff` (installs the embedded SKILL.md into each platform's skill location).",
+            ["update"] = "`intent-cli update [--check] [--format markdown|json]` (G703 path-derived channel detection and self-update; no marker is persisted)."
         };
 
     private static void WriteHelp(TextWriter writer) => WriteHelp(writer, includeAll: false);
@@ -741,6 +765,10 @@ internal static class CommandRouter
         writer.WriteLine("- `intent-cli <group> --help` (e.g. `intent-cli guide --help`, `intent-cli worker --help`) — list the group's subcommands.");
         writer.WriteLine("- `intent-cli guide help [--format markdown|json]` — external-user self-discovery surface with examples + workflow guide pointers.");
         writer.WriteLine("- `intent-cli guide commands list [--format markdown|json]` — classified catalog (primary / support).");
+        writer.WriteLine();
+        writer.WriteLine("Self-update:");
+        writer.WriteLine("- `intent-cli update [--format markdown|json]` — derive the install channel from the resolved executable path and update through that channel.");
+        writer.WriteLine("- `intent-cli update --check --format json` — report current/latest/would-be action with zero process spawn or writes.");
 
         writer.WriteLine();
         writer.WriteLine("Automation commands:");

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -144,6 +144,15 @@ internal static class GuideCommandsListCommand
         },
         new CommandGroupEntry
         {
+            Name = "update",
+            Role = RoleChildImplementation,
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityMixed,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "G703 channel-aware self-update: `intent-cli update` derives the installation channel from the fully resolved executable path on every run; `--check` reports current/latest/would-be action without process spawn or writes, and unknown paths fail closed."
+        },
+        new CommandGroupEntry
+        {
             Name = "session-layer",
             Role = RoleDesign,
             Classification = ClassificationSupport,

--- a/src/IntentSystem.Cli/Commands/GuideOnboardingCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideOnboardingCommand.cs
@@ -145,6 +145,13 @@ internal static class GuideOnboardingCommand
                     NoMutation = "Pure read; the operator owns the runtime contract that this command surfaces."
                 }
             },
+            UpdateChannelGuidance = new GuideOnboardingUpdateChannelGuidance
+            {
+                JsonCommand = "intent-cli update --check --format json",
+                MarkdownCommand = "intent-cli update --check --format markdown",
+                Contract = "The channel is re-derived from the fully resolved executable real path on every run; no channel marker is persisted. Unknown or ambiguous paths fail closed with manual guidance for dotnet tool, npm global, npx, and standalone binary updates.",
+                CheckSafety = "--check reports current_version, latest_version, and would_be_action with process_spawned=false and writes_performed=false."
+            },
             HostDataBoundary = new GuideOnboardingHostDataBoundary
             {
                 CanonicalRoots = new[]
@@ -206,6 +213,14 @@ internal static class GuideOnboardingCommand
             writer.WriteLine($"- no-mutation: {step.NoMutation}");
             writer.WriteLine();
         }
+
+        writer.WriteLine("## Channel-aware update route (G703)");
+        writer.WriteLine();
+        writer.WriteLine($"- JSON: `{result.UpdateChannelGuidance.JsonCommand}`");
+        writer.WriteLine($"- Markdown: `{result.UpdateChannelGuidance.MarkdownCommand}`");
+        writer.WriteLine($"- contract: {result.UpdateChannelGuidance.Contract}");
+        writer.WriteLine($"- check safety: {result.UpdateChannelGuidance.CheckSafety}");
+        writer.WriteLine();
 
         writer.WriteLine("## Host git repository data boundary");
         writer.WriteLine();
@@ -311,11 +326,29 @@ internal sealed record GuideOnboardingResult
     [JsonPropertyName("first_call_sequence")]
     public required IReadOnlyList<GuideOnboardingStep> FirstCallSequence { get; init; }
 
+    [JsonPropertyName("update_channel_guidance")]
+    public required GuideOnboardingUpdateChannelGuidance UpdateChannelGuidance { get; init; }
+
     [JsonPropertyName("host_data_boundary")]
     public required GuideOnboardingHostDataBoundary HostDataBoundary { get; init; }
 
     [JsonPropertyName("hard_rules")]
     public required IReadOnlyList<string> HardRules { get; init; }
+}
+
+internal sealed record GuideOnboardingUpdateChannelGuidance
+{
+    [JsonPropertyName("json_command")]
+    public required string JsonCommand { get; init; }
+
+    [JsonPropertyName("markdown_command")]
+    public required string MarkdownCommand { get; init; }
+
+    [JsonPropertyName("contract")]
+    public required string Contract { get; init; }
+
+    [JsonPropertyName("check_safety")]
+    public required string CheckSafety { get; init; }
 }
 
 internal sealed record GuideOnboardingStep

--- a/src/IntentSystem.Cli/Commands/UpdateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/UpdateCommand.cs
@@ -1,0 +1,1359 @@
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Net.Http.Headers;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// The installation channels understood by G703. The channel is deliberately
+/// not persisted: every invocation derives it again from the real executable
+/// path so a copied or moved binary cannot carry stale installation metadata.
+/// </summary>
+internal enum UpdateChannel
+{
+    Unknown,
+    DotnetTool,
+    NpmGlobal,
+    Npx,
+    Standalone
+}
+
+internal static class UpdateChannelName
+{
+    internal static string For(UpdateChannel channel) => channel switch
+    {
+        UpdateChannel.DotnetTool => "dotnet-tool",
+        UpdateChannel.NpmGlobal => "npm-global",
+        UpdateChannel.Npx => "npx-cache",
+        UpdateChannel.Standalone => "standalone",
+        _ => "unknown"
+    };
+}
+
+internal sealed record ExecutablePathResolution(
+    string? OriginalPath,
+    string? ResolvedPath,
+    IReadOnlyList<string> PathHops,
+    string? Error);
+
+internal interface IExecutablePathResolver
+{
+    ExecutablePathResolution Resolve();
+}
+
+/// <summary>
+/// Resolves the running process path and follows filesystem links before the
+/// detector sees it. It performs no writes and keeps the complete path chain as
+/// evidence for the operator.
+/// </summary>
+internal sealed class ProcessExecutablePathResolver : IExecutablePathResolver
+{
+    private const int MaximumLinkHops = 32;
+
+    public ExecutablePathResolution Resolve() => ResolvePath(Environment.ProcessPath);
+
+    internal static ExecutablePathResolution ResolvePath(string? original)
+    {
+        if (string.IsNullOrWhiteSpace(original))
+        {
+            return new ExecutablePathResolution(null, null, Array.Empty<string>(), "Environment.ProcessPath was empty.");
+        }
+
+        try
+        {
+            var current = Path.GetFullPath(original);
+            var hops = new List<string> { current };
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { current };
+
+            for (var hop = 0; hop < MaximumLinkHops; hop++)
+            {
+                var link = new FileInfo(current).ResolveLinkTarget(returnFinalTarget: false);
+                if (link is null)
+                {
+                    return new ExecutablePathResolution(original, current, hops, null);
+                }
+
+                var target = link.FullName;
+                if (!Path.IsPathRooted(target))
+                {
+                    target = Path.GetFullPath(target, Path.GetDirectoryName(current)!);
+                }
+
+                if (!visited.Add(target))
+                {
+                    hops.Add(target);
+                    return new ExecutablePathResolution(
+                        original,
+                        target,
+                        hops,
+                        "The executable path contains a symlink cycle.");
+                }
+
+                current = target;
+                hops.Add(current);
+            }
+
+            return new ExecutablePathResolution(
+                original,
+                current,
+                hops,
+                $"The executable path exceeded the {MaximumLinkHops}-link resolution bound.");
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or UnauthorizedAccessException
+            or ArgumentException
+            or NotSupportedException)
+        {
+            return new ExecutablePathResolution(original, null, new[] { original }, exception.Message);
+        }
+    }
+}
+
+internal sealed record UpdateChannelDetection
+{
+    [JsonIgnore]
+    internal UpdateChannel Kind { get; init; }
+
+    [JsonPropertyName("channel")]
+    public required string Channel { get; init; }
+
+    [JsonPropertyName("executable_path")]
+    public string? ExecutablePath { get; init; }
+
+    [JsonPropertyName("resolved_executable_path")]
+    public string? ResolvedExecutablePath { get; init; }
+
+    [JsonPropertyName("path_hops")]
+    public required IReadOnlyList<string> PathHops { get; init; }
+
+    [JsonPropertyName("path_evidence")]
+    public required string PathEvidence { get; init; }
+
+    [JsonPropertyName("ambiguous")]
+    public bool Ambiguous { get; init; }
+
+    [JsonPropertyName("detection_error")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DetectionError { get; init; }
+}
+
+/// <summary>
+/// Pure path-shape classification. Only the fully resolved path is classified;
+/// the original path is retained for evidence. A path that is not clearly a
+/// supported intent-cli executable or carries conflicting channel markers is
+/// fail-closed rather than guessed.
+/// </summary>
+internal static class UpdateChannelDetector
+{
+    internal static UpdateChannelDetection Detect(ExecutablePathResolution resolution)
+    {
+        ArgumentNullException.ThrowIfNull(resolution);
+
+        if (string.IsNullOrWhiteSpace(resolution.ResolvedPath))
+        {
+            return Unknown(resolution, ambiguous: false, resolution.Error ?? "The executable real path could not be resolved.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(resolution.Error))
+        {
+            return Unknown(
+                resolution,
+                ambiguous: false,
+                $"The executable real path could not be fully resolved: {resolution.Error}");
+        }
+
+        var path = resolution.ResolvedPath!;
+        var normalized = path.Replace('\\', '/');
+        var segments = normalized
+            .Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var fileName = Path.GetFileName(path);
+        var isIntentCli = string.Equals(fileName, "intent-cli", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(fileName, "intent-cli.exe", StringComparison.OrdinalIgnoreCase);
+
+        if (!isIntentCli)
+        {
+            return Unknown(
+                resolution,
+                ambiguous: false,
+                $"The resolved executable name '{fileName}' is not intent-cli or intent-cli.exe.");
+        }
+
+        var dotnetTool = HasAdjacentSegments(segments, ".dotnet", "tools");
+        var npxCache = segments.Any(segment =>
+            string.Equals(segment, "_npx", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(segment, ".npx", StringComparison.OrdinalIgnoreCase));
+        var npmPackage = HasIntentNpmPackage(segments);
+
+        // An npx cache path necessarily contains both `_npx` and
+        // `node_modules/<intent-system package>`; those two markers describe
+        // one channel, not an ambiguity. Dotnet plus either npm marker is a
+        // genuine conflict and must fail closed.
+        if (npxCache && !npmPackage)
+        {
+            return Unknown(
+                resolution,
+                ambiguous: false,
+                "The npx cache marker was present without the intent-system npm package marker.");
+        }
+
+        if (dotnetTool && (npxCache || npmPackage))
+        {
+            return Unknown(
+                resolution,
+                ambiguous: true,
+                "The resolved path contains conflicting installation-channel markers.");
+        }
+
+        var kind = dotnetTool
+            ? UpdateChannel.DotnetTool
+            : npxCache
+                ? UpdateChannel.Npx
+                : npmPackage
+                    ? UpdateChannel.NpmGlobal
+                    : UpdateChannel.Standalone;
+
+        var evidence = BuildEvidence(
+            resolution,
+            kind,
+            dotnetTool,
+            npmPackage,
+            npxCache,
+            fileName);
+
+        return new UpdateChannelDetection
+        {
+            Kind = kind,
+            Channel = UpdateChannelName.For(kind),
+            ExecutablePath = resolution.OriginalPath,
+            ResolvedExecutablePath = resolution.ResolvedPath,
+            PathHops = resolution.PathHops,
+            PathEvidence = evidence,
+            Ambiguous = false,
+            DetectionError = resolution.Error
+        };
+    }
+
+    private static bool HasIntentNpmPackage(IReadOnlyList<string> segments)
+    {
+        for (var index = 0; index < segments.Count - 1; index++)
+        {
+            if (!string.Equals(segments[index], "node_modules", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var package = segments[index + 1];
+            if (string.Equals(package, "intent-system", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (string.Equals(package, "@j-tech-japan", StringComparison.OrdinalIgnoreCase)
+                && index + 2 < segments.Count
+                && segments[index + 2].StartsWith("intent-cli-", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasAdjacentSegments(IReadOnlyList<string> segments, string first, string second)
+    {
+        for (var index = 0; index < segments.Count - 1; index++)
+        {
+            if (string.Equals(segments[index], first, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(segments[index + 1], second, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string BuildEvidence(
+        ExecutablePathResolution resolution,
+        UpdateChannel kind,
+        bool dotnetTool,
+        bool npmPackage,
+        bool npxCache,
+        string fileName)
+    {
+        var hops = resolution.PathHops.Count == 0
+            ? "none"
+            : string.Join(" -> ", resolution.PathHops.Select(path => $"'{path}'"));
+        return $"real path resolved through {hops}; executable={fileName}; "
+            + $"markers(dotnet-tools={dotnetTool}, npm-package={npmPackage}, npx-cache={npxCache}); "
+            + $"selected={UpdateChannelName.For(kind)}";
+    }
+
+    private static UpdateChannelDetection Unknown(
+        ExecutablePathResolution resolution,
+        bool ambiguous,
+        string error)
+    {
+        var path = resolution.ResolvedPath ?? resolution.OriginalPath ?? "<unavailable>";
+        var evidence = $"real path observed as '{path}'; "
+            + (resolution.PathHops.Count > 0
+                ? $"resolution hops={string.Join(" -> ", resolution.PathHops.Select(hop => $"'{hop}'"))}; "
+                : string.Empty)
+            + $"classification=fail-closed; reason={error}";
+        return new UpdateChannelDetection
+        {
+            Kind = UpdateChannel.Unknown,
+            Channel = UpdateChannelName.For(UpdateChannel.Unknown),
+            ExecutablePath = resolution.OriginalPath,
+            ResolvedExecutablePath = resolution.ResolvedPath,
+            PathHops = resolution.PathHops,
+            PathEvidence = evidence,
+            Ambiguous = ambiguous,
+            DetectionError = error
+        };
+    }
+}
+
+internal sealed record UpdateReleaseAsset(string Name, Uri DownloadUrl);
+
+internal sealed record UpdateRelease(
+    string TagName,
+    string Version,
+    IReadOnlyList<UpdateReleaseAsset> Assets);
+
+internal interface IUpdateReleaseClient
+{
+    UpdateRelease GetLatestRelease();
+
+    void Download(UpdateReleaseAsset asset, Stream destination);
+}
+
+/// <summary>Public GitHub Releases adapter used only by the update command.</summary>
+internal sealed class GitHubUpdateReleaseClient : IUpdateReleaseClient
+{
+    private const string LatestReleaseUri =
+        "https://api.github.com/repos/J-Tech-Japan/intent-system/releases/latest";
+
+    private static readonly HttpClient Client = CreateClient();
+
+    public UpdateRelease GetLatestRelease()
+    {
+        using var response = Client.GetAsync(
+                LatestReleaseUri,
+                HttpCompletionOption.ResponseHeadersRead)
+            .GetAwaiter()
+            .GetResult();
+        response.EnsureSuccessStatusCode();
+        using var stream = response.Content.ReadAsStream();
+        using var document = JsonDocument.Parse(stream);
+        var root = document.RootElement;
+        var tagName = root.GetProperty("tag_name").GetString();
+        if (string.IsNullOrWhiteSpace(tagName))
+        {
+            throw new InvalidOperationException("GitHub latest release did not contain tag_name.");
+        }
+
+        var assets = new List<UpdateReleaseAsset>();
+        if (root.TryGetProperty("assets", out var assetsElement))
+        {
+            foreach (var asset in assetsElement.EnumerateArray())
+            {
+                var name = asset.TryGetProperty("name", out var nameElement)
+                    ? nameElement.GetString()
+                    : null;
+                var url = asset.TryGetProperty("browser_download_url", out var urlElement)
+                    ? urlElement.GetString()
+                    : null;
+                if (!string.IsNullOrWhiteSpace(name)
+                    && Uri.TryCreate(url, UriKind.Absolute, out var downloadUrl))
+                {
+                    assets.Add(new UpdateReleaseAsset(name, downloadUrl));
+                }
+            }
+        }
+
+        return new UpdateRelease(tagName, NormalizeVersion(tagName), assets);
+    }
+
+    public void Download(UpdateReleaseAsset asset, Stream destination)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+        ArgumentNullException.ThrowIfNull(destination);
+
+        using var response = Client.GetAsync(
+                asset.DownloadUrl,
+                HttpCompletionOption.ResponseHeadersRead)
+            .GetAwaiter()
+            .GetResult();
+        response.EnsureSuccessStatusCode();
+        using var source = response.Content.ReadAsStream();
+        source.CopyTo(destination);
+    }
+
+    internal static string NormalizeVersion(string tagName) =>
+        tagName.StartsWith('v') ? tagName[1..] : tagName;
+
+    private static HttpClient CreateClient()
+    {
+        var client = new HttpClient();
+        client.DefaultRequestHeaders.UserAgent.Add(
+            new ProductInfoHeaderValue("intent-cli-update", "G703"));
+        client.DefaultRequestHeaders.Accept.Add(
+            new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        return client;
+    }
+}
+
+internal sealed record UpdateProcessResult(
+    int ExitCode,
+    string StandardOutput,
+    string StandardError);
+
+internal interface IUpdateProcessRunner
+{
+    UpdateProcessResult Run(string executable, IReadOnlyList<string> arguments);
+}
+
+internal sealed class ProcessUpdateRunner : IUpdateProcessRunner
+{
+    public UpdateProcessResult Run(string executable, IReadOnlyList<string> arguments)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executable);
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = executable,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
+                CreateNoWindow = true
+            }
+        };
+        foreach (var argument in arguments)
+        {
+            process.StartInfo.ArgumentList.Add(argument);
+        }
+
+        try
+        {
+            if (!process.Start())
+            {
+                return new UpdateProcessResult(-1, string.Empty, $"Could not start {executable}.");
+            }
+
+            var stdout = process.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+            process.WaitForExit();
+            return new UpdateProcessResult(
+                process.ExitCode,
+                stdout.GetAwaiter().GetResult(),
+                stderr.GetAwaiter().GetResult());
+        }
+        catch (Exception exception) when (
+            exception is InvalidOperationException
+            or System.ComponentModel.Win32Exception
+            or IOException)
+        {
+            return new UpdateProcessResult(-1, string.Empty, exception.Message);
+        }
+    }
+}
+
+internal sealed record StandaloneUpdateOutcome(
+    string ArchiveName,
+    string ExpectedChecksum,
+    string ActualChecksum,
+    string TargetPath);
+
+internal interface IStandaloneBinaryReplacer
+{
+    void Replace(string targetPath, string stagedPath);
+}
+
+/// <summary>
+/// Uses an atomic same-volume replacement. Windows gets File.Replace, which
+/// preserves the rename/replace semantics needed by a running installation;
+/// unsupported filesystems fall back only when the platform explicitly says
+/// File.Replace is unavailable. The current binary is never written in place.
+/// </summary>
+internal sealed class AtomicStandaloneBinaryReplacer : IStandaloneBinaryReplacer
+{
+    public void Replace(string targetPath, string stagedPath) =>
+        Replace(targetPath, stagedPath, OperatingSystem.IsWindows());
+
+    internal static void Replace(string targetPath, string stagedPath, bool windows)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(stagedPath);
+
+        if (windows && File.Exists(targetPath))
+        {
+            try
+            {
+                File.Replace(stagedPath, targetPath, destinationBackupFileName: null, ignoreMetadataErrors: true);
+                return;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Some Windows-compatible filesystems do not implement the
+                // Replace API. MoveFileEx-style overwrite is the safe fallback
+                // on those filesystems; never stream bytes into the target.
+            }
+        }
+
+        File.Move(stagedPath, targetPath, overwrite: true);
+    }
+}
+
+internal sealed class StandaloneUpdateException : InvalidOperationException
+{
+    internal StandaloneUpdateException(
+        string message,
+        string targetPath,
+        bool targetWasModified,
+        string? expectedChecksum = null,
+        string? actualChecksum = null)
+        : base(message)
+    {
+        TargetPath = targetPath;
+        TargetWasModified = targetWasModified;
+        ExpectedChecksum = expectedChecksum;
+        ActualChecksum = actualChecksum;
+    }
+
+    internal string TargetPath { get; }
+
+    internal bool TargetWasModified { get; }
+
+    internal string? ExpectedChecksum { get; }
+
+    internal string? ActualChecksum { get; }
+}
+
+/// <summary>
+/// Downloads the release archive and sidecar into a sibling staging directory,
+/// verifies the archive before extracting or replacing the running binary, and
+/// then performs one same-volume temp+rename replacement. The original target
+/// is untouched on every pre-replacement failure.
+/// </summary>
+internal sealed class StandaloneUpdateInstaller : IStandaloneUpdateInstaller
+{
+    private readonly IUpdateReleaseClient releaseClient;
+    private readonly IStandaloneBinaryReplacer replacer;
+
+    internal StandaloneUpdateInstaller(
+        IUpdateReleaseClient releaseClient,
+        IStandaloneBinaryReplacer? replacer = null)
+    {
+        this.releaseClient = releaseClient ?? throw new ArgumentNullException(nameof(releaseClient));
+        this.replacer = replacer ?? new AtomicStandaloneBinaryReplacer();
+    }
+
+    public StandaloneUpdateOutcome Apply(string targetPath, UpdateRelease release)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
+        ArgumentNullException.ThrowIfNull(release);
+
+        if (!File.Exists(targetPath))
+        {
+            throw new StandaloneUpdateException(
+                $"The standalone executable '{targetPath}' does not exist; no replacement was attempted.",
+                targetPath,
+                targetWasModified: false);
+        }
+
+        var (archive, checksum) = SelectAssets(release);
+        var targetDirectory = Path.GetDirectoryName(targetPath);
+        if (string.IsNullOrWhiteSpace(targetDirectory))
+        {
+            throw new StandaloneUpdateException(
+                $"Could not determine the standalone executable directory for '{targetPath}'; no replacement was attempted.",
+                targetPath,
+                targetWasModified: false);
+        }
+
+        var stagingRoot = Path.Combine(
+            targetDirectory,
+            $".intent-cli-update-{Guid.NewGuid():N}");
+        var archivePath = Path.Combine(stagingRoot, archive.Name);
+        var checksumPath = Path.Combine(stagingRoot, checksum.Name);
+        var extractionRoot = Path.Combine(stagingRoot, "extract");
+        var stagedBinaryPath = Path.Combine(stagingRoot, "replacement", Path.GetFileName(targetPath));
+        var replaced = false;
+
+        try
+        {
+            Directory.CreateDirectory(stagingRoot);
+            using (var archiveStream = new FileStream(archivePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                releaseClient.Download(archive, archiveStream);
+            }
+
+            using (var checksumStream = new FileStream(checksumPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                releaseClient.Download(checksum, checksumStream);
+            }
+
+            var expectedChecksum = ReadExpectedChecksum(checksumPath, archive.Name, targetPath);
+            var actualChecksum = ComputeSha256(archivePath);
+            if (!string.Equals(expectedChecksum, actualChecksum, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new StandaloneUpdateException(
+                    $"Checksum mismatch for release asset '{archive.Name}': expected {expectedChecksum}, actual {actualChecksum}. "
+                    + $"The original standalone binary '{targetPath}' was left byte-identical; no replacement was attempted.",
+                    targetPath,
+                    targetWasModified: false,
+                    expectedChecksum,
+                    actualChecksum);
+            }
+
+            Directory.CreateDirectory(extractionRoot);
+            ExtractArchive(archive.Name, archivePath, extractionRoot);
+            var expectedBinaryName = Path.GetFileName(targetPath);
+            var extractedBinaries = Directory.EnumerateFiles(
+                    extractionRoot,
+                    expectedBinaryName,
+                    SearchOption.AllDirectories)
+                .ToArray();
+            if (extractedBinaries.Length != 1)
+            {
+                throw new StandaloneUpdateException(
+                    $"Release asset '{archive.Name}' did not contain exactly one '{expectedBinaryName}' binary; "
+                    + $"found {extractedBinaries.Length}. The original binary '{targetPath}' was left untouched.",
+                    targetPath,
+                    targetWasModified: false,
+                    expectedChecksum,
+                    actualChecksum);
+            }
+
+            Directory.CreateDirectory(Path.GetDirectoryName(stagedBinaryPath)!);
+            File.Copy(extractedBinaries[0], stagedBinaryPath, overwrite: true);
+            PreserveUnixMode(extractedBinaries[0], stagedBinaryPath);
+            replacer.Replace(targetPath, stagedBinaryPath);
+            replaced = true;
+
+            return new StandaloneUpdateOutcome(
+                archive.Name,
+                expectedChecksum,
+                actualChecksum,
+                targetPath);
+        }
+        catch (StandaloneUpdateException)
+        {
+            throw;
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or UnauthorizedAccessException
+            or InvalidDataException
+            or CryptographicException
+            or NotSupportedException)
+        {
+            var untouched = !replaced;
+            throw new StandaloneUpdateException(
+                $"Standalone update failed for '{targetPath}': {exception.Message}. "
+                + (untouched
+                    ? "The original binary was left untouched."
+                    : "The replacement had already completed."),
+                targetPath,
+                targetWasModified: replaced);
+        }
+        finally
+        {
+            TryDeleteOwnedStagingDirectory(stagingRoot);
+        }
+    }
+
+    internal static (UpdateReleaseAsset Archive, UpdateReleaseAsset Checksum) SelectAssets(UpdateRelease release)
+    {
+        var rid = CurrentRuntimeIdentifier();
+        var extension = rid == "win-x64" ? ".zip" : ".tar.gz";
+        var archiveName = $"intent-cli-{release.Version}-{rid}{extension}";
+        var checksumName = $"{archiveName}.sha256";
+        var archive = release.Assets.SingleOrDefault(asset =>
+            string.Equals(asset.Name, archiveName, StringComparison.Ordinal));
+        var checksum = release.Assets.SingleOrDefault(asset =>
+            string.Equals(asset.Name, checksumName, StringComparison.Ordinal));
+        if (archive is null || checksum is null)
+        {
+            throw new InvalidOperationException(
+                $"Latest release '{release.TagName}' is missing the standalone assets '{archiveName}' and/or '{checksumName}'.");
+        }
+
+        return (archive, checksum);
+    }
+
+    internal static string CurrentRuntimeIdentifier()
+    {
+        if (OperatingSystem.IsWindows() && System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.X64)
+        {
+            return "win-x64";
+        }
+
+        if (OperatingSystem.IsLinux() && System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.X64)
+        {
+            return "linux-x64";
+        }
+
+        if (OperatingSystem.IsMacOS() && System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture == System.Runtime.InteropServices.Architecture.Arm64)
+        {
+            return "osx-arm64";
+        }
+
+        throw new PlatformNotSupportedException(
+            $"No self-contained intent-cli release asset is defined for {System.Runtime.InteropServices.RuntimeInformation.OSDescription} / {System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture}.");
+    }
+
+    private static string ReadExpectedChecksum(string path, string archiveName, string targetPath)
+    {
+        var line = File.ReadLines(path)
+            .Select(value => value.Trim())
+            .FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
+        var tokens = line?.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        var token = tokens?.FirstOrDefault();
+        if (token is null || token.Length != 64 || !token.All(Uri.IsHexDigit))
+        {
+            throw new StandaloneUpdateException(
+                $"Checksum sidecar for '{archiveName}' did not contain a 64-character SHA-256 digest. "
+                + $"The original binary '{targetPath}' was left untouched.",
+                targetPath,
+                targetWasModified: false);
+        }
+
+        if (tokens!.Length > 1)
+        {
+            var reportedName = tokens[1].TrimStart('*').Replace('\\', '/');
+            if (!string.Equals(
+                    Path.GetFileName(reportedName),
+                    archiveName,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new StandaloneUpdateException(
+                    $"Checksum sidecar '{Path.GetFileName(path)}' names '{tokens[1]}' instead of '{archiveName}'. "
+                    + $"The original binary '{targetPath}' was left untouched.",
+                    targetPath,
+                    targetWasModified: false);
+            }
+        }
+
+        return token.ToLowerInvariant();
+    }
+
+    private static string ComputeSha256(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+    }
+
+    private static void ExtractArchive(string name, string archivePath, string extractionRoot)
+    {
+        if (name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
+        {
+            ZipFile.ExtractToDirectory(archivePath, extractionRoot, overwriteFiles: true);
+            return;
+        }
+
+        if (name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase))
+        {
+            using var archive = File.OpenRead(archivePath);
+            using var gzip = new GZipStream(archive, CompressionMode.Decompress);
+            TarFile.ExtractToDirectory(gzip, extractionRoot, overwriteFiles: true);
+            return;
+        }
+
+        throw new InvalidDataException($"Unsupported standalone release archive '{name}'.");
+    }
+
+    private static void PreserveUnixMode(string source, string destination)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        try
+        {
+            File.SetUnixFileMode(destination, File.GetUnixFileMode(source));
+        }
+        catch (PlatformNotSupportedException)
+        {
+            // The bytes and atomic replacement remain valid on filesystems
+            // that do not expose Unix mode bits.
+        }
+    }
+
+    private static void TryDeleteOwnedStagingDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A failed cleanup must not turn a successful verified swap into
+            // an ambiguous update result. The directory is uniquely named and
+            // owned by this invocation.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Same rationale as the IOException case above.
+        }
+    }
+}
+
+internal interface IStandaloneUpdateInstaller
+{
+    StandaloneUpdateOutcome Apply(string targetPath, UpdateRelease release);
+}
+
+internal sealed class UpdateDependencies
+{
+    internal required IExecutablePathResolver ExecutablePathResolver { get; init; }
+
+    internal required IUpdateReleaseClient ReleaseClient { get; init; }
+
+    internal required IUpdateProcessRunner ProcessRunner { get; init; }
+
+    internal required IStandaloneUpdateInstaller StandaloneInstaller { get; init; }
+
+    internal required Func<string> CurrentVersionProvider { get; init; }
+
+    internal static UpdateDependencies CreateDefault()
+    {
+        var releaseClient = new GitHubUpdateReleaseClient();
+        return new UpdateDependencies
+        {
+            ExecutablePathResolver = new ProcessExecutablePathResolver(),
+            ReleaseClient = releaseClient,
+            ProcessRunner = new ProcessUpdateRunner(),
+            StandaloneInstaller = new StandaloneUpdateInstaller(releaseClient),
+            CurrentVersionProvider = VersionCommand.GetCurrentPackageVersion
+        };
+    }
+}
+
+internal sealed record UpdateOperationResult
+{
+    [JsonPropertyName("outcome")]
+    public required string Outcome { get; init; }
+
+    [JsonPropertyName("current_version")]
+    public string? CurrentVersion { get; init; }
+
+    [JsonPropertyName("latest_version")]
+    public string? LatestVersion { get; init; }
+
+    [JsonPropertyName("would_be_action")]
+    public required string WouldBeAction { get; init; }
+
+    [JsonPropertyName("action")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Action { get; init; }
+
+    [JsonPropertyName("check")]
+    public bool Check { get; init; }
+
+    [JsonPropertyName("process_spawned")]
+    public bool ProcessSpawned { get; init; }
+
+    [JsonPropertyName("writes_performed")]
+    public bool WritesPerformed { get; init; }
+
+    [JsonPropertyName("target_replaced")]
+    public bool TargetReplaced { get; init; }
+
+    [JsonPropertyName("target_untouched_on_failure")]
+    public bool TargetUntouchedOnFailure { get; init; }
+
+    [JsonPropertyName("command")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Command { get; init; }
+
+    [JsonPropertyName("process_exit_code")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? ProcessExitCode { get; init; }
+
+    [JsonPropertyName("process_stdout")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ProcessStandardOutput { get; init; }
+
+    [JsonPropertyName("process_stderr")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ProcessStandardError { get; init; }
+
+    [JsonPropertyName("error")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Error { get; init; }
+
+    [JsonPropertyName("manual_guidance")]
+    public required IReadOnlyList<string> ManualGuidance { get; init; }
+
+    [JsonIgnore]
+    internal int ExitCode { get; init; }
+}
+
+internal static class UpdateManualGuidance
+{
+    internal static readonly IReadOnlyList<string> AllChannels =
+    [
+        "dotnet tool update -g JTechJapan.IntentSystem.Cli",
+        "npm install -g intent-system@latest",
+        "npx intent-system@latest <command>",
+        "Download the matching intent-cli release asset, verify its .sha256 sidecar, then replace the standalone binary through a temp+rename swap."
+    ];
+
+    internal static readonly IReadOnlyList<string> Standalone =
+    [
+        "Download the matching intent-cli release asset and its .sha256 sidecar.",
+        "Verify the archive SHA-256 before replacing the binary; if it mismatches, keep the original binary byte-identical and retry from the latest release."
+    ];
+}
+
+/// <summary>
+/// G703 channel-aware update command. It is intentionally independent of
+/// <see cref="CliContext"/> so it can run from a bare metadata-free directory.
+/// </summary>
+internal static class UpdateCommand
+{
+    private const string FormatMarkdown = "markdown";
+    private const string FormatJson = "json";
+    private const string PackageId = "JTechJapan.IntentSystem.Cli";
+    private const string NpmPackage = "intent-system";
+    private const string UsageLine =
+        "Usage: intent-cli update [--check] [--format markdown|json]";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        WriteIndented = false
+    };
+
+    internal static bool IsUpdateRequest(string[] args) =>
+        args is { Length: > 0 }
+        && string.Equals(args[0], "update", StringComparison.Ordinal);
+
+    internal static int Execute(
+        string[] args,
+        TextWriter writer,
+        UpdateDependencies? dependencies = null)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine("intent-cli update");
+            writer.WriteLine(UsageLine);
+            writer.WriteLine("Derives the channel from the fully resolved executable path on every run.");
+            writer.WriteLine("Use --check for current/latest/would-be action with no process spawn or writes.");
+            return 0;
+        }
+
+        if (!TryParseArguments(args, out var check, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        dependencies ??= UpdateDependencies.CreateDefault();
+        var resolution = dependencies.ExecutablePathResolver.Resolve();
+        var detection = UpdateChannelDetector.Detect(resolution);
+        var json = string.Equals(format, FormatJson, StringComparison.Ordinal);
+        if (json)
+        {
+            BeginJsonEnvelope(writer, detection);
+        }
+        else
+        {
+            WriteDetectionMarkdown(writer, detection);
+            writer.Flush();
+        }
+
+        UpdateOperationResult result;
+        try
+        {
+            result = ExecuteOperation(check, detection, dependencies);
+        }
+        catch (StandaloneUpdateException exception)
+        {
+            result = new UpdateOperationResult
+            {
+                Outcome = "checksum-or-standalone-failure",
+                CurrentVersion = TryGetCurrentVersion(dependencies),
+                WouldBeAction = "verified standalone release asset + temp+rename swap",
+                Action = "standalone checksum-verified replacement",
+                Check = check,
+                WritesPerformed = exception.TargetWasModified,
+                TargetReplaced = exception.TargetWasModified,
+                TargetUntouchedOnFailure = !exception.TargetWasModified,
+                Error = exception.Message,
+                ManualGuidance = UpdateManualGuidance.Standalone,
+                ExitCode = 1
+            };
+        }
+        catch (Exception exception) when (
+            exception is HttpRequestException
+            or InvalidOperationException
+            or IOException
+            or UnauthorizedAccessException
+            or PlatformNotSupportedException
+            or InvalidDataException)
+        {
+            result = new UpdateOperationResult
+            {
+                Outcome = check ? "check-failed" : "update-failed",
+                CurrentVersion = TryGetCurrentVersion(dependencies),
+                WouldBeAction = WouldBeAction(detection.Kind, latestVersion: null),
+                Check = check,
+                ProcessSpawned = false,
+                WritesPerformed = false,
+                Error = exception.Message,
+                ManualGuidance = detection.Kind == UpdateChannel.Standalone
+                    ? UpdateManualGuidance.Standalone
+                    : UpdateManualGuidance.AllChannels,
+                ExitCode = 1
+            };
+        }
+
+        if (json)
+        {
+            writer.Write(JsonSerializer.Serialize(result, JsonOptions));
+            writer.WriteLine("}");
+        }
+        else
+        {
+            WriteResultMarkdown(writer, result);
+        }
+
+        return result.ExitCode;
+    }
+
+    private static UpdateOperationResult ExecuteOperation(
+        bool check,
+        UpdateChannelDetection detection,
+        UpdateDependencies dependencies)
+    {
+        if (detection.Kind == UpdateChannel.Unknown)
+        {
+            return new UpdateOperationResult
+            {
+                Outcome = detection.Ambiguous ? "fail-closed-ambiguous-path" : "fail-closed-unknown-path",
+                WouldBeAction = "manual channel selection required",
+                Check = check,
+                Error = detection.DetectionError ?? "The installation channel could not be determined.",
+                ManualGuidance = UpdateManualGuidance.AllChannels,
+                ExitCode = 1
+            };
+        }
+
+        var currentVersion = TryGetCurrentVersion(dependencies);
+        if (!check && detection.Kind == UpdateChannel.Npx)
+        {
+            return new UpdateOperationResult
+            {
+                Outcome = "guidance-only",
+                CurrentVersion = currentVersion,
+                WouldBeAction = WouldBeAction(UpdateChannel.Npx, latestVersion: null),
+                Action = "npx intent-system@latest <command>",
+                Check = false,
+                ProcessSpawned = false,
+                WritesPerformed = false,
+                ManualGuidance = ["npx intent-system@latest <command>", "For a persistent install, run: npm install -g intent-system@latest."],
+                ExitCode = 0
+            };
+        }
+
+        var release = dependencies.ReleaseClient.GetLatestRelease();
+        var latestVersion = release.Version;
+        var wouldBeAction = WouldBeAction(detection.Kind, latestVersion);
+        if (check)
+        {
+            var checkCurrent = NormalizeComparableVersion(currentVersion);
+            var checkLatest = NormalizeComparableVersion(latestVersion);
+            var noOp = checkCurrent is not null
+                && checkLatest is not null
+                && string.Equals(checkCurrent, checkLatest, StringComparison.OrdinalIgnoreCase);
+            return new UpdateOperationResult
+            {
+                Outcome = "check",
+                CurrentVersion = currentVersion,
+                LatestVersion = latestVersion,
+                WouldBeAction = noOp ? "no action — current version is latest" : wouldBeAction,
+                Check = true,
+                ProcessSpawned = false,
+                WritesPerformed = false,
+                ManualGuidance = Array.Empty<string>(),
+                ExitCode = 0
+            };
+        }
+
+        if (NormalizeComparableVersion(currentVersion) is { } current
+            && NormalizeComparableVersion(latestVersion) is { } latest
+            && string.Equals(current, latest, StringComparison.OrdinalIgnoreCase))
+        {
+            return new UpdateOperationResult
+            {
+                Outcome = "already-current",
+                CurrentVersion = currentVersion,
+                LatestVersion = latestVersion,
+                WouldBeAction = "no action — current version is latest",
+                Check = false,
+                ManualGuidance = Array.Empty<string>(),
+                ExitCode = 0
+            };
+        }
+
+        return detection.Kind switch
+        {
+            UpdateChannel.DotnetTool => RunPackageManagerUpdate(
+                "dotnet",
+                ["tool", "update", "-g", PackageId],
+                currentVersion,
+                latestVersion,
+                wouldBeAction,
+                dependencies.ProcessRunner),
+            UpdateChannel.NpmGlobal => RunPackageManagerUpdate(
+                "npm",
+                ["install", "-g", $"{NpmPackage}@latest"],
+                currentVersion,
+                latestVersion,
+                wouldBeAction,
+                dependencies.ProcessRunner),
+            UpdateChannel.Standalone => RunStandaloneUpdate(
+                detection,
+                currentVersion,
+                latestVersion,
+                wouldBeAction,
+                release,
+                dependencies),
+            _ => throw new InvalidOperationException($"Unsupported update channel '{detection.Channel}'.")
+        };
+    }
+
+    private static UpdateOperationResult RunPackageManagerUpdate(
+        string executable,
+        IReadOnlyList<string> arguments,
+        string? currentVersion,
+        string latestVersion,
+        string wouldBeAction,
+        IUpdateProcessRunner runner)
+    {
+        var process = runner.Run(executable, arguments);
+        var success = process.ExitCode == 0;
+        return new UpdateOperationResult
+        {
+            Outcome = success ? "updated" : "update-failed",
+            CurrentVersion = currentVersion,
+            LatestVersion = latestVersion,
+            WouldBeAction = wouldBeAction,
+            Action = FormatCommand(executable, arguments),
+            Check = false,
+            ProcessSpawned = true,
+            WritesPerformed = true,
+            Command = FormatCommand(executable, arguments),
+            ProcessExitCode = process.ExitCode,
+            ProcessStandardOutput = process.StandardOutput,
+            ProcessStandardError = process.StandardError,
+            Error = success ? null : $"{executable} exited with code {process.ExitCode}.",
+            ManualGuidance = success ? Array.Empty<string>() : UpdateManualGuidance.AllChannels,
+            ExitCode = success ? 0 : 1
+        };
+    }
+
+    private static UpdateOperationResult RunStandaloneUpdate(
+        UpdateChannelDetection detection,
+        string? currentVersion,
+        string latestVersion,
+        string wouldBeAction,
+        UpdateRelease release,
+        UpdateDependencies dependencies)
+    {
+        var target = detection.ResolvedExecutablePath
+            ?? throw new InvalidOperationException("The standalone executable real path was unavailable.");
+        var outcome = dependencies.StandaloneInstaller.Apply(target, release);
+        return new UpdateOperationResult
+        {
+            Outcome = "updated",
+            CurrentVersion = currentVersion,
+            LatestVersion = latestVersion,
+            WouldBeAction = wouldBeAction,
+            Action = "checksum-verified standalone temp+rename replacement",
+            Check = false,
+            WritesPerformed = true,
+            TargetReplaced = true,
+            TargetUntouchedOnFailure = false,
+            ManualGuidance = Array.Empty<string>(),
+            ExitCode = 0
+        };
+    }
+
+    private static string WouldBeAction(UpdateChannel channel, string? latestVersion)
+    {
+        var version = string.IsNullOrWhiteSpace(latestVersion) ? "latest" : latestVersion;
+        return channel switch
+        {
+            UpdateChannel.DotnetTool => "dotnet tool update -g JTechJapan.IntentSystem.Cli",
+            UpdateChannel.NpmGlobal => "npm install -g intent-system@latest",
+            UpdateChannel.Npx => "npx intent-system@latest <command> (guidance only; no mutation)",
+            UpdateChannel.Standalone => $"download intent-cli-{version}-{RuntimeIdentifierForGuidance()}.<archive>, verify .sha256, then temp+rename",
+            _ => "manual channel selection required"
+        };
+    }
+
+    private static string RuntimeIdentifierForGuidance()
+    {
+        try
+        {
+            return StandaloneUpdateInstaller.CurrentRuntimeIdentifier();
+        }
+        catch (PlatformNotSupportedException)
+        {
+            return "<platform>";
+        }
+    }
+
+    private static string? TryGetCurrentVersion(UpdateDependencies dependencies)
+    {
+        try
+        {
+            return dependencies.CurrentVersionProvider();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string? NormalizeComparableVersion(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return null;
+        }
+
+        var value = version.Trim();
+        if (value.StartsWith("intent-cli ", StringComparison.OrdinalIgnoreCase))
+        {
+            value = value["intent-cli ".Length..].Trim();
+        }
+
+        if (value.StartsWith('v'))
+        {
+            value = value[1..];
+        }
+
+        return value.Split(['+', '-'], 2, StringSplitOptions.None)[0];
+    }
+
+    private static string FormatCommand(string executable, IReadOnlyList<string> arguments) =>
+        string.Join(' ', new[] { executable }.Concat(arguments.Select(ShellQuote)));
+
+    private static string ShellQuote(string value) =>
+        value.Any(char.IsWhiteSpace) ? $"'{value.Replace("'", "'\\''", StringComparison.Ordinal)}'" : value;
+
+    private static void WriteDetectionMarkdown(TextWriter writer, UpdateChannelDetection detection)
+    {
+        writer.WriteLine("## intent-cli update — channel detection");
+        writer.WriteLine();
+        writer.WriteLine($"- channel: `{detection.Channel}`");
+        writer.WriteLine($"- executable path: `{detection.ExecutablePath ?? "<unavailable>"}`");
+        writer.WriteLine($"- resolved real path: `{detection.ResolvedExecutablePath ?? "<unavailable>"}`");
+        writer.WriteLine($"- path evidence: {detection.PathEvidence}");
+        writer.WriteLine($"- fail-closed ambiguity: `{detection.Ambiguous}`");
+        writer.WriteLine();
+    }
+
+    private static void BeginJsonEnvelope(TextWriter writer, UpdateChannelDetection detection)
+    {
+        var detectionJson = JsonSerializer.Serialize(detection, JsonOptions);
+        writer.Write(detectionJson[..^1]);
+        writer.Write(",\"result\":");
+        writer.Flush();
+    }
+
+    private static void WriteResultMarkdown(TextWriter writer, UpdateOperationResult result)
+    {
+        writer.WriteLine("## intent-cli update — result");
+        writer.WriteLine();
+        writer.WriteLine($"- outcome: `{result.Outcome}`");
+        writer.WriteLine($"- current version: `{result.CurrentVersion ?? "<unknown>"}`");
+        writer.WriteLine($"- latest version: `{result.LatestVersion ?? "<not queried>"}`");
+        writer.WriteLine($"- would-be action: {result.WouldBeAction}");
+        writer.WriteLine($"- check: `{result.Check}`");
+        writer.WriteLine($"- process spawned: `{result.ProcessSpawned}`");
+        writer.WriteLine($"- writes performed: `{result.WritesPerformed}`");
+        writer.WriteLine($"- target replaced: `{result.TargetReplaced}`");
+        writer.WriteLine($"- target untouched on failure: `{result.TargetUntouchedOnFailure}`");
+        if (!string.IsNullOrWhiteSpace(result.Command))
+        {
+            writer.WriteLine($"- command: `{result.Command}`");
+        }
+        if (!string.IsNullOrWhiteSpace(result.Error))
+        {
+            writer.WriteLine($"- error: {result.Error}");
+        }
+        if (result.ManualGuidance.Count > 0)
+        {
+            writer.WriteLine("- manual guidance:");
+            foreach (var line in result.ManualGuidance)
+            {
+                writer.WriteLine($"  - {line}");
+            }
+        }
+    }
+
+    private static bool TryParseArguments(
+        string[] args,
+        out bool check,
+        out string format,
+        out string error)
+    {
+        check = false;
+        format = FormatMarkdown;
+        error = string.Empty;
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--check":
+                    check = true;
+                    break;
+                case "--format":
+                    if (index + 1 >= args.Length)
+                    {
+                        error = "--format requires a value (markdown or json).";
+                        return false;
+                    }
+
+                    format = args[++index];
+                    if (!string.Equals(format, FormatMarkdown, StringComparison.Ordinal)
+                        && !string.Equals(format, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = $"--format must be 'markdown' or 'json' (got '{format}').";
+                        return false;
+                    }
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/VersionCommand.cs
+++ b/src/IntentSystem.Cli/Commands/VersionCommand.cs
@@ -111,6 +111,30 @@ internal static class VersionCommand
     }
 
     /// <summary>
+    /// G703: returns the package-version portion of the running CLI identity
+    /// without consulting host state. The update command uses this as its
+    /// current-version field and tests can override the existing version seam.
+    /// </summary>
+    internal static string GetCurrentPackageVersion()
+    {
+        var version = OverrideVersionString
+            ?? BuildVersionString(typeof(VersionCommand).Assembly);
+        var firstLine = version
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .FirstOrDefault()
+            ?.Trim();
+        if (string.IsNullOrWhiteSpace(firstLine))
+        {
+            return "unknown";
+        }
+
+        const string prefix = "intent-cli ";
+        return firstLine.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? firstLine[prefix.Length..].Trim().Split(['+', '-'], 2, StringSplitOptions.None)[0]
+            : firstLine;
+    }
+
+    /// <summary>
     /// Test seam exposing the pure builder so tests can verify the
     /// shape independently of the executing assembly's actual
     /// InformationalVersion.

--- a/src/IntentSystem.Cli/Program.cs
+++ b/src/IntentSystem.Cli/Program.cs
@@ -23,6 +23,15 @@ internal static class Program
                 return VersionCommand.Execute(Console.Out);
             }
 
+            // G703: channel detection and self-update are installation-local
+            // operations. They must run before the host-state bootstrap gate
+            // (and before preview expiry) so `intent-cli update` works from a
+            // bare metadata-free directory and can repair an old install.
+            if (UpdateCommand.IsUpdateRequest(args))
+            {
+                return UpdateCommand.Execute(args[1..], Console.Out);
+            }
+
             // G368: CI-packed private-preview artifacts expire 14 days
             // after their build timestamp (G367 metadata). Once the
             // expiry passes, fail closed BEFORE any workflow command or

--- a/tests/IntentSystem.Cli.Tests/UpdateCommandG703Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/UpdateCommandG703Tests.cs
@@ -1,0 +1,510 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class UpdateCommandG703Tests
+{
+    [Fact]
+    public void Resolver_FollowsExecutableSymlinkAndRetainsPathEvidence()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var root = NewFixtureRoot("symlink");
+        var target = Path.Combine(root, "intent-cli");
+        var link = Path.Combine(root, "intent-cli-link");
+        File.WriteAllBytes(target, "standalone"u8.ToArray());
+        File.CreateSymbolicLink(link, target);
+
+        var resolution = ProcessExecutablePathResolver.ResolvePath(link);
+
+        Assert.Null(resolution.Error);
+        Assert.Equal(Path.GetFullPath(target), resolution.ResolvedPath);
+        Assert.Equal(2, resolution.PathHops.Count);
+        Assert.Contains(Path.GetFullPath(link), resolution.PathHops);
+        Assert.Contains(Path.GetFullPath(target), resolution.PathHops);
+    }
+
+    [Theory]
+    [InlineData("/Users/operator/.dotnet/tools/intent-cli", "dotnet-tool")]
+    [InlineData("/usr/local/lib/node_modules/intent-system/bin/intent-cli", "npm-global")]
+    [InlineData("/Users/operator/.npm/_npx/abc123/node_modules/intent-system/bin/intent-cli", "npx-cache")]
+    [InlineData("/opt/intent-cli/intent-cli", "standalone")]
+    public void Detector_ClassifiesSupportedRealPathShapes(string path, string expectedChannel)
+    {
+        var resolution = new ExecutablePathResolution(path, path, [path], null);
+
+        var detection = UpdateChannelDetector.Detect(resolution);
+
+        Assert.Equal(expectedChannel, detection.Channel);
+        Assert.False(detection.Ambiguous);
+        Assert.Contains("real path", detection.PathEvidence, StringComparison.Ordinal);
+        Assert.Contains(path, detection.PathEvidence, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Detector_FailsClosedForUnknownAndConflictingPaths()
+    {
+        var unknown = UpdateChannelDetector.Detect(ResolutionForPath("/opt/other-tool/other-command"));
+        var ambiguous = UpdateChannelDetector.Detect(
+            ResolutionForPath("/Users/operator/.dotnet/tools/node_modules/intent-system/bin/intent-cli"));
+
+        Assert.Equal("unknown", unknown.Channel);
+        Assert.False(unknown.Ambiguous);
+        Assert.Contains("fail-closed", unknown.PathEvidence, StringComparison.Ordinal);
+        Assert.Equal("unknown", ambiguous.Channel);
+        Assert.True(ambiguous.Ambiguous);
+        Assert.Contains("conflicting", ambiguous.DetectionError, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DotnetToolUpdate_EmitsDetectionBeforeSpawningExactCommand()
+    {
+        using var output = new StringWriter();
+        var process = new RecordingProcessRunner(output);
+        var dependencies = Dependencies(
+            "/Users/operator/.dotnet/tools/intent-cli",
+            processRunner: process,
+            currentVersion: "1.0.0");
+
+        var exitCode = UpdateCommand.Execute([], output, dependencies);
+
+        Assert.Equal(0, exitCode);
+        var invocation = Assert.Single(process.Invocations);
+        Assert.Equal("dotnet", invocation.Executable);
+        Assert.Equal(["tool", "update", "-g", "JTechJapan.IntentSystem.Cli"], invocation.Arguments);
+        Assert.Contains("channel: `dotnet-tool`", process.OutputBeforeRun, StringComparison.Ordinal);
+        Assert.Contains("dotnet tool update -g JTechJapan.IntentSystem.Cli", output.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NpmGlobalUpdate_UsesLatestPackageAndNpxIsGuidanceOnly()
+    {
+        using var npmOutput = new StringWriter();
+        var npmProcess = new RecordingProcessRunner(npmOutput);
+        var npmDependencies = Dependencies(
+            "/usr/local/lib/node_modules/intent-system/bin/intent-cli",
+            processRunner: npmProcess,
+            currentVersion: "1.0.0");
+
+        Assert.Equal(0, UpdateCommand.Execute([], npmOutput, npmDependencies));
+        var npmInvocation = Assert.Single(npmProcess.Invocations);
+        Assert.Equal("npm", npmInvocation.Executable);
+        Assert.Equal(["install", "-g", "intent-system@latest"], npmInvocation.Arguments);
+
+        using var npxOutput = new StringWriter();
+        var npxProcess = new RecordingProcessRunner(npxOutput);
+        var npxRelease = new RecordingReleaseClient();
+        var npxDependencies = Dependencies(
+            "/Users/operator/.npm/_npx/abc123/node_modules/intent-system/bin/intent-cli",
+            processRunner: npxProcess,
+            releaseClient: npxRelease,
+            currentVersion: "1.0.0");
+
+        Assert.Equal(0, UpdateCommand.Execute([], npxOutput, npxDependencies));
+        Assert.Empty(npxProcess.Invocations);
+        Assert.Equal(0, npxRelease.GetLatestCalls);
+        Assert.Contains("guidance-only", npxOutput.ToString(), StringComparison.Ordinal);
+        Assert.Contains("npx intent-system@latest <command>", npxOutput.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CheckReportsCurrentLatestAndWouldBeActionWithoutProcessOrWrites()
+    {
+        using var output = new StringWriter();
+        var process = new RecordingProcessRunner(output);
+        var release = new RecordingReleaseClient();
+        var dependencies = Dependencies(
+            "/Users/operator/.dotnet/tools/intent-cli",
+            processRunner: process,
+            releaseClient: release,
+            currentVersion: "1.0.0");
+
+        var exitCode = UpdateCommand.Execute(["--check", "--format", "json"], output, dependencies);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(output.ToString());
+        var root = document.RootElement;
+        Assert.Equal("dotnet-tool", root.GetProperty("channel").GetString());
+        var result = root.GetProperty("result");
+        Assert.Equal("1.0.0", result.GetProperty("current_version").GetString());
+        Assert.Equal("2.0.0", result.GetProperty("latest_version").GetString());
+        Assert.Contains("dotnet tool update", result.GetProperty("would_be_action").GetString(), StringComparison.Ordinal);
+        Assert.True(result.GetProperty("check").GetBoolean());
+        Assert.False(result.GetProperty("process_spawned").GetBoolean());
+        Assert.False(result.GetProperty("writes_performed").GetBoolean());
+        Assert.Empty(process.Invocations);
+        Assert.Equal(1, release.GetLatestCalls);
+    }
+
+    [Fact]
+    public void UnknownPathFailsClosedWithAllChannelManualGuidanceAndNoReleaseLookup()
+    {
+        using var output = new StringWriter();
+        var release = new RecordingReleaseClient();
+        var process = new RecordingProcessRunner(output);
+        var dependencies = Dependencies(
+            "/opt/other-tool/other-command",
+            processRunner: process,
+            releaseClient: release,
+            currentVersion: "1.0.0");
+
+        var exitCode = UpdateCommand.Execute(["--format", "json"], output, dependencies);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(output.ToString());
+        var root = document.RootElement;
+        Assert.Equal("unknown", root.GetProperty("channel").GetString());
+        var result = root.GetProperty("result");
+        Assert.StartsWith("fail-closed", result.GetProperty("outcome").GetString(), StringComparison.Ordinal);
+        var guidance = result.GetProperty("manual_guidance").EnumerateArray().Select(item => item.GetString()).ToArray();
+        Assert.Contains(guidance, line => line!.StartsWith("dotnet tool update", StringComparison.Ordinal));
+        Assert.Contains(guidance, line => line!.StartsWith("npm install", StringComparison.Ordinal));
+        Assert.Contains(guidance, line => line!.StartsWith("npx intent-system", StringComparison.Ordinal));
+        Assert.Contains(guidance, line => line!.Contains(".sha256", StringComparison.Ordinal));
+        Assert.Empty(process.Invocations);
+        Assert.Equal(0, release.GetLatestCalls);
+    }
+
+    [Fact]
+    public void CorruptChecksumLeavesStandaloneBinaryByteIdentical()
+    {
+        var root = NewFixtureRoot("checksum");
+        var target = Path.Combine(root, OperatingSystem.IsWindows() ? "intent-cli.exe" : "intent-cli");
+        var original = "original-standalone-binary"u8.ToArray();
+        File.WriteAllBytes(target, original);
+
+        var archiveName = ArchiveName("2.0.0");
+        var checksumName = $"{archiveName}.sha256";
+        var archive = BuildArchive(target, "replacement-binary"u8.ToArray());
+        var release = Release("2.0.0", archiveName, checksumName);
+        var client = new RecordingReleaseClient(release, new Dictionary<string, byte[]>
+        {
+            [archiveName] = archive,
+            [checksumName] = Encoding.UTF8.GetBytes(new string('0', 64) + "  " + archiveName + "\n")
+        });
+        var installer = new StandaloneUpdateInstaller(client);
+
+        var exception = Assert.Throws<StandaloneUpdateException>(() => installer.Apply(target, release));
+
+        Assert.False(exception.TargetWasModified);
+        Assert.Contains("Checksum mismatch", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(target, exception.Message, StringComparison.Ordinal);
+        Assert.Equal(original, File.ReadAllBytes(target));
+    }
+
+    [Fact]
+    public void MismatchedChecksumFilenameLeavesStandaloneBinaryByteIdentical()
+    {
+        var root = NewFixtureRoot("checksum-name");
+        var target = Path.Combine(root, OperatingSystem.IsWindows() ? "intent-cli.exe" : "intent-cli");
+        var original = "original-standalone-binary"u8.ToArray();
+        File.WriteAllBytes(target, original);
+
+        var archiveName = ArchiveName("2.0.0");
+        var checksumName = $"{archiveName}.sha256";
+        var archive = BuildArchive(target, "replacement-binary"u8.ToArray());
+        var digest = Convert.ToHexString(SHA256.HashData(archive)).ToLowerInvariant();
+        var release = Release("2.0.0", archiveName, checksumName);
+        var client = new RecordingReleaseClient(release, new Dictionary<string, byte[]>
+        {
+            [archiveName] = archive,
+            [checksumName] = Encoding.UTF8.GetBytes($"{digest}  another-asset{Path.GetExtension(archiveName)}\n")
+        });
+
+        var exception = Assert.Throws<StandaloneUpdateException>(
+            () => new StandaloneUpdateInstaller(client).Apply(target, release));
+
+        Assert.False(exception.TargetWasModified);
+        Assert.Contains("names", exception.Message, StringComparison.Ordinal);
+        Assert.Equal(original, File.ReadAllBytes(target));
+    }
+
+    [Fact]
+    public void UpdateCommand_ChecksumFailureReportsNoTargetWrite()
+    {
+        var root = NewFixtureRoot("checksum-result");
+        var target = Path.Combine(root, OperatingSystem.IsWindows() ? "intent-cli.exe" : "intent-cli");
+        var original = "original-standalone-binary"u8.ToArray();
+        File.WriteAllBytes(target, original);
+
+        var archiveName = ArchiveName("2.0.0");
+        var checksumName = $"{archiveName}.sha256";
+        var archive = BuildArchive(target, "replacement-binary"u8.ToArray());
+        var release = Release("2.0.0", archiveName, checksumName);
+        var client = new RecordingReleaseClient(release, new Dictionary<string, byte[]>
+        {
+            [archiveName] = archive,
+            [checksumName] = Encoding.UTF8.GetBytes(new string('0', 64) + "  " + archiveName + "\n")
+        });
+        var dependencies = Dependencies(
+            target,
+            releaseClient: client,
+            currentVersion: "1.0.0",
+            standaloneInstaller: new StandaloneUpdateInstaller(client));
+        using var output = new StringWriter();
+
+        Assert.Equal(1, UpdateCommand.Execute(["--format", "json"], output, dependencies));
+        using var document = JsonDocument.Parse(output.ToString());
+        var result = document.RootElement.GetProperty("result");
+        Assert.False(result.GetProperty("writes_performed").GetBoolean());
+        Assert.True(result.GetProperty("target_untouched_on_failure").GetBoolean());
+        Assert.Equal(original, File.ReadAllBytes(target));
+    }
+
+    [Fact]
+    public void StandaloneUpdate_VerifiesThenUsesTempRenameAndReplacesTarget()
+    {
+        var root = NewFixtureRoot("success");
+        var target = Path.Combine(root, OperatingSystem.IsWindows() ? "intent-cli.exe" : "intent-cli");
+        File.WriteAllBytes(target, "original"u8.ToArray());
+
+        var archiveName = ArchiveName("2.0.0");
+        var checksumName = $"{archiveName}.sha256";
+        var archive = BuildArchive(target, "replacement-binary"u8.ToArray());
+        var digest = Convert.ToHexString(SHA256.HashData(archive)).ToLowerInvariant();
+        var release = Release("2.0.0", archiveName, checksumName);
+        var client = new RecordingReleaseClient(release, new Dictionary<string, byte[]>
+        {
+            [archiveName] = archive,
+            [checksumName] = Encoding.UTF8.GetBytes($"{digest}  {archiveName}\n")
+        });
+
+        var outcome = new StandaloneUpdateInstaller(client).Apply(target, release);
+
+        Assert.Equal(archiveName, outcome.ArchiveName);
+        Assert.Equal(digest, outcome.ExpectedChecksum);
+        Assert.Equal(digest, outcome.ActualChecksum);
+        Assert.Equal("replacement-binary", File.ReadAllText(target));
+        Assert.DoesNotContain(Directory.EnumerateFileSystemEntries(root), path =>
+            Path.GetFileName(path).StartsWith(".intent-cli-update-", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void WindowsSafeReplacerUsesReplacementSemanticsWithoutInPlaceWrite()
+    {
+        var root = NewFixtureRoot("windows-swap");
+        var target = Path.Combine(root, "intent-cli.exe");
+        var staged = Path.Combine(root, "intent-cli.exe.new");
+        File.WriteAllBytes(target, "old"u8.ToArray());
+        File.WriteAllBytes(staged, "new"u8.ToArray());
+
+        // Model a running Windows apphost: the process keeps a read handle,
+        // but permits delete/replace sharing. The replacement must still use
+        // the separate staged path rather than writing through the handle.
+        using (var runningHandle = new FileStream(
+                   target,
+                   FileMode.Open,
+                   FileAccess.Read,
+                   FileShare.ReadWrite | FileShare.Delete))
+        {
+            AtomicStandaloneBinaryReplacer.Replace(target, staged, windows: true);
+        }
+
+        Assert.Equal("new", File.ReadAllText(target));
+        Assert.False(File.Exists(staged));
+    }
+
+    private static UpdateDependencies Dependencies(
+        string executablePath,
+        IUpdateProcessRunner? processRunner = null,
+        IUpdateReleaseClient? releaseClient = null,
+        string currentVersion = "1.0.0",
+        IStandaloneUpdateInstaller? standaloneInstaller = null)
+    {
+        releaseClient ??= new RecordingReleaseClient();
+        return new UpdateDependencies
+        {
+            ExecutablePathResolver = new StaticPathResolver(executablePath),
+            ReleaseClient = releaseClient,
+            ProcessRunner = processRunner ?? new RecordingProcessRunner(new StringWriter()),
+            StandaloneInstaller = standaloneInstaller ?? new FakeStandaloneInstaller(),
+            CurrentVersionProvider = () => currentVersion
+        };
+    }
+
+    private static ExecutablePathResolution ResolutionForPath(string value) =>
+        new(value, value, [value], null);
+
+    private static string NewFixtureRoot(string name)
+    {
+        var root = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            ".artifacts",
+            $"g703-update-tests-{name}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        return root;
+    }
+
+    private static string ArchiveName(string version)
+    {
+        var rid = StandaloneUpdateInstaller.CurrentRuntimeIdentifier();
+        return $"intent-cli-{version}-{rid}{(rid == "win-x64" ? ".zip" : ".tar.gz")}";
+    }
+
+    private static UpdateRelease Release(string version, string archiveName, string checksumName) =>
+        new(
+            $"v{version}",
+            version,
+            [
+                new UpdateReleaseAsset(archiveName, new Uri($"https://example.invalid/{archiveName}")),
+                new UpdateReleaseAsset(checksumName, new Uri($"https://example.invalid/{checksumName}"))
+            ]);
+
+    private static byte[] BuildArchive(string targetPath, byte[] contents)
+    {
+        var binaryName = System.IO.Path.GetFileName(targetPath);
+        using var output = new MemoryStream();
+        if (binaryName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+        {
+            using (var zip = new ZipArchive(output, ZipArchiveMode.Create, leaveOpen: true))
+            using (var entry = zip.CreateEntry(binaryName).Open())
+            {
+                entry.Write(contents, 0, contents.Length);
+            }
+        }
+        else
+        {
+            using (var gzip = new GZipStream(output, CompressionLevel.Optimal, leaveOpen: true))
+            using (var tar = new TarWriter(gzip, leaveOpen: true))
+            {
+                var entry = new PaxTarEntry(TarEntryType.RegularFile, binaryName)
+                {
+                    DataStream = new MemoryStream(contents)
+                };
+                tar.WriteEntry(entry);
+            }
+        }
+
+        return output.ToArray();
+    }
+
+    private sealed class StaticPathResolver(string path) : IExecutablePathResolver
+    {
+        public ExecutablePathResolution Resolve() => ResolutionForPath(path);
+    }
+
+    private sealed class RecordingProcessRunner(StringWriter output) : IUpdateProcessRunner
+    {
+        public List<(string Executable, IReadOnlyList<string> Arguments)> Invocations { get; } = [];
+
+        public string OutputBeforeRun { get; private set; } = string.Empty;
+
+        public UpdateProcessResult Run(string executable, IReadOnlyList<string> arguments)
+        {
+            OutputBeforeRun = output.ToString();
+            Invocations.Add((executable, arguments.ToArray()));
+            return new UpdateProcessResult(0, "updated", string.Empty);
+        }
+    }
+
+    private sealed class RecordingReleaseClient : IUpdateReleaseClient
+    {
+        private readonly IReadOnlyDictionary<string, byte[]> downloads;
+
+        public RecordingReleaseClient(
+            UpdateRelease? release = null,
+            IReadOnlyDictionary<string, byte[]>? downloads = null)
+        {
+            Release = release ?? new UpdateRelease("v2.0.0", "2.0.0", []);
+            this.downloads = downloads ?? new Dictionary<string, byte[]>();
+        }
+
+        public UpdateRelease Release { get; }
+
+        public int GetLatestCalls { get; private set; }
+
+        public UpdateRelease GetLatestRelease()
+        {
+            GetLatestCalls++;
+            return Release;
+        }
+
+        public void Download(UpdateReleaseAsset asset, Stream destination)
+        {
+            if (!downloads.TryGetValue(asset.Name, out var bytes))
+            {
+                throw new InvalidOperationException($"No fake download for {asset.Name}.");
+            }
+
+            destination.Write(bytes, 0, bytes.Length);
+        }
+    }
+
+    private sealed class FakeStandaloneInstaller : IStandaloneUpdateInstaller
+    {
+        public StandaloneUpdateOutcome Apply(string targetPath, UpdateRelease release) =>
+            new("fake", "fake", "fake", targetPath);
+    }
+}
+
+public sealed class GuideOnboardingG703Tests
+{
+    [Fact]
+    public void OnboardingJsonAndMarkdownExposeTheSameMetadataFreeUpdateRoute()
+    {
+        using var jsonWriter = new StringWriter();
+        var context = new CliContext
+        {
+            RepoRoot = RepoVersionPolicySource.RepoRoot(),
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = "intent-cli",
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees"
+                }
+            }
+        };
+
+        Assert.Equal(0, GuideOnboardingCommand.Execute(context, ["--format", "json"], jsonWriter));
+        using var document = JsonDocument.Parse(jsonWriter.ToString());
+        var guidance = document.RootElement.GetProperty("update_channel_guidance");
+        Assert.Equal("intent-cli update --check --format json", guidance.GetProperty("json_command").GetString());
+        Assert.Equal("intent-cli update --check --format markdown", guidance.GetProperty("markdown_command").GetString());
+        Assert.Contains("fully resolved executable", guidance.GetProperty("contract").GetString(), StringComparison.Ordinal);
+        Assert.Contains("process_spawned=false", guidance.GetProperty("check_safety").GetString(), StringComparison.Ordinal);
+
+        using var markdownWriter = new StringWriter();
+        Assert.Equal(0, GuideOnboardingCommand.Execute(context, [], markdownWriter));
+        Assert.Contains("## Channel-aware update route (G703)", markdownWriter.ToString(), StringComparison.Ordinal);
+        Assert.Contains("intent-cli update --check --format json", markdownWriter.ToString(), StringComparison.Ordinal);
+        Assert.Contains("intent-cli update --check --format markdown", markdownWriter.ToString(), StringComparison.Ordinal);
+    }
+}
+
+public sealed class UpdateDocsG703Tests
+{
+    [Fact]
+    public void EnglishAndJapaneseDistributionDocsCarryTheChannelAndCheckContract()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var english = File.ReadAllText(Path.Combine(root, "docs", "en", "13-npm-distribution.md"));
+        var japanese = File.ReadAllText(Path.Combine(root, "docs", "ja", "13-npm-distribution.md"));
+
+        foreach (var document in new[] { english, japanese })
+        {
+            Assert.Contains("intent-cli update", document, StringComparison.Ordinal);
+            Assert.Contains("dotnet tool update -g JTechJapan.IntentSystem.Cli", document, StringComparison.Ordinal);
+            Assert.Contains("npm install -g intent-system@latest", document, StringComparison.Ordinal);
+            Assert.Contains("npx intent-system@latest", document, StringComparison.Ordinal);
+            Assert.Contains(".sha256", document, StringComparison.Ordinal);
+            Assert.Contains("temp+rename", document, StringComparison.Ordinal);
+            Assert.Contains("--check", document, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("process_spawned=false", english, StringComparison.Ordinal);
+        Assert.Contains("process_spawned=false", japanese, StringComparison.Ordinal);
+        Assert.Contains("fail closed", english, StringComparison.Ordinal);
+        Assert.Contains("fail closed", japanese, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes #1525

Implements channel detection from the fully resolved executable path on every run, with visible path evidence before action and no persisted marker.

Channels:
- dotnet-tool: dotnet tool update -g JTechJapan.IntentSystem.Cli
- npm-global: npm install -g intent-system@latest
- npx cache: guidance-only npx intent-system@latest <command> with no mutation
- standalone: release archive + matching .sha256 verification, then same-volume temp+rename replacement; corrupt/mismatched checksums leave the target byte-identical.

--check reports current_version, latest_version, and would_be_action with process_spawned=false and writes_performed=false. Unknown and ambiguous paths fail closed with all-channel manual guidance.

Verification: focused G703 17/17; npm smoke 7/7; full CLI Debug 5062 total, 5061 executed, 1 existing skip, 0 failures; exact CI-equivalent Release solution test 5392 total, 5391 executed, 1 existing skip, 0 failures; Release solution build; metadata-free self-contained Release guide onboarding JSON and Markdown from a bare directory; git diff --check.

Guide route: intent-cli guide onboarding --format json|markdown exposes update_channel_guidance and the no-effect commands intent-cli update --check --format json|markdown. Tests use injectable process/release/installer boundaries and exercise symlink resolution, unknown/ambiguous fail-closed guidance, zero-effect check, checksum failure byte identity, and Windows-safe staged replacement.