### PR TITLE
G710: roll v0.22.0 release state to v0.22.1

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2673,7 +2673,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0220)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0221)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2766,46 +2766,47 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.22.0)
+### Next release readiness (v0.22.1)
 
-**`v0.21.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.22.0`. [The v0.22.0 notes](release-notes-v0.22.0.md) are substantive
-prepare-only notes. See [release-notes-v0.21.0.md](release-notes-v0.21.0.md)
-for the preceding shipped scope; it is linked, not restated.
+**`v0.22.0` shipped** (GitHub Release + NuGet), and the next prepared line is
+`0.22.1`. [The v0.22.0 notes](release-notes-v0.22.0.md) are the frozen
+released evidence; [the v0.22.1 DRAFT](release-notes-v0.22.1.md) is the next
+line's stub. See [release-notes-v0.21.0.md](release-notes-v0.21.0.md) for the
+older shipped scope; it is linked, not restated.
 
-**Release-readiness verification (run before merging the `v0.22.0`
-release-preparation PR):**
+Rolled policy: `stableVersion → 0.22.0`; `nextVersion → 0.22.1`.
+
+**Release-readiness verification for the `v0.22.1` line:**
 
 On a claims-enabled host, acquire and verify the release scope before editing
 release artifacts. The same shared verification gates all G680 start surfaces;
-no claims store preserves legacy single-team behavior. This is a preparation
-record: it creates no tag or Release, publishes no package, and handles no
-credentials.
+no claims store preserves legacy single-team behavior. This roll changes only
+release documentation and version policy: it creates no tag or Release,
+publishes no package, and handles no credentials.
 
 ```bash
-# 0. Acquire and verify release-prep ownership (preview-through-1.x).
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.22.0 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.22.0 --team <team> --format json
+# 0. Acquire and verify release-prep ownership for the next patch line.
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.22.1 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.22.1 --team <team> --format json
 
-# 1. Confirm the version policy records the release-to-be-cut.
-cat eng/version.json   # stableVersion 0.21.0 (published), nextVersion 0.22.0 (to release)
+# 1. Confirm the rolled version policy.
+cat eng/version.json   # stableVersion 0.22.0 (published), nextVersion 0.22.1 (next line)
 
-# 2. Build and confirm the display version identity (version + git SHA + G-unit).
+# 2. Build and confirm the display version identity from the next line.
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-#   expected shape: intent-cli 0.22.0-<sha>-G<unit>   (NOT a stale literal)
+#   expected shape: intent-cli 0.22.1-<sha>-G<unit>
 
-# 3. Package publication is intentionally not run in this preparation PR.
-# Package publication is intentionally skipped for v0.22.0.
-# If a separately approved operator run performs packing later, the expected
-# identity is JTechJapan.IntentSystem.Cli.0.22.0.nupkg; this PR does not create it.
+# 3. Do not publish a package in this roll. The v0.22.0 npm gap is documented
+#    below; the four npm tarballs and checksum companions remain attached.
+#    The next-line package identity is JTechJapan.IntentSystem.Cli.0.22.1.nupkg.
 
-# 4. From a metadata-free directory, execute the installed guide entry point.
+# 4. From a metadata-free directory, execute the existing installed guide route.
 intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent <agent> --format json
 intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent <agent> --format markdown
-#   follow the route to this v0.22.0 readiness section; do not read host metadata.
+#   no new guide-facing surface is declared by this roll; verify no reachability debt.
 
-# 5. Confirm the G709 notes/count guards and release/version guards.
+# 5. Confirm the frozen v0.22.0 evidence and v0.22.1 version guards.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
   "FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
@@ -2815,26 +2816,25 @@ git diff --check
 dotnet test IntentSystem.sln -c Release
 ```
 
-The npm publication step is intentionally skipped for v0.22.0: npm
-organisation (organization) access and package-name reservation are incomplete operator
-account actions. The G702 npm publish step does not run in this preparation
-cycle; this is a distribution gap, not a defect. No npm credentials are
-requested or handled. The existing npm entry-point guidance remains available
-for the later operator action.
-
-After the preparation merge lands on `main` and the readiness evidence holds,
-the operator must explicitly approve Release creation. Only then may a
-maintainer/operator (or authorized external release automation) create and
-publish the GitHub Release for `v0.22.0`; publishing it triggers `release.yml`
-(`on: release: published`) to build and publish the NuGet package and the
-per-platform binary artifacts. **Then roll `eng/version.json` immediately** —
-`stableVersion → 0.22.0`, `nextVersion → 0.22.1` — carrying, per **steps 4–6** of the
-[post-release version roll](#post-release-version-roll-g554--required-immediate):
+This roll follows **steps 4–6** of the [post-release version roll](#post-release-version-roll-g554--required-immediate):
 the **DRAFT note stubs in the same commit** (step 4), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step
 5), and a **post-roll green child-main CI check** before the roll counts as
-complete (step 6). The v0.22.0 npm publication remains a separate operator
-account/reservation action rather than a defect in this release.
+complete (step 6).
+
+The v0.22.0 npm registry publication remains skipped because npm organisation
+(organization) access and package-name reservation are incomplete operator
+account actions and `NPM_TOKEN` is absent. The G702 npm publish step does not
+run for v0.22.0; four npm tarballs and their checksum companions are attached
+to the existing Release. This is a distribution gap, not a defect. No npm
+credentials are requested or handled.
+
+The frozen v0.22.0 notes are suitable for the post-merge orchestration action:
+`gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md`.
+This implementation roll does not execute that command or mutate GitHub
+Release state. The roll adds no new guide-facing surface and creates no guide
+reachability debt; existing metadata-free guide entry points remain the
+operator/agent interface.
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2829,12 +2829,13 @@ run for v0.22.0; four npm tarballs and their checksum companions are attached
 to the existing Release. This is a distribution gap, not a defect. No npm
 credentials are requested or handled.
 
-The frozen v0.22.0 notes are suitable for the post-merge orchestration action:
+The published v0.22.0 notes are the canonical EN source for the GitHub Release
+body. If a body resync is needed, orchestration uses only this source:
 `gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md`.
-This implementation roll does not execute that command or mutate GitHub
-Release state. The roll adds no new guide-facing surface and creates no guide
-reachability debt; existing metadata-free guide entry points remain the
-operator/agent interface.
+The published body is already present; this implementation roll does not
+execute that command or mutate GitHub Release state. The roll adds no new
+guide-facing surface and creates no guide reachability debt; existing
+metadata-free guide entry points remain the operator/agent interface.
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.22.0.md
+++ b/docs/en/release-notes-v0.22.0.md
@@ -1,13 +1,15 @@
 # Release Notes — intent-cli v0.22.0
 
-> **prepare-only / UNRELEASED.** This document prepares the v0.22.0 release
-> body and readiness evidence. It creates no GitHub Release or tag, publishes
-> no package, and does not handle credentials. `v0.22.0` is not released by
-> this preparation PR.
+> **RELEASED.** v0.22.0 is the published release at
+> https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.22.0. Its
+> release target is `c06dc49e89446bf3b723612dd72004d628914734`, and workflow
+> run `31903789754` completed successfully with five jobs. The release body
+> and evidence below are the source that orchestration can apply after this
+> roll merges.
 
-Install verification after a separately approved release: `JTechJapan.IntentSystem.Cli --version 0.22.0`.
-The eventual Release location is
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.22.0.
+Clean-install verification observed exactly: `intent-cli 0.22.0-c06dc49-G708`.
+The verification command was `JTechJapan.IntentSystem.Cli --version 0.22.0`.
+NuGet public package index: https://www.nuget.org/packages/JTechJapan.IntentSystem.Cli/0.22.0.
 The preceding shipped scope remains in
 [release-notes-v0.21.0.md](release-notes-v0.21.0.md); it is linked, not restated.
 
@@ -76,31 +78,52 @@ operator decisions. The minor version is justified by these fourteen
 user-visible orchestration and distribution surfaces; the preview boundary and
 the 1.0 compatibility promise remain explicit.
 
+## Published release evidence
+
+- The existing Release has all sixteen attached assets and each checksum companion:
+  `intent-cli-0.22.0-linux-x64.tar.gz`,
+  `intent-cli-0.22.0-linux-x64.tar.gz.sha256`,
+  `intent-cli-0.22.0-osx-arm64.tar.gz`,
+  `intent-cli-0.22.0-osx-arm64.tar.gz.sha256`,
+  `intent-cli-0.22.0-win-x64.zip`,
+  `intent-cli-0.22.0-win-x64.zip.sha256`,
+  `intent-system-0.22.0.tgz`,
+  `intent-system-0.22.0.tgz.sha256`,
+  `j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz`,
+  `j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz.sha256`,
+  `j-tech-japan-intent-cli-linux-x64-0.22.0.tgz`,
+  `j-tech-japan-intent-cli-linux-x64-0.22.0.tgz.sha256`,
+  `j-tech-japan-intent-cli-win32-x64-0.22.0.tgz`,
+  `j-tech-japan-intent-cli-win32-x64-0.22.0.tgz.sha256`,
+  `JTechJapan.IntentSystem.Cli.0.22.0.nupkg`, and
+  `JTechJapan.IntentSystem.Cli.0.22.0.nupkg.sha256`.
+- NuGet is public at version `0.22.0`; the package page and public index are
+  https://www.nuget.org/packages/JTechJapan.IntentSystem.Cli/0.22.0 and
+  https://api.nuget.org/v3/registration5-gz-semver2/jtechjapan.intentsystem.cli/index.json.
+
 ## Distribution boundary — npm is skipped for v0.22.0
 
-npm publication is skipped for v0.22.0 because npm organisation (organization) access and
-package-name reservation are incomplete operator account actions. Therefore
-the G702 npm publish step does not run for v0.22.0. This is a distribution gap,
-not a defect. No credentials are requested or handled, and no package or
-registry state is changed by this prepare-only PR. The existing npm entry-point
-guidance remains documented; publication is a later operator action after the
-account and reservation prerequisites are complete.
+npm registry publication was skipped because npm organisation (organization)
+access, package-name reservation, and `NPM_TOKEN` are absent or incomplete
+operator account prerequisites. No npm package was published to a registry,
+and the G702 npm publish step does not run for v0.22.0. This is a distribution
+gap, not a defect. The existing Release nevertheless has all four npm tarballs
+and their checksum companions attached: `intent-system-0.22.0.tgz`,
+`intent-system-0.22.0.tgz.sha256`,
+`j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz`,
+`j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz.sha256`,
+`j-tech-japan-intent-cli-linux-x64-0.22.0.tgz`,
+`j-tech-japan-intent-cli-linux-x64-0.22.0.tgz.sha256`,
+`j-tech-japan-intent-cli-win32-x64-0.22.0.tgz`, and
+`j-tech-japan-intent-cli-win32-x64-0.22.0.tgz.sha256`. No credentials or
+operator account actions are performed by this roll.
 
-## Release-readiness gate (G709)
+## Release body source for orchestration
 
-- [ ] Keep `eng/version.json` at stable `0.21.0` and next `0.22.0` until an
-      operator separately approves a release.
-- [ ] Verify the fourteen-unit inventory and all fifteen first-parent commits
-      with the command above, then run the focused guards and full Release suite.
-- [ ] Build the CLI and execute the existing metadata-free
-      `intent-cli guide orchestrator-thread` route before following this
-      readiness section; the installed guide is the operator/agent entry point.
-- [ ] Confirm EN/JA notes and readiness have the same unit, merge, and npm-skip
-      contract.
-- [ ] Do not create a tag or GitHub Release, publish NuGet or npm, or handle
-      credentials in this prepare-only slice.
+After this PR merges, orchestration may apply this exact source to the existing
+Release with:
 
-Publishing v0.22.0 remains an explicitly operator-approved future action. The
-G702 npm publish step does not run in this release-preparation cycle; the
-incomplete npm organization and package-name reservation remain a distribution
-gap, not a defect.
+`gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md`
+
+This implementation roll does not execute that command and does not mutate
+GitHub Release state.

--- a/docs/en/release-notes-v0.22.0.md
+++ b/docs/en/release-notes-v0.22.0.md
@@ -3,12 +3,17 @@
 > **RELEASED.** v0.22.0 is the published release at
 > https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.22.0. Its
 > release target is `c06dc49e89446bf3b723612dd72004d628914734`, and workflow
-> run `31903789754` completed successfully with five jobs. The release body
-> and evidence below are the source that orchestration can apply after this
-> roll merges.
+> run `31903789754` completed successfully with five jobs. This document
+> records the published Release body and evidence; the canonical GitHub Release
+> body source is this English note.
 
 Clean-install verification observed exactly: `intent-cli 0.22.0-c06dc49-G708`.
-The verification command was `JTechJapan.IntentSystem.Cli --version 0.22.0`.
+The executable verification pair was:
+
+`dotnet tool install JTechJapan.IntentSystem.Cli --version 0.22.0 --tool-path <clean-dir> --source https://api.nuget.org/v3/index.json`
+
+followed by `<clean-dir>/intent-cli --version`, yielding exactly
+`intent-cli 0.22.0-c06dc49-G708`.
 NuGet public package index: https://www.nuget.org/packages/JTechJapan.IntentSystem.Cli/0.22.0.
 The preceding shipped scope remains in
 [release-notes-v0.21.0.md](release-notes-v0.21.0.md); it is linked, not restated.
@@ -118,12 +123,13 @@ and their checksum companions attached: `intent-system-0.22.0.tgz`,
 `j-tech-japan-intent-cli-win32-x64-0.22.0.tgz.sha256`. No credentials or
 operator account actions are performed by this roll.
 
-## Release body source for orchestration
+## Canonical GitHub Release body source
 
-After this PR merges, orchestration may apply this exact source to the existing
-Release with:
+This English note is the canonical source for the published GitHub Release
+body. Orchestration may re-apply this exact EN source when a body resync is
+needed with:
 
 `gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md`
 
-This implementation roll does not execute that command and does not mutate
-GitHub Release state.
+The published body is already present; this repair does not execute that
+command and does not mutate GitHub Release state.

--- a/docs/en/release-notes-v0.22.1.md
+++ b/docs/en/release-notes-v0.22.1.md
@@ -1,0 +1,15 @@
+# Release Notes — intent-cli v0.22.1
+
+> **⚠️ DRAFT / UNRELEASED.** This stub is created by the mandatory immediate
+> post-release version roll after v0.22.0. The release-prep packet authors the
+> real content; this must not be treated as a changelog until that packet
+> replaces it.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.22.1`.
+The eventual release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.22.1.
+
+## Release-readiness gate
+
+This DRAFT has no feature scope yet. The release-prep packet must replace it
+with substantive notes and record the full readiness evidence before release.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2884,9 +2884,11 @@ package-name reservation が未完了の operator account action であり、`NP
 G702 npm publish step は v0.22.0 では実行せず、四つの npm tarball と checksum companion は既存 Release に添付されている。
 これは defect ではなく distribution gap です。npm credentials は要求・処理しません。
 
-凍結した v0.22.0 notes は merge 後の orchestration が次の command で既存 Release に適用できる source です:
-`gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/ja/release-notes-v0.22.0.md`。
-この implementation roll は command を実行せず、GitHub Release state を変更しません。
+凍結した v0.22.0 の EN note が公開済み GitHub Release body の canonical source です。JA note は
+明示的な parity mirror であり、同じ Release を JA note で上書きしてはいけません。body resync が必要な場合も
+orchestration は EN source のみを使います:
+`gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md`。
+公開済みの body はすでに存在し、この implementation roll は command を実行せず GitHub Release state を変更しません。
 この roll は新しい guide-facing surface を追加せず、reachability debt も作りません。既存の metadata-free
 guide entry point が operator/agent interface のままです。
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2826,44 +2826,45 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.22.0)
+### 次リリース準備(v0.22.1)
 
-**`v0.21.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.22.0` です。[v0.22.0 notes](release-notes-v0.22.0.md) は substantive な
-prepare-only notes です。直前の出荷範囲は
-[release-notes-v0.21.0.md](release-notes-v0.21.0.md) を参照し、ここでは重複記載しません。
+**`v0.22.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
+`0.22.1` です。[v0.22.0 notes](release-notes-v0.22.0.md) は凍結された
+released evidence で、[v0.22.1 DRAFT](release-notes-v0.22.1.md) は次のラインの stub です。
+古い出荷範囲は [release-notes-v0.21.0.md](release-notes-v0.21.0.md) を参照し、ここでは重複記載しません。
 
-**リリース準備検証(`v0.22.0` release-preparation PR のマージ前に実行):**
+Rolled policy: `stableVersion → 0.22.0`; `nextVersion → 0.22.1`。
+
+**`v0.22.1` のリリース準備検証:**
 
 claims-enabled host では release artifact を編集する前に release scope を acquire / verify します。
 同じ shared verification が G680 の全 start surface を gate し、claims store が無ければ legacy
-single-team behavior を維持します。
-この記録は preparation 用であり、tag または Release を作成せず、package を publish せず、
-credentials を扱いません。
+single-team behavior を維持します。この roll は release documentation と version policy だけを変更し、
+tag または Release を作成せず、package を publish せず、credentials を扱いません。
 
 ```bash
-# 0. release-prep ownership を acquire / verify (preview-through-1.x)。
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.22.0 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.22.0 --team <team> --format json
+# 0. 次の patch line の release-prep ownership を acquire / verify。
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.22.1 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.22.1 --team <team> --format json
 
-# 1. version policy が release-to-be-cut を記録していることを確認。
-cat eng/version.json   # stableVersion 0.21.0 (published), nextVersion 0.22.0 (to release)
+# 1. roll 済み version policy を確認。
+cat eng/version.json   # stableVersion 0.22.0 (published), nextVersion 0.22.1 (next line)
 
-# 2. build して表示バージョン識別(version + git SHA + G-unit)を確認。
+# 2. 次のラインの表示バージョン識別を build して確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-#   期待する形: intent-cli 0.22.0-<sha>-G<unit>   (古いリテラルではない)
+#   期待する形: intent-cli 0.22.1-<sha>-G<unit>
 
-# 3. v0.22.0 では package publication を意図的に実行しない。
-# 別途承認された operator run で後から pack する場合の expected identity は
-# JTechJapan.IntentSystem.Cli.0.22.0.nupkg。この PR はそれを作成しない。
+# 3. この roll では package を publish しない。v0.22.0 の npm gap は下記に記録し、
+#    四つの npm tarball と checksum companion は既存 Release に残る。
+#    次のラインの package identity は JTechJapan.IntentSystem.Cli.0.22.1.nupkg。
 
-# 4. metadata-free directory から installed guide の入口を実行。
+# 4. metadata-free directory から既存 installed guide route を実行。
 intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent <agent> --format json
 intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent <agent> --format markdown
-#   この route から v0.22.0 readiness section に進む。host metadata は読まない。
+#   この roll は新しい guide-facing surface を宣言しないため、reachability debt が無いことを確認。
 
-# 5. G709 notes/count guard と release/version guard を確認。
+# 5. 凍結した v0.22.0 evidence と v0.22.1 version guard を確認。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
   -c Release --filter \
   "FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
@@ -2873,23 +2874,21 @@ git diff --check
 dotnet test IntentSystem.sln -c Release
 ```
 
-v0.22.0 の npm publication は意図的に skip します。npm organisation (organization) access と package-name
-reservation は未完了の operator account action です。そのため G702 npm publish step は v0.22.0
-では実行しません。これは defect ではなく distribution gap です。npm credentials は要求・処理せず、
-既存の npm entry-point guidance は後の operator action のために利用可能なままにします。
-
-準備コミットが `main` に入り readiness の証跡が揃ったら、operator が Release 作成を
-明示的に承認しなければなりません。そのうえで初めて maintainer/operator(または承認済みの
-外部リリース自動化)が `v0.22.0` の GitHub Release を作成・公開できます。公開すると
-`release.yml`(`on: release: published`)が起動し、NuGet package とプラットフォーム別
-バイナリを build/publish します。**その後すぐに `eng/version.json` を roll します** —
-`stableVersion → 0.22.0`、`nextVersion → 0.22.1` —
-[リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
-**ステップ 4–6** に従い、**同一コミットに DRAFT note スタブ**(ステップ 4)、
+この roll は [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
+**ステップ 4–6** に従います。**同一コミットに DRAFT note スタブ**(ステップ 4)、
 **「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 5)、
-そして roll を完了とみなす前の **roll 後の child main CI green 確認**(ステップ 6)を
-伴います。v0.22.0 の npm publication は別途 operator account / reservation action であり、
-この release の defect ではありません。
+そして **roll 後の child main CI green 確認**(ステップ 6)が完了条件です。
+
+v0.22.0 の npm registry publication は、npm organisation (organization) access、
+package-name reservation が未完了の operator account action であり、`NPM_TOKEN` も absent のため skip した。
+G702 npm publish step は v0.22.0 では実行せず、四つの npm tarball と checksum companion は既存 Release に添付されている。
+これは defect ではなく distribution gap です。npm credentials は要求・処理しません。
+
+凍結した v0.22.0 notes は merge 後の orchestration が次の command で既存 Release に適用できる source です:
+`gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/ja/release-notes-v0.22.0.md`。
+この implementation roll は command を実行せず、GitHub Release state を変更しません。
+この roll は新しい guide-facing surface を追加せず、reachability debt も作りません。既存の metadata-free
+guide entry point が operator/agent interface のままです。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.22.0.md
+++ b/docs/ja/release-notes-v0.22.0.md
@@ -3,11 +3,16 @@
 > **公開済み (RELEASED)。** v0.22.0 は
 > https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.22.0 で公開済みです。
 > release target は `c06dc49e89446bf3b723612dd72004d628914734`、workflow run
-> `31903789754` は五つの job すべてで成功しました。以下の Release 本文と evidence は、
-> この roll の merge 後に orchestration が適用できる source です。
+> `31903789754` は五つの job すべてで成功しました。この文書は公開済みの Release 本文と
+> evidence を記録します。GitHub Release 本文の canonical source は English note です。
 
 clean-install で観測した version string は正確に `intent-cli 0.22.0-c06dc49-G708` です。
-verification command は `JTechJapan.IntentSystem.Cli --version 0.22.0` です。
+実行した verification pair は次の通りです:
+
+`dotnet tool install JTechJapan.IntentSystem.Cli --version 0.22.0 --tool-path <clean-dir> --source https://api.nuget.org/v3/index.json`
+
+続いて `<clean-dir>/intent-cli --version` を実行し、正確に
+`intent-cli 0.22.0-c06dc49-G708` を得ました。
 NuGet public package index:
 https://www.nuget.org/packages/JTechJapan.IntentSystem.Cli/0.22.0。
 直前の出荷範囲は [release-notes-v0.21.0.md](release-notes-v0.21.0.md) にリンクし、
@@ -106,10 +111,12 @@ skip しました。registry に npm package は publish しておらず、G702 
 `j-tech-japan-intent-cli-linux-x64-0.22.0.tgz`、`j-tech-japan-intent-cli-linux-x64-0.22.0.tgz.sha256`、
 `j-tech-japan-intent-cli-win32-x64-0.22.0.tgz`、`j-tech-japan-intent-cli-win32-x64-0.22.0.tgz.sha256`。この roll は credentials や operator account action を行いません。
 
-## Release body source for orchestration — リリース本文 source
+## Release body mirror — リリース本文 mirror
 
-この PR の merge 後、orchestration は既存 Release に次の source を適用できます:
+この Japanese note は EN canonical GitHub Release body の明示的な parity mirror です。
+公開済みの同じ Release を JA note で上書きしてはいけません。body resync が必要な場合も、
+orchestration は canonical EN source のみを使います:
 
-`gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/ja/release-notes-v0.22.0.md`
+`gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md`
 
-この implementation roll は command を実行せず、GitHub Release state を変更しません。
+公開済みの body はすでに存在し、この repair は command を実行せず、GitHub Release state を変更しません。

--- a/docs/ja/release-notes-v0.22.0.md
+++ b/docs/ja/release-notes-v0.22.0.md
@@ -1,14 +1,15 @@
 # リリースノート — intent-cli v0.22.0
 
-> **prepare-only / 未リリース。** この文書は v0.22.0 の Release 本文と
-> readiness evidence を準備します。この準備 PR は GitHub Release または tag を作成せず、
-> package を publish せず、credentials を扱いません。`v0.22.0` はこの準備 PR では
-> release されません。
+> **公開済み (RELEASED)。** v0.22.0 は
+> https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.22.0 で公開済みです。
+> release target は `c06dc49e89446bf3b723612dd72004d628914734`、workflow run
+> `31903789754` は五つの job すべてで成功しました。以下の Release 本文と evidence は、
+> この roll の merge 後に orchestration が適用できる source です。
 
-Release を別途承認した後の install verification:
-`JTechJapan.IntentSystem.Cli --version 0.22.0`。
-将来の Release の場所は
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.22.0 です。
+clean-install で観測した version string は正確に `intent-cli 0.22.0-c06dc49-G708` です。
+verification command は `JTechJapan.IntentSystem.Cli --version 0.22.0` です。
+NuGet public package index:
+https://www.nuget.org/packages/JTechJapan.IntentSystem.Cli/0.22.0。
 直前の出荷範囲は [release-notes-v0.21.0.md](release-notes-v0.21.0.md) にリンクし、
 ここでは重複記載しません。
 
@@ -75,20 +76,40 @@ distribution、update channel、feedback guidance は operator decision を記�
 minor version はこの十四件の user-visible な orchestration / distribution surface により妥当で、
 preview boundary と 1.0 compatibility promise は明示したままです。
 
+## 公開済み Release evidence
+
+- 既存の Release には十六個の asset と、それぞれの checksum companion が添付されています。
+  `intent-cli-0.22.0-linux-x64.tar.gz`、`intent-cli-0.22.0-linux-x64.tar.gz.sha256`、
+  `intent-cli-0.22.0-osx-arm64.tar.gz`、`intent-cli-0.22.0-osx-arm64.tar.gz.sha256`、
+  `intent-cli-0.22.0-win-x64.zip`、`intent-cli-0.22.0-win-x64.zip.sha256`、
+  `intent-system-0.22.0.tgz`、`intent-system-0.22.0.tgz.sha256`、
+  `j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz`、
+  `j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz.sha256`、
+  `j-tech-japan-intent-cli-linux-x64-0.22.0.tgz`、
+  `j-tech-japan-intent-cli-linux-x64-0.22.0.tgz.sha256`、
+  `j-tech-japan-intent-cli-win32-x64-0.22.0.tgz`、
+  `j-tech-japan-intent-cli-win32-x64-0.22.0.tgz.sha256`、
+  `JTechJapan.IntentSystem.Cli.0.22.0.nupkg`、
+  `JTechJapan.IntentSystem.Cli.0.22.0.nupkg.sha256` です。
+- NuGet は version `0.22.0` で public です。package page と public index は
+  https://www.nuget.org/packages/JTechJapan.IntentSystem.Cli/0.22.0 と
+  https://api.nuget.org/v3/registration5-gz-semver2/jtechjapan.intentsystem.cli/index.json です。
+
 ## Distribution boundary — v0.22.0 の npm skip
 
-v0.22.0 では npm publication を skip します。npm organisation (organization) access と package-name reservation
-は未完了の operator account action です。そのため G702 npm publish step は v0.22.0 では実行しません。
-これは defect ではなく distribution gap です。この prepare-only PR は credentials を要求・処理せず、
-package や registry state を変更しません。既存の npm entry-point guidance は記録したままにし、
-account と reservation の前提が完了した後の operator action として publication を扱います。
+v0.22.0 の npm registry publication は、npm organisation (organization) access、
+package-name reservation、`NPM_TOKEN` が absent または未完了の operator account prerequisite のため
+skip しました。registry に npm package は publish しておらず、G702 npm publish step は v0.22.0 では実行しません。
+これは defect ではなく distribution gap です。既存の Release には四つの npm tarball と checksum companion が添付されています:
+`intent-system-0.22.0.tgz`、`intent-system-0.22.0.tgz.sha256`、
+`j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz`、`j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz.sha256`、
+`j-tech-japan-intent-cli-linux-x64-0.22.0.tgz`、`j-tech-japan-intent-cli-linux-x64-0.22.0.tgz.sha256`、
+`j-tech-japan-intent-cli-win32-x64-0.22.0.tgz`、`j-tech-japan-intent-cli-win32-x64-0.22.0.tgz.sha256`。この roll は credentials や operator account action を行いません。
 
-## Release-readiness gate (G709) — リリース準備ゲート
+## Release body source for orchestration — リリース本文 source
 
-- [ ] operator が別途 Release を承認するまで `eng/version.json` を stable `0.21.0`、next `0.22.0` に保つ。
-- [ ] 上記 command で十四 unit と十五 first-parent commit を確認し、focused guard と full Release suite を実行する。
-- [ ] CLI を build し、metadata-free な `intent-cli guide orchestrator-thread` の既存 route を実行してから、この readiness section に進む。installed guide が operator/agent の入口です。
-- [ ] EN/JA notes と readiness が同じ unit、merge、npm-skip contract を持つことを確認する。
-- [ ] この prepare-only slice では tag、GitHub Release、NuGet または npm publish を行わず、credentials を扱わない。
+この PR の merge 後、orchestration は既存 Release に次の source を適用できます:
 
-v0.22.0 の publish は operator が明示的に承認する将来の action です。v0.22.0 の publish では G702 npm publish step を実行せず、未完了の npm organization と package-name reservation は defect ではなく distribution gap として残ります。
+`gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/ja/release-notes-v0.22.0.md`
+
+この implementation roll は command を実行せず、GitHub Release state を変更しません。

--- a/docs/ja/release-notes-v0.22.1.md
+++ b/docs/ja/release-notes-v0.22.1.md
@@ -1,0 +1,14 @@
+# リリースノート — intent-cli v0.22.1
+
+> **⚠️ DRAFT / 未リリース。** この stub は v0.22.0 後の mandatory immediate
+> post-release version roll で作成されました。release-prep パケットが author します。
+> そのパケットが置き換えるまで、このファイルを changelog として扱ってはいけません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.22.1`。
+将来の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.22.1 に publish されます。
+
+## リリース準備ゲート
+
+この DRAFT にはまだ feature scope がありません。release-prep パケットが substantive な
+notes と置き換え、Release 前に full readiness evidence を記録しなければなりません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.21.0",
-  "nextVersion": "0.22.0"
+  "stableVersion": "0.22.0",
+  "nextVersion": "0.22.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0150DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0150DocsTests.cs
@@ -17,8 +17,6 @@ public sealed class ReleaseNotesV0150DocsTests
         var path = Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md");
         var reference = File.ReadAllText(path);
         var policy = RepoVersionPolicySource.Read();
-        var nextPatch = NextPatch(policy.NextVersion);
-        var nextMinor = NextMinor(policy.NextVersion);
 
         Assert.Contains(
             language == "en"
@@ -26,9 +24,10 @@ public sealed class ReleaseNotesV0150DocsTests
                 : $"### 次リリース準備(v{policy.NextVersion})",
             reference,
             StringComparison.Ordinal);
-        Assert.Contains($"stableVersion → {policy.NextVersion}", reference, StringComparison.Ordinal);
-        Assert.Contains($"nextVersion → {nextPatch}", reference, StringComparison.Ordinal);
-        Assert.DoesNotContain($"nextVersion → {nextMinor}", reference, StringComparison.Ordinal);
+        Assert.Contains($"stableVersion → {policy.StableVersion}", reference, StringComparison.Ordinal);
+        Assert.Contains($"nextVersion → {policy.NextVersion}", reference, StringComparison.Ordinal);
+        Assert.DoesNotContain($"nextVersion → {NextPatch(policy.NextVersion)}", reference, StringComparison.Ordinal);
+        Assert.DoesNotContain($"nextVersion → {NextMinor(policy.NextVersion)}", reference, StringComparison.Ordinal);
     }
 
     private static string NextPatch(string version)

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
@@ -4,8 +4,8 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G694 keeps the published v0.21.0 notes bilingual and frozen while G709
-/// points the post-release readiness at substantive v0.22.0 preparation notes.
+/// G694 keeps the published v0.21.0 notes bilingual and frozen while G710
+/// points post-release readiness at the v0.22.1 draft line.
 /// </summary>
 public sealed class ReleaseNotesV0210DocsTests
 {
@@ -134,7 +134,7 @@ public sealed class ReleaseNotesV0210DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void CurrentPolicyAndReadinessFollowVersionPolicyAndNextNotesAreReal(string language)
+    public void CurrentPolicyAndReadinessFollowVersionPolicyAndNextNotesAreDraft(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
@@ -142,6 +142,7 @@ public sealed class ReleaseNotesV0210DocsTests
         var notes = Read(language);
         var currentNotes = $"release-notes-v{policy.NextVersion}.md";
         var shippedNotes = $"release-notes-v{policy.StableVersion}.md";
+        var stableNotes = File.ReadAllText(Path.Combine(root, "docs", language, shippedNotes));
 
         RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
         Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
@@ -154,21 +155,33 @@ public sealed class ReleaseNotesV0210DocsTests
                 : $"次リリース準備(v{policy.NextVersion})",
             reference,
             StringComparison.Ordinal);
-        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.StableVersion}", notes, StringComparison.Ordinal);
-        Assert.Contains($"releases/tag/v{policy.StableVersion}", notes, StringComparison.Ordinal);
+        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.StableVersion}", stableNotes, StringComparison.Ordinal);
+        Assert.Contains($"releases/tag/v{policy.StableVersion}", stableNotes, StringComparison.Ordinal);
         var currentNotesText = File.ReadAllText(Path.Combine(root, "docs", language, currentNotes));
-        Assert.Contains("prepare-only", currentNotesText, StringComparison.OrdinalIgnoreCase);
+        var currentNotesCompact = Regex.Replace(currentNotesText, @"[>\s]+", " ");
         Assert.Contains(
-            language == "en" ? "exactly fourteen merged feature units" : "正確に十四件の merged feature unit",
+            "DRAFT /",
             currentNotesText,
+            StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "UNRELEASED" : "未リリース", currentNotesCompact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en"
+                ? "release-prep packet authors the real content"
+                : "release-prep パケットが author します",
+            currentNotesCompact,
             StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("DRAFT /", currentNotesText, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en"
+                ? "must not be treated as a changelog"
+                : "changelog として扱ってはいけません",
+            currentNotesCompact,
+            StringComparison.OrdinalIgnoreCase);
         Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", currentNotesText, StringComparison.Ordinal);
         Assert.Contains($"releases/tag/v{policy.NextVersion}", currentNotesText, StringComparison.Ordinal);
-        Assert.DoesNotContain("DRAFT /", notes, StringComparison.Ordinal);
-        Assert.DoesNotContain("UNRELEASED", notes, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("未リリース", notes, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("DRAFT /", stableNotes, StringComparison.Ordinal);
+        Assert.DoesNotContain("UNRELEASED", stableNotes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("未リリース", stableNotes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("prepare-only", stableNotes, StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
@@ -23,6 +23,9 @@ public sealed class ReleaseNotesV0210DocsTests
         .. Units.Select(unit => unit.Merge),
     ];
 
+    private const string StableCleanInstallCommand =
+        "dotnet tool install JTechJapan.IntentSystem.Cli --version 0.22.0 --tool-path <clean-dir> --source https://api.nuget.org/v3/index.json";
+
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
@@ -155,7 +158,9 @@ public sealed class ReleaseNotesV0210DocsTests
                 : $"次リリース準備(v{policy.NextVersion})",
             reference,
             StringComparison.Ordinal);
-        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.StableVersion}", stableNotes, StringComparison.Ordinal);
+        Assert.Contains(StableCleanInstallCommand, stableNotes, StringComparison.Ordinal);
+        Assert.Contains("<clean-dir>/intent-cli --version", stableNotes, StringComparison.Ordinal);
+        Assert.DoesNotContain("`JTechJapan.IntentSystem.Cli --version 0.22.0`", stableNotes, StringComparison.Ordinal);
         Assert.Contains($"releases/tag/v{policy.StableVersion}", stableNotes, StringComparison.Ordinal);
         var currentNotesText = File.ReadAllText(Path.Combine(root, "docs", language, currentNotes));
         var currentNotesCompact = Regex.Replace(currentNotesText, @"[>\s]+", " ");

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -4,8 +4,8 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G709: the v0.22.0 preparation notes are a checkable, bilingual inventory
-/// of the exact first-parent range, not a second copy of an unverified changelog.
+/// G710: the v0.22.0 released notes are a checkable, bilingual inventory of the
+/// exact first-parent range and published distribution evidence.
 /// </summary>
 public sealed class ReleaseNotesV0220DocsTests
 {
@@ -31,6 +31,38 @@ public sealed class ReleaseNotesV0220DocsTests
     [
         "8ee71bc81697b91b9e155a52a25b64225ecc7427",
         .. Units.Select(unit => unit.Merge),
+    ];
+
+    private static readonly string[] ReleaseAssets =
+    [
+        "intent-cli-0.22.0-linux-x64.tar.gz",
+        "intent-cli-0.22.0-linux-x64.tar.gz.sha256",
+        "intent-cli-0.22.0-osx-arm64.tar.gz",
+        "intent-cli-0.22.0-osx-arm64.tar.gz.sha256",
+        "intent-cli-0.22.0-win-x64.zip",
+        "intent-cli-0.22.0-win-x64.zip.sha256",
+        "intent-system-0.22.0.tgz",
+        "intent-system-0.22.0.tgz.sha256",
+        "j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz",
+        "j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz.sha256",
+        "j-tech-japan-intent-cli-linux-x64-0.22.0.tgz",
+        "j-tech-japan-intent-cli-linux-x64-0.22.0.tgz.sha256",
+        "j-tech-japan-intent-cli-win32-x64-0.22.0.tgz",
+        "j-tech-japan-intent-cli-win32-x64-0.22.0.tgz.sha256",
+        "JTechJapan.IntentSystem.Cli.0.22.0.nupkg",
+        "JTechJapan.IntentSystem.Cli.0.22.0.nupkg.sha256",
+    ];
+
+    private static readonly string[] NpmAssets =
+    [
+        "intent-system-0.22.0.tgz",
+        "intent-system-0.22.0.tgz.sha256",
+        "j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz",
+        "j-tech-japan-intent-cli-darwin-arm64-0.22.0.tgz.sha256",
+        "j-tech-japan-intent-cli-linux-x64-0.22.0.tgz",
+        "j-tech-japan-intent-cli-linux-x64-0.22.0.tgz.sha256",
+        "j-tech-japan-intent-cli-win32-x64-0.22.0.tgz",
+        "j-tech-japan-intent-cli-win32-x64-0.22.0.tgz.sha256",
     ];
 
     [Theory]
@@ -99,32 +131,58 @@ public sealed class ReleaseNotesV0220DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void NotesMakePrepareOnlyAndNpmDistributionGapCheckable(string language)
+    public void NotesMakeReleasedEvidenceAndNpmDistributionGapCheckable(string language)
     {
         var notes = Read(language);
         var compact = Regex.Replace(notes, @"\s+", " ");
 
-        Assert.Contains("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(language == "en" ? "UNRELEASED" : "未リリース", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(language == "en" ? "RELEASED" : "公開済み", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("UNRELEASED", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("未リリース", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("v0.22.0 is not released", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("v0.22.0 は未リリース", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.22.0", notes, StringComparison.Ordinal);
+        Assert.Contains("c06dc49e89446bf3b723612dd72004d628914734", notes, StringComparison.Ordinal);
+        Assert.Contains("31903789754", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "five jobs" : "五つの job", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-cli 0.22.0-c06dc49-G708", notes, StringComparison.Ordinal);
+        Assert.Contains("https://www.nuget.org/packages/JTechJapan.IntentSystem.Cli/0.22.0", notes, StringComparison.Ordinal);
+        Assert.Contains("https://api.nuget.org/v3/registration5-gz-semver2/jtechjapan.intentsystem.cli/index.json", notes, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "all sixteen attached assets" : "十六個の asset", compact, StringComparison.OrdinalIgnoreCase);
+        foreach (var asset in ReleaseAssets)
+        {
+            Assert.Contains(asset, notes, StringComparison.Ordinal);
+        }
+
         Assert.Contains("G702 npm publish step", compact, StringComparison.Ordinal);
         Assert.Contains("v0.22.0", compact, StringComparison.Ordinal);
+        Assert.Contains("npm organisation", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("package-name reservation", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("NPM_TOKEN", compact, StringComparison.Ordinal);
         Assert.Contains(
-            language == "en" ? "npm organisation" : "npm organisation",
+            language == "en" ? "No npm package was published to a registry" : "registry に npm package は publish しておらず",
             compact,
             StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("package-name reservation", compact, StringComparison.OrdinalIgnoreCase);
+        foreach (var asset in NpmAssets)
+        {
+            Assert.Contains(asset, notes, StringComparison.Ordinal);
+        }
+
         Assert.Contains(
             language == "en" ? "distribution gap, not a defect" : "defect ではなく distribution gap",
             compact,
             StringComparison.OrdinalIgnoreCase);
         Assert.Contains(
-            language == "en" ? "creates no GitHub Release or tag" : "GitHub Release または tag を作成せず",
+            language == "en" ? "does not execute that command and does not mutate GitHub Release state" : "command を実行せず、GitHub Release state を変更しません",
             compact,
             StringComparison.OrdinalIgnoreCase);
         Assert.Contains(
-            language == "en" ? "Release-readiness gate" : "リリース準備ゲート",
+            language == "en"
+                ? "gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md"
+                : "gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/ja/release-notes-v0.22.0.md",
             notes,
-            StringComparison.OrdinalIgnoreCase);
+            StringComparison.Ordinal);
     }
 
     [Theory]
@@ -188,24 +246,31 @@ public sealed class ReleaseNotesV0220DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void DeveloperReadinessMirrorsThePrepareOnlyContract(string language)
+    public void DeveloperReadinessMirrorsTheReleasedRollContract(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
         var heading = language == "en"
-            ? "### Next release readiness (v0.22.0)"
-            : "### 次リリース準備(v0.22.0)";
+            ? "### Next release readiness (v0.22.1)"
+            : "### 次リリース準備(v0.22.1)";
         var start = reference.IndexOf(heading, StringComparison.Ordinal);
         Assert.True(start >= 0);
         var nextHeading = reference.IndexOf("\n### ", start + heading.Length, StringComparison.Ordinal);
         var section = reference[start..(nextHeading < 0 ? reference.Length : nextHeading)];
+        var compact = Regex.Replace(section, @"\s+", " ");
 
         Assert.Contains("release-notes-v0.22.0.md", section, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.22.1.md", section, StringComparison.Ordinal);
         Assert.Contains("G702 npm publish step", section, StringComparison.Ordinal);
         Assert.Contains("distribution gap", section, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("guide orchestrator-thread", section, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0220DocsTests", section, StringComparison.Ordinal);
         Assert.DoesNotContain("v0.21.1", section, StringComparison.Ordinal);
+        Assert.Contains("gh release edit v0.22.0", section, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "no guide reachability debt" : "reachability debt も作りません",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     private static void AssertUnitCitationAssociations(

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -65,6 +65,10 @@ public sealed class ReleaseNotesV0220DocsTests
         "j-tech-japan-intent-cli-win32-x64-0.22.0.tgz.sha256",
     ];
 
+    private const string CleanInstallCommand =
+        "dotnet tool install JTechJapan.IntentSystem.Cli --version 0.22.0 --tool-path <clean-dir> --source https://api.nuget.org/v3/index.json";
+    private const string CleanQueryCommand = "<clean-dir>/intent-cli --version";
+
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
@@ -146,7 +150,7 @@ public sealed class ReleaseNotesV0220DocsTests
         Assert.Contains("c06dc49e89446bf3b723612dd72004d628914734", notes, StringComparison.Ordinal);
         Assert.Contains("31903789754", notes, StringComparison.Ordinal);
         Assert.Contains(language == "en" ? "five jobs" : "五つの job", compact, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("intent-cli 0.22.0-c06dc49-G708", notes, StringComparison.Ordinal);
+        AssertCleanInstallEvidence(notes, language);
         Assert.Contains("https://www.nuget.org/packages/JTechJapan.IntentSystem.Cli/0.22.0", notes, StringComparison.Ordinal);
         Assert.Contains("https://api.nuget.org/v3/registration5-gz-semver2/jtechjapan.intentsystem.cli/index.json", notes, StringComparison.Ordinal);
         Assert.Contains(language == "en" ? "all sixteen attached assets" : "十六個の asset", compact, StringComparison.OrdinalIgnoreCase);
@@ -180,9 +184,36 @@ public sealed class ReleaseNotesV0220DocsTests
         Assert.Contains(
             language == "en"
                 ? "gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md"
-                : "gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/ja/release-notes-v0.22.0.md",
+                : "gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md",
             notes,
             StringComparison.Ordinal);
+        if (language == "en")
+        {
+            Assert.Contains("canonical source", compact, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Contains("parity mirror", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("JA note で上書きしてはいけません", compact, StringComparison.Ordinal);
+            Assert.DoesNotContain("--notes-file docs/ja/release-notes-v0.22.0.md", notes, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void CleanInstallGuardRejectsPackageIdAsCommand(string language)
+    {
+        var notes = Read(language);
+        AssertCleanInstallEvidence(notes, language);
+
+        var invalid = notes.Replace(
+            CleanInstallCommand,
+            "JTechJapan.IntentSystem.Cli --version 0.22.0",
+            StringComparison.Ordinal);
+
+        Assert.ThrowsAny<Xunit.Sdk.XunitException>(
+            () => AssertCleanInstallEvidence(invalid, language));
     }
 
     [Theory]
@@ -266,7 +297,15 @@ public sealed class ReleaseNotesV0220DocsTests
         Assert.Contains("guide orchestrator-thread", section, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0220DocsTests", section, StringComparison.Ordinal);
         Assert.DoesNotContain("v0.21.1", section, StringComparison.Ordinal);
-        Assert.Contains("gh release edit v0.22.0", section, StringComparison.Ordinal);
+        Assert.Contains(
+            "gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md",
+            section,
+            StringComparison.Ordinal);
+        if (language == "ja")
+        {
+            Assert.Contains("parity mirror", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("--notes-file docs/ja/release-notes-v0.22.0.md", section, StringComparison.Ordinal);
+        }
         Assert.Contains(
             language == "en" ? "no guide reachability debt" : "reachability debt も作りません",
             compact,
@@ -290,6 +329,18 @@ public sealed class ReleaseNotesV0220DocsTests
             Assert.Contains(unit.Unit, table.Value, StringComparison.Ordinal);
             Assert.Contains(unit.Pr, table.Value, StringComparison.Ordinal);
         }
+    }
+
+    private static void AssertCleanInstallEvidence(string notes, string language)
+    {
+        Assert.Contains(CleanInstallCommand, notes, StringComparison.Ordinal);
+        Assert.Contains(CleanQueryCommand, notes, StringComparison.Ordinal);
+        Assert.Contains("intent-cli 0.22.0-c06dc49-G708", notes, StringComparison.Ordinal);
+        Assert.DoesNotContain("`JTechJapan.IntentSystem.Cli --version 0.22.0`", notes, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "yielding exactly" : "正確に",
+            notes,
+            StringComparison.OrdinalIgnoreCase);
     }
 
     private static string SwapUnitCitations(


### PR DESCRIPTION
Closes #1536

## Summary
- roll eng/version.json to stable 0.22.0 and next 0.22.1
- freeze bilingual v0.22.0 notes with Release, workflow, asset, NuGet, clean-install, and truthful npm-skip evidence
- add bilingual v0.22.1 DRAFT stubs and refresh release-readiness guards
- preserve the post-merge orchestration gh release edit source without mutating the existing Release

## Verification
- focused release/readiness guards: 82 passed
- full Release suite: 5,098 passed, 1 skipped
- git diff --check: passed
- built CLI guide orchestrator-thread: JSON and Markdown passed from a metadata-free directory
- no tag, Release edit, package publish, or credential/account action performed

Exact release target: c06dc49e89446bf3b723612dd72004d628914734
Workflow evidence: run 31903789754, five jobs succeeded
Clean-install observed version: intent-cli 0.22.0-c06dc49-G708