### PR TITLE
G711: publish npm through Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@
 #
 #   3. Prepares the npm entry package plus its per-platform optional packages,
 #      verifies checksums/version identity, and publishes them only on the same
-#      real-release event and guarded secret path as NuGet.
+#      real-release event through GitHub Actions OIDC trusted publishing.
 #
 #   4. Attaches the .nupkg, npm packages, and per-platform binary archives
 #      (plus checksums) to the triggering GitHub Release.
@@ -289,6 +289,9 @@ jobs:
     needs: [nupkg, binaries]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -298,8 +301,16 @@ jobs:
       - name: Setup Node.js for release packaging
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.14.0
           registry-url: https://registry.npmjs.org
+
+      - name: Pin npm CLI for trusted publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm install --global npm@11.5.1
+          test "$(node --version)" = "v22.14.0"
+          test "$(npm --version)" = "11.5.1"
 
       - name: Resolve the same tag-derived release version as NuGet and binaries
         id: ver
@@ -384,22 +395,32 @@ jobs:
             .artifacts/npm-tarballs/* \
             --repo "${{ github.repository }}" --clobber
 
-      - name: Publish npm packages (guarded; same release gate as NuGet)
+      - name: Publish npm packages through OIDC trusted publishing
         if: ${{ github.event_name == 'release' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "NPM_TOKEN is not set (fork or missing secret); skipping npm publish."
-            echo "Packages were still packed, checksum-verified, and attached to the release."
-            exit 0
-          fi
-          for package in \
+          publish_package() {
+            local package_path="$1"
+            local package_name="$2"
+            local publish_output
+            if ! publish_output="$(npm publish "${package_path}" --access public 2>&1)"; then
+              printf '%s\n' "${publish_output}" >&2
+              echo "npm trusted publishing authentication failed for package ${package_name}: register this package's npmjs.com trusted publisher for repository ${GITHUB_REPOSITORY} and workflow .github/workflows/release.yml, and keep id-token: write on the npm job; no npm token fallback is supported." >&2
+              return 1
+            fi
+            printf '%s\n' "${publish_output}"
+          }
+
+          publish_package \
             .artifacts/npm-tarballs/j-tech-japan-intent-cli-darwin-arm64-*.tgz \
+            "@j-tech-japan/intent-cli-darwin-arm64"
+          publish_package \
             .artifacts/npm-tarballs/j-tech-japan-intent-cli-linux-x64-*.tgz \
+            "@j-tech-japan/intent-cli-linux-x64"
+          publish_package \
             .artifacts/npm-tarballs/j-tech-japan-intent-cli-win32-x64-*.tgz \
-            .artifacts/npm-tarballs/intent-system-*.tgz; do
-            npm publish "${package}" --access public
-          done
+            "@j-tech-japan/intent-cli-win32-x64"
+          publish_package \
+            .artifacts/npm-tarballs/intent-system-*.tgz \
+            "intent-system"

--- a/docs/en/13-npm-distribution.md
+++ b/docs/en/13-npm-distribution.md
@@ -73,6 +73,37 @@ NuGet. Pull-request CI runs package preparation, `npm pack`, checksum/version
 verification, and a packed-install smoke test; it never publishes to npm and
 does not require npm organization credentials.
 
+## Trusted publishing for releases (G711)
+
+The npm publish job runs only for a published GitHub Release, after the same
+tag-derived packaging, checksum verification, and release-asset steps used by
+the other distribution jobs. It authenticates with GitHub Actions OIDC
+trusted publishing. The job is explicitly pinned to Node `22.14.0` and npm
+`11.5.1`; it has job-scoped `id-token: write` permission and stores no npm
+token or registry credential in this repository.
+
+Before the first release, an operator must perform the one-time npmjs.com
+trusted-publisher registration separately for each package:
+
+- `intent-system`
+- `@j-tech-japan/intent-cli-darwin-arm64`
+- `@j-tech-japan/intent-cli-linux-x64`
+- `@j-tech-japan/intent-cli-win32-x64`
+
+For each package, select GitHub Actions as the trusted publisher and register
+the `J-Tech-Japan/intent-system` repository with the workflow file
+`.github/workflows/release.yml`. These are operator account actions; this
+repository neither creates the npm organization nor stores a publish secret.
+Successful GitHub Actions trusted publishes receive npm provenance
+attestations automatically, which consumers can verify from the published
+package metadata.
+
+If OIDC authentication or the per-package registration is missing, the
+release job fails with the package name and the missing trusted-publisher or
+`id-token: write` configuration. It never reports a successful skip. A
+workflow-dispatch dry run still prepares, packs, checksums, and verifies the
+packages without attempting publication.
+
 ## Coexisting with the .NET tool
 
 The npm route and the .NET global tool can coexist:

--- a/docs/ja/13-npm-distribution.md
+++ b/docs/ja/13-npm-distribution.md
@@ -65,6 +65,34 @@ npm パッケージ、ランタイム同梱バイナリ、およびバイナリ�
 Pull request CI は package preparation、`npm pack`、checksum/version 検証、packed-install smoke test
 までを実行します。npm への公開は行わず、npm 組織の credential も必要としません。
 
+## リリースの Trusted publishing (G711)
+
+npm publish job は公開済み GitHub Release の場合だけ動き、他の配布 job と同じ
+tag-derived version、package の checksum 検証、Release asset attachment を先に完了してから実行します。
+認証には GitHub Actions OIDC trusted publishing を使います。job は Node `22.14.0` と npm
+`11.5.1` を明示的に固定し、job 単位の `id-token: write` permission だけを追加します。
+repository に npm token や registry credential は保存しません。
+
+最初の release の前に、operator は npmjs.com で次の各 package に対して一度だけ
+trusted-publisher registration を行う必要があります。
+
+- `intent-system`
+- `@j-tech-japan/intent-cli-darwin-arm64`
+- `@j-tech-japan/intent-cli-linux-x64`
+- `@j-tech-japan/intent-cli-win32-x64`
+
+各 package で GitHub Actions を trusted publisher として選び、
+`J-Tech-Japan/intent-system` repository と workflow file
+`.github/workflows/release.yml` を登録します。これは operator の account action であり、
+この repository が npm 組織を作成したり publish secret を保存したりすることはありません。
+GitHub Actions の trusted publish が成功すると npm provenance attestation は自動生成され、
+consumer は公開 package metadata から検証できます。
+
+OIDC 認証または package ごとの registration が不足している場合、release job は対象 package 名と
+不足している trusted-publisher または `id-token: write` configuration を示して fail します。
+成功した skip として報告することはありません。workflow-dispatch の dry run は publication を試みず、
+package の prepare、pack、checksum、verification だけを続けます。
+
 ## .NET tool との共存
 
 npm 経路と .NET global tool は共存できます。

--- a/tests/IntentSystem.Cli.Tests/NpmDistributionG702Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NpmDistributionG702Tests.cs
@@ -79,7 +79,12 @@ public sealed class NpmDistributionG702Tests
         Assert.Contains("github.event.release.tag_name", release, StringComparison.Ordinal);
         Assert.Contains("VERSION=\"${RAW#v}\"", release, StringComparison.Ordinal);
         Assert.Contains("needs: [nupkg, binaries]", release, StringComparison.Ordinal);
-        Assert.Contains("NPM_TOKEN", release, StringComparison.Ordinal);
+        Assert.DoesNotContain("NPM_TOKEN", release, StringComparison.Ordinal);
+        Assert.DoesNotContain("NODE_AUTH_TOKEN", release, StringComparison.Ordinal);
+        Assert.Contains("id-token: write", release, StringComparison.Ordinal);
+        Assert.Contains("node-version: 22.14.0", release, StringComparison.Ordinal);
+        Assert.Contains("npm@11.5.1", release, StringComparison.Ordinal);
+        Assert.Contains("OIDC trusted publishing", release, StringComparison.Ordinal);
         Assert.Contains("npm publish", release, StringComparison.Ordinal);
         Assert.Contains("if: ${{ github.event_name == 'release' }}", release, StringComparison.Ordinal);
         Assert.Contains("NUGET_API_KEY", release, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/NpmTrustedPublishingG711Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NpmTrustedPublishingG711Tests.cs
@@ -1,0 +1,133 @@
+using System.Text.RegularExpressions;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G711: release npm publication must use job-scoped GitHub Actions OIDC
+/// trusted publishing. The workflow source is the contract boundary for the
+/// permission, toolchain, credential absence, and named authentication
+/// failure that ordinary unit tests cannot exercise against npmjs.com.
+/// </summary>
+public sealed class NpmTrustedPublishingG711Tests
+{
+    private static readonly string[] PackageNames =
+    [
+        "intent-system",
+        "@j-tech-japan/intent-cli-darwin-arm64",
+        "@j-tech-japan/intent-cli-linux-x64",
+        "@j-tech-japan/intent-cli-win32-x64",
+    ];
+
+    [Fact]
+    public void Workflow_UsesJobScopedOidcAndPinnedNodeAndNpmWithoutCredentialPaths()
+    {
+        var workflow = ReadWorkflow();
+        var npmJob = ExtractNpmJob(workflow);
+
+        Assert.DoesNotContain("id-token: write", workflow[..workflow.IndexOf("\n  npm:", StringComparison.Ordinal)], StringComparison.Ordinal);
+        Assert.Contains("permissions:\n      contents: write\n      id-token: write", npmJob, StringComparison.Ordinal);
+        Assert.Contains("node-version: 22.14.0", npmJob, StringComparison.Ordinal);
+        Assert.Contains("npm install --global npm@11.5.1", npmJob, StringComparison.Ordinal);
+        Assert.Contains("test \"$(npm --version)\" = \"11.5.1\"", npmJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("NPM_TOKEN", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("NODE_AUTH_TOKEN", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("secrets.NPM", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Workflow_FailsNamedForThePackageWhenOidcConfigurationIsMissing()
+    {
+        var workflow = ReadWorkflow();
+        var npmJob = ExtractNpmJob(workflow);
+
+        AssertTrustedPublishingFailureContract(npmJob);
+        foreach (var packageName in PackageNames)
+        {
+            Assert.Contains(packageName, npmJob, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("if: ${{ github.event_name == 'release' }}", npmJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("exit 0", npmJob, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WorkflowGuardRejectsTheFormerExitZeroSilentSkipShape()
+    {
+        var workflow = ReadWorkflow();
+        var invalid = workflow.Replace(
+            "npm trusted publishing authentication failed for package",
+            "NPM_TOKEN is not set; skipping npm publish.\n            exit 0\n            npm trusted publishing authentication failed for package",
+            StringComparison.Ordinal);
+
+        var failure = Assert.ThrowsAny<Xunit.Sdk.XunitException>(
+            () => AssertTrustedPublishingFailureContract(ExtractNpmJob(invalid)));
+
+        Assert.Contains("exit 0", failure.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void OperatorDocsDescribePerPackageRegistrationProvenanceAndFailure(string language)
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var path = Path.Combine(root, "docs", language, "13-npm-distribution.md");
+        var document = File.ReadAllText(path);
+
+        Assert.Contains("G711", document, StringComparison.Ordinal);
+        Assert.Contains("22.14.0", document, StringComparison.Ordinal);
+        Assert.Contains("11.5.1", document, StringComparison.Ordinal);
+        Assert.Contains("J-Tech-Japan/intent-system", document, StringComparison.Ordinal);
+        Assert.Contains(".github/workflows/release.yml", document, StringComparison.Ordinal);
+        Assert.Contains("id-token: write", document, StringComparison.Ordinal);
+        Assert.Contains("npmjs.com", document, StringComparison.Ordinal);
+        Assert.Contains("trusted", document, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("provenance", document, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("dry run", document, StringComparison.OrdinalIgnoreCase);
+
+        foreach (var packageName in PackageNames)
+        {
+            Assert.Contains(packageName, document, StringComparison.Ordinal);
+        }
+
+        if (language == "en")
+        {
+            Assert.Contains("one-time", document, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("stores no npm", document, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("fails with the package name", document, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Contains("一度だけ", document, StringComparison.Ordinal);
+            Assert.Contains("保存しません", document, StringComparison.Ordinal);
+            Assert.Contains("対象 package 名", document, StringComparison.Ordinal);
+        }
+    }
+
+    private static void AssertTrustedPublishingFailureContract(string npmJob)
+    {
+        Assert.Contains("publish_package()", npmJob, StringComparison.Ordinal);
+        Assert.Contains("if ! publish_output=\"$(npm publish", npmJob, StringComparison.Ordinal);
+        Assert.Contains("npm trusted publishing authentication failed for package", npmJob, StringComparison.Ordinal);
+        Assert.Contains("register this package's npmjs.com trusted publisher", npmJob, StringComparison.Ordinal);
+        Assert.Contains("${GITHUB_REPOSITORY}", npmJob, StringComparison.Ordinal);
+        Assert.Contains(".github/workflows/release.yml", npmJob, StringComparison.Ordinal);
+        Assert.Contains("id-token: write", npmJob, StringComparison.Ordinal);
+        Assert.DoesNotContain("exit 0", npmJob, StringComparison.Ordinal);
+    }
+
+    private static string ReadWorkflow()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        return File.ReadAllText(Path.Combine(root, ".github", "workflows", "release.yml"));
+    }
+
+    private static string ExtractNpmJob(string workflow)
+    {
+        var match = Regex.Match(
+            workflow,
+            @"(?ms)^  npm:\s*\n(?<job>.*?)(?=^  [A-Za-z0-9_-]+:\s*$|\z)");
+        Assert.True(match.Success, "release workflow must define an npm job");
+        return match.Groups["job"].Value;
+    }
+}


### PR DESCRIPTION
Closes #1538. Adds job-scoped GitHub Actions OIDC for npm publication, pins Node 22.14.0 and npm 11.5.1, removes npm token auth paths, and makes missing trusted-publisher configuration fail with the package name. Adds EN/JA operator guidance and regressions. Verification: focused workflow/npm tests 15 passed; full Release solution 5,105 passed, 1 skipped; actionlint and git diff --check passed. No npm publish, credential, tag, or Release mutation performed.