### PR TITLE
G712: restore supervision-setup guide route

### DIFF
--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -484,6 +484,23 @@ Operator-dogfooding prompt templates that wire these loops entirely through the
 deterministic worker/metadata commands live under
 [`docs/automation-templates/`](../automation-templates/README.md).
 
+## Session-scoped supervision setup (G712)
+
+The declared supervision setup route is executable from a bare directory with
+no `.intent-cli/config.toml` or host metadata:
+
+```bash
+intent-cli guide workflow task supervision-setup --format json
+intent-cli guide workflow task supervision-setup --format markdown
+```
+
+It renders the shipped session-scoped contract: `notify supervise install`
+authors and proves the artifact without registering a process, the printed
+`launchctl bootstrap gui/$(id -u) '<artifact-path>'` is an explicit current-GUI
+session action, and `notify supervise reconcile --write` / `uninstall --write`
+reports before/after state and removes only managed drift. The route is
+read-only and does not execute any of those lifecycle commands.
+
 ## Recovery
 
 ```bash

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -447,6 +447,23 @@ intent-cli guide oneshot --kind host-review-next-slice    --domain <name>
 worker/metadata コマンドだけでループを回す operator dogfooding 向けプロンプトテンプレートは
 [`docs/automation-templates/`](../automation-templates/README.md) にあります。
 
+## セッションスコープの supervision セットアップ（G712）
+
+宣言された supervision setup route は、`.intent-cli/config.toml` や host metadata
+のない bare directory から実行できます。
+
+```bash
+intent-cli guide workflow task supervision-setup --format json
+intent-cli guide workflow task supervision-setup --format markdown
+```
+
+この route は shipped の session-scoped contract を表示します。`notify supervise install`
+は artifact を作成して first-cycle proof を確認するだけで process を登録せず、表示された
+`launchctl bootstrap gui/$(id -u) '<artifact-path>'` は現在の GUI session で operator が明示的に
+実行する action です。`notify supervise reconcile --write` / `uninstall --write` は before/after
+を報告し、managed drift だけを削除します。route 自体は read-only で、これらの lifecycle command
+を実行しません。
+
 ## 復旧
 
 ```bash

--- a/src/IntentSystem.Cli/Commands/CommandRouter.cs
+++ b/src/IntentSystem.Cli/Commands/CommandRouter.cs
@@ -793,8 +793,8 @@ internal static class CommandRouter
     /// G334: canonical one-line pointers for the six workflow phases the
     /// issue names (init / interview / packet / issue / automation /
     /// bug repair), the G338 loop-setup pair (implementation-loop /
-    /// review-next-slice-loop), and the G339 bug-to-intent-repair
-    /// chain. Tests assert each phase appears in the top-level help
+    /// review-next-slice-loop), the G339 bug-to-intent-repair
+    /// chain, and the G712 supervision-setup route. Tests assert each phase appears in the top-level help
     /// output so external agents can find the workflow entry without
     /// reading local rules.
     /// </summary>
@@ -809,6 +809,7 @@ internal static class CommandRouter
         "implementation-loop — `intent-cli guide workflow task implementation-loop --target-repo <r> --agent claude --frequency 5m --format markdown` (paste-ready child implementation-loop prompt with current label/claim/complete rules, G338).",
         "review-next-slice-loop — `intent-cli guide workflow task review-next-slice-loop --domain <d> --target-repo <r> --agent claude --frequency 20m --format markdown` (paste-ready host review / next-slice-loop prompt with current host-sync preflight + packet/issue lifecycle rules, G338).",
         "bug-to-intent-repair — `intent-cli guide workflow task bug-to-intent-repair --format json` (report → triage → plan → intent-repair → implementation-repair chain; classifies implementation-mismatch / intent-gap / packet-gap / rule-gap / metadata-workflow-gap; recommends packet creation when the bug is in intent-cli rules/guidance, G339).",
+        "supervision-setup — `intent-cli guide workflow task supervision-setup --format json` (metadata-free G712 session-scoped install/current-GUI registration/reconcile/uninstall contract; renders guidance only).",
         "improve (design-thread reflection) — `intent-cli improve --domain <d> --format markdown` returns the realignment guide. Preview `improve window ... --write` declares the independent recency bound; `improve record ... --write` appends evidence after human/agent review and never grades quality, G456/G457/G662. NOT a scheduler, auto-run, stalled-work class, or operational recovery.",
         "grill (persistent interview mode) — `intent-cli grill --domain <d> --format markdown` (alias of `intent-cli guide grill`): once the user asks to grill a topic, stay in grill mode — generate an open-question backlog from current intents/packets/ADRs/docs, ask one question at a time, and continue after each answer until a stop condition holds, G463. Built on the interview artifacts; NOT clarification (blocker resolution) and NOT improve (retrospective realignment).",
         "stack (packet backlog creation) — `intent-cli stack --domain <d> --target-repo <r> --format markdown` (alias of `intent-cli guide stack`): forward planning — create an ordered packet backlog from the current intents (often ~10), commit/push durable state, and publish AT MOST the first GitHub issue by default, G464. Distinct from improve (retrospective realignment), grill (open-question interview), clarification (blocker resolution), and runtime queue transitions.",

--- a/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideCommandsListCommand.cs
@@ -358,6 +358,15 @@ internal static class GuideCommandsListCommand
             RecommendedCaller = CallerChatAgent,
             Purpose = "Canonical host review / next-slice-loop prompt generator: `intent-cli guide workflow task review-next-slice-loop --domain <d> --target-repo <r> --agent claude --frequency 20m --format markdown` emits the paste-ready host loop prompt with current preflight + packet/issue lifecycle rules (G338)."
         },
+        new CommandGroupEntry
+        {
+            Name = "guide workflow task supervision-setup",
+            Role = RoleHostReview,
+            Classification = ClassificationPrimary,
+            Mutability = MutabilityReadOnly,
+            RecommendedCaller = CallerChatAgent,
+            Purpose = "G712 metadata-free supervision setup route: `intent-cli guide workflow task supervision-setup --format json|markdown` renders the shipped session-scoped install, current-GUI registration, reconcile, and uninstall contract without reading host metadata or executing lifecycle commands."
+        },
     };
 
     public static int Execute(CliContext context, string[] args, TextWriter writer)

--- a/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideHelpCommand.cs
@@ -42,7 +42,8 @@ internal static class GuideHelpCommand
     /// <c>interview</c>, <c>packet</c>, <c>issue</c>,
     /// <c>automation</c>, <c>bug-repair</c>, <c>implementation-loop</c>
     /// (G338), <c>review-next-slice-loop</c> (G338),
-    /// <c>bug-to-intent-repair</c> (G339).
+    /// <c>bug-to-intent-repair</c> (G339), and <c>supervision-setup</c>
+    /// (G712).
     /// </summary>
     internal static readonly IReadOnlyList<WorkflowGuidePointer> WorkflowGuides = new[]
     {
@@ -101,6 +102,13 @@ internal static class GuideHelpCommand
             Command = "intent-cli guide workflow task review-next-slice-loop --domain <name> --target-repo <owner/repo> --agent claude --frequency 20m --format markdown",
             Purpose = "Generate a paste-ready host review / next-slice-loop prompt from minimal inputs (domain, target-repo, agent, frequency). Forwards to `guide prompt-matrix --mode host-loop`; the generated prompt carries the host-sync preflight gate, automation summary call, packet/issue lifecycle handoff, and label transition rules so the operator does not need them from memory (G338).",
             SeeAlso = new[] { "intent-cli guide prompt-matrix --mode host-loop --format json", "intent-cli automation host-sync-preflight --format json", "intent-cli automation summary --domain <name> --format json" }
+        },
+        new WorkflowGuidePointer
+        {
+            Phase = "supervision-setup",
+            Command = "intent-cli guide workflow task supervision-setup --format json",
+            Purpose = "Render the G712 session-scoped supervision contract from a bare metadata-free directory: install authors and proves first-cycle evidence, current-GUI registration is explicit, and reconcile/uninstall remove managed drift without touching unrelated jobs.",
+            SeeAlso = new[] { "intent-cli notify supervise install", "intent-cli notify supervise reconcile --write --format json", "intent-cli notify supervise uninstall --write --format json", "intent-cli guide orchestrator-thread --format markdown" }
         },
         new WorkflowGuidePointer
         {
@@ -195,8 +203,8 @@ internal static class GuideHelpCommand
         new GuideSubcommandEntry
         {
             Name = "workflow",
-            Purpose = "Workflow suggestion / scaffold plans. Subcommands: suggest (pick the right intent-cli entry for an operator goal); task <name> (bounded scaffold/init/loop/repair plan — today: `task init-host` (G335), `task intent-interview` (G336), `task packet-draft` / `task issue-publish` (G337), `task implementation-loop` / `task review-next-slice-loop` (G338), `task bug-to-intent-repair` (G339)).",
-            Example = "intent-cli guide workflow task bug-to-intent-repair --format markdown"
+            Purpose = "Workflow suggestion / scaffold plans. Subcommands: suggest (pick the right intent-cli entry for an operator goal); task <name> (bounded scaffold/init/loop/repair/operations plan — today: `task init-host` (G335), `task intent-interview` (G336), `task packet-draft` / `task issue-publish` (G337), `task implementation-loop` / `task review-next-slice-loop` (G338), `task bug-to-intent-repair` (G339), `task supervision-setup` (G712)).",
+            Example = "intent-cli guide workflow task supervision-setup --format markdown"
         },
         new GuideSubcommandEntry
         {

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskCommand.cs
@@ -22,7 +22,9 @@ namespace IntentSystem.Cli.Commands;
 ///         (forwards to <c>guide prompt-matrix --mode host-loop</c>);</item>
 ///   <item><c>bug-to-intent-repair</c> (G339) — guided bug-to-intent-repair
 ///         workflow: report → triage → plan → intent-repair →
-///         implementation-repair, with five gap classifications.</item>
+///         implementation-repair, with five gap classifications;</item>
+///   <item><c>supervision-setup</c> (G712) — metadata-free session-scoped
+///         supervision install/reconcile/uninstall contract.</item>
 /// </list>
 /// Future tasks (deploy-host, retire-host, migrate-host) can plug
 /// in without touching the router. Pure read-only — never mutates
@@ -30,6 +32,18 @@ namespace IntentSystem.Cli.Commands;
 /// </summary>
 internal static class GuideWorkflowTaskCommand
 {
+    internal static readonly IReadOnlyList<string> SupportedTasks = new[]
+    {
+        "init-host",
+        "intent-interview",
+        "packet-draft",
+        "issue-publish",
+        "implementation-loop",
+        "review-next-slice-loop",
+        "bug-to-intent-repair",
+        GuideWorkflowTaskSupervisionSetupCommand.TaskName,
+    };
+
     public static int Execute(CliContext context, string[] args, TextWriter writer)
     {
         ArgumentNullException.ThrowIfNull(context);
@@ -44,7 +58,7 @@ internal static class GuideWorkflowTaskCommand
 
         if (args.Length == 0)
         {
-            writer.WriteLine("guide workflow task requires a task name. Supported: init-host, intent-interview, packet-draft, issue-publish, implementation-loop, review-next-slice-loop, bug-to-intent-repair.");
+            writer.WriteLine($"guide workflow task requires a task name. Supported: {string.Join(", ", SupportedTasks)}.");
             WriteHelp(writer);
             return 1;
         }
@@ -77,13 +91,16 @@ internal static class GuideWorkflowTaskCommand
             // and the five gap classifications so observed bugs feed
             // back into intent repair packets, not ad-hoc comments.
             "bug-to-intent-repair" => GuideWorkflowTaskBugToIntentRepairCommand.Execute(context, args[1..], writer),
+            // G712: expose the declared metadata-free supervision setup
+            // route and reuse the shipped session-scoped contract.
+            GuideWorkflowTaskSupervisionSetupCommand.TaskName => GuideWorkflowTaskSupervisionSetupCommand.Execute(context, args[1..], writer),
             _ => UnknownTask(writer, task)
         };
     }
 
     private static int UnknownTask(TextWriter writer, string task)
     {
-        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: init-host, intent-interview, packet-draft, issue-publish, implementation-loop, review-next-slice-loop, bug-to-intent-repair.");
+        writer.WriteLine($"Unknown 'guide workflow task' name '{task}'. Supported: {string.Join(", ", SupportedTasks)}.");
         WriteHelp(writer);
         return 1;
     }
@@ -101,5 +118,6 @@ internal static class GuideWorkflowTaskCommand
         writer.WriteLine("- implementation-loop — paste-ready child implementation-loop prompt from minimal inputs (target-repo, agent, frequency, base-branch-policy). Forwards to `guide prompt-matrix --mode child-loop`; carries the current label/claim/complete rules so the operator does not need them from memory (G338).");
         writer.WriteLine("- review-next-slice-loop — paste-ready host review / next-slice-loop prompt from minimal inputs (domain, target-repo, agent, frequency). Forwards to `guide prompt-matrix --mode host-loop`; carries the host-sync preflight gate, automation summary call, and packet/issue lifecycle rules (G338).");
         writer.WriteLine("- bug-to-intent-repair — guided bug-to-intent-repair workflow: report → triage → plan → intent-repair → implementation-repair. Classifies five gap types (implementation-mismatch, intent-gap, packet-gap, rule-gap, metadata-workflow-gap), recommends packet creation when the bug is in intent-cli rules/guidance rather than child code, and preserves original instruction / linked issue / PR refs across the chain (G339).");
+        writer.WriteLine("- supervision-setup — metadata-free G712 session-scoped supervision install, current-GUI registration, reconcile, and uninstall contract. Read-only; executes none of the emitted commands.");
     }
 }

--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskSupervisionSetupCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskSupervisionSetupCommand.cs
@@ -1,0 +1,211 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G712 repair: the declared supervision-setup workflow task must be a real,
+/// metadata-free guide entry. It renders the already-shipped session-scoped
+/// supervision contract; it does not install, register, inspect, or reconcile
+/// a supervisor itself.
+/// </summary>
+internal static class GuideWorkflowTaskSupervisionSetupCommand
+{
+    internal const string TaskName = "supervision-setup";
+    internal const string ContractVersion = "g712-session-scoped-supervision/v1";
+    internal const string UsageLine =
+        "Usage: intent-cli guide workflow task supervision-setup [--format markdown|json]";
+
+    internal static readonly IReadOnlyList<string> ContractStatements = new[]
+    {
+        SupervisionGuideText.InstallBoundRule,
+        SupervisionGuideText.InstallArtifactRule,
+        SupervisionGuideText.InstallEvidenceRule,
+        SupervisionGuideText.SessionLifetimeRule,
+    };
+
+    internal static readonly IReadOnlyList<SupervisionSetupCommand> Commands = new[]
+    {
+        new SupervisionSetupCommand
+        {
+            Name = "install",
+            Command = "intent-cli notify supervise install --domain <domain> --team <team> --repo <owner/repo> --owner-role orchestration --bound 900 --interval 300 --startup-bound 30 --platform macos --write --format json",
+            Purpose = "Emit the current-session artifact and require bounded first-cycle proof; install does not execute lifecycle registration.",
+        },
+        new SupervisionSetupCommand
+        {
+            Name = "register-current-gui-session",
+            Command = "launchctl bootstrap gui/$(id -u) '<artifact-path>'",
+            Purpose = "Explicit operator action for the current GUI session only; never a login-auto-loaded registration.",
+        },
+        new SupervisionSetupCommand
+        {
+            Name = "reconcile",
+            Command = "intent-cli notify supervise reconcile --write --format json",
+            Purpose = "Report loaded-before/after state, unload managed jobs, remove managed and legacy artifacts, and preserve unrelated jobs.",
+        },
+        new SupervisionSetupCommand
+        {
+            Name = "uninstall",
+            Command = "intent-cli notify supervise uninstall --write --format json",
+            Purpose = "Run the same explicit current-session drift-removal contract when the operator wants supervision removed.",
+        },
+    };
+
+    internal static readonly IReadOnlyList<string> NegativeChecks = new[]
+    {
+        "This guide route must not read .intent-cli/config.toml, queue-state, packets, or intents; it is executable from a bare directory.",
+        "The generated macOS artifact must omit RunAtLoad and must not be emitted under ~/Library/LaunchAgents.",
+        "Install must not execute registration or start a process; reconcile/uninstall may unload only managed intent-cli.supervise.* jobs and never auto-kill or mutate unrelated jobs.",
+        "A missing supervision-setup task is a route failure, not permission to substitute guide next, source archaeology, or an unbounded process action.",
+    };
+
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            WriteHelp(writer);
+            return 0;
+        }
+
+        if (!TryParseFormat(args, out var format, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UsageLine);
+            return 1;
+        }
+
+        var payload = new SupervisionSetupGuide
+        {
+            Task = TaskName,
+            ContractVersion = ContractVersion,
+            MetadataFree = true,
+            ReadOnly = true,
+            Summary = "G712 session-scoped supervision setup: emit an artifact, explicitly bootstrap the current GUI session only when wanted, and use reconcile/uninstall for bounded drift removal.",
+            ContractStatements = ContractStatements,
+            Commands = Commands,
+            ArtifactLocation = "Artifacts remain under `.intent-cli/supervision/<domain>/<team>/install/`; no managed artifact is emitted to `~/Library/LaunchAgents`.",
+            AuthorityBoundary = "This route only renders guidance. Install authors and first-cycle-probes; registration is an explicit operator action; reconcile/uninstall is the bounded current-session unload/removal command and does not grant workflow or recovery authority.",
+            NegativeChecks = NegativeChecks,
+        };
+
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(payload, JsonOptions));
+        }
+        else
+        {
+            WriteMarkdown(writer, payload);
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseFormat(string[] args, out string format, out string error)
+    {
+        format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var argument = args[index];
+            if (!string.Equals(argument, "--format", StringComparison.Ordinal))
+            {
+                error = $"Unknown argument '{argument}'.";
+                return false;
+            }
+
+            if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[++index]))
+            {
+                error = "--format requires markdown or json.";
+                return false;
+            }
+
+            format = args[index];
+            if (format is not FormatJson and not FormatMarkdown)
+            {
+                error = "--format must be markdown or json.";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static void WriteHelp(TextWriter writer)
+    {
+        writer.WriteLine("guide workflow task supervision-setup");
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("Read-only and metadata-free. Renders the G712 session-scoped install, current-GUI registration, reconcile, and uninstall contract; it executes none of them.");
+    }
+
+    private static void WriteMarkdown(TextWriter writer, SupervisionSetupGuide payload)
+    {
+        writer.WriteLine("# intent-cli — supervision setup workflow guide (G712)");
+        writer.WriteLine();
+        writer.WriteLine(UsageLine);
+        writer.WriteLine();
+        writer.WriteLine("This is a read-only, metadata-free route: it runs from a bare directory and does not read `.intent-cli/config.toml`, queue-state, packets, or intents.");
+        writer.WriteLine();
+        writer.WriteLine("## Session-scoped contract");
+        writer.WriteLine();
+        writer.WriteLine(payload.Summary);
+        writer.WriteLine();
+        foreach (var statement in payload.ContractStatements)
+        {
+            writer.WriteLine($"- {statement}");
+        }
+        writer.WriteLine();
+        writer.WriteLine($"- artifact location: {payload.ArtifactLocation}");
+        writer.WriteLine($"> **Authority boundary:** {payload.AuthorityBoundary}");
+        writer.WriteLine();
+        writer.WriteLine("## Commands emitted by the shipped contract");
+        writer.WriteLine();
+        foreach (var command in payload.Commands)
+        {
+            writer.WriteLine($"- **{command.Name}:** `{command.Command}` — {command.Purpose}");
+        }
+        writer.WriteLine();
+        writer.WriteLine("## Negative checks");
+        writer.WriteLine();
+        foreach (var check in payload.NegativeChecks)
+        {
+            writer.WriteLine($"- {check}");
+        }
+    }
+
+    internal sealed record SupervisionSetupCommand
+    {
+        [JsonPropertyName("name")] public required string Name { get; init; }
+        [JsonPropertyName("command")] public required string Command { get; init; }
+        [JsonPropertyName("purpose")] public required string Purpose { get; init; }
+    }
+
+    private sealed record SupervisionSetupGuide
+    {
+        [JsonPropertyName("task")] public required string Task { get; init; }
+        [JsonPropertyName("contract_version")] public required string ContractVersion { get; init; }
+        [JsonPropertyName("metadata_free")] public required bool MetadataFree { get; init; }
+        [JsonPropertyName("read_only")] public required bool ReadOnly { get; init; }
+        [JsonPropertyName("summary")] public required string Summary { get; init; }
+        [JsonPropertyName("contract_statements")] public required IReadOnlyList<string> ContractStatements { get; init; }
+        [JsonPropertyName("commands")] public required IReadOnlyList<SupervisionSetupCommand> Commands { get; init; }
+        [JsonPropertyName("artifact_location")] public required string ArtifactLocation { get; init; }
+        [JsonPropertyName("authority_boundary")] public required string AuthorityBoundary { get; init; }
+        [JsonPropertyName("negative_checks")] public required IReadOnlyList<string> NegativeChecks { get; init; }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ExternalUserHappyPathAuditTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ExternalUserHappyPathAuditTests.cs
@@ -61,6 +61,9 @@ public sealed class ExternalUserHappyPathAuditTests
          true),
         ("bug-to-intent-repair",
          new[] { "guide", "workflow", "task", "bug-to-intent-repair", "--format", "json" },
+         true),
+        ("supervision-setup",
+         new[] { "guide", "workflow", "task", "supervision-setup", "--format", "json" },
          true)
     };
 

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskSupervisionSetupG712Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskSupervisionSetupG712Tests.cs
@@ -1,0 +1,142 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G712 guide-reachability repair: the declared supervision-setup route must
+/// execute from a bare metadata-free directory and must remain discoverable.
+/// The route renders guidance only; these tests never register or reconcile a
+/// real supervisor and retain their repo-local scratch directories.
+/// </summary>
+public sealed class GuideWorkflowTaskSupervisionSetupG712Tests
+{
+    private readonly string root = Path.Combine(
+        RepoVersionPolicySource.RepoRoot(),
+        ".artifacts",
+        "g712-guide-repair-bare-" + Guid.NewGuid().ToString("N"));
+
+    public GuideWorkflowTaskSupervisionSetupG712Tests()
+    {
+        Directory.CreateDirectory(root);
+    }
+
+    [Fact]
+    public void JsonRoute_RendersTheShippedSessionScopedContract_FromBareDirectory()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            ["supervision-setup", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var result = document.RootElement;
+        Assert.Equal("supervision-setup", result.GetProperty("task").GetString());
+        Assert.Equal("g712-session-scoped-supervision/v1", result.GetProperty("contract_version").GetString());
+        Assert.True(result.GetProperty("metadata_free").GetBoolean());
+        Assert.True(result.GetProperty("read_only").GetBoolean());
+
+        var commands = result.GetProperty("commands").EnumerateArray().ToArray();
+        Assert.Equal(4, commands.Length);
+        Assert.Contains(commands, command =>
+            command.GetProperty("name").GetString() == "install"
+            && command.GetProperty("command").GetString()!.Contains("notify supervise install", StringComparison.Ordinal));
+        Assert.Contains(commands, command =>
+            command.GetProperty("name").GetString() == "register-current-gui-session"
+            && command.GetProperty("command").GetString()!.Contains("launchctl bootstrap gui/$(id -u)", StringComparison.Ordinal));
+        Assert.Contains(commands, command =>
+            command.GetProperty("name").GetString() == "reconcile"
+            && command.GetProperty("command").GetString()!.Contains("notify supervise reconcile --write", StringComparison.Ordinal));
+        Assert.Contains(commands, command =>
+            command.GetProperty("name").GetString() == "uninstall"
+            && command.GetProperty("command").GetString()!.Contains("notify supervise uninstall --write", StringComparison.Ordinal));
+
+        Assert.Contains(
+            "no managed artifact is emitted to `~/Library/LaunchAgents`",
+            result.GetProperty("artifact_location").GetString()!,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "does not grant workflow or recovery authority",
+            result.GetProperty("authority_boundary").GetString()!,
+            StringComparison.Ordinal);
+        Assert.False(File.Exists(Path.Combine(root, ".intent-cli", "config.toml")));
+        Assert.False(Directory.Exists(Path.Combine(root, ".intent-cli")));
+    }
+
+    [Fact]
+    public void MarkdownRoute_RendersLifecycleCommandsAndNegativeBoundaries_FromBareDirectory()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            ["supervision-setup", "--format", "markdown"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("# intent-cli — supervision setup workflow guide (G712)", output, StringComparison.Ordinal);
+        Assert.Contains("metadata-free route", output, StringComparison.Ordinal);
+        Assert.Contains("notify supervise install", output, StringComparison.Ordinal);
+        Assert.Contains("launchctl bootstrap gui/$(id -u)", output, StringComparison.Ordinal);
+        Assert.Contains("notify supervise reconcile --write --format json", output, StringComparison.Ordinal);
+        Assert.Contains("notify supervise uninstall --write --format json", output, StringComparison.Ordinal);
+        Assert.Contains("must not read .intent-cli/config.toml", output, StringComparison.Ordinal);
+        Assert.Contains("must not be emitted under ~/Library/LaunchAgents", output, StringComparison.Ordinal);
+        Assert.Contains("never auto-kill or mutate unrelated jobs", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("launchctl load ", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("launchctl unload ", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MissingTask_IsRejectedButSupportedHelpKeepsTheDeclaredRouteVisible()
+    {
+        using var writer = new StringWriter();
+        var exitCode = GuideWorkflowTaskCommand.Execute(
+            CreateContext(),
+            ["supervision-setup-missing", "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("Unknown 'guide workflow task' name 'supervision-setup-missing'", output, StringComparison.Ordinal);
+        Assert.Contains("supervision-setup", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CatalogAndTopLevelHelp_AdvertiseTheSameReachableRoute()
+    {
+        Assert.Contains("supervision-setup", GuideWorkflowTaskCommand.SupportedTasks);
+
+        var catalog = GuideCommandsListCommand.Groups.Single(
+            group => string.Equals(group.Name, "guide workflow task supervision-setup", StringComparison.Ordinal));
+        Assert.Contains("metadata-free", catalog.Purpose, StringComparison.Ordinal);
+        Assert.Contains("reconcile", catalog.Purpose, StringComparison.Ordinal);
+
+        var pointer = GuideHelpCommand.WorkflowGuides.Single(
+            item => string.Equals(item.Phase, "supervision-setup", StringComparison.Ordinal));
+        Assert.Equal("intent-cli guide workflow task supervision-setup --format json", pointer.Command);
+        Assert.Contains("session-scoped", pointer.Purpose, StringComparison.Ordinal);
+
+        var topLevelPointer = CommandRouter.WorkflowGuidePointersHelp.Single(
+            line => line.StartsWith("supervision-setup —", StringComparison.Ordinal));
+        Assert.Contains("guide workflow task supervision-setup", topLevelPointer, StringComparison.Ordinal);
+    }
+
+    private CliContext CreateContext() => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+}


### PR DESCRIPTION
Closes #1540

## G712 guide-reachability repair

The post-merge G712 contract declared `intent-cli guide workflow task supervision-setup`, but the merged CLI did not expose that task. This PR restores the declared route from the exact `origin/main` base containing `037c4acc`.

### Production route

- Adds `GuideWorkflowTaskSupervisionSetupCommand` with structured JSON and Markdown output, contract version `g712-session-scoped-supervision/v1`.
- Registers `supervision-setup` in the workflow dispatcher, supported-task failures, workflow help, command catalog, top-level guide pointers, and the EN/JA command references.
- Reuses the shipped G712 session-scoped supervision contract: install, explicit current-GUI-session bootstrap, reconcile, and uninstall.
- The route is read-only and metadata-free. It does not read `.intent-cli/config.toml`, queue-state, packets, or intents, and it executes none of the emitted lifecycle commands.
- The rendered contract preserves the GUI-session fallback, no `RunAtLoad`/`~/Library/LaunchAgents` persistence, bounded first-cycle proof, managed-only reconcile/uninstall, and no workflow/recovery authority.

### Reachability evidence

From a fresh bare directory containing only `.` and no `.intent-cli` configuration:

```text
dotnet .../IntentSystem.Cli.dll guide workflow task supervision-setup --format json     # exit 0; metadata_free=true; read_only=true
dotnet .../IntentSystem.Cli.dll guide workflow task supervision-setup --format markdown  # exit 0; session-scoped commands and negative checks rendered
find . -maxdepth 3 -print                                                               # .
```

The JSON and Markdown outputs both name the install, explicit `launchctl bootstrap gui/$(id -u) '<artifact-path>'`, reconcile, and uninstall commands plus the no-registration/no-login-persistence boundaries.

### Verification

- Focused route regressions: 4 passed.
- External-user route audit plus new route regressions: 10 passed.
- Affected guide/G712 matrix: 349 passed.
- Release full CLI suite: 5,115 passed, 1 expected skip, 0 failed.
- CI-equivalent Release solution build: passed with 0 warnings and 0 errors.
- CI-equivalent Release solution tests: all 11 assemblies passed (5,445 passed, 1 expected skip, 0 failed).
- `git diff --check`: passed.

No G712 supervision detection or lifecycle implementation was changed; this PR only restores the shipped guide route, its discoverability registrations, documentation parity, and negative reachability coverage.
