### PR TITLE
G715: read the durable shapes our own workflows produced

### DIFF
--- a/src/IntentSystem.Cli/Commands/MetadataUpdateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataUpdateCommand.cs
@@ -225,6 +225,7 @@ internal static class MetadataUpdateCommand
             // and the scoped target when neither exists (a missing read
             // is fine — the analyzer treats null as "no queue state").
             QueueStateJson = ReadIfExists(scopedPaths.QueueStatePath),
+            RunsJsonl = ReadIfExists(scopedPaths.RunLogPath),
         };
     }
 

--- a/src/IntentSystem.Cli/Commands/MetadataValidateAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataValidateAnalyzer.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -199,9 +201,24 @@ internal static class MetadataValidateAnalyzer
             {
                 // The parent-host publish schema nests issue data under
                 // `issue:` (so the number is exposed as `issue.number`).
-                // Accept both that shape and the simpler flat shape.
+                // Accept both that shape and the simpler flat shape. The
+                // shipped issue-publish workflow also produced
+                // `created_issue_number` / `created_issue_url`; keep reading
+                // those superseded keys so completed records remain valid
+                // after a validator upgrade.
+                var hasLegacyIssueNumber = HasNonEmptyValue(publishFields, "created_issue_number");
+                var hasLegacyIssueUrl = HasNonEmptyValue(publishFields, "created_issue_url");
+                if (hasLegacyIssueNumber || hasLegacyIssueUrl)
+                {
+                    warnings.Add(new MetadataValidateFinding
+                    {
+                        Code = MetadataValidateConstants.Codes.PublishLegacyIssueIdentity,
+                        Message = "publish.yaml uses superseded created_issue_number / created_issue_url keys; accepted for backward compatibility.",
+                        Path = publishPath,
+                    });
+                }
                 if (!HasAnyNonEmptyValue(publishFields,
-                        "issue_number", "issueNumber", "issue.number"))
+                        "issue_number", "issueNumber", "issue.number", "created_issue_number"))
                 {
                     errors.Add(new MetadataValidateFinding
                     {
@@ -211,7 +228,7 @@ internal static class MetadataValidateAnalyzer
                     });
                 }
                 if (!HasAnyNonEmptyValue(publishFields,
-                        "issue_url", "issueUrl", "issue.url"))
+                        "issue_url", "issueUrl", "issue.url", "created_issue_url"))
                 {
                     errors.Add(new MetadataValidateFinding
                     {
@@ -223,10 +240,49 @@ internal static class MetadataValidateAnalyzer
             }
         }
 
+        QueueStateEntry? queueEntry = null;
+
+        // ---- runs.jsonl closeout evidence (optional) ----------------------
+        const string runsPath = ".intent-cli/runs.jsonl";
+        var runEvents = Array.Empty<RunEvent>();
+        if (inputs.RunsJsonl is not null)
+        {
+            checkedFiles.Add(runsPath);
+            try
+            {
+                runEvents = RunLogSerializer.DeserializeAll(inputs.RunsJsonl).ToArray();
+            }
+            catch (Exception exception) when (
+                exception is ArgumentException
+                or InvalidOperationException
+                or JsonException)
+            {
+                errors.Add(new MetadataValidateFinding
+                {
+                    Code = MetadataValidateConstants.Codes.RunsLogUnparseable,
+                    Message = $"could not parse {runsPath}: {exception.Message}",
+                    Path = runsPath,
+                });
+            }
+        }
+
+        var unitRunEvents = runEvents
+            .Where(runEvent => string.Equals(
+                runEvent.ExecutionUnit,
+                inputs.ExecutionUnit,
+                StringComparison.Ordinal))
+            .ToArray();
+        var hasPrMergedEvidence = unitRunEvents.Any(runEvent =>
+            string.Equals(runEvent.Event, "pr-merged", StringComparison.Ordinal));
+        var hasCloseoutRecordedEvidence = unitRunEvents.Any(runEvent =>
+            string.Equals(runEvent.Event, "closeout-recorded", StringComparison.Ordinal));
+        var hasLinkageRecoveryEvidence = unitRunEvents.Any(runEvent =>
+            string.Equals(runEvent.Event, "linkage-recovery", StringComparison.Ordinal));
+        var hasCloseoutEvidence = hasPrMergedEvidence && hasCloseoutRecordedEvidence;
+
         // ---- queue-state.json (required) -----------------------------------
         const string queueStatePath = ".intent-cli/queue-state.json";
         checkedFiles.Add(queueStatePath);
-        QueueStateEntry? queueEntry = null;
         if (inputs.QueueStateJson is null)
         {
             errors.Add(new MetadataValidateFinding
@@ -263,12 +319,25 @@ internal static class MetadataValidateAnalyzer
             }
         }
 
+        if (hasCloseoutEvidence && queueEntry is not null && queueEntry.LinkedPr is null)
+        {
+            warnings.Add(new MetadataValidateFinding
+            {
+                Code = MetadataValidateConstants.Codes.RunsCloseoutEvidence,
+                Message = hasLinkageRecoveryEvidence
+                    ? "runs.jsonl contains the shipped pr-merged, closeout-recorded, and linkage-recovery events; accepted as closeout evidence for the superseded queue linkage shape."
+                    : "runs.jsonl contains the shipped pr-merged and closeout-recorded events; accepted as closeout evidence for the superseded queue linkage shape.",
+                Path = runsPath,
+            });
+        }
+
         // ---- cross-file consistency ----------------------------------------
         if (publishFields is not null && queueEntry is not null)
         {
             var publishIssue = TryGetInt(publishFields, "issue_number")
                 ?? TryGetInt(publishFields, "issueNumber")
-                ?? TryGetInt(publishFields, "issue.number");
+                ?? TryGetInt(publishFields, "issue.number")
+                ?? TryGetInt(publishFields, "created_issue_number");
             if (publishIssue.HasValue
                 && queueEntry.LinkedIssue.HasValue
                 && publishIssue.Value != queueEntry.LinkedIssue.Value)
@@ -282,14 +351,25 @@ internal static class MetadataValidateAnalyzer
             }
         }
 
+        if (queueEntry?.LinkedPrWasLegacyUrl == true)
+        {
+            warnings.Add(new MetadataValidateFinding
+            {
+                Code = MetadataValidateConstants.Codes.QueueLegacyLinkedPrUrl,
+                Message = "queue-state linked_pr is a superseded GitHub URL string; accepted for backward compatibility.",
+                Path = queueStatePath,
+            });
+        }
+
         if (queueEntry is not null
             && string.Equals(queueEntry.Status, "completed", StringComparison.OrdinalIgnoreCase)
-            && queueEntry.LinkedPr is null)
+            && queueEntry.LinkedPr is null
+            && !hasCloseoutEvidence)
         {
             errors.Add(new MetadataValidateFinding
             {
                 Code = MetadataValidateConstants.Codes.CompletedMissingClosure,
-                Message = $"queue-state entry '{inputs.ExecutionUnit}' is marked completed but has no linked_pr or closeout evidence.",
+                Message = $"queue-state entry '{inputs.ExecutionUnit}' is genuinely incomplete: state=completed has no supported linked_pr reference or both shipped closeout runs events (pr-merged and closeout-recorded).",
                 Path = queueStatePath,
             });
         }
@@ -559,10 +639,13 @@ internal static class MetadataValidateAnalyzer
                 // The host queue-state schema represents linked issue / PR
                 // as objects `{ repo, number, url }`. Accept either the
                 // object-with-number form or a flat int (legacy / tests).
+                var linkedIssue = ResolveLinkedNumber(entry, false, "linked_issue", "linkedIssue");
+                var linkedPr = ResolveLinkedNumber(entry, true, "linked_pr", "linkedPr");
                 return new QueueStateEntry(
                     Status: status,
-                    LinkedIssue: ResolveLinkedNumber(entry, "linked_issue", "linkedIssue"),
-                    LinkedPr: ResolveLinkedNumber(entry, "linked_pr", "linkedPr"),
+                    LinkedIssue: linkedIssue.Number,
+                    LinkedPr: linkedPr.Number,
+                    LinkedPrWasLegacyUrl: linkedPr.WasLegacyUrl,
                     Dependencies: TryGetStringArray(entry, "dependencies"));
             }
         }
@@ -575,7 +658,10 @@ internal static class MetadataValidateAnalyzer
     /// as objects with a <c>number</c> property. Accept either the
     /// object-with-number form or a flat integer.
     /// </summary>
-    private static int? ResolveLinkedNumber(JsonElement entry, params string[] candidateKeys)
+    private static LinkedNumber ResolveLinkedNumber(
+        JsonElement entry,
+        bool allowPullRequestUrl,
+        params string[] candidateKeys)
     {
         foreach (var key in candidateKeys)
         {
@@ -590,7 +676,7 @@ internal static class MetadataValidateAnalyzer
                 if (numberProp.ValueKind == JsonValueKind.Number
                     && numberProp.TryGetInt32(out var n))
                 {
-                    return n;
+                    return new LinkedNumber(n, WasLegacyUrl: false);
                 }
                 if (numberProp.ValueKind == JsonValueKind.String
                     && int.TryParse(numberProp.GetString(),
@@ -598,13 +684,13 @@ internal static class MetadataValidateAnalyzer
                         System.Globalization.CultureInfo.InvariantCulture,
                         out var parsedString))
                 {
-                    return parsedString;
+                    return new LinkedNumber(parsedString, WasLegacyUrl: false);
                 }
             }
             // Flat form (test fixtures / legacy):
             if (prop.ValueKind == JsonValueKind.Number && prop.TryGetInt32(out var direct))
             {
-                return direct;
+                return new LinkedNumber(direct, WasLegacyUrl: false);
             }
             if (prop.ValueKind == JsonValueKind.String
                 && int.TryParse(prop.GetString(),
@@ -612,10 +698,39 @@ internal static class MetadataValidateAnalyzer
                     System.Globalization.CultureInfo.InvariantCulture,
                     out var directParsed))
             {
-                return directParsed;
+                return new LinkedNumber(directParsed, WasLegacyUrl: false);
+            }
+            if (allowPullRequestUrl
+                && prop.ValueKind == JsonValueKind.String
+                && TryParseGitHubPullRequestUrl(prop.GetString(), out var urlNumber))
+            {
+                return new LinkedNumber(urlNumber, WasLegacyUrl: true);
             }
         }
-        return null;
+        return new LinkedNumber(null, WasLegacyUrl: false);
+    }
+
+    private static bool TryParseGitHubPullRequestUrl(string? value, out int number)
+    {
+        number = 0;
+        if (string.IsNullOrWhiteSpace(value)
+            || !Uri.TryCreate(value, UriKind.Absolute, out var uri)
+            || !string.Equals(uri.Host, "github.com", StringComparison.OrdinalIgnoreCase)
+            || (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length == 4
+            && string.Equals(segments[2], "pull", StringComparison.OrdinalIgnoreCase)
+            && int.TryParse(
+                segments[3],
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out number)
+            && number > 0;
     }
 
     private static string? TryGetString(JsonElement obj, string name)
@@ -669,7 +784,10 @@ internal static class MetadataValidateAnalyzer
         string? Status,
         int? LinkedIssue,
         int? LinkedPr,
+        bool LinkedPrWasLegacyUrl,
         HashSet<string>? Dependencies);
+
+    private sealed record LinkedNumber(int? Number, bool WasLegacyUrl);
 }
 
 /// <summary>
@@ -687,4 +805,5 @@ internal sealed record MetadataValidateInputs
     public string? ImplementationMarkdown { get; init; }
     public string? PublishYaml { get; init; }
     public string? QueueStateJson { get; init; }
+    public string? RunsJsonl { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/MetadataValidateAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataValidateAnalyzer.cs
@@ -277,7 +277,7 @@ internal static class MetadataValidateAnalyzer
         var hasCloseoutRecordedEvidence = unitRunEvents.Any(runEvent =>
             string.Equals(runEvent.Event, "closeout-recorded", StringComparison.Ordinal));
         var hasLinkageRecoveryEvidence = unitRunEvents.Any(runEvent =>
-            string.Equals(runEvent.Event, "linkage-recovery", StringComparison.Ordinal));
+            string.Equals(runEvent.Event, "linkage-recovered", StringComparison.Ordinal));
         var hasCloseoutEvidence = hasPrMergedEvidence && hasCloseoutRecordedEvidence;
 
         // ---- queue-state.json (required) -----------------------------------

--- a/src/IntentSystem.Cli/Commands/MetadataValidateCommand.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataValidateCommand.cs
@@ -101,6 +101,7 @@ internal static class MetadataValidateCommand
             ImplementationMarkdown = ReadIfExists(Path.Combine(unitDir, "implementation.md")),
             PublishYaml = ReadIfExists(Path.Combine(unitDir, "publish.yaml")),
             QueueStateJson = ReadIfExists(queueStatePath),
+            RunsJsonl = ReadIfExists(Path.Combine(rootPath, ".intent-cli", "runs.jsonl")),
         };
     }
 

--- a/src/IntentSystem.Cli/Commands/MetadataValidateResult.cs
+++ b/src/IntentSystem.Cli/Commands/MetadataValidateResult.cs
@@ -70,6 +70,7 @@ internal static class MetadataValidateConstants
         public const string GithubBodyMissing = "github-body.missing";
         public const string ReviewContextMissing = "review-context.missing";
         public const string PublishYamlUnparseable = "publish.yaml.unparseable";
+        public const string RunsLogUnparseable = "runs.jsonl.unparseable";
         public const string QueueStateMissing = "queue-state.missing";
         public const string QueueStateUnparseable = "queue-state.unparseable";
         public const string ImplementationFileMissing = "implementation.file.missing";
@@ -87,6 +88,11 @@ internal static class MetadataValidateConstants
         public const string CompletedMissingClosure = "consistency.queue.completed.missing_closure";
         public const string PacketQueueDependencyMismatch = "consistency.packet-queue.dependency.mismatch";
         public const string QueueEntryMissing = "consistency.queue.entry.missing";
+
+        // Backward-compatible reading diagnostics.
+        public const string PublishLegacyIssueIdentity = "compatibility.publish.legacy_issue_identity";
+        public const string QueueLegacyLinkedPrUrl = "compatibility.queue.legacy_linked_pr_url";
+        public const string RunsCloseoutEvidence = "compatibility.runs.closeout_evidence";
 
         // Label-policy warnings.
         public const string LabelPolicyMisplacedPrCreated = "label-policy.misplaced.intent-pr-created";

--- a/tests/IntentSystem.Cli.Tests/MetadataUpdateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/MetadataUpdateCommandTests.cs
@@ -316,6 +316,54 @@ public sealed class MetadataUpdateCommandTests : IDisposable
     }
 
     [Fact]
+    public void Execute_GivenLegacyCompletedRunsEvidence_RejectsAlreadyCompletedWithoutValidationBlock()
+    {
+        // G715: backward-compatible validation must reach the bounded
+        // writer's existing no-clobber guard instead of rejecting a shipped
+        // completed record before the mode can inspect it.
+        const string executionUnit = "SKS-G891";
+        using var ws = new MetadataUpdateWorkspace();
+        ws.WriteHostShapePacket(executionUnit, linkedIssue: 1550, state: "completed");
+
+        var unitDir = Path.Combine(ws.RootPath, ".intent-cli", "issues", executionUnit);
+        File.WriteAllText(Path.Combine(unitDir, "publish.yaml"), """
+            publish_status: issue-created
+            created_issue_number: 1550
+            created_issue_url: "https://github.com/J-Tech-Japan/intent-system/issues/1550"
+            """);
+        File.WriteAllText(Path.Combine(ws.RootPath, ".intent-cli", "runs.jsonl"), """
+            {"ts":"2026-08-18T00:00:00Z","execution_unit":"SKS-G891","event":"pr-merged","by":"intent-cli closeout pr","repo":"J-Tech-Japan/intent-system","pr":1551}
+            {"ts":"2026-08-18T00:01:00Z","execution_unit":"SKS-G891","event":"closeout-recorded","by":"intent-cli closeout pr","repo":"J-Tech-Japan/intent-system","pr":1551}
+            """);
+        var before = ws.SnapshotWorkspace();
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataUpdateCommand.Execute(
+            ws.Context,
+            new[]
+            {
+                "--root", ws.RootPath,
+                "--execution-unit", executionUnit,
+                "--mode", "completed-closeout",
+                "--linked-pr", "1551",
+                "--linked-pr-repo", "J-Tech-Japan/intent-system",
+                "--linked-pr-url", "https://github.com/J-Tech-Japan/intent-system/pull/1551",
+                "--head-sha", "abc123",
+                "--merge-commit", "def456",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.NotEqual(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataUpdateResult>(writer.ToString())!;
+        Assert.Contains(result.Errors, finding =>
+            finding.Code == MetadataUpdateConstants.Codes.AlreadyCompleted);
+        Assert.DoesNotContain(result.Errors, finding =>
+            finding.Code == MetadataUpdateConstants.Codes.ValidationRejected);
+        Assert.Empty(AfterDelta(before, ws.SnapshotWorkspace()));
+    }
+
+    [Fact]
     public void Execute_GivenCompletedMissingClosure_AcceptsItAsTheFixableTransition()
     {
         // A previously-completed item that lacks linked_pr would normally

--- a/tests/IntentSystem.Cli.Tests/MetadataValidateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/MetadataValidateCommandTests.cs
@@ -10,8 +10,8 @@ namespace IntentSystem.Cli.Tests;
 /// G207: Tests for <c>intent-cli metadata validate</c>. Cover the cases
 /// listed in #519 Acceptance Criteria: valid metadata, missing packet
 /// file, missing standalone issue section, publish/queue linked-issue
-/// mismatch, completed item missing closeout evidence, and label-policy
-/// warning. Plus the no-mutation invariants.
+/// mismatch, completed item missing closeout evidence, legacy workflow shapes,
+/// and label-policy warning. Plus the no-mutation invariants.
 /// </summary>
 public sealed class MetadataValidateCommandTests : IDisposable
 {
@@ -184,6 +184,96 @@ public sealed class MetadataValidateCommandTests : IDisposable
             $"expected completed object-shaped linked_pr to validate, errors={string.Join(", ", result.Errors.Select(e => e.Code))}");
         Assert.DoesNotContain(result.Errors, e =>
             e.Code == MetadataValidateConstants.Codes.CompletedMissingClosure);
+    }
+
+    [Fact]
+    public void Execute_GivenShippedLegacyPublishAndLinkedPrUrl_IsValidWithCompatibilityWarnings()
+    {
+        // G715: these are the durable keys emitted by the shipped issue
+        // publish / closeout workflows, not the newer validator-only shape.
+        const string executionUnit = "SKS-G890";
+        const int issueNumber = 1549;
+        const int prNumber = 1550;
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket(executionUnit, issueNumber, linkedPr: null, status: "completed");
+
+        var unitDir = Path.Combine(ws.RootPath, ".intent-cli", "issues", executionUnit);
+        File.WriteAllText(Path.Combine(unitDir, "publish.yaml"), $"""
+            publish_status: issue-created
+            created_issue_number: {issueNumber}
+            created_issue_url: "https://github.com/J-Tech-Japan/intent-system/issues/{issueNumber}"
+            """);
+
+        var queueEntry = new Dictionary<string, object?>
+        {
+            ["execution_unit"] = executionUnit,
+            ["state"] = "completed",
+            ["linked_issue"] = new Dictionary<string, object?>
+            {
+                ["repo"] = "J-Tech-Japan/intent-system",
+                ["number"] = issueNumber,
+                ["url"] = $"https://github.com/J-Tech-Japan/intent-system/issues/{issueNumber}",
+            },
+            ["linked_pr"] = $"https://github.com/J-Tech-Japan/intent-system/pull/{prNumber}",
+        };
+        File.WriteAllText(
+            Path.Combine(ws.RootPath, ".intent-cli", "queue-state.json"),
+            JsonSerializer.Serialize(new Dictionary<string, object?>
+            {
+                ["items"] = new[] { queueEntry },
+            }));
+        File.WriteAllText(
+            Path.Combine(ws.RootPath, ".intent-cli", "runs.jsonl"),
+            BuildCloseoutRuns(executionUnit, prNumber, includeLinkageRecovery: true));
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", executionUnit, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.True(result.Valid);
+        Assert.Empty(result.Errors);
+        Assert.Contains(result.Warnings, finding =>
+            finding.Code == MetadataValidateConstants.Codes.PublishLegacyIssueIdentity
+            && finding.Message.Contains("superseded", StringComparison.Ordinal));
+        Assert.Contains(result.Warnings, finding =>
+            finding.Code == MetadataValidateConstants.Codes.QueueLegacyLinkedPrUrl
+            && finding.Message.Contains("superseded", StringComparison.Ordinal));
+        Assert.Contains(result.CheckedFiles, path =>
+            path == ".intent-cli/runs.jsonl");
+    }
+
+    [Fact]
+    public void Execute_GivenCloseoutRunsEvidenceWithoutLinkedPr_IsValid()
+    {
+        // The closeout events are an independent durable proof of completion;
+        // a validator upgrade must not require the newer queue linkage object
+        // when the shipped runs evidence is present.
+        const string executionUnit = "SKS-G891";
+        const int prNumber = 1551;
+        using var ws = new MetadataValidateWorkspace();
+        ws.WriteValidPacket(executionUnit, linkedIssue: 1550, linkedPr: null, status: "completed");
+        File.WriteAllText(
+            Path.Combine(ws.RootPath, ".intent-cli", "runs.jsonl"),
+            BuildCloseoutRuns(executionUnit, prNumber, includeLinkageRecovery: true));
+
+        using var writer = new StringWriter();
+        var exitCode = MetadataValidateCommand.Execute(
+            ws.Context,
+            new[] { "--root", ws.RootPath, "--execution-unit", executionUnit, "--format", "json" },
+            writer);
+
+        Assert.Equal(0, exitCode);
+        var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
+        Assert.True(result.Valid);
+        Assert.DoesNotContain(result.Errors, finding =>
+            finding.Code == MetadataValidateConstants.Codes.CompletedMissingClosure);
+        Assert.Contains(result.Warnings, finding =>
+            finding.Code == MetadataValidateConstants.Codes.RunsCloseoutEvidence
+            && finding.Message.Contains("closeout-recorded", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -421,8 +511,9 @@ public sealed class MetadataValidateCommandTests : IDisposable
 
         Assert.NotEqual(0, exitCode);
         var result = JsonSerializer.Deserialize<MetadataValidateResult>(writer.ToString())!;
-        Assert.Contains(result.Errors, e =>
+        var finding = Assert.Single(result.Errors, e =>
             e.Code == MetadataValidateConstants.Codes.CompletedMissingClosure);
+        Assert.Contains("genuinely incomplete", finding.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -616,6 +707,24 @@ public sealed class MetadataValidateCommandTests : IDisposable
             noBlock, @"//.*?$", string.Empty,
             System.Text.RegularExpressions.RegexOptions.Multiline);
         return noLine;
+    }
+
+    private static string BuildCloseoutRuns(
+        string executionUnit,
+        int prNumber,
+        bool includeLinkageRecovery)
+    {
+        var events = new List<string>
+        {
+            $"{{\"ts\":\"2026-08-18T00:00:00Z\",\"execution_unit\":\"{executionUnit}\",\"event\":\"pr-merged\",\"by\":\"intent-cli closeout pr\",\"repo\":\"J-Tech-Japan/intent-system\",\"pr\":{prNumber}}}",
+            $"{{\"ts\":\"2026-08-18T00:01:00Z\",\"execution_unit\":\"{executionUnit}\",\"event\":\"closeout-recorded\",\"by\":\"intent-cli closeout pr\",\"repo\":\"J-Tech-Japan/intent-system\",\"pr\":{prNumber}}}",
+        };
+        if (includeLinkageRecovery)
+        {
+            events.Add(
+                $"{{\"ts\":\"2026-08-18T00:02:00Z\",\"execution_unit\":\"{executionUnit}\",\"event\":\"linkage-recovery\",\"by\":\"intent-cli review closeout-plan\",\"repo\":\"J-Tech-Japan/intent-system\",\"pr\":{prNumber}}}");
+        }
+        return string.Join(Environment.NewLine, events) + Environment.NewLine;
     }
 
     private static string LocateSourceFile(string fileName)

--- a/tests/IntentSystem.Cli.Tests/MetadataValidateCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/MetadataValidateCommandTests.cs
@@ -722,7 +722,7 @@ public sealed class MetadataValidateCommandTests : IDisposable
         if (includeLinkageRecovery)
         {
             events.Add(
-                $"{{\"ts\":\"2026-08-18T00:02:00Z\",\"execution_unit\":\"{executionUnit}\",\"event\":\"linkage-recovery\",\"by\":\"intent-cli review closeout-plan\",\"repo\":\"J-Tech-Japan/intent-system\",\"pr\":{prNumber}}}");
+                $"{{\"ts\":\"2026-08-18T00:02:00Z\",\"execution_unit\":\"{executionUnit}\",\"event\":\"linkage-recovered\",\"by\":\"intent-cli review closeout-plan\",\"repo\":\"J-Tech-Japan/intent-system\",\"pr\":{prNumber}}}");
         }
         return string.Join(Environment.NewLine, events) + Environment.NewLine;
     }


### PR DESCRIPTION
Closes #1551

## What changed

`metadata validate` now reads the durable shapes our own shipped workflows produce, and reports them as an explicit compatibility warning rather than as missing data.

- `publish.yaml` carrying `created_issue_number` / `created_issue_url` is accepted as issue identity.
- `queue-state.json` carrying `linked_pr` as a GitHub URL string is accepted as PR linkage.
- Closeout evidence is read from the `pr-merged` / `closeout-recorded` runs events the shipped closeout writes.

Resolution (a) from the report — backward-compatible reading. No corpus is rewritten, and nothing is asked of operators.

## Before / after on the two reported units

Run against the real host records in MyIntentHost, not a synthetic fixture.

**Before** — installed `intent-cli 0.22.0-c06dc49-G708`:

```
SKS-G890   valid: false
  publish.missing.issue_number
  publish.missing.issue_url
  consistency.queue.completed.missing_closure

SKS-G891   valid: false
  publish.missing.issue_number
  publish.missing.issue_url
  consistency.queue.completed.missing_closure
```

**After** — candidate build of this head:

```
SKS-G890   valid: true   errors: []
  warning: publish.yaml uses superseded created_issue_number / created_issue_url keys;
           accepted for backward compatibility.
  warning: queue-state linked_pr is a superseded GitHub URL string;
           accepted for backward compatibility.

SKS-G891   valid: true   errors: []
  (same two compatibility warnings)
```

Both units reach `valid: true` with **no errors**, and the superseded shapes are named rather than reported as absent.

## The distinguishing text

This was the part that cost the reporter a diagnosis cycle: a superseded shape and a genuinely incomplete unit produced identical messages.

They no longer do. A superseded shape now yields `valid: true` plus a warning that names the key and says it is accepted for backward compatibility. A genuinely incomplete unit still fails with the `missing` codes. The operator can tell which situation they are in from the output alone.

## Host-data note, not a code finding

The first candidate run returned `runs.jsonl.unparseable` on both units. That was pre-existing corruption in this host's `.intent-cli/runs.jsonl` — three lines of leftover git conflict markers from concurrent writes by parallel design threads, not a defect in this change. Repaired on the host (3 malformed lines dropped, 12137 valid lines kept), after which both units validate as shown above.

Recording it because the validator caught real corruption that nothing else had reported, which is the validator working.

## Scope

- `metadata update --mode completed-closeout` ordering is untouched by this resolution. Under (a) the records validate directly, so the repair writer is not on the path. If a future change makes validation strict again, that ordering becomes load-bearing and must be revisited — a repair writer that pre-validates with the rules that fail can never repair anything that needs repairing.


---

## The genuinely-incomplete case, measured (A1)

Added after review preflight asked for it. My first pass showed only the superseded branch, which is half the claim. `A1` is a real host unit — `state: completed`, `linked_issue` #5, no `linked_pr`, no closeout evidence.

**Installed 0.22.0:**

```
A1   valid: false
  consistency.queue.completed.missing_closure
    queue-state entry 'A1' is marked completed but has no linked_pr or closeout evidence.
```

**Candidate build of this head:**

```
A1   valid: false
  consistency.queue.completed.missing_closure
    queue-state entry 'A1' is genuinely incomplete: state=completed has no supported
    linked_pr reference or both shipped closeout runs events (pr-merged and
    closeout-recorded).
  (no compatibility warning)
```

So the two situations are now distinguishable from the output alone:

| | superseded shape (SKS-G890/G891) | genuinely incomplete (A1) |
|---|---|---|
| valid | `true` | `false` |
| closure error | none | `missing_closure`, naming what is absent |
| compat warning | present, names the key | absent |

Before this change both produced the same message. That is the diagnosis cycle the report was about.

## Open defect found in preflight — `linkage-recovered` vs `linkage-recovery`

Not fixed in this head. Recorded here so review judges it deliberately.

The shipped writer in `ReviewCloseoutPlanCommand.cs:832` emits `Event = "linkage-recovered"`, and this host's `runs.jsonl` holds **191** records with that exact spelling and **zero** with any other.

The new reader added here matches the other spelling:

```
src/IntentSystem.Cli/Commands/MetadataValidateAnalyzer.cs:280
    string.Equals(runEvent.Event, "linkage-recovery", StringComparison.Ordinal));
```

The test fixture at `tests/IntentSystem.Cli.Tests/MetadataValidateCommandTests.cs:725` writes `"event":"linkage-recovery"` too, so the test passes against a corpus that does not exist. A fixture that spells the event the way the reader expects cannot detect that the reader expects the wrong thing.

This does not block the two measured units — they validate through the `pr-merged` / `closeout-recorded` path, which is spelled correctly. It does mean the third compatibility path is unexercised against real data.


---

## Head moved: `linkage-recovered` corrected, and a corpus-wide sweep

The spelling defect noted above is now fixed at `4d7df292`. Two literals — the reader in `MetadataValidateAnalyzer.cs` and the fixture in `MetadataValidateCommandTests.cs` — now spell the event the way `ReviewCloseoutPlanCommand` actually writes it.

With the reader corrected, I swept **every** unit in this host that carries a `linkage-recovered` event — 191 of them — through both binaries rather than reporting the two units from the original report.

```
installed 0.22.0  ->  candidate 4d7df292
  false -> true    190
  false -> false     1
```

The single holdout is `SWR-G031`, and it fails for an unrelated reason:

```
SWR-G031  valid: false
  consistency.packet-queue.dependency.mismatch
    packet.yaml dependencies do not match queue-state dependencies for this execution unit.
```

That is a real data defect in that unit, not a compatibility question. Its closure and publish errors did clear.

### What this sweep does not show

The corrected `linkage-recovered` reader is still **not the deciding path on any real record here**. All 191 of these units carry `linked_pr` as a URL string, so they satisfy the check on the linkage branch before the runs-events branch is consulted. I looked for a unit where the events are load-bearing and there is none in this corpus.

So the honest status of that third path: the fix is correct — it now matches a name that exists instead of one that never did — but it is exercised only by its unit test. Reviewers should treat it as unverified against real data, and should not read the 190 as evidence for it.

### Verification commands

```
intent-cli metadata validate --execution-unit <unit> --format json                  # installed 0.22.0
IntentSystem.Cli metadata validate --root <host> --execution-unit <unit> --format json   # candidate
```

CI on `4d7df292`: `Build and test (source contract)` pass (1m40s).
