### PR TITLE
G720: validate Target paths before issue creation

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideWorkflowTaskPacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkflowTaskPacketDraftCommand.cs
@@ -68,7 +68,7 @@ internal static class GuideWorkflowTaskPacketDraftCommand
         new IssueContractSection { Section = "why-this-slice-exists-now", Purpose = "Why this slice cannot wait. Names the blocker and the user observation that forced the slice." },
         new IssueContractSection { Section = "current-observed-state", Purpose = "What an external agent or operator sees today, before the slice lands. Pins the regression target." },
         new IssueContractSection { Section = "accepted-baseline-you-may-assume", Purpose = "What the agent does not have to relitigate (collaboration model, intent-cli routing, no-local-rule rule, etc.)." },
-        new IssueContractSection { Section = "target-repo-path-part", Purpose = "Exact repository / folder / surface the change must land in. Disambiguates host-vs-child mutation targets." },
+        new IssueContractSection { Section = "target-repo-path-part", Purpose = "Exact repository / folder / surface the change must land in. Disambiguates host-vs-child mutation targets. Include the literal bullet `- Target paths: <comma- or space-separated paths>` with authored paths; do not infer it from other fields." },
         new IssueContractSection { Section = "in-scope", Purpose = "Bullet list of what is in scope. Mirrors the slice goal; one slice cuts cleanly so this list stays small." },
         new IssueContractSection { Section = "out-of-scope", Purpose = "Bullet list of what is explicitly NOT in this slice. Reviewers refuse PRs that broaden scope without an out-of-scope amendment." },
         // G482: standalone restatement and base branch policy are publish-ready
@@ -136,7 +136,7 @@ internal static class GuideWorkflowTaskPacketDraftCommand
         "On a claims-enabled host, `packet draft` runs the shared claim verification first. Stop when `execution-unit:<id>` is unheld or held by another team; the refusal names the scope, holder, and holder team. A host with no claims store follows the legacy path byte-for-byte.",
         "`packet draft --dry-run` flags missing files: stop, repair the design host packet directory before publishing. Hand-editing the four files is allowed during design; routine automation mutates them through `packet draft --write` only.",
         "**Dry-run the publish validation BEFORE declaring the packet issue-ready (G482)**: never call a packet ready for GitHub issue creation until a publish-validation dry-run reports zero missing contract sections. Run `intent-cli issue validate-body --from-file <github-body.md> --format json` (offline body check), `intent-cli packet draft --execution-unit <id> --dry-run --format json` (re-scaffold + contract check), and — for the host loop — `intent-cli intent next-slice --dry-run --format json`; all three share one required-section source of truth, so a clean result on one is a clean result on all. A freshly scaffolded packet already carries every required section (Goal, Current Observed State, Why This Slice Exists Now, Accepted Baseline You May Assume, Target Repo / Path / Part, In Scope, Out Of Scope, Standalone Child Issue Contract, Acceptance Criteria, Verification, Related Links, Base Branch Policy); fill the placeholders, do not delete sections.",
-        "`issue validate-body --from-file <github-body.md> --format json` reports `errors[]` (missing contract sections): stop, repair the body, validate again, only then move to `issue publish-flow`.",
+        "`issue validate-body --from-file <github-body.md> --format json` reports either missing headings or a separate `target_paths_invalid` declaration error: stop, repair the body, validate again, only then move to `issue publish-flow`. When `Target Repo / Path / Part` is present, it must contain the literal `- Target paths: <comma- or space-separated paths>` line.",
         "`packet.yaml` lacks `intent_reference_paths` or names them with broad-domain placeholders: stop, narrow to PR-specific references. Broad-domain intent paths defeat G316 review-context isolation.",
         "Operator names `intent-target` on the GitHub issue manually (raw `gh issue edit --add-label intent-target`): refuse, surface the gap — `intent-target` is the FINAL publish boundary applied by `automation issue-publish --write` after `issue publish-flow` succeeds, never the default."
     };
@@ -221,6 +221,12 @@ internal static class GuideWorkflowTaskPacketDraftCommand
         {
             writer.WriteLine($"- **{section.Section}** — {section.Purpose}");
         }
+        writer.WriteLine();
+        writer.WriteLine("When composing **target-repo-path-part**, put this declaration inside the section with the authored paths (do not infer it):");
+        writer.WriteLine();
+        writer.WriteLine("- Target paths: `<comma- or space-separated paths>`");
+        writer.WriteLine();
+        writer.WriteLine("`issue validate-body` reports a missing heading separately from a missing target-path declaration, so the two omissions remain distinguishable before GitHub mutation.");
         writer.WriteLine();
 
         writer.WriteLine("## Packet-time intent maintenance (optional, normal path)");

--- a/src/IntentSystem.Cli/Commands/IssueValidateBodyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/IssueValidateBodyCommand.cs
@@ -4,7 +4,8 @@ namespace IntentSystem.Cli.Commands;
 /// G183: Read-only <c>intent-cli issue validate-body --from-file &lt;path&gt;
 /// [--format text|json]</c> command. Validates a standalone Markdown child
 /// issue body against the host-review-loop Child Issue Contract: required
-/// headings present, <c>Related Links</c> contains at least one
+/// headings present, the <c>Target Repo / Path / Part</c> section contains a
+/// target-path declaration, and <c>Related Links</c> contains at least one
 /// non-placeholder list item. Exits 0 when valid and non-zero otherwise.
 /// Never mutates parent queue state, runs, packets, GitHub objects, or labels.
 /// </summary>
@@ -32,7 +33,10 @@ internal static class IssueValidateBodyCommand
         }
 
         var content = File.ReadAllText(fromFile);
-        var result = IssueValidateBodyValidator.Validate(fromFile, content);
+        var result = IssueValidateBodyValidator.Validate(
+            fromFile,
+            content,
+            requireTargetPathsDeclaration: true);
 
         if (string.Equals(format, FormatJson, StringComparison.Ordinal))
         {

--- a/src/IntentSystem.Cli/Commands/IssueValidateBodyRenderer.cs
+++ b/src/IntentSystem.Cli/Commands/IssueValidateBodyRenderer.cs
@@ -37,6 +37,11 @@ internal static class IssueValidateBodyRenderer
             }
         }
 
+        if (result.TargetPathsInvalid)
+        {
+            writer.WriteLine($"Target paths declaration: {result.TargetPathsReason ?? "invalid."}");
+        }
+
         if (result.RelatedLinksInvalid)
         {
             writer.WriteLine($"Related Links: {result.RelatedLinksReason ?? "invalid."}");

--- a/src/IntentSystem.Cli/Commands/IssueValidateBodyResult.cs
+++ b/src/IntentSystem.Cli/Commands/IssueValidateBodyResult.cs
@@ -23,4 +23,10 @@ internal sealed record IssueValidateBodyResult
 
     [JsonPropertyName("related_links_reason")]
     public string? RelatedLinksReason { get; init; }
+
+    [JsonPropertyName("target_paths_invalid")]
+    public required bool TargetPathsInvalid { get; init; }
+
+    [JsonPropertyName("target_paths_reason")]
+    public string? TargetPathsReason { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/IssueValidateBodyValidator.cs
+++ b/src/IntentSystem.Cli/Commands/IssueValidateBodyValidator.cs
@@ -1,13 +1,19 @@
+using System.Text.RegularExpressions;
+
 namespace IntentSystem.Cli.Commands;
 
 /// <summary>
 /// Pure validator for standalone Markdown child issue bodies (G183). Checks
-/// the 10 host-review-loop Child Issue Contract headings and ensures the
-/// <c>Related Links</c> section contains at least one non-placeholder list
-/// item. Read-only and side-effect-free.
+/// the 10 host-review-loop Child Issue Contract headings and, when requested
+/// by the drafter-facing command, ensures the <c>Target Repo / Path / Part</c>
+/// section declares target paths. It also ensures the <c>Related Links</c>
+/// section contains at least one non-placeholder list item. Read-only and
+/// side-effect-free.
 /// </summary>
 internal static class IssueValidateBodyValidator
 {
+    private const string TargetRepoPathPartHeading = "Target Repo / Path / Part";
+
     /// <summary>
     /// Required Child Issue Contract headings, in canonical order.
     /// "Target Repo / Path / Part" is the canonical form; the hyphen variant
@@ -42,7 +48,21 @@ internal static class IssueValidateBodyValidator
         "-"
     };
 
-    public static IssueValidateBodyResult Validate(string sourcePath, string content)
+    // The strict drafter-facing check requires the canonical bullet form. The
+    // packet-draft guide and scaffold emit this exact line; legacy consumers
+    // do not opt into this check, so already-published bodies are not
+    // retroactively invalidated.
+    private static readonly Regex TargetPathsDeclarationRegex = new(
+        @"^\s*-\s+Target paths:\s*(?<paths>\S.*)$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // The strict target-path check is opt-in so legacy consumers that inspect
+    // already-published bodies do not retroactively invalidate them. The
+    // standalone `issue validate-body` command opts in before issue creation.
+    public static IssueValidateBodyResult Validate(
+        string sourcePath,
+        string content,
+        bool requireTargetPathsDeclaration = false)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(sourcePath);
         ArgumentNullException.ThrowIfNull(content);
@@ -64,7 +84,17 @@ internal static class IssueValidateBodyValidator
             (relatedLinksInvalid, relatedLinksReason) = ValidateRelatedLinks(relatedLinksBody);
         }
 
-        var isValid = missing.Count == 0 && !relatedLinksInvalid;
+        var targetPathsInvalid = false;
+        string? targetPathsReason = null;
+        if (requireTargetPathsDeclaration
+            && TryGetSection(TargetRepoPathPartHeading, sections, out var targetSectionBody))
+        {
+            (targetPathsInvalid, targetPathsReason) = ValidateTargetPathsDeclaration(targetSectionBody);
+        }
+
+        var isValid = missing.Count == 0
+            && !relatedLinksInvalid
+            && !targetPathsInvalid;
 
         return new IssueValidateBodyResult
         {
@@ -72,7 +102,9 @@ internal static class IssueValidateBodyValidator
             IsValid = isValid,
             MissingHeadings = missing,
             RelatedLinksInvalid = relatedLinksInvalid,
-            RelatedLinksReason = relatedLinksReason
+            RelatedLinksReason = relatedLinksReason,
+            TargetPathsInvalid = targetPathsInvalid,
+            TargetPathsReason = targetPathsReason
         };
     }
 
@@ -91,6 +123,31 @@ internal static class IssueValidateBodyValidator
             }
         }
 
+        return false;
+    }
+
+    private static bool TryGetSection(
+        string canonicalHeading,
+        IReadOnlyDictionary<string, string> sections,
+        out string body)
+    {
+        if (sections.TryGetValue(canonicalHeading, out body!))
+        {
+            return true;
+        }
+
+        if (HeadingAliases.TryGetValue(canonicalHeading, out var aliases))
+        {
+            foreach (var alias in aliases)
+            {
+                if (sections.TryGetValue(alias, out body!))
+                {
+                    return true;
+                }
+            }
+        }
+
+        body = string.Empty;
         return false;
     }
 
@@ -185,6 +242,23 @@ internal static class IssueValidateBodyValidator
         }
 
         return (false, null);
+    }
+
+    private static (bool Invalid, string? Reason) ValidateTargetPathsDeclaration(string body)
+    {
+        foreach (var rawLine in body.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'))
+        {
+            if (TargetPathsDeclarationRegex.IsMatch(rawLine))
+            {
+                return (false, null);
+            }
+        }
+
+        return (
+            true,
+            "Target Repo / Path / Part is present, but the declaration is missing. "
+                + "Add the literal `- Target paths: <path>` line (for example, "
+                + "`- Target paths: src/IntentSystem.Cli/Commands`).");
     }
 
     private static string StripWrappers(string value)

--- a/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
+++ b/src/IntentSystem.Cli/Commands/PacketDraftCommand.cs
@@ -765,7 +765,7 @@ internal static class PacketDraftCommand
 
             Repository: `<owner/repo>`
 
-            Target paths: `<comma- or space-separated paths>`
+            - Target paths: `<comma- or space-separated paths>`
 
             Target part: `<one-line target description>`
 

--- a/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideWorkflowTaskPacketDraftCommandTests.cs
@@ -41,6 +41,8 @@ public sealed class GuideWorkflowTaskPacketDraftCommandTests
         // Stop conditions surface BEFORE GitHub mutation (acceptance criterion 4).
         Assert.Contains("BEFORE", output, StringComparison.Ordinal);
         Assert.Contains("issue validate-body", output, StringComparison.Ordinal);
+        Assert.Contains("- Target paths: `<comma- or space-separated paths>`", output, StringComparison.Ordinal);
+        Assert.Contains("target_paths_invalid", output, StringComparison.Ordinal);
         // intent-target warning (acceptance criterion 3).
         Assert.Contains("intent-target", output, StringComparison.Ordinal);
     }
@@ -69,6 +71,10 @@ public sealed class GuideWorkflowTaskPacketDraftCommandTests
 
         var fileNames = files.EnumerateArray().Select(f => f.GetProperty("name").GetString()).ToArray();
         Assert.Equal(new[] { "packet.yaml", "implementation.md", "review-context.md", "github-body.md" }, fileNames);
+
+        var targetSection = sections.EnumerateArray()
+            .Single(section => section.GetProperty("section").GetString() == "target-repo-path-part");
+        Assert.Contains("- Target paths: <comma- or space-separated paths>", targetSection.GetProperty("purpose").GetString(), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/IntentSystem.Cli.Tests/IssueValidateBodyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/IssueValidateBodyCommandTests.cs
@@ -99,6 +99,86 @@ public sealed class IssueValidateBodyCommandTests
     }
 
     [Fact]
+    public void Execute_GivenTargetSectionWithoutDeclaration_ReportsDistinctFailureThenValidatesAfterLineAdded()
+    {
+        // G720: the target heading and its required declaration are separate
+        // checks. Exercise the full drafter walk: omit the line, observe the
+        // refusal, add the authored line, and validate again.
+        using var workspace = new IssueValidateBodyWorkspace();
+        var bodyWithoutTargetPaths = CompleteValidBody.Replace(
+            "- Target paths: `src/IntentSystem.Cli/Commands`, `tests/IntentSystem.Cli.Tests`\n",
+            string.Empty,
+            StringComparison.Ordinal);
+        workspace.WriteBody("issue.md", bodyWithoutTargetPaths);
+
+        using var refusalWriter = new StringWriter();
+        var refusalExitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md")],
+            refusalWriter);
+
+        Assert.Equal(1, refusalExitCode);
+        var refusalOutput = refusalWriter.ToString();
+        Assert.Contains("Target paths declaration:", refusalOutput, StringComparison.Ordinal);
+        Assert.Contains("- Target paths: <path>", refusalOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("Missing required headings:", refusalOutput, StringComparison.Ordinal);
+
+        using var refusalJsonWriter = new StringWriter();
+        var refusalJsonExitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md"), "--format", "json"],
+            refusalJsonWriter);
+
+        Assert.Equal(1, refusalJsonExitCode);
+        using (var refusalDocument = JsonDocument.Parse(refusalJsonWriter.ToString()))
+        {
+            var refusalRoot = refusalDocument.RootElement;
+            Assert.False(refusalRoot.GetProperty("is_valid").GetBoolean());
+            Assert.True(refusalRoot.GetProperty("target_paths_invalid").GetBoolean());
+            Assert.Equal(0, refusalRoot.GetProperty("missing_headings").GetArrayLength());
+        }
+
+        var repairedBody = bodyWithoutTargetPaths.Replace(
+            "- Likely areas: src/, tests/\n",
+            "- Target paths: `src/IntentSystem.Cli/Commands`, `tests/IntentSystem.Cli.Tests`\n- Likely areas: src/, tests/\n",
+            StringComparison.Ordinal);
+        workspace.WriteBody("issue.md", repairedBody);
+
+        using var validWriter = new StringWriter();
+        var validExitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md"), "--format", "json"],
+            validWriter);
+
+        Assert.Equal(0, validExitCode);
+        using var validDocument = JsonDocument.Parse(validWriter.ToString());
+        var validRoot = validDocument.RootElement;
+        Assert.True(validRoot.GetProperty("is_valid").GetBoolean());
+        Assert.False(validRoot.GetProperty("target_paths_invalid").GetBoolean());
+    }
+
+    [Fact]
+    public void Execute_GivenTargetPathsWithoutCanonicalBullet_ReportsTargetDeclarationFailure()
+    {
+        using var workspace = new IssueValidateBodyWorkspace();
+        var nonCanonicalBody = CompleteValidBody.Replace(
+            "- Target paths:",
+            "Target paths:",
+            StringComparison.Ordinal);
+        workspace.WriteBody("issue.md", nonCanonicalBody);
+
+        using var writer = new StringWriter();
+        var exitCode = IssueValidateBodyCommand.Execute(
+            workspace.Context,
+            ["--from-file", workspace.GetPath("issue.md")],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Target paths declaration:", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("literal `- Target paths: <path>`", writer.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_GivenMissingFromFileFlag_ReturnsNonZero()
     {
         // Required scenario 4 (a): missing --from-file flag.
@@ -160,6 +240,7 @@ public sealed class IssueValidateBodyCommandTests
         var root = document.RootElement;
         Assert.True(root.GetProperty("is_valid").GetBoolean());
         Assert.False(root.GetProperty("related_links_invalid").GetBoolean());
+        Assert.False(root.GetProperty("target_paths_invalid").GetBoolean());
         Assert.Equal(JsonValueKind.Array, root.GetProperty("missing_headings").ValueKind);
         Assert.Equal(0, root.GetProperty("missing_headings").GetArrayLength());
         Assert.True(root.TryGetProperty("source_path", out _));
@@ -226,6 +307,7 @@ public sealed class IssueValidateBodyCommandTests
         ## Target Repo / Path / Part
 
         - Repository: J-Tech-Japan/intent-system
+        - Target paths: `src/IntentSystem.Cli/Commands`, `tests/IntentSystem.Cli.Tests`
         - Likely areas: src/, tests/
 
         ## In Scope


### PR DESCRIPTION
Closes #1561

## Summary

- Make the drafter-facing `issue validate-body` command reject a present target section that lacks the canonical `- Target paths: <path>` declaration.
- Emit a distinct `target_paths_invalid` JSON/text diagnostic so a missing heading is distinguishable from a missing declaration.
- Show the declaration in the packet-draft guide and scaffold, without changing legacy consumers that inspect already-published packets.

## Verification

- Focused: 24 passed (`IssueValidateBodyCommandTests`, `GuideWorkflowTaskPacketDraftCommandTests`).
- Affected surfaces: 208 passed (issue preparation, packet drafting, readiness, worker preflight, bridge, and prepared-packet tests).
- Full CLI suite: 5,143 passed, 1 skipped; 2 packaged-invocation smoke tests failed in the existing subprocess/package path.
- `git diff --check` passed.

## G720 review repair: durable AC 4–7 evidence

All captures below were run against the unchanged PR head. The checkout and PR both reported the same exact SHA:

```text
$ git rev-parse HEAD
bf413be050a46fffb065dcac1d97d397a782839d
$ gh pr view 1563 --repo J-Tech-Japan/intent-system --json headRefOid --jq .headRefOid
bf413be050a46fffb065dcac1d97d397a782839d
```

### AC 4 — rendered packet-draft guidance contains the declaration

Command:

```text
dotnet src/IntentSystem.Cli/bin/Debug/net10.0/IntentSystem.Cli.dll guide workflow task packet-draft
```

Actual rendered excerpt:

```text
## Standalone issue contract

Every `github-body.md` MUST carry these sections in order. Missing sections are caught by `intent-cli issue validate-body --from-file <path> --format json` BEFORE any GitHub mutation:

- **target-repo-path-part** — Exact repository / folder / surface the change must land in. Disambiguates host-vs-child mutation targets. Include the literal bullet `- Target paths: <comma- or space-separated paths>` with authored paths; do not infer it from other fields.

When composing **target-repo-path-part**, put this declaration inside the section with the authored paths (do not infer it):

- Target paths: `<comma- or space-separated paths>`

`issue validate-body` reports a missing heading separately from a missing target-path declaration, so the two omissions remain distinguishable before GitHub mutation.
```

### AC 5 — an actual historical published body still succeeds through the legacy consumer

Source evidence: closed GitHub issue [#1544 / G713](https://github.com/J-Tech-Japan/intent-system/issues/1544). Its actual Target section was:

```text
## Target Repo / Path / Part

- Repo: `J-Tech-Japan/intent-system`
- Part: the rendered herdr-only provisioning checklist, and what `session-layer topology validate` reports about panes it has recorded
```

The body was copied unchanged from GitHub into the isolated evidence fixture and passed through the legacy `issue prepare` consumer. This is the actual command output and exit status:

```text
$ dotnet src/IntentSystem.Cli/bin/Debug/net10.0/IntentSystem.Cli.dll issue prepare --from-file historical-g713-1544.md --execution-unit G713-historical-evidence --title "Historical G713 published body" --out .intent-cli/g713-historical-packet.json
Prepared reviewed publish packet for G713-historical-evidence at .intent-cli/g713-historical-packet.json
exit code: 0
```

The emitted packet confirms the legacy consumer accepted the body:

```json
{
  "execution_unit": "G713-historical-evidence",
  "title": "Historical G713 published body",
  "source_path": "historical-g713-1544.md",
  "source_body_sha256": "a75233cc752c3c4541ec8eed7f6f4c32d815455a56e21942009672b50eb33bcc",
  "validation_status": "valid",
  "reviewed": true,
  "published": false,
  "issue_number": null,
  "issue_url": null,
  "prepared_at_utc": "2026-08-20T06:08:03.517Z",
  "published_at_utc": null
}
```

### AC 6 — captured draft → refusal → authored line → valid walk

The exact-head packet draft command created all four scratch packet files and emitted `mode: "write"`; its generated `github-body.md` contained the target declaration:

```text
$ dotnet src/IntentSystem.Cli/bin/Debug/net10.0/IntentSystem.Cli.dll packet draft --execution-unit G720-draft-evidence --domain intent-cli --target-repo J-Tech-Japan/intent-system --format json
{
  "execution_unit": "G720-draft-evidence",
  "domain": "intent-cli",
  "target_repo": "J-Tech-Japan/intent-system",
  "packet_directory": "/Users/tomohisa/dev/GitHub/intent-system/.g720-work/.g720-evidence/.intent-cli/issues/G720-draft-evidence",
  "mode": "write",
  "files": [
    {
      "name": "packet.yaml",
      "path": "/Users/tomohisa/dev/GitHub/intent-system/.g720-work/.g720-evidence/.intent-cli/issues/G720-draft-evidence/packet.yaml",
      "status": "created"
    },
    {
      "name": "implementation.md",
      "path": "/Users/tomohisa/dev/GitHub/intent-system/.g720-work/.g720-evidence/.intent-cli/issues/G720-draft-evidence/implementation.md",
      "status": "created"
    },
    {
      "name": "review-context.md",
      "path": "/Users/tomohisa/dev/GitHub/intent-system/.g720-work/.g720-evidence/.intent-cli/issues/G720-draft-evidence/review-context.md",
      "status": "created"
    },
    {
      "name": "github-body.md",
      "path": "/Users/tomohisa/dev/GitHub/intent-system/.g720-work/.g720-evidence/.intent-cli/issues/G720-draft-evidence/github-body.md",
      "status": "created"
    }
  ],
  "missing_canonical_files": [],
  "missing_contract_sections": [],
  "refusal_reasons": [
    "missing-domain-binding-regex"
  ],
  "recommended_actions": [
    "Add the active domain\u0027s top-level \u0060execution_unit_regex\u0060 to bindings.md, then re-run readiness.",
    "After repairing every reported item, re-run \u0060intent-cli packet draft --execution-unit G720-draft-evidence --domain intent-cli --target-repo J-Tech-Japan/intent-system --dry-run --format json\u0060 and proceed only when \u0060contract_publishable\u0060 is true."
  ],
  "contract_publishable": false
}
$ rg -n -C 4 'Target Repo / Path / Part|Target paths:' .intent-cli/issues/G720-draft-evidence/github-body.md
17:## Target Repo / Path / Part
19:Repository: `<owner/repo>`
21:- Target paths: `<comma- or space-separated paths>`
23:Target part: `<one-line target description>`
```

For the authored-body walk, the only change to the contract fixture was removing and then restoring that authored declaration. The following are the exact validator outputs.

#### Before adding the line — text, exit 1

```text
Source: without-target.md
Result: invalid
Target paths declaration: Target Repo / Path / Part is present, but the declaration is missing. Add the literal `- Target paths: <path>` line (for example, `- Target paths: src/IntentSystem.Cli/Commands`).
```

#### Before adding the line — JSON, exit 1

```json
{
  "source_path": "without-target.md",
  "is_valid": false,
  "missing_headings": [],
  "related_links_invalid": false,
  "related_links_reason": null,
  "target_paths_invalid": true,
  "target_paths_reason": "Target Repo / Path / Part is present, but the declaration is missing. Add the literal \u0060- Target paths: \u003Cpath\u003E\u0060 line (for example, \u0060- Target paths: src/IntentSystem.Cli/Commands\u0060)."
}
```

#### After adding the authored line — text, exit 0

```text
Source: with-target.md
Result: valid — issue body satisfies the Child Issue Contract.
```

#### After adding the authored line — JSON, exit 0

```json
{
  "source_path": "with-target.md",
  "is_valid": true,
  "missing_headings": [],
  "related_links_invalid": false,
  "related_links_reason": null,
  "target_paths_invalid": false,
  "target_paths_reason": null
}
```

### AC 7 — heading and declaration failures are distinguishable

The refusal JSON above has `missing_headings: []` and `target_paths_invalid: true`; the text output labels the independent failure `Target paths declaration:` rather than adding `Target Repo / Path / Part` to the missing-heading list. The valid after-state has both `missing_headings: []` and `target_paths_invalid: false`.
