### PR TITLE
G721: extend v0.23.0 release notes to G720

### DIFF
--- a/docs/en/release-notes-v0.23.0.md
+++ b/docs/en/release-notes-v0.23.0.md
@@ -30,22 +30,25 @@ credential, and does not perform the post-release roll.
 
 ## Preview lane — read before the feature description
 
-G710 through G716 remain preview-through-1.x surfaces. They are outside the
+G710 through G720 remain preview-through-1.x surfaces. They are outside the
 [1.0 compatibility promise](1.0-compatibility-promise.md) until that promise
 is explicitly updated; the minor version does not by itself add a stability
 guarantee.
 
-## Seven merged feature units
+## Eleven merged feature units
 
 The v0.22.0 tag `c06dc49e89446bf3b723612dd72004d628914734` through the prepared
-head `e25d770caacbcdafa2aa9bebea72e895dc22fcbb` contains exactly twenty commits.
+head `be13f7c0b9b306dad99d692903cee8837b31f0e8` contains exactly twenty-six commits.
 The post-release roll `c48a5635` is one of those commits but is **not a release
-execution unit**. The release inventory below covers exactly seven merged feature units, G710 through G716. The first-parent accounting was checked with:
+execution unit**. The release inventory below covers exactly eleven merged feature units, G710 through G720. The first-parent accounting was checked with:
 
 ```bash
+git rev-list --count v0.22.0..HEAD
 git log --first-parent v0.22.0..origin/main
 git log --first-parent v0.22.0..main
 ```
+
+The count command returned `26` for the named prepared head.
 
 - G710 — PR #1537; repaired the released v0.22.0 verification evidence,
   policy-derived version checks, and bilingual release documentation rather
@@ -66,6 +69,21 @@ git log --first-parent v0.22.0..main
   the exact `<repo>/.git` root enables the measured metadata write, while this
   recipe retains non-sandboxed host-state routing because that is the
   least-privilege choice and `git worktree add` remains unmeasured; merge commit `4b0a1a31b075746927d0d73c6f9b370c531e9845`.
+- G717 — PR #1559; on a claims-enabled host, a stale `intent-issue-in-progress`
+  label no longer makes a worker appear to own an issue: an unheld execution-unit
+  claim lets preflight proceed, while a held claim still stops the worker and
+  identifies its owner; merge commit `68c11039f4335df7799c65c814c39873132f4c68`.
+- G718 — PR #1558; prepared the bilingual v0.23.0 release notes and
+  release-readiness evidence for this line without creating a tag or GitHub
+  Release, publishing a package, handling credentials, or performing the
+  post-release roll; merge commit `e7cbba0ce2d143edd19e1c60804073e41ac9401d`.
+- G719 — PR #1562; a sender-local implementation seat can write its report and
+  hand it to orchestration when the host routing root is not writable, while an
+  external reader reports a delegation-level routing fault; merge commit `bc13c9436b98cc48aa02c4eb85cfbb99e9fab598`.
+- G720 — PR #1563; `issue validate-body` rejects a Target section without the
+  authored `- Target paths: <path>` line with a distinct diagnostic before issue
+  creation, while historical published bodies remain accepted by the legacy
+  consumer; merge commit `be13f7c0b9b306dad99d692903cee8837b31f0e8`.
 
 The first-parent merge accounting for the prepared line is:
 
@@ -80,16 +98,21 @@ The first-parent merge accounting for the prepared line is:
 | `c21c2c7e2e976914eed5231148cc1f1f6cf3c5e3` | G714 / PR #1548 |
 | `4b0a1a31b075746927d0d73c6f9b370c531e9845` | G716 / PR #1553 |
 | `e25d770caacbcdafa2aa9bebea72e895dc22fcbb` | G715 / PR #1554 |
+| `e7cbba0ce2d143edd19e1c60804073e41ac9401d` | G718 / PR #1558 |
+| `ea17d02d9489c60ee96e0d088693814b1daad945` | G717 claim handoff; not a release execution unit |
+| `68c11039f4335df7799c65c814c39873132f4c68` | G717 / PR #1559 |
+| `7f0233080366c86dd449aa7873b339037a7f8f39` | G719 claim handoff; not a release execution unit |
+| `bc13c9436b98cc48aa02c4eb85cfbb99e9fab598` | G719 / PR #1562 |
+| `be13f7c0b9b306dad99d692903cee8837b31f0e8` | G720 / PR #1563; prepared head |
 
 ## Release-readiness evidence
 
 - `eng/version.json` is the single policy source: `stableVersion` is `0.22.0`
   and `nextVersion` is `0.23.0`.
 - **Release identity evidence source revision:**
-  `39611e5e0f024591cc961b20bc99ada2b8e22c38`, the reviewed PR head before
-  this documentation-only repair. This provenance is intentional: the repair
-  changes the PR head, so the pasted identity below must not be presented as
-  output from the post-repair commit.
+  `be13f7c0b9b306dad99d692903cee8837b31f0e8`, the exact prepared head named
+  above. The Release build below was run from that revision before this
+  documentation-only PR changed the checkout.
 - The Release build command was:
 
 ```bash
@@ -97,7 +120,7 @@ dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
 ```
 
-It reported exactly `intent-cli 0.23.0-39611e5-G718`.
+It reported exactly `intent-cli 0.23.0-be13f7c-G718`.
 - The two new command surfaces were independently probed from that build:
 
 ```bash
@@ -107,18 +130,27 @@ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll guide workf
 
 The first exited 0 with the reconcile/uninstall usage; the second exited 0
 with `metadata_free: true` and `read_only: true`.
-- The required release-note documentation tests and version-source policy guard
-  command (the filter shown in the readiness section) passed with **136 passed,
-  0 skipped, 0 failed, 136 total**.
-- The full command `dotnet test IntentSystem.sln --configuration Release -p:NuGetAudit=false`
-  passed with **5,462 passed, 1 skipped, 0 failed, 5,463 total**.
+- The focused release-note documentation and version-source policy guards were
+  run with:
+
+```bash
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-build --no-restore -p:IsTestProject=true --filter 'FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests'
+```
+
+They passed with **12 passed, 0 skipped, 0 failed, 12 total**.
+- The full Release sweep over all eleven test projects used the Release/no-restore
+  settings and recorded **5,474 passed, 1 skipped, 2 failed, 5,477 total**.
+  The only failures were the pre-existing `PackagedInvocationSmokeTests`; their
+  child `dotnet pack` could not update the shared NuGet vulnerability cache
+  (`NU1900`, permission denied), not a failure in these documentation/test edits.
 - Both `docs/en/release-notes-v0.22.1.md` and
   `docs/ja/release-notes-v0.22.1.md` are superseded and deleted; these 0.23.0
   notes are the prepared bilingual replacement.
 
 ## Prepare-only boundary
 
-This change set changes version policy and release documentation only. It does
+This change set changes the prepared bilingual release documentation and its
+documentation tests only. It does
 not create a tag or GitHub Release, publish a package, handle credentials, or
 perform the post-release roll. The post-release roll remains a later action:
 after publication, set `stableVersion` to the released version, choose the

--- a/docs/ja/release-notes-v0.23.0.md
+++ b/docs/ja/release-notes-v0.23.0.md
@@ -30,22 +30,25 @@ GitHub Release を作成せず、package を publish せず、credential を扱�
 
 ## Preview lane — feature description より先に読む
 
-G710 から G716 は引き続き preview-through-1.x surface です。
+G710 から G720 は引き続き preview-through-1.x surface です。
 [1.0 compatibility promise](1.0-compatibility-promise.md) が明示的に更新されるまでこの範囲の外であり、
 minor version だけから stability guarantee を推測しないでください。
 
-## 正確に七件の merged feature unit
+## 正確に十一件の merged feature unit
 
 v0.22.0 tag `c06dc49e89446bf3b723612dd72004d628914734` から prepared head
-`e25d770caacbcdafa2aa9bebea72e895dc22fcbb` までには正確に twenty commits があります。
+`be13f7c0b9b306dad99d692903cee8837b31f0e8` までには正確に twenty-six commits があります。
 post-release roll の `c48a5635` はその一つですが、**release execution unit ではありません**。
-下記の inventory は正確に七件、G710 から G716 だけを対象にします。first-parent accounting
+下記の inventory は正確に十一件、G710 から G720 を対象にします。first-parent accounting
 には次を使いました:
 
 ```bash
+git rev-list --count v0.22.0..HEAD
 git log --first-parent v0.22.0..origin/main
 git log --first-parent v0.22.0..main
 ```
+
+count command の結果は、指定した prepared head に対して `26` でした。
 
 - G710 — PR #1537; v0.22.0 の released verification evidence、policy-derived version check、
   bilingual release documentation を修復しました。product feature の追加ではありません。merge commit `335bb686ba966368abbdadac149bc27d9aea7c6b`。
@@ -62,6 +65,18 @@ git log --first-parent v0.22.0..main
   `.git` claim は retracted/corrected されました。corrected rule は exact `<repo>/.git` root が
   measured metadata write を可能にすることを示しつつ、この recipe では least privilege を保つ
   non-sandboxed host-state routing を選びます。`git worktree add` は未測定です。merge commit `4b0a1a31b075746927d0d73c6f9b370c531e9845`。
+- G717 — PR #1559; claims-enabled host では、古い `intent-issue-in-progress` label だけで worker が
+  issue を所有済みとは扱いません。execution-unit claim が未保持なら preflight は進み、保持中なら
+  worker を止めて owner を示します。merge commit `68c11039f4335df7799c65c814c39873132f4c68`。
+- G718 — PR #1558; この line の bilingual v0.23.0 release notes と release-readiness evidence を
+  prepare しました。tag、GitHub Release、package publish、credential の処理、post-release roll は
+  作成・実行しません。merge commit `e7cbba0ce2d143edd19e1c60804073e41ac9401d`。
+- G719 — PR #1562; host routing root に write できない implementation seat でも report を sender-local
+  （seat-local）に保存して orchestration に handoff でき、external reader には delegation-level routing fault を
+  表示します。merge commit `bc13c9436b98cc48aa02c4eb85cfbb99e9fab598`。
+- G720 — PR #1563; Target section に authored `- Target paths: <path>` line がなければ、
+  `issue validate-body` が issue creation 前に distinct diagnostic で拒否し、historical published
+  body は legacy consumer で引き続き受理されます。merge commit `be13f7c0b9b306dad99d692903cee8837b31f0e8`。
 
 prepared line の first-parent merge accounting は次の通りです:
 
@@ -76,15 +91,21 @@ prepared line の first-parent merge accounting は次の通りです:
 | `c21c2c7e2e976914eed5231148cc1f1f6cf3c5e3` | G714 / PR #1548 |
 | `4b0a1a31b075746927d0d73c6f9b370c531e9845` | G716 / PR #1553 |
 | `e25d770caacbcdafa2aa9bebea72e895dc22fcbb` | G715 / PR #1554 |
+| `e7cbba0ce2d143edd19e1c60804073e41ac9401d` | G718 / PR #1558 |
+| `ea17d02d9489c60ee96e0d088693814b1daad945` | G717 claim handoff; release execution unit ではありません |
+| `68c11039f4335df7799c65c814c39873132f4c68` | G717 / PR #1559 |
+| `7f0233080366c86dd449aa7873b339037a7f8f39` | G719 claim handoff; release execution unit ではありません |
+| `bc13c9436b98cc48aa02c4eb85cfbb99e9fab598` | G719 / PR #1562 |
+| `be13f7c0b9b306dad99d692903cee8837b31f0e8` | G720 / PR #1563; prepared head |
 
 ## Release-readiness evidence
 
 - `eng/version.json` が single policy source です: `stableVersion` は `0.22.0`、
   `nextVersion` は `0.23.0` です。
 - **Release identity evidence source revision:**
-  `39611e5e0f024591cc961b20bc99ada2b8e22c38`（この documentation-only repair
-  前の reviewed PR head。この source tree から build した結果を貼り付けて
-  います。repair 後の commit の出力とは主張しません。）
+  `be13f7c0b9b306dad99d692903cee8837b31f0e8`（上で指定した exact prepared
+  head。この documentation-only PR で checkout を変更する前に、この revision
+  から Release build を実行しました。）
 - Release build の command は次の通りです:
 
 ```bash
@@ -92,7 +113,7 @@ dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
 ```
 
-表示された identity は正確に `intent-cli 0.23.0-39611e5-G718` でした。
+表示された identity は正確に `intent-cli 0.23.0-be13f7c-G718` でした。
 - その build から二つの新 command surface を独立に probe しました:
 
 ```bash
@@ -102,16 +123,22 @@ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll guide workf
 
 前者は reconcile/uninstall usage を表示して exit 0、後者は
 `metadata_free: true` と `read_only: true` を含む contract を表示して exit 0 でした。
-- required release-note documentation tests と version-source policy guard の command（readiness section の
-  filter）は **136 passed、0 skipped、0 failed、total 136** でした。
-- full command `dotnet test IntentSystem.sln --configuration Release -p:NuGetAudit=false` は
-  **5,462 passed、1 skipped、0 failed、total 5,463** でした。
+- focused release-note documentation と version-source policy guard は次の command で実行しました:
+
+```bash
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-build --no-restore -p:IsTestProject=true --filter 'FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests'
+```
+
+**12 passed、0 skipped、0 failed、total 12** でした。
+- eleven test project を対象にした full Release sweep は **5,474 passed、1 skipped、2 failed、total 5,477** でした。
+  failure は既存の `PackagedInvocationSmokeTests` だけで、child `dotnet pack` が shared NuGet vulnerability cache を
+  更新できず (`NU1900`、permission denied) に失敗しました。この documentation/test edit の failure ではありません。
 - `docs/en/release-notes-v0.22.1.md` と `docs/ja/release-notes-v0.22.1.md` は superseded のため削除し、
   この 0.23.0 notes を bilingual replacement にします。
 
 ## Prepare-only boundary
 
-この change set は version policy と release documentation だけを変更します。tag や GitHub Release を
+この change set は prepared bilingual release documentation とその documentation test だけを変更します。tag や GitHub Release を
 作成せず、package を publish せず、credential を扱わず、post-release roll を実行しません。
 公開後の post-release roll は別の action です: `stableVersion` を公開済み version にし、
 `nextVersion` を次の patch にし、次の DRAFT stub を追加し、両言語の readiness section を更新して、

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0230DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0230DocsTests.cs
@@ -4,15 +4,15 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G718: the prepared v0.23.0 notes are a bilingual inventory of exactly
-/// G710 through G716, with the two new command surfaces and the G714/G716
-/// guidance corrections made explicit.
+/// G721: the prepared v0.23.0 notes are a bilingual inventory of exactly
+/// G710 through G720, with operator-observable G717/G719/G720 behaviour and
+/// the prepared-head release identity made explicit.
 /// </summary>
 public sealed class ReleaseNotesV0230DocsTests
 {
     private const string ReleaseIdentityEvidenceSourceRevision =
-        "39611e5e0f024591cc961b20bc99ada2b8e22c38";
-    private const string ReleaseIdentityEvidence = "intent-cli 0.23.0-39611e5-G718";
+        "be13f7c0b9b306dad99d692903cee8837b31f0e8";
+    private const string ReleaseIdentityEvidence = "intent-cli 0.23.0-be13f7c-G718";
 
     private static readonly (string Unit, string[] Prs, string[] Merges)[] Units =
     [
@@ -26,6 +26,10 @@ public sealed class ReleaseNotesV0230DocsTests
         ("G714", ["#1548"], ["c21c2c7e2e976914eed5231148cc1f1f6cf3c5e3"]),
         ("G715", ["#1554"], ["e25d770caacbcdafa2aa9bebea72e895dc22fcbb"]),
         ("G716", ["#1553"], ["4b0a1a31b075746927d0d73c6f9b370c531e9845"]),
+        ("G717", ["#1559"], ["68c11039f4335df7799c65c814c39873132f4c68"]),
+        ("G718", ["#1558"], ["e7cbba0ce2d143edd19e1c60804073e41ac9401d"]),
+        ("G719", ["#1562"], ["bc13c9436b98cc48aa02c4eb85cfbb99e9fab598"]),
+        ("G720", ["#1563"], ["be13f7c0b9b306dad99d692903cee8837b31f0e8"]),
     ];
 
     private static readonly string[] RangeCommits =
@@ -39,12 +43,18 @@ public sealed class ReleaseNotesV0230DocsTests
         "c21c2c7e2e976914eed5231148cc1f1f6cf3c5e3",
         "4b0a1a31b075746927d0d73c6f9b370c531e9845",
         "e25d770caacbcdafa2aa9bebea72e895dc22fcbb",
+        "e7cbba0ce2d143edd19e1c60804073e41ac9401d",
+        "ea17d02d9489c60ee96e0d088693814b1daad945",
+        "68c11039f4335df7799c65c814c39873132f4c68",
+        "7f0233080366c86dd449aa7873b339037a7f8f39",
+        "bc13c9436b98cc48aa02c4eb85cfbb99e9fab598",
+        "be13f7c0b9b306dad99d692903cee8837b31f0e8",
     ];
 
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void NotesCoverExactlyG710ThroughG716WithVerifiedPrsAndMerges(string language)
+    public void NotesCoverExactlyG710ThroughG720WithVerifiedPrsAndMerges(string language)
     {
         var notes = Read(language);
         var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
@@ -52,7 +62,7 @@ public sealed class ReleaseNotesV0230DocsTests
             .ToArray();
 
         Assert.Equal(Units.Select(unit => unit.Unit), listed);
-        Assert.Equal(7, listed.Length);
+        Assert.Equal(11, listed.Length);
         foreach (var unit in Units)
         {
             var bullet = Regex.Match(notes, $@"(?m)^- {Regex.Escape(unit.Unit)} —[^\r\n]*$");
@@ -72,10 +82,12 @@ public sealed class ReleaseNotesV0230DocsTests
         Assert.Contains("git log --first-parent v0.22.0..origin/main", notes, StringComparison.Ordinal);
         Assert.Contains("git log --first-parent v0.22.0..main", notes, StringComparison.Ordinal);
         Assert.Contains(
-            language == "en" ? "exactly seven merged feature units" : "正確に七件の merged feature unit",
+            language == "en" ? "exactly eleven merged feature units" : "正確に十一件の merged feature unit",
             notes,
             StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("twenty commits", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("twenty-six commits", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("be13f7c0b9b306dad99d692903cee8837b31f0e8", notes, StringComparison.Ordinal);
+        Assert.Contains("git rev-list --count v0.22.0..HEAD", notes, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -85,7 +97,7 @@ public sealed class ReleaseNotesV0230DocsTests
     {
         var notes = Read(language);
 
-        Assert.Equal(9, RangeCommits.Length);
+        Assert.Equal(15, RangeCommits.Length);
         Assert.Equal(RangeCommits.Length, RangeCommits.Distinct(StringComparer.Ordinal).Count());
         foreach (var commit in RangeCommits)
         {
@@ -114,6 +126,15 @@ public sealed class ReleaseNotesV0230DocsTests
         Assert.Contains("linkage-recovered", notes, StringComparison.Ordinal);
         Assert.Contains("G714", notes, StringComparison.Ordinal);
         Assert.Contains("G716", notes, StringComparison.Ordinal);
+        Assert.Contains("G717", notes, StringComparison.Ordinal);
+        Assert.Contains("G718", notes, StringComparison.Ordinal);
+        Assert.Contains("G719", notes, StringComparison.Ordinal);
+        Assert.Contains("G720", notes, StringComparison.Ordinal);
+        Assert.Contains("claims-enabled host", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("intent-issue-in-progress", compact, StringComparison.Ordinal);
+        Assert.Contains("sender-local", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("delegation-level routing fault", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Target paths", notes, StringComparison.Ordinal);
         Assert.Contains(
             language == "en" ? "correction, not a feature" : "feature ではなく correction",
             compact,
@@ -151,7 +172,7 @@ public sealed class ReleaseNotesV0230DocsTests
     }
 
     [Fact]
-    public void ReleaseIdentityEvidence_IsMirroredAndBoundToItsProducingRevision_G718Repair()
+    public void ReleaseIdentityEvidence_IsMirroredAndBoundToItsProducingRevision_G721()
     {
         var notes = new[] { Read("en"), Read("ja") };
         var sourceRevisions = notes
@@ -176,7 +197,7 @@ public sealed class ReleaseNotesV0230DocsTests
             sourceRevisions[0].Groups["sha"].Value[..7],
             identities[0].Groups["sha"].Value);
         Assert.Equal("G718", identities[0].Groups["unit"].Value);
-        Assert.All(notes, note => Assert.Contains("documentation-only repair", note, StringComparison.OrdinalIgnoreCase));
+        Assert.All(notes, note => Assert.Contains("exact prepared", note, StringComparison.OrdinalIgnoreCase));
     }
 
     private static string Read(string language) =>


### PR DESCRIPTION
Closes #1564

## Summary

- Extend both v0.23.0 release-note mirrors from exactly G710–G716 to exactly G710–G720 without changing the reviewed G710–G716 entries.
- Add operator-observable descriptions and merge SHAs for G717, G718, G719, and G720.
- Pin the prepared range to `v0.22.0` (`c06dc49e89446bf3b723612dd72004d628914734`) through exact prepared head `be13f7c0b9b306dad99d692903cee8837b31f0e8` and its observed full count of 26 commits.
- Update `ReleaseNotesV0230DocsTests` to pin the inventory, range, operator-facing evidence, and build identity.

## Release-readiness evidence

Prepared-head range:

```text
prepared_head=be13f7c0b9b306dad99d692903cee8837b31f0e8
git rev-list --count v0.22.0..HEAD=26
inventory=G710,G711,G712,G713,G714,G715,G716,G717,G718,G719,G720
```

The Release build was run from the exact prepared head before this documentation PR changed the checkout:

```text
dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release -p:NuGetAudit=false
Build succeeded. 0 Warning(s), 0 Error(s)
dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
intent-cli 0.23.0-be13f7c-G718
```

The full producing revision is `be13f7c0b9b306dad99d692903cee8837b31f0e8`; the display identity is copied verbatim from that build. The `G718` suffix is the tool's emitted latest execution-unit identity.

Focused release-note and version-source guards:

```text
dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj --configuration Release --no-build --no-restore -p:IsTestProject=true --filter 'FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests'
Test Run Successful.
Total tests: 12
     Passed: 12
     Skipped: 0
```

Full Release test-project sweep (all 11 test projects):

```text
failed=0; for project in tests/*/*.csproj; do dotnet test "$project" --configuration Release --no-build --no-restore -p:IsTestProject=true --logger 'console;verbosity=minimal' || failed=1; done; exit $failed
5,474 passed, 1 skipped, 2 failed, 5,477 total
```

The two failures are the existing `PackagedInvocationSmokeTests`; their child `dotnet pack` cannot update the shared NuGet vulnerability cache in this managed environment (`NU1900`, permission denied). The focused guards and every other test project passed. `git diff --check` passed.

## Scope boundary

Changed files are only:

- `docs/en/release-notes-v0.23.0.md`
- `docs/ja/release-notes-v0.23.0.md`
- `tests/IntentSystem.Cli.Tests/ReleaseNotesV0230DocsTests.cs`

This is prepare-only: no tag, GitHub Release, package publish, credential handling, post-release roll, or unrelated source change was performed.
