### PR TITLE
G722: fix npm platform provenance metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,10 +406,22 @@ jobs:
             local publish_output
             if ! publish_output="$(npm publish "${package_path}" --access public 2>&1)"; then
               printf '%s\n' "${publish_output}" >&2
-              echo "npm trusted publishing authentication failed for package ${package_name}: register this package's npmjs.com trusted publisher for repository ${GITHUB_REPOSITORY} and workflow .github/workflows/release.yml, and keep id-token: write on the npm job; no npm token fallback is supported." >&2
+              classify_publish_failure "${package_name}" "${publish_output}"
               return 1
             fi
             printf '%s\n' "${publish_output}"
+          }
+
+          classify_publish_failure() {
+            local package_name="$1"
+            local publish_output="$2"
+            if printf '%s\n' "${publish_output}" | grep -Eiq 'E422|provenance|repository information|Unprocessable Entity'; then
+              echo "npm registry/provenance rejection for package ${package_name}: the authenticated publish reached npm but the registry rejected the package metadata. Clear this by publishing a package whose repository.url matches https://github.com/J-Tech-Japan/intent-system, then rerun this release publish." >&2
+            elif printf '%s\n' "${publish_output}" | grep -Eiq 'E401|ENEEDAUTH|E403|not authorized|authentication|trusted publisher'; then
+              echo "npm trusted publishing authentication failure for package ${package_name}: the publish could not authenticate with npm. Clear this by registering this package's npmjs.com trusted publisher for repository ${GITHUB_REPOSITORY} and workflow .github/workflows/release.yml, keeping id-token: write on the npm job, then rerun this release publish." >&2
+            else
+              echo "npm publish failure for package ${package_name}: the registry or client rejected the request; the npm output above is the source of the failure. Clear this by correcting the reported publish error, then rerun this release publish." >&2
+            fi
           }
 
           publish_package \

--- a/packaging/npm/platforms/darwin-arm64/package.json
+++ b/packaging/npm/platforms/darwin-arm64/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0-dev",
   "description": "Self-contained intent-cli binary for macOS Apple Silicon.",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/J-Tech-Japan/intent-system"
+  },
   "os": [
     "darwin"
   ],

--- a/packaging/npm/platforms/linux-x64/package.json
+++ b/packaging/npm/platforms/linux-x64/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0-dev",
   "description": "Self-contained intent-cli binary for Linux x64.",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/J-Tech-Japan/intent-system"
+  },
   "os": [
     "linux"
   ],

--- a/packaging/npm/platforms/win32-x64/package.json
+++ b/packaging/npm/platforms/win32-x64/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0-dev",
   "description": "Self-contained intent-cli binary for Windows x64.",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/J-Tech-Japan/intent-system"
+  },
   "os": [
     "win32"
   ],

--- a/packaging/npm/scripts/verify-packages.js
+++ b/packaging/npm/scripts/verify-packages.js
@@ -6,6 +6,7 @@ const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
 
+const provenanceRepositoryUrl = 'https://github.com/J-Tech-Japan/intent-system';
 const platforms = [
   { directory: 'darwin-arm64', package: '@j-tech-japan/intent-cli-darwin-arm64', rid: 'osx-arm64', binary: 'intent-cli' },
   { directory: 'linux-x64', package: '@j-tech-japan/intent-cli-linux-x64', rid: 'linux-x64', binary: 'intent-cli' },
@@ -59,6 +60,7 @@ function main() {
   assert(mainPackage.name === 'intent-system', 'main package name drifted');
   assert(mainPackage.version === options.expectedversion, `main package version ${mainPackage.version} != ${options.expectedversion}`);
   assert(mainPackage.bin?.['intent-cli'] === 'bin/intent-cli.js', 'main package must expose the intent-cli shim');
+  assert(mainPackage.repository?.url === 'git+https://github.com/J-Tech-Japan/intent-system.git', 'main package repository.url drifted');
   assert(!mainPackage.scripts?.postinstall, 'main package must not have a postinstall hook');
 
   for (const platform of platforms) {
@@ -66,6 +68,7 @@ function main() {
     const packageJson = readJson(path.join(directory, 'package.json'));
     assert(packageJson.name === platform.package, `${platform.rid} package name drifted`);
     assert(packageJson.version === options.expectedversion, `${platform.rid} package version drifted`);
+    assert(packageJson.repository?.url === provenanceRepositoryUrl, `${platform.rid} package repository.url must match npm provenance source`);
     assert(packageJson.intentCli?.version === options.expectedversion, `${platform.rid} recorded binary version drifted`);
     assert(packageJson.intentCli?.platform === platform.rid, `${platform.rid} platform metadata drifted`);
     assert(!packageJson.scripts?.postinstall, `${platform.rid} package must not have a postinstall hook`);

--- a/packaging/npm/test/package-contract.test.js
+++ b/packaging/npm/test/package-contract.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const test = require('node:test');
 
 const packageRoot = path.resolve(__dirname, '..');
+const provenanceRepositoryUrl = 'https://github.com/J-Tech-Japan/intent-system';
 const platforms = [
   { directory: 'darwin-arm64', name: '@j-tech-japan/intent-cli-darwin-arm64', os: 'darwin', cpu: 'arm64', rid: 'osx-arm64' },
   { directory: 'linux-x64', name: '@j-tech-japan/intent-cli-linux-x64', os: 'linux', cpu: 'x64', rid: 'linux-x64' },
@@ -33,6 +34,8 @@ test('platform templates declare npm selection, release RID, and checksum metada
     assert.equal(manifest.name, platform.name);
     assert.deepEqual(manifest.os, [platform.os]);
     assert.deepEqual(manifest.cpu, [platform.cpu]);
+    assert.equal(manifest.repository?.type, 'git');
+    assert.equal(manifest.repository?.url, provenanceRepositoryUrl);
     assert.equal(manifest.intentCli.platform, platform.rid);
     assert.equal(manifest.intentCli.binarySha256, '__BINARY_SHA256__');
     assert.equal(manifest.scripts?.postinstall, undefined);

--- a/tests/IntentSystem.Cli.Tests/NpmDistributionG702Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NpmDistributionG702Tests.cs
@@ -40,6 +40,8 @@ public sealed class NpmDistributionG702Tests
             Assert.Equal("0.0.0-dev", template.RootElement.GetProperty("version").GetString());
             Assert.Equal(platform.Os, template.RootElement.GetProperty("os")[0].GetString());
             Assert.Equal(platform.Cpu, template.RootElement.GetProperty("cpu")[0].GetString());
+            Assert.Equal("git", template.RootElement.GetProperty("repository").GetProperty("type").GetString());
+            Assert.Equal("https://github.com/J-Tech-Japan/intent-system", template.RootElement.GetProperty("repository").GetProperty("url").GetString());
             Assert.Equal(platform.Rid, template.RootElement.GetProperty("intentCli").GetProperty("platform").GetString());
             Assert.Equal("0.0.0-dev", template.RootElement.GetProperty("intentCli").GetProperty("version").GetString());
             Assert.Equal("__BINARY_SHA256__", template.RootElement.GetProperty("intentCli").GetProperty("binarySha256").GetString());

--- a/tests/IntentSystem.Cli.Tests/NpmTrustedPublishingG711Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NpmTrustedPublishingG711Tests.cs
@@ -5,7 +5,7 @@ namespace IntentSystem.Cli.Tests;
 /// <summary>
 /// G711: release npm publication must use job-scoped GitHub Actions OIDC
 /// trusted publishing. The workflow source is the contract boundary for the
-/// permission, toolchain, credential absence, and named authentication
+/// permission, toolchain, credential absence, and classified publish
 /// failure that ordinary unit tests cannot exercise against npmjs.com.
 /// </summary>
 public sealed class NpmTrustedPublishingG711Tests
@@ -35,7 +35,7 @@ public sealed class NpmTrustedPublishingG711Tests
     }
 
     [Fact]
-    public void Workflow_FailsNamedForThePackageWhenOidcConfigurationIsMissing()
+    public void Workflow_ClassifiesTheActualFailureAndNamesTheClearingAct()
     {
         var workflow = ReadWorkflow();
         var npmJob = ExtractNpmJob(workflow);
@@ -55,8 +55,8 @@ public sealed class NpmTrustedPublishingG711Tests
     {
         var workflow = ReadWorkflow();
         var invalid = workflow.Replace(
-            "npm trusted publishing authentication failed for package",
-            "NPM_TOKEN is not set; skipping npm publish.\n            exit 0\n            npm trusted publishing authentication failed for package",
+            "npm registry/provenance rejection for package",
+            "NPM_TOKEN is not set; skipping npm publish.\n            exit 0\n            npm registry/provenance rejection for package",
             StringComparison.Ordinal);
 
         var failure = Assert.ThrowsAny<Xunit.Sdk.XunitException>(
@@ -108,11 +108,16 @@ public sealed class NpmTrustedPublishingG711Tests
     {
         Assert.Contains("publish_package()", npmJob, StringComparison.Ordinal);
         Assert.Contains("if ! publish_output=\"$(npm publish", npmJob, StringComparison.Ordinal);
-        Assert.Contains("npm trusted publishing authentication failed for package", npmJob, StringComparison.Ordinal);
+        Assert.Contains("classify_publish_failure()", npmJob, StringComparison.Ordinal);
+        Assert.Contains("npm registry/provenance rejection for package", npmJob, StringComparison.Ordinal);
+        Assert.Contains("the authenticated publish reached npm", npmJob, StringComparison.Ordinal);
+        Assert.Contains("repository.url matches https://github.com/J-Tech-Japan/intent-system", npmJob, StringComparison.Ordinal);
+        Assert.Contains("npm trusted publishing authentication failure for package", npmJob, StringComparison.Ordinal);
         Assert.Contains("register this package's npmjs.com trusted publisher", npmJob, StringComparison.Ordinal);
         Assert.Contains("${GITHUB_REPOSITORY}", npmJob, StringComparison.Ordinal);
         Assert.Contains(".github/workflows/release.yml", npmJob, StringComparison.Ordinal);
         Assert.Contains("id-token: write", npmJob, StringComparison.Ordinal);
+        Assert.Contains("then rerun this release publish", npmJob, StringComparison.Ordinal);
         Assert.DoesNotContain("exit 0", npmJob, StringComparison.Ordinal);
     }
 

--- a/tests/IntentSystem.Cli.Tests/NpmTrustedPublishingG711Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NpmTrustedPublishingG711Tests.cs
@@ -113,7 +113,7 @@ public sealed class NpmTrustedPublishingG711Tests
         Assert.Contains("the authenticated publish reached npm", npmJob, StringComparison.Ordinal);
         Assert.Contains("repository.url matches https://github.com/J-Tech-Japan/intent-system", npmJob, StringComparison.Ordinal);
         Assert.Contains("npm trusted publishing authentication failure for package", npmJob, StringComparison.Ordinal);
-        Assert.Contains("register this package's npmjs.com trusted publisher", npmJob, StringComparison.Ordinal);
+        Assert.Contains("registering this package's npmjs.com trusted publisher", npmJob, StringComparison.Ordinal);
         Assert.Contains("${GITHUB_REPOSITORY}", npmJob, StringComparison.Ordinal);
         Assert.Contains(".github/workflows/release.yml", npmJob, StringComparison.Ordinal);
         Assert.Contains("id-token: write", npmJob, StringComparison.Ordinal);


### PR DESCRIPTION
Closes #1566

## Summary

- Add the exact provenance source repository to all three generated platform npm manifests.
- Make generated-package verification fail when a platform manifest lacks that repository URL.
- Classify npm publish failures as registry/provenance rejection versus authentication failure, and state the clearing action for each.
- Complete the amended recovery as coordinated `0.23.1` artifacts across GitHub, NuGet, binaries, and all four npm packages.

## Static pre-publish guard boundary

`verify-packages.js` and the package-contract tests are static, local pre-publish guards. They prevent a missing or mismatched `repository` field from reaching the release workflow; they do not contact npm, perform a publish, or prove that npm accepted signed provenance. The actual acceptance evidence is release run `32347417910` ([workflow run](https://github.com/J-Tech-Japan/intent-system/actions/runs/32347417910)) plus the independent public registry reads and decoded provenance recorded below.

## Settled recovery decision

This does **not** republish npm `0.23.0` under the existing `v0.23.0` tag. The tag `v0.23.0` names `ff24f4521d94a6f145a9cdb6354da2a39a5558c7`, which contains the broken platform manifests; corrected tarballs necessarily come from a different revision and would make npm `0.23.0` provenance disagree with the NuGet and GitHub artifacts already shipped from that tag. An npm-only `0.23.1` would also leave the same source under different version numbers because NuGet `0.23.0` is already published.

The coordinated recovery is therefore `0.23.1` on every channel. Tag `v0.23.1` and the producing source revision are:

```text
v0.23.1 -> d49984dae761d589b2568f8eb1677ce3ff2facbc
```

## Durable release evidence

Release workflow: [run 32347417910](https://github.com/J-Tech-Japan/intent-system/actions/runs/32347417910), head `v0.23.1` at `d49984dae761d589b2568f8eb1677ce3ff2facbc`, conclusion `success`.

All release jobs passed: NuGet package `96358982607`, self-contained osx-arm64 `96358982785`, self-contained linux-x64 `96358982827`, self-contained win-x64 `96358982880`, and npm packages `96359560360`.

The [v0.23.1 release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.1) contains the `0.23.1` NuGet package, three `0.23.1` binary archives, and the four `0.23.1` npm tarballs (plus checksums). The NuGet job emitted and published:

```text
Successfully created package 'JTechJapan.IntentSystem.Cli.0.23.1.nupkg'
Pushing JTechJapan.IntentSystem.Cli.0.23.1.nupkg to 'https://www.nuget.org/api/v2/package'...
Your package was pushed.
```

Post-publish NuGet registry reads returned `0.23.0` and `0.23.1` in the package index, and the exact `0.23.1` flat-container package URL returned HTTP 200:

```text
{"versions":["0.23.0","0.23.1"]}
HTTP/2 200 ... /jtechjapan.intentsystem.cli/0.23.1/jtechjapan.intentsystem.cli.0.23.1.nupkg
```

The npm release job emitted four actual registry publishes, not a dry run:

```text
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=2528504609
+ @j-tech-japan/intent-cli-darwin-arm64@0.23.1

npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=2528507798
+ @j-tech-japan/intent-cli-linux-x64@0.23.1

npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=2528511056
+ @j-tech-japan/intent-cli-win32-x64@0.23.1

npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=2528513873
+ intent-system@0.23.1
```

Direct `npm view` reads for all four packages returned version `0.23.1`, repository `git+https://github.com/J-Tech-Japan/intent-system.git`, and SLSA provenance attestations:

```text
intent-system                         0.23.1  https://registry.npmjs.org/-/npm/v1/attestations/intent-system@0.23.1
@j-tech-japan/intent-cli-darwin-arm64 0.23.1  https://registry.npmjs.org/-/npm/v1/attestations/@j-tech-japan%2fintent-cli-darwin-arm64@0.23.1
@j-tech-japan/intent-cli-linux-x64    0.23.1  https://registry.npmjs.org/-/npm/v1/attestations/@j-tech-japan%2fintent-cli-linux-x64@0.23.1
@j-tech-japan/intent-cli-win32-x64    0.23.1  https://registry.npmjs.org/-/npm/v1/attestations/@j-tech-japan%2fintent-cli-win32-x64@0.23.1
repository.type = git; repository.url = git+https://github.com/J-Tech-Japan/intent-system.git
dist.attestations.provenance.predicateType = https://slsa.dev/provenance/v1
```

Decoded registry SLSA attestations for each package all reported the same identity:

```text
workflow.ref        = refs/tags/v0.23.1
workflow.repository = https://github.com/J-Tech-Japan/intent-system
workflow.path       = .github/workflows/release.yml
sourceCommit        = d49984dae761d589b2568f8eb1677ce3ff2facbc
invocation           = https://github.com/J-Tech-Japan/intent-system/actions/runs/32347417910/attempts/1
```

An isolated global install from the published registry also succeeded:

```text
added 2 packages in 1s
intent-cli 0.23.1-d49984d-G721
```

The [v0.23.0 release page](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0) now explicitly says that NuGet and binary `0.23.0` artifacts shipped, npm `0.23.0` was never published, and its attached npm tarballs are historical artifacts rather than registry packages.

## Verification

- `npm test --prefix packaging/npm` — 7 passed, 0 failed.
- Generated package set plus `verify-packages.js` — passed, including all three platform repository fields.
- `actionlint .github/workflows/release.yml` — passed.
- Full Release .NET suite with isolated caches — 5,146 passed, 1 skipped, 0 failed, 5,147 total.
- Exact PR head CI [run 32346869876](https://github.com/J-Tech-Japan/intent-system/actions/runs/32346869876) — source contract and npm dry-run jobs passed.
