### PR TITLE
Fix heartbeat coordinator role alias resolution

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -3139,6 +3139,8 @@ visible on the operator's screen the moment it breaks.
   only an `actionable-stall` verdict with its returned canonical notify command
   ever produces a sent nudge. Do not use `stale` or `message_body` to infer the
   action; the closed verdict is the sole decision trigger.
+- **Recorded coordinating-seat name** — `session-layer topology record --role <name>` accepts operator-supplied logical names. Heartbeat treats `orchestration` as the canonical coordinating role and `orchestrator` as its accepted recorded alias through the shared role-contract normalization used by topology delivery. A topology recorded as `orchestrator` therefore works without renaming or migration; when recording a new or corrected coordinating seat, choose either spelling and keep it in the team record. If no coordinating seat is genuinely present, `cannot-determine` names the source, missing role, recorded roster, and the `topology record --write` action that clears it.
+- **Role-consumer sweep** — `notify` delivery, pending-recipient metadata, task-envelope selection, recipient-delivery judgment, topology show, and heartbeat all use the same resolver. Semantic actor labels such as `action_owner: orchestration` are not topology lookups and remain canonical; no second alias table is maintained.
 - **Failure visibility** — silence is reserved for `healthy-active-wait`
   ONLY. A heartbeat command execution failure or
   malformed/non-object output must be surfaced **visibly** in the watchdog's

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -2731,6 +2731,8 @@ credential/keychain セットアップも不要で(セッションの他の部�
   nudge を捏造・送信することは決してありません。送信する nudge は
   `actionable-stall` verdict とともに返された canonical notify command の場合だけです。
   `stale` や `message_body` から action を推論せず、closed verdict だけを decision trigger にします。
+- **記録する coordinating seat の名前** — `session-layer topology record --role <name>` は operator が logical role 名を指定する surface です。heartbeat は `orchestration` を canonical な coordinating role とし、topology delivery と共有する role-contract normalization によって `orchestrator` を記録済み alias として受け入れます。したがって `orchestrator` で記録済みの topology を rename や migration なしで使えます。新規または修正の coordinating seat を記録するときは、どちらかの spelling を team record に残してください。本当に seat がない場合の `cannot-determine` は source、missing role、記録済み roster、それを解消する `topology record --write` action を出力します。
+- **role consumer の sweep** — `notify` delivery、pending recipient metadata、task-envelope 選択、recipient-delivery judgment、topology show、heartbeat はすべて同じ resolver を使います。`action_owner: orchestration` のような semantic actor label は topology lookup ではないため canonical のままです。alias table を別に持ちません。
 - **failure visibility** — 沈黙は `healthy-active-wait` の heartbeat 結果にのみ
   許されます。heartbeat コマンドの実行失敗や不正な/オブジェクトでない出力は、
   この wake の watchdog 自身の turn 出力で **可視的に** 表面化させなければ

--- a/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationHeartbeatCommand.cs
@@ -110,6 +110,8 @@ internal static class AutomationHeartbeatCommand
             DedupeKey = decision.DedupeKey,
             ActionOwner = decision.ActionOwner,
             TargetRole = decision.TargetRole,
+            ResolvedRecordedRole = decision.ResolvedRecordedRole,
+            ResolvedDestination = decision.ResolvedDestination,
             CanonicalNotifyCommand = decision.CanonicalNotifyCommand,
             WaitCondition = decision.WaitCondition,
             WaitEndSignal = decision.WaitEndSignal,
@@ -368,7 +370,11 @@ internal static class AutomationHeartbeatCommand
         var route = ResolveOrchestratorRoute(context, domain, team);
         if (!route.Resolved)
         {
-            return CannotDetermine(route.Reason!, stalledWork.Items.FirstOrDefault(), "recorded topology");
+            return CannotDetermine(
+                route.Reason!,
+                stalledWork.Items.FirstOrDefault(),
+                "recorded topology",
+                route.Reason);
         }
 
         // A concrete actionable finding always wins over a legitimate active
@@ -400,7 +406,9 @@ internal static class AutomationHeartbeatCommand
                 WaitCondition: $"CI for PR #{ciPending.Pr?.Number} head {ciPending.PrHeadSha} to reach a terminal outcome",
                 WaitEndSignal: "the mode-specific CI-completion wake followed by an exact-head GitHub re-check",
                 WaitBoundMinutes: staleMinutes,
-                SuggestedAction: "Wait for the named CI completion signal, then re-evaluate this heartbeat decision.");
+                SuggestedAction: "Wait for the named CI completion signal, then re-evaluate this heartbeat decision.",
+                ResolvedRecordedRole: route.RecordedRole,
+                ResolvedDestination: route.Destination);
         }
 
         if (ciPending is not null)
@@ -430,7 +438,9 @@ internal static class AutomationHeartbeatCommand
             WaitCondition: null,
             WaitEndSignal: null,
             WaitBoundMinutes: null,
-            SuggestedAction: "Run the canonical notify command once for this no-pending-transition dedupe key.");
+            SuggestedAction: "Run the canonical notify command once for this no-pending-transition dedupe key.",
+            ResolvedRecordedRole: route.RecordedRole,
+            ResolvedDestination: route.Destination);
     }
 
     private static HeartbeatDecision AttentionRequired(StalledWorkItem record, string owner, HeartbeatRoute? route)
@@ -453,7 +463,9 @@ internal static class AutomationHeartbeatCommand
             WaitCondition: null,
             WaitEndSignal: null,
             WaitBoundMinutes: null,
-            SuggestedAction: action);
+            SuggestedAction: action,
+            ResolvedRecordedRole: route?.RecordedRole,
+            ResolvedDestination: route?.Destination);
     }
 
     private static HeartbeatDecision ActionableStall(
@@ -479,10 +491,16 @@ internal static class AutomationHeartbeatCommand
             WaitCondition: null,
             WaitEndSignal: null,
             WaitBoundMinutes: null,
-            SuggestedAction: $"Run the canonical notify command once for dedupe key '{dedupeKey}'.");
+            SuggestedAction: $"Run the canonical notify command once for dedupe key '{dedupeKey}'.",
+            ResolvedRecordedRole: route.RecordedRole,
+            ResolvedDestination: route.Destination);
     }
 
-    private static HeartbeatDecision CannotDetermine(string reason, StalledWorkItem? item, string source) => new(
+    private static HeartbeatDecision CannotDetermine(
+        string reason,
+        StalledWorkItem? item,
+        string source,
+        string? suggestedAction = null) => new(
         Verdict: "cannot-determine",
         Reason: reason,
         LastProgressBasis: item is null ? source : ProgressBasis(item),
@@ -495,7 +513,8 @@ internal static class AutomationHeartbeatCommand
         WaitCondition: null,
         WaitEndSignal: null,
         WaitBoundMinutes: null,
-        SuggestedAction: $"Repair or inspect the named {source} failure before treating this heartbeat as healthy.");
+        SuggestedAction: suggestedAction
+            ?? $"Repair or inspect the named {source} failure before treating this heartbeat as healthy.");
 
     private static HeartbeatRoute ResolveOrchestratorRoute(
         CliContext context,
@@ -522,7 +541,13 @@ internal static class AutomationHeartbeatCommand
             + " --summary <one-line-summary>"
             + $" --routing-root '{context.RepoRoot.Replace("'", "'\\''", StringComparison.Ordinal)}'"
             + " --write --format json";
-        return new HeartbeatRoute(true, null, "orchestration", command);
+        return new HeartbeatRoute(
+            true,
+            null,
+            "orchestration",
+            command,
+            recipient.RecordedRole,
+            $"{recipient.TargetKind}:{recipient.Target}");
     }
 
     private static HeartbeatRoute ResolveAttentionOwnerRoute(CliContext context, string domain, string team, string owner)
@@ -546,7 +571,13 @@ internal static class AutomationHeartbeatCommand
             + " --summary <one-line-summary>"
             + $" --routing-root '{context.RepoRoot.Replace("'", "'\\''", StringComparison.Ordinal)}'"
             + " --write --format json";
-        return new HeartbeatRoute(true, null, owner, command);
+        return new HeartbeatRoute(
+            true,
+            null,
+            owner,
+            command,
+            recipient.RecordedRole,
+            $"{recipient.TargetKind}:{recipient.Target}");
     }
 
     private static string MaterialKey(string verdict, StalledWorkItem? item, string owner, string? targetRole) =>
@@ -671,6 +702,14 @@ internal static class AutomationHeartbeatCommand
         if (result.TargetRole is not null)
         {
             writer.WriteLine($"- target_role: {result.TargetRole}");
+        }
+        if (result.ResolvedRecordedRole is not null)
+        {
+            writer.WriteLine($"- resolved_recorded_role: {result.ResolvedRecordedRole}");
+        }
+        if (result.ResolvedDestination is not null)
+        {
+            writer.WriteLine($"- resolved_destination: {result.ResolvedDestination}");
         }
         if (result.WaitCondition is not null)
         {
@@ -826,6 +865,14 @@ internal sealed record AutomationHeartbeatResult
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string? TargetRole { get; init; }
 
+    [JsonPropertyName("resolved_recorded_role")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ResolvedRecordedRole { get; init; }
+
+    [JsonPropertyName("resolved_destination")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ResolvedDestination { get; init; }
+
     [JsonPropertyName("canonical_notify_command")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public required string? CanonicalNotifyCommand { get; init; }
@@ -908,9 +955,17 @@ internal sealed record HeartbeatDecision(
     string? WaitCondition,
     string? WaitEndSignal,
     int? WaitBoundMinutes,
-    string SuggestedAction);
+    string SuggestedAction,
+    string? ResolvedRecordedRole = null,
+    string? ResolvedDestination = null);
 
-internal sealed record HeartbeatRoute(bool Resolved, string? Reason, string? TargetRole, string? CanonicalNotifyCommand)
+internal sealed record HeartbeatRoute(
+    bool Resolved,
+    string? Reason,
+    string? TargetRole,
+    string? CanonicalNotifyCommand,
+    string? RecordedRole = null,
+    string? Destination = null)
 {
     public static HeartbeatRoute Failure(string reason) => new(false, reason, null, null);
 }

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -1772,12 +1772,14 @@ internal static class NotifyCommand
         IReadOnlyList<string>? launchArguments = null;
         var identity = $"role={options.ToRole}";
         var topology = NotifyRoleTopologyStore.Resolve(options.RoutingRoot!, options.Domain!, options.Team!);
-        if (topology.Resolved
-            && topology.Topology is { } teamTopology
-            && teamTopology.Roles.TryGetValue(options.ToRole!, out var recorded))
+        var roleResolution = topology.Resolved && topology.Topology is { } teamTopology
+            ? NotifyRoleTopologyStore.ResolveRecordedRole(teamTopology, options.ToRole!)
+            : null;
+        if (roleResolution?.Resolved == true
+            && roleResolution.Record is { } recorded)
         {
             resident = recorded.Resident;
-            workspaceId = recorded.WorkspaceId ?? teamTopology.WorkspaceId;
+            workspaceId = recorded.WorkspaceId ?? topology.Topology!.WorkspaceId;
             paneId = recorded.PaneId;
             reader = recorded.Reader;
             cwd = recorded.Cwd;
@@ -1993,9 +1995,11 @@ internal static class NotifyCommand
     private static NotifyInlinePayloadWarning? ResolveInlinePayloadWarning(NotifyOptions options, string payload)
     {
         var topology = NotifyRoleTopologyStore.Resolve(options.RoutingRoot!, options.Domain!, options.Team!);
-        if (!topology.Resolved
-            || topology.Topology is null
-            || !topology.Topology.Roles.TryGetValue(options.ToRole!, out var recipient)
+        var roleResolution = topology.Resolved && topology.Topology is { } teamTopology
+            ? NotifyRoleTopologyStore.ResolveRecordedRole(teamTopology, options.ToRole!)
+            : null;
+        if (roleResolution?.Resolved != true
+            || roleResolution.Record is not { } recipient
             || !string.Equals(recipient.Kind, "copilot", StringComparison.OrdinalIgnoreCase)
             || payload.Length <= CopilotObservedPasteRiskWarningChars)
         {

--- a/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyRoleTopology.cs
@@ -41,9 +41,20 @@ internal sealed record NotifyRoleDeliveryResolution
 {
     public required bool Resolved { get; init; }
     public required string Role { get; init; }
+    public string? RecordedRole { get; init; }
     public string? Resident { get; init; }
     public string? TargetKind { get; init; }
     public string? Target { get; init; }
+    public string? Cause { get; init; }
+    public required string Summary { get; init; }
+}
+
+internal sealed record NotifyRecordedRoleResolution
+{
+    public required bool Resolved { get; init; }
+    public required string Role { get; init; }
+    public string? RecordedRole { get; init; }
+    public NotifyRecordedRole? Record { get; init; }
     public string? Cause { get; init; }
     public required string Summary { get; init; }
 }
@@ -371,12 +382,13 @@ internal static class NotifyRoleTopologyStore
         NotifyTeamTopology topology,
         string role)
     {
-        if (!topology.Roles.TryGetValue(role, out var record))
+        var roleResolution = ResolveRecordedRole(topology, role);
+        if (!roleResolution.Resolved || roleResolution.Record is not { } record)
         {
             return DeliveryFailure(
                 role,
-                "unknown-role",
-                $"Recorded role topology '{topology.SourcePath}' does not contain logical role '{role}'.");
+                roleResolution.Cause ?? "unknown-role",
+                roleResolution.Summary);
         }
 
         if (string.Equals(record.Resident, NotifyRecordedRole.ExternalResident, StringComparison.Ordinal))
@@ -410,10 +422,13 @@ internal static class NotifyRoleTopologyStore
             {
                 Resolved = true,
                 Role = role,
+                RecordedRole = roleResolution.RecordedRole,
                 Resident = record.Resident,
                 TargetKind = "reader",
                 Target = readerPath,
-                Summary = $"Resolved external logical role '{role}' to recorded reader '{readerPath}'.",
+                Summary = $"Resolved external logical role '{role}'"
+                    + RoleAliasSuffix(role, roleResolution.RecordedRole)
+                    + $" to recorded reader '{readerPath}'.",
             };
         }
 
@@ -429,12 +444,91 @@ internal static class NotifyRoleTopologyStore
         {
             Resolved = true,
             Role = role,
+            RecordedRole = roleResolution.RecordedRole,
             Resident = record.Resident,
             TargetKind = "pane",
             Target = record.PaneId,
-            Summary = $"Resolved herdr logical role '{role}' to recorded pane '{record.PaneId}' in workspace "
+            Summary = $"Resolved herdr logical role '{role}'"
+                + RoleAliasSuffix(role, roleResolution.RecordedRole)
+                + $" to recorded pane '{record.PaneId}' in workspace "
                 + $"'{topology.WorkspaceId}'.",
         };
+    }
+
+    /// <summary>
+    /// Resolves a requested logical role against the operator-recorded roster.
+    /// The role-contract guidance owns normalization and its aliases; every
+    /// topology consumer reaches this lookup instead of maintaining a second
+    /// role map.
+    /// </summary>
+    public static NotifyRecordedRoleResolution ResolveRecordedRole(
+        NotifyTeamTopology topology,
+        string role)
+    {
+        if (string.IsNullOrWhiteSpace(role))
+        {
+            return RoleResolutionFailure(
+                topology,
+                role,
+                "unknown-role",
+                "A non-empty logical role is required.");
+        }
+
+        if (topology.Roles.TryGetValue(role, out var exactRecord))
+        {
+            return new NotifyRecordedRoleResolution
+            {
+                Resolved = true,
+                Role = role,
+                RecordedRole = role,
+                Record = exactRecord,
+                Summary = $"Resolved recorded logical role '{role}' in topology '{topology.SourcePath}'.",
+            };
+        }
+
+        var canonicalRole = GuideRoleContractGuidance.Normalize(role) ?? role;
+        var aliasMatches = topology.Roles
+            .Where(entry => string.Equals(
+                GuideRoleContractGuidance.Normalize(entry.Key) ?? entry.Key,
+                canonicalRole,
+                StringComparison.Ordinal))
+            .ToArray();
+        if (aliasMatches.Length == 1)
+        {
+            var match = aliasMatches[0];
+            return new NotifyRecordedRoleResolution
+            {
+                Resolved = true,
+                Role = role,
+                RecordedRole = match.Key,
+                Record = match.Value,
+                Summary = $"Resolved requested logical role '{role}' through accepted recorded alias '{match.Key}' "
+                    + $"in topology '{topology.SourcePath}'.",
+            };
+        }
+
+        if (aliasMatches.Length > 1)
+        {
+            return RoleResolutionFailure(
+                topology,
+                role,
+                "ambiguous-role",
+                $"Multiple recorded roles ({string.Join(", ", aliasMatches.Select(entry => $"'{entry.Key}'"))}) "
+                + $"normalize to logical role '{canonicalRole}'. Keep one accepted spelling in the team record "
+                + "before retrying notify.");
+        }
+
+        var acceptedName = string.Equals(canonicalRole, "orchestration", StringComparison.Ordinal)
+            ? " The coordinating seat is accepted as canonical 'orchestration' or accepted recorded alias 'orchestrator'; an existing record under either name does not need renaming."
+            : string.Empty;
+        return RoleResolutionFailure(
+            topology,
+            role,
+            "unknown-role",
+            $"Recorded role topology '{topology.SourcePath}' for team '{topology.Team}' workspace "
+            + $"'{topology.WorkspaceId}' does not contain logical role '{role}' (found in that team scope: "
+            + $"{FormatRoles(topology.Roles.Keys)}). Record that role for this team before retrying notify."
+            + acceptedName);
     }
 
     /// <summary>
@@ -1001,6 +1095,37 @@ internal static class NotifyRoleTopologyStore
         Cause = cause,
         Summary = summary,
     };
+
+    private static NotifyRecordedRoleResolution RoleResolutionFailure(
+        NotifyTeamTopology topology,
+        string role,
+        string cause,
+        string summary)
+    {
+        var canonicalRole = GuideRoleContractGuidance.Normalize(role) ?? role;
+        var roleOptions = string.Equals(canonicalRole, "orchestration", StringComparison.Ordinal)
+            ? "<orchestration|orchestrator>"
+            : $"<{role}>";
+        var domain = topology.Domain ?? "<domain>";
+        var remedy = $" Record it with \u0060intent-cli session-layer topology record --domain {domain} --team "
+            + $"{topology.Team} --role {roleOptions} ... --write\u0060; do not rename an existing accepted alias."
+            + " Then rerun the heartbeat/notify command.";
+        return new NotifyRecordedRoleResolution
+        {
+            Resolved = false,
+            Role = role,
+            Cause = cause,
+            Summary = summary + remedy,
+        };
+    }
+
+    private static string RoleAliasSuffix(string requestedRole, string? recordedRole) =>
+        string.IsNullOrWhiteSpace(recordedRole)
+            || string.Equals(requestedRole, recordedRole, StringComparison.Ordinal)
+            ? string.Empty
+            : $" through recorded alias '{recordedRole}'";
+
+    private static string FormatRoles(IEnumerable<string> roles) => string.Join(", ", roles.OrderBy(role => role, StringComparer.Ordinal));
 
     private static SessionLayerTopologyFinding Finding(
         string role,

--- a/src/IntentSystem.Cli/Commands/NotifyTaskEnvelopeStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyTaskEnvelopeStore.cs
@@ -88,8 +88,11 @@ internal sealed record NotifyTaskEnvelopeDelivery
     public static NotifyTaskEnvelopeDelivery Resolve(NotifyOptions options, string payload)
     {
         var topology = NotifyRoleTopologyStore.Resolve(options.RoutingRoot!, options.Domain!, options.Team!);
-        if (!topology.Resolved || topology.Topology is null
-            || !topology.Topology.Roles.TryGetValue(options.ToRole!, out var recipient)
+        var roleResolution = topology.Resolved && topology.Topology is { } teamTopology
+            ? NotifyRoleTopologyStore.ResolveRecordedRole(teamTopology, options.ToRole!)
+            : null;
+        if (roleResolution?.Resolved != true
+            || roleResolution.Record is not { } recipient
             || string.IsNullOrWhiteSpace(recipient.DeliveryMethod))
         {
             return Inline(payload);

--- a/src/IntentSystem.Cli/Commands/NotifyTransport.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyTransport.cs
@@ -319,18 +319,23 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
         var topology = topologyResolution.Topology!;
         foreach (var role in rolesToValidate.Distinct(StringComparer.Ordinal))
         {
-            if (!topology.Roles.ContainsKey(role))
+            var roleResolution = NotifyRoleTopologyStore.ResolveRecordedRole(topology, role);
+            if (!roleResolution.Resolved)
             {
                 return Failure(
-                    "unknown-role",
-                    $"Recorded role topology '{topology.SourcePath}' for team '{team}' workspace "
-                    + $"'{topology.WorkspaceId}' does not contain logical role '{role}' (found in that team scope: "
-                    + $"{FormatRoles(topology.Roles.Keys)}). Record that role for this team before retrying notify. "
-                    + NotifyRoleTopologyStore.TopologyRemedy(team));
+                    roleResolution.Cause ?? "unknown-role",
+                    roleResolution.Summary + " " + NotifyRoleTopologyStore.TopologyRemedy(team));
             }
         }
 
-        var recipient = topology.Roles[toRole];
+        var recipientResolution = NotifyRoleTopologyStore.ResolveRecordedRole(topology, toRole);
+        if (!recipientResolution.Resolved || recipientResolution.Record is not { } recipient)
+        {
+            return Failure(
+                recipientResolution.Cause ?? "unknown-role",
+                recipientResolution.Summary + " " + NotifyRoleTopologyStore.TopologyRemedy(team));
+        }
+
         var deliveryTarget = NotifyRoleTopologyStore.ResolveDeliveryTarget(routingRoot, topology, toRole);
         if (!deliveryTarget.Resolved)
         {
@@ -826,12 +831,6 @@ internal sealed class HerdrNotifyTransport : INotifyTransport
     {
         var separator = paneId?.IndexOf(':', StringComparison.Ordinal) ?? -1;
         return separator > 0 ? paneId![..separator] : null;
-    }
-
-    private static string FormatRoles(IEnumerable<string> roles)
-    {
-        var ordered = roles.OrderBy(value => value, StringComparer.Ordinal).ToArray();
-        return ordered.Length == 0 ? "none" : string.Join(", ", ordered);
     }
 
     private static string FormatAgents(IEnumerable<HerdrAgentState> agents)

--- a/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
@@ -24,7 +24,9 @@ internal static class SessionLayerTopologyCommand
         + "[--format markdown|json]\n"
         + "   or: intent-cli session-layer topology record --domain <name> --team <name> --role <name> --resident external "
         + "--reader <routing-root-relative-path> [--frontend <name>] [--dry-run|--write] "
-        + "[--format markdown|json]";
+        + "[--format markdown|json]\n"
+        + "   Heartbeat coordination accepts recorded role 'orchestration' or the alias 'orchestrator'; existing "
+        + "records under either name need no rename or migration.";
     private const string ShowUsage =
         "Usage: intent-cli session-layer topology show --domain <name> --team <name> [--format markdown|json]";
     private const string ValidateUsage =
@@ -1254,8 +1256,12 @@ internal static class SessionLayerTopologyWriter
             AlreadyRecorded = false,
             Conflict = false,
             Summary = request.Write
-                ? $"Recorded operator-supplied role '{request.Role}' for team '{request.Team}'."
-                : $"Dry-run: would record operator-supplied role '{request.Role}' for team '{request.Team}'.",
+                ? $"Recorded operator-supplied role '{request.Role}' for team '{request.Team}'. "
+                    + "Heartbeat coordination accepts recorded role 'orchestration' or the alias 'orchestrator'; "
+                    + "existing records under either name need no rename or migration."
+                : $"Dry-run: would record operator-supplied role '{request.Role}' for team '{request.Team}'. "
+                    + "Heartbeat coordination accepts recorded role 'orchestration' or the alias 'orchestrator'; "
+                    + "existing records under either name need no rename or migration.",
         };
     }
 

--- a/tests/IntentSystem.Cli.Tests/AutomationHeartbeatDecisionG597Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationHeartbeatDecisionG597Tests.cs
@@ -71,6 +71,41 @@ public sealed class AutomationHeartbeatDecisionG597Tests : IDisposable
     }
 
     [Fact]
+    public void Execute_RecordedOrchestratorAliasResolvesAndEmitsDestination_G723()
+    {
+        using var workspace = new HeartbeatWorkspace();
+        workspace.WriteTopology("orchestrator");
+        workspace.WritePacketDomain("G600");
+        var issue = Issue(1600, "G600: action needed", FixedNow.AddHours(-2), "intent-target");
+
+        var result = Run(workspace, new FakeLister([issue]));
+
+        Assert.Equal("actionable-stall", result.GetProperty("verdict").GetString());
+        Assert.Equal("orchestration", result.GetProperty("target_role").GetString());
+        Assert.Equal("orchestrator", result.GetProperty("resolved_recorded_role").GetString());
+        Assert.Equal("pane:wH:p1", result.GetProperty("resolved_destination").GetString());
+        Assert.Contains("--to orchestration", result.GetProperty("canonical_notify_command").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_GenuineMissingCoordinatingSeatExplainsTheRecordAction_G723()
+    {
+        using var workspace = new HeartbeatWorkspace();
+        workspace.WriteTopology(coordinatingRole: null);
+
+        var result = Run(workspace, new FakeLister());
+
+        Assert.Equal("cannot-determine", result.GetProperty("verdict").GetString());
+        var reason = result.GetProperty("reason").GetString()!;
+        Assert.Contains("logical role 'orchestration'", reason, StringComparison.Ordinal);
+        Assert.Contains("accepted recorded alias 'orchestrator'", reason, StringComparison.Ordinal);
+        Assert.Contains("session-layer topology record", reason, StringComparison.Ordinal);
+        Assert.Contains("--write", reason, StringComparison.Ordinal);
+        Assert.Contains("do not rename", reason, StringComparison.Ordinal);
+        Assert.Contains("session-layer topology record", result.GetProperty("suggested_action").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Execute_DedupeKeyIsStableAcrossPollsAndChangesOnlyWithMaterialState_G597()
     {
         using var workspace = new HeartbeatWorkspace();
@@ -307,20 +342,24 @@ public sealed class AutomationHeartbeatDecisionG597Tests : IDisposable
             File.WriteAllText(Path.Combine(directory, "packet.yaml"), "domain: intent-cli\n");
         }
 
-        public void WriteTopology()
+        public void WriteTopology(string? coordinatingRole = "orchestration")
         {
             var path = NotifyRoleTopologyStore.ResolvePath(RootPath, "intent-cli", "intent-cli-dev");
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var roles = new Dictionary<string, object>
+            {
+                ["design"] = new { resident = "herdr", workspace_id = "wH", pane_id = "wH:p3" },
+            };
+            if (coordinatingRole is not null)
+            {
+                roles[coordinatingRole] = new { resident = "herdr", workspace_id = "wH", pane_id = "wH:p1" };
+            }
             File.WriteAllText(path, JsonSerializer.Serialize(new
             {
                 domain = "intent-cli",
                 team = "intent-cli-dev",
                 workspace_id = "wH",
-                roles = new Dictionary<string, object>
-                {
-                    ["design"] = new { resident = "herdr", workspace_id = "wH", pane_id = "wH:p3" },
-                    ["orchestration"] = new { resident = "herdr", workspace_id = "wH", pane_id = "wH:p1" },
-                },
+                roles,
             }));
         }
 


### PR DESCRIPTION
Closes #1569

## Summary

- Centralized recorded-role resolution in the topology store, delegating alias normalization to the existing `GuideRoleContractGuidance.Normalize` source.
- Updated heartbeat, notify delivery, pending delegation metadata, inline payload warnings, and task-envelope selection to use the shared resolver.
- Added explicit heartbeat evidence for the recorded role and delivery destination, plus actionable remediation when the coordinating seat is genuinely missing.
- Documented the `orchestration` / `orchestrator` contract in mirrored English and Japanese guidance.

## Emitted evidence

- Baseline CLI against a topology recorded with `roles.orchestrator`: `cannot-determine`; it reported that logical role `orchestration` was absent.
- Branch build against that same topology: `actionable-stall`, `target_role=orchestration`, `resolved_recorded_role=orchestrator`, `resolved_destination=pane:wG723:p1`, and canonical notify command `--to orchestration`.
- Branch build against the same topology with the coordinating seat removed: `cannot-determine`; both `reason` and `suggested_action` name the roster, `session-layer topology record --role <orchestration|orchestrator> ... --write`, the no-rename rule, and rerunning heartbeat/notify.

## Verification

- `dotnet test ... --filter FullyQualifiedName~AutomationHeartbeatDecisionG597Tests --no-restore` — 11 passed.
- Focused affected command suites — 41 passed.
- Full repository test project with an isolated writable NuGet cache — 5,148 passed, 1 skipped, 0 failed.
- Role-consumer sweep: no remaining direct topology role lookup outside the shared resolver (the remaining structural comparison is not a consumer); the only alias mapping remains `GuideRoleContractGuidance.Normalize`.
