### PR TITLE
fix: isolate multi-domain session-layer worker identity

### DIFF
--- a/docs/adr/0009-session-layer-domain-identity-authority.md
+++ b/docs/adr/0009-session-layer-domain-identity-authority.md
@@ -21,7 +21,10 @@ causes silent rewrites and can make a worker for another domain fail closed.
    specific than a domain-wide entry, exactly as the existing mode resolver
    defines. Durable execution-unit or packet domain metadata is authoritative
    for the execution unit itself. An explicit worker `--domain` is accepted
-   only when it agrees with that durable domain metadata.
+   only when it agrees with the durable queue/packet domain or, for a legacy
+   domain-less queue row, with the authoritative session-layer record. It is
+   a migration binding for that legacy shape, never an override of declared
+   durable data.
 2. The generated startup-file marker is display and verification evidence
    only. It carries the domain, team, mode, and record hash so an operator can
    see which durable record a block represents, but it never establishes

--- a/docs/adr/0009-session-layer-domain-identity-authority.md
+++ b/docs/adr/0009-session-layer-domain-identity-authority.md
@@ -1,0 +1,70 @@
+# ADR 0009: Durable session-layer records own domain identity
+
+- Status: Accepted (preview-through-1.x)
+- Date: 2026-08-20
+- Deciders: Operator and implementation seat, recorded by G724
+- Related: G601 session-layer markers, G717 claim authority, G724 / #1570
+
+## Context
+
+The host carries more than one supported domain. The durable
+`.intent-cli/session-layer-mode.json` record is already scoped by domain and,
+when applicable, team. The generated `AGENTS.md` / `CLAUDE.md` marker is a
+single working-tree display surface, so treating that block as the host's
+domain identity makes the last marker writer appear to own every domain. That
+causes silent rewrites and can make a worker for another domain fail closed.
+
+## Decision
+
+1. `.intent-cli/session-layer-mode.json` is authoritative for host
+   session-layer domain identity and mode. A team-scoped entry is more
+   specific than a domain-wide entry, exactly as the existing mode resolver
+   defines. Durable execution-unit or packet domain metadata is authoritative
+   for the execution unit itself. An explicit worker `--domain` is accepted
+   only when it agrees with that durable domain metadata.
+2. The generated startup-file marker is display and verification evidence
+   only. It carries the domain, team, mode, and record hash so an operator can
+   see which durable record a block represents, but it never establishes
+   identity, selects a worker domain, or overrides the durable record. Marker
+   precedence is therefore below the durable record: a marker for domain A
+   does not block or rewrite domain B.
+3. Marker generation is domain-scoped and additive. It replaces only the
+   requested domain/team block and preserves every other block byte-for-byte.
+   When a recorded domain/team has no block, the canonical writer appends its
+   block under `--write`; an operator must not hand-edit `CLAUDE.md` or
+   `AGENTS.md`. A command that cannot prove it will preserve another domain's
+   block refuses with an explanation before writing.
+4. Worker completion resolves the execution-unit domain from the durable
+   queue/packet record, with an explicit matching `--domain` available from
+   the worker surface. It never reads the startup marker as an identity claim.
+   If durable domain evidence is absent or contradictory, the worker remains
+   fail-closed and emits the exact domain-scoped re-invocation needed to
+   repair or select the durable record. This is the sanctioned recovery and
+   preserves queue linkage; the reporter's accidental PR-linkage recovery is
+   not a sanctioned substitute.
+
+## Migration and compatibility
+
+- A valid existing single-domain marker remains valid and is unchanged when
+  its own domain is regenerated; no migration is required and the unchanged
+  path remains byte-identical.
+- A multi-domain host carrying only domain A's existing marker is not asked to
+  edit the file. The next canonical `marker generate --domain B ... --write`
+  appends B's generated block while retaining A. Existing A content is never
+  silently replaced by B.
+- Existing durable mode records are read in their current schema and remain
+  the source of truth. No conversion of `.intent-cli/session-layer-mode.json`
+  is required.
+
+## Consequences
+
+- Multiple domain/team markers can coexist in one startup file without a
+  last-writer-wins claim.
+- A domain-B worker can complete while domain A is the visible marker owner,
+  because worker identity follows durable execution-unit evidence rather than
+  the display file.
+- Stale or missing display evidence is visible and repairable, but cannot
+  silently change routing or ownership.
+- A genuine durable-domain contradiction still stops the worker; the worker
+  itself names the sanctioned explicit-domain recovery instead of inviting a
+  manual label edit or an undocumented PR-linkage workaround.

--- a/docs/en/02a-getting-started-orchestration.md
+++ b/docs/en/02a-getting-started-orchestration.md
@@ -136,14 +136,15 @@ in [doc 12](12-agent-message-orchestration.md).
 
 ### 2.3 Generate the visible marker
 
-Before generating, add the one empty managed marker block for this domain/team
-to `AGENTS.md` or `CLAUDE.md` exactly as [doc 12's generated-marker
-section](12-agent-message-orchestration.md#visible-generated-mode-markers)
-specifies. Then paste this prompt:
+If `AGENTS.md` or `CLAUDE.md` already has another valid managed marker block,
+do not edit it or add a placeholder by hand. The canonical writer will append
+the missing `(domain, team)` block. Only a startup file with no managed block
+at all still needs the one empty placeholder described by [doc 12's
+generated-marker section](12-agent-message-orchestration.md#visible-generated-mode-markers).
+Then paste this prompt:
 
 > Generate the marker for the recorded domain `<domain>` and team `<team>`.
-> Run `intent-cli session-layer marker generate --domain <domain> --team <team> --file AGENTS.md --write --format json`, then show the JSON. Change only the
-> managed marker block.
+> Run `intent-cli session-layer marker generate --domain <domain> --team <team> --file AGENTS.md --write --format json`, then show the JSON. The command may append this domain's block when another managed block exists; it must preserve every other block.
 
 The scratch-host run returned this success shape (the record hash is dynamic):
 
@@ -155,7 +156,9 @@ The scratch-host run returned this success shape (the record hash is dynamic):
   "team": "docs-team",
   "mode": "herdr-only",
   "verify_command": "intent-cli session-layer show --domain onboarding --team docs-team",
-  "summary": "Generated the managed session-layer marker for team 'docs-team' in 'AGENTS.md'."
+  "marker_action": "appended",
+  "preserved_existing_blocks": 1,
+  "summary": "Appended the managed session-layer marker for domain 'onboarding' and team 'docs-team' in 'AGENTS.md'; preserved 1 existing managed block(s)."
 }
 ```
 

--- a/docs/en/05-implementation-loop.md
+++ b/docs/en/05-implementation-loop.md
@@ -58,6 +58,25 @@ copy a long loop body from this document.
 - A child agent never applies `intent-target` (host-owned) or `intent-pr-created` (issue-side marker) to a PR
 - `linked_pr_synced: false` from `worker complete` is the expected child-cwd warning — record it and move on
 
+## G724: worker domain identity on a multi-domain host
+
+The startup marker is display evidence, not a worker binding. In host context,
+`worker complete --kind issue --outcome pr-created` resolves the execution-unit
+domain from the durable queue/packet record. A domain-B worker therefore remains
+eligible even when the shared `CLAUDE.md` currently displays domain A. The JSON
+result reports the selected `domain`, `domain_source` (normally
+`queue-record`), and `execution_unit`; worker completion does not rewrite the
+marker.
+
+If a host invocation supplies `--domain`, it must match the durable queue
+domain, or the authoritative session-layer record for a legacy domain-less
+queue row. Missing, contradictory, unreadable, or ambiguous durable identity
+is a fail-closed result with an exact re-invocation using `--domain <name>`.
+Use that worker-surface recovery after repairing/selecting the canonical queue
+or packet record. Do not hand-edit the marker, apply labels manually, or use
+PR-linkage recovery as a domain-identity workaround. Child `--github-only`
+remains metadata-free and does not read host queue state.
+
 ## Preview: Git-backed cross-clone scope claims (G679)
 
 The decision and its boundaries are recorded in
@@ -147,6 +166,11 @@ intent-cli worker claim --kind issue --number <n> --repo <owner>/<repo> --github
 intent-cli worker result-summary --kind issue-to-pr --repo <owner>/<repo> --issue <n> --pr <pr> --outcome <outcome> --format json
 intent-cli worker complete --kind issue --number <n> --repo <owner>/<repo> --github-only --outcome <outcome> --pr <pr> --write --format json
 ```
+
+For a host-side completion that needs explicit domain selection, add
+`--domain <durable-domain>` to the same `worker complete` command. It must
+agree with the queue/packet record; the startup marker never supplies or
+overrides it.
 
 ## Next
 

--- a/docs/en/07-recovery.md
+++ b/docs/en/07-recovery.md
@@ -89,20 +89,26 @@ you whether a child-loop-owned repair exists. Host-owned categories surface as
 > `--issue <n>`. Child `--github-only` loops never write `linked_pr`; this recovery
 > belongs to the host closeout surface.
 
-> **Repository-qualified linkage and completed repairs (G603).** A GitHub
+> **Repository-qualified linkage and completed repairs (G603/G724).** A GitHub
 > issue or PR number is an identity only together with `owner/repo`. Worker
 > completion, closeout, review planning, and stalled-work therefore reject a
 > bare or wrong-repository linkage rather than letting a colliding number pick
-> a foreign queue item. In host context, `worker complete` also refuses a
-> queue write when the selected unit's declared domain disagrees with the
-> command domain. For a completed unit whose `linked_pr` points at the wrong
-> repository, use `automation host-queue-item-recovery --repo <owner/repo>
-> --unit <unit> --issue <n> --pr <n> --write`: it requires GitHub evidence
-> that the proposed PR exists, is merged, and closes that unit's own issue,
-> then appends a `completed-linkage-repair` run event containing the evidence.
-> A legacy packet without a readable `publish.yaml` identity stops with
-> `legacy-publish-identity-missing` and names the missing evidence; it never
-> guesses or changes a completed linkage.
+> a foreign queue item. In host context, `worker complete` resolves the
+> execution-unit domain from the durable queue/packet record; the visible
+> `AGENTS.md`/`CLAUDE.md` marker and host default domain are display/default
+> context only. A supplied `--domain` must agree with the durable domain. If
+> the durable identity is missing, contradictory, unreadable, or ambiguous,
+> the worker fails closed and prints the exact `worker complete ... --domain
+> <name>` re-invocation after the canonical queue/packet record is repaired.
+> This worker-surface recovery is the sanctioned domain recovery; PR-linkage
+> recovery is not a substitute. For a completed unit whose `linked_pr` points
+> at the wrong repository, use `automation host-queue-item-recovery --repo
+> <owner/repo> --unit <unit> --issue <n> --pr <n> --write`: it requires GitHub
+> evidence that the proposed PR exists, is merged, and closes that unit's own
+> issue, then appends a `completed-linkage-repair` run event containing the
+> evidence. A legacy packet without a readable `publish.yaml` identity stops
+> with `legacy-publish-identity-missing` and names the missing evidence; it
+> never guesses or changes a completed linkage.
 
 ### Repeated-stall recovery (G408)
 

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1640,10 +1640,11 @@ shape still refuses its conflict and has no force flag.
 
 #### Visible, generated mode markers
 
-The mode record remains the only source of truth, but a team should not have to
-remember to query it before noticing which transport it uses. Put one explicit
-empty managed block for each `(domain, team)` in an agent-startup file
-(`AGENTS.md` or `CLAUDE.md`), then generate its display from the recorded mode:
+The mode record remains the only source of truth for host session-layer domain
+identity and mode. A team should not have to remember to query it before
+noticing which transport it uses. Put one explicit empty managed block for each
+`(domain, team)` in an agent-startup file (`AGENTS.md` or `CLAUDE.md`), then
+generate its display from the recorded mode:
 
 ```text
 <!-- intent-cli:session-layer-marker:start domain="<domain>" team="<team>" -->
@@ -1654,10 +1655,24 @@ intent-cli session-layer marker generate --domain <domain> --team <team> --file 
 
 The generated block carries the domain, team, mode, canonical `session-layer
 show` verification command, and a hash of the resolved canonical record. It is
-never a host-global or bare mode claim. The writer reads only the record and
-updates only that delimited block; it refuses an unrecorded team (naming
-`session-layer set ... --write`), an absent block, or malformed markers, and
-never writes `session-layer-mode.json`.
+never a host-global or bare mode claim, and it never selects a worker domain.
+The writer reads only the record and updates only the requested delimited block.
+If another valid managed block is already present and the requested
+`(domain, team)` block is missing, `marker generate --write` appends the new
+block and reports `marker_action: appended`; it preserves the existing blocks
+and never asks the operator to hand-edit `AGENTS.md` or `CLAUDE.md`. An
+otherwise unmanaged file still refuses the first marker and names the
+placeholder contract. Unrecorded teams (naming `session-layer set ... --write`)
+and malformed markers are refused, and the writer never writes
+`session-layer-mode.json`.
+
+This distinction matters on a multi-domain host: `worker complete` resolves an
+issue-to-PR execution unit from its durable queue/packet domain, not from the
+visible marker or the host's default config domain. A matching durable domain
+is reported in the worker result (`domain_source: queue-record`); an explicit
+`--domain` must agree with it. A missing or contradictory durable identity
+fails closed with an exact worker re-invocation. PR-linkage recovery is not a
+domain-identity repair.
 
 The shared preflight discovers managed markers in `AGENTS.md` / `CLAUDE.md`.
 An unmarked recorded team produces informational `marker-not-generated` with

--- a/docs/ja/02a-getting-started-orchestration.md
+++ b/docs/ja/02a-getting-started-orchestration.md
@@ -127,13 +127,14 @@ residency の選択肢と検証規則の詳細は [doc 12](12-agent-message-orch
 
 ### 2.3 可視の marker を生成する
 
-生成の前に、domain/team 用の空の managed marker block を `AGENTS.md` または `CLAUDE.md` に
-[doc 12 の生成済み marker 節](12-agent-message-orchestration.md#可視な生成済み-mode-marker)の
-指定どおり 1 つ置きます。続けて次のプロンプトを貼り付けます。
+`AGENTS.md` または `CLAUDE.md` に別 domain の valid な managed marker block がすでにある場合は、
+手編集したり placeholder を追加したりしません。canonical writer が不足している `(domain, team)` block
+を append します。managed block が 1 つもない file だけは、[doc 12 の生成済み marker 節](12-agent-message-orchestration.md#可視な生成済み-mode-marker)
+の指定どおり空の placeholder を 1 つ置きます。続けて次のプロンプトを貼り付けます。
 
 > 記録済み domain `<domain>`、team `<team>` の marker を生成してください。
 > `intent-cli session-layer marker generate --domain <domain> --team <team> --file AGENTS.md --write --format json`
-> を実行して JSON を表示してください。managed marker block だけを変更してください。
+> を実行して JSON を表示してください。別の managed block がある場合はこの domain の block を append し、他の block をすべて保持してください。
 
 scratch-host の実行時の成功形は次のとおりです（記録 hash は動的）。
 
@@ -145,7 +146,9 @@ scratch-host の実行時の成功形は次のとおりです（記録 hash は�
   "team": "docs-team",
   "mode": "herdr-only",
   "verify_command": "intent-cli session-layer show --domain onboarding --team docs-team",
-  "summary": "Generated the managed session-layer marker for team 'docs-team' in 'AGENTS.md'."
+  "marker_action": "appended",
+  "preserved_existing_blocks": 1,
+  "summary": "Appended the managed session-layer marker for domain 'onboarding' and team 'docs-team' in 'AGENTS.md'; preserved 1 existing managed block(s)."
 }
 ```
 

--- a/docs/ja/05-implementation-loop.md
+++ b/docs/ja/05-implementation-loop.md
@@ -57,6 +57,21 @@
 - child agent は PR に `intent-target`（host 所有）や `intent-pr-created`（issue 側マーカー）を付けない
 - `worker complete` の `linked_pr_synced: false` は child-cwd で想定される警告 — 記録して先に進む
 
+## G724: multi-domain host の worker domain identity
+
+startup marker は display evidence であり、worker binding ではありません。host context の
+`worker complete --kind issue --outcome pr-created` は execution-unit の domain を durable な
+queue/packet record から解決します。そのため shared `CLAUDE.md` が現在 domain A を表示していても、
+domain B の worker は完了できます。JSON result には選択された `domain`、通常は `queue-record` となる
+`domain_source`、`execution_unit` が出力され、worker complete は marker を書き換えません。
+
+host invocation で `--domain` を指定する場合は durable queue domain、または domain のない legacy queue
+row では authoritative な session-layer record と一致する必要があります。durable identity が欠落、矛盾、
+読取不能、または曖昧な場合は fail closed し、`--domain <name>` を含む正確な再実行 command を出力します。
+canonical queue/packet record を修復または選択してから、その worker surface recovery を使います。marker の
+手編集、手動 label 操作、PR-linkage recovery による domain identity 回避は行いません。child の
+`--github-only` は metadata-free のままで host queue state を読みません。
+
 ## Preview: Git-backed cross-clone scope claim (G679)
 
 この decision と boundary は
@@ -141,6 +156,10 @@ intent-cli worker claim --kind issue --number <n> --repo <owner>/<repo> --github
 intent-cli worker result-summary --kind issue-to-pr --repo <owner>/<repo> --issue <n> --pr <pr> --outcome <outcome> --format json
 intent-cli worker complete --kind issue --number <n> --repo <owner>/<repo> --github-only --outcome <outcome> --pr <pr> --write --format json
 ```
+
+host-side completion で domain を明示的に選ぶ場合は、同じ `worker complete` command に
+`--domain <durable-domain>` を加えます。queue/packet record と一致しなければならず、startup marker が
+domain を供給・上書きすることはありません。
 
 ## 次へ
 

--- a/docs/ja/07-recovery.md
+++ b/docs/ja/07-recovery.md
@@ -88,11 +88,16 @@ child-loop 所有の修復が存在するかを示す。host 所有のカテゴ�
 > `linkage-ambiguous` エラーで fail closed する。その場合のみ正しい `--issue <n>` で再実行する。
 > child `--github-only` ループは `linked_pr` を書かない。この recovery は host closeout surface の責務。
 
-> **repo-qualified linkage と completed repair（G603）。** GitHub の issue / PR
+> **repo-qualified linkage と completed repair（G603/G724）。** GitHub の issue / PR
 > 番号は `owner/repo` と組になって初めて identity になる。worker complete、closeout、
 > review planning、stalled-work は bare な番号または別 repo の linkage を拒否し、
-> 同じ番号の foreign queue item を選ばない。host context の `worker complete` は、
-> 選ばれた unit の declared domain と command domain が違う write も拒否する。
+> 同じ番号の foreign queue item を選ばない。host context の `worker complete` は
+> execution-unit の domain を durable な queue/packet record から解決する。
+> `AGENTS.md` / `CLAUDE.md` の visible marker と host の default domain は display/default
+> context にすぎず、明示した `--domain` は durable domain と一致しなければならない。
+> durable identity が欠落、矛盾、読取不能、または曖昧なら worker は fail closed し、canonical
+> queue/packet record を修復した後に実行する正確な `worker complete ... --domain <name>` 再実行を出す。
+> これが sanctioned な domain recovery であり、PR-linkage recovery は代替にならない。
 > completed unit の `linked_pr` が別 repo を指す場合は
 > `automation host-queue-item-recovery --repo <owner/repo> --unit <unit> --issue <n> --pr <n> --write`
 > を使う。提案する PR の存在・merged・その unit 自身の issue を closes することを

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -1406,9 +1406,10 @@ unknown または dotted name は任意の JSON path を編集できないよう
 
 #### 可視な生成済み mode marker
 
-mode record は唯一の source of truth のままですが、team が transport を知るために毎回 query を
-思い出す必要はありません。agent-startup file（`AGENTS.md` または `CLAUDE.md`）に各
-`(domain, team)` 用の明示的な空の managed block を 1 つ置き、recorded mode から display を生成します。
+mode record は host の session-layer domain identity と mode に対する唯一の source of truth です。
+team が transport を知るために毎回 query を思い出す必要はありません。agent-startup file
+（`AGENTS.md` または `CLAUDE.md`）に各 `(domain, team)` 用の明示的な空の managed block を 1 つ置き、
+recorded mode から display を生成します。
 
 ```text
 <!-- intent-cli:session-layer-marker:start domain="<domain>" team="<team>" -->
@@ -1418,10 +1419,20 @@ intent-cli session-layer marker generate --domain <domain> --team <team> --file 
 ```
 
 生成済み block は domain、team、mode、canonical な `session-layer show` verification command、
-resolved canonical record の hash を持ちます。host-global または bare な mode claim にはなりません。
-writer は record だけを読み、その delimited block だけを更新します。unrecorded team（`session-layer
-set ... --write` を明記）、absent block、malformed marker は拒否し、
+resolved canonical record の hash を持ちます。host-global または bare な mode claim にはならず、worker の
+domain を選択もしません。writer は record だけを読み、要求された delimited block だけを更新します。
+別の valid な managed block がすでにあり、要求された `(domain, team)` block だけが無い場合は、
+`marker generate --write` が新しい block を追加し、`marker_action: appended` を出力します。既存 block
+は保持され、operator に `AGENTS.md` / `CLAUDE.md` の手編集を求めません。managed block が 1 つもない
+通常の file では従来どおり最初の marker を拒否し、placeholder contract を示します。unrecorded team
+（`session-layer set ... --write` を明記）と malformed marker は拒否し、writer は
 `session-layer-mode.json` を書きません。
+
+この違いは multi-domain host で重要です。`worker complete` は issue-to-PR execution unit の永続的な
+queue/packet domain を使い、visible marker や host の default config domain を使いません。永続 domain
+が一致すると worker result に `domain_source: queue-record` が出ます。明示した `--domain` は永続的な
+domain と一致しなければなりません。永続 identity が欠落または矛盾する場合は安全側で停止し、正確な
+worker 再実行 command を出します。PR-linkage recovery は domain identity の修復ではありません。
 
 shared preflight は `AGENTS.md` / `CLAUDE.md` 内の managed marker を発見します。recorded team に
 marker がなければ generating command を含む informational な `marker-not-generated` です。mode または

--- a/src/IntentSystem.Cli/Commands/GuideWorkerIssueToPrCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideWorkerIssueToPrCommand.cs
@@ -95,7 +95,7 @@ Implementation steps:
 5. Run the most relevant targeted tests. Report the command and the result. If broader validation is required by the repository contract or the touched area, run it too.
 6. Push the branch and create a draft PR with `gh pr create --draft --title ""..."" --body ""..."" --repo <OWNER>/<REPO>`.
 7. Do not add `intent-target` or `intent-pr-created` to the PR.
-8. From the parent host root, run `intent-cli worker result-summary --kind issue-to-pr --issue <n> --pr <pr-n> --repo <OWNER>/<REPO> --format json`, then `intent-cli worker complete --kind issue --number <n> --repo <OWNER>/<REPO> --outcome pr-created --write --format json`.
+8. From the parent host root, run `intent-cli worker result-summary --kind issue-to-pr --issue <n> --pr <pr-n> --repo <OWNER>/<REPO> --format json`, then `intent-cli worker complete --kind issue --number <n> --repo <OWNER>/<REPO> --outcome pr-created --write --format json`. On a multi-domain host, the worker resolves the execution-unit domain from durable queue/packet evidence; add `--domain <durable-domain>` only when selecting that recorded domain. The visible startup marker never supplies worker identity.
 
 Outcome classification:
 - `pr-created` — draft PR created successfully.
@@ -112,6 +112,7 @@ Hard rules:
 - Do not add `intent-target` to the PR; it is host-owned.
 - Do not add `intent-pr-created` to the PR; it is an issue-side completion marker applied by `worker complete`.
 - All label transitions go through `intent-cli worker claim` / `intent-cli worker complete`. No manual `gh ... edit --add-label` / `--remove-label` fallback for workflow labels.
+- If host-side completion reports missing, contradictory, unreadable, or ambiguous durable domain identity, follow the exact `worker complete ... --domain <name>` re-invocation it emits after repairing/selecting the canonical queue/packet record. Do not hand-edit `AGENTS.md` / `CLAUDE.md` or use PR-linkage recovery as a domain workaround.
 - Do not call `intent-cli run`. `run` is for integration smoke/replay/dogfooding, not the chat-first implementation path.
 - Do not run `dotnet run` as a fallback for `intent-cli`.
 - Do not ask `intent-cli` to launch Claude/Codex or any AI provider.

--- a/src/IntentSystem.Cli/Commands/SessionLayerMarkerCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerMarkerCommand.cs
@@ -102,7 +102,13 @@ internal static class SessionLayerMarkerCommand
             .Where(block => string.Equals(block.Domain, request.Domain, StringComparison.Ordinal)
                 && string.Equals(block.Team, request.Team, StringComparison.Ordinal))
             .ToArray();
-        if (candidates.Length != 1)
+        // G724: when a valid managed block already exists for another
+        // domain/team, the canonical writer performs the additive migration
+        // itself. Requiring a hand-placed placeholder would recreate the
+        // shared-file race this command is meant to prevent. Keep the
+        // first-time refusal for a file with no managed blocks.
+        var append = candidates.Length == 0 && parsed.Blocks.Count > 0;
+        if (candidates.Length > 1 || (candidates.Length == 0 && !append))
         {
             return Emit(writer, request.Format, new SessionLayerMarkerGenerateResult
             {
@@ -117,8 +123,8 @@ internal static class SessionLayerMarkerCommand
             });
         }
 
-        var marker = candidates[0];
-        if (!marker.IsEmpty && !marker.IsGenerated)
+        var marker = candidates.SingleOrDefault();
+        if (marker is not null && !marker.IsEmpty && !marker.IsGenerated)
         {
             return Emit(writer, request.Format, new SessionLayerMarkerGenerateResult
             {
@@ -132,7 +138,9 @@ internal static class SessionLayerMarkerCommand
 
         var recordHash = SessionLayerMarkerStore.Hash(resolution.Entry);
         var replacement = SessionLayerMarkerStore.Render(request.Domain, request.Team, resolution.Mode, recordHash);
-        var updated = content[..marker.StartIndex] + replacement + content[marker.EndIndex..];
+        var updated = append
+            ? content + (content.EndsWith("\n", StringComparison.Ordinal) ? string.Empty : "\n") + replacement
+            : content[..marker!.StartIndex] + replacement + content[marker.EndIndex..];
         if (request.Write && !string.Equals(content, updated, StringComparison.Ordinal))
         {
             File.WriteAllText(path, updated);
@@ -147,9 +155,15 @@ internal static class SessionLayerMarkerCommand
             Mode = resolution.Mode,
             VerifyCommand = SessionLayerMarkerStore.VerifyCommand(request.Domain, request.Team),
             RecordHash = recordHash,
+            MarkerAction = append ? "appended" : "replaced",
+            PreservedExistingBlocks = parsed.Blocks.Count,
             Summary = request.Write
-                ? $"Generated the managed session-layer marker for team '{request.Team}' in '{relativePath}'."
-                : $"Would generate the managed session-layer marker for team '{request.Team}' in '{relativePath}'.",
+                ? append
+                    ? $"Appended the managed session-layer marker for domain '{request.Domain}' and team '{request.Team}' in '{relativePath}'; preserved {parsed.Blocks.Count} existing managed block(s)."
+                    : $"Generated the managed session-layer marker for team '{request.Team}' in '{relativePath}'."
+                : append
+                    ? $"Would append the managed session-layer marker for domain '{request.Domain}' and team '{request.Team}' in '{relativePath}'; existing managed blocks would be preserved."
+                    : $"Would generate the managed session-layer marker for team '{request.Team}' in '{relativePath}'.",
         });
     }
 
@@ -257,6 +271,8 @@ internal sealed record SessionLayerMarkerGenerateResult
     [JsonPropertyName("mode")] public string? Mode { get; init; }
     [JsonPropertyName("verify_command")] public string? VerifyCommand { get; init; }
     [JsonPropertyName("record_hash")] public string? RecordHash { get; init; }
+    [JsonPropertyName("marker_action")] public string? MarkerAction { get; init; }
+    [JsonPropertyName("preserved_existing_blocks")] public int? PreservedExistingBlocks { get; init; }
     [JsonPropertyName("cause")] public string? Cause { get; init; }
     [JsonPropertyName("recording_command")] public string? RecordingCommand { get; init; }
     [JsonPropertyName("summary")] public required string Summary { get; init; }

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
@@ -77,6 +77,7 @@ internal static class WorkerCompleteCommand
                 out var number,
                 out var outcome,
                 out var prNumber,
+                out var explicitDomain,
                 out var mode,
                 out var childCwd,
                 out var githubOnly,
@@ -119,15 +120,39 @@ internal static class WorkerCompleteCommand
             return 1;
         }
 
-        // G603: the host-side linked_pr projection is a write path. Verify
-        // the command's declared domain agrees with the selected queue item
-        // before touching GitHub labels or durable state. A child github-only
-        // worker never reads queue state, so this guard is host-only.
-        if (isPrCreatedOutcome && !inChildCwdMode
-            && TryFindDomainDisagreement(context, repo!, number, out var disagreement))
+        // G724: the startup marker and the context's default domain are not
+        // execution identity. Resolve the issue's domain from durable queue /
+        // packet evidence before touching GitHub labels or linked_pr. A child
+        // github-only worker deliberately does not read host state.
+        string? resolvedDomain = null;
+        string? domainSource = null;
+        string? resolvedExecutionUnit = null;
+        if (isPrCreatedOutcome && !inChildCwdMode)
         {
-            writer.WriteLine(disagreement);
-            return 1;
+            var resolution = ResolveWorkerDomain(
+                context,
+                explicitDomain,
+                repo!,
+                number,
+                outcome!,
+                prNumber,
+                mode);
+            if (resolution.ErrorMessage is not null)
+            {
+                writer.WriteLine(resolution.ErrorMessage);
+                return 1;
+            }
+
+            resolvedDomain = resolution.Domain;
+            domainSource = resolution.Source;
+            resolvedExecutionUnit = resolution.ExecutionUnit;
+        }
+        else if (isPrCreatedOutcome)
+        {
+            resolvedDomain = explicitDomain;
+            domainSource = explicitDomain is null
+                ? "github-only-no-host-state"
+                : "explicit-no-host-state";
         }
 
         // G389: refuse to complete an issue whose contract bundles multiple
@@ -340,7 +365,13 @@ internal static class WorkerCompleteCommand
                     }
                     else
                     {
-                        var (synced, warning) = TryPatchQueueStateLinkedPr(context, number, repo!, prNumberValue);
+                        var (synced, warning) = TryPatchQueueStateLinkedPr(
+                            context,
+                            number,
+                            repo!,
+                            prNumberValue,
+                            resolvedExecutionUnit,
+                            resolvedDomain);
                         linkedPrSynced = synced;
                         if (!string.IsNullOrWhiteSpace(warning))
                         {
@@ -392,6 +423,9 @@ internal static class WorkerCompleteCommand
             PrNumber = prNumber,
             PrTargetApplied = prTargetApplied,
             LinkedPrSynced = linkedPrSynced,
+            Domain = resolvedDomain,
+            DomainSource = domainSource,
+            ExecutionUnit = resolvedExecutionUnit,
             ChildCwd = inChildCwdMode,
             GithubOnly = githubOnly,
         };
@@ -421,7 +455,9 @@ internal static class WorkerCompleteCommand
         CliContext context,
         int sourceIssueNumber,
         string repo,
-        int prNumber)
+        int prNumber,
+        string? executionUnit,
+        string? resolvedDomain)
     {
         var queueStatePath = ResolveQueueStatePath(context);
         if (!File.Exists(queueStatePath))
@@ -436,9 +472,31 @@ internal static class WorkerCompleteCommand
             var matchedIndex = -1;
             for (var index = 0; index < queueState.Items.Count; index++)
             {
-                var linkedIssue = queueState.Items[index].LinkedIssue;
+                var candidate = queueState.Items[index];
+                var linkedIssue = candidate.LinkedIssue;
                 if (GitHubWorkItemIdentity.MatchesIssue(linkedIssue, repo, sourceIssueNumber))
                 {
+                    // G724: when resolution identified the durable unit,
+                    // project linked_pr onto that same unit. This prevents a
+                    // colliding issue number from selecting another domain's
+                    // queue row merely because it appeared first.
+                    if (!string.IsNullOrWhiteSpace(executionUnit)
+                        && !string.Equals(candidate.ExecutionUnit, executionUnit, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(resolvedDomain)
+                        && string.IsNullOrWhiteSpace(executionUnit))
+                    {
+                        var candidateDomain = TryGetQueueItemDomain(candidate);
+                        if (candidateDomain is not null
+                            && !string.Equals(candidateDomain, resolvedDomain, StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+                    }
+
                     matchedIndex = index;
                     break;
                 }
@@ -474,39 +532,275 @@ internal static class WorkerCompleteCommand
         }
     }
 
-    private static bool TryFindDomainDisagreement(CliContext context, string repo, int issueNumber, out string message)
+    /// <summary>
+    /// G724: resolve the execution-unit domain before the worker writes labels
+    /// or linked_pr. The visible startup marker and the host config are
+    /// display/default bindings, not evidence that can override a durable
+    /// queue row. A matching queue row with a declared domain wins; an
+    /// explicit --domain may select one matching row and must agree with its
+    /// declaration. Ambiguous or unreadable durable evidence fails closed with
+    /// an exact worker re-invocation instead of silently falling back.
+    /// </summary>
+    private static WorkerDomainResolution ResolveWorkerDomain(
+        CliContext context,
+        string? explicitDomain,
+        string repo,
+        int issueNumber,
+        string outcome,
+        int? prNumber,
+        string mode)
     {
-        message = string.Empty;
+        var normalizedExplicit = string.IsNullOrWhiteSpace(explicitDomain)
+            ? null
+            : explicitDomain.Trim();
         var queueStatePath = ResolveQueueStatePath(context);
-        if (!File.Exists(queueStatePath)) return false;
+        QueueState? queueState = null;
 
-        try
+        if (File.Exists(queueStatePath))
         {
-            var queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
-            foreach (var item in queueState.Items)
+            try
             {
-                if (!GitHubWorkItemIdentity.MatchesIssue(item.LinkedIssue, repo, issueNumber)) continue;
-                var marker = "intents/";
-                var path = item.ClarificationReturnPath.Replace('\\', '/');
-                var start = path.IndexOf(marker, StringComparison.Ordinal);
-                if (start < 0) continue;
-                var remainder = path[(start + marker.Length)..];
-                var slash = remainder.IndexOf('/');
-                var itemDomain = slash < 0 ? remainder : remainder[..slash];
-                if (!string.IsNullOrWhiteSpace(itemDomain)
-                    && !string.Equals(itemDomain, context.Config.Project.Domain, StringComparison.Ordinal))
-                {
-                    message = $"refused queue write: command identity '{context.Config.Project.Domain}/{repo}#{issueNumber}' conflicts with queue identity '{itemDomain}/{repo}#{issueNumber}' on unit '{item.ExecutionUnit}'.";
-                    return true;
-                }
+                queueState = QueueStateSerializer.Deserialize(File.ReadAllText(queueStatePath));
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+            {
+                var rerunDomain = normalizedExplicit ?? context.Config.Project.Domain;
+                return WorkerDomainResolution.Error(
+                    $"refused worker complete: durable queue state at '{queueStatePath}' could not be read ({exception.Message}). "
+                    + "The startup marker is display-only and cannot resolve this identity. Repair the durable queue state "
+                    + "through its canonical host surface, then re-run: "
+                    + $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, rerunDomain, mode)}`. "
+                    + "Do not use PR-linkage recovery as a substitute for domain resolution.");
             }
         }
-        catch (Exception exception) when (exception is IOException or InvalidOperationException or JsonException)
+
+        var matches = queueState?.Items
+            .Where(item => GitHubWorkItemIdentity.MatchesIssue(item.LinkedIssue, repo, issueNumber))
+            .Select(item => new QueueDomainCandidate(item, TryGetQueueItemDomain(item)))
+            .ToArray() ?? Array.Empty<QueueDomainCandidate>();
+        var declaredDomains = matches
+            .Where(candidate => candidate.Domain is not null)
+            .Select(candidate => candidate.Domain!)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(domain => domain, StringComparer.Ordinal)
+            .ToArray();
+
+        if (declaredDomains.Length > 0)
         {
-            // Existing sync handling emits the precise persistence warning.
-            _ = exception;
+            if (matches.Any(candidate => candidate.Domain is null))
+            {
+                var candidateText = string.Join(", ", declaredDomains);
+                var rerunDomain = normalizedExplicit ?? declaredDomains[0];
+                return WorkerDomainResolution.Error(
+                    $"refused worker complete: durable queue rows for {repo}#{issueNumber} mix declared domain "
+                    + $"and legacy domain-less identity (declared candidates: {candidateText}). Repair the queue so the "
+                    + "execution unit has one domain, then re-run: "
+                    + $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, rerunDomain, mode)}`. "
+                    + "The startup marker and PR-linkage recovery cannot choose the execution unit.");
+            }
+
+            if (normalizedExplicit is not null
+                && !declaredDomains.Contains(normalizedExplicit, StringComparer.Ordinal))
+            {
+                var suggestedDomain = declaredDomains[0];
+                return WorkerDomainResolution.Error(
+                    $"refused worker complete: explicit domain '{normalizedExplicit}' conflicts with durable queue domain "
+                    + $"'{suggestedDomain}' for {repo}#{issueNumber}. The startup marker is display-only. Re-invoke the "
+                    + "worker with the durable domain: "
+                    + $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, suggestedDomain, mode)}`.");
+            }
+
+            var selectedDomain = normalizedExplicit ?? (declaredDomains.Length == 1 ? declaredDomains[0] : null);
+            if (selectedDomain is null)
+            {
+                var suggestions = string.Join(
+                    " or ",
+                    declaredDomains.Select(domain => $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, domain, mode)}`"));
+                return WorkerDomainResolution.Error(
+                    $"refused worker complete: {repo}#{issueNumber} resolves to more than one durable domain "
+                    + $"({string.Join(", ", declaredDomains)}). Choose the execution-unit domain explicitly from the "
+                    + $"worker surface: {suggestions}. The startup marker is not an identity selector.");
+            }
+
+            var selected = matches
+                .Where(candidate => string.Equals(candidate.Domain, selectedDomain, StringComparison.Ordinal))
+                .ToArray();
+            if (selected.Length != 1)
+            {
+                return WorkerDomainResolution.Error(
+                    $"refused worker complete: durable domain '{selectedDomain}' still maps {selected.Length} queue rows "
+                    + $"for {repo}#{issueNumber}; the execution unit is not uniquely resolvable. Repair the durable queue "
+                    + $"and re-run `{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, selectedDomain, mode)}`. "
+                    + "Do not edit the startup marker or recover through PR linkage.");
+            }
+
+            return WorkerDomainResolution.Ok(
+                selectedDomain,
+                normalizedExplicit is null ? "queue-record" : "explicit+queue-record",
+                selected[0].Item.ExecutionUnit);
         }
-        return false;
+
+        if (matches.Length > 1)
+        {
+            var rerunDomain = normalizedExplicit ?? context.Config.Project.Domain;
+            return WorkerDomainResolution.Error(
+                $"refused worker complete: {repo}#{issueNumber} matches {matches.Length} legacy queue rows without a "
+                + "declared domain, so the durable execution unit cannot be selected. Add domain evidence through the "
+                + "canonical queue/packet surface, then re-run: "
+                + $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, rerunDomain, mode)}`.");
+        }
+
+        var sessionRoot = context.ResolveParentIntentRepoRootPath();
+        if (string.IsNullOrWhiteSpace(sessionRoot))
+        {
+            sessionRoot = context.RepoRoot;
+        }
+
+        string[] recordedDomains;
+        try
+        {
+            recordedDomains = (SessionLayerModeStore.TryRead(sessionRoot!)?.Entries ?? Array.Empty<SessionLayerModeEntry>())
+                .Select(entry => entry.Domain)
+                .Distinct(StringComparer.Ordinal)
+                .OrderBy(domain => domain, StringComparer.Ordinal)
+                .ToArray();
+        }
+        catch (InvalidOperationException exception)
+        {
+            var rerunDomain = normalizedExplicit ?? context.Config.Project.Domain;
+            return WorkerDomainResolution.Error(
+                $"refused worker complete: authoritative session-layer record at '{SessionLayerModeStore.ResolvePath(sessionRoot!)}' "
+                + $"could not be read ({exception.Message}). Repair it through `intent-cli session-layer set`, then re-run: "
+                + $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, rerunDomain, mode)}`. "
+                + "The startup marker is display-only.");
+        }
+
+        if (normalizedExplicit is not null
+            && recordedDomains.Length > 0
+            && !recordedDomains.Contains(normalizedExplicit, StringComparer.Ordinal))
+        {
+            var suggestions = string.Join(
+                " or ",
+                recordedDomains.Select(domain => $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, domain, mode)}`"));
+            return WorkerDomainResolution.Error(
+                $"refused worker complete: explicit domain '{normalizedExplicit}' conflicts with the authoritative "
+                + $"session-layer record ({string.Join(", ", recordedDomains)}) for {repo}#{issueNumber}. Re-invoke "
+                + $"with the recorded domain: {suggestions}. The startup marker is display-only.");
+        }
+
+        if (normalizedExplicit is not null)
+        {
+            var source = matches.Length == 1
+                ? recordedDomains.Length > 0 ? "explicit+session-layer-record+legacy-queue" : "explicit+legacy-queue"
+                : recordedDomains.Length > 0 ? "explicit+session-layer-record" : "explicit-no-queue-record";
+            return WorkerDomainResolution.Ok(
+                normalizedExplicit,
+                source,
+                matches.Length == 1 ? matches[0].Item.ExecutionUnit : null);
+        }
+
+        if (matches.Length == 1)
+        {
+            if (recordedDomains.Length == 1)
+            {
+                return WorkerDomainResolution.Ok(
+                    recordedDomains[0],
+                    "session-layer-record+legacy-queue",
+                    matches[0].Item.ExecutionUnit);
+            }
+
+            var suggestedDomain = context.Config.Project.Domain;
+            return WorkerDomainResolution.Error(
+                $"refused worker complete: queue row '{matches[0].Item.ExecutionUnit}' for {repo}#{issueNumber} has no "
+                + "declared domain. Re-invoke from the worker surface with the domain recorded for its packet: "
+                + $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, suggestedDomain, mode)}`. "
+                + "A startup marker or PR-linkage recovery cannot supply missing durable identity.");
+        }
+
+        if (recordedDomains.Length > 1)
+        {
+            var suggestions = string.Join(
+                " or ",
+                recordedDomains.Select(domain => $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, domain, mode)}`"));
+            return WorkerDomainResolution.Error(
+                $"refused worker complete: {repo}#{issueNumber} has no queue domain and this host records multiple "
+                + $"session-layer domains ({string.Join(", ", recordedDomains)}). Choose the packet domain explicitly: {suggestions}. "
+                + "The startup marker is display-only.");
+        }
+
+        if (recordedDomains.Length == 1)
+        {
+            return WorkerDomainResolution.Ok(
+                recordedDomains[0],
+                "session-layer-record",
+                null);
+        }
+
+        var fallbackDomain = context.Config.Project.Domain;
+        if (string.IsNullOrWhiteSpace(fallbackDomain))
+        {
+            return WorkerDomainResolution.Error(
+                $"refused worker complete: no durable domain evidence exists for {repo}#{issueNumber}, and the host has no "
+                + $"configured domain. Re-invoke with `--domain <name>` using the packet's recorded domain: "
+                + $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, "<domain>", mode)}`.");
+        }
+
+        return WorkerDomainResolution.Ok(
+            fallbackDomain,
+            matches.Length == 0 ? "configured-no-queue-record" : "configured-legacy-queue",
+            matches.Length == 1 ? matches[0].Item.ExecutionUnit : null);
+    }
+
+    private static string? TryGetQueueItemDomain(QueueItem item)
+    {
+        var path = item.ClarificationReturnPath.Replace('\\', '/');
+        var segments = path.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        for (var index = 0; index + 1 < segments.Length; index++)
+        {
+            if (string.Equals(segments[index], "intents", StringComparison.Ordinal)
+                && !string.IsNullOrWhiteSpace(segments[index + 1]))
+            {
+                return segments[index + 1];
+            }
+        }
+
+        return null;
+    }
+
+    private static string BuildDomainReinvocation(
+        string repo,
+        int issueNumber,
+        string outcome,
+        int? prNumber,
+        string domain,
+        string mode)
+    {
+        var command = $"intent-cli worker complete --kind issue --number {issueNumber} --repo {repo} "
+            + $"--domain {domain} --outcome {outcome}";
+        if (prNumber is { } number)
+        {
+            command += $" --pr {number}";
+        }
+
+        command += string.Equals(mode, WorkerClaimCompleteConstants.Modes.Write, StringComparison.Ordinal)
+            ? " --write"
+            : " --dry-run";
+        return command + " --format json";
+    }
+
+    private sealed record QueueDomainCandidate(QueueItem Item, string? Domain);
+
+    private sealed record WorkerDomainResolution(
+        string? Domain,
+        string? Source,
+        string? ExecutionUnit,
+        string? ErrorMessage)
+    {
+        public static WorkerDomainResolution Ok(string domain, string source, string? executionUnit) =>
+            new(domain, source, executionUnit, null);
+
+        public static WorkerDomainResolution Error(string message) =>
+            new(null, null, null, message);
     }
 
     /// <summary>
@@ -727,6 +1021,14 @@ internal static class WorkerCompleteCommand
         writer.WriteLine();
         writer.WriteLine($"- outcome: {result.Outcome}");
         writer.WriteLine($"- mode: {result.Mode}");
+        if (result.Domain is not null)
+        {
+            writer.WriteLine($"- domain: {result.Domain} ({result.DomainSource ?? "unknown source"})");
+        }
+        if (result.ExecutionUnit is not null)
+        {
+            writer.WriteLine($"- execution-unit: {result.ExecutionUnit}");
+        }
         writer.WriteLine($"- proceed: {result.Proceed}");
         writer.WriteLine($"- applied: {result.Applied}");
         writer.WriteLine($"- add: {(result.AddLabels.Count == 0 ? "(none)" : string.Join(", ", result.AddLabels))}");
@@ -769,6 +1071,7 @@ internal static class WorkerCompleteCommand
         out int number,
         out string? outcome,
         out int? prNumber,
+        out string? explicitDomain,
         out string mode,
         out bool childCwd,
         out bool githubOnly,
@@ -780,6 +1083,7 @@ internal static class WorkerCompleteCommand
         number = 0;
         outcome = null;
         prNumber = null;
+        explicitDomain = null;
         mode = WorkerClaimCompleteConstants.Modes.DryRun;
         childCwd = false;
         githubOnly = false;
@@ -811,6 +1115,16 @@ internal static class WorkerCompleteCommand
                         return false;
                     }
                     repo = args[index + 1];
+                    index++;
+                    break;
+
+                case "--domain":
+                    if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+                    {
+                        error = "--domain requires a value (the durable execution-unit domain).";
+                        return false;
+                    }
+                    explicitDomain = args[index + 1].Trim();
                     index++;
                     break;
 
@@ -885,7 +1199,7 @@ internal static class WorkerCompleteCommand
 
                 default:
                     error =
-                        $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --kind <issue|pr> --number <N> --outcome <outcome> [--pr <N>] [--write] [--dry-run] [--format text|json].";
+                        $"Unknown argument '{argument}'. Supported: --repo <owner/repo> --domain <name> --kind <issue|pr> --number <N> --outcome <outcome> [--pr <N>] [--write] [--dry-run] [--format text|json].";
                     return false;
             }
         }

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteCommand.cs
@@ -709,11 +709,22 @@ internal static class WorkerCompleteCommand
                     matches[0].Item.ExecutionUnit);
             }
 
-            var suggestedDomain = context.Config.Project.Domain;
+            if (recordedDomains.Length > 1)
+            {
+                var suggestions = string.Join(
+                    " or ",
+                    recordedDomains.Select(domain => $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, domain, mode)}`"));
+                return WorkerDomainResolution.Error(
+                    $"refused worker complete: queue row '{matches[0].Item.ExecutionUnit}' for {repo}#{issueNumber} has no "
+                    + "declared domain and this host records multiple session-layer domains "
+                    + $"({string.Join(", ", recordedDomains)}). Choose the packet domain explicitly: {suggestions}. "
+                    + "A startup marker or PR-linkage recovery cannot supply missing durable identity.");
+            }
+
             return WorkerDomainResolution.Error(
                 $"refused worker complete: queue row '{matches[0].Item.ExecutionUnit}' for {repo}#{issueNumber} has no "
                 + "declared domain. Re-invoke from the worker surface with the domain recorded for its packet: "
-                + $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, suggestedDomain, mode)}`. "
+                + $"`{BuildDomainReinvocation(repo, issueNumber, outcome, prNumber, "<domain>", mode)}`. "
                 + "A startup marker or PR-linkage recovery cannot supply missing durable identity.");
         }
 

--- a/src/IntentSystem.Cli/Commands/WorkerCompleteResult.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerCompleteResult.cs
@@ -90,6 +90,20 @@ internal sealed record WorkerCompleteResult
     public bool? LinkedPrSyncedCamel => LinkedPrSynced;
 
     /// <summary>
+    /// G724: durable execution-unit domain resolved for host-side issue-to-PR
+    /// completion. This is deliberately separate from the startup marker,
+    /// which is display-only.
+    /// </summary>
+    [JsonPropertyName("domain")]
+    public string? Domain { get; init; }
+
+    [JsonPropertyName("domain_source")]
+    public string? DomainSource { get; init; }
+
+    [JsonPropertyName("execution_unit")]
+    public string? ExecutionUnit { get; init; }
+
+    /// <summary>
     /// G330: true when the command ran in child-cwd mode — either the
     /// operator passed <c>--child-cwd</c> explicitly OR the
     /// environment is implicitly a child cwd (no parent intent repo

--- a/tests/IntentSystem.Cli.Tests/SessionLayerMarkerG601Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerMarkerG601Tests.cs
@@ -75,6 +75,45 @@ public sealed class SessionLayerMarkerG601Tests : IDisposable
     }
 
     [Fact]
+    public void Generate_SecondRecordedDomainAppendsWithoutChangingExistingClaim_G724()
+    {
+        workspace.RecordDomain("domain-a", "alpha", SessionLayerMode.Agmsg);
+        workspace.RecordDomain("domain-b", "alpha", SessionLayerMode.HerdrOnly);
+        var file = workspace.WriteStartup(Placeholder("domain-a", "alpha") + "\n");
+
+        Assert.Equal(0, workspace.GenerateDomain("domain-a", "alpha", file).ExitCode);
+        var domainABefore = File.ReadAllText(file);
+
+        var (exitCode, result) = workspace.GenerateDomain("domain-b", "alpha", file);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("appended", result.GetProperty("marker_action").GetString());
+        Assert.True(result.GetProperty("written").GetBoolean());
+        var content = File.ReadAllText(file);
+        Assert.StartsWith(domainABefore, content, StringComparison.Ordinal);
+        Assert.Contains("domain=\"domain-a\" team=\"alpha\"", content, StringComparison.Ordinal);
+        Assert.Contains("domain=\"domain-b\" team=\"alpha\"", content, StringComparison.Ordinal);
+        Assert.Contains("mode=\"herdr-only\"", content, StringComparison.Ordinal);
+        Assert.Contains("preserved 1 existing managed block(s)", result.GetProperty("summary").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Generate_SingleDomainNoChangePreservesBytes_G724()
+    {
+        workspace.Record("alpha", SessionLayerMode.Agmsg);
+        var file = workspace.WriteStartup(Placeholder("alpha") + "\n");
+        Assert.Equal(0, workspace.Generate("alpha", file).ExitCode);
+        var before = File.ReadAllBytes(file);
+
+        var (exitCode, result) = workspace.Generate("alpha", file);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(result.GetProperty("written").GetBoolean());
+        Assert.Equal("replaced", result.GetProperty("marker_action").GetString());
+        Assert.Equal(before, File.ReadAllBytes(file));
+    }
+
+    [Fact]
     public void Preflight_StaleMarkerFailsClosedAndNamesFileClaimAndTruth_G601()
     {
         workspace.Record("alpha", SessionLayerMode.HerdrOnly);
@@ -195,8 +234,10 @@ public sealed class SessionLayerMarkerG601Tests : IDisposable
         Assert.Contains("source of truth", guide, StringComparison.Ordinal);
     }
 
-    private static string Placeholder(string team) =>
-        $"<!-- intent-cli:session-layer-marker:start domain=\"intent-cli\" team=\"{team}\" -->\n"
+    private static string Placeholder(string team) => Placeholder("intent-cli", team);
+
+    private static string Placeholder(string domain, string team) =>
+        $"<!-- intent-cli:session-layer-marker:start domain=\"{domain}\" team=\"{team}\" -->\n"
         + "<!-- intent-cli:session-layer-marker:end -->";
 
     private static NotifyProcessResult Success(string output = "") => new(0, output, "");
@@ -266,18 +307,24 @@ public sealed class SessionLayerMarkerG601Tests : IDisposable
         }
 
         public void Record(string team, string mode)
+            => RecordDomain(Domain, team, mode);
+
+        public void RecordDomain(string domain, string team, string mode)
         {
             using var writer = new StringWriter();
             var exitCode = SessionLayerCommand.ExecuteSet(Context,
-                ["--domain", Domain, "--team", team, "--mode", mode, "--write", "--format", "json"], writer);
+                ["--domain", domain, "--team", team, "--mode", mode, "--write", "--format", "json"], writer);
             Assert.True(exitCode == 0, writer.ToString());
         }
 
         public (int ExitCode, JsonElement Result) Generate(string team, string file)
+            => GenerateDomain(Domain, team, file);
+
+        public (int ExitCode, JsonElement Result) GenerateDomain(string domain, string team, string file)
         {
             using var writer = new StringWriter();
             var exitCode = SessionLayerMarkerCommand.Execute(Context,
-                ["generate", "--domain", Domain, "--team", team, "--file", file, "--write", "--format", "json"], writer);
+                ["generate", "--domain", domain, "--team", team, "--file", file, "--write", "--format", "json"], writer);
             return (exitCode, JsonDocument.Parse(writer.ToString()).RootElement.Clone());
         }
 

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -239,7 +239,67 @@ public sealed class WorkerCompleteCommandTests : IDisposable
     }
 
     [Fact]
-    public void Execute_DomainDisagreement_RefusesBeforeLabelOrQueueWrite()
+    public void Execute_DurableQueueDomainWinsOverHostDefaultAndCompletes()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        workspace.WriteQueueState(workspace.CreateItem("G724", "J-Tech-Japan/intent-system", 1305, "sekiban-as-a-service"));
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+        WorkerCompleteCommand.PrLookupFactory = () => new StubPrLookup
+        {
+            Body = "Closes #1305",
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "1305",
+             "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated, "--pr", "1306", "--write", "--format", "json"], writer);
+
+        Assert.True(exitCode == 0, writer.ToString());
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.Equal("sekiban-as-a-service", result.Domain);
+        Assert.Equal("queue-record", result.DomainSource);
+        Assert.Equal("G724", result.ExecutionUnit);
+        Assert.NotEmpty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_TwoDomainHost_CompletesDomainBAndLeavesDomainAMarkerUntouched_G724()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        workspace.RecordSessionLayer("intent-cli", "alpha", SessionLayerMode.Agmsg);
+        workspace.RecordSessionLayer("sekiban-as-a-service", "beta", SessionLayerMode.HerdrOnly);
+        var startup = workspace.WriteStartupMarker(
+            "<!-- intent-cli:session-layer-marker:start domain=\"intent-cli\" team=\"alpha\" -->\n"
+            + "<!-- intent-cli:session-layer-marker:end -->\n");
+        workspace.GenerateSessionLayerMarker("intent-cli", "alpha", startup);
+        var markerBefore = File.ReadAllBytes(startup);
+        workspace.WriteQueueState(workspace.CreateItem("G724", "J-Tech-Japan/intent-system", 1570, "sekiban-as-a-service"));
+
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+        WorkerCompleteCommand.PrLookupFactory = () => new StubPrLookup
+        {
+            Body = "Closes #1570",
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "1570",
+             "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated, "--pr", "1571", "--write", "--format", "json"], writer);
+
+        Assert.True(exitCode == 0, writer.ToString());
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.Equal("sekiban-as-a-service", result.Domain);
+        Assert.Equal("queue-record", result.DomainSource);
+        Assert.Equal("G724", result.ExecutionUnit);
+        Assert.Equal(markerBefore, File.ReadAllBytes(startup));
+        Assert.Contains("domain=\"intent-cli\" team=\"alpha\"", File.ReadAllText(startup), StringComparison.Ordinal);
+        Assert.DoesNotContain("sekiban-as-a-service", File.ReadAllText(startup), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ExplicitDomainContradiction_RefusesBeforeLabelOrQueueWrite()
     {
         using var workspace = new WorkerCompleteWorkspace();
         workspace.WriteQueueState(workspace.CreateItem("SKS-G593", "J-Tech-Japan/intent-system", 1305, "sekiban-as-a-service"));
@@ -249,14 +309,85 @@ public sealed class WorkerCompleteCommandTests : IDisposable
 
         using var writer = new StringWriter();
         var exitCode = WorkerCompleteCommand.Execute(workspace.Context,
-            ["--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "1305",
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--kind", "issue", "--number", "1305",
              "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated, "--pr", "1306", "--write", "--format", "json"], writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("J-Tech-Japan/intent-system#1305", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("explicit domain 'intent-cli'", writer.ToString(), StringComparison.Ordinal);
         Assert.Contains("sekiban-as-a-service", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--domain sekiban-as-a-service", writer.ToString(), StringComparison.Ordinal);
         Assert.Empty(mutator.AppliedTransitions);
         Assert.Equal(before, File.ReadAllBytes(workspace.QueueStatePath));
+    }
+
+    [Fact]
+    public void Execute_MissingDurableDomainOnMultiDomainHost_EmitsWorkerRecovery()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        workspace.RecordSessionLayer("intent-cli", "alpha", SessionLayerMode.Agmsg);
+        workspace.RecordSessionLayer("sekiban-as-a-service", "beta", SessionLayerMode.HerdrOnly);
+        workspace.WriteQueueState(workspace.CreateItemWithoutDomain("G724-legacy", "J-Tech-Japan/intent-system", 1570));
+        var before = File.ReadAllBytes(workspace.QueueStatePath);
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "1570",
+             "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated, "--pr", "1571", "--write", "--format", "json"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("has no declared domain", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--domain intent-cli", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("startup marker", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(mutator.AppliedTransitions);
+        Assert.Equal(before, File.ReadAllBytes(workspace.QueueStatePath));
+    }
+
+    [Fact]
+    public void Execute_ExplicitLegacyDomainMustAgreeWithRecordedSessionLayer_G724()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        workspace.RecordSessionLayer("sekiban-as-a-service", "beta", SessionLayerMode.HerdrOnly);
+        workspace.WriteQueueState(workspace.CreateItemWithoutDomain("G724-legacy", "J-Tech-Japan/intent-system", 1570));
+        var before = File.ReadAllBytes(workspace.QueueStatePath);
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--domain", "intent-cli", "--kind", "issue", "--number", "1570",
+             "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated, "--pr", "1571", "--write", "--format", "json"], writer);
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("explicit domain 'intent-cli'", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("session-layer record", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("--domain sekiban-as-a-service", writer.ToString(), StringComparison.Ordinal);
+        Assert.Empty(mutator.AppliedTransitions);
+        Assert.Equal(before, File.ReadAllBytes(workspace.QueueStatePath));
+    }
+
+    [Fact]
+    public void Execute_RecordedSessionLayerDomainIsUsedWhenIssueHasNoQueueMatch_G724()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        workspace.RecordSessionLayer("sekiban-as-a-service", "beta", SessionLayerMode.HerdrOnly);
+        workspace.WriteQueueState(workspace.CreateItemWithoutDomain("unrelated", "J-Tech-Japan/intent-system", 9999));
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+        WorkerCompleteCommand.PrLookupFactory = () => new StubPrLookup { Body = "Closes #1570" };
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "1570",
+             "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated, "--pr", "1571", "--dry-run", "--format", "json"], writer);
+
+        Assert.True(exitCode == 0, writer.ToString());
+        var result = JsonSerializer.Deserialize<WorkerCompleteResult>(writer.ToString())!;
+        Assert.True(string.Equals(result.Domain, "sekiban-as-a-service", StringComparison.Ordinal), writer.ToString());
+        Assert.Equal("session-layer-record", result.DomainSource);
+        Assert.Null(result.ExecutionUnit);
+        Assert.Empty(mutator.AppliedTransitions);
     }
 
     [Theory]
@@ -2057,6 +2188,29 @@ public sealed class WorkerCompleteCommandTests : IDisposable
 
         public string QueueStatePath => Path.Combine(RootPath, ".intent-cli", "queue-state.json");
 
+        public void RecordSessionLayer(string domain, string team, string mode)
+        {
+            using var writer = new StringWriter();
+            var exitCode = SessionLayerCommand.ExecuteSet(Context,
+                ["--domain", domain, "--team", team, "--mode", mode, "--write", "--format", "json"], writer);
+            Assert.Equal(0, exitCode);
+        }
+
+        public string WriteStartupMarker(string content)
+        {
+            var path = Path.Combine(RootPath, "CLAUDE.md");
+            File.WriteAllText(path, content);
+            return path;
+        }
+
+        public void GenerateSessionLayerMarker(string domain, string team, string path)
+        {
+            using var writer = new StringWriter();
+            var exitCode = SessionLayerMarkerCommand.Execute(Context,
+                ["generate", "--domain", domain, "--team", team, "--file", path, "--write", "--format", "json"], writer);
+            Assert.Equal(0, exitCode);
+        }
+
         /// <summary>G283: seed queue-state.json with a single execution-unit row whose
         /// linked_issue.number matches the source issue, optionally pre-filling linked_pr
         /// (for the idempotent rerun test).</summary>
@@ -2079,7 +2233,7 @@ public sealed class WorkerCompleteCommandTests : IDisposable
                         State = QueueItemState.Queued,
                         Dependencies = Array.Empty<string>(),
                         BlockedBy = Array.Empty<string>(),
-                        ClarificationReturnPath = string.Empty,
+                        ClarificationReturnPath = "intents/intent-cli/clarifications/open.md",
                         PacketPaths = new PacketPaths
                         {
                             Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
@@ -2114,6 +2268,23 @@ public sealed class WorkerCompleteCommandTests : IDisposable
                 PacketPaths = new PacketPaths { Implementation = "i", ReviewContext = "r", Yaml = "p" },
                 LinkedIssue = new LinkedIssue { Repo = repo, Number = issue, Url = $"https://github.com/{repo}/issues/{issue}" },
                 LinkedPr = existingLinkedPr,
+                WorkerRole = "child-impl",
+                ReviewRole = "host-review",
+                Priority = "normal",
+            };
+
+        public QueueItem CreateItemWithoutDomain(string executionUnit, string repo, int issue) =>
+            new()
+            {
+                ExecutionUnit = executionUnit,
+                Title = executionUnit,
+                State = QueueItemState.Queued,
+                Dependencies = Array.Empty<string>(),
+                BlockedBy = Array.Empty<string>(),
+                ClarificationReturnPath = string.Empty,
+                PacketPaths = new PacketPaths { Implementation = "i", ReviewContext = "r", Yaml = "p" },
+                LinkedIssue = new LinkedIssue { Repo = repo, Number = issue, Url = $"https://github.com/{repo}/issues/{issue}" },
+                LinkedPr = null,
                 WorkerRole = "child-impl",
                 ReviewRole = "host-review",
                 Priority = "normal",

--- a/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerCompleteCommandTests.cs
@@ -337,9 +337,36 @@ public sealed class WorkerCompleteCommandTests : IDisposable
              "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated, "--pr", "1571", "--write", "--format", "json"], writer);
 
         Assert.Equal(1, exitCode);
-        Assert.Contains("has no declared domain", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("--domain intent-cli", writer.ToString(), StringComparison.Ordinal);
-        Assert.Contains("startup marker", writer.ToString(), StringComparison.OrdinalIgnoreCase);
+        var output = writer.ToString();
+        Assert.Contains("has no declared domain", output, StringComparison.Ordinal);
+        Assert.Contains("--domain intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("--domain sekiban-as-a-service", output, StringComparison.Ordinal);
+        Assert.Contains(" or ", output, StringComparison.Ordinal);
+        Assert.Contains("startup marker", output, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(mutator.AppliedTransitions);
+        Assert.Equal(before, File.ReadAllBytes(workspace.QueueStatePath));
+    }
+
+    [Fact]
+    public void Execute_LegacyDomainlessRowWithoutRecordedSessionDomains_UsesPlaceholderRecovery_G724()
+    {
+        using var workspace = new WorkerCompleteWorkspace();
+        workspace.WriteQueueState(workspace.CreateItemWithoutDomain("G724-legacy", "J-Tech-Japan/intent-system", 1570));
+        var before = File.ReadAllBytes(workspace.QueueStatePath);
+        var mutator = new FakeMutator { Labels = new[] { "intent-target", "intent-issue-in-progress" } };
+        WorkerCompleteCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerCompleteCommand.Execute(workspace.Context,
+            ["--repo", "J-Tech-Japan/intent-system", "--kind", "issue", "--number", "1570",
+             "--outcome", WorkerResultSummaryConstants.Outcomes.PrCreated, "--pr", "1571", "--write", "--format", "json"], writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("has no declared domain", output, StringComparison.Ordinal);
+        Assert.Contains("--domain <domain>", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("--domain intent-cli", output, StringComparison.Ordinal);
+        Assert.Contains("startup marker", output, StringComparison.OrdinalIgnoreCase);
         Assert.Empty(mutator.AppliedTransitions);
         Assert.Equal(before, File.ReadAllBytes(workspace.QueueStatePath));
     }


### PR DESCRIPTION
Closes #1570

## Decision before mechanics

Added [ADR 0009](https://github.com/J-Tech-Japan/intent-system/blob/claude/g724-session-identity-authority/docs/adr/0009-session-layer-domain-identity-authority.md) before the marker or worker changes. The authoritative host session-layer identity/mode is the domain/team-scoped `.intent-cli/session-layer-mode.json` record; durable queue/packet domain metadata is authoritative for an execution unit. The generated `AGENTS.md`/`CLAUDE.md` block is display/verification evidence only and never selects a worker domain. The ADR also defines additive migration, legacy domain-less recovery, and explicitly rejects PR-linkage recovery as a domain identity workaround.

## Implementation

- Marker generation appends a missing recorded domain/team block when another valid managed block exists, reports `marker_action: appended`, and preserves existing blocks byte-for-byte. A truly unmanaged first marker still requires the documented placeholder; no hand edit is requested for an existing multi-domain marker.
- Host `worker complete` resolves the execution-unit domain from the durable queue/packet record, validates explicit `--domain`, uses the authoritative session-layer record for legacy domain-less migration, and fails closed with an exact worker-surface re-invocation for missing, ambiguous, contradictory, or unreadable evidence.
- `linked_pr` projection follows the resolved execution unit, preventing colliding issue numbers from selecting another domain's queue row.
- Child `--github-only` remains metadata-free.
- Updated the English/Japanese getting-started, implementation-loop, recovery, and orchestration documentation.

## Acceptance evidence

The focused G724 test uses two recorded domains, generates A first, then appends B:

```text
marker_generate_domain_b: marker_action=appended, preserved_existing_blocks=1
marker_after_b:
<!-- intent-cli:session-layer-marker:start domain="domain-a" team="alpha" -->
<!-- ... mode="agmsg" ... -->
<!-- intent-cli:session-layer-marker:end -->
<!-- intent-cli:session-layer-marker:start domain="domain-b" team="alpha" -->
<!-- ... mode="herdr-only" ... -->
<!-- intent-cli:session-layer-marker:end -->
```

The end-to-end host test then runs domain B while A owns the visible marker:

```text
marker_before:
<!-- intent-cli:session-layer-marker:start domain="intent-cli" team="alpha" -->
<!-- ... mode="agmsg" ... -->
<!-- intent-cli:session-layer-marker:end -->

worker_complete_after:
"proceed": true,
"applied": true,
"linked_pr_synced": true,
"domain": "sekiban-as-a-service",
"domain_source": "queue-record",
"execution_unit": "G724"

marker_after: byte-identical to marker_before; no sekiban-as-a-service block was written by worker complete.
```

For a genuine missing domain on a two-domain host, the worker stops before labels or queue writes and emits the worker recovery, including `--domain intent-cli` (and the alternate recorded domain). The output says the startup marker and PR-linkage recovery cannot supply the missing durable identity.

## Verification

- Focused CLI tests: `SessionLayerMarkerG601Tests`, `WorkerCompleteCommandTests`, and `GuideWorkerIssueToPrCommandTests` — passing.
- Full solution: `5154 passed, 1 skipped` under SDK `10.0.100`; packaged invocation smoke is `11 passed`. The sandbox required a temporary local NuGet audit override and writable CLI/NuGet homes for nested pack/tool execution; no verification override is committed.
- No manual GitHub label mutation or PR linkage recovery was used. The issue-side lifecycle transition was performed through `intent-cli worker claim`; completion will be performed through the canonical worker command after PR creation.
