### PR TITLE
[G725] Detect skipped post-release version rolls

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -320,7 +320,8 @@ reset, budget requests, change transport, cache, or batch.
 Every item carries `is_informational` (`bool`) distinguishing two families:
 
 **Actionable categories** (`is_informational: false` — `recommended_action`
-is always a runnable `intent-cli` command):
+names a runnable `intent-cli` command where one exists; `version-roll-required`
+deliberately names the required human edit):
 
 - `published-not-delegated` — an OPEN issue carries `intent-target` but has
   no claim label (`intent-issue-in-progress` / `intent-pr-created`) yet, and
@@ -389,6 +390,19 @@ is always a runnable `intent-cli` command):
   closed like `claimed-but-silent`: a missing or malformed `updatedAt` means
   silence cannot be established, so the PR is **not** promoted rather than
   flagged on unusable evidence.
+- `version-roll-required` (G725) — `stalled-work` also reads the repository's
+  published stable releases and compares the newest stable tag with
+  `eng/version.json`. A release is considered only when it is published,
+  non-draft, non-prerelease, and a valid `major.minor.patch` tag. If no such
+  release exists, a host with a stale-looking local policy is silent; if the
+  policy already says `stableVersion = <releasedVersion>` and
+  `nextVersion = <nextPatch>`, it is silent as well. Otherwise the finding
+  carries `released_version`, `expected_stable_version`, and
+  `expected_next_version`, plus the exact follow-up edit in
+  `recommended_action`. The roll stays a human follow-up commit: this
+  surface is deliberately read-only, and the roll must be coordinated with
+  release-note stubs, the next-release readiness section, and child-main CI;
+  detection alone is the in-scope recovery signal, not release automation.
 - `design-decision-pending` (G552) — a hold blocked on a **design decision**,
   recorded as an OPEN clarification artifact through the canonical clarify
   surface (`intent-cli clarify open`). Reports the blocking execution unit,
@@ -2709,6 +2723,20 @@ subsequent preview builds as `<released>-preview.N` — and a prerelease sorts
 manual uninstall/install was the only way forward. Rolling immediately makes the
 next preview `0.6.2-preview.N`, which sorts above `0.6.1`, and `dotnet tool
 update` works again.
+
+#### Detecting a skipped roll (G725)
+
+The existing `intent-cli automation stalled-work --domain <d> --repo <r>`
+surface checks this closeout. It reads published stable GitHub Releases and,
+when one is newer than the policy's recorded stable line (or the next value is
+not the following patch), emits `version-roll-required` with the released
+version, expected `stableVersion`, expected `nextVersion`, and the edit that
+clears the finding. No published release and an already-correct pair both
+produce no finding; an empty result in either healthy case must not be treated
+as evidence that a release was skipped. The command remains read-only and
+does not edit `eng/version.json` or publish a release. The operator makes the
+follow-up edit together with the release-note/readiness updates and verifies
+child-main CI, as required by this closeout rule.
 
 **Release closeout checklist** (the roll is step 4 — do not stop at step 3, and
 the roll is not done until step 6):

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2738,6 +2738,12 @@ does not edit `eng/version.json` or publish a release. The operator makes the
 follow-up edit together with the release-note/readiness updates and verifies
 child-main CI, as required by this closeout rule.
 
+When the command runs from a configured host root that does not contain
+`eng/version.json`, it follows that domain's `automation summary` binding to
+the named target checkout (for example, `submodules/intent-system`) and reads
+the policy there. It does not guess another sibling repository or synchronize
+the checkout; the finding's edit path names the configured child file.
+
 **Release closeout checklist** (the roll is step 4 — do not stop at step 3, and
 the roll is not done until step 6):
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2800,6 +2800,11 @@ read-only のままで、`eng/version.json` を編集したり release を publi
 operator が release-note / readiness の更新と一緒に follow-up edit を行い、child-main CI を
 検証します。これは closeout ルールが要求する手順であり、検出だけがこの slice の scope です。
 
+command を、`eng/version.json` を持たない configured host root から実行した場合は、domain の
+`automation summary` binding が指定する target checkout（例: `submodules/intent-system`）に
+従って、その場所の policy を読みます。別の sibling repository を推測したり checkout を
+同期したりはせず、finding の edit path に configured child のファイルを明示します。
+
 **リリース closeout チェックリスト**(roll はステップ 4 — ステップ 3 で止めないこと。
 そして roll はステップ 6 まで終えて初めて完了です):
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -306,7 +306,8 @@ batching を行いません。
 区別します:
 
 **actionable なカテゴリ**（`is_informational: false` —
-`recommended_action` は常に実行可能な `intent-cli` コマンド）:
+`recommended_action` は、存在する場合は実行可能な `intent-cli` コマンドを
+名指しします。`version-roll-required` は意図的に必要な human edit を名指しします）:
 
 - `published-not-delegated` — OPEN の issue が `intent-target` を持つが、
   claim label（`intent-issue-in-progress` / `intent-pr-created`）がまだ無く、
@@ -382,6 +383,19 @@ batching を行いません。
   これを更新します)。`claimed-but-silent` と同様に fail closed です:
   `updatedAt` が欠落・不正な場合は沈黙を確立できないため、使えない証拠に
   基づいて flag するのではなく promotion **しません**。
+- `version-roll-required` (G725) — `stalled-work` は repository の公開済み
+  stable release も読み取り、最新の stable tag と `eng/version.json` を
+  比較します。対象は publish 済み、draft でなく、prerelease でなく、
+  有効な `major.minor.patch` tag だけです。そのような release が無ければ、
+  local policy が古く見えても host は沈黙します。policy がすでに
+  `stableVersion = <releasedVersion>`、`nextVersion = <nextPatch>` なら
+  それも沈黙します。それ以外では finding が `released_version`、
+  `expected_stable_version`、`expected_next_version` と、
+  `recommended_action` に finding を消すための正確な follow-up edit を
+  持ちます。roll は human の follow-up commit のままです。この surface は
+  意図的に read-only であり、roll は release-note stub、次リリース準備
+  section、child-main CI と一緒に調整する必要があります。検出だけをこの
+  slice の scope とし、release automation は行いません。
 - `design-decision-pending` (G552) — **design の判断** で止まっている hold で、
   canonical な clarify surface (`intent-cli clarify open`) を通じて OPEN な
   clarification artifact として記録されたもの。ブロックされている execution
@@ -2772,6 +2786,19 @@ closeout の 1 ステップであり、飛ばすと preview チャンネルが�
 `dotnet tool update` は新しい build を「より古い」として拒否し、手動 uninstall/install
 以外に手段がありませんでした。直ちに roll すれば次の preview は `0.6.2-preview.N` となり
 `0.6.1` より上にソートされるため、`dotnet tool update` が再び機能します。
+
+#### roll 飛ばしの検出(G725)
+
+既存の `intent-cli automation stalled-work --domain <d> --repo <r>`
+surface がこの closeout を確認します。公開済みの stable GitHub Release を読み、policy の
+記録済み stable line より新しい release がある場合（または next value が次の patch でない
+場合）に、`version-roll-required` を出力します。finding には release version、期待する
+`stableVersion`、期待する `nextVersion`、そして解消するための edit が含まれます。公開済み
+release が無い場合と、すでに正しい組になっている場合はどちらも finding を出しません —
+健康な host の empty result を release の取りこぼしと解釈してはいけません。この command は
+read-only のままで、`eng/version.json` を編集したり release を publish したりしません。
+operator が release-note / readiness の更新と一緒に follow-up edit を行い、child-main CI を
+検証します。これは closeout ルールが要求する手順であり、検出だけがこの slice の scope です。
 
 **リリース closeout チェックリスト**(roll はステップ 4 — ステップ 3 で止めないこと。
 そして roll はステップ 6 まで終えて初めて完了です):

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -714,7 +714,7 @@ internal static class AutomationStalledWorkCommand
         CollectDraftRepairStalled(context, domain, candidateDomains, openIssues, openPrs, repo, now, repairSilentMinutes, items, excluded);
         CollectMergedNotClosedOut(context, domain, candidateDomains, repo, mergedPrs, now, items, excluded, warnings);
         CollectClaimedButSilent(context, domain, candidateDomains, openIssues, openPrs, repo, now, claimedSilentMinutes, items, excluded, warnings);
-        CollectVersionRollRequired(context, now, publishedReleases, items, warnings);
+        CollectVersionRollRequired(context, domain, repo, now, publishedReleases, items, warnings);
         CollectBacklogReadyIdle(context, domain, candidateDomains, openIssues, openPrs, repo, now, backlogIdleMinutes, items, excluded);
         CollectDesignDecisionPending(context, domain, candidateDomains, repo, now, items, excluded);
         CollectKnowledgeWritebackPending(
@@ -835,6 +835,8 @@ internal static class AutomationStalledWorkCommand
     /// </summary>
     private static void CollectVersionRollRequired(
         CliContext context,
+        string domain,
+        string repo,
         DateTimeOffset now,
         IReadOnlyList<GitHubAutomationReleaseCandidate> releases,
         List<StalledWorkItem> items,
@@ -864,11 +866,29 @@ internal static class AutomationStalledWorkCommand
             return;
         }
 
-        var policy = VersionPolicy.TryReadFromRepo(context.RepoRoot);
+        var policyRoot = context.RepoRoot;
+        var policyFile = Path.Combine("eng", "version.json");
+        var policy = VersionPolicy.TryReadFromRepo(policyRoot);
+        if (policy is null
+            && !File.Exists(Path.Combine(context.RepoRoot, policyFile)))
+        {
+            var configuredTargetRoot = AutomationSummaryAnalyzer.TryResolveConfiguredTargetRepoRoot(
+                context,
+                domain,
+                repo);
+            if (!string.IsNullOrWhiteSpace(configuredTargetRoot))
+            {
+                policyRoot = configuredTargetRoot;
+                var configuredPolicyPath = Path.Combine(policyRoot, "eng", "version.json");
+                policyFile = ToDisplayPath(context.RepoRoot, configuredPolicyPath);
+                policy = VersionPolicy.TryReadFromFile(configuredPolicyPath);
+            }
+        }
+
         if (policy is null)
         {
             warnings.Add(
-                $"version-roll detection could not read '{Path.Combine("eng", "version.json")}' "
+                $"version-roll detection could not read '{policyFile}' "
                 + $"after published release {latestVersion}; no version-roll finding was fabricated.");
             return;
         }
@@ -877,7 +897,7 @@ internal static class AutomationStalledWorkCommand
             || !VersionPolicy.TryNormalizeStableVersion(policy.NextVersion, out _))
         {
             warnings.Add(
-                $"version-roll detection found malformed values in 'eng/version.json' "
+                $"version-roll detection found malformed values in '{policyFile}' "
                 + $"after published release {latestVersion}; no version-roll finding was fabricated.");
             return;
         }
@@ -895,13 +915,21 @@ internal static class AutomationStalledWorkCommand
             AgeMinutes = ageMinutes,
             IsInformational = false,
             RecommendedAction =
-                $"Edit eng/version.json in a follow-up commit: set stableVersion to {expectation.ExpectedStableVersion} "
+                $"Edit {policyFile} in a follow-up commit: set stableVersion to {expectation.ExpectedStableVersion} "
                 + $"and nextVersion to {expectation.ExpectedNextVersion}; then verify child-main CI. "
                 + "This detector is read-only and does not perform the release roll.",
             ReleasedVersion = expectation.ReleasedVersion,
             ExpectedStableVersion = expectation.ExpectedStableVersion,
             ExpectedNextVersion = expectation.ExpectedNextVersion,
         });
+    }
+
+    private static string ToDisplayPath(string repoRoot, string absolutePath)
+    {
+        var relative = Path.GetRelativePath(repoRoot, absolutePath);
+        return relative
+            .Replace(Path.DirectorySeparatorChar, '/')
+            .Replace(Path.AltDirectorySeparatorChar, '/');
     }
 
     private static void CollectStaleClaims(

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using IntentSystem.Clarify.Models;
 using IntentSystem.Clarify.Serialization;
+using IntentSystem.Cli.Infrastructure;
 using IntentSystem.Supervisor.Models;
 using IntentSystem.Supervisor.Serialization;
 
@@ -17,8 +18,10 @@ namespace IntentSystem.Cli.Commands;
 /// heartbeat) can detect a stall without a human cross-checking GitHub
 /// labels, PR state, and queue-state by hand.
 ///
-/// Actionable categories (carry a runnable <c>recommended_action</c> command,
-/// <see cref="StalledWorkItem.IsInformational"/> is <see langword="false"/>):
+/// Actionable categories carry an actionable <c>recommended_action</c> (a
+/// runnable transition command where one exists; the version-roll category
+/// deliberately names a human edit), and <see
+/// cref="StalledWorkItem.IsInformational"/> is <see langword="false"/>:
 /// <list type="bullet">
 /// <item><c>published-not-delegated</c> — an OPEN issue carries
 ///   <c>intent-target</c>, has no claim label
@@ -70,6 +73,11 @@ namespace IntentSystem.Cli.Commands;
 ///   <see cref="BuildRepairStalledAction"/>). Covers draft PRs too, which
 ///   every other PR kind here deliberately skips — the four-day G545 stall
 ///   was invisible precisely because its repair PR was a draft.</item>
+/// <item><c>version-roll-required</c> — a published stable release is newer
+///   than the local <c>eng/version.json</c> policy, or the policy does not
+///   name the required next patch. The finding includes both expected values
+///   and deliberately recommends a human follow-up edit; this read-only
+///   surface never mutates release or version state.</item>
 /// </list>
 ///
 /// Informational categories (G533 — age for visibility only,
@@ -446,6 +454,14 @@ internal static class AutomationStalledWorkCommand
     public const string KindGuideReachabilityPending = "guide-reachability-pending";
 
     /// <summary>
+    /// G725: a published stable release requires the post-release roll in
+    /// <c>eng/version.json</c>. This is actionable immediately and remains
+    /// read-only because the human follow-up also owns release-note,
+    /// readiness, and child-main CI closeout.
+    /// </summary>
+    public const string KindVersionRollRequired = "version-roll-required";
+
+    /// <summary>
     /// G564: a closed-out unit's write-back metadata — its packet's G461
     /// declaration, the runs log the closeout is read from, or an existing
     /// write-back record — is present but unreadable. Reported here WITH the
@@ -620,6 +636,9 @@ internal static class AutomationStalledWorkCommand
             repo,
             Array.Empty<string>(),
             GitHubAutomationReadSurface.StalledWork));
+        var publishedReleases = ReadGitHub(() => lister.ListPublishedReleases(
+            repo,
+            GitHubAutomationReadSurface.StalledWork));
 
         var candidateDomains = DomainCandidateScanner.Scan(context);
         var items = new List<StalledWorkItem>();
@@ -695,6 +714,7 @@ internal static class AutomationStalledWorkCommand
         CollectDraftRepairStalled(context, domain, candidateDomains, openIssues, openPrs, repo, now, repairSilentMinutes, items, excluded);
         CollectMergedNotClosedOut(context, domain, candidateDomains, repo, mergedPrs, now, items, excluded, warnings);
         CollectClaimedButSilent(context, domain, candidateDomains, openIssues, openPrs, repo, now, claimedSilentMinutes, items, excluded, warnings);
+        CollectVersionRollRequired(context, now, publishedReleases, items, warnings);
         CollectBacklogReadyIdle(context, domain, candidateDomains, openIssues, openPrs, repo, now, backlogIdleMinutes, items, excluded);
         CollectDesignDecisionPending(context, domain, candidateDomains, repo, now, items, excluded);
         CollectKnowledgeWritebackPending(
@@ -736,6 +756,7 @@ internal static class AutomationStalledWorkCommand
             .Where(item => item.Kind is KindOperatorAttentionPending or KindOperatorAttentionCannotDetermine
                 or KindCiPending or KindCiAllGreenNotTransitioned or KindCiFailedNotTransitioned or KindCiHeadMoved
                 or KindBranchRoutingConflict or KindAwaitingOperatorMerge or KindOperatorMergeDetected
+                or KindVersionRollRequired
                 || item.AgeMinutes >= staleMinutes)
             .Where(item => capabilityMatrix.IsStalledKindApplicable(item.Kind))
             .OrderByDescending(item => item.AgeMinutes)
@@ -803,6 +824,84 @@ internal static class AutomationStalledWorkCommand
 
         return $"cause={exception.Cause}; operation={exception.Operation}; detection is unavailable; "
             + "local-only findings are partial. No automatic retry or wait is scheduled.";
+    }
+
+    /// <summary>
+    /// G725: compare the repository's latest published stable release with
+    /// the local version policy. No release means no closeout obligation, so
+    /// an empty release observation intentionally remains silent. When a
+    /// release is present but the policy cannot be read, retain an explicit
+    /// warning rather than claiming the host is healthy.
+    /// </summary>
+    private static void CollectVersionRollRequired(
+        CliContext context,
+        DateTimeOffset now,
+        IReadOnlyList<GitHubAutomationReleaseCandidate> releases,
+        List<StalledWorkItem> items,
+        List<string> warnings)
+    {
+        var latestRelease = default(GitHubAutomationReleaseCandidate);
+        var latestVersion = string.Empty;
+        foreach (var release in releases)
+        {
+            if (release.IsDraft
+                || release.IsPrerelease
+                || !VersionPolicy.TryNormalizeStableVersion(release.TagName, out var normalized))
+            {
+                continue;
+            }
+
+            if (latestRelease is null
+                || VersionPolicy.CompareStableVersions(normalized, latestVersion) > 0)
+            {
+                latestRelease = release;
+                latestVersion = normalized;
+            }
+        }
+
+        if (latestRelease is null)
+        {
+            return;
+        }
+
+        var policy = VersionPolicy.TryReadFromRepo(context.RepoRoot);
+        if (policy is null)
+        {
+            warnings.Add(
+                $"version-roll detection could not read '{Path.Combine("eng", "version.json")}' "
+                + $"after published release {latestVersion}; no version-roll finding was fabricated.");
+            return;
+        }
+
+        if (!VersionPolicy.TryNormalizeStableVersion(policy.StableVersion, out _)
+            || !VersionPolicy.TryNormalizeStableVersion(policy.NextVersion, out _))
+        {
+            warnings.Add(
+                $"version-roll detection found malformed values in 'eng/version.json' "
+                + $"after published release {latestVersion}; no version-roll finding was fabricated.");
+            return;
+        }
+
+        if (!policy.TryGetRequiredPostReleaseRoll(latestVersion, out var expectation))
+        {
+            return;
+        }
+
+        var ageMinutes = ComputeAgeMinutes(latestRelease.PublishedAt, now);
+        items.Add(new StalledWorkItem
+        {
+            Kind = KindVersionRollRequired,
+            ExecutionUnit = "version-roll",
+            AgeMinutes = ageMinutes,
+            IsInformational = false,
+            RecommendedAction =
+                $"Edit eng/version.json in a follow-up commit: set stableVersion to {expectation.ExpectedStableVersion} "
+                + $"and nextVersion to {expectation.ExpectedNextVersion}; then verify child-main CI. "
+                + "This detector is read-only and does not perform the release roll.",
+            ReleasedVersion = expectation.ReleasedVersion,
+            ExpectedStableVersion = expectation.ExpectedStableVersion,
+            ExpectedNextVersion = expectation.ExpectedNextVersion,
+        });
     }
 
     private static void CollectStaleClaims(
@@ -4527,6 +4626,18 @@ internal static class AutomationStalledWorkCommand
                 {
                     writer.WriteLine($"- pr: #{pr.Number} — {pr.Url}");
                 }
+                if (item.ReleasedVersion is { } releasedVersion)
+                {
+                    writer.WriteLine($"- released_version: {releasedVersion}");
+                }
+                if (item.ExpectedStableVersion is { } expectedStableVersion)
+                {
+                    writer.WriteLine($"- expected_stable_version: {expectedStableVersion}");
+                }
+                if (item.ExpectedNextVersion is { } expectedNextVersion)
+                {
+                    writer.WriteLine($"- expected_next_version: {expectedNextVersion}");
+                }
                 if (item.LaneId is { } laneId)
                 {
                     writer.WriteLine($"- lane_id: {laneId}");
@@ -4834,6 +4945,22 @@ internal sealed record StalledWorkItem
 
     [JsonPropertyName("recommended_action")]
     public required string RecommendedAction { get; init; }
+
+    /// <summary>
+    /// G725: the release and the two policy values required to clear the
+    /// post-release roll finding. Null for all other stalled-work kinds.
+    /// </summary>
+    [JsonPropertyName("released_version")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ReleasedVersion { get; init; }
+
+    [JsonPropertyName("expected_stable_version")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ExpectedStableVersion { get; init; }
+
+    [JsonPropertyName("expected_next_version")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? ExpectedNextVersion { get; init; }
 
     /// <summary>G673: this finding remains computable but is partial because a
     /// GitHub-derived detector was unavailable during the scan.</summary>

--- a/src/IntentSystem.Cli/Commands/AutomationSummaryAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationSummaryAnalyzer.cs
@@ -10,6 +10,47 @@ namespace IntentSystem.Cli.Commands;
 /// </summary>
 internal static class AutomationSummaryAnalyzer
 {
+    /// <summary>
+    /// Resolve the configured checkout for a requested GitHub repository using
+    /// the same domain bindings that <c>automation summary</c> emits. This is
+    /// deliberately a configuration lookup only: it does not infer a sibling
+    /// repository, inspect an arbitrary path, or synchronize a checkout.
+    /// </summary>
+    public static string? TryResolveConfiguredTargetRepoRoot(
+        CliContext context,
+        string domain,
+        string repo)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentException.ThrowIfNullOrWhiteSpace(domain);
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+
+        var bindings = LoadBindings(context, domain, new List<string>());
+        if (!string.Equals(bindings.Repo, repo, StringComparison.OrdinalIgnoreCase)
+            || string.IsNullOrWhiteSpace(bindings.SubmodulePath))
+        {
+            return null;
+        }
+
+        var baseRoot = context.ResolveParentIntentRepoRootPath();
+        if (string.IsNullOrWhiteSpace(baseRoot))
+        {
+            baseRoot = context.RepoRoot;
+        }
+
+        try
+        {
+            return Path.GetFullPath(
+                Path.IsPathRooted(bindings.SubmodulePath)
+                    ? bindings.SubmodulePath
+                    : Path.Combine(baseRoot, bindings.SubmodulePath));
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+    }
+
     public static AutomationSummaryResult Analyze(CliContext context, string? domainOverride)
     {
         ArgumentNullException.ThrowIfNull(context);

--- a/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
+++ b/src/IntentSystem.Cli/Commands/IGitHubAutomationCandidateLister.cs
@@ -69,6 +69,21 @@ internal interface IGitHubAutomationCandidateLister
         IReadOnlyCollection<string> requiredLabels,
         GitHubAutomationReadSurface surface)
         => ListClosedPullRequests(repo, requiredLabels);
+
+    /// <summary>
+    /// G725: list published GitHub Releases so repository-level release
+    /// closeout can be compared with the local version policy. Existing
+    /// fakes retain the empty default, which represents a repository with no
+    /// published release rather than inventing a release from local state.
+    /// </summary>
+    IReadOnlyList<GitHubAutomationReleaseCandidate> ListPublishedReleases(
+        string repo)
+        => Array.Empty<GitHubAutomationReleaseCandidate>();
+
+    IReadOnlyList<GitHubAutomationReleaseCandidate> ListPublishedReleases(
+        string repo,
+        GitHubAutomationReadSurface surface)
+        => ListPublishedReleases(repo);
 }
 
 /// <summary>
@@ -210,6 +225,22 @@ internal sealed record GitHubAutomationLabel
 {
     [JsonPropertyName("name")]
     public string Name { get; init; } = string.Empty;
+}
+
+/// <summary>G725: published stable-release metadata used by stalled-work.</summary>
+internal sealed record GitHubAutomationReleaseCandidate
+{
+    [JsonPropertyName("tagName")]
+    public string TagName { get; init; } = string.Empty;
+
+    [JsonPropertyName("publishedAt")]
+    public string PublishedAt { get; init; } = string.Empty;
+
+    [JsonPropertyName("isDraft")]
+    public bool IsDraft { get; init; }
+
+    [JsonPropertyName("isPrerelease")]
+    public bool IsPrerelease { get; init; }
 }
 
 /// <summary>G674: captured read-only <c>gh</c> process result for adapter tests.</summary>
@@ -368,6 +399,25 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
     }
 
     /// <summary>
+    /// G725: builds the read-only release list used to observe published
+    /// stable releases. Draft and prerelease rows are filtered after
+    /// deserialization so the transport remains a simple existing <c>gh</c>
+    /// read and the no-release case remains an honest empty observation.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildReleaseListArguments(string repo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repo);
+        return
+        [
+            "release",
+            "list",
+            "--repo", repo,
+            "--json", "tagName,publishedAt,isDraft,isPrerelease",
+            "--limit", "100",
+        ];
+    }
+
+    /// <summary>
     /// G674: builds the REST issue-list request. <c>--paginate --slurp</c>
     /// preserves the old adapter's 200-row upper bound by flattening the
     /// server's ordered pages in the deserializer; no cross-agent cache,
@@ -477,6 +527,32 @@ internal sealed class GhCliGitHubAutomationCandidateLister : IGitHubAutomationCa
         var args = BuildMergedPrListArguments(repo, requiredLabels);
         var stdout = RunGh(args, $"list merged PRs in {repo}");
         return DeserializeList<GitHubAutomationPrCandidate>(stdout, $"`gh pr list --state merged` for {repo}");
+    }
+
+    public IReadOnlyList<GitHubAutomationReleaseCandidate> ListPublishedReleases(
+        string repo)
+    {
+        var args = BuildReleaseListArguments(repo);
+        var stdout = RunGh(args, $"list published releases in {repo}");
+        return DeserializeList<GitHubAutomationReleaseCandidate>(
+            stdout,
+            $"`gh release list` for {repo}");
+    }
+
+    public IReadOnlyList<GitHubAutomationReleaseCandidate> ListPublishedReleases(
+        string repo,
+        GitHubAutomationReadSurface surface)
+    {
+        var args = BuildReleaseListArguments(repo);
+        var stdout = RunGh(
+            args,
+            $"list published releases in {repo}",
+            GitHubApiQuotaConstants.GraphQlResource,
+            GitHubApiReadDependencies.GraphQlBound,
+            GitHubApiReadInventory.UnverifiedFieldsFor(surface));
+        return DeserializeList<GitHubAutomationReleaseCandidate>(
+            stdout,
+            $"`gh release list` for {repo}");
     }
 
     public IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(

--- a/src/IntentSystem.Cli/Commands/TeamModeCapabilityMatrix.cs
+++ b/src/IntentSystem.Cli/Commands/TeamModeCapabilityMatrix.cs
@@ -92,6 +92,7 @@ internal sealed record TeamModeCapabilityMatrix
             or AutomationStalledWorkCommand.KindBlockedParked
             or AutomationStalledWorkCommand.KindStateDrift
             or AutomationStalledWorkCommand.KindDesignDecisionPending
+            or AutomationStalledWorkCommand.KindVersionRollRequired
             => TeamModeCapabilityClasses.ContractReadiness,
         AutomationStalledWorkCommand.KindCiPending
             or AutomationStalledWorkCommand.KindCiAllGreenNotTransitioned

--- a/src/IntentSystem.Cli/Infrastructure/VersionPolicy.cs
+++ b/src/IntentSystem.Cli/Infrastructure/VersionPolicy.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 
 namespace IntentSystem.Cli.Infrastructure;
@@ -40,6 +41,118 @@ internal sealed record VersionPolicy
         ArgumentException.ThrowIfNullOrWhiteSpace(runNumber);
         ArgumentException.ThrowIfNullOrWhiteSpace(runAttempt);
         return $"{NextVersion}-preview.{runNumber}.{runAttempt}";
+    }
+
+    /// <summary>
+    /// Determines whether the policy still needs the required post-release
+    /// roll for <paramref name="releasedVersion"/>. A release older than the
+    /// recorded stable line is not evidence of a new closeout obligation;
+    /// the latest release at or beyond that line must have both fields
+    /// settled to the released version and its next patch.
+    /// </summary>
+    public bool TryGetRequiredPostReleaseRoll(
+        string releasedVersion,
+        out VersionRollExpectation expectation)
+    {
+        expectation = null!;
+        if (!TryNormalizeStableVersion(releasedVersion, out var released)
+            || !TryNormalizeStableVersion(StableVersion, out var stable)
+            || !TryNormalizeStableVersion(NextVersion, out var nextVersion))
+        {
+            return false;
+        }
+
+        var comparison = CompareNormalizedStableVersions(released, stable);
+        if (comparison < 0)
+        {
+            return false;
+        }
+
+        var next = IncrementPatch(released);
+        if (comparison == 0 && string.Equals(nextVersion, next, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        expectation = new VersionRollExpectation
+        {
+            ReleasedVersion = released,
+            ExpectedStableVersion = released,
+            ExpectedNextVersion = next,
+        };
+        return true;
+    }
+
+    /// <summary>
+    /// Normalizes a stable release tag or policy value to a strict
+    /// <c>major.minor.patch</c> form. Prerelease tags are deliberately not
+    /// accepted here; the stalled-work detector only compares published
+    /// stable releases.
+    /// </summary>
+    public static bool TryNormalizeStableVersion(string value, out string normalized)
+    {
+        normalized = string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var candidate = value.Trim();
+        if (candidate.StartsWith('v') || candidate.StartsWith('V'))
+        {
+            candidate = candidate[1..];
+        }
+
+        var parts = candidate.Split('.', StringSplitOptions.None);
+        if (parts.Length != 3
+            || !int.TryParse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture, out var major)
+            || !int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out var minor)
+            || !int.TryParse(parts[2], NumberStyles.None, CultureInfo.InvariantCulture, out var patch)
+            || major < 0
+            || minor < 0
+            || patch < 0)
+        {
+            return false;
+        }
+
+        normalized = $"{major}.{minor}.{patch}";
+        return true;
+    }
+
+    /// <summary>Compares two values already accepted by <see cref="TryNormalizeStableVersion"/>.</summary>
+    public static int CompareStableVersions(string left, string right)
+    {
+        if (!TryNormalizeStableVersion(left, out var normalizedLeft)
+            || !TryNormalizeStableVersion(right, out var normalizedRight))
+        {
+            throw new ArgumentException("Both stable versions must be major.minor.patch values.");
+        }
+
+        return CompareNormalizedStableVersions(normalizedLeft, normalizedRight);
+    }
+
+    private static int CompareNormalizedStableVersions(string left, string right)
+    {
+        var leftParts = left.Split('.');
+        var rightParts = right.Split('.');
+        for (var index = 0; index < 3; index++)
+        {
+            var comparison = int.Parse(leftParts[index], CultureInfo.InvariantCulture)
+                .CompareTo(int.Parse(rightParts[index], CultureInfo.InvariantCulture));
+            if (comparison != 0)
+            {
+                return comparison;
+            }
+        }
+
+        return 0;
+    }
+
+    private static string IncrementPatch(string normalizedVersion)
+    {
+        var parts = normalizedVersion.Split('.');
+        var patch = checked(int.Parse(parts[2], CultureInfo.InvariantCulture) + 1);
+        return $"{parts[0]}.{parts[1]}.{patch}";
     }
 
     /// <summary>
@@ -87,4 +200,11 @@ internal sealed record VersionPolicy
         var filePath = Path.Combine(repoRoot, "eng", "version.json");
         return TryReadFromFile(filePath);
     }
+}
+
+internal sealed record VersionRollExpectation
+{
+    public required string ReleasedVersion { get; init; }
+    public required string ExpectedStableVersion { get; init; }
+    public required string ExpectedNextVersion { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -85,6 +85,87 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     }
 
     [Fact]
+    public void Analyze_HostRootWithoutVersionPolicy_UsesConfiguredTargetCheckout_G725Repair()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WriteConfiguredChildVersionPolicy(
+            "J-Tech-Japan/intent-system",
+            "0.22.0",
+            "0.23.0");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(
+            releases:
+            [
+                new GitHubAutomationReleaseCandidate
+                {
+                    TagName = "v0.23.1",
+                    PublishedAt = "2026-07-13T12:00:00Z",
+                },
+            ]);
+
+        var result = AutomationStalledWorkCommand.Analyze(
+            workspace.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 60);
+
+        var item = Assert.Single(result.Items, item =>
+            item.Kind == AutomationStalledWorkCommand.KindVersionRollRequired);
+        Assert.Equal("0.23.1", item.ReleasedVersion);
+        Assert.Equal("0.23.1", item.ExpectedStableVersion);
+        Assert.Equal("0.23.2", item.ExpectedNextVersion);
+        Assert.Contains(
+            "submodules/intent-system/eng/version.json",
+            item.RecommendedAction,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            result.Warnings,
+            warning => warning.Contains("version-roll detection", StringComparison.Ordinal));
+        Assert.False(File.Exists(Path.Combine(workspace.RootPath, "eng", "version.json")));
+        Assert.Equal(
+            "0.22.0",
+            JsonDocument.Parse(File.ReadAllText(Path.Combine(
+                workspace.RootPath,
+                "submodules",
+                "intent-system",
+                "eng",
+                "version.json")))
+                .RootElement.GetProperty("stableVersion")
+                .GetString());
+    }
+
+    [Fact]
+    public void Analyze_HostRootWithoutVersionPolicy_DoesNotGuessAnotherConfiguredRepo_G725Repair()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WriteConfiguredChildVersionPolicy(
+            "J-Tech-Japan/another-repo",
+            "0.22.0",
+            "0.23.0");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(
+            releases:
+            [
+                new GitHubAutomationReleaseCandidate
+                {
+                    TagName = "v0.23.1",
+                    PublishedAt = "2026-07-13T12:00:00Z",
+                },
+            ]);
+
+        var result = AutomationStalledWorkCommand.Analyze(
+            workspace.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 60);
+
+        Assert.DoesNotContain(result.Items, item =>
+            item.Kind == AutomationStalledWorkCommand.KindVersionRollRequired);
+        Assert.Contains(
+            result.Warnings,
+            warning => warning.Contains("version-roll detection", StringComparison.Ordinal)
+                && warning.Contains("eng/version.json", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Analyze_NoPublishedRelease_DoesNotNagAboutStaleVersionPolicy_G725()
     {
         using var workspace = new StalledWorkWorkspace();
@@ -3944,6 +4025,29 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         {
             WriteFile(
                 "eng/version.json",
+                $$"""
+                {
+                  "stableVersion": "{{stableVersion}}",
+                  "nextVersion": "{{nextVersion}}"
+                }
+                """);
+        }
+
+        public void WriteConfiguredChildVersionPolicy(
+            string configuredRepo,
+            string stableVersion,
+            string nextVersion)
+        {
+            WriteFile(
+                "intents/intent-cli/automation/bindings.md",
+                $$"""
+                ---
+                child_repo: {{configuredRepo}}
+                child_submodule_path: submodules/intent-system
+                ---
+                """);
+            WriteFile(
+                "submodules/intent-system/eng/version.json",
                 $$"""
                 {
                   "stableVersion": "{{stableVersion}}",

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -46,6 +46,89 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     }
 
     [Fact]
+    public void Analyze_PostReleaseVersionRoll_ReportsRealExpectedValuesWithoutMutatingHost_G725()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WriteVersionPolicy("0.22.0", "0.23.0");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(
+            releases:
+            [
+                new GitHubAutomationReleaseCandidate
+                {
+                    TagName = "v0.23.0",
+                    PublishedAt = "2026-07-13T11:00:00Z",
+                },
+                new GitHubAutomationReleaseCandidate
+                {
+                    TagName = "v0.23.1",
+                    PublishedAt = "2026-07-13T12:00:00Z",
+                },
+            ]);
+
+        var result = AutomationStalledWorkCommand.Analyze(
+            workspace.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 60);
+
+        var item = Assert.Single(result.Items, item =>
+            item.Kind == AutomationStalledWorkCommand.KindVersionRollRequired);
+        Assert.True(result.Stalled);
+        Assert.Equal("0.23.1", item.ReleasedVersion);
+        Assert.Equal("0.23.1", item.ExpectedStableVersion);
+        Assert.Equal("0.23.2", item.ExpectedNextVersion);
+        Assert.Contains("0.23.1", item.RecommendedAction, StringComparison.Ordinal);
+        Assert.Contains("0.23.2", item.RecommendedAction, StringComparison.Ordinal);
+        Assert.Contains("read-only", item.RecommendedAction, StringComparison.Ordinal);
+        Assert.Equal("0.22.0", JsonDocument.Parse(File.ReadAllText(Path.Combine(workspace.RootPath, "eng", "version.json")))
+            .RootElement.GetProperty("stableVersion").GetString());
+    }
+
+    [Fact]
+    public void Analyze_NoPublishedRelease_DoesNotNagAboutStaleVersionPolicy_G725()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WriteVersionPolicy("0.22.0", "0.23.0");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        var result = AutomationStalledWorkCommand.Analyze(
+            workspace.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 60);
+
+        Assert.False(result.Stalled);
+        Assert.DoesNotContain(result.Items, item =>
+            item.Kind == AutomationStalledWorkCommand.KindVersionRollRequired);
+    }
+
+    [Fact]
+    public void Analyze_CorrectlyRolledVersionPolicy_IsSilentAfterPublishedRelease_G725()
+    {
+        using var workspace = new StalledWorkWorkspace();
+        workspace.WriteVersionPolicy("0.23.1", "0.23.2");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(
+            releases:
+            [
+                new GitHubAutomationReleaseCandidate
+                {
+                    TagName = "v0.23.1",
+                    PublishedAt = "2026-07-13T12:00:00Z",
+                },
+            ]);
+
+        var result = AutomationStalledWorkCommand.Analyze(
+            workspace.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 60);
+
+        Assert.False(result.Stalled);
+        Assert.DoesNotContain(result.Items, item =>
+            item.Kind == AutomationStalledWorkCommand.KindVersionRollRequired);
+    }
+
+    [Fact]
     public void Execute_DispositionSettledDelegationLeavesSupervisionAndStalledWorkOpenPopulation_G671()
     {
         using var workspace = new StalledWorkWorkspace();
@@ -3793,15 +3876,18 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         private readonly IReadOnlyList<GitHubAutomationIssueCandidate> issues;
         private readonly IReadOnlyList<GitHubAutomationPrCandidate> prs;
         private readonly IReadOnlyList<GitHubAutomationPrCandidate> mergedPrs;
+        private readonly IReadOnlyList<GitHubAutomationReleaseCandidate> releases;
 
         public FakeLister(
             IReadOnlyList<GitHubAutomationIssueCandidate>? issues = null,
             IReadOnlyList<GitHubAutomationPrCandidate>? prs = null,
-            IReadOnlyList<GitHubAutomationPrCandidate>? mergedPrs = null)
+            IReadOnlyList<GitHubAutomationPrCandidate>? mergedPrs = null,
+            IReadOnlyList<GitHubAutomationReleaseCandidate>? releases = null)
         {
             this.issues = issues ?? Array.Empty<GitHubAutomationIssueCandidate>();
             this.prs = prs ?? Array.Empty<GitHubAutomationPrCandidate>();
             this.mergedPrs = mergedPrs ?? Array.Empty<GitHubAutomationPrCandidate>();
+            this.releases = releases ?? Array.Empty<GitHubAutomationReleaseCandidate>();
         }
 
         public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => prs;
@@ -3809,6 +3895,8 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(string repo, IReadOnlyCollection<string> requiredLabels) => issues;
 
         public IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => mergedPrs;
+
+        public IReadOnlyList<GitHubAutomationReleaseCandidate> ListPublishedReleases(string repo) => releases;
     }
 
     private sealed class EmptyNotifyProcessRunner : INotifyProcessRunner
@@ -3850,6 +3938,18 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
             var fullPath = Path.Combine(RootPath, relativePath);
             Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
             File.WriteAllText(fullPath, content);
+        }
+
+        public void WriteVersionPolicy(string stableVersion, string nextVersion)
+        {
+            WriteFile(
+                "eng/version.json",
+                $$"""
+                {
+                  "stableVersion": "{{stableVersion}}",
+                  "nextVersion": "{{nextVersion}}"
+                }
+                """);
         }
 
         /// <summary>

--- a/tests/IntentSystem.Cli.Tests/GitHubApiReadG674Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/GitHubApiReadG674Tests.cs
@@ -65,6 +65,45 @@ public sealed class GitHubApiReadG674Tests : IDisposable
     }
 
     [Fact]
+    public void ReleaseListArguments_ReadPublishedStableReleaseMetadataWithoutMutation_G725()
+    {
+        var args = GhCliGitHubAutomationCandidateLister.BuildReleaseListArguments(
+            "J-Tech-Japan/intent-system");
+
+        Assert.Equal(["release", "list"], args.Take(2));
+        Assert.Contains("--repo", args);
+        Assert.Contains("J-Tech-Japan/intent-system", args);
+        Assert.Contains("--json", args);
+        Assert.Contains("tagName,publishedAt,isDraft,isPrerelease", args);
+        Assert.Contains("--limit", args);
+        Assert.Contains("100", args);
+        Assert.DoesNotContain("delete", args, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("publish", args, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ReleaseLister_ProjectsPublishedReleaseRows_G725()
+    {
+        GhCliGitHubAutomationCandidateLister.ProcessRunner = args =>
+        {
+            Assert.Equal("release", args[0]);
+            return new GhCliProcessResult(
+                0,
+                "[{\"tagName\":\"v0.23.1\",\"publishedAt\":\"2026-08-20T08:09:24Z\",\"isDraft\":false,\"isPrerelease\":false}]",
+                string.Empty);
+        };
+
+        var release = Assert.Single(new GhCliGitHubAutomationCandidateLister().ListPublishedReleases(
+            "J-Tech-Japan/intent-system",
+            GitHubAutomationReadSurface.StalledWork));
+
+        Assert.Equal("v0.23.1", release.TagName);
+        Assert.Equal("2026-08-20T08:09:24Z", release.PublishedAt);
+        Assert.False(release.IsDraft);
+        Assert.False(release.IsPrerelease);
+    }
+
+    [Fact]
     public void RestIssueDeserializer_FiltersPullRequestsAndNormalizesExistingShape()
     {
         const string restPages = """


### PR DESCRIPTION
Closes #1573

## Summary

G725 adds post-release version-roll detection to the existing read-only
`automation stalled-work` host surface. It observes published stable GitHub
Releases, compares the newest semantic release tag with the configured target
checkout's `eng/version.json`, and reports the exact follow-up values without
mutating release or version state.

## Acceptance criteria

- Published releases are checked by `stalled-work` itself. A stale policy
  emits `version-roll-required` immediately, so this is a host-surface
  detector rather than a documentation-only reminder.
- No published stable release is an explicit silent case. A policy already
  rolled to the released version and its next patch is also silent.
- The finding emits `released_version`, `expected_stable_version`, and
  `expected_next_version`; `recommended_action` names the exact policy edit
  and child-main CI verification.
- When the command runs from a host root without `eng/version.json`, it uses
  the existing domain `automation summary` binding only when its configured
  repo matches the requested target. The real binding is
  `repo: J-Tech-Japan/intent-system` plus
  `submodule_path: submodules/intent-system`. No sibling-repo guessing or
  checkout synchronization was added.
- The roll remains a human follow-up edit. `stalled-work` is intentionally
  read-only, and the post-release roll is coupled to release-note stubs,
  readiness documentation, and child-main CI; release automation is outside
  this issue's detection scope.

## Actual host-root evidence

The actual orchestration cwd has no `eng/version.json`; its binding names
`submodules/intent-system` as the target checkout.

Before this repair, at reviewed head `fc3ca037e78261920c3cd8cd0c4e8f8cdd950603`:

```json
{
  "stalled": true,
  "version_roll_items": [],
  "version_roll_warnings": [
    "version-roll detection could not read 'eng/version.json' after published release 0.23.1; no version-roll finding was fabricated."
  ]
}
```

After this repair, at head `54b050df80aab021d16de55a5a8c01309f301cbc`:

```json
{
  "stalled": true,
  "version_roll_items": [
    {
      "kind": "version-roll-required",
      "execution_unit": "version-roll",
      "released_version": "0.23.1",
      "expected_stable_version": "0.23.1",
      "expected_next_version": "0.23.2",
      "recommended_action": "Edit submodules/intent-system/eng/version.json in a follow-up commit: set stableVersion to 0.23.1 and nextVersion to 0.23.2; then verify child-main CI. This detector is read-only and does not perform the release roll."
    }
  ],
  "version_roll_warnings": []
}
```

The same actual host-root invocation of `automation heartbeat` now reports
`status: actionable-stall` and carries the same `version-roll-required` item,
so the host can wake the responsible worker.

## Preserved healthy and failure evidence

- Corrected child policy (`0.23.1` / `0.23.2`) with the published `v0.23.1`:
  `{ "stalled": false, "version_roll_items": [], "version_roll_warnings": [] }`.
- No-release fixture, including the configured child-policy topology:
  `{ "stalled": false, "version_roll_items": [], "version_roll_warnings": [] }`.
- Offline/API-failure fixture: no version item was fabricated; output was
  `partial: true`, `detection_available: false`,
  `cause: github-command-failed`, with the existing
  `detection is unavailable` warning.

## Verification

- Focused `AutomationStalledWorkCommandTests`: 116 passed.
- Focused `AutomationSummaryCommandTests`: 16 passed.
- Full `IntentSystem.sln`: 5,163 passed, 1 expected skip, 0 failed.
- `git diff --check`: clean.
- No release, tag, package publish, or version-policy edit was performed.

Head: `54b050df80aab021d16de55a5a8c01309f301cbc`
