### PR TITLE
G727: report stalled-work checkout freshness

### DIFF
--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -365,6 +365,29 @@ when quota makes GitHub-consulting surfaces inoperable. Callers decide whether
 to wait for reset; no command retries, sleeps, schedules a reset, budgets
 requests, changes transport, caches, or batches in G673.
 
+### Checkout freshness in host-state reports (G727)
+
+`automation stalled-work` also reports what checkout its answer came from when
+that fact is not safely current. It compares the local `HEAD` with the actual
+default-branch `HEAD` returned by `git ls-remote --symref origin HEAD`:
+
+- `checkout_freshness: stale` names the local and remote commit IDs and tells
+  the operator to sync and rerun the report.
+- A genuinely current checkout omits `checkout_freshness` and emits no
+  freshness banner. This keeps the notice rare enough to remain useful.
+- If the remote cannot be queried (offline, missing remote, or an incomplete
+  response), `checkout_freshness: unknown` is emitted with a reason. Unknown
+  must not be read as current.
+
+The probe is read-only: it uses no `fetch`, `pull`, `reset`, or other sync
+operation, and it does not change the existing stalled-work finding logic.
+`automation heartbeat` wraps `stalled-work` and therefore carries the same
+warning. The sibling read-only surfaces were surveyed: `automation summary`,
+`intent status`, `automation state-doctor`, `status brief`,
+`host-loop-next-action`, and host-review diagnostics do not make this
+stalled-work checkout-freshness claim and remain unchanged. The survey is not
+a reason to widen G727 to those surfaces.
+
 G672 adds an optional invoking-role pointer (preview-through-1.x):
 
 ```bash

--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -378,15 +378,27 @@ default-branch `HEAD` returned by `git ls-remote --symref origin HEAD`:
 - If the remote cannot be queried (offline, missing remote, or an incomplete
   response), `checkout_freshness: unknown` is emitted with a reason. Unknown
   must not be read as current.
+- The remote probe is bounded to three seconds, reads stdout and stderr under
+  that same bound, kills the Git process tree on expiry, closes stdin, and
+  disables terminal/SSH prompts. A timeout is therefore an actionable
+  `unknown`, not a stalled wake.
 
 The probe is read-only: it uses no `fetch`, `pull`, `reset`, or other sync
 operation, and it does not change the existing stalled-work finding logic.
 `automation heartbeat` wraps `stalled-work` and therefore carries the same
-warning. The sibling read-only surfaces were surveyed: `automation summary`,
-`intent status`, `automation state-doctor`, `status brief`,
-`host-loop-next-action`, and host-review diagnostics do not make this
-stalled-work checkout-freshness claim and remain unchanged. The survey is not
-a reason to widen G727 to those surfaces.
+warning. The survey does **not** classify every sibling as unaffected:
+`intent status` was independently demonstrated on the same stale clone to
+return stale local queue state without checkout provenance. Source inspection
+also shows `automation summary`, `automation state-doctor`,
+`host-loop-next-action`, and `automation heartbeat` read `context.RepoRoot`, so
+they share the unstated-checkout provenance property (heartbeat inherits the
+new warning here, while the others remain follow-up work). This slice is
+deliberately scoped to `stalled-work` plus heartbeat inheritance. A follow-up
+must extend and test an explicit freshness/provenance contract for those
+RepoRoot-reading siblings. `status brief` and host-review diagnostics were
+also inspected and do not read `RepoRoot` for these answers; they are
+unaffected by this specific unstated-checkout path, not globally certified as
+current. The survey is not a reason to widen G727 here.
 
 G672 adds an optional invoking-role pointer (preview-through-1.x):
 

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -2666,6 +2666,18 @@ timer.
 intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json
 ```
 
+G727 makes the input view explicit without adding noise to healthy wakes.
+`stalled-work` emits `checkout_freshness: stale` with the local `HEAD`, the
+actual `origin` default-branch `HEAD`, and a sync-and-rerun instruction when
+the remote has moved. A genuinely current checkout emits no freshness notice.
+When the remote cannot be checked, it emits `checkout_freshness: unknown`
+with the reason instead of implying currency. The probe uses only
+`git rev-parse` and `git ls-remote --symref`; it never fetches, pulls, resets,
+or otherwise syncs the shared host checkout. `automation heartbeat` carries
+the same warning because it wraps this scan. Other read-only host-state
+surfaces remain outside this slice because they do not make the same
+stalled-work answer-from-checkout claim.
+
 - **Never defer** — process every actionable item the check reports in THIS
   wake (delegate, repair, or route to closeout) before sleeping. Do not
   announce work for a future wake unless an explicit fallback/legacy timer

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -2673,10 +2673,17 @@ the remote has moved. A genuinely current checkout emits no freshness notice.
 When the remote cannot be checked, it emits `checkout_freshness: unknown`
 with the reason instead of implying currency. The probe uses only
 `git rev-parse` and `git ls-remote --symref`; it never fetches, pulls, resets,
-or otherwise syncs the shared host checkout. `automation heartbeat` carries
-the same warning because it wraps this scan. Other read-only host-state
-surfaces remain outside this slice because they do not make the same
-stalled-work answer-from-checkout claim.
+or otherwise syncs the shared host checkout. The remote probe is bounded to
+three seconds across process exit and both output reads, kills the process
+tree on expiry, closes stdin, and disables terminal/SSH prompts; expiry is an
+explicit `unknown` result. `automation heartbeat` carries the same warning
+because it wraps this scan. The sibling survey found that `intent status` is
+independently stale-provenance-bearing on the same clone, and that
+`automation summary`, `automation state-doctor`, and
+`host-loop-next-action` also read `context.RepoRoot`; they need a follow-up
+freshness/provenance contract. This slice remains scoped to stalled-work plus
+heartbeat inheritance. `status brief` and host-review diagnostics do not read
+`RepoRoot` for these answers and are unaffected by this specific path.
 
 - **Never defer** — process every actionable item the check reports in THIS
   wake (delegate, repair, or route to closeout) before sleeping. Do not

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -342,6 +342,27 @@ quota exhaustion では machine-readable な `cause: github-api-quota-exhausted`
 `ok` 以外の verdict を返します。reset を待つかどうかは caller が判断します。G673 は retry、sleep、
 reset scheduling、request budgeting、transport change、cache、batching を追加しません。
 
+### host-state report の checkout freshness（G727）
+
+`automation stalled-work` は、answer を計算した checkout が current であると
+安全に言えない場合、その事実も報告します。local `HEAD` と、
+`git ls-remote --symref origin HEAD` が返す実際の default branch の `HEAD` を比較します。
+
+- `checkout_freshness: stale` は local と remote の commit ID を示し、sync して
+  report を再実行するよう案内します。
+- 本当に current な checkout では `checkout_freshness` を省略し、freshness banner も
+  出しません。notice を稀に保つことで signal としての意味を維持します。
+- remote を問い合わせられない場合（offline、remote 不在、応答不完全）は理由つきで
+  `checkout_freshness: unknown` を出します。unknown を current と解釈してはいけません。
+
+この probe は read-only です。`fetch`、`pull`、`reset`、その他の sync operation を
+実行せず、既存の stalled-work の finding logic も変更しません。`automation heartbeat` は
+`stalled-work` を wrapper するため同じ warning を運びます。兄弟の read-only surface も
+survey しました: `automation summary`、`intent status`、`automation state-doctor`、
+`status brief`、`host-loop-next-action`、host-review diagnostics はこの
+stalled-work checkout-freshness claim を行わず、変更していません。この survey を理由に
+G727 の scope を広げません。
+
 G672 は invoking role の pointer を optional に追加します（preview-through-1.x）。
 
 ```bash

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -354,14 +354,23 @@ reset scheduling、request budgeting、transport change、cache、batching を�
   出しません。notice を稀に保つことで signal としての意味を維持します。
 - remote を問い合わせられない場合（offline、remote 不在、応答不完全）は理由つきで
   `checkout_freshness: unknown` を出します。unknown を current と解釈してはいけません。
+- remote probe は 3 秒で bounded です。stdout と stderr の read も同じ bound に含め、
+  expiry では Git process tree を終了させ、stdin を閉じ、terminal/SSH prompt を無効にします。
+  timeout は wake を止めず、理由つきの actionable な `unknown` になります。
 
 この probe は read-only です。`fetch`、`pull`、`reset`、その他の sync operation を
 実行せず、既存の stalled-work の finding logic も変更しません。`automation heartbeat` は
-`stalled-work` を wrapper するため同じ warning を運びます。兄弟の read-only surface も
-survey しました: `automation summary`、`intent status`、`automation state-doctor`、
-`status brief`、`host-loop-next-action`、host-review diagnostics はこの
-stalled-work checkout-freshness claim を行わず、変更していません。この survey を理由に
-G727 の scope を広げません。
+`stalled-work` を wrapper するため同じ warning を運びます。兄弟をすべて unaffected とは
+分類していません。同じ stale clone で `intent status` が stale な local queue state を
+checkout provenance なしに返すことを独立に実証しました。source survey でも
+`automation summary`、`automation state-doctor`、`host-loop-next-action`、
+`automation heartbeat` は `context.RepoRoot` を読むため、unstated checkout provenance の
+property を共有します（heartbeat はこの slice の warning を継承し、他は follow-up です）。
+この slice の scope は `stalled-work` と heartbeat inheritance に限定します。これらの
+RepoRoot-reading sibling には、freshness/provenance contract と test を追加する follow-up
+が必要です。`status brief` と host-review diagnostics はこの answer で `RepoRoot` を読まず、
+この特定の unstated-checkout path には unaffected です。ただし全体が current だと証明した
+わけではありません。この survey を理由に G727 の scope をここで広げません。
 
 G672 は invoking role の pointer を optional に追加します（preview-through-1.x）。
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -2325,6 +2325,16 @@ publish-then-sleep と silent-completion の stall class を、タイマーを�
 intent-cli automation stalled-work --domain <domain> --repo <owner/repo> --format json
 ```
 
+G727 は healthy な wake に noise を追加せず、answer の input view を明示します。
+remote が動いている場合、`stalled-work` は local `HEAD`、実際の `origin` default branch の
+`HEAD`、sync 後に再実行する案内とともに `checkout_freshness: stale` を出します。
+本当に current な checkout では freshness notice を出しません。remote を確認できない場合は
+current を暗黙に意味させず、理由つきで `checkout_freshness: unknown` を出します。probe が使うのは
+`git rev-parse` と `git ls-remote --symref` だけで、共有 host checkout を fetch、pull、reset、
+その他の sync で変更しません。`automation heartbeat` はこの scan を wrapper するため同じ
+warning を運びます。同じ stalled-work の answer-from-checkout claim を行わない他の
+read-only host-state surface はこの slice の scope 外に残します。
+
 - **先送りしない** — このチェックが報告するすべての actionable item を、眠りにつく前に
   この wake の中で処理する（delegate、repair、または closeout へのルーティング）。
   明示的な fallback/legacy タイマーが実際にそれを実行するようスケジュールされていない

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -2331,9 +2331,15 @@ remote が動いている場合、`stalled-work` は local `HEAD`、実際の `o
 本当に current な checkout では freshness notice を出しません。remote を確認できない場合は
 current を暗黙に意味させず、理由つきで `checkout_freshness: unknown` を出します。probe が使うのは
 `git rev-parse` と `git ls-remote --symref` だけで、共有 host checkout を fetch、pull、reset、
-その他の sync で変更しません。`automation heartbeat` はこの scan を wrapper するため同じ
-warning を運びます。同じ stalled-work の answer-from-checkout claim を行わない他の
-read-only host-state surface はこの slice の scope 外に残します。
+その他の sync で変更しません。remote probe は process exit と stdout/stderr の read を含めて
+3 秒で bounded であり、expiry では process tree を終了させ、stdin と terminal/SSH prompt を
+閉じて `unknown` を返します。`automation heartbeat` はこの scan を wrapper するため同じ
+warning を運びます。同じ stale clone で `intent status` が checkout provenance なしに stale
+local queue state を返すことを独立に実証しました。`automation summary`、
+`automation state-doctor`、`host-loop-next-action` も `context.RepoRoot` を読むため同じ
+unstated-checkout provenance property を持ちます。これらは follow-up であり、この slice は
+`stalled-work` と heartbeat inheritance に限定します。`status brief` と host-review diagnostics
+はこの answer で `RepoRoot` を読まず、この特定の path には unaffected です。
 
 - **先送りしない** — このチェックが報告するすべての actionable item を、眠りにつく前に
   この wake の中で処理する（delegate、repair、または closeout へのルーティング）。

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -833,7 +833,8 @@ internal static class AutomationStalledWorkCommand
         {
             var observation = CheckoutFreshnessProbe.Capture(
                 context.RepoRoot,
-                GitCommandRunnerFactory?.Invoke() ?? new GitRemoteCommandRunner());
+                GitCommandRunnerFactory?.Invoke()
+                    ?? new CheckoutFreshnessGitCommandRunner(CheckoutFreshnessProbe.DefaultTimeout));
             if (observation is { Status: not CheckoutFreshnessProbe.Current })
             {
                 warnings.Add(observation.Warning);

--- a/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStalledWorkCommand.cs
@@ -504,6 +504,13 @@ internal static class AutomationStalledWorkCommand
 
     public static Func<DateTimeOffset>? UtcNowFactory { get; set; }
 
+    /// <summary>
+    /// G727 test seam for the read-only checkout freshness probe. The default
+    /// runner only invokes <c>git rev-parse</c> and
+    /// <c>git ls-remote --symref</c>; it never fetches or changes the checkout.
+    /// </summary>
+    public static Func<IGitRemoteCommandRunner>? GitCommandRunnerFactory { get; set; }
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
@@ -596,6 +603,7 @@ internal static class AutomationStalledWorkCommand
         var capabilityMatrix = TeamModeCapabilityMatrix.Resolve(context.RepoRoot, domain, team);
         var now = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
         var warnings = new List<string>();
+        var checkoutFreshness = CaptureCheckoutFreshness(context, warnings);
         GitHubApiRequestException? githubApiFailure = null;
         GitHubApiDegradedState? githubApiDegradedState = null;
         var lister = CandidateListerFactory?.Invoke() ?? new GhCliGitHubAutomationCandidateLister();
@@ -788,6 +796,11 @@ internal static class AutomationStalledWorkCommand
             Items = resultItems,
             Excluded = excluded,
             Warnings = warnings,
+            // G727: current checkouts stay silent; stale and unknown
+            // observations carry their structured evidence and warning.
+            CheckoutFreshness = checkoutFreshness is { Status: not CheckoutFreshnessProbe.Current }
+                ? checkoutFreshness
+                : null,
             Partial = githubApiFailure is not null,
             DetectionAvailable = detectionAvailable ? null : false,
             DetectionStatus = detectionAvailable ? null : "unavailable",
@@ -810,6 +823,37 @@ internal static class AutomationStalledWorkCommand
                 ? null
                 : operatorAttention.Error,
         };
+    }
+
+    private static CheckoutFreshnessObservation? CaptureCheckoutFreshness(
+        CliContext context,
+        List<string> warnings)
+    {
+        try
+        {
+            var observation = CheckoutFreshnessProbe.Capture(
+                context.RepoRoot,
+                GitCommandRunnerFactory?.Invoke() ?? new GitRemoteCommandRunner());
+            if (observation is { Status: not CheckoutFreshnessProbe.Current })
+            {
+                warnings.Add(observation.Warning);
+            }
+            return observation;
+        }
+        catch (Exception exception) when (
+            exception is IOException
+            or InvalidOperationException
+            or UnauthorizedAccessException
+            or System.ComponentModel.Win32Exception)
+        {
+            var observation = new CheckoutFreshnessObservation
+            {
+                Status = CheckoutFreshnessProbe.Unknown,
+                Reason = $"the checkout freshness probe failed ({exception.Message})",
+            };
+            warnings.Add(observation.Warning);
+            return observation;
+        }
     }
 
     private static string GitHubApiFailureMessage(GitHubApiRequestException exception)
@@ -4634,6 +4678,26 @@ internal static class AutomationStalledWorkCommand
         {
             writer.WriteLine($"- operator_attention_error: {result.OperatorAttentionError}");
         }
+        if (result.CheckoutFreshness is { } checkoutFreshness)
+        {
+            writer.WriteLine($"- checkout_freshness: {checkoutFreshness.Status}");
+            if (checkoutFreshness.LocalHead is { } localHead)
+            {
+                writer.WriteLine($"- checkout_local_head: {localHead}");
+            }
+            if (checkoutFreshness.DefaultBranch is { } defaultBranch)
+            {
+                writer.WriteLine($"- checkout_default_branch: {defaultBranch}");
+            }
+            if (checkoutFreshness.RemoteHead is { } remoteHead)
+            {
+                writer.WriteLine($"- checkout_remote_head: {remoteHead}");
+            }
+            if (checkoutFreshness.Reason is { } reason)
+            {
+                writer.WriteLine($"- checkout_freshness_reason: {reason}");
+            }
+        }
         writer.WriteLine();
 
         if (result.Items.Count == 0)
@@ -4879,6 +4943,15 @@ internal sealed record AutomationStalledWorkResult
 
     [JsonPropertyName("warnings")]
     public required IReadOnlyList<string> Warnings { get; init; }
+
+    /// <summary>
+    /// G727: omitted for a genuinely current checkout so healthy reports stay
+    /// quiet. Stale and unknown observations name the local and remote
+    /// evidence (or the reason it could not be established).
+    /// </summary>
+    [JsonPropertyName("checkout_freshness")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public CheckoutFreshnessObservation? CheckoutFreshness { get; init; }
 
     [JsonPropertyName("operator_attention_status")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/src/IntentSystem.Cli/Commands/CheckoutFreshnessProbe.cs
+++ b/src/IntentSystem.Cli/Commands/CheckoutFreshnessProbe.cs
@@ -1,0 +1,198 @@
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G727: observes whether a host-state answer was computed from the current
+/// checkout without changing that checkout. The remote is queried with
+/// <c>git ls-remote --symref origin HEAD</c>; unlike fetch/pull/reset, that
+/// command does not update local refs or the working tree. If the remote
+/// cannot be queried, the result is explicitly unknown rather than current.
+/// </summary>
+internal static class CheckoutFreshnessProbe
+{
+    public const string Current = "current";
+    public const string Stale = "stale";
+    public const string Unknown = "unknown";
+
+    public static CheckoutFreshnessObservation? Capture(
+        string repoRoot,
+        IGitRemoteCommandRunner runner)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repoRoot);
+        ArgumentNullException.ThrowIfNull(runner);
+
+        // A unit-test workspace or a host-side directory can be a valid
+        // intent-cli root without being a Git checkout. There is no checkout
+        // freshness claim to make in that shape, so preserve the historical
+        // output instead of manufacturing an unknown banner for every test
+        // and non-Git invocation.
+        var gitMarker = Path.Combine(repoRoot, ".git");
+        if (!File.Exists(gitMarker) && !Directory.Exists(gitMarker))
+        {
+            return null;
+        }
+
+        string localHead;
+        try
+        {
+            var local = runner.Run(repoRoot, ["rev-parse", "HEAD"]);
+            if (local.ExitCode != 0 || string.IsNullOrWhiteSpace(local.StdOut))
+            {
+                return UnknownObservation(
+                    null,
+                    null,
+                    null,
+                    "the local checkout HEAD could not be read");
+            }
+
+            localHead = local.StdOut.Trim();
+        }
+        catch (Exception exception) when (IsProbeFailure(exception))
+        {
+            return UnknownObservation(
+                null,
+                null,
+                null,
+                $"the local checkout HEAD could not be read ({exception.Message})");
+        }
+
+        GitRemoteCommandResult remote;
+        try
+        {
+            remote = runner.Run(repoRoot, ["ls-remote", "--symref", "origin", "HEAD"]);
+        }
+        catch (Exception exception) when (IsProbeFailure(exception))
+        {
+            return UnknownObservation(
+                localHead,
+                null,
+                null,
+                $"the origin default branch could not be queried ({exception.Message})");
+        }
+
+        if (remote.ExitCode != 0)
+        {
+            var detail = FirstNonEmpty(remote.StdErr, "the origin default branch could not be queried");
+            return UnknownObservation(localHead, null, null, detail);
+        }
+
+        if (!TryParseRemoteHead(remote.StdOut, out var defaultBranch, out var remoteHead))
+        {
+            return UnknownObservation(
+                localHead,
+                null,
+                null,
+                "the origin response did not identify a default branch and HEAD");
+        }
+
+        if (string.Equals(localHead, remoteHead, StringComparison.OrdinalIgnoreCase))
+        {
+            return new CheckoutFreshnessObservation
+            {
+                Status = Current,
+                LocalHead = localHead,
+                DefaultBranch = defaultBranch,
+                RemoteHead = remoteHead,
+            };
+        }
+
+        return new CheckoutFreshnessObservation
+        {
+            Status = Stale,
+            LocalHead = localHead,
+            DefaultBranch = defaultBranch,
+            RemoteHead = remoteHead,
+        };
+    }
+
+    private static CheckoutFreshnessObservation UnknownObservation(
+        string? localHead,
+        string? defaultBranch,
+        string? remoteHead,
+        string reason) => new()
+        {
+            Status = Unknown,
+            LocalHead = localHead,
+            DefaultBranch = defaultBranch,
+            RemoteHead = remoteHead,
+            Reason = reason,
+        };
+
+    private static bool TryParseRemoteHead(
+        string output,
+        out string defaultBranch,
+        out string remoteHead)
+    {
+        defaultBranch = string.Empty;
+        remoteHead = string.Empty;
+
+        foreach (var rawLine in output.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.StartsWith("ref: refs/heads/", StringComparison.Ordinal)
+                && line.EndsWith("\tHEAD", StringComparison.Ordinal))
+            {
+                const string refPrefix = "ref: refs/heads/";
+                const string headSuffix = "\tHEAD";
+                defaultBranch = line[refPrefix.Length..(line.Length - headSuffix.Length)];
+                continue;
+            }
+
+            var separator = line.IndexOf('\t');
+            if (separator > 0
+                && string.Equals(line[(separator + 1)..], "HEAD", StringComparison.Ordinal))
+            {
+                remoteHead = line[..separator];
+            }
+        }
+
+        return !string.IsNullOrWhiteSpace(defaultBranch)
+            && !string.IsNullOrWhiteSpace(remoteHead);
+    }
+
+    private static string FirstNonEmpty(string value, string fallback) =>
+        string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+
+    private static bool IsProbeFailure(Exception exception) =>
+        exception is IOException
+            or InvalidOperationException
+            or UnauthorizedAccessException
+            or System.ComponentModel.Win32Exception;
+}
+
+internal sealed record CheckoutFreshnessObservation
+{
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("local_head")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LocalHead { get; init; }
+
+    [JsonPropertyName("default_branch")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? DefaultBranch { get; init; }
+
+    [JsonPropertyName("remote_head")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? RemoteHead { get; init; }
+
+    [JsonPropertyName("reason")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Reason { get; init; }
+
+    [JsonIgnore]
+    public string Warning => Status switch
+    {
+        CheckoutFreshnessProbe.Stale =>
+            $"checkout freshness: stale; this answer was computed from local HEAD {LocalHead} "
+            + $"but origin/{DefaultBranch} is {RemoteHead}. Sync the checkout and re-run the report; "
+            + "this command is read-only and does not fetch, pull, reset, or sync.",
+        CheckoutFreshnessProbe.Unknown =>
+            $"checkout freshness: unknown; {Reason ?? "the checkout freshness probe could not determine a result"}. "
+            + "Do not treat this report as evidence that the checkout is current; verify the checkout and re-run. "
+            + "This command is read-only and does not fetch, pull, reset, or sync.",
+        _ => string.Empty,
+    };
+}

--- a/src/IntentSystem.Cli/Commands/CheckoutFreshnessProbe.cs
+++ b/src/IntentSystem.Cli/Commands/CheckoutFreshnessProbe.cs
@@ -15,6 +15,10 @@ internal static class CheckoutFreshnessProbe
     public const string Stale = "stale";
     public const string Unknown = "unknown";
 
+    // Keep the timeout short enough that a stalled host wake remains useful,
+    // while allowing ordinary local and remote Git calls to complete.
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(3);
+
     public static CheckoutFreshnessObservation? Capture(
         string repoRoot,
         IGitRemoteCommandRunner runner)
@@ -73,6 +77,17 @@ internal static class CheckoutFreshnessProbe
 
         if (remote.ExitCode != 0)
         {
+            if (remote.TimedOut)
+            {
+                return UnknownObservation(
+                    localHead,
+                    null,
+                    null,
+                    FirstNonEmpty(
+                        remote.StdErr,
+                        $"git ls-remote --symref origin HEAD timed out after {DefaultTimeout.TotalSeconds:0.###} seconds"));
+            }
+
             var detail = FirstNonEmpty(remote.StdErr, "the origin default branch could not be queried");
             return UnknownObservation(localHead, null, null, detail);
         }

--- a/src/IntentSystem.Cli/GitCommandResult.cs
+++ b/src/IntentSystem.Cli/GitCommandResult.cs
@@ -7,4 +7,6 @@ internal sealed record GitRemoteCommandResult
     public required string StdOut { get; init; }
 
     public required string StdErr { get; init; }
+
+    public bool TimedOut { get; init; }
 }

--- a/src/IntentSystem.Cli/GitCommandRunner.cs
+++ b/src/IntentSystem.Cli/GitCommandRunner.cs
@@ -5,6 +5,47 @@ namespace IntentSystem.Cli;
 internal sealed class GitRemoteCommandRunner : IGitRemoteCommandRunner
 {
     public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        => GitProcessRunner.Run(
+            workingDirectory,
+            arguments,
+            timeout: null,
+            nonInteractive: false);
+}
+
+/// <summary>
+/// G727: the freshness probe is the only Git surface with a bounded,
+/// non-interactive process policy. Other shared Git callers retain the
+/// historical runner above and are not silently given this timeout.
+/// </summary>
+internal sealed class CheckoutFreshnessGitCommandRunner : IGitRemoteCommandRunner
+{
+    private readonly TimeSpan timeout;
+
+    public CheckoutFreshnessGitCommandRunner(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(timeout));
+        }
+
+        this.timeout = timeout;
+    }
+
+    public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        => GitProcessRunner.Run(
+            workingDirectory,
+            arguments,
+            timeout,
+            nonInteractive: true);
+}
+
+internal static class GitProcessRunner
+{
+    public static GitRemoteCommandResult Run(
+        string workingDirectory,
+        IReadOnlyList<string> arguments,
+        TimeSpan? timeout,
+        bool nonInteractive)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(workingDirectory);
         ArgumentNullException.ThrowIfNull(arguments);
@@ -15,10 +56,21 @@ internal sealed class GitRemoteCommandRunner : IGitRemoteCommandRunner
             WorkingDirectory = workingDirectory,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            RedirectStandardInput = nonInteractive,
             StandardOutputEncoding = ProcessOutputEncoding.Utf8NoBom,
             StandardErrorEncoding = ProcessOutputEncoding.Utf8NoBom,
+            CreateNoWindow = true,
             UseShellExecute = false
         };
+
+        if (nonInteractive)
+        {
+            // G727: a read-only freshness check must never wait for a
+            // credential or SSH prompt. Closing stdin supplies EOF as an
+            // additional guard for transports that consult stdin directly.
+            startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
+            startInfo.Environment["GIT_SSH_COMMAND"] = NonInteractiveSshCommand();
+        }
 
         foreach (var argument in arguments)
         {
@@ -27,15 +79,83 @@ internal sealed class GitRemoteCommandRunner : IGitRemoteCommandRunner
 
         using var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("Failed to start git process.");
-        var stdOut = process.StandardOutput.ReadToEnd();
-        var stdErr = process.StandardError.ReadToEnd();
-        process.WaitForExit();
+
+        if (nonInteractive)
+        {
+            process.StandardInput.Close();
+        }
+
+        // Read both pipes concurrently and include both reads in the same
+        // completion task as process exit. A synchronous ReadToEnd on one
+        // pipe can block before WaitForExit when the other pipe fills.
+        var stdOutTask = process.StandardOutput.ReadToEndAsync();
+        var stdErrTask = process.StandardError.ReadToEndAsync();
+        var completion = Task.WhenAll(
+            process.WaitForExitAsync(),
+            stdOutTask,
+            stdErrTask);
+
+        try
+        {
+            if (timeout is { } boundedTimeout)
+            {
+                completion.WaitAsync(boundedTimeout).GetAwaiter().GetResult();
+            }
+            else
+            {
+                completion.GetAwaiter().GetResult();
+            }
+        }
+        catch (TimeoutException)
+        {
+            KillProcessTree(process);
+            return new GitRemoteCommandResult
+            {
+                ExitCode = -1,
+                StdOut = stdOutTask.IsCompletedSuccessfully ? stdOutTask.Result : string.Empty,
+                StdErr = $"git {string.Join(' ', arguments)} timed out after {timeout?.TotalSeconds:0.###} seconds",
+                TimedOut = true,
+            };
+        }
 
         return new GitRemoteCommandResult
         {
             ExitCode = process.ExitCode,
-            StdOut = stdOut,
-            StdErr = stdErr
+            StdOut = stdOutTask.Result,
+            StdErr = stdErrTask.Result,
         };
+    }
+
+    private static void KillProcessTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // The process exited between the timeout and the kill attempt.
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            // The process may already have been reaped; the timeout result
+            // remains the safe freshness answer either way.
+        }
+    }
+
+    private static string NonInteractiveSshCommand()
+    {
+        var configured = Environment.GetEnvironmentVariable("GIT_SSH_COMMAND");
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return "ssh -o BatchMode=yes";
+        }
+
+        return configured.Contains("BatchMode", StringComparison.OrdinalIgnoreCase)
+            ? configured
+            : $"{configured} -o BatchMode=yes";
     }
 }

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -18,12 +18,14 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     {
         AutomationStalledWorkCommand.CandidateListerFactory = null;
         AutomationStalledWorkCommand.UtcNowFactory = () => FixedNow;
+        AutomationStalledWorkCommand.GitCommandRunnerFactory = null;
     }
 
     public void Dispose()
     {
         AutomationStalledWorkCommand.CandidateListerFactory = null;
         AutomationStalledWorkCommand.UtcNowFactory = null;
+        AutomationStalledWorkCommand.GitCommandRunnerFactory = null;
     }
 
     [Fact]
@@ -207,6 +209,87 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         Assert.False(result.Stalled);
         Assert.DoesNotContain(result.Items, item =>
             item.Kind == AutomationStalledWorkCommand.KindVersionRollRequired);
+    }
+
+    [Fact]
+    public void Analyze_MovedRemoteReportsStaleThenSyncMakesCurrentCheckoutSilent_G727()
+    {
+        using var fixture = new FreshnessCheckoutFixture();
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+
+        var localHeadBefore = fixture.RunGit("rev-parse", "HEAD");
+        var trackingHeadBefore = fixture.RunGit("rev-parse", "refs/remotes/origin/main");
+        fixture.MoveRemoteForward();
+
+        var stale = AutomationStalledWorkCommand.Analyze(
+            fixture.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 60);
+
+        Assert.Equal(CheckoutFreshnessProbe.Stale, stale.CheckoutFreshness?.Status);
+        Assert.Equal("main", stale.CheckoutFreshness?.DefaultBranch);
+        Assert.NotEqual(stale.CheckoutFreshness?.LocalHead, stale.CheckoutFreshness?.RemoteHead);
+        Assert.Contains(stale.Warnings, warning =>
+            warning.Contains("checkout freshness: stale", StringComparison.Ordinal)
+            && warning.Contains("fetch, pull, reset, or sync", StringComparison.Ordinal));
+        Assert.Equal(localHeadBefore, fixture.RunGit("rev-parse", "HEAD"));
+        Assert.Equal(trackingHeadBefore, fixture.RunGit("rev-parse", "refs/remotes/origin/main"));
+
+        // The operator performs the sync outside the read-only report. The
+        // next report sees the moved remote and stays quiet once equal.
+        fixture.SyncToOrigin();
+        var current = AutomationStalledWorkCommand.Analyze(
+            fixture.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 60);
+
+        Assert.Null(current.CheckoutFreshness);
+        Assert.DoesNotContain(current.Warnings, warning =>
+            warning.Contains("checkout freshness", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Analyze_OfflineFreshnessReportsUnknownWithoutSyncCommands_G727()
+    {
+        using var fixture = new FreshnessCheckoutFixture();
+        var runner = new RecordingGitRunner
+        {
+            Responses = new Dictionary<string, GitRemoteCommandResult>(StringComparer.Ordinal)
+            {
+                ["rev-parse HEAD"] = new GitRemoteCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = "local-head\n",
+                    StdErr = string.Empty,
+                },
+                ["ls-remote --symref origin HEAD"] = new GitRemoteCommandResult
+                {
+                    ExitCode = 128,
+                    StdOut = string.Empty,
+                    StdErr = "Could not resolve host: offline\n",
+                },
+            },
+        };
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationStalledWorkCommand.GitCommandRunnerFactory = () => runner;
+
+        var result = AutomationStalledWorkCommand.Analyze(
+            fixture.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 60);
+
+        Assert.Equal(CheckoutFreshnessProbe.Unknown, result.CheckoutFreshness?.Status);
+        Assert.Contains(result.Warnings, warning =>
+            warning.Contains("checkout freshness: unknown", StringComparison.Ordinal)
+            && warning.Contains("Do not treat this report as evidence", StringComparison.Ordinal));
+        Assert.DoesNotContain(runner.Calls, call =>
+            call.Arguments.Any(argument =>
+                string.Equals(argument, "fetch", StringComparison.Ordinal)
+                || string.Equals(argument, "pull", StringComparison.Ordinal)
+                || string.Equals(argument, "reset", StringComparison.Ordinal)));
     }
 
     [Fact]
@@ -3978,6 +4061,138 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         public IReadOnlyList<GitHubAutomationPrCandidate> ListMergedPullRequests(string repo, IReadOnlyCollection<string> requiredLabels) => mergedPrs;
 
         public IReadOnlyList<GitHubAutomationReleaseCandidate> ListPublishedReleases(string repo) => releases;
+    }
+
+    private sealed class RecordingGitRunner : IGitRemoteCommandRunner
+    {
+        public Dictionary<string, GitRemoteCommandResult> Responses { get; init; } = new(StringComparer.Ordinal);
+
+        public List<GitCommandCall> Calls { get; } = [];
+
+        public GitRemoteCommandResult Run(string workingDirectory, IReadOnlyList<string> arguments)
+        {
+            Calls.Add(new GitCommandCall
+            {
+                WorkingDirectory = workingDirectory,
+                Arguments = [.. arguments],
+            });
+
+            var key = string.Join(' ', arguments);
+            return Responses.TryGetValue(key, out var response)
+                ? response
+                : new GitRemoteCommandResult
+                {
+                    ExitCode = 1,
+                    StdOut = string.Empty,
+                    StdErr = $"unexpected git probe: {key}",
+                };
+        }
+    }
+
+    private sealed record GitCommandCall
+    {
+        public required string WorkingDirectory { get; init; }
+
+        public required IReadOnlyList<string> Arguments { get; init; }
+    }
+
+    private sealed class FreshnessCheckoutFixture : IDisposable
+    {
+        private readonly string root;
+        private readonly string publisher;
+        private readonly string remote;
+
+        public FreshnessCheckoutFixture()
+        {
+            root = Directory.CreateTempSubdirectory("stalled-work-g727-git-").FullName;
+            publisher = Path.Combine(root, "publisher");
+            remote = Path.Combine(root, "remote.git");
+            CheckoutPath = Path.Combine(root, "checkout");
+
+            RunGit(root, "init", "--bare", remote);
+            RunGit(root, "init", "-q", publisher);
+            RunGit(publisher, "config", "user.email", "g727@example.invalid");
+            RunGit(publisher, "config", "user.name", "G727 Test");
+            File.WriteAllText(Path.Combine(publisher, "state.txt"), "initial\n");
+            RunGit(publisher, "add", "state.txt");
+            RunGit(publisher, "commit", "-m", "initial");
+            RunGit(publisher, "branch", "-M", "main");
+            RunGit(publisher, "remote", "add", "origin", remote);
+            RunGit(publisher, "push", "-u", "origin", "main");
+            RunGit(root, "--git-dir", remote, "symbolic-ref", "HEAD", "refs/heads/main");
+            RunGit(root, "clone", remote, CheckoutPath);
+            Directory.CreateDirectory(Path.Combine(CheckoutPath, ".intent-cli"));
+
+            Context = new CliContext
+            {
+                RepoRoot = CheckoutPath,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                        WorktreeRoot = ".intent-cli/worktrees",
+                    },
+                },
+            };
+        }
+
+        public string CheckoutPath { get; }
+
+        public CliContext Context { get; }
+
+        public string RunGit(params string[] arguments) => RunGit(CheckoutPath, arguments);
+
+        public void MoveRemoteForward()
+        {
+            File.AppendAllText(Path.Combine(publisher, "state.txt"), "moved\n");
+            RunGit(publisher, "add", "state.txt");
+            RunGit(publisher, "commit", "-m", "move remote");
+            RunGit(publisher, "push", "origin", "main");
+        }
+
+        public void SyncToOrigin()
+        {
+            RunGit(CheckoutPath, "fetch", "origin", "main");
+            RunGit(CheckoutPath, "merge", "--ff-only", "origin/main");
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+
+        private static string RunGit(string workingDirectory, params string[] arguments)
+        {
+            var startInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "git",
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            foreach (var argument in arguments)
+            {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            using var process = System.Diagnostics.Process.Start(startInfo)
+                ?? throw new InvalidOperationException("Could not start git for G727 fixture.");
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            if (process.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"G727 git fixture command failed ({string.Join(' ', arguments)}): {error}");
+            }
+            return output.Trim();
+        }
     }
 
     private sealed class EmptyNotifyProcessRunner : INotifyProcessRunner

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
 using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
@@ -290,6 +293,47 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
                 string.Equals(argument, "fetch", StringComparison.Ordinal)
                 || string.Equals(argument, "pull", StringComparison.Ordinal)
                 || string.Equals(argument, "reset", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void Analyze_BlackholeRemoteTimesOutAndLeavesCheckoutUntouched_G727()
+    {
+        using var fixture = new FreshnessCheckoutFixture();
+        using var blackhole = new BlackholeGitTransport();
+        fixture.SetOrigin($"http://127.0.0.1:{blackhole.Port}/blackhole.git");
+        fixture.WritePacketDomain("G727", "intent-cli");
+
+        var localHeadBefore = fixture.RunGit("rev-parse", "HEAD");
+        var trackingHeadBefore = fixture.RunGit("rev-parse", "refs/remotes/origin/main");
+        var worktreeBefore = fixture.RunGit("status", "--porcelain");
+        var issue = BuildIssue(1575, "G727: blackhole freshness evidence", FixedNow.AddHours(-26), "intent-target");
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister(issues: [issue]);
+        AutomationStalledWorkCommand.GitCommandRunnerFactory = () =>
+            new CheckoutFreshnessGitCommandRunner(TimeSpan.FromMilliseconds(250));
+
+        var stopwatch = Stopwatch.StartNew();
+        var result = AutomationStalledWorkCommand.Analyze(
+            fixture.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 60);
+        stopwatch.Stop();
+
+        Assert.True(blackhole.Accepted, "The blackhole transport must receive the real ls-remote connection.");
+        Assert.Equal(CheckoutFreshnessProbe.Unknown, result.CheckoutFreshness?.Status);
+        Assert.Contains("timed out", result.CheckoutFreshness?.Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(result.Warnings, warning =>
+            warning.Contains("checkout freshness: unknown", StringComparison.Ordinal)
+            && warning.Contains("timed out", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(result.Items, item =>
+            item.Kind == AutomationStalledWorkCommand.KindPublishedNotDelegated);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TimeSpan.FromSeconds(3));
+
+        // The freshness probe may observe the remote, but it must not update
+        // local refs, HEAD, or the worktree while handling the timeout.
+        Assert.Equal(localHeadBefore, fixture.RunGit("rev-parse", "HEAD"));
+        Assert.Equal(trackingHeadBefore, fixture.RunGit("rev-parse", "refs/remotes/origin/main"));
+        Assert.Equal(worktreeBefore, fixture.RunGit("status", "--porcelain"));
     }
 
     [Fact]
@@ -4144,6 +4188,15 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
 
         public string RunGit(params string[] arguments) => RunGit(CheckoutPath, arguments);
 
+        public void SetOrigin(string url) => RunGit(CheckoutPath, "remote", "set-url", "origin", url);
+
+        public void WritePacketDomain(string executionUnit, string domain)
+        {
+            var directory = Path.Combine(CheckoutPath, ".intent-cli", "issues", executionUnit);
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(Path.Combine(directory, "packet.yaml"), $"domain: {domain}\n");
+        }
+
         public void MoveRemoteForward()
         {
             File.AppendAllText(Path.Combine(publisher, "state.txt"), "moved\n");
@@ -4192,6 +4245,52 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
                     $"G727 git fixture command failed ({string.Join(' ', arguments)}): {error}");
             }
             return output.Trim();
+        }
+    }
+
+    private sealed class BlackholeGitTransport : IDisposable
+    {
+        private readonly TcpListener listener;
+        private readonly Thread acceptThread;
+        private TcpClient? connection;
+
+        public BlackholeGitTransport()
+        {
+            listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            Port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            acceptThread = new Thread(AcceptConnection)
+            {
+                IsBackground = true,
+            };
+            acceptThread.Start();
+        }
+
+        public int Port { get; }
+
+        public bool Accepted => Volatile.Read(ref connection) is not null;
+
+        public void Dispose()
+        {
+            listener.Stop();
+            Interlocked.Exchange(ref connection, null)?.Dispose();
+            acceptThread.Join(TimeSpan.FromSeconds(1));
+        }
+
+        private void AcceptConnection()
+        {
+            try
+            {
+                Interlocked.Exchange(ref connection, listener.AcceptTcpClient());
+            }
+            catch (SocketException)
+            {
+                // Expected when Dispose stops the listener before connect.
+            }
+            catch (ObjectDisposedException)
+            {
+                // Expected when Dispose stops the listener before connect.
+            }
         }
     }
 


### PR DESCRIPTION
Closes #1575

## G727 repair

This update addresses exactly the two semantic findings from the review at
`ced5d13429794e887d973b2ef52f70e93d8b5642`: the unbounded remote probe (AC2)
and the over-broad sibling survey (AC6). The finding logic, stale/current
behavior, heartbeat inheritance, and scope remain otherwise unchanged.

## Finding 1 — bounded, noninteractive freshness probe (AC2)

The shared `GitRemoteCommandRunner` keeps its historical unbounded behavior
for issue/status/publish callers. `automation stalled-work` now uses the
freshness-only `CheckoutFreshnessGitCommandRunner` with a three-second bound.
That deliberate separation avoids silently imposing this policy on unrelated
Git operations.

The scoped runner:

- reads stdout and stderr concurrently and puts both reads plus process exit
  under one `Task.WhenAll(...).WaitAsync(timeout)` bound;
- closes redirected stdin and sets `GIT_TERMINAL_PROMPT=0` plus SSH
  `BatchMode=yes`, so credential and SSH prompts cannot block the report;
- kills the entire Git process tree when the bound expires; and
- returns `checkout_freshness: unknown` with a reason containing the timeout,
  allowing the existing report and findings to continue.

### Real blackhole transcript

The built CLI ran from a real Git clone whose `origin` was changed to a local
TCP listener on `127.0.0.1` that accepted the connection and never replied:

```text
BLACKHOLE_EXIT=0
checkout_freshness: {
  status: unknown,
  local_head: c4641e8a1519bfe8883a2ed3cc674b1d4c406f75,
  reason: "git ls-remote --symref origin HEAD timed out after 3 seconds"
}
warning: ... Do not treat this report as evidence that the checkout is current ...
  This command is read-only and does not fetch, pull, reset, or sync.
HEAD after: c4641e8a1519bfe8883a2ed3cc674b1d4c406f75
refs/remotes/origin/main after: c4641e8a1519bfe8883a2ed3cc674b1d4c406f75
worktree: unchanged
```

The full command returned in 9.744s because it continued through the normal
GitHub candidate reads after the freshness probe timed out; the freshness
probe itself returned its explicit three-second timeout result and did not
silence the report. The deterministic regression uses the same real listener
with a 250ms freshness-only bound, asserts completion within three seconds,
asserts the preserved `published-not-delegated` finding, and verifies HEAD,
the tracking ref, and worktree status are unchanged.

The existing fast-failure unknown case and moved-remote stale → external-sync
→ current-silence cases remain covered.

## Finding 2 — honest sibling survey (AC6)

The survey no longer calls all siblings unaffected.

- `intent status` was independently demonstrated on the same stale clone to
  return stale local queue state without any checkout-provenance statement.
- Source inspection shows `automation summary`, `automation state-doctor`,
  `host-loop-next-action`, and `automation heartbeat` read `context.RepoRoot`
  and therefore share the unstated-checkout provenance property. Heartbeat
  inherits the new warning in this slice; the other RepoRoot-reading surfaces
  remain a named follow-up.
- `status brief` and host-review diagnostics were inspected and do not read
  `RepoRoot` for these answers. They are unaffected by this specific
  unstated-checkout path, not globally certified as current.

The remaining sibling follow-up is to define and test an explicit
freshness/provenance contract for the RepoRoot-reading surfaces. This PR stays
scoped to `stalled-work` plus heartbeat inheritance. Both English and Japanese
mirrored docs carry the same qualification.

## Verification

- Focused `AutomationStalledWorkCommandTests`: 119 passed.
- Targeted stale/current/fast-failure/blackhole tests: 3 passed.
- Full solution: 5,172 total, 5,171 passed, 1 intentional skip, 0 failed.
- `git diff --check`: clean.
- CI at `8ef637f5fd4946024ce762a9bef6f2597a00a5e3`: `Build and test (source contract)` passed; `npm package dry-run (no publish)` passed.

## Canonical rereview-ready transition

`intent-cli worker result-summary --kind pr-comment-fix --repo J-Tech-Japan/intent-system --pr 1578 --outcome repair-pushed --format json` returned `status: completed`. The canonical GitHub-only worker claim and `intent-cli worker complete --kind pr --number 1578 --outcome repair-pushed --write --format json` returned `proceed: true`, `applied: true`, added `intent-pr-rereview-ready`, and removed `intent-pr-update-in-progress` plus `intent-pr-request-update`. No host claim or host metadata was acquired or changed.

No host claim was acquired or released from the child, and no host state,
intent tree, tag, release, merge, or closeout was changed.
