### PR TITLE
G728: roll post-release version policy to 0.23.2

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2687,7 +2687,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0230)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0232)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2855,55 +2855,58 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.23.0)
+### Next release readiness (v0.23.2)
 
-**`v0.22.0` shipped** (GitHub Release + NuGet), and the next prepared line is
-`0.23.0`. [The v0.22.0 notes](release-notes-v0.22.0.md) are the frozen
-released evidence; [the v0.23.0 DRAFT](release-notes-v0.23.0.md) is the next
-line's stub. See [release-notes-v0.21.0.md](release-notes-v0.21.0.md) for the
-older shipped scope; it is linked, not restated.
+**`v0.23.1` shipped** (GitHub Release, NuGet, binaries, and npm). The
+published recovery release is recorded by the [v0.23.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.1).
+The child source tree has no tracked `release-notes-v0.23.1.md`; this roll
+does not recreate or edit shipped notes. The [v0.23.2 DRAFT](release-notes-v0.23.2.md)
+is the empty stub for the next line and must remain content-free until a later
+release-prep packet replaces it.
 
-Rolled policy: `stableVersion → 0.22.0`; `nextVersion → 0.23.0`.
+Rolled policy: `stableVersion → 0.23.1`; `nextVersion → 0.23.2`.
 
-**Release-readiness verification for the `v0.23.0` line:**
+The next-line package identity is `JTechJapan.IntentSystem.Cli.0.23.2.nupkg`;
+this is a derived verification value, not release content.
 
-On a claims-enabled host, acquire and verify the release scope before editing
-release artifacts. The same shared verification gates all G680 start surfaces;
-no claims store preserves legacy single-team behavior. This roll changes only
-release documentation and version policy: it creates no tag or Release,
-publishes no package, and handles no credentials.
+**Release-readiness verification for the `v0.23.2` line:**
+
+This post-release roll changes only the version policy, the empty next-line
+stubs, and this readiness section in both language mirrors. It creates no tag
+or Release, publishes no package, handles no credentials, and authors no
+feature notes for the unshipped line.
+
+On a claims-enabled host, acquire and verify release-prep ownership before a
+later release-prep packet edits these artifacts. This roll itself performs no
+claim acquisition:
 
 ```bash
-# 0. Acquire and verify release-prep ownership for the next patch line.
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.23.0 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.23.0 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.23.2 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.23.2 --team <team> --format json
+```
 
-# 1. Confirm the rolled version policy.
-cat eng/version.json   # stableVersion 0.22.0 (published), nextVersion 0.23.0 (next line)
+```bash
+# 1. Confirm the rolled version policy and both content-free DRAFT stubs.
+cat eng/version.json   # stableVersion 0.23.1 (published), nextVersion 0.23.2 (next line)
+test -f docs/en/release-notes-v0.23.2.md
+test -f docs/ja/release-notes-v0.23.2.md
 
 # 2. Build and confirm the display version identity from the next line.
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-#   expected shape: intent-cli 0.23.0-<sha>-G<unit>
+#   expected shape: intent-cli 0.23.2-<sha>-G<unit>
 
-# 3. Do not publish a package in this roll. The v0.22.0 npm gap is documented
-#    below; the four npm tarballs and checksum companions remain attached.
-#    The next-line package identity is JTechJapan.IntentSystem.Cli.0.23.0.nupkg.
+# 3. The G725 detector must be silent after the roll; it is read-only.
+intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json
 
-# 4. From a metadata-free directory, execute the existing installed guide route.
-intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent <agent> --format json
-intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent <agent> --format markdown
-#   Also verify the two new G712 surfaces from the retargeted Release build:
-intent-cli notify supervise reconcile --help
-intent-cli guide workflow task supervision-setup --format json
-#   the first verifies the notify supervise reconcile|uninstall surface; the second is metadata-free and read-only.
+# 4. Confirm the historical v0.23.0 preparation source was not changed and
+#    the published v0.23.1 evidence remains the GitHub Release body.
+git diff -- docs/en/release-notes-v0.23.0.md docs/ja/release-notes-v0.23.0.md
+gh release view v0.23.1 --repo J-Tech-Japan/intent-system
 
-# 5. Confirm the frozen v0.22.0 evidence and v0.23.0 version guards.
-dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
-  -c Release --filter \
-  "FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
-
-# 6. Confirm formatting and run the complete Release suite.
+# 5. Run the focused documentation/version guards, then the full suite.
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release \
+  --filter "FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 git diff --check
 dotnet test IntentSystem.sln -c Release
 ```
@@ -2912,23 +2915,8 @@ This roll follows **steps 5–7** of the [post-release version roll](#post-relea
 the **DRAFT note stubs in the same commit** (step 5), the **"Next release
 readiness" section refreshed to the new line in both language mirrors** (step
 6), and a **post-roll green child-main CI check** before the roll counts as
-complete (step 7).
-
-The v0.22.0 npm registry publication remains skipped because npm organisation
-(organization) access and package-name reservation are incomplete operator
-account actions and `NPM_TOKEN` is absent. The G702 npm publish step does not
-run for v0.22.0; four npm tarballs and their checksum companions are attached
-to the existing Release. This is a distribution gap, not a defect. No npm
-credentials are requested or handled.
-
-The published v0.22.0 notes are the canonical EN source for the GitHub Release
-body. If a body resync is needed, orchestration uses only this source:
-`gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md`.
-The published body is already present; this implementation roll does not
-execute that command or mutate GitHub Release state. This line adds the two
-G712 command surfaces listed above; their reachability is confirmed by the
-Release-build probes above. Existing metadata-free guide entry points remain
-the operator/agent interface.
+complete (step 7). Existing release tags, Releases, packages, and workflows
+are not changed.
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2859,8 +2859,14 @@ to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
 **`v0.23.1` shipped** (GitHub Release, NuGet, binaries, and npm). The
 published recovery release is recorded by the [v0.23.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.1).
-The child source tree has no tracked `release-notes-v0.23.1.md`; this roll
-does not recreate or edit shipped notes. The [v0.23.2 DRAFT](release-notes-v0.23.2.md)
+The published [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0)
+and its tag are authoritative shipped evidence, but the tracked EN and JA
+`release-notes-v0.23.0.md` files still carry `DRAFT / UNRELEASED` banners.
+The source-note inconsistency predates this roll; correcting shipped v0.23.0
+or v0.23.1 notes is out of scope and must be handled by a later explicitly
+scoped remediation. The child source tree has no tracked
+`release-notes-v0.23.1.md`; this roll does not recreate or edit shipped notes.
+The [v0.23.2 DRAFT](release-notes-v0.23.2.md)
 is the empty stub for the next line and must remain content-free until a later
 release-prep packet replaces it.
 
@@ -2899,10 +2905,15 @@ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
 # 3. The G725 detector must be silent after the roll; it is read-only.
 intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json
 
-# 4. Confirm the historical v0.23.0 preparation source was not changed and
-#    the published v0.23.1 evidence remains the GitHub Release body.
-git diff -- docs/en/release-notes-v0.23.0.md docs/ja/release-notes-v0.23.0.md
+# 4. Record the shipped-note check honestly: source notes are unchanged, but
+#    v0.23.0 still has a DRAFT / UNRELEASED banner despite the published Release.
+git diff --quiet -- docs/en/release-notes-v0.23.0.md docs/ja/release-notes-v0.23.0.md
+grep -n "DRAFT / UNRELEASED" docs/en/release-notes-v0.23.0.md
+grep -n "DRAFT / 未リリース" docs/ja/release-notes-v0.23.0.md
+gh release view v0.23.0 --repo J-Tech-Japan/intent-system
 gh release view v0.23.1 --repo J-Tech-Japan/intent-system
+#    Published GitHub Releases/tags are authoritative; note remediation is
+#    explicitly out of scope for this version roll.
 
 # 5. Run the focused documentation/version guards, then the full suite.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release \

--- a/docs/en/release-notes-v0.23.2.md
+++ b/docs/en/release-notes-v0.23.2.md
@@ -1,0 +1,15 @@
+# Release Notes — intent-cli v0.23.2
+
+> **⚠️ DRAFT / UNRELEASED.** This stub is created by the mandatory immediate
+> post-release version roll after v0.23.1. The release-prep packet authors the
+> real content; this must not be treated as a changelog until that packet
+> replaces it.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.23.2`.
+The eventual release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.2.
+
+## Release-readiness gate
+
+This DRAFT has no feature scope yet. The release-prep packet must replace it
+with substantive notes and record the full readiness evidence before release.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2915,8 +2915,13 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 
 **`v0.23.1` は出荷済み**(GitHub Release、NuGet、binary、npm)です。公開済みの recovery
 release は [v0.23.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.1)
-に記録されています。child source tree には tracked な `release-notes-v0.23.1.md` がなく、
-この roll で出荷済み note を再作成・編集しません。[v0.23.2 DRAFT](release-notes-v0.23.2.md)
+に記録されています。公開済みの [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0)
+とその tag が shipped evidence の authoritative source ですが、tracked な EN/JA の
+`release-notes-v0.23.0.md` にはまだ `DRAFT / 未リリース` banner が残っています。
+この source-note inconsistency はこの roll より前から存在し、出荷済み v0.23.0/v0.23.1 note の
+修正は scope 外です。後続の明示的な remediation で扱います。child source tree には tracked な
+`release-notes-v0.23.1.md` がなく、この roll で出荷済み note を再作成・編集しません。
+[v0.23.2 DRAFT](release-notes-v0.23.2.md)
 は次のラインの空の stub で、後続の release-prep packet が置き換えるまで内容を持ちません。
 
 Rolled policy: `stableVersion → 0.23.1`; `nextVersion → 0.23.2`。
@@ -2952,10 +2957,15 @@ dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
 # 3. G725 detector は roll 後に silent でなければならない(read-only)。
 intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json
 
-# 4. 過去の v0.23.0 preparation source に変更がないことと、出荷済み v0.23.1
-#    evidence が GitHub Release body に残っていることを確認。
-git diff -- docs/en/release-notes-v0.23.0.md docs/ja/release-notes-v0.23.0.md
+# 4. shipped-note check を正直に記録する: source note は未変更だが、公開済み
+#    Release にもかかわらず v0.23.0 には DRAFT / 未リリース banner が残る。
+git diff --quiet -- docs/en/release-notes-v0.23.0.md docs/ja/release-notes-v0.23.0.md
+grep -n "DRAFT / UNRELEASED" docs/en/release-notes-v0.23.0.md
+grep -n "DRAFT / 未リリース" docs/ja/release-notes-v0.23.0.md
+gh release view v0.23.0 --repo J-Tech-Japan/intent-system
 gh release view v0.23.1 --repo J-Tech-Japan/intent-system
+#    公開済み GitHub Release/tag が authoritative evidence であり、note remediation は
+#    この version roll の scope 外です。
 
 # 5. focused な documentation/version guard と full suite を実行。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release \

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2911,74 +2911,64 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.23.0)
+### 次リリース準備(v0.23.2)
 
-**`v0.22.0` は出荷済み**(GitHub Release + NuGet)で、次に準備するラインは
-`0.23.0` です。[v0.22.0 notes](release-notes-v0.22.0.md) は凍結された
-released evidence で、[v0.23.0 DRAFT](release-notes-v0.23.0.md) は次のラインの stub です。
-古い出荷範囲は [release-notes-v0.21.0.md](release-notes-v0.21.0.md) を参照し、ここでは重複記載しません。
+**`v0.23.1` は出荷済み**(GitHub Release、NuGet、binary、npm)です。公開済みの recovery
+release は [v0.23.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.1)
+に記録されています。child source tree には tracked な `release-notes-v0.23.1.md` がなく、
+この roll で出荷済み note を再作成・編集しません。[v0.23.2 DRAFT](release-notes-v0.23.2.md)
+は次のラインの空の stub で、後続の release-prep packet が置き換えるまで内容を持ちません。
 
-Rolled policy: `stableVersion → 0.22.0`; `nextVersion → 0.23.0`。
+Rolled policy: `stableVersion → 0.23.1`; `nextVersion → 0.23.2`。
 
-**`v0.23.0` のリリース準備検証:**
+次のラインの package identity は `JTechJapan.IntentSystem.Cli.0.23.2.nupkg` です。
+これは導出された verification value であり、release content ではありません。
 
-claims-enabled host では release artifact を編集する前に release scope を acquire / verify します。
-同じ shared verification が G680 の全 start surface を gate し、claims store が無ければ legacy
-single-team behavior を維持します。この roll は release documentation と version policy だけを変更し、
-tag または Release を作成せず、package を publish せず、credentials を扱いません。
+**`v0.23.2` のリリース準備検証:**
+
+この post-release roll が変更するのは version policy、次のラインの空の stub、そして ja/en
+両ミラーのこの readiness section だけです。tag または Release を作成せず、package を publish せず、
+credentials を扱わず、未出荷ラインの feature note を author しません。
+
+claims-enabled host では、後続の release-prep packet がこれらの artifact を編集する前に
+release-prep ownership を acquire / verify します。この roll 自身は claim acquisition を実行しません:
 
 ```bash
-# 0. 次の patch line の release-prep ownership を acquire / verify。
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.23.0 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.23.0 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.23.2 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.23.2 --team <team> --format json
+```
 
-# 1. roll 済み version policy を確認。
-cat eng/version.json   # stableVersion 0.22.0 (published), nextVersion 0.23.0 (next line)
+```bash
+# 1. roll 済み version policy と、内容のない両言語 DRAFT stub を確認。
+cat eng/version.json   # stableVersion 0.23.1 (published), nextVersion 0.23.2 (next line)
+test -f docs/en/release-notes-v0.23.2.md
+test -f docs/ja/release-notes-v0.23.2.md
 
 # 2. 次のラインの表示バージョン識別を build して確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-#   期待する形: intent-cli 0.23.0-<sha>-G<unit>
+#   期待する形: intent-cli 0.23.2-<sha>-G<unit>
 
-# 3. この roll では package を publish しない。v0.22.0 の npm gap は下記に記録し、
-#    四つの npm tarball と checksum companion は既存 Release に残る。
-#    次のラインの package identity は JTechJapan.IntentSystem.Cli.0.23.0.nupkg。
+# 3. G725 detector は roll 後に silent でなければならない(read-only)。
+intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json
 
-# 4. metadata-free directory から既存 installed guide route を実行。
-intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent <agent> --format json
-intent-cli guide orchestrator-thread --domain intent-cli --target-repo J-Tech-Japan/intent-system --agent <agent> --format markdown
-#   retargeted Release build から二つの新 G712 surface も確認する:
-intent-cli notify supervise reconcile --help
-intent-cli guide workflow task supervision-setup --format json
-#   前者は notify supervise reconcile|uninstall surface、後者は metadata-free かつ read-only です。
+# 4. 過去の v0.23.0 preparation source に変更がないことと、出荷済み v0.23.1
+#    evidence が GitHub Release body に残っていることを確認。
+git diff -- docs/en/release-notes-v0.23.0.md docs/ja/release-notes-v0.23.0.md
+gh release view v0.23.1 --repo J-Tech-Japan/intent-system
 
-# 5. 凍結した v0.22.0 evidence と v0.23.0 version guard を確認。
-dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj \
-  -c Release --filter \
-  "FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
-
-# 6. formatting と complete Release suite を確認。
+# 5. focused な documentation/version guard と full suite を実行。
+dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release \
+  --filter "FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 git diff --check
 dotnet test IntentSystem.sln -c Release
 ```
 
 この roll は [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 5–7** に従います。**同一コミットに DRAFT note スタブ**(ステップ 5)、
-**「次リリース準備」セクションを ja/en 両ミラーで新しいラインへ更新**(ステップ 6)、
-そして **roll 後の child main CI green 確認**(ステップ 7)が完了条件です。
-
-v0.22.0 の npm registry publication は、npm organisation (organization) access、
-package-name reservation が未完了の operator account action であり、`NPM_TOKEN` も absent のため skip した。
-G702 npm publish step は v0.22.0 では実行せず、四つの npm tarball と checksum companion は既存 Release に添付されている。
-これは defect ではなく distribution gap です。npm credentials は要求・処理しません。
-
-凍結した v0.22.0 の EN note が公開済み GitHub Release body の canonical source です。JA note は
-明示的な parity mirror であり、同じ Release を JA note で上書きしてはいけません。body resync が必要な場合も
-orchestration は EN source のみを使います:
-`gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md`。
-公開済みの body はすでに存在し、この implementation roll は command を実行せず GitHub Release state を変更しません。
-この line は上記二つの G712 command surface を追加し、Release-build の probe で reachability を確認します。既存の metadata-free
-guide entry point が operator/agent interface のままです。
+**「次リリース準備」section を ja/en 両ミラーで新しいラインへ更新**(ステップ 6)、
+そして **roll 後の child main CI green 確認**(ステップ 7)が完了条件です。既存の release tag、
+Release、package、workflow は変更しません。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.23.2.md
+++ b/docs/ja/release-notes-v0.23.2.md
@@ -1,0 +1,14 @@
+# リリースノート — intent-cli v0.23.2
+
+> **⚠️ DRAFT / 未リリース。** この stub は v0.23.1 後の mandatory immediate
+> post-release version roll で作成されました。release-prep パケットが author します。
+> そのパケットが置き換えるまで、このファイルを changelog として扱ってはいけません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.23.2`。
+将来の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.2 に publish されます。
+
+## リリース準備ゲート
+
+この DRAFT にはまだ feature scope がありません。release-prep パケットが substantive な
+notes と置き換え、Release 前に full readiness evidence を記録しなければなりません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.22.0",
-  "nextVersion": "0.23.0"
+  "stableVersion": "0.23.1",
+  "nextVersion": "0.23.2"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0190DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0190DocsTests.cs
@@ -123,15 +123,26 @@ public sealed class ReleaseNotesV0190DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
+        var referenceCompact = Regex.Replace(reference, @"\s+", " ");
         var notes = Read(language);
         var currentNotes = $"release-notes-v{policy.NextVersion}.md";
+        var shippedNotes = $"release-notes-v{policy.StableVersion}.md";
+        var shippedNotesPath = Path.Combine(root, "docs", language, shippedNotes);
+        var missingStableNoteMarker = language == "en"
+            ? $"no tracked `{shippedNotes}`"
+            : $"tracked な `{shippedNotes}` がなく";
 
-        // The published v0.23.1 body is on GitHub; this child source tree does
-        // not carry a local v0.23.1 note file, so this historical guard must
-        // not turn the post-release roll into an unrelated note recreation.
         RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
         Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
         Assert.Contains(currentNotes, reference, StringComparison.Ordinal);
+        Assert.Contains(shippedNotes, reference, StringComparison.Ordinal);
+        Assert.True(
+            File.Exists(shippedNotesPath) || referenceCompact.Contains(missingStableNoteMarker, StringComparison.Ordinal),
+            $"Readiness must either carry the policy-derived stable note {shippedNotes} or explain its missing local source file.");
+        if (!File.Exists(shippedNotesPath))
+        {
+            Assert.Contains($"v{policy.StableVersion} GitHub Release", referenceCompact, StringComparison.Ordinal);
+        }
         Assert.Contains(
             language == "en"
                 ? $"Next release readiness (v{policy.NextVersion})"

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0190DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0190DocsTests.cs
@@ -125,13 +125,13 @@ public sealed class ReleaseNotesV0190DocsTests
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
         var notes = Read(language);
         var currentNotes = $"release-notes-v{policy.NextVersion}.md";
-        var shippedNotes = $"release-notes-v{policy.StableVersion}.md";
 
+        // The published v0.23.1 body is on GitHub; this child source tree does
+        // not carry a local v0.23.1 note file, so this historical guard must
+        // not turn the post-release roll into an unrelated note recreation.
         RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
         Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
-        Assert.True(File.Exists(Path.Combine(root, "docs", language, shippedNotes)));
         Assert.Contains(currentNotes, reference, StringComparison.Ordinal);
-        Assert.Contains(shippedNotes, reference, StringComparison.Ordinal);
         Assert.Contains(
             language == "en"
                 ? $"Next release readiness (v{policy.NextVersion})"

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
@@ -139,14 +139,22 @@ public sealed class ReleaseNotesV0210DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
+        var referenceCompact = Regex.Replace(reference, @"\s+", " ");
         var notes = Read(language);
         var currentNotes = $"release-notes-v{policy.NextVersion}.md";
+        var shippedNotes = $"release-notes-v{policy.StableVersion}.md";
+        var shippedNotesPath = Path.Combine(root, "docs", language, shippedNotes);
+        var missingStableNoteMarker = language == "en"
+            ? $"no tracked `{shippedNotes}`"
+            : $"tracked な `{shippedNotes}` がなく";
 
-        // v0.23.1's shipped body is the GitHub Release evidence rather than a
-        // local source note; only the new DRAFT is required in this checkout.
         RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
         Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
         Assert.Contains(currentNotes, reference, StringComparison.Ordinal);
+        Assert.Contains(shippedNotes, reference, StringComparison.Ordinal);
+        Assert.True(
+            File.Exists(shippedNotesPath) || referenceCompact.Contains(missingStableNoteMarker, StringComparison.Ordinal),
+            $"Readiness must either carry the policy-derived stable note {shippedNotes} or explain its missing local source file.");
         Assert.Contains(
             language == "en"
                 ? $"Next release readiness (v{policy.NextVersion})"
@@ -174,7 +182,19 @@ public sealed class ReleaseNotesV0210DocsTests
             StringComparison.OrdinalIgnoreCase);
         Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", currentNotesText, StringComparison.Ordinal);
         Assert.Contains($"releases/tag/v{policy.NextVersion}", currentNotesText, StringComparison.Ordinal);
-        Assert.Contains("v0.23.1 GitHub Release", reference, StringComparison.Ordinal);
+        if (File.Exists(shippedNotesPath))
+        {
+            var stableNotes = File.ReadAllText(shippedNotesPath);
+            Assert.Contains($"releases/tag/v{policy.StableVersion}", stableNotes, StringComparison.Ordinal);
+            Assert.DoesNotContain("DRAFT /", stableNotes, StringComparison.Ordinal);
+            Assert.DoesNotContain("UNRELEASED", stableNotes, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("未リリース", stableNotes, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("prepare-only", stableNotes, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Contains($"v{policy.StableVersion} GitHub Release", referenceCompact, StringComparison.Ordinal);
+        }
     }
 
     [Theory]

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
@@ -23,9 +23,6 @@ public sealed class ReleaseNotesV0210DocsTests
         .. Units.Select(unit => unit.Merge),
     ];
 
-    private const string StableCleanInstallCommand =
-        "dotnet tool install JTechJapan.IntentSystem.Cli --version 0.22.0 --tool-path <clean-dir> --source https://api.nuget.org/v3/index.json";
-
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
@@ -144,24 +141,18 @@ public sealed class ReleaseNotesV0210DocsTests
         var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
         var notes = Read(language);
         var currentNotes = $"release-notes-v{policy.NextVersion}.md";
-        var shippedNotes = $"release-notes-v{policy.StableVersion}.md";
-        var stableNotes = File.ReadAllText(Path.Combine(root, "docs", language, shippedNotes));
 
+        // v0.23.1's shipped body is the GitHub Release evidence rather than a
+        // local source note; only the new DRAFT is required in this checkout.
         RepoVersionPolicySource.AssertReleaseToBeCutIsAheadOfPublishedStable(policy);
         Assert.True(File.Exists(Path.Combine(root, "docs", language, currentNotes)));
-        Assert.True(File.Exists(Path.Combine(root, "docs", language, shippedNotes)));
         Assert.Contains(currentNotes, reference, StringComparison.Ordinal);
-        Assert.Contains(shippedNotes, reference, StringComparison.Ordinal);
         Assert.Contains(
             language == "en"
                 ? $"Next release readiness (v{policy.NextVersion})"
                 : $"次リリース準備(v{policy.NextVersion})",
             reference,
             StringComparison.Ordinal);
-        Assert.Contains(StableCleanInstallCommand, stableNotes, StringComparison.Ordinal);
-        Assert.Contains("<clean-dir>/intent-cli --version", stableNotes, StringComparison.Ordinal);
-        Assert.DoesNotContain("`JTechJapan.IntentSystem.Cli --version 0.22.0`", stableNotes, StringComparison.Ordinal);
-        Assert.Contains($"releases/tag/v{policy.StableVersion}", stableNotes, StringComparison.Ordinal);
         var currentNotesText = File.ReadAllText(Path.Combine(root, "docs", language, currentNotes));
         var currentNotesCompact = Regex.Replace(currentNotesText, @"[>\s]+", " ");
         Assert.Contains(
@@ -183,10 +174,7 @@ public sealed class ReleaseNotesV0210DocsTests
             StringComparison.OrdinalIgnoreCase);
         Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", currentNotesText, StringComparison.Ordinal);
         Assert.Contains($"releases/tag/v{policy.NextVersion}", currentNotesText, StringComparison.Ordinal);
-        Assert.DoesNotContain("DRAFT /", stableNotes, StringComparison.Ordinal);
-        Assert.DoesNotContain("UNRELEASED", stableNotes, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("未リリース", stableNotes, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("prepare-only", stableNotes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("v0.23.1 GitHub Release", reference, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -293,7 +293,24 @@ public sealed class ReleaseNotesV0220DocsTests
 
         Assert.Contains($"release-notes-v{policy.StableVersion}.md", section, StringComparison.Ordinal);
         Assert.Contains($"release-notes-v{policy.NextVersion}.md", section, StringComparison.Ordinal);
-        Assert.Contains("v0.23.1 GitHub Release", section, StringComparison.Ordinal);
+        Assert.Contains($"v{policy.StableVersion} GitHub Release", section, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.23.0.md", section, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "source-note inconsistency predates this roll" : "source-note inconsistency はこの roll より前から存在し",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "DRAFT / UNRELEASED" : "DRAFT / 未リリース",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "authoritative shipped evidence" : "shipped evidence の authoritative source",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "out of scope and must be handled by a later explicitly scoped remediation" : "修正は scope 外です。後続の明示的な remediation で扱います",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
         Assert.Contains("G725 detector", section, StringComparison.Ordinal);
         Assert.Contains(
             language == "en" ? "no tag" : "tag または Release を作成せず",
@@ -303,7 +320,6 @@ public sealed class ReleaseNotesV0220DocsTests
             language == "en" ? "no package" : "package を publish せず",
             compact,
             StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("release-notes-v0.23.1.md", section, StringComparison.Ordinal);
     }
 
     private static void AssertUnitCitationAssociations(

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -293,26 +293,17 @@ public sealed class ReleaseNotesV0220DocsTests
 
         Assert.Contains($"release-notes-v{policy.StableVersion}.md", section, StringComparison.Ordinal);
         Assert.Contains($"release-notes-v{policy.NextVersion}.md", section, StringComparison.Ordinal);
-        Assert.Contains("G702 npm publish step", section, StringComparison.Ordinal);
-        Assert.Contains("distribution gap", section, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("guide orchestrator-thread", section, StringComparison.Ordinal);
-        Assert.Contains("notify supervise reconcile|uninstall", section, StringComparison.Ordinal);
-        Assert.Contains("guide workflow task supervision-setup", section, StringComparison.Ordinal);
-        Assert.Contains("ReleaseNotesV0220DocsTests", section, StringComparison.Ordinal);
-        Assert.DoesNotContain("v0.21.1", section, StringComparison.Ordinal);
+        Assert.Contains("v0.23.1 GitHub Release", section, StringComparison.Ordinal);
+        Assert.Contains("G725 detector", section, StringComparison.Ordinal);
         Assert.Contains(
-            "gh release edit v0.22.0 --repo J-Tech-Japan/intent-system --notes-file docs/en/release-notes-v0.22.0.md",
-            section,
-            StringComparison.Ordinal);
-        if (language == "ja")
-        {
-            Assert.Contains("parity mirror", compact, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("--notes-file docs/ja/release-notes-v0.22.0.md", section, StringComparison.Ordinal);
-        }
-        Assert.Contains(
-            language == "en" ? "metadata-free and read-only" : "metadata-free かつ read-only",
+            language == "en" ? "no tag" : "tag または Release を作成せず",
             compact,
             StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "no package" : "package を publish せず",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("release-notes-v0.23.1.md", section, StringComparison.Ordinal);
     }
 
     private static void AssertUnitCitationAssociations(


### PR DESCRIPTION
Closes #1579

## G728 repair

Repair head: `572e1caf4440047d7d511046e83901c8a867bbc5`.

This update fixes exactly the three findings from the review at `ca9ae0fccc1b25e6ee6469523de2aa803c6aff8f`:

1. The shipped-note report is now honest in this PR body and both readiness mirrors. The tracked EN/JA `docs/*/release-notes-v0.23.0.md` files still contain `DRAFT / UNRELEASED` / `DRAFT / 未リリース` banners even though v0.23.0 is a published GitHub Release. Their unchanged state is not presented as correctness. The published GitHub Release and tag are the authoritative shipped evidence. Correcting the pre-existing shipped-note inconsistency is explicitly out of scope for this roll and is recorded for a later explicitly scoped remediation. No shipped note file was edited.
2. `ReleaseNotesV0190DocsTests` and `ReleaseNotesV0210DocsTests` again derive `release-notes-v{policy.StableVersion}.md`. When that local stable note exists, the historical stable-note guards remain active; when it does not, the guard accepts only the explicit readiness statement for the missing local file plus the policy-derived GitHub Release evidence. No v0.23.1 note was created.
3. `ReleaseNotesV0220DocsTests` derives the stable GitHub Release assertion and no longer contains a hardcoded `v0.23.1` filename/value duplicate.

## Honest shipped-note evidence (AC7)

The source-note check is deliberately not called a correctness check:

```text
git diff --quiet ca9ae0fccc1b25e6ee6469523de2aa803c6aff8f -- docs/en/release-notes-v0.23.0.md docs/ja/release-notes-v0.23.0.md  # exit 0
docs/en/release-notes-v0.23.0.md:3: DRAFT / UNRELEASED
docs/ja/release-notes-v0.23.0.md:3: DRAFT / 未リリース
```

Authoritative published evidence checked:

```text
v0.23.0 draft=false prerelease=false published=2026-08-20T07:37:32Z
v0.23.1 draft=false prerelease=false published=2026-08-20T08:09:24Z
```

The v0.23.0 and v0.23.1 shipped-note remediation remains outside this roll; this report and the mirrored readiness wording keep that inconsistency durable and visible without changing shipped artifacts.

## Real detector before/after at repaired head

The CLI was rebuilt from `572e1caf4440047d7d511046e83901c8a867bbc5` (`intent-cli 0.23.2-572e1ca-G728`). A matched read-only host topology at host commit `5550f2260f192867cf6ef21ade43921982ecf34b` ran the real `automation stalled-work` command first with baseline child `5d2d1ce51530c035944194e6cb762246fc589b13`, then with the repaired child.

```text
BEFORE: stalled=true; items=38; warnings=12; version-roll-required=1
        released=0.23.1; expected_stable=0.23.1; expected_next=0.23.2
AFTER:  stalled=true; items=37; warnings=12; version-roll-required=0
        warning list unchanged; item-set difference is exactly version-roll-required/version-roll
```

The remaining stalled items are unrelated pre-existing host work. The detector is read-only; no host state, tag, Release, package, workflow, or claim data was changed.

## Verification

- Focused repaired guard/readiness tests: **137 passed, 0 failed, 0 skipped**.
- Full CI-equivalent suite: **5,171 passed, 0 failed, 1 expected skip, 5,172 total**.
- Release build: passed with 0 warnings and 0 errors.
- `git diff --check`: passed.
- Shipped v0.23.0 EN/JA source files: unchanged and explicitly reported inconsistent above.
- PR CI will be rerun at the pushed head; this PR remains draft and is not being merged or promoted.

The repair diff is limited to the two mirrored readiness sections and the three release-note guard test files. No release version was chosen, no unshipped notes were authored, and no tag/Release/package publication was performed.
