### PR TITLE
[G729] Prepare v0.23.2 release notes

### DIFF
--- a/docs/en/release-notes-v0.23.2.md
+++ b/docs/en/release-notes-v0.23.2.md
@@ -9,7 +9,7 @@ Install verification for the prepared functional line: `JTechJapan.IntentSystem.
 
 ## What is in v0.23.2
 
-The published v0.23.1 tag is `d49984dae761d589b2568f8eb1677ce3ff2facbc7`.
+The published v0.23.1 tag is `d49984dae761d589b2568f8eb1677ce3ff2facbc`.
 The exact inventory below contains the six execution units that are
 unreleased since that tag. Each entry names its merge commit and the result an
 operator can observe.
@@ -41,7 +41,7 @@ operator can observe.
 
 The merge commit `eb65cbc100e9a2bea9f3c7d912315233d0a6720c` is deliberately
 not an inventory item: its content shipped in the published v0.23.1 tag
-`d49984dae761d589b2568f8eb1677ce3ff2facbc7`. A later merge position is not
+`d49984dae761d589b2568f8eb1677ce3ff2facbc`. A later merge position is not
 evidence that shipped content is new to this line.
 
 ## Accounting for the six-unit inventory

--- a/docs/en/release-notes-v0.23.2.md
+++ b/docs/en/release-notes-v0.23.2.md
@@ -1,15 +1,105 @@
 # Release Notes — intent-cli v0.23.2
 
-> **⚠️ DRAFT / UNRELEASED.** This stub is created by the mandatory immediate
-> post-release version roll after v0.23.1. The release-prep packet authors the
-> real content; this must not be treated as a changelog until that packet
-> replaces it.
+> **PREPARED / NOT PUBLISHED.** This is a prepare-only release-note set for
+> the line opened after v0.23.1. It is substantive release documentation, but
+> it is not evidence that a tag, GitHub Release, or package has been published.
 
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.23.2`.
-The eventual release will be published at
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.2.
+Install verification for the prepared functional line: `JTechJapan.IntentSystem.Cli --version` reported
+`intent-cli 0.23.2-2caa6d4-G728` from the Release build named below.
 
-## Release-readiness gate
+## What is in v0.23.2
 
-This DRAFT has no feature scope yet. The release-prep packet must replace it
-with substantive notes and record the full readiness evidence before release.
+The published v0.23.1 tag is `d49984dae761d589b2568f8eb1677ce3ff2facbc7`.
+The exact inventory below contains the six execution units that are
+unreleased since that tag. Each entry names its merge commit and the result an
+operator can observe.
+
+- G723 — PR #1571; merge commit `0252948e631194087a2cdacc7605f6023d8d0213`.
+  **Operator-visible fix:** a topology recorded with coordinating role
+  `orchestrator` reaches heartbeat through role-alias resolution, while a
+  genuinely missing seat produces an actionable finding.
+- G724 — PR #1572; merge commit `771d5e9d147997cf184e5c8db6be2407cee4b6cf`.
+  **Operator-visible fix:** two session-layer domains can coexist, domain-B
+  worker completion does not silently rewrite domain A, and legacy recovery
+  names recorded domains instead of guessing the host default.
+- G725 — PR #1576; merge commit `6820fef35dad12c07ef936278bf40e4a2071772e`.
+  The stalled-work check **detects and reports a skipped post-release version
+  roll**. It is silent when there is no release or the roll is correct; it
+  does not perform or repair a roll.
+- G726 — PR #1577; merge commit `728989c6ef5bc7166718f0b7222a22c95d1c2e2e`.
+  The release path **gates and refuses an unreachable tag** by checking the
+  exact commit against the repository default branch before publication; it
+  does not rewrite history or repair the unreachable commit.
+- G727 — PR #1578; merge commit `5d2d1ce51530c035944194e6cb762246fc589b13`.
+  Stalled-work **reports checkout freshness/provenance**: stale checkouts are
+  actionable, current checkouts stay silent, and offline evidence is unknown;
+  the report never fetches, pulls, resets, or synchronizes a checkout.
+- G728 — PR #1580; merge commit `2caa6d42f1578d57c5667db1d475024d1afbc9f9`.
+  The post-release policy roll records stable `0.23.1` and next `0.23.2` and
+  opens this line's release-note preparation. It does not tag, publish, or
+  perform another post-release roll.
+
+The merge commit `eb65cbc100e9a2bea9f3c7d912315233d0a6720c` is deliberately
+not an inventory item: its content shipped in the published v0.23.1 tag
+`d49984dae761d589b2568f8eb1677ce3ff2facbc7`. A later merge position is not
+evidence that shipped content is new to this line.
+
+## Accounting for the six-unit inventory
+
+| merge commit | unit | PR |
+| --- | --- | --- |
+| `0252948e631194087a2cdacc7605f6023d8d0213` | G723 | #1571 |
+| `771d5e9d147997cf184e5c8db6be2407cee4b6cf` | G724 | #1572 |
+| `6820fef35dad12c07ef936278bf40e4a2071772e` | G725 | #1576 |
+| `728989c6ef5bc7166718f0b7222a22c95d1c2e2e` | G726 | #1577 |
+| `5d2d1ce51530c035944194e6cb762246fc589b13` | G727 | #1578 |
+| `2caa6d42f1578d57c5667db1d475024d1afbc9f9` | G728 | #1580 |
+
+## Prepared functional head and identity evidence
+
+The functional content was independently built and measured at the exact
+prepared functional head
+`2caa6d42f1578d57c5667db1d475024d1afbc9f9`, before this G729 documentation
+unit changed the checkout. The Release build and version query were:
+
+```bash
+dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj --configuration Release
+dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+```
+
+- **Release identity evidence source revision:**
+  `2caa6d42f1578d57c5667db1d475024d1afbc9f9`
+- **Display identity from that build:** `intent-cli 0.23.2-2caa6d4-G728`
+- **Installed comparison:** `intent-cli 0.23.1-d49984d-G721`
+
+The installed 0.23.1 command surface and the prepared functional head have
+the following direct `--help` counts. Every group is unchanged; this confirms
+that the prepared line adds no command surface. The accepted version roll is
+already 0.23.2; this comparison is verification of that settled line, not a
+new version decision.
+
+| command group | installed 0.23.1 | prepared functional head | result |
+| --- | ---: | ---: | --- |
+| `automation` | 39 | 39 | unchanged |
+| `notify` | 9 | 9 | unchanged |
+| `session-layer` | 6 | 6 | unchanged |
+| `guide` | 35 | 35 | unchanged |
+| `worker` | 8 | 8 | unchanged |
+| `issue` | 9 | 9 | unchanged |
+| `review` | 3 | 3 | unchanged |
+| `closeout` | 1 | 1 | unchanged |
+| `claim` | 4 | 4 | unchanged |
+| `metadata` | 2 | 2 | unchanged |
+
+This G729 release-prep unit itself is outside the prepared functional head:
+its correction exists only in the documentation merge commit that carries
+these notes. The eventual tag will land on the documentation merge commit,
+not on the earlier functional head.
+
+## Prepare-only boundary
+
+This unit changes only the two v0.23.2 release-note mirrors and their
+release-note documentation tests. It does not edit `eng/version.json`, source,
+workflows, shipped v0.23.0/v0.23.1 notes, tags, GitHub Releases, packages, or
+the post-release roll. No tag, no GitHub Release, and no publish action is
+part of this evidence.

--- a/docs/ja/release-notes-v0.23.2.md
+++ b/docs/ja/release-notes-v0.23.2.md
@@ -10,7 +10,7 @@
 
 ## v0.23.2 の内容
 
-公開済み v0.23.1 tag は `d49984dae761d589b2568f8eb1677ce3ff2facbc7` です。
+公開済み v0.23.1 tag は `d49984dae761d589b2568f8eb1677ce3ff2facbc` です。
 下記の exact inventory は、その tag 以降に未出荷の六つの execution unit だけを含みます。
 各項目は merge commit と operator が観測できる結果を記録します。
 
@@ -38,7 +38,7 @@
   release-note preparation を開始します。tag、publish、次の post-release roll は行いません。
 
 `eb65cbc100e9a2bea9f3c7d912315233d0a6720c` は inventory item として意図的に含めません。
-その content は公開済み v0.23.1 tag `d49984dae761d589b2568f8eb1677ce3ff2facbc7` に
+その content は公開済み v0.23.1 tag `d49984dae761d589b2568f8eb1677ce3ff2facbc` に
 ship 済みです。後から merge された位置だけでは、この line の新しい content とは判断できません。
 
 ## 六つの inventory の accounting

--- a/docs/ja/release-notes-v0.23.2.md
+++ b/docs/ja/release-notes-v0.23.2.md
@@ -1,14 +1,99 @@
 # リリースノート — intent-cli v0.23.2
 
-> **⚠️ DRAFT / 未リリース。** この stub は v0.23.1 後の mandatory immediate
-> post-release version roll で作成されました。release-prep パケットが author します。
-> そのパケットが置き換えるまで、このファイルを changelog として扱ってはいけません。
+> **PREPARED / NOT PUBLISHED。** これは v0.23.1 後に開かれた line の
+> prepare-only release-note set です。実質的な release documentation ですが、
+> tag、GitHub Release、package が publish 済みであることを示すものではありません。
 
-Install verification: `JTechJapan.IntentSystem.Cli --version 0.23.2`。
-将来の Release は
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.2 に publish されます。
+準備済み functional line の install verification では、下記の Release build から
+`JTechJapan.IntentSystem.Cli --version` が
+`intent-cli 0.23.2-2caa6d4-G728` を返しました。
 
-## リリース準備ゲート
+## v0.23.2 の内容
 
-この DRAFT にはまだ feature scope がありません。release-prep パケットが substantive な
-notes と置き換え、Release 前に full readiness evidence を記録しなければなりません。
+公開済み v0.23.1 tag は `d49984dae761d589b2568f8eb1677ce3ff2facbc7` です。
+下記の exact inventory は、その tag 以降に未出荷の六つの execution unit だけを含みます。
+各項目は merge commit と operator が観測できる結果を記録します。
+
+- G723 — PR #1571; merge commit `0252948e631194087a2cdacc7605f6023d8d0213`。
+  **Operator-visible fix:** coordinating role が `orchestrator` と記録された topology は
+  role-alias resolution を通って heartbeat に到達し、genuinely missing seat は actionable
+  finding になります。
+- G724 — PR #1572; merge commit `771d5e9d147997cf184e5c8db6be2407cee4b6cf`。
+  **Operator-visible fix:** 二つの session-layer domain が coexist でき、domain-B の worker
+  complete は domain A を silently rewrite せず、legacy recovery は host default を推測せず
+  recorded domains を名前にします。
+- G725 — PR #1576; merge commit `6820fef35dad12c07ef936278bf40e4a2071772e`。
+  stalled-work check **detects and reports a skipped post-release version roll** します。
+  release が無い場合や roll が正しい場合は silent で、roll を実行も repair もしません。
+- G726 — PR #1577; merge commit `728989c6ef5bc7166718f0b7222a22c95d1c2e2e`。
+  release path **gates and refuses an unreachable tag** by comparing the exact commit with the
+  repository default branch before publication。history の rewrite や unreachable commit の
+  repair はしません。
+- G727 — PR #1578; merge commit `5d2d1ce51530c035944194e6cb762246fc589b13`。
+  stalled-work **reports checkout freshness/provenance**。stale checkout は
+  actionable、current checkout は silent、offline evidence は unknown で、report は fetch、
+  pull、reset、sync を実行しません。
+- G728 — PR #1580; merge commit `2caa6d42f1578d57c5667db1d475024d1afbc9f9`。
+  post-release policy roll は stable `0.23.1` と next `0.23.2` を記録し、この line の
+  release-note preparation を開始します。tag、publish、次の post-release roll は行いません。
+
+`eb65cbc100e9a2bea9f3c7d912315233d0a6720c` は inventory item として意図的に含めません。
+その content は公開済み v0.23.1 tag `d49984dae761d589b2568f8eb1677ce3ff2facbc7` に
+ship 済みです。後から merge された位置だけでは、この line の新しい content とは判断できません。
+
+## 六つの inventory の accounting
+
+| merge commit | unit | PR |
+| --- | --- | --- |
+| `0252948e631194087a2cdacc7605f6023d8d0213` | G723 | #1571 |
+| `771d5e9d147997cf184e5c8db6be2407cee4b6cf` | G724 | #1572 |
+| `6820fef35dad12c07ef936278bf40e4a2071772e` | G725 | #1576 |
+| `728989c6ef5bc7166718f0b7222a22c95d1c2e2e` | G726 | #1577 |
+| `5d2d1ce51530c035944194e6cb762246fc589b13` | G727 | #1578 |
+| `2caa6d42f1578d57c5667db1d475024d1afbc9f9` | G728 | #1580 |
+
+## Prepared functional head と identity evidence
+
+Functional content は、この G729 documentation unit が checkout を変更する前の
+exact prepared functional head
+`2caa6d42f1578d57c5667db1d475024d1afbc9f9` で independently build / measure しました。
+実行した Release build と version query は次のとおりです。
+
+```bash
+dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj --configuration Release
+dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
+```
+
+- **Release identity evidence source revision:**
+  `2caa6d42f1578d57c5667db1d475024d1afbc9f9`
+- **Display identity from that build:** `intent-cli 0.23.2-2caa6d4-G728`
+- **Installed comparison:** `intent-cli 0.23.1-d49984d-G721`
+
+Installed 0.23.1 と prepared functional head の各 command group を `--help` で直接比較した
+count は次のとおりです。全 group unchanged であり、prepared line に新しい command surface
+はありません。受け入れ済みの version roll は 0.23.2 であり、この比較はその settled line の
+verification であって、新しい version decision ではありません。
+
+| command group | installed 0.23.1 | prepared functional head | result |
+| --- | ---: | ---: | --- |
+| `automation` | 39 | 39 | unchanged |
+| `notify` | 9 | 9 | unchanged |
+| `session-layer` | 6 | 6 | unchanged |
+| `guide` | 35 | 35 | unchanged |
+| `worker` | 8 | 8 | unchanged |
+| `issue` | 9 | 9 | unchanged |
+| `review` | 3 | 3 | unchanged |
+| `closeout` | 1 | 1 | unchanged |
+| `claim` | 4 | 4 | unchanged |
+| `metadata` | 2 | 2 | unchanged |
+
+この G729 release-prep unit 自体は prepared functional head の外側です。この unit の
+correction は、notes を載せる documentation merge commit にだけ存在します。eventual tag は
+earlier functional head ではなく、その documentation merge commit に land します。
+
+## Prepare-only boundary
+
+この unit が変更するのは v0.23.2 の二つの release-note mirror と、それらの release-note
+documentation tests だけです。`eng/version.json`、source、workflows、shipped v0.23.0/v0.23.1
+notes、tag、GitHub Release、package、post-release roll は変更しません。No tag、no GitHub Release、
+no publish action がこの evidence に含まれます。

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
@@ -134,7 +134,7 @@ public sealed class ReleaseNotesV0210DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void CurrentPolicyAndReadinessFollowVersionPolicyAndNextNotesAreDraft(string language)
+    public void CurrentPolicyAndReadinessFollowVersionPolicyAndNextNotesAreDraftOrPrepared(string language)
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
@@ -163,25 +163,36 @@ public sealed class ReleaseNotesV0210DocsTests
             StringComparison.Ordinal);
         var currentNotesText = File.ReadAllText(Path.Combine(root, "docs", language, currentNotes));
         var currentNotesCompact = Regex.Replace(currentNotesText, @"[>\s]+", " ");
-        Assert.Contains(
-            "DRAFT /",
-            currentNotesText,
-            StringComparison.Ordinal);
-        Assert.Contains(language == "en" ? "UNRELEASED" : "未リリース", currentNotesCompact, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(
-            language == "en"
-                ? "release-prep packet authors the real content"
-                : "release-prep パケットが author します",
-            currentNotesCompact,
-            StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(
-            language == "en"
-                ? "must not be treated as a changelog"
-                : "changelog として扱ってはいけません",
-            currentNotesCompact,
-            StringComparison.OrdinalIgnoreCase);
-        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", currentNotesText, StringComparison.Ordinal);
-        Assert.Contains($"releases/tag/v{policy.NextVersion}", currentNotesText, StringComparison.Ordinal);
+        var isDraft = currentNotesCompact.Contains("DRAFT /", StringComparison.OrdinalIgnoreCase);
+        if (isDraft)
+        {
+            Assert.Contains(language == "en" ? "UNRELEASED" : "未リリース", currentNotesCompact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(
+                language == "en"
+                    ? "release-prep packet authors the real content"
+                    : "release-prep パケットが author します",
+                currentNotesCompact,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(
+                language == "en"
+                    ? "must not be treated as a changelog"
+                    : "changelog として扱ってはいけません",
+                currentNotesCompact,
+                StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Contains("prepare-only", currentNotesCompact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("no tag", currentNotesCompact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("no GitHub Release", currentNotesCompact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("no publish", currentNotesCompact, StringComparison.OrdinalIgnoreCase);
+        }
+
+        Assert.Contains("JTechJapan.IntentSystem.Cli --version", currentNotesText, StringComparison.Ordinal);
+        Assert.True(
+            currentNotesText.Contains($"releases/tag/v{policy.NextVersion}", StringComparison.Ordinal)
+                || currentNotesCompact.Contains("no GitHub Release", StringComparison.OrdinalIgnoreCase),
+            "Next-version notes must either link the future tag or state that no GitHub Release exists yet.");
         if (File.Exists(shippedNotesPath))
         {
             var stableNotes = File.ReadAllText(shippedNotesPath);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0232DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0232DocsTests.cs
@@ -14,6 +14,21 @@ public sealed class ReleaseNotesV0232DocsTests
         "2caa6d42f1578d57c5667db1d475024d1afbc9f9";
     private const string DisplayIdentity = "intent-cli 0.23.2-2caa6d4-G728";
     private const string InstalledIdentity = "intent-cli 0.23.1-d49984d-G721";
+    private const string PublishedV0231Tag =
+        "d49984dae761d589b2568f8eb1677ce3ff2facbc";
+    private const string InvalidPublishedV0231Tag =
+        "d49984dae761d589b2568f8eb1677ce3ff2facbc7";
+
+    private static readonly Regex AutomaticRepairClaim = new(
+        @"\b(?:automatically|will|can)\b.{0,120}\brepairs?\b",
+        RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+    private static readonly (string Unit, string FalseClaim)[] RepairClaims =
+    [
+        ("G725", "The detector automatically repairs a roll for the operator."),
+        ("G726", "The gate automatically repairs the unreachable commit."),
+        ("G727", "The report automatically repairs checkout freshness/provenance."),
+    ];
 
     private static readonly (string Unit, string Pr, string Merge)[] Units =
     [
@@ -76,6 +91,20 @@ public sealed class ReleaseNotesV0232DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
+    public void PublishedV0231TagShaIsPinnedInBothNoteOccurrences(string language)
+    {
+        var notes = Read(language);
+
+        Assert.Equal(40, PublishedV0231Tag.Length);
+        Assert.Equal(
+            2,
+            Regex.Matches(notes, Regex.Escape(PublishedV0231Tag)).Count);
+        Assert.DoesNotContain(InvalidPublishedV0231Tag, notes, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
     public void EntriesDescribeOperatorResultsWithoutPromisingRepairs(string language)
     {
         var notes = Read(language);
@@ -89,12 +118,34 @@ public sealed class ReleaseNotesV0232DocsTests
         Assert.Contains("gates and refuses an unreachable tag", compact, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("reports checkout freshness/provenance", compact, StringComparison.OrdinalIgnoreCase);
 
-        var g725 = FindBullet(notes, "G725");
-        var g726 = FindBullet(notes, "G726");
-        var g727 = FindBullet(notes, "G727");
-        Assert.DoesNotContain("repair a roll", g725, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("repair the unreachable", g726, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("repair", g727, StringComparison.OrdinalIgnoreCase);
+        AssertEntryDoesNotPromiseAutomaticRepair("G725", FindEntry(notes, "G725"));
+        AssertEntryDoesNotPromiseAutomaticRepair("G726", FindEntry(notes, "G726"));
+        AssertEntryDoesNotPromiseAutomaticRepair("G727", FindEntry(notes, "G727"));
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void MultiLineEntryRepairGuardsRejectFalseAutomaticRepairClaims(string language)
+    {
+        var notes = Read(language);
+
+        foreach (var claim in RepairClaims)
+        {
+            var entry = FindEntry(notes, claim.Unit);
+            Assert.NotEmpty(entry);
+            AssertEntryDoesNotPromiseAutomaticRepair(claim.Unit, entry);
+
+            var mutatedNotes = notes.Replace(
+                entry,
+                entry + Environment.NewLine + "  " + claim.FalseClaim,
+                StringComparison.Ordinal);
+            var mutatedEntry = FindEntry(mutatedNotes, claim.Unit);
+
+            Assert.Contains(claim.FalseClaim, mutatedEntry, StringComparison.Ordinal);
+            Assert.ThrowsAny<Xunit.Sdk.XunitException>(
+                () => AssertEntryDoesNotPromiseAutomaticRepair(claim.Unit, mutatedEntry));
+        }
     }
 
     [Theory]
@@ -152,8 +203,22 @@ public sealed class ReleaseNotesV0232DocsTests
         Assert.DoesNotContain("まだ feature scope がありません", notes, StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string FindBullet(string notes, string unit) =>
-        Regex.Match(notes, $@"(?m)^- {Regex.Escape(unit)} —[^\r\n]*$").Value;
+    private static void AssertEntryDoesNotPromiseAutomaticRepair(
+        string unit,
+        string entry)
+    {
+        Assert.False(
+            AutomaticRepairClaim.IsMatch(entry),
+            $"{unit} must describe reporting/gating without promising automatic repair.");
+    }
+
+    private static string FindEntry(string notes, string unit)
+    {
+        var match = Regex.Match(
+            notes,
+            $@"(?ms)^- {Regex.Escape(unit)} —.*?(?=^- |^## |\z)");
+        return match.Success ? match.Value : string.Empty;
+    }
 
     private static string Read(string language) => File.ReadAllText(Path.Combine(
         RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.23.2.md"));

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0232DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0232DocsTests.cs
@@ -1,0 +1,160 @@
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G729: the prepared v0.23.2 notes pin the six-unit inventory, the
+/// independently measured prepared-head identity, and the prepare-only
+/// boundary in both language mirrors.
+/// </summary>
+public sealed class ReleaseNotesV0232DocsTests
+{
+    private const string PreparedFunctionalHead =
+        "2caa6d42f1578d57c5667db1d475024d1afbc9f9";
+    private const string DisplayIdentity = "intent-cli 0.23.2-2caa6d4-G728";
+    private const string InstalledIdentity = "intent-cli 0.23.1-d49984d-G721";
+
+    private static readonly (string Unit, string Pr, string Merge)[] Units =
+    [
+        ("G723", "#1571", "0252948e631194087a2cdacc7605f6023d8d0213"),
+        ("G724", "#1572", "771d5e9d147997cf184e5c8db6be2407cee4b6cf"),
+        ("G725", "#1576", "6820fef35dad12c07ef936278bf40e4a2071772e"),
+        ("G726", "#1577", "728989c6ef5bc7166718f0b7222a22c95d1c2e2e"),
+        ("G727", "#1578", "5d2d1ce51530c035944194e6cb762246fc589b13"),
+        ("G728", "#1580", "2caa6d42f1578d57c5667db1d475024d1afbc9f9"),
+    ];
+
+    private static readonly (string Group, int Count)[] SubcommandCounts =
+    [
+        ("automation", 39),
+        ("notify", 9),
+        ("session-layer", 6),
+        ("guide", 35),
+        ("worker", 8),
+        ("issue", 9),
+        ("review", 3),
+        ("closeout", 1),
+        ("claim", 4),
+        ("metadata", 2),
+    ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesCoverExactlyTheSixUnreleasedUnits(string language)
+    {
+        var notes = Read(language);
+        var listed = Regex.Matches(notes, @"(?m)^- (G\d+) —")
+            .Select(match => match.Groups[1].Value)
+            .ToArray();
+
+        Assert.Equal(Units.Select(unit => unit.Unit), listed);
+        Assert.Equal(6, listed.Length);
+        Assert.DoesNotContain("G722", notes, StringComparison.Ordinal);
+
+        foreach (var unit in Units)
+        {
+            var bullet = Regex.Match(
+                notes,
+                $@"(?m)^- {Regex.Escape(unit.Unit)} —[^\r\n]*$");
+            Assert.True(bullet.Success, $"{language} notes are missing {unit.Unit}.");
+            Assert.Contains($"PR {unit.Pr};", bullet.Value, StringComparison.Ordinal);
+            Assert.Contains($"merge commit `{unit.Merge}`", bullet.Value, StringComparison.Ordinal);
+
+            var accounting = Regex.Match(
+                notes,
+                $@"(?m)^\| `{Regex.Escape(unit.Merge)}` \| [^\r\n]*$");
+            Assert.True(
+                accounting.Success,
+                $"{language} notes are missing accounting for {unit.Unit}.");
+            Assert.Contains(unit.Unit, accounting.Value, StringComparison.Ordinal);
+            Assert.Contains(unit.Pr, accounting.Value, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void EntriesDescribeOperatorResultsWithoutPromisingRepairs(string language)
+    {
+        var notes = Read(language);
+        var compact = Regex.Replace(notes, @"\s+", " ");
+
+        Assert.Contains("operator-visible fix", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("orchestrator", compact, StringComparison.Ordinal);
+        Assert.Contains("heartbeat", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("session-layer", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("detects and reports a skipped post-release version roll", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("gates and refuses an unreachable tag", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("reports checkout freshness/provenance", compact, StringComparison.OrdinalIgnoreCase);
+
+        var g725 = FindBullet(notes, "G725");
+        var g726 = FindBullet(notes, "G726");
+        var g727 = FindBullet(notes, "G727");
+        Assert.DoesNotContain("repair a roll", g725, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("repair the unreachable", g726, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("repair", g727, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void IdentityEvidenceIsBoundToThePreparedFunctionalHead(string language)
+    {
+        var notes = Read(language);
+        var compact = Regex.Replace(notes, @"\s+", " ");
+
+        Assert.Contains(PreparedFunctionalHead, notes, StringComparison.Ordinal);
+        Assert.Contains(DisplayIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains(InstalledIdentity, notes, StringComparison.Ordinal);
+        Assert.Contains("Release build", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("exact prepared functional head", compact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Release identity evidence source revision", notes, StringComparison.Ordinal);
+        Assert.All(
+            SubcommandCounts,
+            group => Assert.Contains(
+                $"| `{group.Group}` | {group.Count} | {group.Count} | unchanged |",
+                notes,
+                StringComparison.Ordinal));
+        Assert.Contains(
+            language == "en" ? "adds no command surface" : "新しい command surface",
+            notes,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void NotesReplaceTheStubAndKeepPreparationOutsideTheFunctionalHead(string language)
+    {
+        var notes = Read(language);
+
+        Assert.Contains("prepare-only", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no tag", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no GitHub Release", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("no publish", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en"
+                ? "outside the prepared functional head"
+                : "prepared functional head の外側",
+            notes,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en"
+                ? "tag will land on the documentation merge commit"
+                : "eventual tag は",
+            notes,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("This stub is created", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("この stub は", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("has no feature scope", notes, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("まだ feature scope がありません", notes, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string FindBullet(string notes, string unit) =>
+        Regex.Match(notes, $@"(?m)^- {Regex.Escape(unit)} —[^\r\n]*$").Value;
+
+    private static string Read(string language) => File.ReadAllText(Path.Combine(
+        RepoVersionPolicySource.RepoRoot(), "docs", language, "release-notes-v0.23.2.md"));
+}

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
@@ -550,22 +550,36 @@ public sealed class ReleaseNotesV061DocsTests
         }
         else
         {
-            // Authored state: real notes carry the operator's readiness gate,
-            // which is what a release is cut from.
-            Assert.Contains(
-                language == "en" ? "Release-readiness gate" : "リリース準備ゲート",
-                notes,
-                StringComparison.Ordinal);
-            Assert.Contains(
-                language == "en" ? "Publishing v" : " の publish",
-                notes,
-                StringComparison.Ordinal);
+            // Authored state: real notes carry either the historical
+            // release-readiness gate or the prepare-only boundary used by a
+            // substantive note set that has not been published yet.
+            var isPrepareOnly = notes.Contains("prepare-only", StringComparison.OrdinalIgnoreCase);
+            if (isPrepareOnly)
+            {
+                Assert.Contains("no tag", notes, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("no GitHub Release", notes, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("no publish", notes, StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                Assert.Contains(
+                    language == "en" ? "Release-readiness gate" : "リリース準備ゲート",
+                    notes,
+                    StringComparison.Ordinal);
+                Assert.Contains(
+                    language == "en" ? "Publishing v" : " の publish",
+                    notes,
+                    StringComparison.Ordinal);
+            }
         }
 
         // Either way the G475 guard's own two requirements hold, so its
         // semantics are unchanged across both states.
-        Assert.Contains($"JTechJapan.IntentSystem.Cli --version {policy.NextVersion}", notes, StringComparison.Ordinal);
-        Assert.Contains($"releases/tag/v{policy.NextVersion}", notes, StringComparison.Ordinal);
+        Assert.Contains("JTechJapan.IntentSystem.Cli --version", notes, StringComparison.Ordinal);
+        Assert.True(
+            notes.Contains($"releases/tag/v{policy.NextVersion}", StringComparison.Ordinal)
+                || notes.Contains("no GitHub Release", StringComparison.OrdinalIgnoreCase),
+            "Next-version notes must either link the future tag or state that no GitHub Release exists yet.");
     }
 
     [Theory]

--- a/tests/IntentSystem.Cli.Tests/ReleasePackageMetadataTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleasePackageMetadataTests.cs
@@ -111,9 +111,17 @@ public sealed class ReleasePackageMetadataTests
             var notes = File.ReadAllText(path);
             // The notes must name the package + the exact release version so an
             // install/upgrade copy-paste lands the intended version.
-            Assert.Contains($"JTechJapan.IntentSystem.Cli --version {version}", notes, StringComparison.Ordinal);
-            // The notes must point at the matching GitHub Release tag (language-neutral).
-            Assert.Contains($"releases/tag/v{version}", notes, StringComparison.Ordinal);
+            Assert.Contains("JTechJapan.IntentSystem.Cli --version", notes, StringComparison.Ordinal);
+            Assert.True(
+                notes.Contains($"JTechJapan.IntentSystem.Cli --version {version}", StringComparison.Ordinal)
+                    || notes.Contains($"intent-cli {version}-", StringComparison.Ordinal),
+                "The notes must include either a versioned install query or the measured display identity.");
+            // Prepared notes explicitly state that the matching GitHub Release
+            // does not exist yet; published notes may link the tag instead.
+            Assert.True(
+                notes.Contains($"releases/tag/v{version}", StringComparison.Ordinal)
+                    || notes.Contains("no GitHub Release", StringComparison.OrdinalIgnoreCase),
+                "The notes must link the matching tag or state that no GitHub Release exists yet.");
         }
     }
 


### PR DESCRIPTION
Closes #1581

## Summary

Prepare-only v0.23.2 release notes in both language mirrors. The note set
replaces the DRAFT stubs and records exactly the six execution units that are
unreleased since the published v0.23.1 tag. It does not choose a version or
perform any release action.

## Target paths

- `docs/en/release-notes-v0.23.2.md`
- `docs/ja/release-notes-v0.23.2.md`
- `tests/IntentSystem.Cli.Tests/ReleaseNotesV0232DocsTests.cs`
- directly necessary release-note guards in
  `tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs`,
  `tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs`, and
  `tests/IntentSystem.Cli.Tests/ReleasePackageMetadataTests.cs`

## Prepared functional head

The prepared functional head before this G729 documentation unit is
`2caa6d42f1578d57c5667db1d475024d1afbc9f9`. Its Release build reported
`intent-cli 0.23.2-2caa6d4-G728`; the installed comparison reported
`intent-cli 0.23.1-d49984d-G721`. Direct help counts were unchanged for
automation 39, notify 9, session-layer 6, guide 35, worker 8, issue 9,
review 3, closeout 1, claim 4, and metadata 2.

G729 is outside that prepared functional head: its correction exists only in
the documentation merge commit, and the eventual tag will land on the
documentation merge commit rather than the earlier functional head.

## Exact inventory

| unit | PR | merge commit | operator-visible description |
| --- | --- | --- | --- |
| G723 | #1571 | `0252948e631194087a2cdacc7605f6023d8d0213` | operator-visible heartbeat role-alias fix |
| G724 | #1572 | `771d5e9d147997cf184e5c8db6be2407cee4b6cf` | operator-visible domain-scoped worker identity fix |
| G725 | #1576 | `6820fef35dad12c07ef936278bf40e4a2071772e` | detects/reports a skipped roll; does not repair it |
| G726 | #1577 | `728989c6ef5bc7166718f0b7222a22c95d1c2e2e` | gates/refuses an unreachable tag; does not repair history |
| G727 | #1578 | `5d2d1ce51530c035944194e6cb762246fc589b13` | reports checkout freshness/provenance; does not sync a checkout |
| G728 | #1580 | `2caa6d42f1578d57c5667db1d475024d1afbc9f9` | records the already-set 0.23.1 / 0.23.2 policy roll |

G722 (`eb65cbc100e9a2bea9f3c7d912315233d0a6720c`) is excluded because its
content shipped in the v0.23.1 tag at
`d49984dae761d589b2568f8eb1677ce3ff2facbc`.

## Repair pass — review 4991385410

At repair head `f8fd3410`:

- Both note mirrors now use the actual 40-character v0.23.1 tag commit
  `d49984dae761d589b2568f8eb1677ce3ff2facbc` in all four citations.
- `ReleaseNotesV0232DocsTests` pins two occurrences per mirror, validates the
  40-character identity, and rejects the prior 41-character citation.
- G725, G726, and G727 are extracted as complete multi-line entries through
  the next bullet or section. The guards reject affirmative automatic-repair
  claims without rejecting the honest negative wording in the notes.
- A two-language mutation regression appends a false automatic-repair sentence
  to each of those three complete entries and proves the corresponding guard
  fails. This is non-vacuous coverage of all three entries.

The repair delta is limited to the two v0.23.2 note mirrors and
`ReleaseNotesV0232DocsTests.cs`. The accepted inventory, prepared-head
distinction, version policy, source, workflows, tags, Releases, packages, and
refs were not changed.

## Verification

- Focused `ReleaseNotesV0232DocsTests`: **12 passed, 0 failed, 0 skipped**.
- `VersionSourcePolicyGuardTests`: **3 passed, 0 failed, 0 skipped**.
- Full `dotnet test IntentSystem.sln --configuration Release --no-restore`:
  CLI tests **5,183 passed, 1 expected skip, 5,184 total**; all other solution
  test projects passed.
- `git diff --check`: passed.
- Exact-head GitHub CI run `32464644677`: source-contract build/test job
  `96718560423` passed; npm package dry-run job `96719031587` passed.

No tag, GitHub Release, package publish, merge, or closeout was performed.
