### PR TITLE
G730: Roll post-release version policy to v0.23.3

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2687,7 +2687,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0232)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0233)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2855,27 +2855,26 @@ For the same reason the version-flow example above uses placeholders rather than
 a worked version pair: a second copy of the current versions is a second thing
 to keep in sync, and it goes stale on exactly the roll nobody is watching.
 
-### Next release readiness (v0.23.2)
+### Next release readiness (v0.23.3)
 
-**`v0.23.1` shipped** (GitHub Release, NuGet, binaries, and npm). The
-published recovery release is recorded by the [v0.23.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.1).
-The published [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0)
-and its tag are authoritative shipped evidence, but the tracked EN and JA
-`release-notes-v0.23.0.md` files still carry `DRAFT / UNRELEASED` banners.
-The source-note inconsistency predates this roll; correcting shipped v0.23.0
-or v0.23.1 notes is out of scope and must be handled by a later explicitly
-scoped remediation. The child source tree has no tracked
+**`v0.23.2` shipped** (GitHub Release, NuGet, binaries, and npm). The
+published release is recorded by the [v0.23.2 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.2).
+That published GitHub Release and its tag are authoritative shipped evidence,
+but the tracked EN and JA `release-notes-v0.23.2.md` files still carry
+`PREPARED / NOT PUBLISHED` banners. This source-note inconsistency predates
+this roll; correcting shipped v0.23.2 notes is out of scope and must be handled
+by a later explicitly scoped remediation. The child source tree has no tracked
 `release-notes-v0.23.1.md`; this roll does not recreate or edit shipped notes.
-The [v0.23.2 DRAFT](release-notes-v0.23.2.md)
+The [v0.23.3 DRAFT](release-notes-v0.23.3.md)
 is the empty stub for the next line and must remain content-free until a later
 release-prep packet replaces it.
 
-Rolled policy: `stableVersion → 0.23.1`; `nextVersion → 0.23.2`.
+Rolled policy: `stableVersion → 0.23.2`; `nextVersion → 0.23.3`.
 
-The next-line package identity is `JTechJapan.IntentSystem.Cli.0.23.2.nupkg`;
+The next-line package identity is `JTechJapan.IntentSystem.Cli.0.23.3.nupkg`;
 this is a derived verification value, not release content.
 
-**Release-readiness verification for the `v0.23.2` line:**
+**Release-readiness verification for the `v0.23.3` line:**
 
 This post-release roll changes only the version policy, the empty next-line
 stubs, and this readiness section in both language mirrors. It creates no tag
@@ -2887,37 +2886,37 @@ later release-prep packet edits these artifacts. This roll itself performs no
 claim acquisition:
 
 ```bash
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.23.2 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.23.2 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.23.3 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.23.3 --team <team> --format json
 ```
 
 ```bash
 # 1. Confirm the rolled version policy and both content-free DRAFT stubs.
-cat eng/version.json   # stableVersion 0.23.1 (published), nextVersion 0.23.2 (next line)
-test -f docs/en/release-notes-v0.23.2.md
-test -f docs/ja/release-notes-v0.23.2.md
+cat eng/version.json   # stableVersion 0.23.2 (published), nextVersion 0.23.3 (next line)
+test -f docs/en/release-notes-v0.23.3.md
+test -f docs/ja/release-notes-v0.23.3.md
 
 # 2. Build and confirm the display version identity from the next line.
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-#   expected shape: intent-cli 0.23.2-<sha>-G<unit>
+#   expected shape: intent-cli 0.23.3-<sha>-G<unit>
 
-# 3. The G725 detector must be silent after the roll; it is read-only.
+# 3. Run the installed 0.23.2 CLI from the canonical host checkout. Record
+#    both the silent verdict and the G727 checkout_freshness/provenance statement.
 intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json
 
-# 4. Record the shipped-note check honestly: source notes are unchanged, but
-#    v0.23.0 still has a DRAFT / UNRELEASED banner despite the published Release.
-git diff --quiet -- docs/en/release-notes-v0.23.0.md docs/ja/release-notes-v0.23.0.md
-grep -n "DRAFT / UNRELEASED" docs/en/release-notes-v0.23.0.md
-grep -n "DRAFT / 未リリース" docs/ja/release-notes-v0.23.0.md
-gh release view v0.23.0 --repo J-Tech-Japan/intent-system
-gh release view v0.23.1 --repo J-Tech-Japan/intent-system
-#    Published GitHub Releases/tags are authoritative; note remediation is
+# 4. Record the shipped-note check honestly: source v0.23.2 notes are unchanged,
+#    but they still have PREPARED / NOT PUBLISHED banners despite the published Release.
+git diff --quiet -- docs/en/release-notes-v0.23.2.md docs/ja/release-notes-v0.23.2.md
+grep -n "PREPARED / NOT PUBLISHED" docs/en/release-notes-v0.23.2.md
+grep -n "PREPARED / NOT PUBLISHED" docs/ja/release-notes-v0.23.2.md
+gh release view v0.23.2 --repo J-Tech-Japan/intent-system
+#    The published GitHub Release/tag is authoritative; note remediation is
 #    explicitly out of scope for this version roll.
 
 # 5. Run the focused documentation/version guards, then the full suite.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release \
-  --filter "FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  --filter "FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~ReleaseNotesV0232DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 git diff --check
 dotnet test IntentSystem.sln -c Release
 ```

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2865,6 +2865,12 @@ but the tracked EN and JA `release-notes-v0.23.2.md` files still carry
 this roll; correcting shipped v0.23.2 notes is out of scope and must be handled
 by a later explicitly scoped remediation. The child source tree has no tracked
 `release-notes-v0.23.1.md`; this roll does not recreate or edit shipped notes.
+The published [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0)
+and its tag are also authoritative shipped evidence, but the tracked EN and JA
+`release-notes-v0.23.0.md` files still carry `DRAFT / UNRELEASED` banners.
+This source-note inconsistency predates this roll; correcting shipped v0.23.0
+notes is out of scope and must be handled by a later explicitly scoped
+remediation. The v0.23.0 note files remain untouched by this roll.
 The [v0.23.3 DRAFT](release-notes-v0.23.3.md)
 is the empty stub for the next line and must remain content-free until a later
 release-prep packet replaces it.

--- a/docs/en/release-notes-v0.23.3.md
+++ b/docs/en/release-notes-v0.23.3.md
@@ -1,0 +1,15 @@
+# Release Notes — intent-cli v0.23.3
+
+> **⚠️ DRAFT / UNRELEASED.** This stub is created by the mandatory immediate
+> post-release version roll after v0.23.2. The release-prep packet authors the
+> real content; this must not be treated as a changelog until that packet
+> replaces it.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.23.3`.
+The eventual release will be published at
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.3.
+
+## Release-readiness gate
+
+This DRAFT has no feature scope yet. The release-prep packet must replace it
+with substantive notes and record the full readiness evidence before release.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2911,25 +2911,25 @@ assert するのは構造的に安定です — 上記のようなインシデ�
 使っています: 現在のバージョンの 2 つ目のコピーは同期し続けるべき対象が 1 つ増えることを
 意味し、しかも誰も見ていない roll でこそ stale になります。
 
-### 次リリース準備(v0.23.2)
+### 次リリース準備(v0.23.3)
 
-**`v0.23.1` は出荷済み**(GitHub Release、NuGet、binary、npm)です。公開済みの recovery
-release は [v0.23.1 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.1)
-に記録されています。公開済みの [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0)
-とその tag が shipped evidence の authoritative source ですが、tracked な EN/JA の
-`release-notes-v0.23.0.md` にはまだ `DRAFT / 未リリース` banner が残っています。
-この source-note inconsistency はこの roll より前から存在し、出荷済み v0.23.0/v0.23.1 note の
-修正は scope 外です。後続の明示的な remediation で扱います。child source tree には tracked な
-`release-notes-v0.23.1.md` がなく、この roll で出荷済み note を再作成・編集しません。
-[v0.23.2 DRAFT](release-notes-v0.23.2.md)
+**`v0.23.2` は出荷済み**(GitHub Release、NuGet、binary、npm)です。公開済みの
+release は [v0.23.2 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.2)
+に記録されています。この published GitHub Release とその tag が shipped evidence の
+authoritative source ですが、tracked な EN/JA の `release-notes-v0.23.2.md` にはまだ
+`PREPARED / NOT PUBLISHED` banner が残っています。この source-note inconsistency はこの roll
+より前から存在し、出荷済み v0.23.2 note の修正は scope 外です。後続の明示的な remediation で
+扱います。child source tree には tracked な `release-notes-v0.23.1.md` がなく、この roll で
+出荷済み note を再作成・編集しません。
+[v0.23.3 DRAFT](release-notes-v0.23.3.md)
 は次のラインの空の stub で、後続の release-prep packet が置き換えるまで内容を持ちません。
 
-Rolled policy: `stableVersion → 0.23.1`; `nextVersion → 0.23.2`。
+Rolled policy: `stableVersion → 0.23.2`; `nextVersion → 0.23.3`。
 
-次のラインの package identity は `JTechJapan.IntentSystem.Cli.0.23.2.nupkg` です。
+次のラインの package identity は `JTechJapan.IntentSystem.Cli.0.23.3.nupkg` です。
 これは導出された verification value であり、release content ではありません。
 
-**`v0.23.2` のリリース準備検証:**
+**`v0.23.3` のリリース準備検証:**
 
 この post-release roll が変更するのは version policy、次のラインの空の stub、そして ja/en
 両ミラーのこの readiness section だけです。tag または Release を作成せず、package を publish せず、
@@ -2939,37 +2939,37 @@ claims-enabled host では、後続の release-prep packet がこれらの artif
 release-prep ownership を acquire / verify します。この roll 自身は claim acquisition を実行しません:
 
 ```bash
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.23.2 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.23.2 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.23.3 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.23.3 --team <team> --format json
 ```
 
 ```bash
 # 1. roll 済み version policy と、内容のない両言語 DRAFT stub を確認。
-cat eng/version.json   # stableVersion 0.23.1 (published), nextVersion 0.23.2 (next line)
-test -f docs/en/release-notes-v0.23.2.md
-test -f docs/ja/release-notes-v0.23.2.md
+cat eng/version.json   # stableVersion 0.23.2 (published), nextVersion 0.23.3 (next line)
+test -f docs/en/release-notes-v0.23.3.md
+test -f docs/ja/release-notes-v0.23.3.md
 
 # 2. 次のラインの表示バージョン識別を build して確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-#   期待する形: intent-cli 0.23.2-<sha>-G<unit>
+#   期待する形: intent-cli 0.23.3-<sha>-G<unit>
 
-# 3. G725 detector は roll 後に silent でなければならない(read-only)。
+# 3. canonical host checkout から installed 0.23.2 CLI を実行し、silent な verdict と
+#    G727 checkout_freshness/provenance statement の両方を記録する(read-only)。
 intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json
 
-# 4. shipped-note check を正直に記録する: source note は未変更だが、公開済み
-#    Release にもかかわらず v0.23.0 には DRAFT / 未リリース banner が残る。
-git diff --quiet -- docs/en/release-notes-v0.23.0.md docs/ja/release-notes-v0.23.0.md
-grep -n "DRAFT / UNRELEASED" docs/en/release-notes-v0.23.0.md
-grep -n "DRAFT / 未リリース" docs/ja/release-notes-v0.23.0.md
-gh release view v0.23.0 --repo J-Tech-Japan/intent-system
-gh release view v0.23.1 --repo J-Tech-Japan/intent-system
+# 4. shipped-note check を正直に記録する: source v0.23.2 note は未変更だが、公開済み
+#    Release にもかかわらず PREPARED / NOT PUBLISHED banner が残る。
+git diff --quiet -- docs/en/release-notes-v0.23.2.md docs/ja/release-notes-v0.23.2.md
+grep -n "PREPARED / NOT PUBLISHED" docs/en/release-notes-v0.23.2.md
+grep -n "PREPARED / NOT PUBLISHED" docs/ja/release-notes-v0.23.2.md
+gh release view v0.23.2 --repo J-Tech-Japan/intent-system
 #    公開済み GitHub Release/tag が authoritative evidence であり、note remediation は
 #    この version roll の scope 外です。
 
 # 5. focused な documentation/version guard と full suite を実行。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release \
-  --filter "FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
+  --filter "FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~ReleaseNotesV0232DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests|FullyQualifiedName~VersionSourcePolicyGuardTests"
 git diff --check
 dotnet test IntentSystem.sln -c Release
 ```

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2921,6 +2921,11 @@ authoritative source ですが、tracked な EN/JA の `release-notes-v0.23.2.md
 より前から存在し、出荷済み v0.23.2 note の修正は scope 外です。後続の明示的な remediation で
 扱います。child source tree には tracked な `release-notes-v0.23.1.md` がなく、この roll で
 出荷済み note を再作成・編集しません。
+公開済みの [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0)
+とその tag も shipped evidence の authoritative source ですが、tracked な EN/JA の
+`release-notes-v0.23.0.md` にはまだ `DRAFT / 未リリース` banner が残っています。
+この source-note inconsistency はこの roll より前から存在し、出荷済み v0.23.0 note の修正は
+scope 外です。後続の明示的な remediation で扱います。この roll は v0.23.0 note file を変更しません。
 [v0.23.3 DRAFT](release-notes-v0.23.3.md)
 は次のラインの空の stub で、後続の release-prep packet が置き換えるまで内容を持ちません。
 

--- a/docs/ja/release-notes-v0.23.3.md
+++ b/docs/ja/release-notes-v0.23.3.md
@@ -1,0 +1,14 @@
+# リリースノート — intent-cli v0.23.3
+
+> **⚠️ DRAFT / 未リリース。** この stub は v0.23.2 後の mandatory immediate
+> post-release version roll で作成されました。release-prep パケットが author します。
+> そのパケットが置き換えるまで、このファイルを changelog として扱ってはいけません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.23.3`。
+将来の Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.3 に publish されます。
+
+## リリース準備ゲート
+
+この DRAFT にはまだ feature scope がありません。release-prep パケットが substantive な
+notes と置き換え、Release 前に full readiness evidence を記録しなければなりません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.23.1",
-  "nextVersion": "0.23.2"
+  "stableVersion": "0.23.2",
+  "nextVersion": "0.23.3"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
@@ -196,11 +196,31 @@ public sealed class ReleaseNotesV0210DocsTests
         if (File.Exists(shippedNotesPath))
         {
             var stableNotes = File.ReadAllText(shippedNotesPath);
-            Assert.Contains($"releases/tag/v{policy.StableVersion}", stableNotes, StringComparison.Ordinal);
-            Assert.DoesNotContain("DRAFT /", stableNotes, StringComparison.Ordinal);
-            Assert.DoesNotContain("UNRELEASED", stableNotes, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("未リリース", stableNotes, StringComparison.OrdinalIgnoreCase);
-            Assert.DoesNotContain("prepare-only", stableNotes, StringComparison.OrdinalIgnoreCase);
+            var stableNoteIsPrepareOnly =
+                stableNotes.Contains("PREPARED / NOT PUBLISHED", StringComparison.OrdinalIgnoreCase)
+                || stableNotes.Contains("prepare-only", StringComparison.OrdinalIgnoreCase);
+            if (stableNoteIsPrepareOnly)
+            {
+                // G730 records the real published Release as authoritative
+                // while deliberately leaving this pre-existing source-note
+                // inconsistency for a separately scoped remediation.
+                Assert.Contains(
+                    $"v{policy.StableVersion} GitHub Release",
+                    referenceCompact,
+                    StringComparison.Ordinal);
+                Assert.Contains(
+                    "source-note inconsistency",
+                    referenceCompact,
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            else
+            {
+                Assert.Contains($"releases/tag/v{policy.StableVersion}", stableNotes, StringComparison.Ordinal);
+                Assert.DoesNotContain("DRAFT /", stableNotes, StringComparison.Ordinal);
+                Assert.DoesNotContain("UNRELEASED", stableNotes, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("未リリース", stableNotes, StringComparison.OrdinalIgnoreCase);
+                Assert.DoesNotContain("prepare-only", stableNotes, StringComparison.OrdinalIgnoreCase);
+            }
         }
         else
         {

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -294,24 +294,32 @@ public sealed class ReleaseNotesV0220DocsTests
         Assert.Contains($"release-notes-v{policy.StableVersion}.md", section, StringComparison.Ordinal);
         Assert.Contains($"release-notes-v{policy.NextVersion}.md", section, StringComparison.Ordinal);
         Assert.Contains($"v{policy.StableVersion} GitHub Release", section, StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.23.0.md", section, StringComparison.Ordinal);
         Assert.Contains(
             language == "en" ? "source-note inconsistency predates this roll" : "source-note inconsistency はこの roll より前から存在し",
             compact,
             StringComparison.OrdinalIgnoreCase);
         Assert.Contains(
-            language == "en" ? "DRAFT / UNRELEASED" : "DRAFT / 未リリース",
+            "PREPARED / NOT PUBLISHED",
             compact,
             StringComparison.OrdinalIgnoreCase);
         Assert.Contains(
             language == "en" ? "authoritative shipped evidence" : "shipped evidence の authoritative source",
             compact,
             StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(
-            language == "en" ? "out of scope and must be handled by a later explicitly scoped remediation" : "修正は scope 外です。後続の明示的な remediation で扱います",
-            compact,
-            StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("G725 detector", section, StringComparison.Ordinal);
+        if (language == "en")
+        {
+            Assert.Contains(
+                "out of scope and must be handled by a later explicitly scoped remediation",
+                compact,
+                StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Contains("scope 外", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("remediation", compact, StringComparison.OrdinalIgnoreCase);
+        }
+        Assert.Contains("installed 0.23.2 CLI", section, StringComparison.Ordinal);
+        Assert.Contains("checkout_freshness/provenance", section, StringComparison.Ordinal);
         Assert.Contains(
             language == "en" ? "no tag" : "tag または Release を作成せず",
             compact,

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -279,21 +279,14 @@ public sealed class ReleaseNotesV0220DocsTests
     [InlineData("ja")]
     public void DeveloperReadinessMirrorsTheReleasedRollContract(string language)
     {
-        var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
-        var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
-        var heading = language == "en"
-            ? $"### Next release readiness (v{policy.NextVersion})"
-            : $"### 次リリース準備(v{policy.NextVersion})";
-        var start = reference.IndexOf(heading, StringComparison.Ordinal);
-        Assert.True(start >= 0);
-        var nextHeading = reference.IndexOf("\n### ", start + heading.Length, StringComparison.Ordinal);
-        var section = reference[start..(nextHeading < 0 ? reference.Length : nextHeading)];
+        var section = ReadinessSection(language, policy.NextVersion);
         var compact = Regex.Replace(section, @"\s+", " ");
 
         Assert.Contains($"release-notes-v{policy.StableVersion}.md", section, StringComparison.Ordinal);
         Assert.Contains($"release-notes-v{policy.NextVersion}.md", section, StringComparison.Ordinal);
         Assert.Contains($"v{policy.StableVersion} GitHub Release", section, StringComparison.Ordinal);
+        AssertV0230SourceNoteDisclosure(section, language);
         Assert.Contains(
             language == "en" ? "source-note inconsistency predates this roll" : "source-note inconsistency はこの roll より前から存在し",
             compact,
@@ -328,6 +321,70 @@ public sealed class ReleaseNotesV0220DocsTests
             language == "en" ? "no package" : "package を publish せず",
             compact,
             StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void V0230SourceNoteDisclosureTripwireRejectsRemovedDisclosure(string language)
+    {
+        var policy = RepoVersionPolicySource.Read();
+        var section = ReadinessSection(language, policy.NextVersion);
+        AssertV0230SourceNoteDisclosure(section, language);
+
+        var removed = section
+            .Replace("v0.23.0", "v0.99.0", StringComparison.Ordinal)
+            .Replace("DRAFT / UNRELEASED", "RELEASED", StringComparison.Ordinal)
+            .Replace("DRAFT / 未リリース", "公開済み", StringComparison.Ordinal);
+
+        Assert.ThrowsAny<Xunit.Sdk.XunitException>(
+            () => AssertV0230SourceNoteDisclosure(removed, language));
+    }
+
+    private static string ReadinessSection(string language, string nextVersion)
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
+        var heading = language == "en"
+            ? $"### Next release readiness (v{nextVersion})"
+            : $"### 次リリース準備(v{nextVersion})";
+        var start = reference.IndexOf(heading, StringComparison.Ordinal);
+        Assert.True(start >= 0);
+        var nextHeading = reference.IndexOf("\n### ", start + heading.Length, StringComparison.Ordinal);
+        return reference[start..(nextHeading < 0 ? reference.Length : nextHeading)];
+    }
+
+    private static void AssertV0230SourceNoteDisclosure(string section, string language)
+    {
+        Assert.Contains(
+            "https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0",
+            section,
+            StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.23.0.md", section, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "DRAFT / UNRELEASED" : "DRAFT / 未リリース",
+            section,
+            StringComparison.OrdinalIgnoreCase);
+
+        var compact = Regex.Replace(section, @"\s+", " ");
+        if (language == "en")
+        {
+            Assert.Contains("source-note inconsistency predates this roll", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(
+                "correcting shipped v0.23.0 notes is out of scope and must be handled by a later explicitly scoped remediation",
+                compact,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("v0.23.0 note files remain untouched by this roll", compact, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Contains("source-note inconsistency はこの roll より前から存在し", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(
+                "出荷済み v0.23.0 note の修正は scope 外です。後続の明示的な remediation で扱います",
+                compact,
+                StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("この roll は v0.23.0 note file を変更しません", compact, StringComparison.OrdinalIgnoreCase);
+        }
     }
 
     private static void AssertUnitCitationAssociations(


### PR DESCRIPTION
Closes #1583

## Summary

- Roll `eng/version.json` from `0.23.1 / 0.23.2` to `0.23.2 / 0.23.3`.
- Add only the EN/JA `v0.23.3` DRAFT stubs, carrying the explicit not-a-changelog warning from the previous roll.
- Refresh the EN/JA next-release readiness sections and the directly necessary policy-dependent release-note guards.
- Preserve the G728 disclosure in both readiness mirrors: the published `v0.23.0` Release is authoritative, while the tracked EN/JA source notes still carry `DRAFT / UNRELEASED`; remediation is outside this G730 roll.
- Leave source, workflows, packages, tags, Releases, and the shipped `v0.23.0`/`v0.23.2` note files untouched.

The `0.23.3` value is only the next-line placeholder required by the detector; no future release version or release-prep content is decided here.

## Acceptance evidence

### Policy and stubs

```json
{
  "stableVersion": "0.23.2",
  "nextVersion": "0.23.3"
}
```

Both `docs/en/release-notes-v0.23.3.md` and `docs/ja/release-notes-v0.23.3.md` are content-free DRAFT stubs with the explicit warning that they are not a changelog until a later release-prep packet replaces them.

### Installed CLI detector before/after

The installed command was `intent-cli 0.23.2-a6f8a9d-G728`. From a fresh disposable checkout of the canonical host at its current `origin/main`, with the real configured `submodules/intent-system` checkout switched only for this read-only evidence to the original candidate implementation head:

```text
host HEAD: a3da490613eca3cdf6e290c3dade124952798375
origin/HEAD: ref: refs/heads/main -> a3da490613eca3cdf6e290c3dade124952798375
child candidate HEAD used for the detector transcript: b57ccf0435bbc591a09e7277c761c6ad95751a45
```

This transcript was captured at the original implementation head before the docs/test-only repair. The repair head is `f67a71deb0879badf7a8f4abaa05e172a0ae9dfa`; it changes no detector or policy inputs, so the accepted detector evidence is retained without falsely claiming a host checkout mutation at the repair head. Base child (`a6f8a9d8d37d0db6fb45ad2d772ce833728e8280`) produced the real finding:

```json
{
  "version_roll_required": [
    {
      "kind": "version-roll-required",
      "released_version": "0.23.2",
      "expected_stable_version": "0.23.2",
      "expected_next_version": "0.23.3"
    }
  ],
  "checkout_freshness": null,
  "checkout_warnings": []
}
```

At the candidate implementation head, the same installed command returned:

```json
{
  "version_roll_required": [],
  "checkout_freshness": null,
  "checkout_warnings": []
}
```

The empty `checkout_freshness`/warning fields are the G727 current-checkout representation: current observations are intentionally omitted so the healthy path stays silent. The read-only provenance above shows local host `HEAD` equals `origin/main`; no stale/unknown warning was emitted. The real working host invocation was also run first and honestly reported stale (`local d13ab33…` versus `origin/main fa769fda…`), so it was not misrepresented as post-roll evidence and was not synchronized.

### Shipped artifacts

`gh release view v0.23.2` reports a published, non-draft, non-prerelease Release at `2026-08-21T09:06:09Z` with the authoritative tag `v0.23.2`. The tracked EN/JA `release-notes-v0.23.2.md` files are unchanged from `origin/main`, but both still contain `PREPARED / NOT PUBLISHED`; that pre-existing source-note inconsistency is reported honestly and remains outside this roll. The published `v0.23.0` Release is likewise authoritative while its tracked EN/JA notes remain `DRAFT / UNRELEASED`; that remediation is also outside this roll. The `ReleaseNotesV0220DocsTests` tripwire now asserts the v0.23.0 disclosure in both mirrors and includes a mutation proof that removing it fails.

### Verification

- Focused release/version documentation filter: **151 passed, 0 failed**.
- Full `IntentSystem.sln` Release suite: **5,185 passed, 1 skipped, 0 failed** out of 5,186.
- `git diff --check`: clean.
- No `v0.23.3` tag or GitHub Release was created; no package was published.

## Branch and claim boundary

The implementation branch is based on child `origin/main` `a6f8a9d8d37d0db6fb45ad2d772ce833728e8280`. The PR range contains the original implementation commit `b57ccf0435bbc591a09e7277c761c6ad95751a45` and this narrow repair commit `f67a71deb0879badf7a8f4abaa05e172a0ae9dfa`; its changed paths remain exactly these seven paths:

- `eng/version.json`
- `docs/en/release-notes-v0.23.3.md`
- `docs/ja/release-notes-v0.23.3.md`
- `docs/en/09-developer-reference.md`
- `docs/ja/09-developer-reference.md`
- `tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs`
- `tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs`

The canonical HOST claim is the host-main record at `fa769fda1574f223b81df35a3657821bf6811ec8` in `tomohisa/MyIntentHost`. The duplicate claim-acquire commit `99d0783861a635c65a4817df10b88cb8eda1e780` exists in the HOST `tomohisa/MyIntentHost` repository at the head of its `origin/design-thread` branch. It is not canonical ownership and is not an ancestor of host `origin/main`; it is absent from this target child PR range. It is not a child-repository commit. Do not rewrite, delete, or release that stray host branch commit. No further child claim transition was performed after the orchestration correction, and this PR contains no host metadata or claim state. Canonical closeout will release the host-main record `fa769fda1` from the HOST store.
