### PR TITLE
G732: mark v0.23.0 notes as shipped

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2866,11 +2866,11 @@ this roll; correcting shipped v0.23.2 notes is out of scope and must be handled
 by a later explicitly scoped remediation. The child source tree has no tracked
 `release-notes-v0.23.1.md`; this roll does not recreate or edit shipped notes.
 The published [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0)
-and its tag are also authoritative shipped evidence, but the tracked EN and JA
-`release-notes-v0.23.0.md` files still carry `DRAFT / UNRELEASED` banners.
-This source-note inconsistency predates this roll; correcting shipped v0.23.0
-notes is out of scope and must be handled by a later explicitly scoped
-remediation. The v0.23.0 note files remain untouched by this roll.
+and its tag are authoritative shipped evidence. The v0.23.0 shipped artifacts
+are the GitHub Release, NuGet package, and self-contained binaries; its npm leg
+never reached the registry, so `0.23.0` must not be treated as available from
+npm. The tracked EN and JA `release-notes-v0.23.0.md` files now state this
+shipped-artifact status.
 The [v0.23.3 DRAFT](release-notes-v0.23.3.md)
 is the empty stub for the next line and must remain content-free until a later
 release-prep packet replaces it.

--- a/docs/en/release-notes-v0.23.0.md
+++ b/docs/en/release-notes-v0.23.0.md
@@ -5,8 +5,9 @@
 > leg never reached the registry; `0.23.0` must not be treated as available
 > from npm.
 
-Install verification for the line being cut: `JTechJapan.IntentSystem.Cli --version 0.23.0`.
-The eventual release will be published at
+Install verification applies to the shipped NuGet/binary line:
+`JTechJapan.IntentSystem.Cli --version 0.23.0`.
+The published release is at
 https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0.
 
 ## Why this line is v0.23.0

--- a/docs/en/release-notes-v0.23.0.md
+++ b/docs/en/release-notes-v0.23.0.md
@@ -1,8 +1,9 @@
 # Release Notes — intent-cli v0.23.0
 
-> **⚠️ DRAFT / UNRELEASED.** This is the release-prep evidence for the line
-> after v0.22.0. The release-prep packet authors the real content; until a
-> GitHub Release is published, this file must not be treated as a changelog.
+> **RELEASED FROM TAG `v0.23.0` — NPM PUBLICATION GAP.** The GitHub Release,
+> NuGet package, and self-contained binaries shipped from this tag. The npm
+> leg never reached the registry; `0.23.0` must not be treated as available
+> from npm.
 
 Install verification for the line being cut: `JTechJapan.IntentSystem.Cli --version 0.23.0`.
 The eventual release will be published at

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2922,10 +2922,10 @@ authoritative source ですが、tracked な EN/JA の `release-notes-v0.23.2.md
 扱います。child source tree には tracked な `release-notes-v0.23.1.md` がなく、この roll で
 出荷済み note を再作成・編集しません。
 公開済みの [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0)
-とその tag も shipped evidence の authoritative source ですが、tracked な EN/JA の
-`release-notes-v0.23.0.md` にはまだ `DRAFT / 未リリース` banner が残っています。
-この source-note inconsistency はこの roll より前から存在し、出荷済み v0.23.0 note の修正は
-scope 外です。後続の明示的な remediation で扱います。この roll は v0.23.0 note file を変更しません。
+とその tag は authoritative shipped evidence です。v0.23.0 の shipped artifact は GitHub Release、
+NuGet package、self-contained binary です。ただし npm leg は registry に到達しなかったため、
+`0.23.0` は npm で利用できると扱ってはいけません。tracked な EN/JA の
+`release-notes-v0.23.0.md` files はこの shipped-artifact status を記録します。
 [v0.23.3 DRAFT](release-notes-v0.23.3.md)
 は次のラインの空の stub で、後続の release-prep packet が置き換えるまで内容を持ちません。
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2923,7 +2923,7 @@ authoritative source ですが、tracked な EN/JA の `release-notes-v0.23.2.md
 出荷済み note を再作成・編集しません。
 公開済みの [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0)
 とその tag は authoritative shipped evidence です。v0.23.0 の shipped artifact は GitHub Release、
-NuGet package、self-contained binary です。ただし npm leg は registry に到達しなかったため、
+NuGet package、自己完結型バイナリです。ただし npm leg は registry に到達しなかったため、
 `0.23.0` は npm で利用できると扱ってはいけません。tracked な EN/JA の
 `release-notes-v0.23.0.md` files はこの shipped-artifact status を記録します。
 [v0.23.3 DRAFT](release-notes-v0.23.3.md)

--- a/docs/ja/release-notes-v0.23.0.md
+++ b/docs/ja/release-notes-v0.23.0.md
@@ -4,9 +4,10 @@
 > GitHub Release、NuGet package、self-contained binary を出荷しました。npm leg は
 > registry に到達しなかったため、`0.23.0` が npm で利用できるとは扱わないでください。
 
-このラインの install verification: `JTechJapan.IntentSystem.Cli --version 0.23.0`。
-将来の Release は
-https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0 で公開されます。
+出荷済みの NuGet/バイナリ line に対する install verification:
+`JTechJapan.IntentSystem.Cli --version 0.23.0`。
+公開済み Release は
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0 にあります。
 
 ## なぜこのラインは v0.23.0 なのか
 

--- a/docs/ja/release-notes-v0.23.0.md
+++ b/docs/ja/release-notes-v0.23.0.md
@@ -1,8 +1,8 @@
 # リリースノート — intent-cli v0.23.0
 
-> **⚠️ DRAFT / 未リリース。** これは v0.22.0 後のラインに対する
-> release-prep evidence です。release-prep パケットが author します。
-> GitHub Release が公開されるまで、このファイルを changelog として扱ってはいけません。
+> **tag `v0.23.0` から出荷済み — NPM PUBLICATION GAP。** この tag から
+> GitHub Release、NuGet package、self-contained binary を出荷しました。npm leg は
+> registry に到達しなかったため、`0.23.0` が npm で利用できるとは扱わないでください。
 
 このラインの install verification: `JTechJapan.IntentSystem.Cli --version 0.23.0`。
 将来の Release は

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
@@ -201,9 +201,9 @@ public sealed class ReleaseNotesV0210DocsTests
                 || stableNotes.Contains("prepare-only", StringComparison.OrdinalIgnoreCase);
             if (stableNoteIsPrepareOnly)
             {
-                // G730 records the real published Release as authoritative
-                // while deliberately leaving this pre-existing source-note
-                // inconsistency for a separately scoped remediation.
+                // A prepare-only stable note can coexist with authoritative
+                // published Release evidence; readiness records that
+                // source-note inconsistency for the still-prepared line.
                 Assert.Contains(
                     $"v{policy.StableVersion} GitHub Release",
                     referenceCompact,

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -286,7 +286,7 @@ public sealed class ReleaseNotesV0220DocsTests
         Assert.Contains($"release-notes-v{policy.StableVersion}.md", section, StringComparison.Ordinal);
         Assert.Contains($"release-notes-v{policy.NextVersion}.md", section, StringComparison.Ordinal);
         Assert.Contains($"v{policy.StableVersion} GitHub Release", section, StringComparison.Ordinal);
-        AssertV0230SourceNoteDisclosure(section, language);
+        AssertV0230ShippedArtifactStatus(section, language);
         Assert.Contains(
             language == "en" ? "source-note inconsistency predates this roll" : "source-note inconsistency はこの roll より前から存在し",
             compact,
@@ -323,24 +323,6 @@ public sealed class ReleaseNotesV0220DocsTests
             StringComparison.OrdinalIgnoreCase);
     }
 
-    [Theory]
-    [InlineData("en")]
-    [InlineData("ja")]
-    public void V0230SourceNoteDisclosureTripwireRejectsRemovedDisclosure(string language)
-    {
-        var policy = RepoVersionPolicySource.Read();
-        var section = ReadinessSection(language, policy.NextVersion);
-        AssertV0230SourceNoteDisclosure(section, language);
-
-        var removed = section
-            .Replace("v0.23.0", "v0.99.0", StringComparison.Ordinal)
-            .Replace("DRAFT / UNRELEASED", "RELEASED", StringComparison.Ordinal)
-            .Replace("DRAFT / 未リリース", "公開済み", StringComparison.Ordinal);
-
-        Assert.ThrowsAny<Xunit.Sdk.XunitException>(
-            () => AssertV0230SourceNoteDisclosure(removed, language));
-    }
-
     private static string ReadinessSection(string language, string nextVersion)
     {
         var root = RepoVersionPolicySource.RepoRoot();
@@ -354,36 +336,36 @@ public sealed class ReleaseNotesV0220DocsTests
         return reference[start..(nextHeading < 0 ? reference.Length : nextHeading)];
     }
 
-    private static void AssertV0230SourceNoteDisclosure(string section, string language)
+    // G732 deliberately retires G730's mutation tripwire: that tripwire
+    // guarded the v0.23.0 source-note disclosure, and this shipped-artifact
+    // assertion now guards the corrected contract whose subject is fixed.
+    private static void AssertV0230ShippedArtifactStatus(string section, string language)
     {
         Assert.Contains(
             "https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0",
             section,
             StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.23.0.md", section, StringComparison.Ordinal);
-        Assert.Contains(
-            language == "en" ? "DRAFT / UNRELEASED" : "DRAFT / 未リリース",
-            section,
-            StringComparison.OrdinalIgnoreCase);
-
         var compact = Regex.Replace(section, @"\s+", " ");
         if (language == "en")
         {
-            Assert.Contains("source-note inconsistency predates this roll", compact, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(
-                "correcting shipped v0.23.0 notes is out of scope and must be handled by a later explicitly scoped remediation",
+                "self-contained binaries",
                 compact,
                 StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("v0.23.0 note files remain untouched by this roll", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("npm leg never reached the registry", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("must not be treated as available from npm", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("DRAFT / UNRELEASED", section, StringComparison.OrdinalIgnoreCase);
         }
         else
         {
-            Assert.Contains("source-note inconsistency はこの roll より前から存在し", compact, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(
-                "出荷済み v0.23.0 note の修正は scope 外です。後続の明示的な remediation で扱います",
+                "self-contained binary",
                 compact,
                 StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("この roll は v0.23.0 note file を変更しません", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("npm leg は registry に到達しなかった", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("npm で利用できると扱ってはいけません", compact, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("DRAFT / 未リリース", section, StringComparison.OrdinalIgnoreCase);
         }
     }
 

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -360,7 +360,7 @@ public sealed class ReleaseNotesV0220DocsTests
         else
         {
             Assert.Contains(
-                "self-contained binary",
+                "自己完結型バイナリ",
                 compact,
                 StringComparison.OrdinalIgnoreCase);
             Assert.Contains("npm leg は registry に到達しなかった", compact, StringComparison.OrdinalIgnoreCase);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0230DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0230DocsTests.cs
@@ -4,9 +4,9 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G721: the prepared v0.23.0 notes are a bilingual inventory of exactly
-/// G710 through G720, with operator-observable G717/G719/G720 behaviour and
-/// the prepared-head release identity made explicit.
+/// G721/G732: the v0.23.0 notes are a bilingual inventory of exactly G710
+/// through G720, with operator-observable G717/G719/G720 behaviour, the
+/// prepared-head release identity, and the shipped-artifact status made explicit.
 /// </summary>
 public sealed class ReleaseNotesV0230DocsTests
 {
@@ -50,6 +50,28 @@ public sealed class ReleaseNotesV0230DocsTests
         "bc13c9436b98cc48aa02c4eb85cfbb99e9fab598",
         "be13f7c0b9b306dad99d692903cee8837b31f0e8",
     ];
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ShippedArtifactBannerNamesTheNpmPublicationGap(string language)
+    {
+        var notes = Read(language);
+        var banner = notes.Split("\n\n", StringSplitOptions.None)[1];
+
+        Assert.DoesNotContain("DRAFT /", banner, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("UNRELEASED", banner, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("未リリース", banner, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("v0.23.0", banner, StringComparison.Ordinal);
+        Assert.Contains("NuGet", banner, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("self-contained", banner, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("npm", banner, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("registry", banner, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "RELEASED FROM TAG" : "出荷済み",
+            banner,
+            StringComparison.OrdinalIgnoreCase);
+    }
 
     [Theory]
     [InlineData("en")]


### PR DESCRIPTION
## Summary

- Closes #1587.
- Replace only the EN/JA v0.23.0 unreleased banners with shipped-artifact wording: the GitHub Release, NuGet package, and self-contained binaries shipped from tag `v0.23.0`.
- Preserve the npm publication gap explicitly: the npm leg never reached the registry, so `0.23.0` must not be treated as available from npm.
- Update both readiness mirrors to describe the shipped artifacts and remove the obsolete v0.23.0 source-note disclosure.

## Deliberate G730 tripwire retirement

G730's `V0230SourceNoteDisclosureTripwireRejectsRemovedDisclosure` test was a mutation-proved guard for the old v0.23.0 readiness disclosure: it made silent weakening of that disclosure fail. G732 fixes the condition the disclosure described, so retaining that tripwire would protect a statement that is no longer true. The tripwire and its old helper were therefore removed deliberately in this same change, with the reason recorded in the replacement test helper and this PR. Positive EN/JA shipped-artifact and npm-gap assertions now guard the corrected contract; this is not a test-only deletion to make the suite pass.

## Before / after evidence

EN before:

```text
> **⚠️ DRAFT / UNRELEASED.** This is the release-prep evidence for the line
> after v0.22.0. The release-prep packet authors the real content; until a
> GitHub Release is published, this file must not be treated as a changelog.
```

EN after:

```text
> **RELEASED FROM TAG `v0.23.0` — NPM PUBLICATION GAP.** The GitHub Release,
> NuGet package, and self-contained binaries shipped from this tag. The npm
> leg never reached the registry; `0.23.0` must not be treated as available
> from npm.
```

JA before:

```text
> **⚠️ DRAFT / 未リリース。** これは v0.22.0 後のラインに対する
> release-prep evidence です。release-prep パケットが author します。
> GitHub Release が公開されるまで、このファイルを changelog として扱ってはいけません。
```

JA after:

```text
> **tag `v0.23.0` から出荷済み — NPM PUBLICATION GAP。** この tag から
> GitHub Release、NuGet package、self-contained binary を出荷しました。npm leg は
> registry に到達しなかったため、`0.23.0` が npm で利用できるとは扱わないでください。
```

Only these release-note files changed:

- `docs/en/release-notes-v0.23.0.md`
- `docs/ja/release-notes-v0.23.0.md`

## Verification

- Focused contract: `ReleaseNotesV0210DocsTests|ReleaseNotesV0220DocsTests|ReleaseNotesV0230DocsTests|VersionSourcePolicyGuardTests` — **50 passed, 0 skipped, 0 failed**.
- All release-note tests (`FullyQualifiedName~ReleaseNotes`) — **185 passed, 0 skipped, 0 failed**.
- `git diff --check` — passed.
