### PR TITLE
G738: bound claim transaction teardown

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2670,6 +2670,37 @@ incomplete packet through publication. The tolerance is scoped to `clarify open`
 
 ---
 
+## Claim transaction teardown (G738)
+
+`claim acquire`, `claim release`, and `claim takeover` use a temporary clone
+under the OS temp root. The successful plain push of the claim state is the
+transaction boundary; cleanup of that temporary clone happens after the
+boundary.
+
+- Before the claim state is committed and pushed, a transaction or teardown
+  failure remains a command failure. Cleanup cannot turn an incomplete claim
+  into success.
+- After a successful push, cleanup is best-effort. A delete attempt is bounded
+  to 250 ms, up to three attempts are allowed for ordinary failures, and the
+  retry backoff is 50 ms. A timed-out attempt is not retried while its worker
+  may still be touching the directory. The worst-case added wait is therefore
+  850 ms (`3 × 250 ms + 2 × 50 ms`), stated by the implementation constants.
+- If cleanup still cannot remove the directory, the command writes a warning
+  to stderr naming the leftover path. The committed claim result on stdout and
+  the exit code are unchanged. The leftover remains under the OS temp root so
+  the operating system's reaper can clean it up later.
+
+The warning has this shape, with the actual temporary path substituted:
+
+```text
+warning: claim transaction committed successfully, but best-effort cleanup could not remove temporary directory '<path>' after 3 bounded attempt(s); the claim result and exit code are unchanged. The leftover path remains under the OS temp root.
+```
+
+This keeps the committed claim visible to the operator and to downstream
+claim-gated flows without backgrounding the claim or hand-writing its packet.
+
+---
+
 ## Version flow
 
 The repository version policy lives in `eng/version.json` — the single source of

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2736,6 +2736,33 @@ strict な projection serializer は**変更していません**。publish-flow 
 
 ---
 
+## claim transaction の teardown (G738)
+
+`claim acquire`、`claim release`、`claim takeover` は OS の temp root 配下に一時 clone を
+作ります。claim state の plain push 成功が transaction boundary であり、その一時 clone の
+cleanup は boundary の後に実行されます。
+
+- claim state が commit され push される前は、transaction または teardown の failure は
+  command failure のままです。cleanup が未完了の claim を成功に変えることはありません。
+- push 成功後の cleanup は best-effort です。delete の 1 回ごとの待機は 250 ms に制限し、
+  通常の failure には最大 3 回まで試行し、retry 間には 50 ms の backoff を置きます。
+  timeout した試行は、worker が directory に触れている可能性がある間は retry しません。
+  最悪時の追加待機は 850 ms (`3 × 250 ms + 2 × 50 ms`) で、実装の定数にも明記しています。
+- cleanup で directory を削除できなかった場合、command は leftover path を含む warning を
+  stderr に出力します。commit 済み claim の stdout result と exit code は変わりません。
+  leftover は OS temp root 配下に残るため、OS の reaper が後で cleanup できます。
+
+warning は実際の一時 path を差し込むと次の形です:
+
+```text
+warning: claim transaction committed successfully, but best-effort cleanup could not remove temporary directory '<path>' after 3 bounded attempt(s); the claim result and exit code are unchanged. The leftover path remains under the OS temp root.
+```
+
+これにより、commit 済み claim は operator と downstream の claim-gated flow から見え続け、
+claim の background 実行や packet の手書きは不要です。
+
+---
+
 ## バージョンフロー
 
 リポジトリのバージョンポリシーは `eng/version.json` に記載されています。`stableVersion`

--- a/src/IntentSystem.Cli/Commands/ClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClaimCommand.cs
@@ -30,6 +30,14 @@ internal static class ClaimCommand
     public static int ExecuteAcquire(CliContext context, string[] args, TextWriter writer) =>
         Execute(context, args, writer, ClaimOperation.Acquire);
 
+    internal static int ExecuteAcquire(
+        CliContext context,
+        string[] args,
+        TextWriter writer,
+        TextWriter warningWriter,
+        Action<string> deleteDirectory) =>
+        Execute(context, args, writer, ClaimOperation.Acquire, warningWriter, deleteDirectory);
+
     public static int ExecuteRelease(CliContext context, string[] args, TextWriter writer) =>
         Execute(context, args, writer, ClaimOperation.Release);
 
@@ -41,10 +49,20 @@ internal static class ClaimCommand
         string[] args,
         TextWriter writer,
         ClaimOperation operation)
+        => Execute(context, args, writer, operation, Console.Error, null);
+
+    private static int Execute(
+        CliContext context,
+        string[] args,
+        TextWriter writer,
+        ClaimOperation operation,
+        TextWriter warningWriter,
+        Action<string>? deleteDirectory)
     {
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(args);
         ArgumentNullException.ThrowIfNull(writer);
+        ArgumentNullException.ThrowIfNull(warningWriter);
 
         if (args.Length == 1 && args[0] == "--help")
         {
@@ -62,7 +80,7 @@ internal static class ClaimCommand
         ClaimTransactionResult result;
         try
         {
-            result = RunTransaction(context.RepoRoot, request!);
+            result = RunTransaction(context.RepoRoot, request!, warningWriter, deleteDirectory);
         }
         catch (HostStateGitFailureException exception)
         {

--- a/src/IntentSystem.Cli/Commands/ClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClaimCommand.cs
@@ -16,6 +16,9 @@ internal static class ClaimCommand
 {
     internal const string ClaimsDirectory = ".intent-cli/claims";
     internal const int DefaultMaxAttempts = 2;
+    internal const int CleanupMaxAttempts = 3;
+    internal static readonly TimeSpan CleanupAttemptTimeout = TimeSpan.FromMilliseconds(250);
+    internal static readonly TimeSpan CleanupRetryDelay = TimeSpan.FromMilliseconds(50);
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -81,8 +84,18 @@ internal static class ClaimCommand
         return result.Status is "acquired" or "released" or "taken-over" or "planned" ? 0 : 1;
     }
 
-    internal static ClaimTransactionResult RunTransaction(string repoRoot, ClaimRequest request)
+    internal static ClaimTransactionResult RunTransaction(string repoRoot, ClaimRequest request) =>
+        RunTransaction(repoRoot, request, Console.Error);
+
+    internal static ClaimTransactionResult RunTransaction(
+        string repoRoot,
+        ClaimRequest request,
+        TextWriter warningWriter,
+        Action<string>? deleteDirectory = null)
     {
+        ArgumentNullException.ThrowIfNull(warningWriter);
+        deleteDirectory ??= path => Directory.Delete(path, recursive: true);
+
         var origin = RunGit(repoRoot, ["remote", "get-url", "origin"]);
         EnsureSuccess(origin, "resolve origin");
         var branch = RunGit(repoRoot, ["branch", "--show-current"]);
@@ -112,6 +125,7 @@ internal static class ClaimCommand
         {
             var transactionRoot = Path.Combine(
                 Path.GetTempPath(), $"intent-cli-claim-{Guid.NewGuid():N}");
+            var committed = false;
             try
             {
                 var clone = RunGit(Path.GetTempPath(),
@@ -220,6 +234,10 @@ internal static class ClaimCommand
                 }
                 if (push.ExitCode == 0)
                 {
+                    // The plain push is the transaction boundary. Everything
+                    // after it, including local refresh and temporary clone
+                    // teardown, is best-effort and cannot change the result.
+                    committed = true;
                     var pushedHead = RunGit(transactionRoot, ["rev-parse", "HEAD"]);
                     EnsureSuccess(pushedHead, "resolve pushed claim commit");
                     var status = request.Operation switch
@@ -285,14 +303,128 @@ internal static class ClaimCommand
             }
             finally
             {
-                if (Directory.Exists(transactionRoot))
-                {
-                    Directory.Delete(transactionRoot, recursive: true);
-                }
+                CleanupTransactionRoot(transactionRoot, committed, warningWriter, deleteDirectory);
             }
         }
 
         throw new InvalidOperationException("claim transaction exhausted unexpectedly");
+    }
+
+    private static void CleanupTransactionRoot(
+        string transactionRoot,
+        bool committed,
+        TextWriter warningWriter,
+        Action<string> deleteDirectory)
+    {
+        if (!Directory.Exists(transactionRoot)) return;
+
+        Exception? lastFailure = null;
+        var attempts = 0;
+        var timedOut = false;
+        try
+        {
+            // At most 3 * 250 ms of bounded delete attempts plus 2 * 50 ms
+            // backoff delays are added. A timed-out delete is not retried
+            // while its bounded worker may still be touching the directory.
+            for (var attempt = 1; attempt <= CleanupMaxAttempts; attempt++)
+            {
+                attempts = attempt;
+                if (attempt > 1) Thread.Sleep(CleanupRetryDelay);
+
+                if (TryDeleteTransactionRoot(
+                        transactionRoot, deleteDirectory, out lastFailure, out timedOut))
+                {
+                    return;
+                }
+
+                if (timedOut) break;
+            }
+        }
+        catch (Exception exception)
+        {
+            lastFailure = exception;
+        }
+
+        if (committed)
+        {
+            var detail = lastFailure?.Message;
+            try
+            {
+                warningWriter.WriteLine(
+                    $"warning: claim transaction committed successfully, but best-effort cleanup "
+                    + $"could not remove temporary directory '{transactionRoot}' after {attempts} "
+                    + $"bounded attempt(s); the claim result and exit code are unchanged. "
+                    + $"The leftover path remains under the OS temp root."
+                    + (string.IsNullOrWhiteSpace(detail) ? string.Empty : $" Last error: {detail}"));
+            }
+            catch
+            {
+                // A broken warning sink must not cross the commit boundary
+                // and turn a successful claim into a failed command.
+            }
+            return;
+        }
+
+        throw new IOException(
+            $"Could not clean up claim transaction temporary directory '{transactionRoot}' before "
+            + "the claim state was committed.", lastFailure);
+    }
+
+    private static bool TryDeleteTransactionRoot(
+        string transactionRoot,
+        Action<string> deleteDirectory,
+        out Exception? failure,
+        out bool timedOut)
+    {
+        failure = null;
+        timedOut = false;
+
+        Task deletion;
+        try
+        {
+            deletion = Task.Run(() => deleteDirectory(transactionRoot));
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+            return false;
+        }
+
+        try
+        {
+            if (!deletion.Wait(CleanupAttemptTimeout))
+            {
+                ObserveFault(deletion);
+                timedOut = true;
+                failure = new TimeoutException(
+                    $"temporary directory deletion exceeded {CleanupAttemptTimeout.TotalMilliseconds:0} ms");
+                return false;
+            }
+
+            deletion.GetAwaiter().GetResult();
+        }
+        catch (Exception exception)
+        {
+            failure = exception;
+            return false;
+        }
+
+        if (Directory.Exists(transactionRoot))
+        {
+            failure = new IOException("temporary directory deletion returned without removing the directory");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static void ObserveFault(Task task)
+    {
+        _ = task.ContinueWith(
+            completed => _ = completed.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     internal static string ClaimPath(string scope)

--- a/tests/IntentSystem.Cli.Tests/ClaimCommandG679Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClaimCommandG679Tests.cs
@@ -163,24 +163,23 @@ public sealed class ClaimCommandG679Tests : IDisposable
     public void PostCommitCleanupFailure_PreservesCommittedResultAndWarnsWithLeftoverPath_G738()
     {
         using var repos = new ClaimRepositories();
+        using var output = new StringWriter();
         using var warnings = new StringWriter();
         var deleteAttempts = 0;
         string? leftoverPath = null;
 
         try
         {
-            var result = ClaimCommand.RunTransaction(
-                repos.FirstClone,
-                new ClaimRequest(
-                    ClaimOperation.Acquire,
-                    "execution-unit:G738",
-                    "alice",
-                    "implementation",
-                    null,
-                    null,
-                    true,
-                    "json",
-                    ClaimCommand.DefaultMaxAttempts),
+            var exitCode = ClaimCommand.ExecuteAcquire(
+                Context(repos.FirstClone),
+                [
+                    "--scope", "execution-unit:G738",
+                    "--actor", "alice",
+                    "--team", "implementation",
+                    "--write",
+                    "--format", "json",
+                ],
+                output,
                 warnings,
                 path =>
                 {
@@ -189,9 +188,11 @@ public sealed class ClaimCommandG679Tests : IDisposable
                     throw new IOException("injected cleanup failure");
                 });
 
-            Assert.Equal("acquired", result.Status);
-            Assert.True(result.PushSucceeded);
-            Assert.NotNull(result.Commit);
+            Assert.Equal(0, exitCode);
+            using var emitted = JsonDocument.Parse(output.ToString());
+            Assert.Equal("acquired", emitted.RootElement.GetProperty("status").GetString());
+            Assert.True(emitted.RootElement.GetProperty("push_succeeded").GetBoolean());
+            Assert.False(string.IsNullOrWhiteSpace(emitted.RootElement.GetProperty("commit").GetString()));
             Assert.Equal(ClaimCommand.CleanupMaxAttempts, deleteAttempts);
             Assert.NotNull(leftoverPath);
             Assert.StartsWith(Path.GetTempPath(), leftoverPath!, StringComparison.OrdinalIgnoreCase);

--- a/tests/IntentSystem.Cli.Tests/ClaimCommandG679Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClaimCommandG679Tests.cs
@@ -160,6 +160,116 @@ public sealed class ClaimCommandG679Tests : IDisposable
     }
 
     [Fact]
+    public void PostCommitCleanupFailure_PreservesCommittedResultAndWarnsWithLeftoverPath_G738()
+    {
+        using var repos = new ClaimRepositories();
+        using var warnings = new StringWriter();
+        var deleteAttempts = 0;
+        string? leftoverPath = null;
+
+        try
+        {
+            var result = ClaimCommand.RunTransaction(
+                repos.FirstClone,
+                new ClaimRequest(
+                    ClaimOperation.Acquire,
+                    "execution-unit:G738",
+                    "alice",
+                    "implementation",
+                    null,
+                    null,
+                    true,
+                    "json",
+                    ClaimCommand.DefaultMaxAttempts),
+                warnings,
+                path =>
+                {
+                    leftoverPath = path;
+                    deleteAttempts++;
+                    throw new IOException("injected cleanup failure");
+                });
+
+            Assert.Equal("acquired", result.Status);
+            Assert.True(result.PushSucceeded);
+            Assert.NotNull(result.Commit);
+            Assert.Equal(ClaimCommand.CleanupMaxAttempts, deleteAttempts);
+            Assert.NotNull(leftoverPath);
+            Assert.StartsWith(Path.GetTempPath(), leftoverPath!, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(leftoverPath, warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("claim result and exit code are unchanged", warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("OS temp root", warnings.ToString(), StringComparison.Ordinal);
+
+            var inspection = repos.CloneForInspection();
+            Assert.True(File.Exists(Path.Combine(
+                inspection, ClaimCommand.ClaimPath("execution-unit:G738"))));
+        }
+        finally
+        {
+            if (leftoverPath is not null && Directory.Exists(leftoverPath))
+            {
+                Directory.Delete(leftoverPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void PreCommitCleanupFailure_RemainsAFailure_G738()
+    {
+        using var repos = new ClaimRepositories();
+        var scope = "execution-unit:G738";
+        var acquired = ClaimCommand.RunTransaction(
+            repos.FirstClone,
+            new ClaimRequest(
+                ClaimOperation.Acquire,
+                scope,
+                "alice",
+                "implementation",
+                null,
+                null,
+                true,
+                "json",
+                ClaimCommand.DefaultMaxAttempts));
+        Assert.Equal("acquired", acquired.Status);
+
+        using var warnings = new StringWriter();
+        var deleteAttempts = 0;
+        string? leftoverPath = null;
+        try
+        {
+            var exception = Assert.Throws<IOException>(() => ClaimCommand.RunTransaction(
+                repos.SecondClone,
+                new ClaimRequest(
+                    ClaimOperation.Acquire,
+                    scope,
+                    "bob",
+                    "review",
+                    null,
+                    null,
+                    true,
+                    "json",
+                    ClaimCommand.DefaultMaxAttempts),
+                warnings,
+                path =>
+                {
+                    leftoverPath = path;
+                    deleteAttempts++;
+                    throw new IOException("injected pre-commit cleanup failure");
+                }));
+
+            Assert.Contains("before the claim state was committed", exception.Message, StringComparison.Ordinal);
+            Assert.Equal(ClaimCommand.CleanupMaxAttempts, deleteAttempts);
+            Assert.Empty(warnings.ToString());
+        }
+        finally
+        {
+            if (leftoverPath is not null && Directory.Exists(leftoverPath))
+            {
+                Directory.Delete(leftoverPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public void FreshInit_ClaimsAreNonUnionAfterBroadJsonlRule_G679()
     {
         using var temp = new TempDirectory("claim-attributes-");


### PR DESCRIPTION
## Summary

- Treat the successful plain push as the claim transaction boundary.
- Bound temporary clone teardown with timed attempts and bounded retry backoff.
- Preserve pre-commit failures, and emit a stderr warning with the leftover OS-temp path after a committed claim.
- Document the contract in English and Japanese.

Closes #1606

## Verification

- Focused deterministic cleanup-failure tests: 2 passed.
- Adjacent claim regression tests: 23 passed.
- Full Release suite: Failed: 0, Passed: 5234, Skipped: 1, Total: 5235.
- Release build: 0 warnings, 0 errors.
- git diff --check: passed.

Warning format verified by the focused test:
warning: claim transaction committed successfully, but best-effort cleanup could not remove temporary directory <actual OS temp path> after 3 bounded attempt(s); the claim result and exit code are unchanged. The leftover path remains under the OS temp root.