### PR TITLE
G740: roll post-release version policy to v0.24.1

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2718,7 +2718,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0240)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0241)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2924,12 +2924,23 @@ rotated by this command; the result and `shrink-audit.jsonl` say so explicitly.
 out of scope. Use `--dry-run` to inspect the measured plan without writing the
 manifest, JSONL files, or audit.
 
-### Next release readiness (v0.24.0)
+### Next release readiness (v0.24.1)
 
-**`v0.23.2` shipped** (GitHub Release, NuGet, binaries, and npm). The
-published release is recorded by the [v0.23.2 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.2).
-That published GitHub Release and its tag are authoritative shipped evidence,
-but the tracked EN and JA `release-notes-v0.23.2.md` files still carry
+**`v0.24.0` shipped** (GitHub Release, NuGet, binaries, and npm). The
+published release is recorded by the [v0.24.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.24.0).
+That published GitHub Release and its tag are authoritative shipped evidence.
+The shipped v0.24.0 real-install identity is
+`intent-cli 0.24.0-df472fe-G737`, measured from source revision
+`df472fe5663c1a8b3682959aab6fbbf93c4d76ef`.
+The v0.24.0 line was measured against the installed 0.23.2 CLI.
+The tracked EN and JA `release-notes-v0.24.0.md` files remain untouched by
+this roll and still carry `PREPARED / NOT PUBLISHED` banners from the preceding
+prepare-only notes. This source-note inconsistency predates this roll;
+correcting shipped v0.24.0 notes is out of scope and must be handled by a later
+explicitly scoped remediation.
+
+The published `v0.23.2` release remains authoritative shipped evidence, but the
+tracked EN and JA `release-notes-v0.23.2.md` files still carry
 `PREPARED / NOT PUBLISHED` banners. This source-note inconsistency predates
 this roll; correcting shipped v0.23.2 notes is out of scope and must be handled
 by a later explicitly scoped remediation. The child source tree has no tracked
@@ -2940,86 +2951,71 @@ are the GitHub Release, NuGet package, and self-contained binaries; its npm leg
 never reached the registry, so `0.23.0` must not be treated as available from
 npm. The tracked EN and JA `release-notes-v0.23.0.md` files now state this
 shipped-artifact status.
-The [v0.24.0 prepare-only notes](release-notes-v0.24.0.md) are the substantive
-next line; the superseded v0.23.3 DRAFT stubs were deleted by this release-prep
-unit rather than left as a competing line.
+The [v0.24.1 DRAFT](release-notes-v0.24.1.md) is the empty placeholder for the
+next line. `0.24.1` is only a placeholder: release-prep will replace the stub
+after measuring the next real release line, and this file is not a changelog.
 
-The post-release roll had left `nextVersion` at `0.23.3` before this line had
-feature content. Release-prep retargets to `0.24.0` because the measured line
-adds the new command surfaces `notify supervise shrink` and
-`session-layer topology record-host-state`, both absent from the installed
-0.23.2 CLI. The six release units and the excluded G730 roll are accounted for
-in the v0.24.0 notes.
+Rolled policy: `stableVersion → 0.24.0`; `nextVersion → 0.24.1`.
 
-Rolled policy: `stableVersion → 0.23.2`; `nextVersion → 0.24.0`.
-
-The next-line package identity is `JTechJapan.IntentSystem.Cli.0.24.0.nupkg`;
+The next-line package identity is `JTechJapan.IntentSystem.Cli.0.24.1.nupkg`;
 this is a derived verification value, not release content.
 
-**Release-readiness verification for the `v0.24.0` line:**
+**Release-readiness verification for the `v0.24.1` line:**
 
-This prepare-only unit changes the version policy, the substantive EN/JA
-v0.24.0 notes, this readiness section, the release-note/version tests, and
-deletes the superseded v0.23.3 stubs. It creates no tag or Release, publishes no
-package, handles no credentials, and performs no post-release roll.
-
-The functional prepared head is outside this release-prep unit. Its exact
-Release identity evidence is source revision
-`a7d10026a9a4dd2693f464a5c5e34ce134b2c661`, which produced
-`intent-cli 0.23.3-a7d1002-G734` before this unit retargeted the policy. The
-eventual v0.24.0 tag belongs after this documentation merge commit lands.
+This post-release roll changes only the version policy, the empty next-line
+stubs, this readiness section in both language mirrors, and the necessary
+release-note/version test pins. It creates no tag or Release, publishes no
+package, handles no credentials, and authors no feature notes for the
+unreleased placeholder line. The next real release number remains a
+release-prep decision by measurement.
 
 On a claims-enabled host, a release-prep operator acquires and verifies the
 current release-prep scope before editing these artifacts. This child PR does
 not execute those host-state commands:
 
 ```bash
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.24.0 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.24.0 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.24.1 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.24.1 --team <team> --format json
 ```
 
 ```bash
-# 1. Confirm the retargeted policy, the real v0.24.0 notes, and deleted stubs.
-cat eng/version.json   # stableVersion 0.23.2 (published), nextVersion 0.24.0 (next line)
-test -f docs/en/release-notes-v0.24.0.md
-test -f docs/ja/release-notes-v0.24.0.md
-test ! -e docs/en/release-notes-v0.23.3.md
-test ! -e docs/ja/release-notes-v0.23.3.md
+# 1. Confirm the rolled policy and both content-free DRAFT stubs.
+cat eng/version.json   # stableVersion 0.24.0 (published), nextVersion 0.24.1 (placeholder)
+test -f docs/en/release-notes-v0.24.1.md
+test -f docs/ja/release-notes-v0.24.1.md
 
-# 2. Record the first-parent inventory and the prepared functional identity.
-git log --first-parent v0.23.2..main
-git rev-list --first-parent --count v0.23.2..main
+# 2. Build and confirm the next-line display version shape.
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-#   prepared functional head: a7d10026a9a4dd2693f464a5c5e34ce134b2c661
-#   identity from that revision: intent-cli 0.23.3-a7d1002-G734
+#   expected shape: intent-cli 0.24.1-<sha>-G<unit>
 
-# 3. Run the installed 0.23.2 CLI read-only and retain checkout freshness evidence.
+# 3. Run the installed G725 detector read-only from a synced checkout.
 intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json
-#   record both the silent verdict and the checkout_freshness/provenance statement.
+#   record the silent version-roll-required verdict, checkout commit, and
+#   checkout_freshness/provenance statement; do not treat stale checkout data as proof.
 
-# 4. Record the shipped-note check honestly: source v0.23.2 notes are unchanged,
-#    but they still have PREPARED / NOT PUBLISHED banners despite the published Release.
-git diff --quiet -- docs/en/release-notes-v0.23.2.md docs/ja/release-notes-v0.23.2.md
-grep -n "PREPARED / NOT PUBLISHED" docs/en/release-notes-v0.23.2.md
-grep -n "PREPARED / NOT PUBLISHED" docs/ja/release-notes-v0.23.2.md
-gh release view v0.23.2 --repo J-Tech-Japan/intent-system
+# 4. Record the shipped-note check honestly: source v0.24.0 notes are unchanged,
+#    but they retain their PREPARED / NOT PUBLISHED banners.
+git diff --quiet -- docs/en/release-notes-v0.24.0.md docs/ja/release-notes-v0.24.0.md
+grep -n "PREPARED / NOT PUBLISHED" docs/en/release-notes-v0.24.0.md
+grep -n "PREPARED / NOT PUBLISHED" docs/ja/release-notes-v0.24.0.md
+gh release view v0.24.0 --repo J-Tech-Japan/intent-system
 
-# 5. Run targeted release-prep guards and the full Release suite.
+# 5. Run the focused documentation/version guards, diff check, and full Release suite.
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release \
   --filter "FullyQualifiedName~ReleaseNotesV0240DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~VersionSourcePolicyGuardTests|FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~ReleaseNotesV0232DocsTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests"
 git diff --check
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release
 ```
 
-The targeted and full Release test counts are pasted into the v0.24.0 notes
-after the final documentation edit. This prepare-only unit follows **steps
-5–7** of the [post-release version roll](#post-release-version-roll-g554--required-immediate):
-the **DRAFT note stubs in the same commit** (step 5), the **"Next release
-readiness" section refreshed to the new line in both language mirrors** (step
-6), and the **post-roll green child-main CI check** before the roll counts as
-complete (step 7). Existing release tags, Releases, packages, workflows, and
-the post-release roll are not changed.
+The targeted and full Release test counts are reported with the final PR head.
+This post-release roll follows **steps 5–7** of the [post-release version
+roll](#post-release-version-roll-g554--required-immediate): the **DRAFT note
+stubs in the same commit** (step 5), the **"Next release readiness" section
+refreshed to the new line in both language mirrors** (step 6), and the
+**post-roll green child-main CI check** before the roll counts as complete (step
+7). Existing release tags, Releases, packages, workflows, and shipped note
+files are not changed.
 
 ### Re-creating a deleted release tag (`v0.3.3`)
 

--- a/docs/en/release-notes-v0.24.1.md
+++ b/docs/en/release-notes-v0.24.1.md
@@ -1,0 +1,15 @@
+# Release Notes — intent-cli v0.24.1
+
+> **⚠️ DRAFT / UNRELEASED.** This is the mandatory post-release placeholder
+> after v0.24.0. The release-prep packet authors the real content; release-prep
+> will replace this stub with the measured release notes. This must not be
+> treated as a changelog.
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.24.1`.
+No GitHub Release exists yet for v0.24.1. This placeholder does not publish or
+choose the next real release number.
+
+## Release-readiness gate
+
+release-prep will replace this stub after measuring the next real release line.
+It contains no release content and must not be treated as a changelog.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2970,91 +2970,90 @@ result は literal bytes の削減、追加した reference bytes、record の n
 `shrink-audit.jsonl` に明記します。`.intent-cli/runs/*.provider.jsonl` は別の provider-run state なので
 scope 外です。`--dry-run` なら manifest、JSONL、audit を書き込まずに測定済み plan だけを確認できます。
 
-### 次リリース準備(v0.24.0)
+### 次リリース準備(v0.24.1)
 
-**`v0.23.2` は出荷済み**(GitHub Release、NuGet、binary、npm)です。公開済みの
-release は [v0.23.2 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.2)
+**`v0.24.0` は出荷済み**(GitHub Release、NuGet、binary、npm)です。公開済みの
+release は [v0.24.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.24.0)
 に記録されています。この published GitHub Release とその tag が shipped evidence の
-authoritative source ですが、tracked な EN/JA の `release-notes-v0.23.2.md` にはまだ
-`PREPARED / NOT PUBLISHED` banner が残っています。この source-note inconsistency はこの roll
-より前から存在し、出荷済み v0.23.2 note の修正は scope 外です。後続の明示的な remediation で
-扱います。child source tree には tracked な `release-notes-v0.23.1.md` がなく、この roll で
-出荷済み note を再作成・編集しません。
+authoritative source です。v0.24.0 の shipped real-install identity は
+`intent-cli 0.24.0-df472fe-G737` で、source revision
+`df472fe5663c1a8b3682959aab6fbbf93c4d76ef` から測定しました。
+この v0.24.0 line は installed 0.23.2 CLI と比較して測定しました。
+tracked な EN/JA の `release-notes-v0.24.0.md` はこの roll で変更せず、前回の
+prepare-only notes に由来する `PREPARED / NOT PUBLISHED` banner を保持します。この
+source-note inconsistency はこの roll より前から存在し、出荷済み v0.24.0 note の修正は
+scope 外です。後続の明示的な remediation で扱います。
+
+公開済みの `v0.23.2` release も authoritative shipped evidence ですが、tracked な EN/JA の
+`release-notes-v0.23.2.md` にはまだ `PREPARED / NOT PUBLISHED` banner が残っています。
+この source-note inconsistency はこの roll より前から存在し、出荷済み v0.23.2 note の修正は
+scope 外です。後続の明示的な remediation で扱います。child source tree には tracked な
+`release-notes-v0.23.1.md` がなく、この roll で出荷済み note を再作成・編集しません。
 公開済みの [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0)
 とその tag は authoritative shipped evidence です。v0.23.0 の shipped artifact は GitHub Release、
 NuGet package、自己完結型バイナリです。ただし npm leg は registry に到達しなかったため、
 `0.23.0` は npm で利用できると扱ってはいけません。tracked な EN/JA の
 `release-notes-v0.23.0.md` files はこの shipped-artifact status を記録します。
-[v0.24.0 prepare-only notes](release-notes-v0.24.0.md) が実質的な次の line です。不要になった
-v0.23.3 DRAFT stub は、競合する line を残さないため、この release-prep unit で削除しました。
+[v0.24.1 DRAFT](release-notes-v0.24.1.md) が次の line の空の placeholder です。
+`0.24.1` は placeholder にすぎません。release-prep will replace the stub after
+next real release line の測定が完了し、この file は changelog ではありません。
 
-post-release roll は feature content が入る前に `nextVersion` を `0.23.3` placeholder として記録しました。
-Release-prep は、測定した line に `notify supervise shrink` と
-`session-layer topology record-host-state` が追加され、installed 0.23.2 CLI には無いため、`0.24.0` に retarget します。
-六つの release unit と除外した G730 roll は v0.24.0 notes で account します。
+Rolled policy: `stableVersion → 0.24.0`; `nextVersion → 0.24.1`。
 
-Rolled policy: `stableVersion → 0.23.2`; `nextVersion → 0.24.0`。
-
-次の line の package identity は `JTechJapan.IntentSystem.Cli.0.24.0.nupkg` です。
+次の line の package identity は `JTechJapan.IntentSystem.Cli.0.24.1.nupkg` です。
 これは導出された verification value であり、release content ではありません。
 
-**`v0.24.0` のリリース準備検証:**
+**`v0.24.1` のリリース準備検証:**
 
-この prepare-only unit が変更するのは version policy、実質的な EN/JA v0.24.0 notes、この readiness section、
-release-note/version tests、そして superseded v0.23.3 stub の削除です。tag または Release を作成せず、package を publish せず、
-credentials を扱わず、post-release roll を実行しません。
-
-Functional prepared head はこの release-prep unit の外側です。正確な Release identity evidence の source revision は
-`a7d10026a9a4dd2693f464a5c5e34ce134b2c661`、そこから生成された display identity は
-`intent-cli 0.23.3-a7d1002-G734` です。この unit が policy を retarget する前の測定値であり、eventual v0.24.0 tag はこの documentation merge commit の後です。
+この post-release roll が変更するのは version policy、次の line の空の stub、両言語 mirror の readiness section、
+そして必要な release-note/version test pin だけです。tag または Release を作成せず、package を publish せず、
+credentials を扱わず、未リリースの placeholder line の feature notes を author しません。次の real release number は
+measurement に基づく release-prep の decision のままです。
 
 claims-enabled host では、release-prep operator がこれらの artifact を編集する前に current release-prep scope を acquire / verify します。
 この child PR は host-state command を実行しません:
 
 ```bash
-intent-cli claim acquire --scope release-prep:<owner/repo>:0.24.0 --actor <actor> --team <team> --write --format json
-intent-cli claim verify --scope release-prep:<owner/repo>:0.24.0 --team <team> --format json
+intent-cli claim acquire --scope release-prep:<owner/repo>:0.24.1 --actor <actor> --team <team> --write --format json
+intent-cli claim verify --scope release-prep:<owner/repo>:0.24.1 --team <team> --format json
 ```
 
 ```bash
-# 1. retarget 済み policy、実在する v0.24.0 notes、削除した stub を確認。
-cat eng/version.json   # stableVersion 0.23.2 (published), nextVersion 0.24.0 (next line)
-test -f docs/en/release-notes-v0.24.0.md
-test -f docs/ja/release-notes-v0.24.0.md
-test ! -e docs/en/release-notes-v0.23.3.md
-test ! -e docs/ja/release-notes-v0.23.3.md
+# 1. roll 済み policy と、内容のない両言語 DRAFT stub を確認。
+cat eng/version.json   # stableVersion 0.24.0 (published), nextVersion 0.24.1 (placeholder)
+test -f docs/en/release-notes-v0.24.1.md
+test -f docs/ja/release-notes-v0.24.1.md
 
-# 2. first-parent inventory と prepared functional identity を記録。
-git log --first-parent v0.23.2..main
-git rev-list --first-parent --count v0.23.2..main
+# 2. 次の line の表示バージョン形式を build して確認。
 dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release
 dotnet src/IntentSystem.Cli/bin/Release/net10.0/IntentSystem.Cli.dll --version
-#   prepared functional head: a7d10026a9a4dd2693f464a5c5e34ce134b2c661
-#   identity from that revision: intent-cli 0.23.3-a7d1002-G734
+#   期待する形: intent-cli 0.24.1-<sha>-G<unit>
 
-# 3. installed 0.23.2 CLI を read-only で実行して freshness evidence を残す。
+# 3. 同期済み checkout から installed G725 detector を read-only で実行。
 intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json
-#   silent verdict と checkout_freshness/provenance statement の両方を記録。
+#   version-roll-required が silent であること、checkout commit、
+#   checkout_freshness/provenance statement を記録する。stale な checkout を evidence として扱わない。
 
-# 4. shipped-note check を正直に記録: source v0.23.2 note は未変更だが、公開済み
-#    Release にもかかわらず PREPARED / NOT PUBLISHED banner が残る。
-git diff --quiet -- docs/en/release-notes-v0.23.2.md docs/ja/release-notes-v0.23.2.md
-grep -n "PREPARED / NOT PUBLISHED" docs/en/release-notes-v0.23.2.md
-grep -n "PREPARED / NOT PUBLISHED" docs/ja/release-notes-v0.23.2.md
-gh release view v0.23.2 --repo J-Tech-Japan/intent-system
+# 4. shipped-note check を正直に記録: source v0.24.0 note は未変更だが、
+#    PREPARED / NOT PUBLISHED banner を保持する。
+git diff --quiet -- docs/en/release-notes-v0.24.0.md docs/ja/release-notes-v0.24.0.md
+grep -n "PREPARED / NOT PUBLISHED" docs/en/release-notes-v0.24.0.md
+grep -n "PREPARED / NOT PUBLISHED" docs/ja/release-notes-v0.24.0.md
+gh release view v0.24.0 --repo J-Tech-Japan/intent-system
 
-# 5. targeted release-prep guard と full Release suite を実行。
+# 5. focused な documentation/version guard、diff check、full Release suite を実行。
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release \
   --filter "FullyQualifiedName~ReleaseNotesV0240DocsTests|FullyQualifiedName~ReleasePackageMetadataTests|FullyQualifiedName~VersionSourcePolicyGuardTests|FullyQualifiedName~ReleaseNotesV0220DocsTests|FullyQualifiedName~ReleaseNotesV0230DocsTests|FullyQualifiedName~ReleaseNotesV0232DocsTests|FullyQualifiedName~ReleaseNotesV0210DocsTests|FullyQualifiedName~ReleaseNotesV0190DocsTests|FullyQualifiedName~ReleaseNotesV0180DocsTests|FullyQualifiedName~ReleaseNotesV0170DocsTests|FullyQualifiedName~ReleaseNotesV061DocsTests"
 git diff --check
 dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release
 ```
 
-Targeted と full Release の test count は、final documentation edit 後の v0.24.0 notes に貼り付けます。
-この prepare-only unit は [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
+Targeted と full Release の test count は final PR head と一緒に report します。
+この post-release roll は [リリース後の version roll](#リリース後の-version-rollg554--必須即時) の
 **ステップ 5–7** に従います。**同一コミットに DRAFT note スタブ**(ステップ 5)、
 **「次リリース準備」section を ja/en 両ミラーで新しいラインへ更新**(ステップ 6)、
-そして **roll 後の child main CI green 確認**(ステップ 7)が完了条件です。既存の release tag、Release、package、workflow、post-release roll は変更しません。
+そして **roll 後の child main CI green 確認**(ステップ 7)が完了条件です。既存の release tag、Release、package、workflow、
+shipped note file は変更しません。
 
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 

--- a/docs/ja/release-notes-v0.24.1.md
+++ b/docs/ja/release-notes-v0.24.1.md
@@ -1,0 +1,15 @@
+# リリースノート — intent-cli v0.24.1
+
+> **⚠️ DRAFT / 未リリース。** これは v0.24.0 後の mandatory post-release
+> placeholder です。release-prep パケットが author します。release-prep will
+> replace this stub with the measured release notes。この file は changelog として
+> 扱ってはいけません。
+
+Install verification: `JTechJapan.IntentSystem.Cli --version 0.24.1`。
+No GitHub Release exists yet for v0.24.1。v0.24.1 の GitHub Release はまだ存在しません。この placeholder は publish を行わず、
+次の real release number を選択しません。
+
+## リリース準備ゲート
+
+release-prep will replace this stub after measuring the next real release line。
+この file には release content がなく、changelog として扱ってはいけません。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.23.2",
-  "nextVersion": "0.24.0"
+  "stableVersion": "0.24.0",
+  "nextVersion": "0.24.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
@@ -165,21 +165,24 @@ public sealed class ReleaseNotesV0240DocsTests
     }
 
     [Fact]
-    public void VersionPolicyAndReadinessPointAtThePreparedV0240Line()
+    public void ShippedV0240NotesAndReadinessPointAtTheRolledV0241Line()
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.23.2", policy.StableVersion);
-        Assert.Equal("0.24.0", policy.NextVersion);
+        Assert.Equal("0.24.0", policy.StableVersion);
+        Assert.Equal("0.24.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.24.0.md")));
-            Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.23.3.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.24.1.md")));
 
             var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
             Assert.Contains("0.24.0", reference, StringComparison.Ordinal);
             Assert.Contains("release-notes-v0.24.0.md", reference, StringComparison.Ordinal);
+            Assert.Contains("0.24.1", reference, StringComparison.Ordinal);
+            Assert.Contains("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
+            Assert.Contains("intent-cli 0.24.0-df472fe-G737", reference, StringComparison.Ordinal);
             Assert.Contains("ReleasePackageMetadataTests", reference, StringComparison.Ordinal);
             Assert.Contains("VersionSourcePolicyGuardTests", reference, StringComparison.Ordinal);
         }


### PR DESCRIPTION
Closes #1608

## Summary

- Rolled eng/version.json to stableVersion 0.24.0 and nextVersion 0.24.1.
- Added bilingual v0.24.1 DRAFT placeholder notes; release-prep will replace them, and they are not changelogs.
- Refreshed both developer-reference readiness mirrors with shipped v0.24.0 evidence, including intent-cli 0.24.0-df472fe-G737.
- Left shipped v0.24.0 release-note files untouched.

## Verification

- Focused release/documentation tests: Failed: 0, Passed: 164, Skipped: 0, Total: 164.
- Full Release suite: Failed: 0, Passed: 5240, Skipped: 1, Total: 5241.
- git diff --check: passed.
- Shipped v0.24.0 note hashes: EN ed6ec29dbf279477722fac2a4eece268cc7e5b10; JA 96b00d9d1b9f17056cf265d843e8129c463a32ac.
- G725 detector run from the child checkout produced no version-roll-required item while synced at checkout HEAD f0ea90fd3df65de3f1b95bd38f6f8c79b011d171; unrelated pre-existing stale-claim findings remained.
- The post-push PR head is 356c1e410ec0bcce3c5be40e70d28841fe7fed4. Canonical host-side synced-checkout proof is requested separately because the child seat must not enter host state.