### PR TITLE
G741: detect delivered delegations with no observable start

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -529,6 +529,28 @@ recovery for that finding. A declared bound below the configured interval is a
 structural false-alarm warning, emitted at supervise start and on each cycle,
 not a value the CLI silently corrects.
 
+### Delivered delegation with no observable start (G741)
+
+`notify supervise` emits `delegation-delivered-never-executed` only when a
+delegation's durable delivery evidence says `delivery_succeeded=true`, the
+recipient is still running but `agent_status=idle` on a later observation, and
+the configured `--delegation-execution-window-seconds` (default `300s`) has
+elapsed. The full conjunction also requires the canonical report for the task
+to be absent, every expected artifact source to be absent, and the durable
+target-entity transition source to be absent. A working/started seat, visible
+artifact, report, or target transition is a non-finding.
+
+The finding names `task_id`, seat, `delivered_at`, the window, and every
+checked source. It wakes the delegation's owner role through the recorded
+transport, but is observation-only: it sends no keys, answers no dialogs, does
+not prompt the recipient or mutate a seat, restart anything, or redispatch
+work.
+
+This is an observable-start proxy, not an inference about opaque in-seat thought.
+The child can only check recorded local artifact/event and continuation sources;
+unreadable evidence fails closed. Hosts that never emit this kind retain the
+existing supervision state and emission-policy JSON shape.
+
 **Report outbox (G653 — preview-through-1.x).** `notify report --write`
 persists the sender-side outbox entry before it attempts transport. The entry
 keeps the task id, result nonce, status, artifact, summary, and delivery

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -468,8 +468,29 @@ message を黙らせず、2 つの outcome を operator が整合できるよう
 
 **活動証拠 (G652 — 1.x を通じた preview)。** 実行中 process は作業の証拠ではありません。herdr では status が `agent_status`、`state_change_seq`、最後の状態変更時刻も示します。`working` には working agent と進行する活動が必要です。sequence baseline がまだない場合、status は `live-idle` を断定せず `activity-unknown` を返します。dispatch 後の状態変更時刻は cold-start の `working` の十分な証拠です。supervision は最初の baseline を live-idle finding なしで記録し、その後に変化しない live-idle recipient に report がなければ一度だけ表示して terminal の確認を remedy として示します。この finding のために terminal content を読んだり recovery に入ったりしません。declared bound が configured interval より小さい場合は、supervise start と各 cycle で structural false alarm warning を出し、CLI が黙って補正する値ではありません。
 
-**report outbox (G653 — 1.x を通じた preview)。** `notify report --write` は transport を試す前に sender-side outbox entry を保存します。entry は task id、result nonce、status、artifact、summary、delivery timestamp を保持し、delivery failure は完了した作業を失わず `undelivered` として残ります。supervision は entry と `notify collect` の remedy を表示するだけで自動送信しません。recipient-side terminal の `ORCH_RESULT` は人間向けの record のままで、intent-cli は terminal を `parse` しません。visible result に arrived report がないときは、recipient を `re-delegate` したり task を `redo` したりせず persisted outbox entry を `collect` します。collection は同じ task id の original report だけを一度送信し、already-delivered entry は拒否します。entry は dispatch generation（result nonce）単位なので、再委譲された task id も新しい report を運べ、unmatched report も message として継続します。undelivered の current generation に対する二回目の report は fail-closed で拒否し、正確な `notify collect` recovery command を示します。
+### delivery 済みだが observable start がない委譲 (G741)
 
+`notify supervise` は、永続的な delivery evidence が
+`delivery_succeeded=true`、recipient が後続 observation でも
+`agent_status=idle`、かつ `--delegation-execution-window-seconds`（default
+`300s`）経過である場合にだけ
+`delegation-delivered-never-executed` を出します。さらに full conjunction として、
+task の canonical report が absent、全 expected artifact source が absent、
+永続的な target-entity transition source が absent でなければなりません。
+seat が working/started、artifact・report・target transition が見える場合は
+non-finding です。
+
+finding には `task_id`、seat、`delivered_at`、使用した window、確認した
+全 source を記録し、delegation の owner role に recorded transport で通知します。
+ただし observation-only であり、key を送らず、dialog に答えず、recipient への再促し・
+再起動、seat の変更、work の再配分を行いません。
+
+これは observable start の proxy であり、seat 内部の opaque な thought を推測するものではありません。
+child が確認できるのは recorded local artifact/event と continuation sources だけで、
+unreadable evidence は fail closed です。この kind を出力しない host は既存の
+supervision state と emission-policy JSON shape を保持します。
+
+**report outbox (G653 — 1.x を通じた preview)。** `notify report --write` は transport を試す前に sender-side outbox entry を保存します。entry は task id、result nonce、status、artifact、summary、delivery timestamp を保持し、delivery failure は完了した作業を失わず `undelivered` として残ります。supervision は entry と `notify collect` の remedy を表示するだけで自動送信しません。recipient-side terminal の `ORCH_RESULT` は人間向けの record のままで、intent-cli は terminal を `parse` しません。visible result に arrived report がないときは、recipient を `re-delegate` したり task を `redo` したりせず persisted outbox entry を `collect` します。collection は同じ task id の original report だけを一度送信し、already-delivered entry は拒否します。entry は dispatch generation（result nonce）単位なので、再委譲された task id も新しい report を運べ、unmatched report も message として継続します。undelivered の current generation に対する二回目の report は fail-closed で拒否し、正確な `notify collect` recovery command を示します。
 新しい委譲を開始する前に、`notify delegate --write` は undelivered report entry がある task を拒否し、supervision finding と同じ `notify collect` command を示します。これにより finding の対象と collect できる entry は一致します。また、report が settled になった task id/result nonce の組も作業開始前に拒否し、fresh `--result-nonce` または新しい task id を要求します。outbox がない open generation は idempotent に再送できます。
 
 **sender-local report routing と executability/actionability 診断 (G719/G731 — preview-through-1.x)。** implementation seat には checkout/worktree 用の境界付き `--add-dir <role-work-root>` を 1 つだけ与え、`--add-dir <host-routing-root>` や MyIntentHost への write access は与えません。canonical report は `--routing-root <host-routing-root> --report-root .` を持ち、host root は read/transport の基準経路、role root は sender-local outbox の write root です。host routing root を実際には書けない seat でも local outbox を保存し、`report_storage_mode: sender-local-role-work-root` と `host_state_sync: deferred-to-orchestration` を示して、orchestration が `intent-cli notify reconcile --domain <d> --team <t> --task-id <id> --routing-root <host> --report-root <role-work-root> --write --format json` で host の pending/continuation state を整合します。host write の retry、hand-write transport、seat boundary の拡大はしません。

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -66,6 +66,7 @@ internal static class NotifyCommand
         "Usage: intent-cli notify supervise --domain <d> --team <t> [--interval <seconds>] "
         + "[--repo <owner/repo>] [--owner-role <role>] [--bound <seconds>] "
         + "[--repeat-backoff-seconds <seconds>] [--debounce-consecutive-observations <count>] "
+        + "[--delegation-execution-window-seconds <seconds>; default 300] "
         + "[--stale-minutes <m>] [--claimed-silent-minutes <m>] [--backlog-idle-minutes <m>] "
         + "[--repair-silent-minutes <m>] [--auto-redispatch] [--event-mode] [--once] [--routing-root <host-root>] [--dry-run|--write] "
         + "[--herdr-executable <absolute-path>] [--bash-executable <absolute-path>] "
@@ -1097,7 +1098,8 @@ internal static class NotifyCommand
             options.BashExecutable ?? BashExecutableFactory?.Invoke() ?? NotifyTransportPaths.ResolveBashExecutable(),
             scopedPolicies: options.ScopedPolicies,
             repeatBackoffSeconds: options.RepeatBackoffSeconds,
-            debounceConsecutiveObservations: options.DebounceConsecutiveObservations);
+            debounceConsecutiveObservations: options.DebounceConsecutiveObservations,
+            delegationExecutionWindowSeconds: options.DelegationExecutionWindowSeconds);
         using var cancellation = new CancellationTokenSource();
         ConsoleCancelEventHandler? cancelHandler = null;
         if (!Console.IsOutputRedirected)
@@ -1564,6 +1566,25 @@ internal static class NotifyCommand
                 summary: "The canonical external-reader event append completed exactly once; pane transition observation does not apply.");
         }
 
+        string? deliveryEvidenceAdvisory = null;
+        if (pendingRecord is not null
+            && options.Write
+            && delivery.Resolved
+            && (delivery.Delivered || eventAppended))
+        {
+            var deliveredAt = (UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+            var deliveryWrite = NotifyDelegationDeliveryStore.Write(
+                options.RoutingRoot!,
+                pendingRecord,
+                deliveredAt);
+            if (!deliveryWrite.Written)
+            {
+                deliveryEvidenceAdvisory =
+                    $"Delivery succeeded for task '{pendingRecord.TaskId}', but durable delivery evidence could not be recorded: "
+                    + $"{deliveryWrite.Error} Supervision will fail closed for the delivered-but-never-executed finding.";
+            }
+        }
+        reportAdvisory = CombineAdvisories(reportAdvisory, deliveryEvidenceAdvisory);
         if (isReport
             && options.Write
             && reportPendingRecord is not null
@@ -2390,6 +2411,7 @@ internal static class NotifyCommand
         int? detectionBoundSeconds = null;
         int? repeatBackoffSeconds = null;
         int? debounceConsecutiveObservations = null;
+        int? delegationExecutionWindowSeconds = null;
         int? staleMinutes = null;
         int? claimedSilentMinutes = null;
         int? backlogIdleMinutes = null;
@@ -2453,6 +2475,15 @@ internal static class NotifyCommand
                         return false;
                     }
                     detectionBoundSeconds = parsedBound;
+                    break;
+                case "--delegation-execution-window-seconds":
+                    if (!ReadValue(args, ref index, argument, out var delegationWindowValue, out error)
+                        || !int.TryParse(delegationWindowValue, out var parsedDelegationWindow))
+                    {
+                        error = $"{argument} requires a whole-number seconds value.";
+                        return false;
+                    }
+                    delegationExecutionWindowSeconds = parsedDelegationWindow;
                     break;
                 case "--repeat-backoff-seconds":
                 case "--backoff-seconds":
@@ -2621,6 +2652,7 @@ internal static class NotifyCommand
             BashExecutable = bashExecutable,
             IntervalSeconds = intervalSeconds,
             DetectionBoundSeconds = detectionBoundSeconds,
+            DelegationExecutionWindowSeconds = delegationExecutionWindowSeconds,
             RepeatBackoffSeconds = repeatBackoffSeconds,
             DebounceConsecutiveObservations = debounceConsecutiveObservations,
             StaleMinutes = staleMinutes,
@@ -2732,6 +2764,14 @@ internal static class NotifyCommand
                 && (options.DetectionBoundSeconds < 1 || options.DetectionBoundSeconds > 86_400))
             {
                 error = "supervise --bound must be between 1 and 86400 seconds.";
+                return false;
+            }
+
+            if (options.DelegationExecutionWindowSeconds is not null
+                && (options.DelegationExecutionWindowSeconds < 1
+                    || options.DelegationExecutionWindowSeconds > NotifyMeasuredSupervisor.MaximumDelegationExecutionWindowSeconds))
+            {
+                error = $"supervise --delegation-execution-window-seconds must be between 1 and {NotifyMeasuredSupervisor.MaximumDelegationExecutionWindowSeconds} seconds.";
                 return false;
             }
 
@@ -2967,6 +3007,7 @@ internal sealed record NotifyOptions
     public string? BashExecutable { get; init; }
     public int? IntervalSeconds { get; init; }
     public int? DetectionBoundSeconds { get; init; }
+    public int? DelegationExecutionWindowSeconds { get; init; }
     public int? RepeatBackoffSeconds { get; init; }
     public int? DebounceConsecutiveObservations { get; init; }
     public int? StaleMinutes { get; init; }

--- a/src/IntentSystem.Cli/Commands/NotifyDelegationDeliveryStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyDelegationDeliveryStore.cs
@@ -1,0 +1,199 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+internal sealed record NotifyDelegationDeliveryEvidence
+{
+    [JsonPropertyName("event")] public required string Event { get; init; }
+    [JsonPropertyName("domain")] public required string Domain { get; init; }
+    [JsonPropertyName("team")] public required string Team { get; init; }
+    [JsonPropertyName("task_id")] public required string TaskId { get; init; }
+    [JsonPropertyName("result_nonce")] public string? ResultNonce { get; init; }
+    [JsonPropertyName("delivery_succeeded")] public required bool DeliverySucceeded { get; init; }
+    [JsonPropertyName("delivered_at")] public required DateTimeOffset DeliveredAt { get; init; }
+}
+
+internal sealed record NotifyDelegationDeliveryLookup
+{
+    public required bool Resolved { get; init; }
+    public required string Path { get; init; }
+    public NotifyDelegationDeliveryEvidence? Evidence { get; init; }
+    public string? Error { get; init; }
+}
+
+internal sealed record NotifyDelegationDeliveryWriteResult(
+    bool Written,
+    string Path,
+    string? Error);
+
+internal static class NotifyDelegationDeliveryStore
+{
+    private const string RelativeDirectory = ".intent-cli/notify";
+    private const string FileName = "delivery.jsonl";
+    private const string DeliveryEvent = "delivery";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static readonly object Sync = new();
+
+    public static string ResolvePath(string routingRoot, string domain, string team) => Path.GetFullPath(Path.Combine(
+        routingRoot,
+        RelativeDirectory,
+        ValidateSegment(domain, "domain"),
+        ValidateSegment(team, "team"),
+        FileName));
+
+    public static NotifyDelegationDeliveryWriteResult Write(
+        string routingRoot,
+        NotifyPendingDelegation record,
+        DateTimeOffset deliveredAt)
+    {
+        string path;
+        try
+        {
+            path = ResolvePath(routingRoot, record.Domain, record.Team);
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            return new NotifyDelegationDeliveryWriteResult(
+                false,
+                Path.Combine(routingRoot, RelativeDirectory, record.Domain, record.Team, FileName),
+                exception.Message);
+        }
+
+        lock (Sync)
+        {
+            var current = ReadCurrent(path, out var readError);
+            if (readError is not null)
+            {
+                return new NotifyDelegationDeliveryWriteResult(false, path, readError);
+            }
+
+            if (current.ContainsKey(Key(record.TaskId, record.ResultNonce)))
+            {
+                return new NotifyDelegationDeliveryWriteResult(true, path, null);
+            }
+
+            var evidence = new NotifyDelegationDeliveryEvidence
+            {
+                Event = DeliveryEvent,
+                Domain = record.Domain,
+                Team = record.Team,
+                TaskId = record.TaskId,
+                ResultNonce = record.ResultNonce,
+                DeliverySucceeded = true,
+                DeliveredAt = deliveredAt.ToUniversalTime(),
+            };
+            var line = JsonSerializer.Serialize(evidence, JsonOptions);
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                using var stream = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+                using var writer = new StreamWriter(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+                writer.WriteLine(line);
+                return new NotifyDelegationDeliveryWriteResult(true, path, null);
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+            {
+                return new NotifyDelegationDeliveryWriteResult(false, path, exception.Message);
+            }
+        }
+    }
+
+    public static NotifyDelegationDeliveryLookup Find(
+        string routingRoot,
+        string domain,
+        string team,
+        string taskId,
+        string? resultNonce)
+    {
+        string path;
+        try
+        {
+            path = ResolvePath(routingRoot, domain, team);
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            return new NotifyDelegationDeliveryLookup
+            {
+                Resolved = false,
+                Path = Path.Combine(routingRoot, RelativeDirectory, domain, team, FileName),
+                Error = exception.Message,
+            };
+        }
+
+        var current = ReadCurrent(path, out var error);
+        return new NotifyDelegationDeliveryLookup
+        {
+            Resolved = error is null,
+            Path = path,
+            Evidence = error is null ? current.GetValueOrDefault(Key(taskId, resultNonce)) : null,
+            Error = error,
+        };
+    }
+
+    private static Dictionary<string, NotifyDelegationDeliveryEvidence> ReadCurrent(
+        string path,
+        out string? error)
+    {
+        error = null;
+        var current = new Dictionary<string, NotifyDelegationDeliveryEvidence>(StringComparer.Ordinal);
+        if (!File.Exists(path))
+        {
+            return current;
+        }
+
+        try
+        {
+            foreach (var line in File.ReadLines(path))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                {
+                    continue;
+                }
+
+                var evidence = JsonSerializer.Deserialize<NotifyDelegationDeliveryEvidence>(line, JsonOptions)
+                    ?? throw new InvalidDataException("delivery evidence line was empty.");
+                if (!string.Equals(evidence.Event, DeliveryEvent, StringComparison.Ordinal)
+                    || string.IsNullOrWhiteSpace(evidence.Domain)
+                    || string.IsNullOrWhiteSpace(evidence.Team)
+                    || string.IsNullOrWhiteSpace(evidence.TaskId)
+                    || !evidence.DeliverySucceeded
+                    || evidence.DeliveredAt == default)
+                {
+                    throw new InvalidDataException("delivery evidence line has an unsupported event shape.");
+                }
+
+                current[Key(evidence.TaskId, evidence.ResultNonce)] = evidence;
+            }
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException or InvalidDataException)
+        {
+            error = "Delegation delivery evidence store '" + path + "' could not be read: " + exception.Message;
+        }
+
+        return current;
+    }
+
+    private static string Key(string taskId, string? resultNonce) =>
+        taskId + "|" + (resultNonce ?? string.Empty);
+
+    private static string ValidateSegment(string value, string name)
+    {
+        if (string.IsNullOrWhiteSpace(value)
+            || value is "." or ".."
+            || value.Contains('/')
+            || value.Contains('\\')
+            || value.Contains("..", StringComparison.Ordinal))
+        {
+            throw new ArgumentException(name + " must be a safe path segment.", name);
+        }
+
+        return value;
+    }
+}

--- a/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyDelegationExecutionEvidence.cs
@@ -1,0 +1,217 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// Read-only evidence used by G741 to distinguish a delivered delegation
+/// without an observable start from a delegation whose work has become
+/// visible. Unknown or unreadable evidence is deliberately not a finding.
+/// </summary>
+internal sealed record NotifyDelegationExecutionEvidence
+{
+    public bool? ExpectedArtifactPresent { get; init; }
+    public bool? TargetEntityTransitionPresent { get; init; }
+    public required string ArtifactSource { get; init; }
+    public required string TargetEntitySource { get; init; }
+    public IReadOnlyList<string> ArtifactDetails { get; init; } = [];
+    public IReadOnlyList<string> TargetEntityDetails { get; init; } = [];
+    public string? Error { get; init; }
+
+    internal bool IsResolved => Error is null
+        && ExpectedArtifactPresent is not null
+        && TargetEntityTransitionPresent is not null;
+
+    internal static NotifyDelegationExecutionEvidence Resolve(
+        string routingRoot,
+        NotifyPendingDelegation record,
+        DateTimeOffset deliveredAt)
+    {
+        var artifactDetails = new List<string>();
+        var artifactSources = new List<string>();
+        string? error = null;
+        var artifactPresent = false;
+
+        IReadOnlyList<string> expectedArtifacts = record.ExpectedArtifacts is { Count: > 0 } artifacts
+            ? artifacts
+            : [record.ExpectedArtifact];
+        foreach (var expectedArtifact in expectedArtifacts)
+        {
+            if (TryResolveArtifactPath(expectedArtifact, record.Cwd, out var artifactPath))
+            {
+                artifactSources.Add(artifactPath);
+                try
+                {
+                    if (File.Exists(artifactPath) || Directory.Exists(artifactPath))
+                    {
+                        artifactPresent = true;
+                        artifactDetails.Add($"path:{artifactPath}");
+                    }
+                }
+                catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+                {
+                    error = $"expected artifact source '{artifactPath}' could not be checked: {exception.Message}";
+                    break;
+                }
+            }
+            else
+            {
+                artifactSources.Add($"non-filesystem:{expectedArtifact}");
+            }
+        }
+
+        var eventSource = ResolveEventSource(routingRoot, record, out var eventPath, out var eventResolutionError);
+        artifactSources.Add(eventSource);
+        if (error is null && !string.IsNullOrWhiteSpace(eventResolutionError))
+        {
+            error = eventResolutionError;
+        }
+
+        if (error is null && eventPath is not null && File.Exists(eventPath))
+        {
+            try
+            {
+                foreach (var line in File.ReadLines(eventPath))
+                {
+                    if (string.IsNullOrWhiteSpace(line))
+                    {
+                        continue;
+                    }
+
+                    using var document = JsonDocument.Parse(line);
+                    var root = document.RootElement;
+                    if (!root.TryGetProperty("unit", out var unit)
+                        || !string.Equals(unit.GetString(), record.TaskId, StringComparison.Ordinal)
+                        || !root.TryGetProperty("timestamp", out var timestampElement)
+                        || !DateTimeOffset.TryParse(
+                            timestampElement.GetString(),
+                            CultureInfo.InvariantCulture,
+                            DateTimeStyles.RoundtripKind,
+                            out var timestamp)
+                        || timestamp <= deliveredAt)
+                    {
+                        continue;
+                    }
+
+                    artifactPresent = true;
+                    var kind = root.TryGetProperty("kind", out var kindElement)
+                        ? kindElement.GetString() ?? "unknown"
+                        : "unknown";
+                    artifactDetails.Add($"event:{eventPath};kind={kind};timestamp={timestamp:O}");
+                }
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException or InvalidOperationException)
+            {
+                error = $"notification event source '{eventPath}' could not be read: {exception.Message}";
+            }
+        }
+
+        var artifactSource = artifactSources.Count == 0
+            ? "expected-artifacts:none; notification-events:none"
+            : $"expected-artifacts={string.Join("|", artifactSources)}";
+
+        var continuation = ContinuationChainStore.Read(
+            routingRoot,
+            record.Domain,
+            record.Team,
+            taskId: record.TaskId);
+        var transitionSource = $"continuation-chain:{continuation.Path}; links={ContinuationChainStore.CanonicalStateClassified}|{ContinuationChainStore.RequiredContinuationStarted}|{ContinuationChainStore.NamedBlockerRecorded}";
+        var transitionDetails = new List<string>();
+        bool? transitionPresent = null;
+        if (error is null && !continuation.Resolved)
+        {
+            error = continuation.Error ?? $"continuation-chain source '{continuation.Path}' could not be read.";
+        }
+        else if (error is null)
+        {
+            var transitionLinks = continuation.Records
+                .SelectMany(chain => chain.Links)
+                .Where(link => link.Name is ContinuationChainStore.CanonicalStateClassified
+                    or ContinuationChainStore.RequiredContinuationStarted
+                    or ContinuationChainStore.NamedBlockerRecorded)
+                .ToArray();
+            transitionPresent = transitionLinks.Length > 0;
+            transitionDetails.AddRange(transitionLinks.Select(link =>
+                $"link:{link.Name};timestamp={link.Timestamp:O};source={link.Source}"));
+        }
+
+        return new NotifyDelegationExecutionEvidence
+        {
+            ExpectedArtifactPresent = error is null ? artifactPresent : null,
+            TargetEntityTransitionPresent = error is null ? transitionPresent : null,
+            ArtifactSource = artifactSource,
+            TargetEntitySource = transitionSource,
+            ArtifactDetails = artifactDetails,
+            TargetEntityDetails = transitionDetails,
+            Error = error,
+        };
+    }
+
+    private static string ResolveEventSource(
+        string routingRoot,
+        NotifyPendingDelegation record,
+        out string? path,
+        out string? error)
+    {
+        if (NotifyEventWriter.TryResolveReadPath(
+            routingRoot,
+            record.Domain,
+            record.Team,
+            record.Reader,
+            out path,
+            out error))
+        {
+            return $"notification-events:{path}";
+        }
+
+        path = null;
+        return $"notification-events:unresolved:{error}";
+    }
+
+    private static bool TryResolveArtifactPath(
+        string value,
+        string? cwd,
+        out string path)
+    {
+        path = string.Empty;
+        var candidate = value.Trim();
+        if (candidate.Length == 0)
+        {
+            return false;
+        }
+
+        if (Uri.TryCreate(candidate, UriKind.Absolute, out var uri))
+        {
+            if (!string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            candidate = uri.LocalPath;
+        }
+        else if (candidate.Contains("://", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!Path.IsPathRooted(candidate))
+        {
+            if (string.IsNullOrWhiteSpace(cwd))
+            {
+                return false;
+            }
+
+            candidate = Path.Combine(cwd, candidate);
+        }
+
+        try
+        {
+            path = Path.GetFullPath(candidate);
+            return true;
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
@@ -16,6 +16,8 @@ namespace IntentSystem.Cli.Commands;
 internal sealed class NotifyMeasuredSupervisor
 {
     private const int FallbackAbsenceHeadroomSeconds = 60;
+    internal const int DefaultDelegationExecutionWindowSeconds = 300;
+    internal const int MaximumDelegationExecutionWindowSeconds = 86_400;
     private const string DesignRole = "design";
     private const string ObservationConflictKind = "observation-conflict";
 
@@ -48,6 +50,8 @@ internal sealed class NotifyMeasuredSupervisor
     private readonly int? configuredRepeatBackoffSeconds;
     private readonly int? configuredDebounceConsecutiveObservations;
     private readonly Func<DateTimeOffset, IReadOnlyList<NotifySupervisionObservation>>? observationProvider;
+    private readonly int delegationExecutionWindowSeconds;
+    private readonly Func<NotifyPendingDelegation, DateTimeOffset, NotifyDelegationExecutionEvidence>? delegationEvidenceProvider;
     private readonly object supervisionSync = new();
     private readonly object writerSync = new();
 
@@ -80,7 +84,9 @@ internal sealed class NotifyMeasuredSupervisor
         IReadOnlyList<NotifyScopedPromptPolicy>? scopedPolicies = null,
         int? repeatBackoffSeconds = null,
         int? debounceConsecutiveObservations = null,
-        Func<DateTimeOffset, IReadOnlyList<NotifySupervisionObservation>>? observationProvider = null)
+        Func<DateTimeOffset, IReadOnlyList<NotifySupervisionObservation>>? observationProvider = null,
+        int? delegationExecutionWindowSeconds = null,
+        Func<NotifyPendingDelegation, DateTimeOffset, NotifyDelegationExecutionEvidence>? delegationEvidenceProvider = null)
     {
         this.context = context;
         this.routingRoot = routingRoot;
@@ -111,6 +117,10 @@ internal sealed class NotifyMeasuredSupervisor
         this.configuredRepeatBackoffSeconds = repeatBackoffSeconds;
         this.configuredDebounceConsecutiveObservations = debounceConsecutiveObservations;
         this.observationProvider = observationProvider;
+        this.delegationExecutionWindowSeconds = delegationExecutionWindowSeconds is > 0
+            ? Math.Min(delegationExecutionWindowSeconds.Value, MaximumDelegationExecutionWindowSeconds)
+            : DefaultDelegationExecutionWindowSeconds;
+        this.delegationEvidenceProvider = delegationEvidenceProvider;
     }
 
     public NotifySupervisorPass RunOnce() => RunOnce("interval");
@@ -332,6 +342,13 @@ internal sealed class NotifyMeasuredSupervisor
                     ? SessionLayerMode.Agmsg
                     : pending.TransportMode!;
                 var activity = NotifyPendingLiveness.Probe(routingRoot, pending, transportMode, runner, herdrExecutable, agmsgScriptsDirectory, bashExecutable);
+                AddDelegationExecutionObservation(
+                    pending,
+                    activity,
+                    previousCycle,
+                    now,
+                    observations,
+                    warnings);
                 if (!activity.Resolved || activity.Running != true || activity.StateChangeSequence is not { } sequence)
                 {
                     continue;
@@ -1270,6 +1287,127 @@ internal sealed class NotifyMeasuredSupervisor
 
     private bool IsOwnerSubject(string? subjectRole) =>
         string.Equals(subjectRole, ownerRole, StringComparison.Ordinal);
+
+    private void AddDelegationExecutionObservation(
+        NotifyPendingDelegation pending,
+        NotifyPendingLivenessResult activity,
+        NotifySupervisionCycle? previousCycle,
+        DateTimeOffset now,
+        ICollection<NotifySupervisionObservation> observations,
+        ICollection<string> warnings)
+    {
+        if (!activity.Resolved
+            || activity.Running != true
+            || !string.Equals(activity.AgentStatus, "idle", StringComparison.Ordinal)
+            || activity.StateChangeSequence is not { } sequence
+            || pending.ReportArrived)
+        {
+            return;
+        }
+
+        var deliveryEvidence = NotifyDelegationDeliveryStore.Find(
+            routingRoot,
+            pending.Domain,
+            pending.Team,
+            pending.TaskId,
+            pending.ResultNonce);
+        if (!deliveryEvidence.Resolved)
+        {
+            warnings.Add($"delegation-delivery-evidence-unavailable: task '{pending.TaskId}': {deliveryEvidence.Error}");
+            return;
+        }
+
+        if (deliveryEvidence.Evidence is not { DeliverySucceeded: true, DeliveredAt: { } deliveredAt }
+            || now - deliveredAt < TimeSpan.FromSeconds(delegationExecutionWindowSeconds))
+        {
+            return;
+        }
+
+        var paneKey = pending.WorkspaceId is not null && pending.PaneId is not null
+            ? $"activity:{pending.WorkspaceId}:{pending.PaneId}"
+            : $"activity:{pending.RecipientIdentity}";
+        if (previousCycle?.LastObservedStateChangeSequences.ContainsKey(paneKey) != true)
+        {
+            return;
+        }
+
+        NotifyDelegationExecutionEvidence evidence;
+        try
+        {
+            evidence = delegationEvidenceProvider?.Invoke(pending, now)
+                ?? NotifyDelegationExecutionEvidence.Resolve(routingRoot, pending, deliveredAt);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or InvalidOperationException)
+        {
+            warnings.Add($"delegation-execution-evidence-unavailable: task '{pending.TaskId}': {exception.Message}");
+            return;
+        }
+
+        if (!evidence.IsResolved
+            || evidence.ExpectedArtifactPresent != false
+            || evidence.TargetEntityTransitionPresent != false)
+        {
+            if (!evidence.IsResolved)
+            {
+                warnings.Add($"delegation-execution-evidence-unavailable: task '{pending.TaskId}': "
+                    + (evidence.Error ?? "one or more evidence sources were unresolved; no finding was emitted."));
+            }
+
+            return;
+        }
+
+        var pendingPath = NotifyPendingDelegationStore.ResolvePath(routingRoot, pending.Domain, pending.Team);
+        var seat = string.IsNullOrWhiteSpace(pending.RecipientIdentity)
+            ? pending.RecipientRole
+            : pending.RecipientIdentity;
+        var window = delegationExecutionWindowSeconds.ToString(CultureInfo.InvariantCulture);
+        var activityObservation =
+            $"activity:{paneKey}: running={activity.Running}; agent_status={activity.AgentStatus}; "
+            + $"state_change_seq={sequence.ToString(CultureInfo.InvariantCulture)}; source={activity.Source}";
+        var checkedSources =
+            $"delivery-evidence:{deliveryEvidence.Path}; pending-store:{pendingPath}; {evidence.ArtifactSource}; {evidence.TargetEntitySource}";
+        var evidenceLines = new List<string>
+        {
+            $"task_id:{pending.TaskId}",
+            $"seat:{seat}",
+            $"delivered_at:{deliveredAt:O}",
+            $"window_seconds:{window}",
+            $"delivery_evidence:success; source={deliveryEvidence.Path}",
+            $"recipient_idle:true; source={activity.Source}; state_change_seq={sequence.ToString(CultureInfo.InvariantCulture)}",
+            $"canonical_report:absent; source={pendingPath}",
+            $"expected_artifact:absent; source={evidence.ArtifactSource}",
+            $"durable_target_entity_transition:absent; source={evidence.TargetEntitySource}",
+        };
+        evidenceLines.AddRange(evidence.ArtifactDetails);
+        evidenceLines.AddRange(evidence.TargetEntityDetails);
+
+        observations.Add(new NotifySupervisionObservation
+        {
+            Key = $"delegation-delivered-never-executed:{pending.TaskId}:{pending.ResultNonce ?? "legacy"}",
+            Kind = "delegation-delivered-never-executed",
+            OwnerRole = pending.DelegatingRole ?? ownerRole,
+            SubjectRole = pending.RecipientRole,
+            Source = "notify-pending-delegation.execution",
+            Summary = $"Delegation task '{pending.TaskId}' was delivered to seat '{seat}' at '{deliveredAt:O}', "
+                + $"but the recipient is idle after the configured {window}s execution-start window. "
+                + $"Canonical report absent, expected artifact absent, and durable target-entity transition absent. "
+                + $"Checked sources: {checkedSources}. This observation is observation-only; it sends no keys, "
+                + "answers no dialog, and restarts no seat; the finding routes to the delegation owner role.",
+            DetectableAt = deliveredAt.AddSeconds(delegationExecutionWindowSeconds),
+            WorkspaceId = pending.WorkspaceId,
+            PaneId = pending.PaneId,
+            Evidence = evidenceLines,
+            ConsultedObservations =
+            [
+                activityObservation,
+                $"delivery-evidence:success; source={deliveryEvidence.Path}; delivered_at={deliveredAt:O}",
+                $"delivery:task_id={pending.TaskId}; delivery_succeeded=true; delivered_at={deliveredAt:O}; source={deliveryEvidence.Path}",
+                $"canonical-report:absent; source={pendingPath}",
+                $"expected-artifact:absent; source={evidence.ArtifactSource}",
+                $"durable-target-entity-transition:absent; source={evidence.TargetEntitySource}",
+            ],
+        });
+    }
 
     private string ResolveWakeTarget(NotifySupervisionObservation observation) =>
         observation.Prompt?.AdjudicationTargetRole

--- a/tests/IntentSystem.Cli.Tests/Fixtures/g741-supervision-state/intent-cli/intent-cli-dev/bound.json
+++ b/tests/IntentSystem.Cli.Tests/Fixtures/g741-supervision-state/intent-cli/intent-cli-dev/bound.json
@@ -1,0 +1,1 @@
+{"domain":"intent-cli","team":"intent-cli-dev","bound_seconds":300,"recorded_at":"2026-08-27T11:00:00.0000000+00:00"}

--- a/tests/IntentSystem.Cli.Tests/Fixtures/g741-supervision-state/intent-cli/intent-cli-dev/cycles.jsonl
+++ b/tests/IntentSystem.Cli.Tests/Fixtures/g741-supervision-state/intent-cli/intent-cli-dev/cycles.jsonl
@@ -1,0 +1,1 @@
+{"kind":"cycle","cycle":{"cycle_id":"g741-fixture-cycle","started_at":"2026-08-27T11:00:00.0000000+00:00","completed_at":"2026-08-27T11:00:05.0000000+00:00","interval_seconds":300}}

--- a/tests/IntentSystem.Cli.Tests/Fixtures/g741-supervision-state/intent-cli/intent-cli-dev/emission-policy.json
+++ b/tests/IntentSystem.Cli.Tests/Fixtures/g741-supervision-state/intent-cli/intent-cli-dev/emission-policy.json
@@ -1,0 +1,1 @@
+{"domain":"intent-cli","team":"intent-cli-dev","full_cadence_seconds":300,"repeat_backoff_seconds":1800,"debounce_consecutive_observations":3,"recorded_at":"2026-08-27T11:00:00.0000000+00:00"}

--- a/tests/IntentSystem.Cli.Tests/Fixtures/g741-supervision-state/intent-cli/intent-cli-dev/stalls.jsonl
+++ b/tests/IntentSystem.Cli.Tests/Fixtures/g741-supervision-state/intent-cli/intent-cli-dev/stalls.jsonl
@@ -1,0 +1,1 @@
+{"kind":"open","stall":{"key":"legacy:fixture","kind":"legacy-supervision-finding","owner_role":"orchestration","source":"legacy-fixture","summary":"legacy supervision state remains readable","surfaced_at":"2026-08-27T11:00:05.0000000+00:00","repeat_count":1}}

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionG741Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionG741Tests.cs
@@ -1,0 +1,500 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G741: a successful delegation delivery is not execution evidence. The
+/// finding is emitted only after a later idle observation and a complete
+/// absence check across the durable report, artifact, and target-transition
+/// sources.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifySupervisionG741Tests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+    private readonly string root = Path.Combine(Path.GetTempPath(), $"intent-g741-{Guid.NewGuid():N}");
+    private readonly DateTimeOffset firstNow = new(2026, 8, 27, 12, 0, 0, TimeSpan.Zero);
+    private DateTimeOffset now;
+
+    public NotifySupervisionG741Tests()
+    {
+        Directory.CreateDirectory(root);
+        now = firstNow;
+        NotifyCommand.UtcNowFactory = () => now;
+        NotifySupervisor.Delay = _ => { };
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.UtcNowFactory = null;
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifyCommand.AgmsgScriptsDirectoryFactory = null;
+        NotifyCommand.HerdrExecutableFactory = null;
+        NotifyCommand.BashExecutableFactory = null;
+        NotifySupervisionStore.WriteOverride = null;
+        NotifyPendingDelegationStore.WriteOverride = null;
+        NotifySupervisor.Delay = Thread.Sleep;
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DeliveredIdleDelegationFiresAfterWindowAndWakesOwner_G741()
+    {
+        var context = CreateContext();
+        RecordHerdrOnlyMode(context);
+        WriteTopology();
+        var pending = WriteDeliveredPending("G741-fired");
+        var runner = new FixtureRunner { AgentStatus = "idle", StateChangeSequence = 7 };
+        var supervisor = CreateSupervisor(context, runner, delegationWindowSeconds: 300);
+
+        var baseline = supervisor.RunOnce();
+        Assert.DoesNotContain(baseline.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+
+        now = firstNow.AddSeconds(301);
+        var pass = supervisor.RunOnce();
+
+        var finding = Assert.Single(
+            pass.Findings,
+            item => item.Kind == "delegation-delivered-never-executed");
+        Assert.Equal("orchestration", finding.OwnerRole);
+        Assert.Equal("orchestration", finding.WakeTargetRole);
+        Assert.True(finding.WakeAttempted);
+        Assert.True(finding.WakeDelivered);
+        Assert.Contains("G741-fired", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("seat 'role=implementation;workspace=wG741;pane=wG741:p2'", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("300s execution-start window", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("Canonical report absent", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("expected artifact absent", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("durable target-entity transition absent", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("Checked sources:", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("task_id:G741-fired", finding.Evidence!, StringComparer.Ordinal);
+        Assert.Contains($"delivered_at:{firstNow:O}", finding.Evidence!, StringComparer.Ordinal);
+        Assert.Contains("window_seconds:300", finding.Evidence!, StringComparer.Ordinal);
+        Assert.Contains(finding.Evidence!, item => item.StartsWith("canonical_report:absent", StringComparison.Ordinal));
+        Assert.Contains(finding.Evidence!, item => item.StartsWith("expected_artifact:absent", StringComparison.Ordinal));
+        Assert.Contains(finding.Evidence!, item => item.StartsWith("durable_target_entity_transition:absent", StringComparison.Ordinal));
+        Assert.Contains(runner.Calls, call =>
+            call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "wG741:p1"]));
+
+        var state = NotifySupervisionStore.Read(
+            context.ResolveSupervisionArtifactRootPath(),
+            Domain,
+            Team);
+        var stored = Assert.Single(
+            state.ActiveStalls.Values,
+            item => item.Kind == "delegation-delivered-never-executed");
+        Assert.Equal(finding.Key, stored.Key);
+        Assert.Contains("task_id:G741-fired", stored.Evidence!, StringComparer.Ordinal);
+        Assert.Equal(pending.TaskId, NotifyPendingDelegationStore.Find(
+            root,
+            Domain,
+            Team,
+            pending.TaskId).Record!.TaskId);
+    }
+
+    [Fact]
+    public void WorkingSeatIsAProvenStartedNonFinding_G741()
+    {
+        var context = CreateContext();
+        RecordHerdrOnlyMode(context);
+        WriteTopology();
+        WriteDeliveredPending("G741-working");
+        var runner = new FixtureRunner { AgentStatus = "working", StateChangeSequence = 8 };
+        var supervisor = CreateSupervisor(context, runner, delegationWindowSeconds: 300);
+
+        supervisor.RunOnce();
+        now = firstNow.AddSeconds(301);
+        var pass = supervisor.RunOnce();
+
+        Assert.DoesNotContain(pass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        Assert.DoesNotContain(runner.Calls, call =>
+            call.Arguments.Take(3).SequenceEqual(["agent", "prompt", "wG741:p1"]));
+    }
+
+    [Fact]
+    public void VisibleExpectedArtifactIsAStartedNonFinding_G741()
+    {
+        var context = CreateContext();
+        RecordHerdrOnlyMode(context);
+        WriteTopology();
+        var pending = WriteDeliveredPending("G741-artifact");
+        Directory.CreateDirectory(pending.Cwd!);
+        var runner = new FixtureRunner { AgentStatus = "idle", StateChangeSequence = 9 };
+        var supervisor = CreateSupervisor(context, runner, delegationWindowSeconds: 300);
+
+        supervisor.RunOnce();
+        File.WriteAllText(Path.Combine(pending.Cwd!, "expected-artifact.txt"), "started");
+        now = firstNow.AddSeconds(301);
+        var pass = supervisor.RunOnce();
+
+        Assert.DoesNotContain(pass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+    }
+
+    [Fact]
+    public void DurableTargetTransitionIsAStartedNonFinding_G741()
+    {
+        var context = CreateContext();
+        RecordHerdrOnlyMode(context);
+        WriteTopology();
+        var pending = WriteDeliveredPending("G741-transition");
+        var runner = new FixtureRunner { AgentStatus = "idle", StateChangeSequence = 10 };
+        var supervisor = CreateSupervisor(context, runner, delegationWindowSeconds: 300);
+
+        supervisor.RunOnce();
+        var signalId = ContinuationChainStore.BuildCompletionSignalId(
+            pending.TaskId,
+            pending.ResultNonce);
+        var chainId = ContinuationChainStore.BuildChainId(signalId);
+        var transition = ContinuationChainStore.RecordLink(
+            root,
+            Domain,
+            Team,
+            signalId,
+            pending.TaskId,
+            chainId,
+            ContinuationChainStore.CanonicalStateClassified,
+            "g741-test",
+            ["target-entity-transition:observed"],
+            timestamp: firstNow.AddSeconds(1),
+            write: true,
+            resultNonce: pending.ResultNonce);
+        Assert.True(transition.Applied || transition.AlreadyConverged, transition.Error);
+
+        now = firstNow.AddSeconds(301);
+        var pass = supervisor.RunOnce();
+
+        Assert.DoesNotContain(pass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+    }
+
+    [Fact]
+    public void DeliveryEvidenceIsRequiredAndLegacyPendingLinesRemainReadable_G741()
+    {
+        var context = CreateContext();
+        RecordHerdrOnlyMode(context);
+        WriteTopology();
+        var pending = WriteDispatchedPending("G741-undelivered");
+        var rawDispatch = File.ReadAllText(NotifyPendingDelegationStore.ResolvePath(root, Domain, Team));
+        Assert.DoesNotContain("delivery_succeeded", rawDispatch, StringComparison.Ordinal);
+
+        var runner = new FixtureRunner { AgentStatus = "idle", StateChangeSequence = 11 };
+        var supervisor = CreateSupervisor(context, runner, delegationWindowSeconds: 300);
+        supervisor.RunOnce();
+        now = firstNow.AddSeconds(301);
+        var pass = supervisor.RunOnce();
+
+        Assert.DoesNotContain(pass.Findings, finding =>
+            finding.Kind == "delegation-delivered-never-executed");
+        var beforeDelivery = NotifyDelegationDeliveryStore.Find(
+            root,
+            Domain,
+            Team,
+            pending.TaskId,
+            pending.ResultNonce);
+        Assert.True(beforeDelivery.Resolved, beforeDelivery.Error);
+        Assert.Null(beforeDelivery.Evidence);
+
+        var delivery = NotifyDelegationDeliveryStore.Write(root, pending, firstNow);
+        Assert.True(delivery.Written, delivery.Error);
+        var afterDelivery = NotifyDelegationDeliveryStore.Find(
+            root,
+            Domain,
+            Team,
+            pending.TaskId,
+            pending.ResultNonce);
+        Assert.True(afterDelivery.Resolved, afterDelivery.Error);
+        Assert.True(afterDelivery.Evidence?.DeliverySucceeded == true);
+        Assert.Equal(firstNow, afterDelivery.Evidence?.DeliveredAt);
+        Assert.Single(File.ReadAllLines(NotifyPendingDelegationStore.ResolvePath(root, Domain, Team)));
+        var rawWithDelivery = File.ReadAllText(delivery.Path);
+        Assert.Contains("\"event\":\"delivery\"", rawWithDelivery, StringComparison.Ordinal);
+        Assert.Contains("\"delivery_succeeded\":true", rawWithDelivery, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LegacySupervisionStateAndEmissionPolicyFixturesReadWithoutMutation_G741()
+    {
+        var fixtureRoot = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "tests",
+            "IntentSystem.Cli.Tests",
+            "Fixtures",
+            "g741-supervision-state");
+        var artifactRoot = Path.Combine(root, "fixture-artifact");
+        CopyDirectory(fixtureRoot, artifactRoot);
+
+        var fixtureFiles = Directory
+            .EnumerateFiles(artifactRoot, "*", SearchOption.AllDirectories)
+            .ToDictionary(
+                path => Path.GetRelativePath(artifactRoot, path),
+                path => Convert.ToHexString(File.ReadAllBytes(path)),
+                StringComparer.Ordinal);
+        var state = NotifySupervisionStore.Read(artifactRoot, Domain, Team);
+
+        Assert.True(state.Resolved, state.Error);
+        Assert.Equal(300, state.Bound!.BoundSeconds);
+        Assert.Equal(1_800, state.EmissionPolicy!.RepeatBackoffSeconds);
+        Assert.Equal(3, state.EmissionPolicy.DebounceConsecutiveObservations);
+        Assert.Equal("g741-fixture-cycle", state.LastCycle!.CycleId);
+        Assert.Contains("legacy:fixture", state.ActiveStalls.Keys, StringComparer.Ordinal);
+
+        foreach (var fixtureFile in fixtureFiles)
+        {
+            var path = Path.Combine(artifactRoot, fixtureFile.Key);
+            Assert.Equal(fixtureFile.Value, Convert.ToHexString(File.ReadAllBytes(path)));
+        }
+
+        Assert.DoesNotContain(
+            "delegation-delivered-never-executed",
+            File.ReadAllText(Path.Combine(
+                artifactRoot,
+                Domain,
+                Team,
+                NotifySupervisionStore.BoundFileName)),
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "delegation-delivered-never-executed",
+            File.ReadAllText(Path.Combine(
+                artifactRoot,
+                Domain,
+                Team,
+                NotifySupervisionStore.EmissionPolicyFileName)),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DelegationExecutionWindowIsBoundedAndDocumentedOnSuperviseSurface_G741()
+    {
+        using var help = new StringWriter();
+        Assert.Equal(0, NotifyCommand.ExecuteSupervise(CreateContext(), ["--help"], help));
+        Assert.Contains("--delegation-execution-window-seconds", help.ToString(), StringComparison.Ordinal);
+        Assert.Contains("300", help.ToString(), StringComparison.Ordinal);
+
+        using var invalid = new StringWriter();
+        Assert.Equal(
+            1,
+            NotifyCommand.ExecuteSupervise(
+                CreateContext(),
+                [
+                    "--domain", Domain,
+                    "--team", Team,
+                    "--delegation-execution-window-seconds", "86401",
+                    "--format", "json",
+                ],
+                invalid));
+        Assert.Contains("between 1 and 86400", invalid.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EnglishAndJapaneseOrchestrationDocsDescribeG741Contract_G741()
+    {
+        var repoRoot = RepoVersionPolicySource.RepoRoot();
+        var english = File.ReadAllText(Path.Combine(repoRoot, "docs", "en", "12-agent-message-orchestration.md"));
+        var japanese = File.ReadAllText(Path.Combine(repoRoot, "docs", "ja", "12-agent-message-orchestration.md"));
+
+        foreach (var document in new[] { english, japanese })
+        {
+            Assert.Contains("G741", document, StringComparison.Ordinal);
+            Assert.Contains("delegation-delivered-never-executed", document, StringComparison.Ordinal);
+            Assert.Contains("--delegation-execution-window-seconds", document, StringComparison.Ordinal);
+            Assert.Contains("300", document, StringComparison.Ordinal);
+            Assert.Contains("delivered_at", document, StringComparison.Ordinal);
+            Assert.Contains("canonical", document, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("expected artifact", document, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("durable", document, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("observation-only", document, StringComparison.OrdinalIgnoreCase);
+        }
+
+        Assert.Contains("opaque in-seat thought", english, StringComparison.Ordinal);
+        Assert.Contains("seat 内部の opaque な thought", japanese, StringComparison.Ordinal);
+    }
+
+    private NotifyMeasuredSupervisor CreateSupervisor(
+        CliContext context,
+        FixtureRunner runner,
+        int delegationWindowSeconds) => new(
+        context: context,
+        routingRoot: root,
+        domain: Domain,
+        team: Team,
+        repo: null,
+        ownerRole: "orchestration",
+        intervalSeconds: 600,
+        declaredBoundSeconds: null,
+        staleMinutes: 45,
+        claimedSilentMinutes: 720,
+        backlogIdleMinutes: 45,
+        repairSilentMinutes: 180,
+        autoRedispatch: false,
+        write: true,
+        format: "json",
+        runner: runner,
+        herdrExecutable: "fake-herdr",
+        agmsgScriptsDirectory: root,
+        delegationExecutionWindowSeconds: delegationWindowSeconds);
+
+    private NotifyPendingDelegation WriteDeliveredPending(string taskId)
+    {
+        var pending = WriteDispatchedPending(taskId);
+        var delivery = NotifyDelegationDeliveryStore.Write(root, pending, firstNow);
+        Assert.True(delivery.Written, delivery.Error);
+        return pending;
+    }
+
+    private NotifyPendingDelegation WriteDispatchedPending(string taskId)
+    {
+        var pending = new NotifyPendingDelegation
+        {
+            Domain = Domain,
+            Team = Team,
+            TaskId = taskId,
+            DelegatingRole = "orchestration",
+            RecipientRole = "implementation",
+            ReportToRole = "orchestration",
+            RecipientIdentity = "role=implementation;workspace=wG741;pane=wG741:p2",
+            ExpectedArtifact = "expected-artifact.txt",
+            ExpectedArtifacts = ["expected-artifact.txt"],
+            Objective = "execute the delegated task",
+            Inputs = ["fixture"],
+            ResultNonce = $"{taskId}-nonce",
+            DispatchedAt = firstNow.AddSeconds(-1),
+            TransportMode = SessionLayerMode.HerdrOnly,
+            Resident = NotifyRecordedRole.HerdrResident,
+            WorkspaceId = "wG741",
+            PaneId = "wG741:p2",
+            Cwd = Path.Combine(root, "work", taskId),
+            Kind = "implementation",
+            LaunchArguments = ["fixture"],
+        };
+        var write = NotifyPendingDelegationStore.WriteDispatch(root, pending);
+        Assert.True(write.Written, write.Error);
+        return pending;
+    }
+
+    private CliContext CreateContext() => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig { Domain = Domain, ArtifactRoot = ".intent-cli" },
+        },
+    };
+
+    private void RecordHerdrOnlyMode(CliContext context)
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            SessionLayerCommand.ExecuteSet(
+                context,
+                ["--domain", Domain, "--team", Team, "--mode", SessionLayerMode.HerdrOnly, "--write", "--format", "json"],
+                writer));
+    }
+
+    private void WriteTopology()
+    {
+        var path = NotifyRoleTopologyStore.ResolvePath(root, Domain, Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(
+            path,
+            JsonSerializer.Serialize(new
+            {
+                domain = Domain,
+                team = Team,
+                workspace_id = "wG741",
+                roles = new Dictionary<string, object>
+                {
+                    ["orchestration"] = new { resident = "herdr", workspace_id = "wG741", pane_id = "wG741:p1" },
+                    ["implementation"] = new { resident = "herdr", workspace_id = "wG741", pane_id = "wG741:p2" },
+                },
+            }));
+    }
+
+    private static string AgentsJson(string status, long sequence)
+    {
+        static object Agent(string role, string pane, string status, long sequence) => new
+        {
+            name = role,
+            workspace_id = "wG741",
+            pane_id = pane,
+            agent = "fixture",
+            agent_session = new { id = role },
+            agent_status = status,
+            agent_running = true,
+            interactive_ready = true,
+            state_change_seq = sequence,
+            last_state_change_at = "2026-08-27T12:00:00.0000000+00:00",
+        };
+
+        return JsonSerializer.Serialize(new
+        {
+            result = new
+            {
+                agents = new[]
+                {
+                    Agent("orchestration", "wG741:p1", "working", 1),
+                    Agent("implementation", "wG741:p2", status, sequence),
+                },
+            },
+        });
+    }
+
+    private static void CopyDirectory(string source, string destination)
+    {
+        foreach (var path in Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(source, path);
+            var target = Path.Combine(destination, relative);
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            File.Copy(path, target);
+        }
+    }
+
+    private sealed class FixtureRunner : INotifyProcessRunner
+    {
+        public string AgentStatus { get; set; } = "idle";
+        public long StateChangeSequence { get; set; } = 7;
+        public List<(string FileName, IReadOnlyList<string> Arguments)> Calls { get; } = [];
+
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            Calls.Add((fileName, arguments.ToArray()));
+            if (arguments.SequenceEqual(["agent", "list"]))
+            {
+                return new NotifyProcessResult(
+                    0,
+                    AgentsJson(AgentStatus, StateChangeSequence),
+                    string.Empty);
+            }
+
+            if (arguments.Count >= 2
+                && arguments[0] == "pane"
+                && arguments[1] == "process-info")
+            {
+                return new NotifyProcessResult(
+                    0,
+                    "{\"result\":{\"process_info\":{\"foreground_processes\":[]}}}",
+                    string.Empty);
+            }
+
+            if (arguments.Count >= 2
+                && arguments[0] == "agent"
+                && arguments[1] is "prompt" or "wait")
+            {
+                return new NotifyProcessResult(0, string.Empty, string.Empty);
+            }
+
+            return new NotifyProcessResult(0, string.Empty, string.Empty);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1612

Implements the delegation-delivered-never-executed supervision finding. Delivery success is recorded separately from the existing pending-delegation JSONL so legacy pending records remain byte-compatible; the classifier requires a later idle observation, the bounded execution window, absent canonical report, absent expected artifact, and absent durable target-entity transition. Findings wake the delegation owner role and remain observation-only.

Verification:
- G741 focused: 8 passed, 0 failed
- Adjacent supervision/delegation: 101 passed, 0 failed
- Release: 5,248 passed, 0 failed, 1 skipped
- Fixture-backed legacy supervision state/emission policy read unchanged
- git diff --check clean
- eng/version.json and shipped release notes untouched