### PR TITLE
G743: preserve committed claim result after push uncertainty

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2670,7 +2670,7 @@ incomplete packet through publication. The tolerance is scoped to `clarify open`
 
 ---
 
-## Claim transaction teardown (G738)
+## Claim transaction teardown (G738, G743)
 
 `claim acquire`, `claim release`, and `claim takeover` use a temporary clone
 under the OS temp root. The successful plain push of the claim state is the
@@ -2679,7 +2679,17 @@ boundary.
 
 - Before the claim state is committed and pushed, a transaction or teardown
   failure remains a command failure. Cleanup cannot turn an incomplete claim
-  into success.
+  into success. If the transaction itself fails before the boundary, its
+  original cause remains authoritative even when a teardown failure also
+  occurs in `finally`; the cleanup failure is reported separately and never
+  masks that cause.
+- A push process can return nonzero after the remote ref has accepted the
+  transaction. The command fetches `origin` and compares the transaction
+  commit and resulting claim state. Only an exact match is treated as the
+  committed ownership fact and reported as `acquired`, `released`, or
+  `taken-over` with `push_succeeded: true`; otherwise the existing rejected-
+  push/retry path remains in force. This prevents a durable claim from being
+  reported as absent and inviting a duplicate acquire.
 - After a successful push, cleanup is best-effort. A delete attempt is bounded
   to 250 ms, up to three attempts are allowed for ordinary failures, and the
   retry backoff is 50 ms. A timed-out attempt is not retried while its worker

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2736,7 +2736,7 @@ strict な projection serializer は**変更していません**。publish-flow 
 
 ---
 
-## claim transaction の teardown (G738)
+## claim transaction の teardown (G738, G743)
 
 `claim acquire`、`claim release`、`claim takeover` は OS の temp root 配下に一時 clone を
 作ります。claim state の plain push 成功が transaction boundary であり、その一時 clone の
@@ -2744,6 +2744,14 @@ cleanup は boundary の後に実行されます。
 
 - claim state が commit され push される前は、transaction または teardown の failure は
   command failure のままです。cleanup が未完了の claim を成功に変えることはありません。
+  transaction 自体が boundary 前に失敗した場合は元の原因を保持し、finally の teardown failure
+  がその原因を隠すことはありません。
+- push process が nonzero を返しても remote ref が transaction を受理している場合があります。
+  command は `origin` を fetch し、transaction commit と結果の claim state を照合します。
+  完全一致だけを ownership fact として `acquired`、`released`、`taken-over` と
+  `push_succeeded: true` で報告します。それ以外は既存の rejected-push/retry path のままで、
+  claim を absent と誤報して duplicate acquire を誘発しません。
+
 - push 成功後の cleanup は best-effort です。delete の 1 回ごとの待機は 250 ms に制限し、
   通常の failure には最大 3 回まで試行し、retry 間には 50 ms の backoff を置きます。
   timeout した試行は、worker が directory に触れている可能性がある間は retry しません。

--- a/src/IntentSystem.Cli/Commands/ClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClaimCommand.cs
@@ -144,6 +144,7 @@ internal static class ClaimCommand
             var transactionRoot = Path.Combine(
                 Path.GetTempPath(), $"intent-cli-claim-{Guid.NewGuid():N}");
             var committed = false;
+            Exception? transactionFailure = null;
             try
             {
                 var clone = RunGit(Path.GetTempPath(),
@@ -243,6 +244,9 @@ internal static class ClaimCommand
                     hostStateWrite: true);
                 CaptureRetry(ref lastGitWriteRetry, commit);
                 EnsureSuccess(commit, "commit claim transaction");
+                var transactionCommit = RunGit(transactionRoot, ["rev-parse", "HEAD"]);
+                EnsureSuccess(transactionCommit, "resolve claim transaction commit");
+                var transactionCommitSha = transactionCommit.StandardOutput.Trim();
 
                 var push = RunGit(transactionRoot, ["push", "origin", "HEAD"], hostStateWrite: true);
                 CaptureRetry(ref lastGitWriteRetry, push);
@@ -256,29 +260,22 @@ internal static class ClaimCommand
                     // after it, including local refresh and temporary clone
                     // teardown, is best-effort and cannot change the result.
                     committed = true;
-                    var pushedHead = RunGit(transactionRoot, ["rev-parse", "HEAD"]);
-                    EnsureSuccess(pushedHead, "resolve pushed claim commit");
                     var status = request.Operation switch
                     {
                         ClaimOperation.Acquire => "acquired",
                         ClaimOperation.Release => "released",
                         _ => "taken-over",
                     };
-                    // Keep the invoking clone on the pushed fact as well. The
-                    // ownership result remains true even if this best-effort
-                    // refresh is blocked by unrelated local workspace state;
-                    // the successful origin push is still authoritative.
-                    var localRefresh = RunGit(repoRoot, ["pull", "--ff-only", "origin", branchName], hostStateWrite: true);
-                    CaptureRetry(ref lastGitWriteRetry, localRefresh);
-                    var detail = localRefresh.ExitCode == 0
-                        ? "The plain push succeeded; this is the ownership transition fact."
-                        : "The plain push succeeded and is the ownership transition fact, but the invoking clone could not fast-forward: "
-                            + localRefresh.StandardError.Trim();
+                    var detail = RefreshInvokingClone(
+                        repoRoot,
+                        branchName,
+                        ref lastGitWriteRetry,
+                        "The plain push succeeded; this is the ownership transition fact.");
                     return new ClaimTransactionResult(
                         status, request.Scope, relativeClaimPath, true, attempt,
                         request.Operation == ClaimOperation.Release ? null : request.Actor,
                         request.Operation == ClaimOperation.Takeover ? current!.Actor : null,
-                        pushedHead.StandardOutput.Trim(),
+                        transactionCommitSha,
                         detail,
                         historyPath)
                     {
@@ -288,12 +285,50 @@ internal static class ClaimCommand
 
                 var fetch = RunGit(transactionRoot, ["fetch", "origin", branchName]);
                 EnsureSuccess(fetch, "inspect rejected claim push");
+                var remoteHead = RunGit(transactionRoot, ["rev-parse", $"origin/{branchName}"]);
+                var remoteCommitMatches = remoteHead.ExitCode == 0
+                    && string.Equals(remoteHead.StandardOutput.Trim(), transactionCommitSha, StringComparison.Ordinal);
+
                 var remoteClaim = RunGit(transactionRoot,
                     ["show", $"origin/{branchName}:{relativeClaimPath}"]);
                 if (remoteClaim.ExitCode == 0)
                 {
                     var holder = JsonSerializer.Deserialize<ClaimRecord>(remoteClaim.StandardOutput, JsonOptions)
                         ?? throw new InvalidOperationException("remote claim record was empty");
+                    if (remoteCommitMatches
+                        && request.Operation != ClaimOperation.Release
+                        && string.Equals(holder.Actor, request.Actor, StringComparison.Ordinal)
+                        && string.Equals(holder.Team, request.Team, StringComparison.Ordinal)
+                        && string.Equals(holder.BaseCommit, head.StandardOutput.Trim(), StringComparison.Ordinal))
+                    {
+                        // A receive-side failure can be reported after the
+                        // remote ref has advanced. The fetched commit and
+                        // resulting claim state are the durable fact, so
+                        // cleanup must see the committed boundary.
+                        committed = true;
+                        var status = request.Operation switch
+                        {
+                            ClaimOperation.Acquire => "acquired",
+                            ClaimOperation.Release => "released",
+                            _ => "taken-over",
+                        };
+                        var detail = RefreshInvokingClone(
+                            repoRoot,
+                            branchName,
+                            ref lastGitWriteRetry,
+                            "The remote branch contains the transaction commit after the push process returned a failure; verified remote state is the ownership transition fact.");
+                        return new ClaimTransactionResult(
+                            status, request.Scope, relativeClaimPath, true, attempt,
+                            request.Operation == ClaimOperation.Release ? null : request.Actor,
+                            request.Operation == ClaimOperation.Takeover ? current!.Actor : null,
+                            transactionCommitSha,
+                            detail,
+                            historyPath)
+                        {
+                            GitWriteRetry = lastGitWriteRetry,
+                        };
+                    }
+
                     var samePreexistingClaim = current is not null
                         && holder == current;
                     if (request.Operation == ClaimOperation.Acquire || !samePreexistingClaim)
@@ -304,6 +339,25 @@ internal static class ClaimCommand
                             GitWriteRetry = lastGitWriteRetry,
                         };
                     }
+                }
+
+                if (remoteCommitMatches
+                    && request.Operation == ClaimOperation.Release
+                    && remoteClaim.ExitCode != 0)
+                {
+                    committed = true;
+                    var status = "released";
+                    var detail = RefreshInvokingClone(
+                        repoRoot,
+                        branchName,
+                        ref lastGitWriteRetry,
+                        "The remote branch contains the transaction commit after the push process returned a failure; verified remote state is the ownership transition fact.");
+                    return new ClaimTransactionResult(
+                        status, request.Scope, relativeClaimPath, true, attempt,
+                        null, null, transactionCommitSha, detail, historyPath)
+                    {
+                        GitWriteRetry = lastGitWriteRetry,
+                    };
                 }
 
                 // Unrelated remote advance: discard this isolated workspace and
@@ -319,9 +373,31 @@ internal static class ClaimCommand
                     };
                 }
             }
+            catch (Exception exception)
+            {
+                transactionFailure = exception;
+                throw;
+            }
             finally
             {
-                CleanupTransactionRoot(transactionRoot, committed, warningWriter, deleteDirectory);
+                try
+                {
+                    CleanupTransactionRoot(transactionRoot, committed, warningWriter, deleteDirectory);
+                }
+                catch (Exception cleanupFailure) when (transactionFailure is not null)
+                {
+                    try
+                    {
+                        warningWriter.WriteLine(
+                            "warning: claim transaction failed before commit; the original transaction "
+                            + "failure is preserved. Cleanup also failed: " + cleanupFailure.Message);
+                    }
+                    catch
+                    {
+                        // A broken warning sink must not replace the original
+                        // pre-commit transaction failure.
+                    }
+                }
             }
         }
 
@@ -386,6 +462,33 @@ internal static class ClaimCommand
         throw new IOException(
             $"Could not clean up claim transaction temporary directory '{transactionRoot}' before "
             + "the claim state was committed.", lastFailure);
+    }
+
+    private static string RefreshInvokingClone(
+        string repoRoot,
+        string branchName,
+        ref HostStateGitRetryEvidence? lastGitWriteRetry,
+        string committedDetail)
+    {
+        try
+        {
+            var localRefresh = RunGit(
+                repoRoot,
+                ["pull", "--ff-only", "origin", branchName],
+                hostStateWrite: true);
+            CaptureRetry(ref lastGitWriteRetry, localRefresh);
+            return localRefresh.ExitCode == 0
+                ? committedDetail
+                : committedDetail
+                    + " The invoking clone could not fast-forward: "
+                    + localRefresh.StandardError.Trim();
+        }
+        catch (Exception exception)
+        {
+            return committedDetail
+                + " The invoking clone refresh could not run: "
+                + exception.Message;
+        }
     }
 
     private static bool TryDeleteTransactionRoot(

--- a/tests/IntentSystem.Cli.Tests/ClaimCommandG743Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClaimCommandG743Tests.cs
@@ -1,0 +1,240 @@
+using System.Diagnostics;
+using System.Text.Json;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection(AutomationStalledWorkSharedStateCollection.Name)]
+public sealed class ClaimCommandG743Tests
+{
+    [Fact]
+    public void RemoteCommitAfterPushProcessFailure_PreservesCommittedResultAndWarns_G743()
+    {
+        if (OperatingSystem.IsWindows()) return;
+
+        using var repos = new ClaimRepositories();
+        using var output = new StringWriter();
+        using var warnings = new StringWriter();
+        var deleteAttempts = 0;
+        string? leftoverPath = null;
+
+        try
+        {
+            using (new GitPushFailureShim())
+            {
+                var exitCode = ClaimCommand.ExecuteAcquire(
+                    Context(repos.FirstClone),
+                    [
+                        "--scope", "execution-unit:G743",
+                        "--actor", "alice",
+                        "--team", "implementation",
+                        "--write",
+                        "--format", "json",
+                    ],
+                    output,
+                    warnings,
+                    path =>
+                    {
+                        leftoverPath = path;
+                        deleteAttempts++;
+                        throw new IOException("injected post-commit cleanup failure");
+                    });
+
+                Assert.True(exitCode == 0, $"expected committed success; exit_code={exitCode}; result={output}; warnings={warnings}");
+            }
+
+            using var emitted = JsonDocument.Parse(output.ToString());
+            Assert.Equal("acquired", emitted.RootElement.GetProperty("status").GetString());
+            Assert.True(emitted.RootElement.GetProperty("push_succeeded").GetBoolean());
+            var commit = emitted.RootElement.GetProperty("commit").GetString();
+            Assert.False(string.IsNullOrWhiteSpace(commit));
+            Assert.Contains("remote branch", emitted.RootElement.GetProperty("detail").GetString()!, StringComparison.Ordinal);
+            Assert.Equal(ClaimCommand.CleanupMaxAttempts, deleteAttempts);
+            Assert.NotNull(leftoverPath);
+            Assert.StartsWith(Path.GetTempPath(), leftoverPath!, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(leftoverPath, warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("claim result and exit code are unchanged", warnings.ToString(), StringComparison.Ordinal);
+
+            var remoteHead = Run(repos.Bare, "git", "rev-parse", "refs/heads/main").Trim();
+            Assert.Equal(commit, remoteHead);
+            var inspection = repos.CloneForInspection();
+            Assert.True(File.Exists(Path.Combine(
+                inspection, ClaimCommand.ClaimPath("execution-unit:G743"))));
+        }
+        finally
+        {
+            if (leftoverPath is not null && Directory.Exists(leftoverPath))
+            {
+                Directory.Delete(leftoverPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void PreCommitFailure_IsNotMaskedByCleanupFailure_G743()
+    {
+        using var repos = new ClaimRepositories();
+        var scope = "execution-unit:G743-precommit";
+        var blockedClaimPath = Path.Combine(
+            repos.FirstClone, ClaimCommand.ClaimPath(scope).Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(blockedClaimPath);
+        File.WriteAllText(Path.Combine(blockedClaimPath, "blocker"), "tracked directory blocker\n");
+        Run(repos.FirstClone, "git", "add", "--", ClaimCommand.ClaimPath(scope));
+        Run(repos.FirstClone, "git", "commit", "--quiet", "-m", "create claim path blocker");
+        Run(repos.FirstClone, "git", "push", "--quiet", "origin", "main");
+
+        using var warnings = new StringWriter();
+        string? leftoverPath = null;
+        try
+        {
+            var exception = Assert.ThrowsAny<Exception>(() => ClaimCommand.RunTransaction(
+                repos.FirstClone,
+                new ClaimRequest(
+                    ClaimOperation.Acquire,
+                    scope,
+                    "alice",
+                    "implementation",
+                    null,
+                    null,
+                    true,
+                    "json",
+                    ClaimCommand.DefaultMaxAttempts),
+                warnings,
+                path =>
+                {
+                    leftoverPath = path;
+                    throw new IOException("injected pre-commit cleanup failure");
+                }));
+
+            Assert.DoesNotContain("before the claim state was committed", exception.Message, StringComparison.Ordinal);
+            Assert.DoesNotContain("injected pre-commit cleanup failure", exception.Message, StringComparison.Ordinal);
+            Assert.NotEmpty(exception.Message);
+            Assert.NotNull(leftoverPath);
+            Assert.Contains(leftoverPath, warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("original transaction failure is preserved", warnings.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (leftoverPath is not null && Directory.Exists(leftoverPath))
+            {
+                Directory.Delete(leftoverPath, recursive: true);
+            }
+        }
+    }
+
+    private static CliContext Context(string root) => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private static string Run(string workdir, string fileName, params string[] arguments)
+    {
+        var info = new ProcessStartInfo(fileName)
+        {
+            WorkingDirectory = workdir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var argument in arguments) info.ArgumentList.Add(argument);
+        using var process = Process.Start(info)!;
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, $"{fileName} {string.Join(' ', arguments)} failed: {error}");
+        return output;
+    }
+
+    private sealed class GitPushFailureShim : IDisposable
+    {
+        private readonly string originalPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        private readonly string root = Directory.CreateTempSubdirectory("claim-git-shim-").FullName;
+
+        public GitPushFailureShim()
+        {
+            var wrapper = Path.Combine(root, "git");
+            File.WriteAllText(
+                wrapper,
+                "#!/bin/sh\n"
+                + "if [ \"${1:-}\" = \"push\" ]; then\n"
+                + "  /usr/bin/git \"$@\"\n"
+                + "  status=$?\n"
+                + "  if [ \"$status\" -eq 0 ]; then exit 77; fi\n"
+                + "  exit \"$status\"\n"
+                + "fi\n"
+                + "exec /usr/bin/git \"$@\"\n");
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    wrapper,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+            Environment.SetEnvironmentVariable(
+                "PATH", root + Path.PathSeparator + originalPath);
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("PATH", originalPath);
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private sealed class ClaimRepositories : IDisposable
+    {
+        private readonly TempDirectory temp = new("claim-repos-g743-");
+
+        public ClaimRepositories()
+        {
+            Bare = Path.Combine(temp.Path, "origin.git");
+            var seed = Path.Combine(temp.Path, "seed");
+            FirstClone = Path.Combine(temp.Path, "first");
+            Directory.CreateDirectory(Bare);
+            Run(Bare, "git", "init", "--bare", "--quiet");
+            Directory.CreateDirectory(seed);
+            Run(seed, "git", "init", "--quiet", "--initial-branch=main");
+            Run(seed, "git", "config", "user.name", "seed");
+            Run(seed, "git", "config", "user.email", "seed@example.invalid");
+            File.WriteAllText(Path.Combine(seed, "README.md"), "seed\n");
+            Run(seed, "git", "add", "README.md");
+            Run(seed, "git", "commit", "--quiet", "-m", "seed");
+            Run(seed, "git", "remote", "add", "origin", Bare);
+            Run(seed, "git", "push", "--quiet", "-u", "origin", "main");
+            Run(Bare, "git", "symbolic-ref", "HEAD", "refs/heads/main");
+            Run(temp.Path, "git", "clone", "--quiet", Bare, FirstClone);
+        }
+
+        public string Bare { get; }
+        public string FirstClone { get; }
+
+        public string CloneForInspection()
+        {
+            var path = Path.Combine(temp.Path, $"inspect-{Guid.NewGuid():N}");
+            Run(temp.Path, "git", "clone", "--quiet", Bare, path);
+            return path;
+        }
+
+        public void Dispose() => temp.Dispose();
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory(string prefix) => Path = Directory.CreateTempSubdirectory(prefix).FullName;
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/ClaimCommandG743Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClaimCommandG743Tests.cs
@@ -80,6 +80,8 @@ public sealed class ClaimCommandG743Tests
             repos.FirstClone, ClaimCommand.ClaimPath(scope).Replace('/', Path.DirectorySeparatorChar));
         Directory.CreateDirectory(blockedClaimPath);
         File.WriteAllText(Path.Combine(blockedClaimPath, "blocker"), "tracked directory blocker\n");
+        Run(repos.FirstClone, "git", "config", "user.name", "g743-fixture");
+        Run(repos.FirstClone, "git", "config", "user.email", "g743-fixture@example.invalid");
         Run(repos.FirstClone, "git", "add", "--", ClaimCommand.ClaimPath(scope));
         Run(repos.FirstClone, "git", "commit", "--quiet", "-m", "create claim path blocker");
         Run(repos.FirstClone, "git", "push", "--quiet", "origin", "main");


### PR DESCRIPTION
Closes #1617

## Summary

- Verify the transaction commit and resulting claim state on origin after a nonzero push process result. Only an exact remote commit and ownership-state match is reported as acquired, released, or taken-over with push_succeeded=true.
- Mark the transaction committed before bounded post-commit refresh and teardown, so cleanup or refresh failures cannot invite a duplicate acquire or change the result.
- Preserve the original pre-commit transaction exception when teardown also fails, with a separate leftover-path warning.
- Keep the existing 250 ms per cleanup attempt, three-attempt bound, 50 ms backoff, claim schema, and push retry semantics unchanged.

## Deterministic reproduction

Before the fix, ClaimCommandG743Tests.RemoteCommitAfterPushProcessFailure used a local bare origin and a git push shim that let the remote receive the commit before returning a nonzero process status. The command emitted status=error, push_succeeded=false, attempts=0, and the cleanup detail saying the claim state was not committed, while the remote branch and claim commit were already present. After the fix the same scenario passes with exit code 0, status=acquired, push_succeeded=true, the remote commit SHA, and the bounded cleanup warning naming the leftover OS-temp path.

## Verification

- ClaimCommandG743Tests: Failed: 0, Passed: 2, Skipped: 0, Total: 2.
- Adjacent claim/consumer/worker tests (G679, G680, WorkerClaimCommand): Failed: 0, Passed: 46, Skipped: 0, Total: 46.
- Full Release suite: Failed: 0, Passed: 5263, Skipped: 1, Total: 5264.
- `git diff --check`: clean.

## Workflow boundary

- Canonical child next-action and issue-preflight could not obtain fresh local claim evidence because `.git/FETCH_HEAD` was unavailable in the original child boundary; they reported wait/claim-unavailable for #1617. The supplied verified host authority for execution-unit:G743 held by implementation/team intent-cli-dev was consumed as authoritative, and no host repository was entered or read.
- Canonical issue claim was run with `--github-only --write` and added only `intent-issue-in-progress`.
- No work touched G744/#1618 or G745/#1619.