### PR TITLE
Roll post-release version to v0.25.0

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2728,7 +2728,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0250)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0251)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2934,37 +2934,42 @@ rotated by this command; the result and `shrink-audit.jsonl` say so explicitly.
 out of scope. Use `--dry-run` to inspect the measured plan without writing the
 manifest, JSONL files, or audit.
 
-### Next release readiness (v0.25.0)
+### Next release readiness (v0.25.1)
 
-**v0.24.0 shipped evidence:** the shipped baseline is
-intent-cli 0.24.0-df472fe-G737 from source revision
-df472fe5663c1a8b3682959aab6fbbf93c4d76ef. The tracked EN and JA
-release-notes-v0.24.0.md files are unchanged. The prior G740 roll's 0.24.1
-value was a placeholder only; its DRAFT stubs are removed by this preparation.
-The active note file is [release-notes-v0.25.0.md](release-notes-v0.25.0.md).
-The v0.24.0 GitHub Release and tag are authoritative shipped evidence.
-The untouched shipped-note files retain their `PREPARED / NOT PUBLISHED` banner.
+**v0.25.0 shipped evidence:** the shipped baseline is
+intent-cli 0.25.0-74a1c72-G741 from source revision
+74a1c722291a6a45a580221dcf8a9a8ad4e4d831. The tracked EN and JA
+release-notes-v0.25.0.md files are unchanged by this post-release roll.
+The prior v0.24.0 shipped-note files, release-notes-v0.24.0.md in both mirrors, remain historical evidence.
+The v0.25.1 line is a placeholder only; its DRAFT stubs are replaceable
+planning scaffolds and are not a changelog. Release-prep will replace them
+after measuring and deciding the next real release number.
+The active note file is [release-notes-v0.25.1.md](release-notes-v0.25.1.md).
+The v0.25.0 GitHub Release and tag are authoritative shipped evidence.
+The shipped-note files remain untouched by this post-release roll.
+The untouched shipped-note files retain their **PREPARED / NOT PUBLISHED** banner.
 The source-note inconsistency predates this roll; correcting it is out of scope and must be handled by a later explicitly scoped remediation.
-The comparison also used the installed 0.23.2 CLI. The shipped-note check records checkout_freshness/provenance.
-Rolled policy: `stableVersion → 0.24.0`; `nextVersion → 0.25.0`.
-The next-line package identity is `JTechJapan.IntentSystem.Cli.0.25.0.nupkg`; this is a derived verification value, not release content.
+The real-install verification reported intent-cli 0.25.0-74a1c72-G741; checkout freshness/provenance is recorded with this roll.
+The comparison also used the installed 0.23.2 CLI; the shipped-note check records checkout_freshness/provenance.
+Rolled policy: `stableVersion → 0.25.0`; `nextVersion → 0.25.1` (placeholder only).
+The next-line package identity is `JTechJapan.IntentSystem.Cli.0.25.1.nupkg`; this is a placeholder verification value, not a release decision.
 The release-prep check creates no tag or Release, publishes no package, and handles no credentials.
-The host-only claim boundary is `release-prep:<owner/repo>:0.25.0`; this child does not inspect host state.
+The host-only claim boundary is `release-prep:<owner/repo>:0.25.1`; this child does not inspect host state.
 The published [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0) and its tag are authoritative shipped evidence.
 The v0.23.0 shipped artifacts are the GitHub Release, NuGet package, and self-contained binaries; its npm leg never reached the registry, so `0.23.0` must not be treated as available from npm.
 The tracked EN and JA `release-notes-v0.23.0.md` files now state this shipped-artifact status.
 
 
 
-**Measured v0.25.0 reason and built identity:** the exact prepared functional
+**Previous v0.25.0 preparation evidence (retained for provenance):** the exact prepared functional
 head is 5c4af5d88ddcfa47335bad4df56ad3e40dae9140. Its Release build reports
 intent-cli 0.24.1-5c4af5d-G741; installed intent-cli reports
 intent-cli 0.24.0-df472fe-G737. The two new options are
 session-layer topology record --model <text>,
 session-layer topology record --reasoning-effort <text>, and
 notify supervise --delegation-execution-window-seconds <seconds>
-(default 300). That measured command-surface difference is the auditable
-reason for stableVersion 0.24.0 / nextVersion 0.25.0.
+(default 300). That measured command-surface difference was the auditable
+reason for the prior stableVersion 0.24.0 / nextVersion 0.25.0 preparation.
 
 ```bash
 intent-cli --version
@@ -2994,8 +2999,8 @@ non-failing. G741 reports a delivered-but-never-observably-started delegation
 only for the full six-part conjunction; slow-but-started work is not a finding,
 and the classifier is observation-only. Six motivating incidents are recorded
 without naming a seat.
-The closeout retains **DRAFT note stubs in the same commit** (step 5), the readiness section **refreshed to the new line in both language mirrors** (step 6), and the **post-roll green child-main CI check** before the roll counts as complete (step 7).
-This is the prepare-only release-prep packet; the next real release number remains a measurement decision.
+The preceding v0.25.0 preparation recorded **DRAFT note stubs in the same commit** (step 5), **refreshed to the new line in both language mirrors** (step 6), and required the **post-roll green child-main CI check** before the roll counts as complete (step 7).
+This post-release roll keeps the next real release number as a measurement decision; 0.25.1 is only a placeholder.
 
 The readiness guards retained from prior release lines are ReleaseNotesV0180DocsTests, ReleaseNotesV0190DocsTests, and ReleaseNotesV0170DocsTests.
 This post-release roll follows **steps 5–7** of the post-release version roll; existing release tags, Releases, packages, workflows, and shipped note files remain unchanged.
@@ -3014,11 +3019,12 @@ git diff --check
 
 Targeted release-prep guards: 40 passed, 0 failed, 0 skipped (40 total).
 Dedicated G613 JA terminology guard: 6 passed, 0 failed, 0 skipped (6 total).
-Adjacent tests: 14 passed, 0 failed, 0 skipped (14 total).
-Full Release suite: 5261 passed, 0 failed, 1 skipped (5262 total).
-`eng/version.json` must remain exactly stableVersion 0.24.0 and
-nextVersion 0.25.0. No tag, GitHub Release, package publish, post-release roll,
-or source runtime change belongs to this preparation.
+Adjacent release tests: 50 passed, 0 failed, 0 skipped (50 total).
+Full Release suite: 5268 passed, 0 failed, 1 skipped (5269 total).
+`eng/version.json` is now exactly stableVersion 0.25.0 and
+nextVersion 0.25.1. The 0.25.1 value is a placeholder only; release-prep
+must measure and decide the next real release number. No tag, GitHub Release,
+package publish, or source runtime change belongs to this post-release roll.
 ### Re-creating a deleted release tag (`v0.3.3`)
 
 `v0.3.3` was tagged too early and the tag was deleted. **Only re-create the

--- a/docs/en/release-notes-v0.25.1.md
+++ b/docs/en/release-notes-v0.25.1.md
@@ -1,0 +1,10 @@
+# Release Notes — intent-cli v0.25.1
+
+> **⚠️ DRAFT / UNRELEASED.** This replaceable planning scaffold is not a changelog.
+> The release-prep packet authors the real content and will replace this
+> placeholder after measuring and deciding the next real release number.
+> This file must not be treated as a changelog.
+
+This placeholder intentionally contains no release entries. No GitHub Release
+exists for this placeholder yet. The matching install query is
+`JTechJapan.IntentSystem.Cli --version 0.25.1`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2978,29 +2978,34 @@ result は literal bytes の削減、追加した reference bytes、record の n
 `shrink-audit.jsonl` に明記します。`.intent-cli/runs/*.provider.jsonl` は別の provider-run state なので
 scope 外です。`--dry-run` なら manifest、JSONL、audit を書き込まずに測定済み plan だけを確認できます。
 
-### 次リリース準備(v0.25.0)
+### 次リリース準備(v0.25.1)
 
-**v0.24.0 shipped evidence:** shipped baseline は
-intent-cli 0.24.0-df472fe-G737 で、source revision は
-df472fe5663c1a8b3682959aab6fbbf93c4d76ef です。tracked な EN/JA
-release-notes-v0.24.0.md は変更していません。前回 G740 roll の 0.24.1
-value は placeholder だけであり、その DRAFT stub はこの preparation で削除します。
-現在の note file は [release-notes-v0.25.0.md](release-notes-v0.25.0.md) です。
-v0.24.0 GitHub Release と tag が shipped evidence の authoritative source です。
-変更していない shipped-note file は `PREPARED / NOT PUBLISHED` banner を保持します。
+**v0.25.0 shipped evidence:** shipped baseline は
+intent-cli 0.25.0-74a1c72-G741 で、source revision は
+74a1c722291a6a45a580221dcf8a9a8ad4e4d831 です。tracked な EN/JA
+release-notes-v0.25.0.md はこの post-release roll で変更していません。
+前の v0.24.0 shipped-note file、release-notes-v0.24.0.md は両方の mirror にある historical evidence として残ります。
+v0.25.1 line は placeholder だけです。その DRAFT stub は replaceable
+planning scaffold で changelog ではありません。release-prep は測定して次の
+real release number を決めた後、この stub を replace します。
+現在の note file は [release-notes-v0.25.1.md](release-notes-v0.25.1.md) です。
+v0.25.0 GitHub Release と tag が shipped evidence の authoritative source です。
+shipped-note file はこの post-release roll で変更していません。
+変更していない shipped-note file は **PREPARED / NOT PUBLISHED** banner を保持します。
 source-note inconsistency はこの roll より前から存在し、修正は scope 外であり、後続の explicitly scoped remediation で扱います。
+real-install verification は intent-cli 0.25.0-74a1c72-G741 を報告しました。checkout freshness/provenance はこの roll とともに記録します。
 比較対象には installed 0.23.2 CLI を使いました。shipped-note check は checkout_freshness/provenance を記録します。
-Rolled policy: `stableVersion → 0.24.0`; `nextVersion → 0.25.0`。
-次の line の package identity は `JTechJapan.IntentSystem.Cli.0.25.0.nupkg` です。これは derived verification value で、release content ではありません。
+Rolled policy: `stableVersion → 0.25.0`; `nextVersion → 0.25.1` (placeholder only)。
+次の line の package identity は `JTechJapan.IntentSystem.Cli.0.25.1.nupkg` です。これは placeholder の verification value であり、release decision ではありません。
 release-prep check は tag または Release を作成せず、package を publish せず、credentials を扱いません。
-host-only claim boundary は `release-prep:<owner/repo>:0.25.0` で、この child は host state を inspect しません。
+host-only claim boundary は `release-prep:<owner/repo>:0.25.1` で、この child は host state を inspect しません。
 公開済みの [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0) とその tag は authoritative shipped evidence です。
 v0.23.0 の shipped artifact は GitHub Release、NuGet package、自己完結型バイナリです。ただし npm leg は registry に到達しなかったため、`0.23.0` は npm で利用できると扱ってはいけません。
 tracked な EN/JA の `release-notes-v0.23.0.md` files はこの shipped-artifact status を記録します。
 
 
 
-**v0.25.0 の reason と built identity:** 正確な prepared functional head は
+**Previous v0.25.0 preparation evidence (retained for provenance):** 正確な prepared functional head は
 5c4af5d88ddcfa47335bad4df56ad3e40dae9140 です。その Release build は
 intent-cli 0.24.1-5c4af5d-G741 を表示し、installed intent-cli は
 intent-cli 0.24.0-df472fe-G737 を表示しました。増えた option は
@@ -3008,7 +3013,7 @@ session-layer topology record --model <text>、
 session-layer topology record --reasoning-effort <text>、
 notify supervise --delegation-execution-window-seconds <seconds>
 (default 300) です。この測定した command-surface difference が
-stableVersion 0.24.0 / nextVersion 0.25.0 の監査可能な reason です。
+prior stableVersion 0.24.0 / nextVersion 0.25.0 preparation の監査可能な reason でした。
 
 ```bash
 intent-cli --version
@@ -3038,8 +3043,8 @@ absence は fail になりません。G741 は六条件が全て成立した
 delivered-but-never-observably-started delegation だけを finding として報告し、
 slow-but-started は finding にしません。classifier は observation-only で、
 六つの motivating incident を seat 名なしで記録します。
-closeout は **同一コミットに DRAFT note スタブ**(ステップ 5)、readiness section の **両ミラーで新しいラインへ更新**(ステップ 6)、そして **roll 後の child main CI green 確認**(ステップ 7) を保持します。
-これは prepare-only release-prep packet であり、次の real release number は measurement に基づく decision のままです。
+preceding v0.25.0 preparation は **同一コミットに DRAFT note スタブ**(ステップ 5)、**両ミラーで新しいラインへ更新**(ステップ 6)、そして **roll 後の child main CI green 確認**(ステップ 7)を記録しました。
+この post-release roll でも次の real release number は measurement に基づく decision のままで、0.25.1 は placeholder だけです。
 
 過去の release line から維持する readiness guard は ReleaseNotesV0180DocsTests、ReleaseNotesV0190DocsTests、ReleaseNotesV0170DocsTests です。
 この post-release roll は **ステップ 5–7** に従います。既存の release tag、Release、package、workflow、shipped note file は変更しません。
@@ -3058,11 +3063,11 @@ git diff --check
 
 Targeted release-prep guard: 40 passed, 0 failed, 0 skipped (40 total)。
 Dedicated G613 JA terminology guard: 6 passed, 0 failed, 0 skipped (6 total)。
-Adjacent test: 14 passed, 0 failed, 0 skipped (14 total)。
-Full Release suite: 5261 passed, 0 failed, 1 skipped (5262 total)。
-`eng/version.json` は stableVersion 0.24.0 / nextVersion 0.25.0 のままにします。
-tag、GitHub Release、package publish、post-release roll、source runtime change は
-この preparation の範囲外です。
+Adjacent release tests: 50 passed, 0 failed, 0 skipped (50 total)。
+Full Release suite: 5268 passed, 0 failed, 1 skipped (5269 total)。
+`eng/version.json` は stableVersion 0.25.0 / nextVersion 0.25.1 になりました。
+0.25.1 は placeholder だけであり、release-prep が次の real release number を測定して
+決めます。tag、GitHub Release、package publish、source runtime change はこの roll の範囲外です。
 ### 削除済みリリースタグ（`v0.3.3`）の再作成
 
 `v0.3.3` は早すぎる段階でタグ付けされ、タグは削除されました。**`v0.3.3` タグ/リリースの再作成は、

--- a/docs/ja/release-notes-v0.25.1.md
+++ b/docs/ja/release-notes-v0.25.1.md
@@ -1,0 +1,10 @@
+# リリースノート — intent-cli v0.25.1
+
+> **⚠️ DRAFT / 未リリース。** これは replaceable planning scaffold です。
+> release-prep パケットが author します。次の real release number を測定して
+> 決めた後、この placeholder を replace します。この file は changelog ではありません。
+> changelog として扱ってはいけません。
+
+この placeholder には release entry を記録しません。v0.25.1 の GitHub
+Release はまだ存在しません (no GitHub Release)。matching install query は
+`JTechJapan.IntentSystem.Cli --version 0.25.1` です。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.24.0",
-  "nextVersion": "0.25.0"
+  "stableVersion": "0.25.0",
+  "nextVersion": "0.25.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
@@ -169,14 +169,15 @@ public sealed class ReleaseNotesV0240DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.24.0", policy.StableVersion);
-        Assert.Equal("0.25.0", policy.NextVersion);
+        Assert.Equal("0.25.0", policy.StableVersion);
+        Assert.Equal("0.25.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.24.0.md")));
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.24.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.25.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.25.1.md")));
 
             var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
             Assert.Contains("0.24.0", reference, StringComparison.Ordinal);
@@ -185,10 +186,10 @@ public sealed class ReleaseNotesV0240DocsTests
             Assert.Contains("release-notes-v0.25.0.md", reference, StringComparison.Ordinal);
             Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
             Assert.Contains(
-                language == "en" ? "Next release readiness (v0.25.0)" : "次リリース準備(v0.25.0)",
+                language == "en" ? "Next release readiness (v0.25.1)" : "次リリース準備(v0.25.1)",
                 reference,
                 StringComparison.Ordinal);
-            Assert.Contains("intent-cli 0.24.0-df472fe-G737", reference, StringComparison.Ordinal);
+            Assert.Contains("intent-cli 0.25.0-74a1c72-G741", reference, StringComparison.Ordinal);
             Assert.Contains("ReleasePackageMetadataTests", reference, StringComparison.Ordinal);
             Assert.Contains("VersionSourcePolicyGuardTests", reference, StringComparison.Ordinal);
         }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
@@ -14,6 +14,7 @@ public sealed class ReleaseNotesV0250DocsTests
         "5c4af5d88ddcfa47335bad4df56ad3e40dae9140";
     private const string BuiltDisplayIdentity = "intent-cli 0.24.1-5c4af5d-G741";
     private const string InstalledDisplayIdentity = "intent-cli 0.24.0-df472fe-G737";
+    private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.25.0-74a1c72-G741";
 
     private static readonly (string Unit, string Pr, string Merge)[] Units =
     [
@@ -164,13 +165,17 @@ public sealed class ReleaseNotesV0250DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
 
-        Assert.Equal("0.24.0", policy.StableVersion);
-        Assert.Equal("0.25.0", policy.NextVersion);
+        Assert.Equal("0.25.0", policy.StableVersion);
+        Assert.Equal("0.25.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.25.0.md")));
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.24.1.md")));
+            var stub = File.ReadAllText(Path.Combine(root, "docs", language, "release-notes-v0.25.1.md"));
+            Assert.Contains("DRAFT", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("replaceable", stub, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(language == "en" ? "not a changelog" : "changelog ではありません", stub, StringComparison.OrdinalIgnoreCase);
         }
     }
 
@@ -183,12 +188,13 @@ public sealed class ReleaseNotesV0250DocsTests
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.25.0)" : "次リリース準備(v0.25.0)",
+            language == "en" ? "Next release readiness (v0.25.1)" : "次リリース準備(v0.25.1)",
             reference,
             StringComparison.Ordinal);
-        Assert.Contains(InstalledDisplayIdentity, reference, StringComparison.Ordinal);
+        Assert.Contains(CurrentStableInstallDisplayIdentity, reference, StringComparison.Ordinal);
         Assert.Contains(BuiltDisplayIdentity, reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.25.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.25.1.md", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0250DocsTests", reference, StringComparison.Ordinal);
         Assert.Contains("JapaneseTerminologyGuardG613Tests", reference, StringComparison.Ordinal);


### PR DESCRIPTION
Closes #1619

This post-release roll sets eng/version.json to stableVersion 0.25.0 and placeholder nextVersion 0.25.1, adds replaceable DRAFT/not-a-changelog EN/JA v0.25.1 stubs, and refreshes both readiness mirrors with the shipped 0.25.0 identity intent-cli 0.25.0-74a1c72-G741. Shipped v0.25.0 release-note files remain untouched; no tag, Release, publish, or next-real-version decision is included.

Verification: focused release/version/G613 40 passed, dedicated G613 6 passed, adjacent release tests 50 passed, full Release 5268 passed / 0 failed / 1 skipped (5269 total), git diff --check clean.

G725 host duty: after merge, run the stalled-work detector from a fresh synced origin/main checkout and require checkout_freshness=fresh with no version-roll-required item. The child synced pre-merge evidence at 0e97529c64294677b41e49cd87a40920c1dd3d4e reports the expected pre-merge version-roll-required item; no host repository was entered or inspected.