### PR TITLE
Make duplicate queue items reportable and repairable

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -3039,3 +3039,26 @@ and the release CI test job is green:**
 
 Re-tagging before a green CI run on a commit that contains both fixes will
 reproduce the original failing release job.
+
+### G746: Duplicate queue items are recoverable, not impossible
+
+Queue-state is an ordered list, but `execution_unit` is the identity of a
+queue item. `automation closeout-drift-check` groups entries by that identity
+before looking up GitHub. It reports every duplicated unit as
+`duplicate-queue-item`, includes both full competing entries, withholds
+closeout for only that unit, and continues the remaining drift checks. A
+duplicate must never crash the command through a dictionary insertion.
+
+`automation state-doctor` reports the same finding. With `--write`, it removes
+duplicates only when one entry is **strictly more informative** than every
+competitor: it may have a more advanced lifecycle state, or carry a
+`linked_pr`/`linked_issue` that is absent from the other entry, while
+preserving every field from the entry kept. Byte-identical/equivalent entries
+and incomparable entries are unsafe stops: the finding names the unit, shows
+the full competing entries, and applies no mutation. The operator must
+reconcile those fields and rerun the canonical command.
+
+This makes duplicate queue items **recoverable, not impossible**. Do not hand
+edit queue-state. The repair is deliberately limited to duplicate reporting
+and strict-dominance reconciliation; concurrent-write prevention, locking,
+CAS, and queue-schema changes remain separate work.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -3081,3 +3081,25 @@ Full Release suite: 5268 passed, 0 failed, 1 skipped (5269 total)。
 
 両修正を含むコミットで green な CI 実行を得る前に再タグすると、元の失敗したリリースジョブが
 再現します。
+
+### G746: 重複 queue item は recoverable であり impossible ではない (duplicates are recoverable, not impossible)
+
+queue-state は順序付きリストですが、queue item の identity は
+`execution_unit` です。`automation closeout-drift-check` は GitHub lookup
+の前にこの identity ごとに entry をまとめます。重複しているすべての unit
+を `duplicate-queue-item` として報告し、両方の full competing entries を
+出力し、その unit の closeout だけを保留して、残りの drift check を継続
+します。Dictionary.Add による未処理例外で command が停止してはいけません。
+
+`automation state-doctor` も同じ finding を報告します。`--write` で削除
+できるのは、他のすべての entry より **strictly more informative** な entry
+が一つだけの場合に限ります。より進んだ lifecycle state、または相手にない
+`linked_pr`/`linked_issue` を持ち、保持する entry から情報を失わない場合です。
+byte-identical/equivalent または incomparable な entry は unsafe stop とし、
+unit 名と full competing entries を示して mutation を行いません。operator
+が competing fields を整理してから canonical command を再実行します。
+
+この修復により duplicate queue item は **recoverable であり、impossible
+ではありません**。queue-state を手編集してはいけません。対象は重複の報告と
+strict dominance による安全な整理だけであり、concurrent-write prevention、
+locking、CAS、queue schema の変更は別の作業です。

--- a/src/IntentSystem.Cli/Commands/AutomationCloseoutDriftCheckCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationCloseoutDriftCheckCommand.cs
@@ -39,6 +39,10 @@ internal static class AutomationCloseoutDriftCheckCommand
     internal const string ReasonAmbiguousMapping = "ambiguous-pr-mapping";
     internal const string ReasonNoLinkedPr = "no-linked-pr";
     internal const string ReasonLookupFailed = "pr-lookup-failed";
+
+    /// <summary>G746: duplicate execution-unit queue entries block closeout until state-doctor reconciles them.</summary>
+    internal const string ReasonDuplicateQueueItem = "duplicate-queue-item";
+
     internal const string ReasonMissingClosingIssueLinkage = "missing-closing-issue-linkage";
     internal const string ReasonClosingIssueMismatch = "closing-issue-mismatch";
 
@@ -131,20 +135,54 @@ internal static class AutomationCloseoutDriftCheckCommand
             return 0;
         }
 
+        // ---- duplicate-queue-item (G746) ------------------------------------
+        // A duplicate unit is withheld from closeout evaluation. The canonical
+        // repair belongs to state-doctor, so closeout reports the unit and
+        // continues checking every non-duplicated unit.
+        var duplicateGroups = DuplicateQueueItemRules.Analyze(
+            queueState.Items
+                .Select((item, index) => DuplicateQueueItemRules.FromQueueItem(item, index))
+                .ToArray());
+        var duplicateUnits = duplicateGroups
+            .Select(group => group.ExecutionUnit)
+            .ToHashSet(StringComparer.Ordinal);
+        var records = new List<CloseoutDriftRecord>();
+        var warnings = new List<string>();
+
+        foreach (var group in duplicateGroups)
+        {
+            var competingEntries = DuplicateQueueItemRules.FormatCompetingEntries(group);
+            var resolution = group.Winner is null
+                ? "entries are incomparable or equivalent; state-doctor will fail closed"
+                : $"entry[{group.Winner.Index}] is strictly more informative; run state-doctor --write for the canonical repair";
+            records.Add(new CloseoutDriftRecord
+            {
+                ExecutionUnit = group.ExecutionUnit,
+                Result = ResultUnsafeStop,
+                ReasonCode = ReasonDuplicateQueueItem,
+                Explanation = $"queue-state contains {group.Entries.Count} entries for execution unit '{group.ExecutionUnit}'; closeout is withheld because {resolution}. Competing full entries:\n{competingEntries}",
+                LinkedPrNumber = null,
+                LinkedIssueNumber = null,
+                CompetingEntries = group.Entries.Select(entry => entry.FullEntryJson).ToArray(),
+            });
+        }
+
         // ── Pass 1 (G356): non-Completed items that have a linked_pr ───────
         var pass1Candidates = queueState.Items
             .Where(item => item.State != QueueItemState.Completed
+                && !duplicateUnits.Contains(item.ExecutionUnit)
                 && !string.IsNullOrWhiteSpace(item.LinkedPr))
             .ToList();
 
         // ── Pass 2 (G358): non-Completed items with linked_issue but no linked_pr ──
         var pass2Candidates = queueState.Items
             .Where(item => item.State != QueueItemState.Completed
+                && !duplicateUnits.Contains(item.ExecutionUnit)
                 && item.LinkedIssue?.Number is { } n and > 0
                 && string.IsNullOrWhiteSpace(item.LinkedPr))
             .ToList();
 
-        if (pass1Candidates.Count == 0 && pass2Candidates.Count == 0)
+        if (pass1Candidates.Count == 0 && pass2Candidates.Count == 0 && records.Count == 0)
         {
             var empty = new CloseoutDriftCheckResult
             {
@@ -185,8 +223,6 @@ internal static class AutomationCloseoutDriftCheckCommand
 
         var prLookup = PrLookupFactory?.Invoke() ?? new GhCliGitHubPrLookup();
         var issueLookup = IssueLookupFactory?.Invoke() ?? new GhCliGitHubIssueClosingPrLookup();
-        var records = new List<CloseoutDriftRecord>();
-        var warnings = new List<string>();
 
         // Items whose linked_pr URL couldn't be parsed → skipped.
         foreach (var item in itemsWithoutPrNumber)
@@ -751,6 +787,10 @@ internal sealed record CloseoutDriftRecord
 
     [JsonPropertyName("linked_issue_number")]
     public int? LinkedIssueNumber { get; init; }
+
+    [JsonPropertyName("competing_entries")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? CompetingEntries { get; init; }
 
     /// <summary>
     /// G358: for records where <c>linked_pr</c> was absent in queue-state and

--- a/src/IntentSystem.Cli/Commands/AutomationStateDoctorAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStateDoctorAnalyzer.cs
@@ -32,6 +32,81 @@ internal static class AutomationStateDoctorAnalyzer
         var findings = new List<AutomationStateDoctorFinding>();
         var unsafeFindings = new List<AutomationStateDoctorUnsafe>();
 
+        // ---- duplicate-queue-item (G746) ------------------------------------
+        // Queue-state is an ordered list, but array order is not authority. A
+        // duplicate is repairable only when one complete entry strictly
+        // dominates every competing entry; otherwise all competing entries are
+        // retained in an unsafe finding and the command must not write.
+        var indexedQueueItems = queueItems
+            .Select((item, index) => item with
+            {
+                SourceIndex = item.SourceIndex >= 0 ? item.SourceIndex : index,
+            })
+            .ToArray();
+        var duplicateGroups = DuplicateQueueItemRules.Analyze(
+            indexedQueueItems
+                .Select((item, index) => DuplicateQueueItemRules.FromProjection(item, index))
+                .ToArray());
+        var duplicateGroupsByUnit = duplicateGroups.ToDictionary(
+            group => group.ExecutionUnit,
+            StringComparer.Ordinal);
+
+        foreach (var group in duplicateGroups)
+        {
+            var competingEntries = DuplicateQueueItemRules.FormatCompetingEntries(group);
+            if (group.Winner is { } winner)
+            {
+                findings.Add(new AutomationStateDoctorFinding
+                {
+                    Category = AutomationStateDoctorCategories.DuplicateQueueItem,
+                    ExecutionUnit = group.ExecutionUnit,
+                    RepairKind = AutomationStateDoctorRepairKinds.DeduplicateQueueItem,
+                    IssueNumber = null,
+                    IssueUrl = null,
+                    IssueRepo = null,
+                    PrNumber = null,
+                    PrUrl = null,
+                    QueueItemIndex = winner.Index,
+                    RemoveQueueItemIndices = group.Entries
+                        .Where(entry => entry.Index != winner.Index)
+                        .Select(entry => entry.Index)
+                        .ToArray(),
+                    Confidence = AutomationStateDoctorConfidence.High,
+                    Applied = false,
+                    Evidence =
+                    [
+                        $"entry[{winner.Index}] for '{group.ExecutionUnit}' strictly dominates the other duplicate entry or entries without losing competing information",
+                        $"state-doctor --write keeps entry[{winner.Index}] and removes only the less informative duplicate entry or entries",
+                        $"competing entries:\n{competingEntries}",
+                    ],
+                    Summary = $"Deduplicate queue-state entries for '{group.ExecutionUnit}' by keeping the strictly more informative entry[{winner.Index}].",
+                });
+            }
+            else
+            {
+                unsafeFindings.Add(new AutomationStateDoctorUnsafe
+                {
+                    Kind = AutomationStateDoctorUnsafeKinds.DuplicateQueueItem,
+                    ExecutionUnit = group.ExecutionUnit,
+                    IssueNumber = null,
+                    Reason = $"duplicate queue-state entries for execution unit '{group.ExecutionUnit}' are incomparable or equivalent; unsafe-stop — no mutation is allowed. Competing full entries:\n{competingEntries}",
+                    MissingEvidence =
+                    [
+                        "operator must provide a strictly more informative canonical entry or reconcile the competing fields before retrying state-doctor --write",
+                    ],
+                    CompetingEntries = group.Entries.Select(entry => entry.FullEntryJson).ToArray(),
+                });
+            }
+        }
+
+        // Analyze only one canonical entry for a dominated group. Ambiguous
+        // groups are omitted from ordinary drift checks because they already
+        // have a fail-closed duplicate finding.
+        var queueItemsForAnalysis = indexedQueueItems
+            .Where(item => !duplicateGroupsByUnit.TryGetValue(item.ExecutionUnit, out var group)
+                || group.Winner?.Index == item.SourceIndex)
+            .ToArray();
+
         // Index PRs by the issue numbers they close (only same-repo numbers are
         // supplied by the command projection). A given issue may be closed by
         // more than one PR — that is the ambiguous case.
@@ -110,7 +185,7 @@ internal static class AutomationStateDoctorAnalyzer
             .GroupBy(evidence => evidence.ExecutionUnit, StringComparer.Ordinal)
             .ToDictionary(g => g.Key, g => g.ToArray(), StringComparer.Ordinal);
 
-        foreach (var queueItem in queueItems)
+        foreach (var queueItem in queueItemsForAnalysis)
         {
             var item = queueItem;
             var hasLinkedIssue = item.LinkedIssueNumber is int && SameRepo(item.LinkedIssueRepo, repo);
@@ -137,6 +212,7 @@ internal static class AutomationStateDoctorAnalyzer
                         IssueRepo = evidence.IssueRepo,
                         PrNumber = null,
                         PrUrl = null,
+                        QueueItemIndex = item.SourceIndex,
                         Confidence = AutomationStateDoctorConfidence.High,
                         Applied = false,
                         Evidence =
@@ -189,6 +265,7 @@ internal static class AutomationStateDoctorAnalyzer
                         IssueRepo = item.LinkedIssueRepo,
                         PrNumber = pr.Number,
                         PrUrl = pr.Url,
+                        QueueItemIndex = item.SourceIndex,
                         Confidence = AutomationStateDoctorConfidence.High,
                         Applied = false,
                         Evidence =
@@ -234,6 +311,7 @@ internal static class AutomationStateDoctorAnalyzer
                         IssueRepo = item.LinkedIssueRepo,
                         PrNumber = pr.Number,
                         PrUrl = pr.Url,
+                        QueueItemIndex = item.SourceIndex,
                         Confidence = AutomationStateDoctorConfidence.High,
                         Applied = false,
                         Evidence =
@@ -270,7 +348,7 @@ internal static class AutomationStateDoctorAnalyzer
         // are fully covered by the durable evidence already supplied.
         var duplicateAnalysis = DuplicateExecutionUnitIssueAnalyzer.Analyze(
             repo,
-            queueItems,
+            queueItemsForAnalysis,
             publishEvidence,
             pullRequests);
         findings.AddRange(duplicateAnalysis.Findings);

--- a/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStateDoctorCommand.cs
@@ -159,7 +159,16 @@ internal static class AutomationStateDoctorCommand
         var warnings = new List<string>();
         if (string.Equals(mode, AutomationStateDoctorModes.Write, StringComparison.Ordinal))
         {
-            findings = ApplyHighConfidenceRepairs(hostContext, findings, warnings);
+            if (analysis.UnsafeFindings.Any(unsafeFinding =>
+                string.Equals(unsafeFinding.Kind, AutomationStateDoctorUnsafeKinds.DuplicateQueueItem, StringComparison.Ordinal)))
+            {
+                warnings.Add(
+                    "ambiguous duplicate-queue-item finding present; state-doctor --write is fail-closed and applied no repairs.");
+            }
+            else
+            {
+                findings = ApplyHighConfidenceRepairs(hostContext, findings, warnings);
+            }
         }
 
         var result = new AutomationStateDoctorResult
@@ -210,13 +219,73 @@ internal static class AutomationStateDoctorCommand
         }
 
         var items = queueState.Items.ToArray();
-        var appliedById = new Dictionary<string, AutomationStateDoctorFinding>(StringComparer.Ordinal);
+        var appliedById = new HashSet<string>(StringComparer.Ordinal);
         var appliedEvents = new List<RunEvent>();
+        var queueItemIndicesToRemove = new HashSet<int>();
         var mutated = false;
 
         foreach (var finding in highConfidence)
         {
-            var index = Array.FindIndex(items, item => string.Equals(item.ExecutionUnit, finding.ExecutionUnit, StringComparison.Ordinal));
+            if (string.Equals(finding.RepairKind, AutomationStateDoctorRepairKinds.DeduplicateQueueItem, StringComparison.Ordinal))
+            {
+                if (finding.QueueItemIndex is not int winnerIndex
+                    || finding.RemoveQueueItemIndices is not { Count: > 0 } requestedRemovalList
+                    || winnerIndex < 0
+                    || winnerIndex >= items.Length)
+                {
+                    warnings.Add($"invalid duplicate-queue-item repair metadata for '{finding.ExecutionUnit}'; skipped.");
+                    continue;
+                }
+
+                var duplicateGroup = DuplicateQueueItemRules.Analyze(
+                        items.Select((item, index) => DuplicateQueueItemRules.FromQueueItem(item, index)).ToArray())
+                    .SingleOrDefault(group => string.Equals(
+                        group.ExecutionUnit, finding.ExecutionUnit, StringComparison.Ordinal));
+                var requestedRemovals = requestedRemovalList.ToHashSet();
+                var actualRemovals = duplicateGroup?.Entries
+                    .Where(entry => entry.Index != duplicateGroup.Winner?.Index)
+                    .Select(entry => entry.Index)
+                    .ToHashSet()
+                    ?? [];
+                if (duplicateGroup?.Winner?.Index != winnerIndex
+                    || !requestedRemovals.SetEquals(actualRemovals))
+                {
+                    warnings.Add($"duplicate-queue-item repair for '{finding.ExecutionUnit}' no longer matches the current queue-state; skipped.");
+                    continue;
+                }
+
+                queueItemIndicesToRemove.UnionWith(requestedRemovals);
+                mutated = true;
+                appliedById.Add(FindingId(finding));
+                appliedEvents.Add(new RunEvent
+                {
+                    Ts = DateTimeOffset.UtcNow,
+                    ExecutionUnit = finding.ExecutionUnit,
+                    Event = RunEventName,
+                    By = "automation state-doctor (G746)",
+                    Reason = finding.Summary,
+                    Repo = finding.IssueRepo,
+                    Pr = finding.PrNumber,
+                });
+                continue;
+            }
+
+            int index;
+            if (finding.QueueItemIndex is int requestedIndex)
+            {
+                if (requestedIndex < 0
+                    || requestedIndex >= items.Length
+                    || !string.Equals(items[requestedIndex].ExecutionUnit, finding.ExecutionUnit, StringComparison.Ordinal))
+                {
+                    warnings.Add($"queue-state item index {requestedIndex} no longer identifies '{finding.ExecutionUnit}'; skipped {finding.Category}.");
+                    continue;
+                }
+                index = requestedIndex;
+            }
+            else
+            {
+                index = Array.FindIndex(items, item => string.Equals(item.ExecutionUnit, finding.ExecutionUnit, StringComparison.Ordinal));
+            }
             if (index < 0)
             {
                 warnings.Add($"queue-state has no item with execution_unit '{finding.ExecutionUnit}'; skipped {finding.Category}.");
@@ -264,7 +333,7 @@ internal static class AutomationStateDoctorCommand
 
             items[index] = updated;
             mutated = true;
-            appliedById[finding.ExecutionUnit + "|" + finding.Category] = finding;
+            appliedById.Add(FindingId(finding));
             appliedEvents.Add(new RunEvent
             {
                 Ts = DateTimeOffset.UtcNow,
@@ -283,7 +352,8 @@ internal static class AutomationStateDoctorCommand
         {
             try
             {
-                var updatedState = queueState with { Items = items, UpdatedAt = DateTimeOffset.UtcNow };
+                var updatedItems = items.Where((_, index) => !queueItemIndicesToRemove.Contains(index)).ToArray();
+                var updatedState = queueState with { Items = updatedItems, UpdatedAt = DateTimeOffset.UtcNow };
                 // G548: guarded write (no-item-loss + stale-base re-application).
                 QueueStatePersistence.Persist(queueStatePath, queueState, updatedState);
                 AppendRunEvents(context, appliedEvents);
@@ -296,9 +366,12 @@ internal static class AutomationStateDoctorCommand
         }
 
         return findings
-            .Select(f => appliedById.ContainsKey(f.ExecutionUnit + "|" + f.Category) ? f with { Applied = true } : f)
+            .Select(f => appliedById.Contains(FindingId(f)) ? f with { Applied = true } : f)
             .ToArray();
     }
+
+    private static string FindingId(AutomationStateDoctorFinding finding) =>
+        $"{finding.QueueItemIndex?.ToString(CultureInfo.InvariantCulture) ?? "*"}|{finding.ExecutionUnit}|{finding.Category}|{finding.RepairKind}";
 
     private static void AppendRunEvents(CliContext context, IReadOnlyList<RunEvent> events)
     {
@@ -343,7 +416,7 @@ internal static class AutomationStateDoctorCommand
         }
 
         return queueState.Items
-            .Select(item => new StateDoctorQueueItem
+            .Select((item, index) => new StateDoctorQueueItem
             {
                 ExecutionUnit = item.ExecutionUnit,
                 LinkedIssueRepo = item.LinkedIssue?.Repo,
@@ -351,6 +424,10 @@ internal static class AutomationStateDoctorCommand
                 LinkedIssueUrl = item.LinkedIssue?.Url,
                 LinkedPrUrl = item.LinkedPr,
                 Completed = item.State == QueueItemState.Completed,
+                SourceIndex = index,
+                State = item.State.ToString(),
+                FullEntryJson = DuplicateQueueItemRules.FromQueueItem(item, index).FullEntryJson,
+                ComparableFields = DuplicateQueueItemRules.GetComparableFields(item),
             })
             .ToArray();
     }

--- a/src/IntentSystem.Cli/Commands/AutomationStateDoctorResult.cs
+++ b/src/IntentSystem.Cli/Commands/AutomationStateDoctorResult.cs
@@ -108,6 +108,14 @@ internal sealed record AutomationStateDoctorFinding
     [JsonPropertyName("prUrl")]
     public string? PrUrlCamel => PrUrl;
 
+    [JsonPropertyName("queue_item_index")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? QueueItemIndex { get; init; }
+
+    [JsonPropertyName("remove_queue_item_indices")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<int>? RemoveQueueItemIndices { get; init; }
+
     [JsonPropertyName("confidence")]
     public required string Confidence { get; init; }
 
@@ -147,6 +155,10 @@ internal sealed record AutomationStateDoctorUnsafe
 
     [JsonPropertyName("missingEvidence")]
     public IReadOnlyList<string> MissingEvidenceCamel => MissingEvidence;
+
+    [JsonPropertyName("competing_entries")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? CompetingEntries { get; init; }
 }
 
 internal static class AutomationStateDoctorModes
@@ -176,6 +188,8 @@ internal static class AutomationStateDoctorCategories
     /// forward-only queue-state write contract.
     /// </summary>
     public const string DuplicateExecutionUnitIssue = "duplicate-execution-unit-issue-detected";
+
+    public const string DuplicateQueueItem = "duplicate-queue-item";
 }
 
 internal static class AutomationStateDoctorRepairKinds
@@ -185,6 +199,7 @@ internal static class AutomationStateDoctorRepairKinds
     public const string SetQueueLinkedPr = "queue-state-linked-pr";
     public const string SetQueueLinkedIssue = "queue-state-linked-issue";
     public const string MarkQueueCompleted = "queue-state-completed";
+    public const string DeduplicateQueueItem = "queue-state-deduplicate";
 }
 
 internal static class AutomationStateDoctorUnsafeKinds
@@ -194,6 +209,7 @@ internal static class AutomationStateDoctorUnsafeKinds
     public const string DuplicateIssueEvidence = "duplicate-issue-evidence";
     public const string AmbiguousPrLinkage = "ambiguous-pr-linkage";
     public const string AmbiguousPublishEvidence = "ambiguous-publish-evidence";
+    public const string DuplicateQueueItem = "duplicate-queue-item";
 
     /// <summary>
     /// G481: a single execution unit resolves to more than one GitHub issue and
@@ -234,6 +250,10 @@ internal sealed record StateDoctorQueueItem
     public string? LinkedIssueUrl { get; init; }
     public string? LinkedPrUrl { get; init; }
     public required bool Completed { get; init; }
+    public int SourceIndex { get; init; } = -1;
+    public string? State { get; init; }
+    public string? FullEntryJson { get; init; }
+    public IReadOnlyDictionary<string, string?>? ComparableFields { get; init; }
 }
 
 /// <summary>

--- a/src/IntentSystem.Cli/Commands/ClarifyListCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClarifyListCommand.cs
@@ -1,5 +1,6 @@
 using IntentSystem.Clarify.Models;
 using IntentSystem.Clarify.Serialization;
+using IntentSystem.Supervisor;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -25,10 +26,10 @@ internal static class ClarifyListCommand
 
         try
         {
+            var queueItemsByExecutionUnit = QueueStateExecutionUnitIndex.BuildUnique(
+                queueState.Items,
+                "clarify list");
             var clarifications = DiscoverOpenClarifications(context.RepoRoot);
-            var queueItemsByExecutionUnit = queueState.Items.ToDictionary(
-                item => item.ExecutionUnit,
-                StringComparer.Ordinal);
 
             ClarifyListRenderer.Write(writer, clarifications, queueItemsByExecutionUnit);
             return 0;

--- a/src/IntentSystem.Cli/Commands/DuplicateQueueItemRules.cs
+++ b/src/IntentSystem.Cli/Commands/DuplicateQueueItemRules.cs
@@ -1,0 +1,302 @@
+using System.Globalization;
+using System.Text.Json;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G746: the partial-order rules for duplicate queue-state entries. Duplicate
+/// entries are not resolved by array order, timestamp, or last-writer-wins.
+/// A winner exists only when one complete entry strictly dominates every other
+/// entry without discarding information carried by a competitor.
+/// </summary>
+internal static class DuplicateQueueItemRules
+{
+    private static readonly JsonSerializerOptions ProjectionJsonOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    public static IReadOnlyList<DuplicateQueueItemGroup> Analyze(
+        IReadOnlyList<DuplicateQueueItemEntry> entries)
+    {
+        ArgumentNullException.ThrowIfNull(entries);
+
+        return entries
+            .GroupBy(entry => entry.ExecutionUnit, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .OrderBy(group => group.Key, StringComparer.Ordinal)
+            .Select(group =>
+            {
+                var competing = group.OrderBy(entry => entry.Index).ToArray();
+                var winners = competing
+                    .Where(candidate => competing.All(other =>
+                        candidate.Index == other.Index || Dominates(candidate, other)))
+                    .ToArray();
+
+                return new DuplicateQueueItemGroup
+                {
+                    ExecutionUnit = group.Key,
+                    Entries = competing,
+                    Winner = winners.Length == 1 ? winners[0] : null,
+                };
+            })
+            .ToArray();
+    }
+
+    public static DuplicateQueueItemEntry FromProjection(
+        StateDoctorQueueItem item,
+        int fallbackIndex)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        var index = item.SourceIndex >= 0 ? item.SourceIndex : fallbackIndex;
+        var state = item.State ?? (item.Completed ? "completed" : "queued");
+        var fields = item.ComparableFields ?? new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["state"] = state,
+            ["linked_pr"] = item.LinkedPrUrl,
+            ["linked_issue"] = FormatLinkedIssue(item.LinkedIssueRepo, item.LinkedIssueNumber, item.LinkedIssueUrl),
+        };
+
+        return new DuplicateQueueItemEntry
+        {
+            Index = index,
+            ExecutionUnit = item.ExecutionUnit,
+            Fields = fields,
+            FullEntryJson = item.FullEntryJson ?? RenderProjection(item, state),
+        };
+    }
+
+    public static DuplicateQueueItemEntry FromQueueItem(QueueItem item, int index)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        return new DuplicateQueueItemEntry
+        {
+            Index = index,
+            ExecutionUnit = item.ExecutionUnit,
+            Fields = GetComparableFields(item),
+            FullEntryJson = RenderQueueItem(item),
+        };
+    }
+
+    public static IReadOnlyDictionary<string, string?> GetComparableFields(QueueItem item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        return new Dictionary<string, string?>(StringComparer.Ordinal)
+        {
+            ["title"] = item.Title,
+            ["state"] = item.State.ToString(),
+            ["dependencies"] = JsonSerializer.Serialize(item.Dependencies),
+            ["blocked_by"] = JsonSerializer.Serialize(item.BlockedBy),
+            ["clarification_return_path"] = item.ClarificationReturnPath,
+            ["packet_paths"] = JsonSerializer.Serialize(new
+            {
+                implementation = item.PacketPaths.Implementation,
+                review_context = item.PacketPaths.ReviewContext,
+                yaml = item.PacketPaths.Yaml,
+            }),
+            ["routing_snapshot"] = item.RoutingSnapshot is null
+                ? null
+                : JsonSerializer.Serialize(new
+                {
+                    lane_id = item.RoutingSnapshot.LaneId,
+                    definition_revision = item.RoutingSnapshot.DefinitionRevision,
+                    start_branch = item.RoutingSnapshot.StartBranch,
+                    pr_base_branch = item.RoutingSnapshot.PrBaseBranch,
+                    landing_mode = item.RoutingSnapshot.LandingMode,
+                }),
+            ["linked_pr"] = item.LinkedPr,
+            ["linked_issue"] = item.LinkedIssue is null
+                ? null
+                : JsonSerializer.Serialize(new
+                {
+                    repo = item.LinkedIssue.Repo,
+                    number = item.LinkedIssue.Number,
+                    url = item.LinkedIssue.Url,
+                }),
+            ["worker_role"] = item.WorkerRole,
+            ["review_role"] = item.ReviewRole,
+            ["priority"] = item.Priority,
+            ["retirement_reason"] = item.RetirementReason,
+            ["priority_revision"] = item.PriorityRevision.ToString(CultureInfo.InvariantCulture),
+        };
+    }
+
+    public static string FormatCompetingEntries(DuplicateQueueItemGroup group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        return string.Join(
+            Environment.NewLine,
+            group.Entries.Select(entry => $"entry[{entry.Index}]: {entry.FullEntryJson}"));
+    }
+
+    private static bool Dominates(DuplicateQueueItemEntry candidate, DuplicateQueueItemEntry other)
+    {
+        var strictlyMoreInformative = false;
+        var keys = candidate.Fields.Keys
+            .Concat(other.Fields.Keys)
+            .Distinct(StringComparer.Ordinal);
+
+        foreach (var key in keys)
+        {
+            candidate.Fields.TryGetValue(key, out var candidateValue);
+            other.Fields.TryGetValue(key, out var otherValue);
+
+            if (string.Equals(candidateValue, otherValue, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (string.Equals(key, "state", StringComparison.Ordinal))
+            {
+                var stateComparison = CompareState(candidateValue, otherValue);
+                if (stateComparison < 0)
+                {
+                    return false;
+                }
+
+                if (stateComparison > 0)
+                {
+                    strictlyMoreInformative = true;
+                    continue;
+                }
+
+                // Unknown, non-equal states are competing information.
+                return false;
+            }
+
+            var candidateHasInformation = HasInformation(candidateValue);
+            var otherHasInformation = HasInformation(otherValue);
+            if (candidateHasInformation && !otherHasInformation)
+            {
+                strictlyMoreInformative = true;
+                continue;
+            }
+
+            // A missing candidate value cannot dominate information held by
+            // its competitor, and two different populated values conflict.
+            return false;
+        }
+
+        return strictlyMoreInformative;
+    }
+
+    private static int CompareState(string? candidate, string? other)
+    {
+        if (TryGetStateRank(candidate, out var candidateRank)
+            && TryGetStateRank(other, out var otherRank))
+        {
+            return candidateRank.CompareTo(otherRank);
+        }
+
+        return 0;
+    }
+
+    private static bool TryGetStateRank(string? value, out int rank)
+    {
+        var normalized = value?.Trim().ToLowerInvariant().Replace("_", string.Empty).Replace("-", string.Empty);
+        switch (normalized)
+        {
+            case "pending":
+            case "queued":
+                rank = 0;
+                return true;
+            case "active":
+            case "issuepublished":
+                rank = 1;
+                return true;
+            case "review":
+                rank = 2;
+                return true;
+            case "fixing":
+                rank = 3;
+                return true;
+            case "clarifyblocked":
+                rank = 4;
+                return true;
+            case "blocked":
+                rank = 5;
+                return true;
+            case "completed":
+                rank = 6;
+                return true;
+            case "retired":
+                rank = 7;
+                return true;
+            default:
+                rank = 0;
+                return false;
+        }
+    }
+
+    private static bool HasInformation(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)
+            || string.Equals(value, "null", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(value, "[]", StringComparison.Ordinal)
+            || string.Equals(value, "{}", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string? FormatLinkedIssue(string? repo, int? number, string? url) =>
+        number is { } issueNumber
+            ? $"{repo}|{issueNumber.ToString(CultureInfo.InvariantCulture)}|{url}"
+            : null;
+
+    private static string RenderProjection(StateDoctorQueueItem item, string state)
+    {
+        var linkedIssue = item.LinkedIssueNumber is { } number
+            ? new
+            {
+                repo = item.LinkedIssueRepo,
+                number,
+                url = item.LinkedIssueUrl,
+            }
+            : null;
+        var payload = new Dictionary<string, object?>(StringComparer.Ordinal)
+        {
+            ["execution_unit"] = item.ExecutionUnit,
+            ["state"] = state,
+            ["linked_pr"] = item.LinkedPrUrl,
+            ["linked_issue"] = linkedIssue,
+        };
+        return JsonSerializer.Serialize(payload, ProjectionJsonOptions);
+    }
+
+    private static string RenderQueueItem(QueueItem item)
+    {
+        var state = new QueueState
+        {
+            SchemaVersion = "1",
+            UpdatedAt = DateTimeOffset.UnixEpoch,
+            Items = [item],
+        };
+
+        using var document = JsonDocument.Parse(QueueStateSerializer.Serialize(state));
+        return document.RootElement.GetProperty("items")[0].GetRawText();
+    }
+}
+
+internal sealed record DuplicateQueueItemEntry
+{
+    public required int Index { get; init; }
+    public required string ExecutionUnit { get; init; }
+    public required IReadOnlyDictionary<string, string?> Fields { get; init; }
+    public required string FullEntryJson { get; init; }
+}
+
+internal sealed record DuplicateQueueItemGroup
+{
+    public required string ExecutionUnit { get; init; }
+    public required IReadOnlyList<DuplicateQueueItemEntry> Entries { get; init; }
+    public DuplicateQueueItemEntry? Winner { get; init; }
+}

--- a/src/IntentSystem.Supervisor/QueueStateExecutionUnitIndex.cs
+++ b/src/IntentSystem.Supervisor/QueueStateExecutionUnitIndex.cs
@@ -1,0 +1,140 @@
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Supervisor;
+
+/// <summary>
+/// Shared duplicate guard for execution-unit-keyed queue-state indexes.
+/// Duplicate rows are a durable-state finding, not an ordering decision:
+/// callers must fail closed and route the operator to the canonical repair
+/// surface instead of silently choosing or discarding a row.
+/// </summary>
+public static class QueueStateExecutionUnitIndex
+{
+    /// <summary>
+    /// Builds an execution-unit index after checking all input rows. The
+    /// returned dictionary is therefore safe by construction.
+    /// </summary>
+    public static IReadOnlyDictionary<string, QueueItem> BuildUnique(
+        IReadOnlyList<QueueItem> items,
+        string operation)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operation);
+
+        EnsureUnique(items, operation);
+
+        var index = new Dictionary<string, QueueItem>(StringComparer.Ordinal);
+        foreach (var item in items)
+        {
+            // EnsureUnique above makes assignment safe by construction while
+            // avoiding Dictionary.Add's raw duplicate-key exception.
+            index[item.ExecutionUnit] = item;
+        }
+
+        return index;
+    }
+
+    /// <summary>
+    /// Ensures model-backed queue rows are unique before a stale delta or
+    /// execution-unit dictionary is built.
+    /// </summary>
+    internal static void EnsureUnique(
+        IReadOnlyList<QueueItem> items,
+        string operation)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operation);
+
+        ThrowIfDuplicate(
+            items.Select((item, index) => new DuplicateEntry(
+                item.ExecutionUnit,
+                index,
+                System.Text.Json.JsonSerializer.Serialize(item, SupervisorJsonOptions.Indented))),
+            operation);
+    }
+
+    /// <summary>
+    /// Ensures raw queue-state items are unique before the raw stale-delta
+    /// map is built. Partial/legacy documents without an items array remain
+    /// accepted by the raw writer.
+    /// </summary>
+    internal static void EnsureRawUnique(string rawText, string operation)
+    {
+        ArgumentNullException.ThrowIfNull(rawText);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operation);
+
+        ThrowIfDuplicate(ReadRawItems(rawText), operation);
+    }
+
+    private static void ThrowIfDuplicate(
+        IEnumerable<DuplicateEntry> entries,
+        string operation)
+    {
+        var duplicateGroups = entries
+            .GroupBy(entry => entry.ExecutionUnit, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .OrderBy(group => group.Key, StringComparer.Ordinal)
+            .ToArray();
+
+        if (duplicateGroups.Length == 0)
+        {
+            return;
+        }
+
+        var units = string.Join(
+            ", ",
+            duplicateGroups.Select(group => $"'{group.Key}'"));
+        var competingEntries = string.Join(
+            Environment.NewLine,
+            duplicateGroups.SelectMany(group => new[]
+            {
+                $"execution unit '{group.Key}':",
+                string.Join(
+                    Environment.NewLine,
+                    group.OrderBy(entry => entry.Index)
+                        .Select(entry => $"entry[{entry.Index}]: {entry.FullEntryJson}")),
+            }));
+
+        throw new QueueStateDuplicateExecutionUnitException(
+            $"duplicate-queue-item: refusing {operation} because queue-state contains duplicate "
+            + $"execution_unit entries for {units}; the operation failed closed, no index was built, "
+            + "and no mutation was performed. Canonical recovery: run "
+            + "`intent-cli automation state-doctor --write` when a strict-dominance repair is available; "
+            + "incomparable or equivalent entries require operator reconciliation. Competing full entries:"
+            + Environment.NewLine
+            + competingEntries);
+    }
+
+    private static IReadOnlyList<DuplicateEntry> ReadRawItems(string rawText)
+    {
+        using var document = System.Text.Json.JsonDocument.Parse(rawText);
+        if (!document.RootElement.TryGetProperty("items", out var items)
+            || items.ValueKind != System.Text.Json.JsonValueKind.Array)
+        {
+            return Array.Empty<DuplicateEntry>();
+        }
+
+        var entries = new List<DuplicateEntry>();
+        var index = 0;
+        foreach (var item in items.EnumerateArray())
+        {
+            if (item.ValueKind == System.Text.Json.JsonValueKind.Object
+                && item.TryGetProperty("execution_unit", out var unit)
+                && unit.ValueKind == System.Text.Json.JsonValueKind.String
+                && unit.GetString() is { Length: > 0 } value)
+            {
+                entries.Add(new DuplicateEntry(value, index, item.GetRawText()));
+            }
+
+            index++;
+        }
+
+        return entries;
+    }
+
+    private sealed record DuplicateEntry(
+        string ExecutionUnit,
+        int Index,
+        string FullEntryJson);
+}

--- a/src/IntentSystem.Supervisor/QueueStatePersistence.cs
+++ b/src/IntentSystem.Supervisor/QueueStatePersistence.cs
@@ -167,11 +167,17 @@ public static class QueueStatePersistence
 
         if (!File.Exists(queueStatePath))
         {
+            QueueStateExecutionUnitIndex.EnsureRawUnique(
+                outgoingRawText,
+                "QueueStatePersistence.PersistRawJson outgoing state");
             WriteText(queueStatePath, outgoingRawText);
             return QueueStatePersistResult.DirectWrite(null);
         }
 
         var onDiskRawText = File.ReadAllText(queueStatePath);
+        QueueStateExecutionUnitIndex.EnsureRawUnique(
+            onDiskRawText,
+            "QueueStatePersistence.PersistRawJson current on-disk state");
 
         if (!RawJsonMatches(onDiskRawText, baseRawText))
         {
@@ -195,6 +201,9 @@ public static class QueueStatePersistence
         // straight out of the JSON, never through the model, so a partial or
         // legacy queue file is checked exactly like any other instead of being
         // rejected by a contract this writer deliberately does not impose.
+        QueueStateExecutionUnitIndex.EnsureRawUnique(
+            outgoingRawText,
+            "QueueStatePersistence.PersistRawJson outgoing state");
         var removalAllowList = new HashSet<string>(expectedRemovals ?? Array.Empty<string>(), StringComparer.Ordinal);
         AssertNoUnrequestedRawLoss(onDiskRawText, outgoingRawText, removalAllowList, queueStatePath);
 
@@ -248,6 +257,8 @@ public static class QueueStatePersistence
         var baseItems = ReadItemsByUnit(baseRawText);
         var outgoingItems = ReadItemsByUnit(outgoingRawText);
 
+        // ReadItemsByUnit rejects duplicate execution_unit rows before this
+        // derived dictionary is built, so this index is safe by construction.
         var upserts = outgoingItems
             .Where(entry => !baseItems.TryGetValue(entry.Key, out var original)
                 || !string.Equals(original, entry.Value, StringComparison.Ordinal))
@@ -303,6 +314,8 @@ public static class QueueStatePersistence
 
     private static Dictionary<string, string> ReadItemsByUnit(string rawText)
     {
+        QueueStateExecutionUnitIndex.EnsureRawUnique(rawText, "QueueStatePersistence raw stale delta");
+
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
         using var document = System.Text.Json.JsonDocument.Parse(rawText);
         if (!document.RootElement.TryGetProperty("items", out var items)
@@ -417,6 +430,13 @@ public static class QueueStatePersistence
         ArgumentException.ThrowIfNullOrWhiteSpace(queueStatePath);
         ArgumentNullException.ThrowIfNull(baseState);
         ArgumentNullException.ThrowIfNull(outgoingState);
+        // A duplicate outgoing state is never an intentional persistence
+        // result. The state-doctor repair path supplies a unique outgoing
+        // state while the clean base may still contain the duplicates it is
+        // explicitly repairing.
+        QueueStateExecutionUnitIndex.EnsureUnique(
+            outgoingState.Items,
+            "QueueStatePersistence.Persist outgoing state");
 
         if (!skipHook)
         {
@@ -527,7 +547,12 @@ public static class QueueStatePersistence
         string queueStatePath)
     {
         var touched = new HashSet<string>(touchedUnits, StringComparer.Ordinal);
-        var finalByUnit = finalState.Items.ToDictionary(item => item.ExecutionUnit, StringComparer.Ordinal);
+        QueueStateExecutionUnitIndex.EnsureUnique(
+            onDiskState.Items,
+            "QueueStatePersistence.AssertItemScoped current on-disk state");
+        var finalByUnit = QueueStateExecutionUnitIndex.BuildUnique(
+            finalState.Items,
+            "QueueStatePersistence.AssertItemScoped final state");
 
         var collateral = new List<string>();
         foreach (var item in onDiskState.Items)
@@ -593,7 +618,15 @@ public sealed record QueueStateItemDelta
 
     public static QueueStateItemDelta Between(QueueState baseState, QueueState outgoingState)
     {
-        var baseByUnit = baseState.Items.ToDictionary(item => item.ExecutionUnit, StringComparer.Ordinal);
+        ArgumentNullException.ThrowIfNull(baseState);
+        ArgumentNullException.ThrowIfNull(outgoingState);
+
+        var baseByUnit = QueueStateExecutionUnitIndex.BuildUnique(
+            baseState.Items,
+            "QueueStateItemDelta.Between base state");
+        QueueStateExecutionUnitIndex.EnsureUnique(
+            outgoingState.Items,
+            "QueueStateItemDelta.Between outgoing state");
         var outgoingUnits = new HashSet<string>(
             outgoingState.Items.Select(item => item.ExecutionUnit), StringComparer.Ordinal);
 
@@ -620,7 +653,14 @@ public sealed record QueueStateItemDelta
     /// </summary>
     public QueueState ApplyTo(QueueState freshState, DateTimeOffset updatedAt)
     {
-        var upsertByUnit = Upserts.ToDictionary(item => item.ExecutionUnit, StringComparer.Ordinal);
+        ArgumentNullException.ThrowIfNull(freshState);
+
+        QueueStateExecutionUnitIndex.EnsureUnique(
+            freshState.Items,
+            "QueueStateItemDelta.ApplyTo fresh state");
+        var upsertByUnit = QueueStateExecutionUnitIndex.BuildUnique(
+            Upserts,
+            "QueueStateItemDelta.ApplyTo upserts");
         var removalSet = new HashSet<string>(Removals, StringComparer.Ordinal);
 
         var items = new List<QueueItem>();
@@ -677,6 +717,20 @@ public sealed record QueueStatePersistResult
         ReappliedOnFreshBase = true,
         ReappliedExecutionUnits = units,
     };
+}
+
+/// <summary>
+/// Raised when duplicate <c>execution_unit</c> rows make an index or stale
+/// re-application ambiguous. It is an <see cref="InvalidOperationException"/>
+/// so CLI entry points emit the canonical diagnostic and exit non-zero rather
+/// than surfacing the framework's duplicate-key <see cref="ArgumentException"/>.
+/// </summary>
+public sealed class QueueStateDuplicateExecutionUnitException : InvalidOperationException
+{
+    public QueueStateDuplicateExecutionUnitException(string message)
+        : base(message)
+    {
+    }
 }
 
 /// <summary>

--- a/tests/IntentSystem.Cli.Tests/ClarifyListCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClarifyListCommandTests.cs
@@ -94,6 +94,43 @@ public sealed class ClarifyListCommandTests
     }
 
     [Fact]
+    public void Execute_GivenDuplicateQueueItems_ReportsCanonicalFindingEvenWithoutOpenClarifications()
+    {
+        using var tempDirectory = new TemporaryDirectory();
+        var repoRoot = tempDirectory.CreateDirectory("repo");
+        var source = CreateQueueState();
+        var duplicateState = source with
+        {
+            Items =
+            [
+                source.Items[0],
+                source.Items[0] with { Title = "[G22] duplicate queue row" },
+            ],
+        };
+        var queueStatePath = tempDirectory.CreateFile(
+            Path.Combine("repo", ".intent-cli", "queue-state.json"),
+            QueueStateSerializer.Serialize(duplicateState));
+        var before = File.ReadAllText(queueStatePath);
+        using var writer = new StringWriter();
+
+        var exitCode = ClarifyListCommand.Execute(CreateContext(repoRoot), [], writer);
+
+        Assert.Equal(1, exitCode);
+        var output = writer.ToString();
+        Assert.Contains("duplicate-queue-item", output, StringComparison.Ordinal);
+        Assert.Contains("execution_unit entries", output, StringComparison.Ordinal);
+        Assert.Contains("'G22'", output, StringComparison.Ordinal);
+        Assert.Contains("entry[0]", output, StringComparison.Ordinal);
+        Assert.Contains("entry[1]", output, StringComparison.Ordinal);
+        Assert.Contains("state-doctor", output, StringComparison.Ordinal);
+        Assert.Contains("no mutation was performed", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("same key has already been added", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("ArgumentException", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("No open clarifications found.", output, StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllText(queueStatePath));
+    }
+
+    [Fact]
     public void Execute_GivenArguments_ReturnsExitCodeOne()
     {
         using var writer = new StringWriter();

--- a/tests/IntentSystem.Cli.Tests/DuplicateQueueItemG746Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/DuplicateQueueItemG746Tests.cs
@@ -1,0 +1,406 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G746: duplicate execution-unit queue rows are observable, repairable only
+/// under a strict dominance rule, and fail closed when the evidence conflicts.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class DuplicateQueueItemG746Tests : IDisposable
+{
+    private const string Repo = "J-Tech-Japan/intent-system";
+
+    public DuplicateQueueItemG746Tests()
+    {
+        AutomationStateDoctorCommand.CandidateListerFactory = null;
+        AutomationCloseoutDriftCheckCommand.PrLookupFactory = null;
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = null;
+        AutomationInstalledCliSurfaceProbe.ProbeRunner = null;
+        AutomationInstalledCliSurfaceProbe.ExplicitInstalledCliPathReader = null;
+    }
+
+    public void Dispose()
+    {
+        AutomationStateDoctorCommand.CandidateListerFactory = null;
+        AutomationCloseoutDriftCheckCommand.PrLookupFactory = null;
+        AutomationCloseoutDriftCheckCommand.IssueLookupFactory = null;
+        AutomationInstalledCliSurfaceProbe.ProbeRunner = null;
+        AutomationInstalledCliSurfaceProbe.ExplicitInstalledCliPathReader = null;
+    }
+
+    [Fact]
+    public void Analyze_ByteIdenticalDuplicate_IsUnsafeAndShowsBothFullEntries()
+    {
+        var fullEntry = """{"execution_unit":"G746","state":"queued","linked_pr":null}""";
+        var queue = new[]
+        {
+            Projection("G746", 0, null, fullEntry),
+            Projection("G746", 1, null, fullEntry),
+        };
+
+        var analysis = AutomationStateDoctorAnalyzer.Analyze(
+            Repo,
+            queue,
+            Array.Empty<StateDoctorPublishEvidence>(),
+            Array.Empty<StateDoctorPr>());
+
+        Assert.Empty(analysis.Findings);
+        var unsafeFinding = Assert.Single(
+            analysis.UnsafeFindings,
+            finding => finding.Kind == AutomationStateDoctorUnsafeKinds.DuplicateQueueItem);
+        Assert.Equal("G746", unsafeFinding.ExecutionUnit);
+        Assert.Contains("unsafe-stop", unsafeFinding.Reason, StringComparison.Ordinal);
+        Assert.Contains("entry[0]", unsafeFinding.Reason, StringComparison.Ordinal);
+        Assert.Contains("entry[1]", unsafeFinding.Reason, StringComparison.Ordinal);
+        Assert.Equal([fullEntry, fullEntry], unsafeFinding.CompetingEntries);
+    }
+
+    [Fact]
+    public void Analyze_LinkedPrOnlyDifference_ProducesStrictDominanceRepair()
+    {
+        var queue = new[]
+        {
+            Projection("G746", 0, null),
+            Projection("G746", 1, $"https://github.com/{Repo}/pull/1624"),
+        };
+
+        var analysis = AutomationStateDoctorAnalyzer.Analyze(
+            Repo,
+            queue,
+            Array.Empty<StateDoctorPublishEvidence>(),
+            Array.Empty<StateDoctorPr>());
+
+        var finding = Assert.Single(
+            analysis.Findings,
+            candidate => candidate.Category == AutomationStateDoctorCategories.DuplicateQueueItem);
+        Assert.Equal(AutomationStateDoctorRepairKinds.DeduplicateQueueItem, finding.RepairKind);
+        Assert.Equal(1, finding.QueueItemIndex);
+        Assert.Equal([0], finding.RemoveQueueItemIndices);
+        Assert.Empty(analysis.UnsafeFindings);
+    }
+
+    [Fact]
+    public void Execute_Write_AmbiguousDuplicate_IsUnsafeStopAndByteIdentical()
+    {
+        using var workspace = new TestWorkspace();
+        var original = QueueStateSerializer.Serialize(
+            new QueueState
+            {
+                SchemaVersion = "1",
+                UpdatedAt = DateTimeOffset.Parse("2026-08-28T03:44:15Z"),
+                Items =
+                [
+                    Item("G746", title: "first competing entry"),
+                    Item("G746", title: "second competing entry"),
+                ],
+            });
+        workspace.WriteQueueState(original);
+        ConfigureStateDoctorSurface(workspace);
+        AutomationStateDoctorCommand.CandidateListerFactory = () => new EmptyLister();
+
+        using var writer = new StringWriter();
+        var exit = AutomationStateDoctorCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var unsafeFinding = Assert.Single(
+            document.RootElement.GetProperty("unsafe_findings").EnumerateArray(),
+            finding => finding.GetProperty("kind").GetString() == "duplicate-queue-item");
+        Assert.Equal("G746", unsafeFinding.GetProperty("execution_unit").GetString());
+        var reason = unsafeFinding.GetProperty("reason").GetString()!;
+        Assert.Contains("unsafe-stop", reason, StringComparison.Ordinal);
+        Assert.Contains("first competing entry", reason, StringComparison.Ordinal);
+        Assert.Contains("second competing entry", reason, StringComparison.Ordinal);
+        Assert.Equal(2, unsafeFinding.GetProperty("competing_entries").GetArrayLength());
+
+        Assert.Equal(original, workspace.QueueStateOnDisk());
+        Assert.False(File.Exists(workspace.Context.GetRunLogPath()));
+    }
+
+    [Fact]
+    public void Execute_Write_LinkedPrDominance_RemovesOnlyLessInformativeEntry()
+    {
+        using var workspace = new TestWorkspace();
+        var linkedPr = $"https://github.com/{Repo}/pull/1624";
+        workspace.WriteQueueState(
+            QueueStateSerializer.Serialize(
+                new QueueState
+                {
+                    SchemaVersion = "1",
+                    UpdatedAt = DateTimeOffset.Parse("2026-08-28T03:44:15Z"),
+                    Items =
+                    [
+                        Item("G746", linkedPr: null),
+                        Item("G746", linkedPr: linkedPr),
+                    ],
+                }));
+        ConfigureStateDoctorSurface(workspace);
+        AutomationStateDoctorCommand.CandidateListerFactory = () => new EmptyLister();
+
+        using var writer = new StringWriter();
+        var exit = AutomationStateDoctorCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var finding = Assert.Single(
+            document.RootElement.GetProperty("findings").EnumerateArray(),
+            candidate => candidate.GetProperty("category").GetString() == "duplicate-queue-item");
+        Assert.True(finding.GetProperty("applied").GetBoolean());
+        Assert.Equal(1, finding.GetProperty("queue_item_index").GetInt32());
+        Assert.Equal([0], finding.GetProperty("remove_queue_item_indices").EnumerateArray().Select(value => value.GetInt32()));
+
+        var after = QueueStateSerializer.Deserialize(workspace.QueueStateOnDisk());
+        var item = Assert.Single(after.Items);
+        Assert.Equal(linkedPr, item.LinkedPr);
+        Assert.Contains("G746", File.ReadAllText(workspace.Context.GetRunLogPath()), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Execute_ReadOnly_DuplicateFreeFixture_IsByteIdentical()
+    {
+        using var workspace = new TestWorkspace();
+        var fixturePath = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "tests",
+            "IntentSystem.Cli.Tests",
+            "Fixtures",
+            "G746",
+            "duplicate-free-queue-state.json");
+        var fixture = File.ReadAllText(fixturePath);
+        workspace.WriteQueueState(fixture);
+        ConfigureStateDoctorSurface(workspace);
+        AutomationStateDoctorCommand.CandidateListerFactory = () => new EmptyLister();
+
+        using var writer = new StringWriter();
+        var exit = AutomationStateDoctorCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exit);
+        Assert.Equal(fixture, workspace.QueueStateOnDisk());
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.Equal(0, document.RootElement.GetProperty("unsafe_findings").GetArrayLength());
+    }
+
+    [Fact]
+    public void Execute_CloseoutReportsDuplicateAndContinuesWithOtherUnits()
+    {
+        using var workspace = new TestWorkspace();
+        workspace.WriteQueueState(
+            QueueStateSerializer.Serialize(
+                new QueueState
+                {
+                    SchemaVersion = "1",
+                    UpdatedAt = DateTimeOffset.Parse("2026-08-28T03:44:15Z"),
+                    Items =
+                    [
+                        Item("G746", linkedPr: $"https://github.com/{Repo}/pull/1624", linkedIssue: 1624),
+                        Item("G746", linkedPr: $"https://github.com/{Repo}/pull/1624", linkedIssue: 1624),
+                        Item("G748", linkedPr: $"https://github.com/{Repo}/pull/1625", linkedIssue: 1625),
+                    ],
+                }));
+        var lookup = new RecordingPrLookup(
+            new Dictionary<int, (bool Merged, int[] Closing)>
+            {
+                [1624] = (true, [1624]),
+                [1625] = (true, [1625]),
+            });
+        AutomationCloseoutDriftCheckCommand.PrLookupFactory = () => lookup;
+
+        using var writer = new StringWriter();
+        var exit = AutomationCloseoutDriftCheckCommand.Execute(
+            workspace.Context,
+            ["--repo", Repo, "--format", "json"],
+            writer);
+
+        Assert.Equal(1, exit);
+        var result = JsonSerializer.Deserialize<CloseoutDriftCheckResult>(writer.ToString())!;
+        Assert.Equal(1, result.SafeRepairCount);
+        Assert.Equal(1, result.UnsafeStopCount);
+        var duplicate = Assert.Single(
+            result.Records,
+            record => record.ReasonCode == AutomationCloseoutDriftCheckCommand.ReasonDuplicateQueueItem);
+        Assert.Equal("G746", duplicate.ExecutionUnit);
+        Assert.Equal(2, duplicate.CompetingEntries!.Count);
+        var remaining = Assert.Single(result.Records, record => record.ExecutionUnit == "G748");
+        Assert.Equal(AutomationCloseoutDriftCheckCommand.ResultSafeRepair, remaining.Result);
+        Assert.Equal([1625], lookup.SeenNumbers);
+    }
+
+    [Fact]
+    public void DeveloperReference_DocumentsDuplicateFindingAndCanonicalRepair_InBothMirrors()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        foreach (var language in new[] { "en", "ja" })
+        {
+            var document = File.ReadAllText(
+                Path.Combine(root, "docs", language, "09-developer-reference.md"));
+            Assert.Contains("G746", document, StringComparison.Ordinal);
+            Assert.Contains("duplicate-queue-item", document, StringComparison.Ordinal);
+            Assert.Contains("closeout-drift-check", document, StringComparison.Ordinal);
+            Assert.Contains("state-doctor", document, StringComparison.Ordinal);
+            Assert.Contains("strictly more informative", document, StringComparison.Ordinal);
+            Assert.Contains("recoverable", document, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("not impossible", document, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static StateDoctorQueueItem Projection(
+        string unit,
+        int sourceIndex,
+        string? linkedPr,
+        string? fullEntry = null) =>
+        new()
+        {
+            ExecutionUnit = unit,
+            LinkedPrUrl = linkedPr,
+            Completed = false,
+            SourceIndex = sourceIndex,
+            State = "queued",
+            FullEntryJson = fullEntry,
+            ComparableFields = new Dictionary<string, string?>(StringComparer.Ordinal)
+            {
+                ["title"] = "same title",
+                ["state"] = "queued",
+                ["linked_pr"] = linkedPr,
+                ["linked_issue"] = null,
+            },
+        };
+
+    private static QueueItem Item(
+        string unit,
+        string title = "same title",
+        string? linkedPr = null,
+        int? linkedIssue = null,
+        QueueItemState state = QueueItemState.Review) =>
+        new()
+        {
+            ExecutionUnit = unit,
+            Title = title,
+            State = state,
+            Dependencies = Array.Empty<string>(),
+            BlockedBy = Array.Empty<string>(),
+            ClarificationReturnPath = string.Empty,
+            PacketPaths = new PacketPaths
+            {
+                Implementation = $"issues/{unit}/implementation.md",
+                ReviewContext = $"issues/{unit}/review-context.md",
+                Yaml = $"issues/{unit}/packet.yaml",
+            },
+            LinkedIssue = linkedIssue is { } number
+                ? new LinkedIssue
+                {
+                    Repo = Repo,
+                    Number = number,
+                    Url = $"https://github.com/{Repo}/issues/{number}",
+                }
+                : null,
+            LinkedPr = linkedPr,
+            WorkerRole = "coder",
+            ReviewRole = "reviewer",
+            Priority = "normal",
+        };
+
+    private static void ConfigureStateDoctorSurface(TestWorkspace workspace)
+    {
+        AutomationInstalledCliSurfaceProbe.ExplicitInstalledCliPathReader =
+            () => workspace.InstalledCliPath;
+        AutomationInstalledCliSurfaceProbe.ProbeRunner = (_, _) =>
+            new InstalledCliProbeResult(
+                0,
+                "automation summary host-review-preflight issue-publish pr-transition review-start request-update approved",
+                string.Empty);
+    }
+
+    private sealed class EmptyLister : IGitHubAutomationCandidateLister
+    {
+        public IReadOnlyList<GitHubAutomationPrCandidate> ListPullRequests(
+            string repo, IReadOnlyCollection<string> requiredLabels) =>
+            Array.Empty<GitHubAutomationPrCandidate>();
+
+        public IReadOnlyList<GitHubAutomationIssueCandidate> ListIssues(
+            string repo, IReadOnlyCollection<string> requiredLabels) =>
+            Array.Empty<GitHubAutomationIssueCandidate>();
+    }
+
+    private sealed class RecordingPrLookup : IGitHubPrLookup
+    {
+        private readonly IReadOnlyDictionary<int, (bool Merged, int[] Closing)> entries;
+
+        public RecordingPrLookup(
+            IReadOnlyDictionary<int, (bool Merged, int[] Closing)> entries) =>
+            this.entries = entries;
+
+        public List<int> SeenNumbers { get; } = [];
+
+        public GitHubPrLookupResult Lookup(string repo, int number)
+        {
+            SeenNumbers.Add(number);
+            var entry = entries[number];
+            return new GitHubPrLookupResult
+            {
+                Number = number,
+                State = entry.Merged ? "MERGED" : "OPEN",
+                Merged = entry.Merged,
+                ClosingIssuesReferences = entry.Closing
+                    .Select(issue => new GitHubPrClosingIssueReference { Number = issue })
+                    .ToArray(),
+            };
+        }
+    }
+
+    private sealed class TestWorkspace : IDisposable
+    {
+        private readonly string root;
+
+        public TestWorkspace()
+        {
+            root = Directory.CreateTempSubdirectory("g746-tests-").FullName;
+            Directory.CreateDirectory(Path.Combine(root, ".intent-cli"));
+            InstalledCliPath = Path.Combine(root, ".intent-cli", "installed-cli-stub");
+            File.WriteAllText(InstalledCliPath, "stub");
+            Context = new CliContext
+            {
+                RepoRoot = root,
+                Config = new CliConfig
+                {
+                    Project = new ProjectConfig
+                    {
+                        Domain = "intent-cli",
+                        ArtifactRoot = ".intent-cli",
+                    },
+                },
+            };
+        }
+
+        public CliContext Context { get; }
+        public string InstalledCliPath { get; }
+
+        public void WriteQueueState(string content) =>
+            File.WriteAllText(Context.GetQueueStatePath(), content);
+
+        public string QueueStateOnDisk() =>
+            File.ReadAllText(Context.GetQueueStatePath());
+
+        public void Dispose()
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/Fixtures/G746/duplicate-free-queue-state.json
+++ b/tests/IntentSystem.Cli.Tests/Fixtures/G746/duplicate-free-queue-state.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "1",
+  "updated_at": "2026-08-28T03:44:15Z",
+  "items": [
+    {
+      "execution_unit": "G746-fixture",
+      "title": "duplicate-free fixture",
+      "state": "queued",
+      "dependencies": [],
+      "blocked_by": [],
+      "clarification_return_path": "",
+      "packet_paths": {
+        "implementation": "issues/G746-fixture/implementation.md",
+        "review_context": "issues/G746-fixture/review-context.md",
+        "yaml": "issues/G746-fixture/packet.yaml"
+      },
+      "linked_issue": null,
+      "linked_pr": null,
+      "worker_role": "coder",

--- a/tests/IntentSystem.Cli.Tests/QueueStatePersistenceG746RepairTests.cs
+++ b/tests/IntentSystem.Cli.Tests/QueueStatePersistenceG746RepairTests.cs
@@ -1,0 +1,247 @@
+using IntentSystem.Supervisor;
+using IntentSystem.Supervisor.Models;
+using IntentSystem.Supervisor.Serialization;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class QueueStatePersistenceG746RepairTests : IDisposable
+{
+    private static readonly DateTimeOffset BaseTime = new(2026, 8, 28, 9, 0, 0, TimeSpan.Zero);
+
+    private readonly string root = Directory.CreateTempSubdirectory("queue-state-g746-repair-tests-").FullName;
+
+    private string QueueStatePath => Path.Combine(root, ".intent-cli", "queue-state.json");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Persist_CleanOutgoingDuplicate_FailsClosedAndLeavesTheFileUnchanged_G746()
+    {
+        var onDisk = State(BaseTime, Item("G746", QueueItemState.Queued));
+        WriteRaw(onDisk);
+        var before = File.ReadAllText(QueueStatePath);
+        var duplicateOutgoing = State(
+            BaseTime.AddMinutes(1),
+            onDisk.Items[0],
+            onDisk.Items[0] with { Title = "duplicate G746 row" });
+
+        var exception = Assert.Throws<QueueStateDuplicateExecutionUnitException>(
+            () => QueueStatePersistence.Persist(QueueStatePath, onDisk, duplicateOutgoing));
+
+        AssertDuplicateDiagnostic(exception, "QueueStatePersistence.Persist outgoing state");
+        Assert.Equal(before, File.ReadAllText(QueueStatePath));
+    }
+
+    [Fact]
+    public void Persist_StaleOnDiskDuplicate_FailsClosedBeforeAnyReapplication_G746()
+    {
+        var baseState = State(BaseTime, Item("G746", QueueItemState.Queued));
+        WriteRaw(baseState);
+        var duplicateOnDisk = State(
+            BaseTime.AddMinutes(1),
+            baseState.Items[0],
+            baseState.Items[0] with { Title = "duplicate G746 row" });
+        WriteRaw(duplicateOnDisk);
+        var before = File.ReadAllText(QueueStatePath);
+        var outgoing = State(
+            BaseTime.AddMinutes(2),
+            baseState.Items[0] with { State = QueueItemState.Active });
+
+        var exception = Assert.Throws<QueueStateDuplicateExecutionUnitException>(
+            () => QueueStatePersistence.Persist(QueueStatePath, baseState, outgoing));
+
+        AssertDuplicateDiagnostic(exception, "QueueStateItemDelta.ApplyTo fresh state");
+        Assert.Equal(before, File.ReadAllText(QueueStatePath));
+    }
+
+    [Fact]
+    public void Delta_Between_DuplicateBaseState_FailsClosedWithFullEntries_G746()
+    {
+        var item = Item("G746", QueueItemState.Queued);
+        var duplicateBase = State(BaseTime, item, item with { Title = "second duplicate" });
+        var outgoing = State(BaseTime.AddMinutes(1), item);
+
+        var exception = Assert.Throws<QueueStateDuplicateExecutionUnitException>(
+            () => QueueStateItemDelta.Between(duplicateBase, outgoing));
+
+        AssertDuplicateDiagnostic(exception, "QueueStateItemDelta.Between base state");
+    }
+
+    [Fact]
+    public void Delta_Between_DuplicateOutgoingState_FailsClosedBeforeDerivingTheDelta_G746()
+    {
+        var item = Item("G746", QueueItemState.Queued);
+        var baseState = State(BaseTime, item);
+        var duplicateOutgoing = State(BaseTime.AddMinutes(1), item, item with { Title = "second duplicate" });
+
+        var exception = Assert.Throws<QueueStateDuplicateExecutionUnitException>(
+            () => QueueStateItemDelta.Between(baseState, duplicateOutgoing));
+
+        AssertDuplicateDiagnostic(exception, "QueueStateItemDelta.Between outgoing state");
+    }
+
+    [Fact]
+    public void Delta_ApplyTo_DuplicateFreshState_FailsClosedWithoutReturningAMutatedState_G746()
+    {
+        var item = Item("G746", QueueItemState.Queued);
+        var duplicateFresh = State(BaseTime, item, item with { Title = "second duplicate" });
+        var delta = new QueueStateItemDelta
+        {
+            Upserts = [item with { State = QueueItemState.Active }],
+            Removals = [],
+        };
+
+        var exception = Assert.Throws<QueueStateDuplicateExecutionUnitException>(
+            () => delta.ApplyTo(duplicateFresh, BaseTime.AddMinutes(1)));
+
+        AssertDuplicateDiagnostic(exception, "QueueStateItemDelta.ApplyTo fresh state");
+    }
+
+    [Fact]
+    public void Delta_ApplyTo_DuplicateUpserts_FailsClosedBeforeApplyingAnyChange_G746()
+    {
+        var item = Item("G746", QueueItemState.Queued);
+        var freshState = State(BaseTime, item);
+        var delta = new QueueStateItemDelta
+        {
+            Upserts = [
+                item with { State = QueueItemState.Active },
+                item with { State = QueueItemState.Review, Title = "second duplicate" },
+            ],
+            Removals = [],
+        };
+
+        var exception = Assert.Throws<QueueStateDuplicateExecutionUnitException>(
+            () => delta.ApplyTo(freshState, BaseTime.AddMinutes(1)));
+
+        AssertDuplicateDiagnostic(exception, "QueueStateItemDelta.ApplyTo upserts");
+    }
+
+    [Fact]
+    public void PersistRawJson_StaleDuplicateBase_FailsClosedBeforeRawMapOverwrite_G746()
+    {
+        var item = Item("G746", QueueItemState.Queued);
+        var onDisk = State(BaseTime, item);
+        WriteRaw(onDisk);
+        var before = File.ReadAllText(QueueStatePath);
+        var duplicateBase = State(BaseTime, item, item with { Title = "second duplicate" });
+        var outgoing = State(BaseTime.AddMinutes(1), item with { State = QueueItemState.Active });
+
+        var exception = Assert.Throws<QueueStateDuplicateExecutionUnitException>(
+            () => QueueStatePersistence.PersistRawJson(
+                QueueStatePath,
+                QueueStateSerializer.Serialize(duplicateBase),
+                QueueStateSerializer.Serialize(outgoing)));
+
+        AssertDuplicateDiagnostic(exception, "QueueStatePersistence raw stale delta");
+        Assert.Equal(before, File.ReadAllText(QueueStatePath));
+    }
+
+    [Fact]
+    public void PersistRawJson_CurrentDuplicate_FailsClosedBeforeComparingOrWriting_G746()
+    {
+        var item = Item("G746", QueueItemState.Queued);
+        var duplicateOnDisk = State(BaseTime, item, item with { Title = "second duplicate" });
+        WriteRaw(duplicateOnDisk);
+        var before = File.ReadAllText(QueueStatePath);
+        var unique = State(BaseTime, item);
+
+        var exception = Assert.Throws<QueueStateDuplicateExecutionUnitException>(
+            () => QueueStatePersistence.PersistRawJson(
+                QueueStatePath,
+                QueueStateSerializer.Serialize(unique),
+                QueueStateSerializer.Serialize(unique with { UpdatedAt = BaseTime.AddMinutes(1) })));
+
+        AssertDuplicateDiagnostic(exception, "QueueStatePersistence.PersistRawJson current on-disk state");
+        Assert.Equal(before, File.ReadAllText(QueueStatePath));
+    }
+
+    [Fact]
+    public void PersistRawJson_CleanOutgoingDuplicate_FailsClosedAndPreservesVerbatimState_G746()
+    {
+        var item = Item("G746", QueueItemState.Queued);
+        var onDisk = State(BaseTime, item);
+        WriteRaw(onDisk);
+        var before = File.ReadAllText(QueueStatePath);
+        var duplicateOutgoing = State(
+            BaseTime.AddMinutes(1),
+            item,
+            item with { Title = "second duplicate" });
+
+        var exception = Assert.Throws<QueueStateDuplicateExecutionUnitException>(
+            () => QueueStatePersistence.PersistRawJson(
+                QueueStatePath,
+                QueueStateSerializer.Serialize(onDisk),
+                QueueStateSerializer.Serialize(duplicateOutgoing)));
+
+        AssertDuplicateDiagnostic(exception, "QueueStatePersistence.PersistRawJson outgoing state");
+        Assert.Equal(before, File.ReadAllText(QueueStatePath));
+    }
+
+    [Fact]
+    public void Delta_ApplyTo_UniqueStateStillPreservesDuplicateFreeBehavior_G746()
+    {
+        var freshState = State(BaseTime, Item("G745", QueueItemState.Queued));
+        var delta = new QueueStateItemDelta
+        {
+            Upserts = [Item("G746", QueueItemState.Active)],
+            Removals = [],
+        };
+
+        var applied = delta.ApplyTo(freshState, BaseTime.AddMinutes(1));
+
+        Assert.Equal(["G745", "G746"], applied.Items.Select(item => item.ExecutionUnit).ToArray());
+        Assert.Equal(QueueItemState.Active, applied.Items.Single(item => item.ExecutionUnit == "G746").State);
+    }
+
+    private static void AssertDuplicateDiagnostic(Exception exception, string operation)
+    {
+        Assert.Contains("duplicate-queue-item", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("execution_unit entries", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("'G746'", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("entry[0]", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("entry[1]", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(operation, exception.Message, StringComparison.Ordinal);
+        Assert.Contains("no mutation was performed", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("same key has already been added", exception.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("ArgumentException", exception.Message, StringComparison.Ordinal);
+    }
+
+    private void WriteRaw(QueueState state)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(QueueStatePath)!);
+        File.WriteAllText(QueueStatePath, QueueStateSerializer.Serialize(state));
+    }
+
+    private static QueueState State(DateTimeOffset updatedAt, params QueueItem[] items) => new()
+    {
+        SchemaVersion = "1",
+        UpdatedAt = updatedAt,
+        Items = items,
+    };
+
+    private static QueueItem Item(string executionUnit, QueueItemState state) => new()
+    {
+        ExecutionUnit = executionUnit,
+        Title = $"{executionUnit} title",
+        State = state,
+        Dependencies = [],
+        BlockedBy = [],
+        ClarificationReturnPath = string.Empty,
+        PacketPaths = new PacketPaths
+        {
+            Yaml = $".intent-cli/issues/{executionUnit}/packet.yaml",
+            Implementation = $".intent-cli/issues/{executionUnit}/implementation.md",
+            ReviewContext = $".intent-cli/issues/{executionUnit}/review-context.md",
+        },
+        WorkerRole = "Claude",
+        ReviewRole = "Codex",
+        Priority = "normal",
+    };
+}


### PR DESCRIPTION
## Summary

- Add reportable `duplicate-queue-item` handling to state-doctor and closeout-drift-check.
- Repair only strict-dominance duplicates; fail closed with the unit and full competing entries for equivalent or incomparable pairs.
- Keep closeout checking remaining non-duplicated units and document the canonical recovery path in EN/JA.

Closes #1624
Closes #1622

## Verification

- G746 focused tests: 7 passed, 0 failed, 0 skipped.
- Adjacent state-doctor/closeout/queue-persistence tests: 74 passed, 0 failed, 0 skipped.
- G613 terminology guard: 6 passed, 0 failed, 0 skipped.
- Full Release suite: 5275 passed, 0 failed, 1 skipped (5276 total).
- `git diff --cached --check`: clean.
- Head: `75cef96417402a14db788fe78c5d122ffe6c5f74`.
