### PR TITLE
G747: repair claim transaction defects

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2709,6 +2709,24 @@ warning: claim transaction committed successfully, but best-effort cleanup could
 This keeps the committed claim visible to the operator and to downstream
 claim-gated flows without backgrounding the claim or hand-writing its packet.
 
+### Remote default-branch targeting (G747)
+
+Every claim transaction resolves the remote default branch from
+`git ls-remote --symref origin HEAD`. The transaction clone starts from that
+branch and pushes the transaction commit explicitly to
+`refs/heads/<resolved-default-branch>`. The invoking checkout current branch
+is never used as the claim target or advanced by the refresh. If the symref is
+missing, ambiguous, unsafe, or cannot be queried, the command fails closed; it
+never falls back to the current branch. Successful transaction results include
+the resolved `target_ref`.
+
+An acquire whose active record already has the same actor and team is an
+intentional no-op. Its result says that the scope is already held and that no
+claim commit was needed (`nothing to commit`). If teardown also fails, the
+warning is separate, names the leftover path, and cannot replace that primary
+no-op cause. With `--format json`, stdout contains exactly one JSON document;
+cleanup warnings go to stderr so stdout can be piped directly to a JSON parser.
+
 ---
 
 ## Version flow

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2769,6 +2769,21 @@ warning: claim transaction committed successfully, but best-effort cleanup could
 これにより、commit 済み claim は operator と downstream の claim-gated flow から見え続け、
 claim の background 実行や packet の手書きは不要です。
 
+### remote の default branch を対象にする場合 (G747)
+
+すべての claim transaction は `git ls-remote --symref origin HEAD` から remote の
+`default branch` を解決します。transaction clone はその branch から始め、transaction
+commit を `refs/heads/<resolved-default-branch>` へ明示的に push します。呼び出し元
+checkout の current branch は claim の target にせず、refresh でも進めません。symref が
+無い、曖昧、安全に扱えない、または query できない場合は fail closed とし、current branch
+へは fallback しません。成功した transaction result には解決した `target_ref` が含まれます。
+
+active record の actor と team が同じ acquire は意図した no-op です。result は scope が
+すでに保持され、claim commit は不要 (`nothing to commit`) であることを示します。teardown
+も失敗した場合は leftover path を含む warning を別に出し、その no-op の主原因を置き換え
+ません。`--format json` の stdout は JSON 文書を 1 つだけ含み、cleanup warning は stderr
+へ出力されるため、stdout を直接 JSON parser に渡せます。
+
 ---
 
 ## バージョンフロー

--- a/src/IntentSystem.Cli/Commands/ClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClaimCommand.cs
@@ -116,15 +116,20 @@ internal static class ClaimCommand
 
         var origin = RunGit(repoRoot, ["remote", "get-url", "origin"]);
         EnsureSuccess(origin, "resolve origin");
-        var branch = RunGit(repoRoot, ["branch", "--show-current"]);
-        EnsureSuccess(branch, "resolve current branch");
+        var defaultBranchResult = RunGit(repoRoot, ["ls-remote", "--symref", "origin", "HEAD"]);
+        EnsureSuccess(defaultBranchResult, "resolve origin default branch");
         var remote = origin.StandardOutput.Trim();
-        var branchName = branch.StandardOutput.Trim();
-        if (remote.Length == 0 || branchName.Length == 0)
+        if (remote.Length == 0)
         {
-            throw new InvalidOperationException("claim requires an origin remote and a named current branch");
+            throw new InvalidOperationException("claim requires an origin remote");
         }
 
+        if (!TryParseRemoteDefaultBranch(defaultBranchResult.StandardOutput, out var defaultBranch))
+        {
+            throw new InvalidOperationException(
+                "Could not resolve origin default branch from its HEAD symref; refusing to "
+                + "fall back to the current branch.");
+        }
         if (!request.Write)
         {
             return new ClaimTransactionResult(
@@ -133,10 +138,12 @@ internal static class ClaimCommand
                 "Dry-run only. Re-run with --write; ownership exists only after a successful plain push.");
         }
 
+        var targetRef = $"refs/heads/{defaultBranch}";
+
         HostStateGitRetryEvidence? lastGitWriteRetry = null;
-        var hostPull = RunGit(repoRoot, ["pull", "--ff-only", "origin", branchName], hostStateWrite: true);
-        CaptureRetry(ref lastGitWriteRetry, hostPull);
-        EnsureSuccess(hostPull, "fast-forward host before claim transaction");
+        var hostFetch = RunGit(repoRoot, ["fetch", "--quiet", "origin", defaultBranch], hostStateWrite: true);
+        CaptureRetry(ref lastGitWriteRetry, hostFetch);
+        EnsureSuccess(hostFetch, "refresh origin default branch before claim transaction");
 
         ClaimRecord? lastObserved = null;
         for (var attempt = 1; attempt <= request.MaxAttempts; attempt++)
@@ -144,16 +151,17 @@ internal static class ClaimCommand
             var transactionRoot = Path.Combine(
                 Path.GetTempPath(), $"intent-cli-claim-{Guid.NewGuid():N}");
             var committed = false;
+            var tolerateCleanupFailure = false;
             Exception? transactionFailure = null;
             try
             {
                 var clone = RunGit(Path.GetTempPath(),
-                    ["clone", "--quiet", "--single-branch", "--branch", branchName, remote, transactionRoot]);
+                    ["clone", "--quiet", "--single-branch", "--branch", defaultBranch, remote, transactionRoot]);
                 EnsureSuccess(clone, "clone claim transaction workspace");
 
                 // The sequence is deliberately visible and invariant: ff-only
                 // pull, create/change, commit, then a non-forced push.
-                var pull = RunGit(transactionRoot, ["pull", "--ff-only", "origin", branchName], hostStateWrite: true);
+                var pull = RunGit(transactionRoot, ["pull", "--ff-only", "origin", defaultBranch], hostStateWrite: true);
                 CaptureRetry(ref lastGitWriteRetry, pull);
                 EnsureSuccess(pull, "fast-forward claim base");
 
@@ -162,6 +170,28 @@ internal static class ClaimCommand
                     transactionRoot, relativeClaimPath.Replace('/', Path.DirectorySeparatorChar));
                 var current = ReadClaim(absoluteClaimPath);
                 lastObserved = current;
+                if (request.Operation == ClaimOperation.Acquire
+                    && current is not null
+                    && string.Equals(current.Actor, request.Actor, StringComparison.Ordinal)
+                    && string.Equals(current.Team, request.Team, StringComparison.Ordinal))
+                {
+                    // An identically held acquire is an intentional no-op.
+                    // Its result must survive teardown, including an
+                    // injected cleanup failure, so operators can distinguish
+                    // "already held" from a broken pre-commit transaction.
+                    tolerateCleanupFailure = true;
+                    return Held(
+                        request,
+                        relativeClaimPath,
+                        attempt,
+                        current,
+                        $"Scope is already held by actor '{current.Actor}' on team '{current.Team}'; "
+                        + "no claim commit was needed (nothing to commit).") with
+                    {
+                        GitWriteRetry = lastGitWriteRetry,
+                        TargetRef = targetRef,
+                    };
+                }
 
                 if (request.Operation == ClaimOperation.Acquire && current is not null)
                 {
@@ -248,7 +278,10 @@ internal static class ClaimCommand
                 EnsureSuccess(transactionCommit, "resolve claim transaction commit");
                 var transactionCommitSha = transactionCommit.StandardOutput.Trim();
 
-                var push = RunGit(transactionRoot, ["push", "origin", "HEAD"], hostStateWrite: true);
+                var push = RunGit(
+                    transactionRoot,
+                    ["push", "origin", $"{transactionCommitSha}:{targetRef}"],
+                    hostStateWrite: true);
                 CaptureRetry(ref lastGitWriteRetry, push);
                 if (push.ExitCode != 0 && push.RetryEvidence is not null)
                 {
@@ -268,7 +301,7 @@ internal static class ClaimCommand
                     };
                     var detail = RefreshInvokingClone(
                         repoRoot,
-                        branchName,
+                        defaultBranch,
                         ref lastGitWriteRetry,
                         "The plain push succeeded; this is the ownership transition fact.");
                     return new ClaimTransactionResult(
@@ -280,17 +313,18 @@ internal static class ClaimCommand
                         historyPath)
                     {
                         GitWriteRetry = lastGitWriteRetry,
+                        TargetRef = targetRef,
                     };
                 }
 
-                var fetch = RunGit(transactionRoot, ["fetch", "origin", branchName]);
+                var fetch = RunGit(transactionRoot, ["fetch", "origin", defaultBranch]);
                 EnsureSuccess(fetch, "inspect rejected claim push");
-                var remoteHead = RunGit(transactionRoot, ["rev-parse", $"origin/{branchName}"]);
-                var remoteCommitMatches = remoteHead.ExitCode == 0
-                    && string.Equals(remoteHead.StandardOutput.Trim(), transactionCommitSha, StringComparison.Ordinal);
+                var remoteDefaultHead = RunGit(transactionRoot, ["rev-parse", $"origin/{defaultBranch}"]);
+                var remoteCommitMatches = remoteDefaultHead.ExitCode == 0
+                    && string.Equals(remoteDefaultHead.StandardOutput.Trim(), transactionCommitSha, StringComparison.Ordinal);
 
                 var remoteClaim = RunGit(transactionRoot,
-                    ["show", $"origin/{branchName}:{relativeClaimPath}"]);
+                    ["show", $"origin/{defaultBranch}:{relativeClaimPath}"]);
                 if (remoteClaim.ExitCode == 0)
                 {
                     var holder = JsonSerializer.Deserialize<ClaimRecord>(remoteClaim.StandardOutput, JsonOptions)
@@ -314,7 +348,7 @@ internal static class ClaimCommand
                         };
                         var detail = RefreshInvokingClone(
                             repoRoot,
-                            branchName,
+                            defaultBranch,
                             ref lastGitWriteRetry,
                             "The remote branch contains the transaction commit after the push process returned a failure; verified remote state is the ownership transition fact.");
                         return new ClaimTransactionResult(
@@ -326,6 +360,7 @@ internal static class ClaimCommand
                             historyPath)
                         {
                             GitWriteRetry = lastGitWriteRetry,
+                            TargetRef = targetRef,
                         };
                     }
 
@@ -349,7 +384,7 @@ internal static class ClaimCommand
                     var status = "released";
                     var detail = RefreshInvokingClone(
                         repoRoot,
-                        branchName,
+                        defaultBranch,
                         ref lastGitWriteRetry,
                         "The remote branch contains the transaction commit after the push process returned a failure; verified remote state is the ownership transition fact.");
                     return new ClaimTransactionResult(
@@ -357,6 +392,7 @@ internal static class ClaimCommand
                         null, null, transactionCommitSha, detail, historyPath)
                     {
                         GitWriteRetry = lastGitWriteRetry,
+                        TargetRef = targetRef,
                     };
                 }
 
@@ -382,7 +418,12 @@ internal static class ClaimCommand
             {
                 try
                 {
-                    CleanupTransactionRoot(transactionRoot, committed, warningWriter, deleteDirectory);
+                    CleanupTransactionRoot(
+                        transactionRoot,
+                        committed,
+                        tolerateCleanupFailure,
+                        warningWriter,
+                        deleteDirectory);
                 }
                 catch (Exception cleanupFailure) when (transactionFailure is not null)
                 {
@@ -407,6 +448,7 @@ internal static class ClaimCommand
     private static void CleanupTransactionRoot(
         string transactionRoot,
         bool committed,
+        bool tolerateCleanupFailure,
         TextWriter warningWriter,
         Action<string> deleteDirectory)
     {
@@ -439,6 +481,11 @@ internal static class ClaimCommand
             lastFailure = exception;
         }
 
+        if (tolerateCleanupFailure)
+        {
+            WriteNoOpCleanupWarning(warningWriter, transactionRoot, attempts, lastFailure);
+            return;
+        }
         if (committed)
         {
             var detail = lastFailure?.Message;
@@ -464,9 +511,31 @@ internal static class ClaimCommand
             + "the claim state was committed.", lastFailure);
     }
 
+    private static void WriteNoOpCleanupWarning(
+        TextWriter warningWriter,
+        string transactionRoot,
+        int attempts,
+        Exception? lastFailure)
+    {
+        var detail = lastFailure?.Message;
+        try
+        {
+            warningWriter.WriteLine(
+                $"warning: claim acquire found the scope already held; no claim commit was needed "
+                + $"(nothing to commit). Best-effort cleanup could not remove temporary directory "
+                + $"'{transactionRoot}' after {attempts} bounded attempt(s); the already-held claim "
+                + $"result and exit code are unchanged. The leftover path remains under the OS temp root."
+                + (string.IsNullOrWhiteSpace(detail) ? string.Empty : $" Last error: {detail}"));
+        }
+        catch
+        {
+            // A broken warning sink must not replace the already-held result.
+        }
+    }
+
     private static string RefreshInvokingClone(
         string repoRoot,
-        string branchName,
+        string defaultBranch,
         ref HostStateGitRetryEvidence? lastGitWriteRetry,
         string committedDetail)
     {
@@ -474,13 +543,13 @@ internal static class ClaimCommand
         {
             var localRefresh = RunGit(
                 repoRoot,
-                ["pull", "--ff-only", "origin", branchName],
+                ["fetch", "--quiet", "origin", defaultBranch],
                 hostStateWrite: true);
             CaptureRetry(ref lastGitWriteRetry, localRefresh);
             return localRefresh.ExitCode == 0
                 ? committedDetail
                 : committedDetail
-                    + " The invoking clone could not fast-forward: "
+                    + " The invoking clone could not refresh the origin default-branch tracking ref: "
                     + localRefresh.StandardError.Trim();
         }
         catch (Exception exception)
@@ -547,6 +616,79 @@ internal static class ClaimCommand
             TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default);
     }
+
+    internal static bool TryParseRemoteDefaultBranch(
+        string output,
+        out string defaultBranch)
+    {
+        defaultBranch = string.Empty;
+        string? branch = null;
+        string? headObject = null;
+
+        foreach (var rawLine in output.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (line.StartsWith("ref: refs/heads/", StringComparison.Ordinal)
+                && line.EndsWith("\tHEAD", StringComparison.Ordinal))
+            {
+                const string prefix = "ref: refs/heads/";
+                const string suffix = "\tHEAD";
+                var candidate = line[prefix.Length..(line.Length - suffix.Length)];
+                if (!IsSafeRemoteBranch(candidate)
+                    || (branch is not null
+                        && !string.Equals(branch, candidate, StringComparison.Ordinal)))
+                {
+                    return false;
+                }
+                branch = candidate;
+                continue;
+            }
+
+            var separator = line.IndexOf('\t');
+            if (separator > 0
+                && string.Equals(line[(separator + 1)..], "HEAD", StringComparison.Ordinal))
+            {
+                var candidate = line[..separator];
+                if (!IsHexObjectId(candidate)
+                    || (headObject is not null
+                        && !string.Equals(headObject, candidate, StringComparison.Ordinal)))
+                {
+                    return false;
+                }
+                headObject = candidate;
+            }
+        }
+
+        if (branch is null || headObject is null)
+        {
+            return false;
+        }
+
+        defaultBranch = branch;
+        return true;
+    }
+
+    private static bool IsSafeRemoteBranch(string value)
+    {
+        if (value.Length == 0
+            || value.StartsWith("-", StringComparison.Ordinal)
+            || value.StartsWith("/", StringComparison.Ordinal)
+            || value.EndsWith("/", StringComparison.Ordinal)
+            || value.EndsWith(".", StringComparison.Ordinal)
+            || value.Contains("..", StringComparison.Ordinal)
+            || value.Contains("//", StringComparison.Ordinal)
+            || value.Contains("@{", StringComparison.Ordinal)
+            || value.Any(c => char.IsControl(c) || char.IsWhiteSpace(c)
+                || c is '~' or '^' or ':' or '?' or '*' or '[' or '\\'))
+        {
+            return false;
+        }
+
+        return value.Split('/').All(segment => segment is not ("" or "." or ".."));
+    }
+
+    private static bool IsHexObjectId(string value) =>
+        value.Length is 40 or 64 && value.All(Uri.IsHexDigit);
 
     internal static string ClaimPath(string scope)
     {
@@ -812,6 +954,7 @@ internal static class ClaimCommand
         writer.WriteLine($"- scope: `{result.Scope}`");
         writer.WriteLine($"- claim_path: `{result.ClaimPath}`");
         writer.WriteLine($"- push_succeeded: {(result.PushSucceeded ? "true" : "false")}");
+        if (result.TargetRef is not null) writer.WriteLine($"- target_ref: `{result.TargetRef}`");
         if (result.Holder is not null) writer.WriteLine($"- holder: {result.Holder}");
         if (result.HolderTeam is not null) writer.WriteLine($"- holder_team: {result.HolderTeam}");
         if (result.DisplacedHolder is not null) writer.WriteLine($"- displaced_holder: {result.DisplacedHolder}");
@@ -878,6 +1021,10 @@ internal sealed record ClaimTransactionResult(
     [JsonPropertyName("holder_team")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? HolderTeam { get; init; }
+
+    [JsonPropertyName("target_ref")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? TargetRef { get; init; }
 
     [JsonPropertyName("git_write_retry")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/tests/IntentSystem.Cli.Tests/ClaimCommandG747Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClaimCommandG747Tests.cs
@@ -1,0 +1,245 @@
+using System.Diagnostics;
+using System.Text.Json;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class ClaimCommandG747Tests
+{
+    [Fact]
+    public void IdenticallyHeldAcquire_CleanupFailureReportsNoOpCauseSeparately_G747()
+    {
+        using var repos = new ClaimRepositories();
+        const string scope = "execution-unit:G747-no-op";
+        var acquired = ClaimCommand.RunTransaction(
+            repos.FirstClone, Request(scope, "alice", "implementation"));
+        Assert.Equal("acquired", acquired.Status);
+        var before = ReadBareRef(repos.Bare, "main");
+
+        using var output = new StringWriter();
+        using var warnings = new StringWriter();
+        var deleteAttempts = 0;
+        string? leftoverPath = null;
+        try
+        {
+            var exitCode = ClaimCommand.ExecuteAcquire(
+                Context(repos.FirstClone),
+                [
+                    "--scope", scope,
+                    "--actor", "alice",
+                    "--team", "implementation",
+                    "--write",
+                    "--format", "json",
+                ],
+                output,
+                warnings,
+                path =>
+                {
+                    leftoverPath = path;
+                    deleteAttempts++;
+                    throw new IOException("injected no-op cleanup failure");
+                });
+
+            Assert.Equal(1, exitCode);
+            using var emitted = JsonDocument.Parse(output.ToString());
+            var result = emitted.RootElement;
+            Assert.Equal("held", result.GetProperty("status").GetString());
+            Assert.Equal(scope, result.GetProperty("scope").GetString());
+            Assert.False(result.GetProperty("push_succeeded").GetBoolean());
+            Assert.False(result.TryGetProperty("commit", out _));
+            Assert.Contains("already held", result.GetProperty("detail").GetString()!, StringComparison.Ordinal);
+            Assert.Contains("nothing to commit", result.GetProperty("detail").GetString()!, StringComparison.Ordinal);
+            Assert.Equal("refs/heads/main", result.GetProperty("target_ref").GetString());
+            Assert.DoesNotContain("warning:", output.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("before the claim state was committed", result.GetProperty("detail").GetString()!, StringComparison.Ordinal);
+            Assert.Equal(ClaimCommand.CleanupMaxAttempts, deleteAttempts);
+            Assert.NotNull(leftoverPath);
+            Assert.Contains(leftoverPath!, warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("cleanup could not remove", warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("already-held claim result and exit code are unchanged", warnings.ToString(), StringComparison.Ordinal);
+            Assert.DoesNotContain("ArgumentException", output.ToString() + warnings.ToString(), StringComparison.Ordinal);
+            Assert.Equal(before, ReadBareRef(repos.Bare, "main"));
+        }
+        finally
+        {
+            if (leftoverPath is not null && Directory.Exists(leftoverPath))
+            {
+                Directory.Delete(leftoverPath, recursive: true);
+            }
+        }
+    }
+    [Fact]
+    public void NonDefaultCheckout_PushesOnlyResolvedRemoteDefaultRef_G747()
+    {
+        using var repos = new ClaimRepositories();
+        repos.PrepareNonDefaultCheckout();
+        var currentBranchBefore = Run(repos.FirstClone, "git", "branch", "--show-current").Trim();
+        var mainBefore = ReadBareRef(repos.Bare, "main");
+        var featureBefore = ReadBareRef(repos.Bare, repos.FeatureBranch);
+
+        var result = ClaimCommand.RunTransaction(
+            repos.FirstClone,
+            Request("execution-unit:G747-default-branch", "alice", "implementation"));
+
+        Assert.Equal("acquired", result.Status);
+        Assert.True(result.PushSucceeded);
+        Assert.Equal("refs/heads/main", result.TargetRef);
+        Assert.Equal(result.Commit, ReadBareRef(repos.Bare, "main"));
+        Assert.NotEqual(mainBefore, ReadBareRef(repos.Bare, "main"));
+        Assert.Equal(featureBefore, ReadBareRef(repos.Bare, repos.FeatureBranch));
+        Assert.Equal(currentBranchBefore, Run(repos.FirstClone, "git", "branch", "--show-current").Trim());
+    }
+
+    [Fact]
+    public void JsonOutput_IsOneDocumentWhileCleanupWarningRemainsObservable_G747()
+    {
+        using var repos = new ClaimRepositories();
+        using var output = new StringWriter();
+        using var warnings = new StringWriter();
+        string? leftoverPath = null;
+        try
+        {
+            var exitCode = ClaimCommand.ExecuteAcquire(
+                Context(repos.FirstClone),
+                [
+                    "--scope", "execution-unit:G747-json",
+                    "--actor", "alice",
+                    "--team", "implementation",
+                    "--write",
+                    "--format", "json",
+                ],
+                output,
+                warnings,
+                path =>
+                {
+                    leftoverPath = path;
+                    throw new IOException("injected JSON cleanup failure");
+                });
+
+            Assert.Equal(0, exitCode);
+            using var emitted = JsonDocument.Parse(output.ToString());
+            Assert.Equal("acquired", emitted.RootElement.GetProperty("status").GetString());
+            Assert.True(emitted.RootElement.GetProperty("push_succeeded").GetBoolean());
+            Assert.Equal("refs/heads/main", emitted.RootElement.GetProperty("target_ref").GetString());
+            Assert.DoesNotContain("warning:", output.ToString(), StringComparison.Ordinal);
+            Assert.NotNull(leftoverPath);
+            Assert.Contains(leftoverPath!, warnings.ToString(), StringComparison.Ordinal);
+            Assert.Contains("claim result and exit code are unchanged", warnings.ToString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (leftoverPath is not null && Directory.Exists(leftoverPath))
+            {
+                Directory.Delete(leftoverPath, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void RemoteDefaultBranchParser_RequiresOneSafeSymrefAndHead_G747()
+    {
+        const string sha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        Assert.True(ClaimCommand.TryParseRemoteDefaultBranch(
+            $"ref: refs/heads/release-line\tHEAD\n{sha}\tHEAD\n",
+            out var branch));
+        Assert.Equal("release-line", branch);
+        Assert.False(ClaimCommand.TryParseRemoteDefaultBranch(
+            $"{sha}\tHEAD\n", out _));
+        Assert.False(ClaimCommand.TryParseRemoteDefaultBranch(
+            $"ref: refs/heads/main\tHEAD\n{sha}\tHEAD\nref: refs/heads/other\tHEAD\n", out _));
+        Assert.False(ClaimCommand.TryParseRemoteDefaultBranch(
+            $"ref: refs/heads/../main\tHEAD\n{sha}\tHEAD\n", out _));
+    }
+
+    private static ClaimRequest Request(string scope, string actor, string team) =>
+        new(ClaimOperation.Acquire, scope, actor, team, null, null, true, "json", ClaimCommand.DefaultMaxAttempts);
+
+    private static CliContext Context(string root) => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private static string ReadBareRef(string bare, string branch) =>
+        Run(bare, "git", "rev-parse", $"refs/heads/{branch}").Trim();
+
+    private static string Run(string workdir, string fileName, params string[] arguments)
+    {
+        var info = new ProcessStartInfo(fileName)
+        {
+            WorkingDirectory = workdir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var argument in arguments) info.ArgumentList.Add(argument);
+        using var process = Process.Start(info)!;
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, $"{fileName} {string.Join(' ', arguments)} failed: {error}");
+        return output;
+    }
+
+    private sealed class ClaimRepositories : IDisposable
+    {
+        private readonly TempDirectory temp = new("claim-repos-g747-");
+
+        public ClaimRepositories()
+        {
+            Bare = Path.Combine(temp.Path, "origin.git");
+            var seed = Path.Combine(temp.Path, "seed");
+            FirstClone = Path.Combine(temp.Path, "first");
+            Directory.CreateDirectory(Bare);
+            Run(Bare, "git", "init", "--bare", "--quiet");
+            Directory.CreateDirectory(seed);
+            Run(seed, "git", "init", "--quiet", "--initial-branch=main");
+            Run(seed, "git", "config", "user.name", "seed");
+            Run(seed, "git", "config", "user.email", "seed@example.invalid");
+            File.WriteAllText(Path.Combine(seed, "README.md"), "seed\n");
+            Run(seed, "git", "add", "README.md");
+            Run(seed, "git", "commit", "--quiet", "-m", "seed");
+            Run(seed, "git", "remote", "add", "origin", Bare);
+            Run(seed, "git", "push", "--quiet", "-u", "origin", "main");
+            Run(Bare, "git", "symbolic-ref", "HEAD", "refs/heads/main");
+            Run(temp.Path, "git", "clone", "--quiet", Bare, FirstClone);
+        }
+
+        public string Bare { get; }
+        public string FirstClone { get; }
+        public string FeatureBranch { get; } = "design-thread";
+
+        public void PrepareNonDefaultCheckout()
+        {
+            Run(FirstClone, "git", "switch", "--quiet", "-c", FeatureBranch);
+            File.WriteAllText(Path.Combine(FirstClone, "feature.txt"), "feature\n");
+            Run(FirstClone, "git", "add", "feature.txt");
+            Run(FirstClone, "git", "-c", "user.name=feature", "-c", "user.email=feature@example.invalid",
+                "commit", "--quiet", "-m", "feature");
+            Run(FirstClone, "git", "push", "--quiet", "-u", "origin", FeatureBranch);
+        }
+
+        public void Dispose() => temp.Dispose();
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory(string prefix) => Path = Directory.CreateTempSubdirectory(prefix).FullName;
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1625

Implements the three G747 claim transaction repairs:

- preserve the already-held/nothing-to-commit no-op cause when bounded cleanup also fails;
- resolve and explicitly push to the remote default branch, including fail-closed symref validation;
- keep JSON stdout as one parseable document while cleanup warnings remain on stderr.

Focused G747 tests, unchanged G738/G743 claim tests, adjacent worker/claim tests, G613, and the full Release suite pass.

The child next-action/preflight registry reported G747 unheld; the supplied verified host claim authority was consumed without creating or mutating any child product-repository claim.