### PR TITLE
G748: recognize done recipients in supervision

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -533,12 +533,17 @@ not a value the CLI silently corrects.
 
 `notify supervise` emits `delegation-delivered-never-executed` only when a
 delegation's durable delivery evidence says `delivery_succeeded=true`, the
-recipient is still running but `agent_status=idle` on a later observation, and
-the configured `--delegation-execution-window-seconds` (default `300s`) has
-elapsed. The full conjunction also requires the canonical report for the task
-to be absent, every expected artifact source to be absent, and the durable
-target-entity transition source to be absent. A working/started seat, visible
-artifact, report, or target transition is a non-finding.
+recipient is still running and its observed `agent_status` is one of `idle` or
+`done` on a later observation, and the configured
+`--delegation-execution-window-seconds` (default `300s`) has elapsed. The
+observed recipient state set is intentionally these two settled states: `idle`
+means the seat never started, while `done` means it completed a turn without
+producing the delegated work. `working` remains positive started-work evidence;
+other or unresolved states do not satisfy this finding. The full conjunction
+also requires the canonical report for the task to be absent, every expected
+artifact source to be absent, and the durable target-entity transition source
+to be absent. A working/started seat, visible artifact, report, or target
+transition is a non-finding.
 
 The finding names `task_id`, seat, `delivered_at`, the window, and every
 checked source. It wakes the delegation's owner role through the recorded

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -539,11 +539,14 @@ recipient is still running and its observed `agent_status` is one of `idle` or
 observed recipient state set is intentionally these two settled states: `idle`
 means the seat never started, while `done` means it completed a turn without
 producing the delegated work. `working` remains positive started-work evidence;
-other or unresolved states do not satisfy this finding. The full conjunction
-also requires the canonical report for the task to be absent, every expected
-artifact source to be absent, and the durable target-entity transition source
-to be absent. A working/started seat, visible artifact, report, or target
-transition is a non-finding.
+`blocked` is deliberately excluded because it represents an explicit impediment
+requiring its own handling and evidence, not proof that the delegation silently
+stopped without executing. `unknown` is deliberately excluded because an
+unobservable seat must never be claimed stopped. Other or unresolved states do
+not satisfy this finding. The full conjunction also requires the canonical
+report for the task to be absent, every expected artifact source to be absent,
+and the durable target-entity transition source to be absent. A working/started
+seat, visible artifact, report, or target transition is a non-finding.
 
 The finding names `task_id`, seat, `delivered_at`, the window, and every
 checked source. It wakes the delegation's owner role through the recorded

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -482,7 +482,10 @@ non-finding です。
 
 recipient activity の観測 state set は `idle` と `done` の 2 つです。`idle` は
 開始されなかった seat、`done` は turn を完了したが delegated work を生成しなかった
-seat を表します。`working` は開始済みの証拠のままであり、その他または解決できない
+seat を表します。`working` は開始済みの証拠のままです。`blocked` は明示的な
+impediment であり、専用の handling と evidence が必要で、delegation が実行されずに
+黙って停止した証拠ではないため、意図的に除外します。`unknown` も観測できない seat を
+停止したと決めつけてはいけないため、意図的に除外します。その他または解決できない
 state はこの finding の条件を満たしません。
 
 finding には `task_id`、seat、`delivered_at`、使用した window、確認した

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -472,13 +472,18 @@ message を黙らせず、2 つの outcome を operator が整合できるよう
 
 `notify supervise` は、永続的な delivery evidence が
 `delivery_succeeded=true`、recipient が後続 observation でも
-`agent_status=idle`、かつ `--delegation-execution-window-seconds`（default
-`300s`）経過である場合にだけ
+`agent_status=idle` または `done`、かつ `--delegation-execution-window-seconds`
+（default `300s`）経過である場合にだけ
 `delegation-delivered-never-executed` を出します。さらに full conjunction として、
 task の canonical report が absent、全 expected artifact source が absent、
 永続的な target-entity transition source が absent でなければなりません。
 seat が working/started、artifact・report・target transition が見える場合は
 non-finding です。
+
+recipient activity の観測 state set は `idle` と `done` の 2 つです。`idle` は
+開始されなかった seat、`done` は turn を完了したが delegated work を生成しなかった
+seat を表します。`working` は開始済みの証拠のままであり、その他または解決できない
+state はこの finding の条件を満たしません。
 
 finding には `task_id`、seat、`delivered_at`、使用した window、確認した
 全 source を記録し、delegation の owner role に recorded transport で通知します。

--- a/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
@@ -22,7 +22,11 @@ internal sealed class NotifyMeasuredSupervisor
     private const string ObservationConflictKind = "observation-conflict";
     // G748: these are the two observed settled recipient states. A recipient
     // that never started is reported as idle; one that completed a turn
-    // without producing the delegated work is reported as done.
+    // without producing the delegated work is reported as done. `blocked` is
+    // deliberately excluded because it is an explicit impediment requiring
+    // its own handling and evidence, not proof that delegation silently
+    // stopped without executing. `unknown` is deliberately excluded because
+    // an unobservable seat must never be claimed stopped.
     private static readonly IReadOnlySet<string> DelegationExecutionRecipientStates =
         new HashSet<string>(StringComparer.Ordinal)
         {

--- a/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
@@ -20,6 +20,15 @@ internal sealed class NotifyMeasuredSupervisor
     internal const int MaximumDelegationExecutionWindowSeconds = 86_400;
     private const string DesignRole = "design";
     private const string ObservationConflictKind = "observation-conflict";
+    // G748: these are the two observed settled recipient states. A recipient
+    // that never started is reported as idle; one that completed a turn
+    // without producing the delegated work is reported as done.
+    private static readonly IReadOnlySet<string> DelegationExecutionRecipientStates =
+        new HashSet<string>(StringComparer.Ordinal)
+        {
+            "idle",
+            "done",
+        };
 
     private readonly CliContext context;
     private readonly string routingRoot;
@@ -1298,7 +1307,8 @@ internal sealed class NotifyMeasuredSupervisor
     {
         if (!activity.Resolved
             || activity.Running != true
-            || !string.Equals(activity.AgentStatus, "idle", StringComparison.Ordinal)
+            || activity.AgentStatus is null
+            || !DelegationExecutionRecipientStates.Contains(activity.AgentStatus)
             || activity.StateChangeSequence is not { } sequence
             || pending.ReportArrived)
         {

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionG748Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionG748Tests.cs
@@ -1,0 +1,239 @@
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifySupervisionG748Tests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+    private readonly string root = Path.Combine(Path.GetTempPath(), $"intent-g748-{Guid.NewGuid():N}");
+    private readonly DateTimeOffset firstNow = new(2026, 8, 28, 12, 0, 0, TimeSpan.Zero);
+    private DateTimeOffset now;
+
+    public NotifySupervisionG748Tests()
+    {
+        Directory.CreateDirectory(root);
+        now = firstNow;
+        NotifyCommand.UtcNowFactory = () => now;
+        NotifySupervisor.Delay = _ => { };
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.UtcNowFactory = null;
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifyCommand.AgmsgScriptsDirectoryFactory = null;
+        NotifyCommand.HerdrExecutableFactory = null;
+        NotifyCommand.BashExecutableFactory = null;
+        NotifySupervisionStore.WriteOverride = null;
+        NotifyPendingDelegationStore.WriteOverride = null;
+        NotifySupervisor.Delay = Thread.Sleep;
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DeliveredDoneDelegationFiresAfterWindow_G748()
+    {
+        var context = CreateContext();
+        RecordHerdrOnlyMode(context);
+        WriteTopology();
+        var pending = WriteDeliveredPending("G748-done");
+        var runner = new FixtureRunner { AgentStatus = "done", StateChangeSequence = 14 };
+        var supervisor = CreateSupervisor(context, runner, delegationWindowSeconds: 300);
+
+        supervisor.RunOnce();
+        now = firstNow.AddSeconds(301);
+        var pass = supervisor.RunOnce();
+
+        var finding = Assert.Single(
+            pass.Findings,
+            item => item.Kind == "delegation-delivered-never-executed");
+        Assert.Contains("G748-done", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("agent_status=done", string.Join("\n", finding.ConsultedObservations!));
+        Assert.Contains("task_id:G748-done", finding.Evidence!, StringComparer.Ordinal);
+        Assert.Contains("seat 'role=implementation;workspace=wG748;pane=wG748:p2'", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("300s execution-start window", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("Canonical report absent", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("expected artifact absent", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("durable target-entity transition absent", finding.Summary, StringComparison.Ordinal);
+        Assert.Contains("window_seconds:300", finding.Evidence!, StringComparer.Ordinal);
+        Assert.Equal(pending.TaskId, NotifyPendingDelegationStore.Find(
+            root,
+            Domain,
+            Team,
+            pending.TaskId).Record!.TaskId);
+    }
+
+    private NotifyMeasuredSupervisor CreateSupervisor(
+        CliContext context,
+        FixtureRunner runner,
+        int delegationWindowSeconds) => new(
+        context: context,
+        routingRoot: root,
+        domain: Domain,
+        team: Team,
+        repo: null,
+        ownerRole: "orchestration",
+        intervalSeconds: 600,
+        declaredBoundSeconds: null,
+        staleMinutes: 45,
+        claimedSilentMinutes: 720,
+        backlogIdleMinutes: 45,
+        repairSilentMinutes: 180,
+        autoRedispatch: false,
+        write: true,
+        format: "json",
+        runner: runner,
+        herdrExecutable: "fake-herdr",
+        agmsgScriptsDirectory: root,
+        delegationExecutionWindowSeconds: delegationWindowSeconds);
+
+    private NotifyPendingDelegation WriteDeliveredPending(string taskId)
+    {
+        var pending = WriteDispatchedPending(taskId);
+        var delivery = NotifyDelegationDeliveryStore.Write(root, pending, firstNow);
+        Assert.True(delivery.Written, delivery.Error);
+        return pending;
+    }
+
+    private NotifyPendingDelegation WriteDispatchedPending(string taskId)
+    {
+        var pending = new NotifyPendingDelegation
+        {
+            Domain = Domain,
+            Team = Team,
+            TaskId = taskId,
+            DelegatingRole = "orchestration",
+            RecipientRole = "implementation",
+            ReportToRole = "orchestration",
+            RecipientIdentity = "role=implementation;workspace=wG748;pane=wG748:p2",
+            ExpectedArtifact = "expected-artifact.txt",
+            ExpectedArtifacts = ["expected-artifact.txt"],
+            Objective = "execute the delegated task",
+            Inputs = ["fixture"],
+            ResultNonce = $"{taskId}-nonce",
+            DispatchedAt = firstNow.AddSeconds(-1),
+            TransportMode = SessionLayerMode.HerdrOnly,
+            Resident = NotifyRecordedRole.HerdrResident,
+            WorkspaceId = "wG748",
+            PaneId = "wG748:p2",
+            Cwd = Path.Combine(root, "work", taskId),
+            Kind = "implementation",
+            LaunchArguments = ["fixture"],
+        };
+        var write = NotifyPendingDelegationStore.WriteDispatch(root, pending);
+        Assert.True(write.Written, write.Error);
+        return pending;
+    }
+
+    private CliContext CreateContext() => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig { Domain = Domain, ArtifactRoot = ".intent-cli" },
+        },
+    };
+
+    private void RecordHerdrOnlyMode(CliContext context)
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            SessionLayerCommand.ExecuteSet(
+                context,
+                ["--domain", Domain, "--team", Team, "--mode", SessionLayerMode.HerdrOnly, "--write", "--format", "json"],
+                writer));
+    }
+
+    private void WriteTopology()
+    {
+        var path = NotifyRoleTopologyStore.ResolvePath(root, Domain, Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(
+            path,
+            JsonSerializer.Serialize(new
+            {
+                domain = Domain,
+                team = Team,
+                workspace_id = "wG748",
+                roles = new Dictionary<string, object>
+                {
+                    ["orchestration"] = new { resident = "herdr", workspace_id = "wG748", pane_id = "wG748:p1" },
+                    ["implementation"] = new { resident = "herdr", workspace_id = "wG748", pane_id = "wG748:p2" },
+                },
+            }));
+    }
+
+    private static string AgentsJson(string status, long sequence)
+    {
+        static object Agent(string role, string pane, string status, long sequence) => new
+        {
+            name = role,
+            workspace_id = "wG748",
+            pane_id = pane,
+            agent = "fixture",
+            agent_session = new { id = role },
+            agent_status = status,
+            agent_running = true,
+            interactive_ready = true,
+            state_change_seq = sequence,
+            last_state_change_at = "2026-08-28T12:00:00.0000000+00:00",
+        };
+
+        return JsonSerializer.Serialize(new
+        {
+            result = new
+            {
+                agents = new[]
+                {
+                    Agent("orchestration", "wG748:p1", "working", 1),
+                    Agent("implementation", "wG748:p2", status, sequence),
+                },
+            },
+        });
+    }
+
+    private sealed class FixtureRunner : INotifyProcessRunner
+    {
+        public string AgentStatus { get; set; } = "done";
+        public long StateChangeSequence { get; set; } = 14;
+
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            if (arguments.SequenceEqual(["agent", "list"]))
+            {
+                return new NotifyProcessResult(
+                    0,
+                    AgentsJson(AgentStatus, StateChangeSequence),
+                    string.Empty);
+            }
+
+            if (arguments.Count >= 2
+                && arguments[0] == "pane"
+                && arguments[1] == "process-info")
+            {
+                return new NotifyProcessResult(
+                    0,
+                    "{\"result\":{\"process_info\":{\"foreground_processes\":[]}}}",
+                    string.Empty);
+            }
+
+            if (arguments.Count >= 2
+                && arguments[0] == "agent"
+                && arguments[1] is "prompt" or "wait")
+            {
+                return new NotifyProcessResult(0, string.Empty, string.Empty);
+            }
+
+            return new NotifyProcessResult(0, string.Empty, string.Empty);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1628

Updates the delivered-but-never-executed supervision guard to recognize the observed settled recipient states `idle` and `done`, while preserving the existing conjunction, probes, window, wake routing, and observation-only behavior. Adds a deterministic done-state regression and mirrors the state-set contract in English and Japanese orchestration docs.