### PR TITLE
G751: stop persisting event-mode no-observation waits

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -455,8 +455,9 @@ operation.
 
 This is ownership repair, not compaction: G734 `notify supervise shrink` keeps
 all records while compacting existing state in place, whereas G750 only changes
-which cycle-history paths are CLI-owned runtime-local files. G751 remains the
-separate later unit for write-rate design and is not part of this change.
+which cycle-history paths are CLI-owned runtime-local files. G751 is the
+separate event-mode persistence unit documented below; it does not change this
+ownership boundary.
 
 > **Preview through 1.x (G750).** Directory-local cycle-history ownership and
 > its named repair command are post-freeze preview behavior outside the 1.0
@@ -1005,6 +1006,41 @@ scheduler artifacts embed their invocation, so an installed interval-only
 artifact stays interval-only. Adoption requires running `notify supervise
 install ... --event-mode` again, inspecting the new artifact, and explicitly
 unregistering/re-registering it with the printed operator commands.
+
+### Event-mode record worthiness and measured cadence (G751 — preview-through-1.x)
+
+G751 separates a successful wait return from a record-worthy observation. A
+wait result is record-worthy when it observes a qualifying `working` to
+settled transition. A wait death, error, identity mismatch, or parse failure
+also remains record-worthy evidence and is still written as an `event-wait`
+cycle with `rearm_attempted: true`. Every periodic interval pass remains a
+recorded safety-floor cycle, including the first-cycle and continuity proof.
+
+A successful wait return with no qualifying observation—including repeated
+immediate returns while the recipient is already settled—is classified as
+`wait-returned-without-observation`. It is re-armed after the existing
+one-second delay and emits the forced `event-wait-no-observation` warning with
+the role, workspace, pane, returned status, and reason. It does not append a
+durable `event-wait` cycle. Repeated instant returns therefore remain visible
+to the operator without turning a no-observation wait into a durable-record
+hot loop; they cannot suppress the interval safety floor, genuine event
+observations, liveness/bound evidence, or the first-cycle proof. Findings,
+wake routing, parking, emission policy, and observation-only discipline are
+unchanged.
+
+The child fixture measurement used a running event-mode supervisor with
+`interval=300` seconds and `bound=900` seconds, a deterministic idle wait
+return, and a 25 ms fixture re-arm delay. Before G751, a 2.010-second sample
+produced 75 raw records (`event-wait:74`, `interval:1`), or 134341.50
+records-per-hour. After G751, a 2.009-second sample produced 1 raw record
+(`interval:1`), or 1792.32 records-per-hour. These are independently measured
+running-fixture counts, not rates inferred from source or unit tests; the
+actual build commit is reported with the PR evidence. The 300-second interval
+and 900-second bound remain the declared cadence and safety contract.
+
+G751 changes event-mode persistence only. G699 duplicate-supervisor
+backoff/park, G744 archive, G750 ownership, findings, wake routing, parking,
+emission policy, and observation-only behavior remain outside this unit.
 
 > **Preview through 1.x (G659).** Event waits, transition/wait records, and
 > event/interval de-duplication are post-freeze preview behavior. They make no

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1028,15 +1028,29 @@ observations, liveness/bound evidence, or the first-cycle proof. Findings,
 wake routing, parking, emission policy, and observation-only discipline are
 unchanged.
 
-The child fixture measurement used a running event-mode supervisor with
-`interval=300` seconds and `bound=900` seconds, a deterministic idle wait
-return, and a 25 ms fixture re-arm delay. Before G751, a 2.010-second sample
-produced 75 raw records (`event-wait:74`, `interval:1`), or 134341.50
-records-per-hour. After G751, a 2.009-second sample produced 1 raw record
-(`interval:1`), or 1792.32 records-per-hour. These are independently measured
-running-fixture counts, not rates inferred from source or unit tests; the
-actual build commit is reported with the PR evidence. The 300-second interval
-and 900-second bound remain the declared cadence and safety contract.
+The before/after cadence comparison keeps startup arithmetic separate from a
+warmed steady-state window. The independent review reproduction on pre-fix
+`b525191a` ran the event-mode supervisor with the same `interval=300` seconds,
+`bound=900` seconds, deterministic idle wait, and 25 ms fixture re-arm. It
+observed 73 raw records in a 2.065-second wall window (`event-wait:72`,
+`interval:1`, including one startup interval), reported 127269.78
+records-per-hour, and is explicitly a startup-plus-two-second observation—not
+a steady-state rate. That measured result is retained as the honest pre-fix
+comparison; it is not used to predict durable-file growth.
+
+`interval_seconds=300 bound_seconds=900 sample_method=running-event-mode-supervisor window=startup-plus-two-second-wall-window raw_records=73 event-wait_records=72 startup_interval_records=1 wall_window_seconds=2.065 records-per-hour=127269.78 steady_state=false`
+
+The repaired focused regression runs the same event-mode supervisor and
+declared interval/bound with a deterministic controlled elapsed-time clock. It
+proves the first-cycle startup record separately, then advances the clock
+through twelve exact 300-second interval passes: the warmed window is 3600
+logical seconds, not a wall-time extrapolation. Its pinned evidence is:
+
+`interval_seconds=300 bound_seconds=900 sample_method=running-event-mode-supervisor-controlled-elapsed-time startup_first_cycle_records=1 warm_window_seconds=3600 warm_interval_records=12 event-wait_records=0 trigger_mix=interval:13 raw_records=13 records-per-hour=12.00`
+
+Thus the post-change steady-state result is 12 interval records per hour after
+startup. The 300-second interval and 900-second bound remain the declared
+cadence and safety contract.
 
 G751 changes event-mode persistence only. G699 duplicate-supervisor
 backoff/park, G744 archive, G750 ownership, findings, wake routing, parking,

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -863,15 +863,27 @@ safety floor、genuine event observation、liveness/bound evidence、first-cycle
 を隠さないことは変わりません。finding、wake routing、parking、emission policy、
 observation-only discipline も変更しません。
 
-child fixture では `interval=300` 秒、`bound=900` 秒、deterministic な idle wait
-return、25 ms の fixture re-arm delay を指定した running event-mode supervisor を
-同じ方法で測りました。G751 前の 2.010 秒 sample は raw record 75 件
-（`event-wait:74`、`interval:1`）、`records-per-hour` は 134341.50 でした。
-G751 後の 2.009 秒 sample は raw record 1 件（`interval:1`）、
-`records-per-hour` は 1792.32 でした。これは source や unit test から推測した rate
-ではなく、running fixture の実測 count です。実際の build commit は PR evidence
-で示します。300 秒 interval と 900 秒 bound は declared cadence と safety contract
-として維持されます。
+before/after の cadence 比較では startup の算術と warmed steady-state window を
+分離します。pre-fix の `b525191a` に対する independent review reproduction は、同じ
+`interval=300` 秒、`bound=900` 秒、deterministic な idle wait、25 ms の fixture re-arm
+を使う running event-mode supervisor でした。2.065 秒の wall window で raw record は
+73 件（`event-wait:72`、`interval:1`、startup interval 1 件を含む）、
+`records-per-hour` は 127269.78 と実測されました。これは startup-plus-two-second の
+observation であり、steady-state rate ではありません。この値は正直な pre-fix
+比較として保持し、永続ファイルの増加予測には使いません。
+
+`interval_seconds=300 bound_seconds=900 sample_method=running-event-mode-supervisor window=startup-plus-two-second-wall-window raw_records=73 event-wait_records=72 startup_interval_records=1 wall_window_seconds=2.065 records-per-hour=127269.78 steady_state=false`
+
+修正後の focused regression は、同じ event-mode supervisor と declared interval/bound
+に deterministic controlled elapsed-time clock を注入して実行します。first-cycle の
+startup record を先に分離して証明し、その後 clock を 300 秒ずつ正確に 12 回進めます。
+warmed window は wall-time の外挿ではなく logical 3600 秒です。固定する evidence は
+次のとおりです。
+
+`interval_seconds=300 bound_seconds=900 sample_method=running-event-mode-supervisor-controlled-elapsed-time startup_first_cycle_records=1 warm_window_seconds=3600 warm_interval_records=12 event-wait_records=0 trigger_mix=interval:13 raw_records=13 records-per-hour=12.00`
+
+したがって修正後の steady-state は startup 後に interval record 12 件 / hour です。
+300 秒 interval と 900 秒 bound は declared cadence と safety contract として維持されます。
 
 G751 の変更は event-mode persistence だけです。G699 duplicate-supervisor の
 backoff/park、G744 archive、G750 ownership、finding、wake routing、parking、

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -409,7 +409,7 @@ repository tracking を修復します。
 
 これは compaction ではありません。G734 の `notify supervise shrink` は全 record を保持したまま
 既存 state を in-place で圧縮しますが、G750 は cycle-history path の ownership だけを分けます。
-G751 は後続の write-rate design unit であり、この変更には含めません。
+G751 は下記の event-mode persistence の別 unit であり、この ownership 境界は変更しません。
 
 > **1.x を通じた preview (G750)。** directory-local cycle-history ownership と named repair command は
 > post-freeze preview であり、1.0 compatibility promise の対象外です。
@@ -842,6 +842,40 @@ G659 が hand-written transition watcher に取って代わるのは operator �
 invocation を埋め込むため、既存の interval-only artifact は interval-only のままです。adoption には
 `notify supervise install ... --event-mode` を再実行し、新しい artifact を確認して、表示された
 operator command で明示的に登録解除 / 再登録する必要があります。
+
+### event-mode の record-worthy 条件と実測 cadence (G751 — preview-through-1.x)
+
+G751 は successful な wait return と record-worthy な observation を分離します。
+`working` から settled への qualifying transition を観測した wait result は
+record-worthy です。wait の death、error、identity mismatch、parse failure も
+record-worthy evidence として残し、`rearm_attempted: true` の `event-wait` cycle
+として記録します。periodic interval pass は、first-cycle と continuity proof を
+含む safety floor として、毎回 cycle にします。
+
+qualifying observation のない successful wait return（recipient が既に settled の
+状態で repeated immediate return になる場合を含む）は
+`wait-returned-without-observation` に分類します。既存の 1 秒 delay 後に再設定し、
+role、workspace、pane、returned status、理由を含む forced
+`event-wait-no-observation` warning を operator に示しますが、永続的な
+`event-wait` cycle は `append` しません。この repeated instant return は silence
+にはならず、no-observation の永続記録 hot loop も作りません。interval の
+safety floor、genuine event observation、liveness/bound evidence、first-cycle proof
+を隠さないことは変わりません。finding、wake routing、parking、emission policy、
+observation-only discipline も変更しません。
+
+child fixture では `interval=300` 秒、`bound=900` 秒、deterministic な idle wait
+return、25 ms の fixture re-arm delay を指定した running event-mode supervisor を
+同じ方法で測りました。G751 前の 2.010 秒 sample は raw record 75 件
+（`event-wait:74`、`interval:1`）、`records-per-hour` は 134341.50 でした。
+G751 後の 2.009 秒 sample は raw record 1 件（`interval:1`）、
+`records-per-hour` は 1792.32 でした。これは source や unit test から推測した rate
+ではなく、running fixture の実測 count です。実際の build commit は PR evidence
+で示します。300 秒 interval と 900 秒 bound は declared cadence と safety contract
+として維持されます。
+
+G751 の変更は event-mode persistence だけです。G699 duplicate-supervisor の
+backoff/park、G744 archive、G750 ownership、finding、wake routing、parking、
+emission policy、observation-only behavior はこの unit の scope 外です。
 
 > **1.x を通じた preview (G659)。** event wait、transition / wait record、event / interval de-dup は
 > post-freeze preview です。release decision は行わず、1.x の間に変更・撤回できます。

--- a/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyMeasuredSupervisor.cs
@@ -1969,6 +1969,27 @@ internal sealed class NotifyMeasuredSupervisor
 
     internal void RecordWaitEvent(TextWriter writer, NotifySupervisionWaitEvent waitEvent)
     {
+        // A successful wait without a qualifying transition is operator-visible
+        // evidence, not a cycle-worthy observation. Keep the warning forced so
+        // repeated instant returns cannot disappear while interval cycles continue.
+        if (string.Equals(
+                waitEvent.Outcome,
+                NotifySupervisionEventMonitor.NoObservationOutcome,
+                StringComparison.Ordinal))
+        {
+            EmitPass(writer, new NotifySupervisorPass
+            {
+                Actions = [],
+                Warnings =
+                [
+                    $"event-wait-no-observation: role '{waitEvent.Role}' workspace '{waitEvent.WorkspaceId}' pane "
+                    + $"'{waitEvent.PaneId}' returned without a qualifying observation; no durable event-wait cycle "
+                    + $"was written; the interval safety floor remains active. Wait was re-armed: {waitEvent.Detail}",
+                ],
+            }, force: true);
+            return;
+        }
+
         lock (supervisionSync)
         {
             var state = NotifySupervisionStore.Read(

--- a/src/IntentSystem.Cli/Commands/NotifySupervisionEventMonitor.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySupervisionEventMonitor.cs
@@ -11,6 +11,7 @@ namespace IntentSystem.Cli.Commands;
 /// </summary>
 internal sealed class NotifySupervisionEventMonitor
 {
+    internal const string NoObservationOutcome = "wait-returned-without-observation";
     internal static Func<TimeSpan, CancellationToken, Task> Delay { get; set; } = Task.Delay;
     private static readonly TimeSpan RearmDelay = TimeSpan.FromSeconds(1);
     private static readonly string[] SettledStatuses = ["done", "blocked", "idle"];
@@ -151,8 +152,11 @@ internal sealed class NotifySupervisionEventMonitor
                 }
                 else
                 {
-                    RecordMonitorFailure(role, workspaceId, paneId,
-                        $"herdr agent wait returned unexpected status '{observed.AgentStatus ?? "<unknown>"}'.");
+                    // A successful return outside the expected direction is
+                    // a no-observation, not a failed wait. Keep re-arming so
+                    // the interval loop remains the independent safety floor.
+                    RecordMonitorNoObservation(role, workspaceId, paneId,
+                        $"herdr agent wait returned status '{observed.AgentStatus ?? "<unknown>"}' without a qualifying state transition while waiting for {(waitForSettled ? "a settled status" : "working")}.");
                     await Delay(RearmDelay, cancellationToken).ConfigureAwait(false);
                 }
             }
@@ -175,6 +179,18 @@ internal sealed class NotifySupervisionEventMonitor
             WorkspaceId = workspaceId,
             PaneId = paneId,
             Outcome = "wait-died-or-errored",
+            Detail = detail,
+            ObservedAt = (NotifyCommand.UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
+            RearmAttempted = true,
+        });
+
+    private void RecordMonitorNoObservation(string role, string workspaceId, string paneId, string detail) =>
+        waitEventObserved(new NotifySupervisionWaitEvent
+        {
+            Role = role,
+            WorkspaceId = workspaceId,
+            PaneId = paneId,
+            Outcome = NoObservationOutcome,
             Detail = detail,
             ObservedAt = (NotifyCommand.UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime(),
             RearmAttempted = true,

--- a/tests/IntentSystem.Cli.Tests/NotifyEventSupervisionG751Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyEventSupervisionG751Tests.cs
@@ -1,0 +1,376 @@
+using System.Diagnostics;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+using Xunit.Abstractions;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G751: a successful event-mode wait that returns without a qualifying
+/// observation is visible to the operator but is not a durable cycle. Genuine
+/// observations and the periodic interval safety floor remain durable.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifyEventSupervisionG751Tests : IDisposable
+{
+    private const string NoObservationOutcome = "wait-returned-without-observation";
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+    private readonly ITestOutputHelper output;
+    private readonly string root = Directory.CreateTempSubdirectory("notify-g751-").FullName;
+    private DateTimeOffset now = new(2026, 8, 29, 12, 0, 0, TimeSpan.Zero);
+
+    public NotifyEventSupervisionG751Tests(ITestOutputHelper output)
+    {
+        this.output = output;
+        NotifyCommand.UtcNowFactory = () => now;
+        NotifySupervisor.Delay = Thread.Sleep;
+        NotifySupervisionEventMonitor.Delay = Task.Delay;
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.UtcNowFactory = null;
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifyCommand.AgmsgScriptsDirectoryFactory = null;
+        NotifyCommand.HerdrExecutableFactory = null;
+        NotifyCommand.BashExecutableFactory = null;
+        NotifySupervisionEventMonitor.Delay = Task.Delay;
+        NotifySupervisor.Delay = Thread.Sleep;
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SuccessfulWaitWithoutObservationIsWarningOnlyAndKeepsIntervalFloor_G751()
+    {
+        var context = CreateContext();
+        RecordMode(context);
+        WriteTopology();
+        using var cancellation = new CancellationTokenSource();
+        var waitEvents = new List<NotifySupervisionWaitEvent>();
+        NotifySupervisionEventMonitor.Delay = (_, _) => Task.CompletedTask;
+        var runner = new EventRunner
+        {
+            AgentsJson = AgentsJson("idle", 7, now),
+        };
+        var monitor = new NotifySupervisionEventMonitor(
+            root,
+            Domain,
+            Team,
+            runner,
+            "fake-herdr",
+            _ => Task.CompletedTask,
+            waitEvent =>
+            {
+                waitEvents.Add(waitEvent);
+                cancellation.Cancel();
+            });
+
+        await monitor.RunAsync(cancellation.Token);
+
+        var noObservation = Assert.Single(waitEvents);
+        Assert.Equal(NoObservationOutcome, noObservation.Outcome);
+        Assert.True(noObservation.RearmAttempted);
+        Assert.Contains("without a qualifying state transition", noObservation.Detail, StringComparison.Ordinal);
+
+        var supervisor = CreateSupervisor(context, runner);
+        using var writer = new StringWriter();
+        supervisor.RecordWaitEvent(writer, noObservation);
+        var warning = writer.ToString();
+        Assert.Contains("event-wait-no-observation", warning, StringComparison.Ordinal);
+        Assert.Contains("no durable event-wait cycle was written", warning, StringComparison.Ordinal);
+        Assert.Contains("interval safety floor remains active", warning, StringComparison.Ordinal);
+        Assert.DoesNotContain("event-wait-rearmed", warning, StringComparison.Ordinal);
+
+        var cyclePath = NotifySupervisionStore.ResolveCyclePath(
+            context.ResolveSupervisionArtifactRootPath(), Domain, Team);
+        Assert.False(File.Exists(cyclePath));
+
+        var intervalPass = supervisor.RunOnce();
+        Assert.Equal(0, intervalPass.ExitCode);
+        var state = NotifySupervisionStore.Read(
+            context.ResolveSupervisionArtifactRootPath(), Domain, Team);
+        Assert.Contains(state.CycleHistory, cycle => cycle.Trigger == "interval");
+        Assert.DoesNotContain(state.CycleHistory, cycle => cycle.Trigger == "event-wait");
+    }
+
+    [Fact]
+    public async Task RepeatedInstantNoObservationReturnsStayObservableWithoutDurableRecords_G751()
+    {
+        var context = CreateContext();
+        WriteTopology();
+        using var cancellation = new CancellationTokenSource();
+        var waitEvents = new List<NotifySupervisionWaitEvent>();
+        NotifySupervisionEventMonitor.Delay = (_, _) => Task.CompletedTask;
+        var runner = new EventRunner
+        {
+            AgentsJson = AgentsJson("idle", 7, now),
+        };
+        var monitor = new NotifySupervisionEventMonitor(
+            root,
+            Domain,
+            Team,
+            runner,
+            "fake-herdr",
+            _ => Task.CompletedTask,
+            waitEvent =>
+            {
+                waitEvents.Add(waitEvent);
+                if (waitEvents.Count == 3)
+                {
+                    cancellation.Cancel();
+                }
+            });
+
+        await monitor.RunAsync(cancellation.Token);
+
+        Assert.Equal(3, waitEvents.Count);
+        Assert.All(waitEvents, waitEvent =>
+        {
+            Assert.Equal(NoObservationOutcome, waitEvent.Outcome);
+            Assert.True(waitEvent.RearmAttempted);
+        });
+
+        var supervisor = CreateSupervisor(context, runner);
+        using var writer = new StringWriter();
+        foreach (var waitEvent in waitEvents)
+        {
+            supervisor.RecordWaitEvent(writer, waitEvent);
+        }
+
+        var warning = writer.ToString();
+        Assert.Equal(3, warning.Split("event-wait-no-observation", StringSplitOptions.None).Length - 1);
+        Assert.DoesNotContain("event-wait-rearmed", warning, StringComparison.Ordinal);
+        Assert.False(File.Exists(NotifySupervisionStore.ResolveCyclePath(
+            context.ResolveSupervisionArtifactRootPath(), Domain, Team)));
+        output.WriteLine("G751 instant-return sample: returns=3, observable_warnings=3, durable_event_wait_cycles=0");
+    }
+
+    [Fact]
+    public void GenuineObservationAndIntervalSafetyFloorRemainDurable_G751()
+    {
+        var context = CreateContext();
+        RecordMode(context);
+        WriteTopology();
+        var runner = new EventRunner
+        {
+            AgentsJson = AgentsJson("working", 7, now),
+        };
+        var supervisor = CreateSupervisor(context, runner);
+
+        Assert.Equal(0, supervisor.RunOnce().ExitCode);
+        now = now.AddSeconds(2);
+        runner.AgentsJson = AgentsJson("done", 8, now.AddSeconds(-1));
+        var eventPass = supervisor.RunOnce("event");
+        Assert.Contains(eventPass.Findings, finding => finding.Kind == "seat-state-transition");
+
+        now = now.AddSeconds(1);
+        Assert.Equal(0, supervisor.RunOnce().ExitCode);
+
+        var state = NotifySupervisionStore.Read(
+            context.ResolveSupervisionArtifactRootPath(), Domain, Team);
+        Assert.Contains(state.CycleHistory, cycle => cycle.Trigger == "event");
+        Assert.Contains(state.CycleHistory, cycle => cycle.Trigger == "interval");
+        Assert.DoesNotContain(state.CycleHistory, cycle => cycle.Trigger == "event-wait");
+    }
+
+    [Fact]
+    public void RunningEventModeSampleReportsRawCadenceAtTheDeclaredFloor_G751()
+    {
+        var context = CreateContext();
+        RecordMode(context);
+        WriteTopology();
+        var runner = new EventRunner
+        {
+            AgentsJson = AgentsJson("idle", 7, now),
+        };
+        var supervisor = CreateSupervisor(context, runner);
+        using var cancellation = new CancellationTokenSource();
+        using var writer = new StringWriter();
+        var sampleDuration = TimeSpan.FromSeconds(2);
+        var intervalDelayCalls = 0;
+        NotifySupervisionEventMonitor.Delay = (_, _) => Task.Delay(TimeSpan.FromMilliseconds(25));
+        NotifySupervisor.Delay = _ =>
+        {
+            intervalDelayCalls++;
+            Thread.Sleep(sampleDuration);
+            cancellation.Cancel();
+        };
+
+        var started = Stopwatch.GetTimestamp();
+        var exitCode = supervisor.RunLoop(writer, cancellation.Token, once: false);
+        var elapsed = Stopwatch.GetElapsedTime(started);
+        var state = NotifySupervisionStore.Read(
+            context.ResolveSupervisionArtifactRootPath(), Domain, Team);
+        var triggerCounts = state.CycleHistory
+            .GroupBy(cycle => string.IsNullOrWhiteSpace(cycle.Trigger) ? "interval" : cycle.Trigger)
+            .ToDictionary(group => group.Key, group => group.Count(), StringComparer.Ordinal);
+        var eventWaitCount = triggerCounts.GetValueOrDefault("event-wait");
+        var intervalCount = triggerCounts.GetValueOrDefault("interval");
+        var totalRecords = state.CycleHistory.Count;
+        var recordsPerHour = totalRecords / elapsed.TotalHours;
+        var triggerMix = string.Join(",", triggerCounts.OrderBy(pair => pair.Key)
+            .Select(pair => $"{pair.Key}:{pair.Value}"));
+
+        output.WriteLine(
+            $"G751 running cadence sample: build=child-fixture interval_seconds=300 bound_seconds=900 "
+            + $"duration_seconds={elapsed.TotalSeconds:F3} sample_method=running-event-mode-supervisor "
+            + $"trigger_mix={triggerMix} raw_records={totalRecords} records_per_hour={recordsPerHour:F2} "
+            + $"interval_delay_calls={intervalDelayCalls}");
+
+        Assert.Equal(0, exitCode);
+        Assert.True(intervalCount >= 1);
+        Assert.Equal(0, eventWaitCount);
+    }
+
+    [Fact]
+    public void EnglishAndJapaneseOrchestrationDocsDescribeG751EventPersistenceContract_G751()
+    {
+        var repoRoot = RepoVersionPolicySource.RepoRoot();
+        var english = File.ReadAllText(Path.Combine(repoRoot, "docs", "en", "12-agent-message-orchestration.md"));
+        var japanese = File.ReadAllText(Path.Combine(repoRoot, "docs", "ja", "12-agent-message-orchestration.md"));
+
+        foreach (var document in new[] { english, japanese })
+        {
+            Assert.Contains("G751", document, StringComparison.Ordinal);
+            Assert.Contains("event-wait-no-observation", document, StringComparison.Ordinal);
+            Assert.Contains("300", document, StringComparison.Ordinal);
+            Assert.Contains("900", document, StringComparison.Ordinal);
+            Assert.Contains("records-per-hour", document, StringComparison.Ordinal);
+            Assert.Contains("interval", document, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private NotifyMeasuredSupervisor CreateSupervisor(CliContext context, EventRunner runner) => new(
+        context,
+        root,
+        Domain,
+        Team,
+        repo: null,
+        ownerRole: "orchestration",
+        intervalSeconds: 300,
+        declaredBoundSeconds: 900,
+        staleMinutes: 45,
+        claimedSilentMinutes: 720,
+        backlogIdleMinutes: 45,
+        repairSilentMinutes: 180,
+        autoRedispatch: false,
+        write: true,
+        format: "json",
+        runner,
+        herdrExecutable: "fake-herdr",
+        agmsgScriptsDirectory: "unused",
+        eventMode: true,
+        debounceConsecutiveObservations: 1);
+
+    private CliContext CreateContext() => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig { Domain = Domain, ArtifactRoot = ".intent-cli" },
+            Supervision = new SupervisionConfig { ArtifactRoot = ".intent-cli/supervision" },
+        },
+    };
+
+    private void RecordMode(CliContext context)
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, SessionLayerCommand.ExecuteSet(
+            context,
+            ["--domain", Domain, "--team", Team, "--mode", SessionLayerMode.HerdrOnly, "--write", "--format", "json"],
+            writer));
+    }
+
+    private void WriteTopology()
+    {
+        var path = NotifyRoleTopologyStore.ResolvePath(root, Domain, Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, JsonSerializer.Serialize(new
+        {
+            domain = Domain,
+            team = Team,
+            workspace_id = "wG751",
+            roles = new Dictionary<string, object>
+            {
+                ["orchestration"] = new { resident = "herdr", workspace_id = "wG751", pane_id = "wG751:p1" },
+                ["implementation"] = new { resident = "herdr", workspace_id = "wG751", pane_id = "wG751:p2" },
+            },
+        }));
+    }
+
+    private static string AgentsJson(string subjectStatus, long sequence, DateTimeOffset changedAt) =>
+        JsonSerializer.Serialize(new
+        {
+            result = new
+            {
+                agents = new object[]
+                {
+                    new { name = "orchestration", workspace_id = "wG751", pane_id = "wG751:p1", agent = "codex", agent_session = new { id = "owner" }, agent_status = "working", interactive_ready = true, state_change_seq = 2L, last_state_change_at = changedAt },
+                    new { name = "implementation", workspace_id = "wG751", pane_id = "wG751:p2", agent = "codex", agent_session = new { id = "subject" }, agent_status = subjectStatus, interactive_ready = true, state_change_seq = sequence, last_state_change_at = changedAt },
+                },
+            },
+        });
+
+    private sealed class EventRunner : INotifyProcessRunner
+    {
+        public string AgentsJson { get; set; } = "";
+        public List<(string FileName, IReadOnlyList<string> Arguments)> Calls { get; } = [];
+
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            Calls.Add((fileName, arguments.ToArray()));
+            if (arguments.SequenceEqual(["agent", "list"]))
+            {
+                return new NotifyProcessResult(0, AgentsJson, "");
+            }
+
+            if (arguments.Take(3).SequenceEqual(["pane", "process-info", "--pane"]))
+            {
+                return new NotifyProcessResult(0, "{\"result\":{\"process_info\":{\"foreground_processes\":[]}}}", "");
+            }
+
+            return new NotifyProcessResult(0, "", "");
+        }
+
+        public async Task<NotifyProcessResult> RunAsync(
+            string fileName,
+            IReadOnlyList<string> arguments,
+            CancellationToken cancellationToken)
+        {
+            if (arguments.SequenceEqual(["agent", "list"]))
+            {
+                return new NotifyProcessResult(0, AgentsJson, "");
+            }
+
+            if (arguments.Take(3).SequenceEqual(["agent", "wait", "wG751:p2"]))
+            {
+                return new NotifyProcessResult(0, WaitJson("idle", 7), "");
+            }
+
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new NotifyProcessResult(1, "", "cancelled");
+        }
+
+        private static string WaitJson(string status, long sequence) => JsonSerializer.Serialize(new
+        {
+            result = new
+            {
+                agent = new
+                {
+                    name = "implementation",
+                    workspace_id = "wG751",
+                    pane_id = "wG751:p2",
+                    agent_status = status,
+                    state_change_seq = sequence,
+                    last_state_change_at = "2026-08-29T12:00:01Z",
+                },
+            },
+        });
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/NotifyEventSupervisionG751Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyEventSupervisionG751Tests.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
@@ -180,7 +179,7 @@ public sealed class NotifyEventSupervisionG751Tests : IDisposable
     }
 
     [Fact]
-    public void RunningEventModeSampleReportsRawCadenceAtTheDeclaredFloor_G751()
+    public void RunningEventModeSampleSeparatesStartupFromWarmCadenceAtTheDeclaredFloor_G751()
     {
         var context = CreateContext();
         RecordMode(context);
@@ -192,19 +191,34 @@ public sealed class NotifyEventSupervisionG751Tests : IDisposable
         var supervisor = CreateSupervisor(context, runner);
         using var cancellation = new CancellationTokenSource();
         using var writer = new StringWriter();
-        var sampleDuration = TimeSpan.FromSeconds(2);
+        const int declaredIntervalSeconds = 300;
+        const int declaredBoundSeconds = 900;
+        const int warmIntervalPasses = 12;
+        const int preFixRawRecords = 73;
+        const int preFixEventWaitRecords = 72;
+        const int preFixStartupIntervalRecords = 1;
+        const double preFixWallSeconds = 2.065;
+        const double preFixRecordsPerHour = 127269.78;
         var intervalDelayCalls = 0;
-        NotifySupervisionEventMonitor.Delay = (_, _) => Task.Delay(TimeSpan.FromMilliseconds(25));
-        NotifySupervisor.Delay = _ =>
+        DateTimeOffset? warmWindowStart = null;
+        NotifySupervisionEventMonitor.Delay = (_, token) =>
+            Task.Delay(TimeSpan.FromMilliseconds(1), token);
+        NotifySupervisor.Delay = delay =>
         {
+            if (intervalDelayCalls == warmIntervalPasses)
+            {
+                cancellation.Cancel();
+                return;
+            }
+
+            Assert.Equal(TimeSpan.FromSeconds(declaredIntervalSeconds), delay);
+            warmWindowStart ??= now;
+            now = now.Add(delay);
             intervalDelayCalls++;
-            Thread.Sleep(sampleDuration);
-            cancellation.Cancel();
+            Thread.Yield();
         };
 
-        var started = Stopwatch.GetTimestamp();
         var exitCode = supervisor.RunLoop(writer, cancellation.Token, once: false);
-        var elapsed = Stopwatch.GetElapsedTime(started);
         var state = NotifySupervisionStore.Read(
             context.ResolveSupervisionArtifactRootPath(), Domain, Team);
         var triggerCounts = state.CycleHistory
@@ -213,19 +227,39 @@ public sealed class NotifyEventSupervisionG751Tests : IDisposable
         var eventWaitCount = triggerCounts.GetValueOrDefault("event-wait");
         var intervalCount = triggerCounts.GetValueOrDefault("interval");
         var totalRecords = state.CycleHistory.Count;
-        var recordsPerHour = totalRecords / elapsed.TotalHours;
+        Assert.NotNull(warmWindowStart);
+        var warmWindowSeconds = (now - warmWindowStart!.Value).TotalSeconds;
+        const int startupIntervalRecords = 1;
+        var warmIntervalRecords = intervalCount - startupIntervalRecords;
+        var recordsPerHour = warmIntervalRecords / (warmWindowSeconds / 3600d);
         var triggerMix = string.Join(",", triggerCounts.OrderBy(pair => pair.Key)
             .Select(pair => $"{pair.Key}:{pair.Value}"));
 
         output.WriteLine(
-            $"G751 running cadence sample: build=child-fixture interval_seconds=300 bound_seconds=900 "
-            + $"duration_seconds={elapsed.TotalSeconds:F3} sample_method=running-event-mode-supervisor "
-            + $"trigger_mix={triggerMix} raw_records={totalRecords} records_per_hour={recordsPerHour:F2} "
+            $"G751 before measurement: build=b525191a independent_review_measurement "
+            + $"interval_seconds={declaredIntervalSeconds} bound_seconds={declaredBoundSeconds} "
+            + $"sample_method=running-event-mode-supervisor window=startup-plus-two-second-wall-window "
+            + $"raw_records={preFixRawRecords} event-wait_records={preFixEventWaitRecords} "
+            + $"startup_interval_records={preFixStartupIntervalRecords} wall_window_seconds={preFixWallSeconds:F3} "
+            + $"records-per-hour={preFixRecordsPerHour:F2} steady_state=false");
+        output.WriteLine(
+            $"G751 after measurement: build=child-fixture interval_seconds={declaredIntervalSeconds} "
+            + $"bound_seconds={declaredBoundSeconds} "
+            + "sample_method=running-event-mode-supervisor-controlled-elapsed-time "
+            + $"startup_first_cycle_records={startupIntervalRecords} warm_window_seconds={warmWindowSeconds:F0} "
+            + $"warm_interval_records={warmIntervalRecords} event-wait_records={eventWaitCount} "
+            + $"trigger_mix={triggerMix} raw_records={totalRecords} records-per-hour={recordsPerHour:F2} "
             + $"interval_delay_calls={intervalDelayCalls}");
 
         Assert.Equal(0, exitCode);
-        Assert.True(intervalCount >= 1);
+        Assert.Equal(1, startupIntervalRecords);
+        Assert.Equal(warmIntervalPasses, intervalDelayCalls);
+        Assert.Equal(warmIntervalPasses + startupIntervalRecords, intervalCount);
+        Assert.Equal(warmIntervalPasses, warmIntervalRecords);
+        Assert.Equal(3600d, warmWindowSeconds, precision: 6);
+        Assert.Equal(warmIntervalPasses + startupIntervalRecords, totalRecords);
         Assert.Equal(0, eventWaitCount);
+        Assert.Equal(12d, recordsPerHour, precision: 6);
     }
 
     [Fact]
@@ -239,11 +273,22 @@ public sealed class NotifyEventSupervisionG751Tests : IDisposable
         {
             Assert.Contains("G751", document, StringComparison.Ordinal);
             Assert.Contains("event-wait-no-observation", document, StringComparison.Ordinal);
-            Assert.Contains("300", document, StringComparison.Ordinal);
-            Assert.Contains("900", document, StringComparison.Ordinal);
-            Assert.Contains("records-per-hour", document, StringComparison.Ordinal);
-            Assert.Contains("interval", document, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("b525191a", document, StringComparison.Ordinal);
+            Assert.Contains("interval_seconds=300", document, StringComparison.Ordinal);
+            Assert.Contains("bound_seconds=900", document, StringComparison.Ordinal);
+            Assert.Contains("event-wait:72", document, StringComparison.Ordinal);
+            Assert.Contains("interval:1", document, StringComparison.Ordinal);
+            Assert.Contains("wall_window_seconds=2.065", document, StringComparison.Ordinal);
+            Assert.Contains("records-per-hour=127269.78", document, StringComparison.Ordinal);
+            Assert.Contains("sample_method=running-event-mode-supervisor-controlled-elapsed-time", document, StringComparison.Ordinal);
+            Assert.Contains("startup_first_cycle_records=1", document, StringComparison.Ordinal);
+            Assert.Contains("warm_window_seconds=3600", document, StringComparison.Ordinal);
+            Assert.Contains("warm_interval_records=12", document, StringComparison.Ordinal);
+            Assert.Contains("event-wait_records=0", document, StringComparison.Ordinal);
+            Assert.Contains("raw_records=13", document, StringComparison.Ordinal);
+            Assert.Contains("records-per-hour=12.00", document, StringComparison.Ordinal);
         }
+
     }
 
     private NotifyMeasuredSupervisor CreateSupervisor(CliContext context, EventRunner runner) => new(


### PR DESCRIPTION
Closes #1633

G751 makes successful event-mode wait returns without a qualifying observation operator-visible through the forced event-wait-no-observation warning without appending a durable event-wait cycle. Genuine transitions, wait failures, and the interval safety-floor cycles remain unchanged.

Verification includes deterministic no-observation, repeated instant-return, genuine-observation, interval-floor, and running-cadence tests plus G613 and the full Release suite. No release-prep or execution-unit claim state was touched.