### PR TITLE
G752: roll post-release version to v0.26.1

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -3013,9 +3013,15 @@ The orchestration-seat preflight recorded `next-action=wait`,
 open `.git/FETCH_HEAD` (`Operation not permitted`). The fresh child selector
 reported local holder none/unheld; the supplied host claim is authoritative and
 this child did not create, modify, release, or verify an execution-unit claim.
-G725 evidence boundary: the design's pre-change host-root run at synced product
-checkout `bb9754859ac8055adbd504f294145b7494668c1a` returned zero findings while
-this version roll was absent. That silence is non-evidence, not a green check.
+G725 evidence boundary: the real host-root pre-roll run against synced target
+checkout `bb9754859ac8055adbd504f294145b7494668c1a` returned one actionable
+`version-roll-required` finding, expecting stableVersion `0.26.0` and nextVersion
+`0.26.1`. The PR-head child-clone run at `c73e12e6d08c6e7698f393c47c571f1320bedf90`
+returned zero `version-roll-required` findings only while reporting stale checkout
+versus origin/main `bb9754859ac8055adbd504f294145b7494668c1a` and missing queue
+state. That zero is non-evidence and does not prove the roll. A valid post-merge
+answer requires a synced host-main measurement. This child did not diagnose or
+fix G725.
 The published [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0) and its tag are authoritative shipped evidence.
 The v0.23.0 shipped artifacts are the GitHub Release, NuGet package, and self-contained binaries; its npm leg never reached the registry, so `0.23.0` must not be treated as available from npm.
 The tracked EN and JA `release-notes-v0.23.0.md` files now state this shipped-artifact status.

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2746,7 +2746,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0260)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0261)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2952,31 +2952,32 @@ rotated by this command; the result and `shrink-audit.jsonl` say so explicitly.
 out of scope. Use `--dry-run` to inspect the measured plan without writing the
 manifest, JSONL files, or audit.
 
-### Next release readiness (v0.26.0)
+### Next release readiness (v0.26.1)
 
-**PREPARED / NOT PUBLISHED.**
+**POST-RELEASE ROLL / PLACEHOLDER ONLY.**
 
-**v0.25.0 shipped evidence:** the shipped baseline is
-intent-cli 0.25.0-74a1c72-G741 from source revision
-74a1c722291a6a45a580221dcf8a9a8ad4e4d831. The tracked EN and JA
-release-notes-v0.25.0.md files remain unchanged by this preparation.
+**v0.26.0 shipped evidence:** the shipped baseline is
+intent-cli 0.26.0-93f07f8-G749 from source revision
+93f07f892f6514bc561493339b11e36de0e36555. The tracked EN and JA
+release-notes-v0.26.0.md files remain unchanged by this post-release roll.
 The prior v0.24.0 shipped-note files, release-notes-v0.24.0.md in both mirrors, remain historical evidence.
-The v0.25.0 GitHub Release and tag are authoritative shipped evidence.
+The v0.26.0 GitHub Release and tag are authoritative shipped evidence.
+The real-install identity is `intent-cli 0.26.0-93f07f8-G749`.
 The source-note inconsistency predates this roll; correcting it is out of scope and must be handled by a later explicitly scoped remediation.
 The comparison also used the installed 0.23.2 CLI; checkout_freshness/provenance is recorded with this preparation.
-The current policy is stableVersion 0.25.0 and nextVersion 0.26.0.
-Rolled policy: stableVersion → 0.25.0; nextVersion → 0.26.0.
-The next-line package identity is `JTechJapan.IntentSystem.Cli.0.26.0.nupkg`; this is a preparation value, not a publish action.
-The release-readiness gate remains separate from this prepare-only documentation update.
+The current policy is stableVersion 0.26.0 and nextVersion 0.26.1.
+Rolled policy: stableVersion → 0.26.0; nextVersion → 0.26.1 (placeholder only).
+The next-line package identity is `JTechJapan.IntentSystem.Cli.0.26.1.nupkg`; this is a placeholder value, not a publish action.
+The release-readiness gate remains separate from this post-release roll.
 
-This preparation sets `eng/version.json` to stableVersion `0.25.0` and
-nextVersion `0.26.0`. The former v0.25.1 DRAFT stubs were deleted; the active
-unpublished note is [release-notes-v0.26.0.md](release-notes-v0.26.0.md).
-The v0.26.0 line is prepare-only: no tag, GitHub Release, and no package is
-published; no post-release roll is performed here, and no real later release
-number is chosen.
+This post-release roll sets `eng/version.json` to stableVersion `0.26.0` and
+nextVersion `0.26.1`. The shipped v0.26.0 note files remain untouched; the
+current placeholder is [release-notes-v0.26.1.md](release-notes-v0.26.1.md).
+The v0.26.1 DRAFT stubs are replaceable planning scaffolds, not a changelog;
+release-prep will replace them after measuring and deciding the next real
+release number. No tag, GitHub Release, or package publish is performed here.
 
-The exact prepared head measured by this child is
+The v0.26.0 preparation measured the exact prepared head
 a49ad93c36bd93d1ccc9317622d36fa01ea346b8. Its own Release build reports
 intent-cli 0.25.1-a49ad93-G748; the installed baseline reports
 intent-cli 0.25.0-74a1c72-G741. Installed `notify supervise archive` rejects
@@ -2995,9 +2996,9 @@ post-v0.25.0 roll is classified in the release-note table and is not a release u
 G743 and G747 finish/repair the claim-transaction contract shipped in v0.25.0;
 G748 repairs the G741 detector that fired zero times across sixteen qualifying
 incidents. The five entries describe operator-observable outcomes in the active
-v0.26.0 notes.
+shipped v0.26.0 notes.
 
-Release-prep verification exact counts are recorded in the active note:
+The v0.26.0 release-prep verification exact counts are recorded in its note:
 Targeted release-prep docs/version guards: 40 passed, 0 failed, 0 skipped (40 total).
 Dedicated G613 JA terminology guard: 6 passed, 0 failed, 0 skipped (6 total).
 Adjacent release/readiness suite: 59 passed, 0 failed, 0 skipped (59 total).
@@ -3006,7 +3007,15 @@ This child consumed the supplied host claim because the
 child issue-preflight was canonical-unavailable only from sandbox denial while
 refreshing `.git/FETCH_HEAD`; it did not create, modify, or release a child
 execution-unit claim and did not enter the host repository.
-The host-only claim boundary is `release-prep:<owner/repo>:0.26.0`; this child does not inspect host state.
+The host-only claim boundary is `release-prep:<owner/repo>:0.26.1`; this child does not inspect host state.
+The orchestration-seat preflight recorded `next-action=wait`,
+`classification=claim-unavailable`, and `actionable=false` because it could not
+open `.git/FETCH_HEAD` (`Operation not permitted`). The fresh child selector
+reported local holder none/unheld; the supplied host claim is authoritative and
+this child did not create, modify, release, or verify an execution-unit claim.
+G725 evidence boundary: the design's pre-change host-root run at synced product
+checkout `bb9754859ac8055adbd504f294145b7494668c1a` returned zero findings while
+this version roll was absent. That silence is non-evidence, not a green check.
 The published [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0) and its tag are authoritative shipped evidence.
 The v0.23.0 shipped artifacts are the GitHub Release, NuGet package, and self-contained binaries; its npm leg never reached the registry, so `0.23.0` must not be treated as available from npm.
 The tracked EN and JA `release-notes-v0.23.0.md` files now state this shipped-artifact status.

--- a/docs/en/release-notes-v0.26.1.md
+++ b/docs/en/release-notes-v0.26.1.md
@@ -1,0 +1,10 @@
+# Release Notes — intent-cli v0.26.1
+
+> **⚠️ DRAFT / UNRELEASED.** This replaceable planning scaffold is not a changelog.
+> The release-prep packet will replace this placeholder after measuring and
+> deciding the next real release number. This file must not be treated as a
+> changelog.
+
+This placeholder intentionally contains no release entries. No GitHub Release
+exists for this placeholder yet. The matching install query is
+`JTechJapan.IntentSystem.Cli --version 0.26.1`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2993,31 +2993,32 @@ result は literal bytes の削減、追加した reference bytes、record の n
 `shrink-audit.jsonl` に明記します。`.intent-cli/runs/*.provider.jsonl` は別の provider-run state なので
 scope 外です。`--dry-run` なら manifest、JSONL、audit を書き込まずに測定済み plan だけを確認できます。
 
-### 次リリース準備(v0.26.0)
+### 次リリース準備(v0.26.1)
 
-**PREPARED / NOT PUBLISHED.**
+**POST-RELEASE ROLL / PLACEHOLDER ONLY。**
 
-**v0.25.0 shipped evidence:** shipped baseline は
-intent-cli 0.25.0-74a1c72-G741、source revision は
-74a1c722291a6a45a580221dcf8a9a8ad4e4d831 です。tracked な EN/JA
-release-notes-v0.25.0.md はこの preparation で変更していません。
+**v0.26.0 shipped evidence:** shipped baseline は
+intent-cli 0.26.0-93f07f8-G749、source revision は
+93f07f892f6514bc561493339b11e36de0e36555 です。tracked な EN/JA
+release-notes-v0.26.0.md はこの post-release roll で変更していません。
 前の v0.24.0 shipped-note file、release-notes-v0.24.0.md は両方の mirror にある historical evidence として残ります。
-v0.25.0 GitHub Release と tag は shipped evidence の authoritative source です。
+v0.26.0 GitHub Release と tag は shipped evidence の正式な根拠です。
+real-install identity は `intent-cli 0.26.0-93f07f8-G749` です。
 source-note inconsistency はこの roll より前から存在し、修正は scope 外であり、後続の explicitly scoped remediation で扱います。
 比較対象には installed 0.23.2 CLI を使い、checkout_freshness/provenance をこの preparation とともに記録します。
-現在の policy は stableVersion 0.25.0 と nextVersion 0.26.0 です。
-Rolled policy: stableVersion → 0.25.0; nextVersion → 0.26.0。
-次の line の package identity は `JTechJapan.IntentSystem.Cli.0.26.0.nupkg` です。これは preparation の値であり、publish action ではありません。
-release-readiness gate はこの prepare-only documentation update とは別です。
+現在の policy は stableVersion 0.26.0 と nextVersion 0.26.1 です。
+Rolled policy: stableVersion → 0.26.0; nextVersion → 0.26.1 (placeholder only)。
+次の line の package identity は `JTechJapan.IntentSystem.Cli.0.26.1.nupkg` です。これは placeholder の値であり、publish action ではありません。
+release-readiness gate はこの post-release roll とは別です。
 
-この preparation は `eng/version.json` を stableVersion `0.25.0`、
-nextVersion `0.26.0` にします。以前の v0.25.1 DRAFT stub は削除し、
-active な unpublished note は
-[release-notes-v0.26.0.md](release-notes-v0.26.0.md) です。v0.26.0 line は
-prepare-only で、ここでは tag または Release を作成せず、package を publish せず、
-post-release roll も実行せず、後続の real release number も決めません。
+この post-release roll は `eng/version.json` を stableVersion `0.26.0`、
+nextVersion `0.26.1` にします。shipped v0.26.0 note file は変更せず、
+current placeholder は [release-notes-v0.26.1.md](release-notes-v0.26.1.md) です。
+v0.26.1 DRAFT stub は replaceable planning scaffold で changelog ではありません。
+release-prep は測定して次の real release number を決めた後、この stub を replace します。
+この roll では tag、GitHub Release、package publish、unreleased content の追加を行いません。
 
-この child が正確な prepared head
+v0.26.0 preparation でこの child が正確な prepared head
 `a49ad93c36bd93d1ccc9317622d36fa01ea346b8` を Release build して測定した
 identity は `intent-cli 0.25.1-a49ad93-G748`、installed baseline は
 `intent-cli 0.25.0-74a1c72-G741` でした。installed の
@@ -3036,10 +3037,10 @@ build した usage は
 post-v0.25.0 roll は release-note table で分類し、release unit には数えません。
 G743 と G747 は v0.25.0 で shipped した claim-transaction contract を
 finish/repair し、G748 は sixteen 件の qualifying incident で zero 回だった
-G741 detector を repair しました。五つの outcome は active な v0.26.0 note に
+G741 detector を repair しました。五つの outcome は shipped v0.26.0 note に
 operator-observable として記録しています。
 
-Release-prep verification の正確な count は active note に記録しています:
+v0.26.0 release-prep verification の正確な count はその note に記録しています:
 Targeted release-prep docs/version guard: 40 passed, 0 failed, 0 skipped (40 total)。
 Dedicated G613 JA terminology guard: 6 passed, 0 failed, 0 skipped (6 total)。
 Adjacent release/readiness suite: 59 passed, 0 failed, 0 skipped (59 total)。
@@ -3047,8 +3048,10 @@ Full Release suite: 5305 passed, 0 failed, 1 skipped (5306 total)。git diff --c
 child issue-preflight が canonical-unavailable になったのは sandbox による
 `.git/FETCH_HEAD` refresh 拒否だけなので、supplied host claim を使用しました。
 child execution-unit claim は作成・変更・release せず、host repository に入りませんでした。
-host-only claim boundary は `release-prep:<owner/repo>:0.26.0` で、この child は host state を inspect しません。
-公開済みの [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0) とその tag は authoritative shipped evidence です。
+host-only claim boundary は `release-prep:<owner/repo>:0.26.1` で、この child は host state を inspect しません。
+orchestration seat の preflight は `next-action=wait`、`classification=claim-unavailable`、`actionable=false` を記録しました。`.git/FETCH_HEAD` (`Operation not permitted`) を open できなかったためです。fresh child selector は local holder none/unheld と報告しました。supplied host claim が正式な根拠であり、この child は execution-unit claim を create、modify、release、verify していません。
+G725 evidence boundary: design の pre-change host-root run は synced product checkout `bb9754859ac8055adbd504f294145b7494668c1a` で zero findings でしたが、version roll は欠けていました。この silence は non-evidence であり green check ではありません。この child は G725 を diagnose/fix せず、post-merge host-root synced-main measurement は host duty です。
+公開済みの [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0) とその tag は shipped evidence の正式な根拠です。
 v0.23.0 の shipped artifact は GitHub Release、NuGet package、自己完結型バイナリです。ただし npm leg は registry に到達しなかったため、`0.23.0` は npm で利用できると扱ってはいけません。
 tracked な EN/JA の `release-notes-v0.23.0.md` files はこの shipped-artifact status を記録します。
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -3050,7 +3050,14 @@ child issue-preflight が canonical-unavailable になったのは sandbox に�
 child execution-unit claim は作成・変更・release せず、host repository に入りませんでした。
 host-only claim boundary は `release-prep:<owner/repo>:0.26.1` で、この child は host state を inspect しません。
 orchestration seat の preflight は `next-action=wait`、`classification=claim-unavailable`、`actionable=false` を記録しました。`.git/FETCH_HEAD` (`Operation not permitted`) を open できなかったためです。fresh child selector は local holder none/unheld と報告しました。supplied host claim が正式な根拠であり、この child は execution-unit claim を create、modify、release、verify していません。
-G725 evidence boundary: design の pre-change host-root run は synced product checkout `bb9754859ac8055adbd504f294145b7494668c1a` で zero findings でしたが、version roll は欠けていました。この silence は non-evidence であり green check ではありません。この child は G725 を diagnose/fix せず、post-merge host-root synced-main measurement は host duty です。
+G725 evidence boundary: real host-root の pre-roll run は synced target checkout
+`bb9754859ac8055adbd504f294145b7494668c1a` で actionable な
+`version-roll-required` finding を 1 件返し、stableVersion `0.26.0` と
+nextVersion `0.26.1` を期待していました。PR-head child-clone run が
+`c73e12e6d08c6e7698f393c47c571f1320bedf90` で `version-roll-required` finding を
+0 件返したのは、origin/main `bb9754859ac8055adbd504f294145b7494668c1a` に対して
+checkout が stale で、queue state も missing と報告した状態だけです。この 0 件は
+non-evidence であり roll の証明ではありません。valid な post-merge answer には synced host-main measurement が必要です。この child は G725 を diagnose/fix していません。
 公開済みの [v0.23.0 GitHub Release](https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0) とその tag は shipped evidence の正式な根拠です。
 v0.23.0 の shipped artifact は GitHub Release、NuGet package、自己完結型バイナリです。ただし npm leg は registry に到達しなかったため、`0.23.0` は npm で利用できると扱ってはいけません。
 tracked な EN/JA の `release-notes-v0.23.0.md` files はこの shipped-artifact status を記録します。

--- a/docs/ja/release-notes-v0.26.1.md
+++ b/docs/ja/release-notes-v0.26.1.md
@@ -1,0 +1,10 @@
+# リリースノート — intent-cli v0.26.1
+
+> **⚠️ DRAFT / 未リリース。** これは replaceable planning scaffold であり、
+> changelog ではありません。release-prep パケットが、次の real release number を
+> 測定して決めた後、この placeholder を replace します。この file は changelog
+> として扱ってはいけません。
+
+この placeholder には release entry を記録しません。v0.26.1 の GitHub
+Release はまだ存在しません (no GitHub Release)。matching install query は
+`JTechJapan.IntentSystem.Cli --version 0.26.1` です。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.25.0",
-  "nextVersion": "0.26.0"
+  "stableVersion": "0.26.0",
+  "nextVersion": "0.26.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0210DocsTests.cs
@@ -169,8 +169,8 @@ public sealed class ReleaseNotesV0210DocsTests
             Assert.Contains(language == "en" ? "UNRELEASED" : "未リリース", currentNotesCompact, StringComparison.OrdinalIgnoreCase);
             Assert.Contains(
                 language == "en"
-                    ? "release-prep packet authors the real content"
-                    : "release-prep パケットが author します",
+                    ? "release-prep packet will replace this placeholder"
+                    : "release-prep パケットが",
                 currentNotesCompact,
                 StringComparison.OrdinalIgnoreCase);
             Assert.Contains(

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0220DocsTests.cs
@@ -292,11 +292,11 @@ public sealed class ReleaseNotesV0220DocsTests
             compact,
             StringComparison.OrdinalIgnoreCase);
         Assert.Contains(
-            "PREPARED / NOT PUBLISHED",
+            "POST-RELEASE ROLL / PLACEHOLDER ONLY",
             compact,
             StringComparison.OrdinalIgnoreCase);
         Assert.Contains(
-            language == "en" ? "authoritative shipped evidence" : "shipped evidence の authoritative source",
+            language == "en" ? "authoritative shipped evidence" : "shipped evidence の正式な根拠",
             compact,
             StringComparison.OrdinalIgnoreCase);
         if (language == "en")
@@ -314,11 +314,11 @@ public sealed class ReleaseNotesV0220DocsTests
         Assert.Contains("installed 0.23.2 CLI", section, StringComparison.Ordinal);
         Assert.Contains("checkout_freshness/provenance", section, StringComparison.Ordinal);
         Assert.Contains(
-            language == "en" ? "no tag" : "tag または Release を作成せず",
+            language == "en" ? "no tag" : "tag、GitHub Release",
             compact,
             StringComparison.OrdinalIgnoreCase);
         Assert.Contains(
-            language == "en" ? "no package" : "package を publish せず",
+            language == "en" ? "package publish" : "package publish",
             compact,
             StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
@@ -165,12 +165,12 @@ public sealed class ReleaseNotesV0240DocsTests
     }
 
     [Fact]
-    public void ShippedV0240NotesAndReadinessPointAtTheCurrentV0250Line()
+    public void ShippedV0240NotesAndReadinessPointAtTheCurrentV0261Line()
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.25.0", policy.StableVersion);
-        Assert.Equal("0.26.0", policy.NextVersion);
+        Assert.Equal("0.26.0", policy.StableVersion);
+        Assert.Equal("0.26.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -179,18 +179,19 @@ public sealed class ReleaseNotesV0240DocsTests
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.25.0.md")));
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.25.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.1.md")));
 
             var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
             Assert.Contains("0.24.0", reference, StringComparison.Ordinal);
             Assert.Contains("release-notes-v0.24.0.md", reference, StringComparison.Ordinal);
             Assert.Contains("0.25.0", reference, StringComparison.Ordinal);
-            Assert.Contains("release-notes-v0.25.0.md", reference, StringComparison.Ordinal);
+            Assert.Contains("release-notes-v0.26.1.md", reference, StringComparison.Ordinal);
             Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
             Assert.Contains(
-                language == "en" ? "Next release readiness (v0.26.0)" : "次リリース準備(v0.26.0)",
+                language == "en" ? "Next release readiness (v0.26.1)" : "次リリース準備(v0.26.1)",
                 reference,
                 StringComparison.Ordinal);
-            Assert.Contains("intent-cli 0.25.0-74a1c72-G741", reference, StringComparison.Ordinal);
+            Assert.Contains("intent-cli 0.26.0-93f07f8-G749", reference, StringComparison.Ordinal);
             Assert.Contains("ReleasePackageMetadataTests", reference, StringComparison.Ordinal);
             Assert.Contains("VersionSourcePolicyGuardTests", reference, StringComparison.Ordinal);
         }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
@@ -14,7 +14,7 @@ public sealed class ReleaseNotesV0250DocsTests
         "5c4af5d88ddcfa47335bad4df56ad3e40dae9140";
     private const string BuiltDisplayIdentity = "intent-cli 0.24.1-5c4af5d-G741";
     private const string InstalledDisplayIdentity = "intent-cli 0.24.0-df472fe-G737";
-    private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.25.0-74a1c72-G741";
+    private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.26.0-93f07f8-G749";
 
     private static readonly (string Unit, string Pr, string Merge)[] Units =
     [
@@ -165,8 +165,8 @@ public sealed class ReleaseNotesV0250DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
 
-        Assert.Equal("0.25.0", policy.StableVersion);
-        Assert.Equal("0.26.0", policy.NextVersion);
+        Assert.Equal("0.26.0", policy.StableVersion);
+        Assert.Equal("0.26.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -174,6 +174,7 @@ public sealed class ReleaseNotesV0250DocsTests
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.24.1.md")));
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.25.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.1.md")));
         }
     }
 
@@ -186,13 +187,12 @@ public sealed class ReleaseNotesV0250DocsTests
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.26.0)" : "次リリース準備(v0.26.0)",
+            language == "en" ? "Next release readiness (v0.26.1)" : "次リリース準備(v0.26.1)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains(CurrentStableInstallDisplayIdentity, reference, StringComparison.Ordinal);
-        Assert.Contains("intent-cli 0.25.1-a49ad93-G748", reference, StringComparison.Ordinal);
-        Assert.Contains("release-notes-v0.25.0.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.26.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.26.1.md", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0250DocsTests", reference, StringComparison.Ordinal);
         Assert.Contains("JapaneseTerminologyGuardG613Tests", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
@@ -17,6 +17,8 @@ public sealed class ReleaseNotesV0260DocsTests
     private const string FinalBuiltDisplayIdentity = "intent-cli 0.26.0-a49ad93-G748";
     private const string InstalledDisplayIdentity = "intent-cli 0.25.0-74a1c72-G741";
     private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.26.0-93f07f8-G749";
+    private const string PreRollTargetCheckout = "bb9754859ac8055adbd504f294145b7494668c1a";
+    private const string PrHead = "c73e12e6d08c6e7698f393c47c571f1320bedf90";
     private const string ArchiveUsage =
         "notify supervise archive --domain <d> --team <t> [--live-window-days <days>] [--dry-run|--write] [--format markdown|json]";
 
@@ -262,11 +264,43 @@ public sealed class ReleaseNotesV0260DocsTests
             language == "en" ? "not a changelog" : "changelog ではありません",
             readiness,
             StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("bb9754859ac8055adbd504f294145b7494668c1a", readiness, StringComparison.Ordinal);
         Assert.Contains(
-            language == "en" ? "silence is non-evidence" : "silence は non-evidence",
+            language == "en" ? "returned one actionable" : "actionable な",
+            readiness,
+            StringComparison.Ordinal);
+        Assert.Contains("`version-roll-required` finding", readiness, StringComparison.Ordinal);
+        Assert.Contains(language == "en" ? "finding, expecting" : "1 件返し、stableVersion", readiness, StringComparison.Ordinal);
+        Assert.Contains("stableVersion `0.26.0`", readiness, StringComparison.Ordinal);
+        Assert.Contains("nextVersion `0.26.1`", readiness, StringComparison.Ordinal);
+        Assert.Contains(PreRollTargetCheckout, readiness, StringComparison.Ordinal);
+        Assert.Contains(PrHead, readiness, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en"
+                ? "returned zero `version-roll-required` findings only"
+                : "0 件返したのは",
+            readiness,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en"
+                ? "origin/main `bb9754859ac8055adbd504f294145b7494668c1a`"
+                : "origin/main `bb9754859ac8055adbd504f294145b7494668c1a` に対して",
+            readiness,
+            StringComparison.Ordinal);
+        var normalizedEvidence = Regex.Replace(readiness, @"\s+", " ");
+        Assert.Contains(
+            language == "en" ? "missing queue state" : "queue state も missing",
+            normalizedEvidence,
+            StringComparison.Ordinal);
+        Assert.Contains("non-evidence", readiness, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "does not prove the roll" : "roll の証明ではありません",
             readiness,
             StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "A valid post-merge" : "valid な post-merge answer",
+            readiness,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("synced host-main measurement", readiness, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(PreparedHead, readiness, StringComparison.Ordinal);
         Assert.Contains(BuiltDisplayIdentity, readiness, StringComparison.Ordinal);
         Assert.Contains(FinalBuiltDisplayIdentity, readiness, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
@@ -5,9 +5,9 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G749: the v0.26.0 release-prep notes pin the measured own-build identity,
-/// the one new archive command surface, the six-commit accounting, and the
-/// exact five-unit operator-observable inventory in both language mirrors.
+/// G749/G752: the frozen v0.26.0 release-prep notes retain their measured
+/// evidence while the post-release roll pins the current v0.26.1 placeholder
+/// and readiness mirrors in both languages.
 /// </summary>
 public sealed class ReleaseNotesV0260DocsTests
 {
@@ -16,6 +16,7 @@ public sealed class ReleaseNotesV0260DocsTests
     private const string BuiltDisplayIdentity = "intent-cli 0.25.1-a49ad93-G748";
     private const string FinalBuiltDisplayIdentity = "intent-cli 0.26.0-a49ad93-G748";
     private const string InstalledDisplayIdentity = "intent-cli 0.25.0-74a1c72-G741";
+    private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.26.0-93f07f8-G749";
     private const string ArchiveUsage =
         "notify supervise archive --domain <d> --team <t> [--live-window-days <days>] [--dry-run|--write] [--format markdown|json]";
 
@@ -206,23 +207,24 @@ public sealed class ReleaseNotesV0260DocsTests
     }
 
     [Fact]
-    public void VersionPolicyIsExactAndFormerPlaceholderFilesAreDeleted()
+    public void VersionPolicyIsExactAndCurrentPlaceholderFilesArePresent()
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policyPath = Path.Combine(root, "eng", "version.json");
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.25.0\",\n  \"nextVersion\": \"0.26.0\"\n}\n",
+            "{\n  \"stableVersion\": \"0.26.0\",\n  \"nextVersion\": \"0.26.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.25.0", policy.StableVersion);
-        Assert.Equal("0.26.0", policy.NextVersion);
+        Assert.Equal("0.26.0", policy.StableVersion);
+        Assert.Equal("0.26.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.25.0.md")));
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.25.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.1.md")));
         }
     }
 
@@ -242,21 +244,35 @@ public sealed class ReleaseNotesV0260DocsTests
     [Theory]
     [InlineData("en")]
     [InlineData("ja")]
-    public void ReadinessMirrorsCurrentMeasuredPreparation(string language)
+    public void ReadinessMirrorsCurrentPostReleasePlaceholder(string language)
     {
         var readiness = ReadCurrentReadiness(language);
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.26.0)" : "次リリース準備(v0.26.0)",
+            language == "en" ? "Next release readiness (v0.26.1)" : "次リリース準備(v0.26.1)",
             readiness,
             StringComparison.Ordinal);
         Assert.Contains("0.25.0", readiness, StringComparison.Ordinal);
         Assert.Contains("0.26.0", readiness, StringComparison.Ordinal);
+        Assert.Contains("0.26.1", readiness, StringComparison.Ordinal);
+        Assert.Contains(CurrentStableInstallDisplayIdentity, readiness, StringComparison.Ordinal);
+        Assert.Contains("placeholder", readiness, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("replaceable", readiness, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "not a changelog" : "changelog ではありません",
+            readiness,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("bb9754859ac8055adbd504f294145b7494668c1a", readiness, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "silence is non-evidence" : "silence は non-evidence",
+            readiness,
+            StringComparison.OrdinalIgnoreCase);
         Assert.Contains(PreparedHead, readiness, StringComparison.Ordinal);
         Assert.Contains(BuiltDisplayIdentity, readiness, StringComparison.Ordinal);
         Assert.Contains(FinalBuiltDisplayIdentity, readiness, StringComparison.Ordinal);
         Assert.Contains(InstalledDisplayIdentity, readiness, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.26.0.md", readiness, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.26.1.md", readiness, StringComparison.Ordinal);
         Assert.DoesNotContain("release-notes-v0.25.1.md", readiness, StringComparison.Ordinal);
         Assert.Contains("byte-identical", readiness, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("G743", readiness, StringComparison.Ordinal);
@@ -264,6 +280,38 @@ public sealed class ReleaseNotesV0260DocsTests
         Assert.Contains("G746", readiness, StringComparison.Ordinal);
         Assert.Contains("G747", readiness, StringComparison.Ordinal);
         Assert.Contains("G748", readiness, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void CurrentPlaceholderStubsDescribeTheirOwnReplaceableRole(string language)
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var stub = File.ReadAllText(Path.Combine(
+            root, "docs", language, "release-notes-v0.26.1.md"));
+
+        Assert.Contains("0.26.1", stub, StringComparison.Ordinal);
+        Assert.Contains("DRAFT", stub, StringComparison.Ordinal);
+        Assert.Contains("replaceable", stub, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "not a changelog" : "changelog ではありません",
+            stub,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("G743", stub, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ShippedV0260NoteBytesRemainPinned()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+
+        Assert.Equal(
+            "b385042d2276067120d1e9412b3a65cbf0d725cee63a93940736ea11472f4cbe",
+            Sha256(Path.Combine(root, "docs", "en", "release-notes-v0.26.0.md")));
+        Assert.Equal(
+            "11a859a307bf2d07c239e7c30f7db95ee78b57f72a3415fe0d047f8ce68e9f9f",
+            Sha256(Path.Combine(root, "docs", "ja", "release-notes-v0.26.0.md")));
     }
 
     private static string FindEntry(string notes, string unit)
@@ -281,7 +329,7 @@ public sealed class ReleaseNotesV0260DocsTests
     {
         var content = File.ReadAllText(Path.Combine(
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
-        var heading = language == "en" ? "### Next release readiness (v0.26.0)" : "### 次リリース準備(v0.26.0)";
+        var heading = language == "en" ? "### Next release readiness (v0.26.1)" : "### 次リリース準備(v0.26.1)";
         var start = content.IndexOf(heading, StringComparison.Ordinal);
         Assert.True(start >= 0, $"Missing current readiness heading in {language}.");
         var end = content.IndexOf("**Previous v0.25.0 preparation evidence", start, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV061DocsTests.cs
@@ -540,7 +540,7 @@ public sealed class ReleaseNotesV061DocsTests
         {
             // Stub state: it must refuse to be mistaken for a changelog.
             Assert.Contains(
-                language == "en" ? "release-prep packet authors the real content" : "release-prep パケットが author します",
+                language == "en" ? "release-prep packet will replace this placeholder" : "release-prep パケットが",
                 notes,
                 StringComparison.Ordinal);
             Assert.Contains(


### PR DESCRIPTION
Closes #1636

Post-release roll only: eng/version.json remains stableVersion 0.26.0 and nextVersion 0.26.1 as a placeholder. The EN/JA 0.26.1 DRAFT stubs and readiness mirrors remain replaceable non-changelog scaffolds. Shipped v0.26.0 notes, product code, G725 behavior, tags, Releases, publishing, and next-real-version choice are out of scope.

G725 evidence boundary:
- The real host-root pre-roll run against synced target checkout bb9754859ac8055adbd504f294145b7494668c1a returned one actionable version-roll-required finding, expecting stableVersion 0.26.0 and nextVersion 0.26.1.
- The PR-head child-clone run at c73e12e6d08c6e7698f393c47c571f1320bedf90 returned zero version-roll-required findings only while reporting stale checkout versus origin/main bb9754859ac8055adbd504f294145b7494668c1a and missing queue state.
- That zero is non-evidence and does not prove the roll. A valid post-merge answer requires a synced host-main measurement.