### PR TITLE
G754: roll post-release version to v0.27.1

### DIFF
--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -3029,6 +3029,14 @@ from a synced host-main target checkout and return the relevant before/after
 `items` entries, checkout commit, and freshness/provenance; do not treat this
 child-side silence as proof.
 
+The final post-change child run at committed checkout
+`a21c1f2334d0a81412fa1f9b49e0b8320e39de91` returned the same non-actionable
+result: `stalled=true` only for informational G717, G719, and G725
+`claim-stale` items, with no `version-roll-required` item. Its freshness
+warning reported local HEAD `a21c1f2` stale versus `origin/main`
+`f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330`, and its child queue-state warning
+remained. This is child evidence, not a synced host-root proof.
+
 The host worker selected #1640 while issue-preflight reported
 `canonical-unavailable` because `.git/FETCH_HEAD` was unreadable. The fresh
 child selector separately returned `next-action=wait` because local

--- a/docs/en/09-developer-reference.md
+++ b/docs/en/09-developer-reference.md
@@ -2746,7 +2746,7 @@ literal:
 ```
 
 The shape is written with placeholders on purpose: **read the actual values from
-`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0270)
+`eng/version.json`**, and see [Next release readiness](#next-release-readiness-v0271)
 for the line currently being cut. A worked example here would be a second copy
 of the version pair that goes stale on the next roll — the defect G557/G560
 exist to remove.
@@ -2952,7 +2952,99 @@ rotated by this command; the result and `shrink-audit.jsonl` say so explicitly.
 out of scope. Use `--dry-run` to inspect the measured plan without writing the
 manifest, JSONL files, or audit.
 
-### Next release readiness (v0.27.0)
+### Next release readiness (v0.27.1)
+
+**POST-RELEASE ROLL / PLACEHOLDER ONLY.**
+
+The shipped stable line is `intent-cli 0.27.0-f43fbd1-G753`, from source
+revision `f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330`. The tracked EN and JA
+`release-notes-v0.27.0.md` files are shipped evidence and remain byte-identical
+in this roll. The current policy after this roll is:
+
+```json
+{
+  "stableVersion": "0.27.0",
+  "nextVersion": "0.27.1"
+}
+```
+
+The `0.27.1` value is a replaceable placeholder only; it is not a decision
+about the next real release number. This roll adds the EN and JA
+`release-notes-v0.27.1.md` DRAFT stubs. Each stub is explicitly a replaceable
+planning scaffold and not a changelog. No tag, GitHub Release, package publish,
+post-release roll, or G725 detector change is part of this work.
+
+The version-flow pair is `stableVersion → 0.27.0` and
+`nextVersion → 0.27.1`; the corresponding package artifact name is
+`JTechJapan.IntentSystem.Cli.0.27.1.nupkg`, a placeholder name only. The
+canonical release-prep coordination scope is
+`release-prep:<owner/repo>:0.27.1`. In plain policy terms, stableVersion
+0.27.0 and nextVersion 0.27.1 are the current values. The v0.27.0 GitHub Release
+is authoritative shipped evidence:
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.27.0. This roll
+does not tag, publish, or create a GitHub Release.
+
+For continuity with the historical readiness audit, the v0.23.0 GitHub Release
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0 and
+`release-notes-v0.23.0.md` record self-contained binaries; the npm leg never
+reached the registry and must not be treated as available from npm. The
+installed 0.23.2 CLI and `checkout_freshness/provenance` remain historical
+evidence. The v0.27.0 release-note files are still the shipped-note evidence;
+their prepare-only wording is a source-note inconsistency with the authoritative
+GitHub Release; that source-note inconsistency predates this roll. It is out of
+scope and must be handled by a later explicitly scoped remediation.
+
+### G725 evidence boundary for this roll
+
+The supplied pre-roll host-root observation ran against target checkout
+`f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330` and returned `stalled=true` with one
+actionable item:
+
+```text
+kind=version-roll-required
+is_informational=false
+released_version=0.27.0
+expected_stable_version=0.27.0
+expected_next_version=0.27.1
+```
+
+The host metadata checkout used for that observation warned that its local
+revision `35c6d96a` was stale versus `origin/main` `209b1369`; that provenance
+is retained and is not presented as a fresh synced-main measurement. The
+available child run before this edit, from the same target checkout, also
+returned the actionable `version-roll-required` item above; it additionally
+reported informational stale-claim items and a missing child queue-state file.
+
+After this child roll, the observed child run from checkout
+`f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330` returned `stalled=true`, with only
+informational `claim-stale` items for G717, G719, and G725, no
+`version-roll-required` item, and a warning that child queue state was not
+found. The policy pair is now correct, but that silence is non-evidence by
+itself and does not prove the roll: a valid answer
+requires the same command from a synced host-main checkout after this PR
+merges, with the checkout commit and provenance recorded. The implementation
+seat cannot enter the host repository. **HOST DUTY REQUEST:** after merge, run
+`intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json`
+from a synced host-main target checkout and return the relevant before/after
+`items` entries, checkout commit, and freshness/provenance; do not treat this
+child-side silence as proof.
+
+The host worker selected #1640 while issue-preflight reported
+`canonical-unavailable` because `.git/FETCH_HEAD` was unreadable. The fresh
+child selector separately returned `next-action=wait` because local
+`execution-unit:G754` was unheld. This is the known child/host registry
+contradiction, not a child ownership decision. The supplied host claim is the
+authority; this child did not create, alter, release, or verify an
+execution-unit claim and did not enter the host repository.
+
+The shipped `intent-cli 0.27.0-f43fbd1-G753` identity is the real-install
+evidence for the stable line. Observed child verification for this roll is:
+the dedicated v0.27.1 guard 4 passed, 0 failed, 0 skipped; adjacent release
+guards 65 passed, 0 failed, 0 skipped; G613 6 passed, 0 failed, 0 skipped;
+the full Release suite 5336 passed, 0 failed, 1 skipped (5337 total); and
+`git diff --check` is clean. CI is a separate post-push check.
+
+### Previous v0.27.0 release-prep evidence (retained for provenance)
 
 **RELEASE PREPARED / NOT PUBLISHED.**
 

--- a/docs/en/release-notes-v0.27.1.md
+++ b/docs/en/release-notes-v0.27.1.md
@@ -1,0 +1,12 @@
+# Release Notes — intent-cli v0.27.1
+
+> **⚠️ DRAFT / UNRELEASED.** This is a replaceable planning scaffold, not a changelog.
+> The next release-prep packet will replace this placeholder after
+> measuring and deciding the next real release number. Do not treat this file
+> as a changelog.
+> This file must not be treated as a changelog.
+
+This placeholder intentionally contains no release entries. No tag, GitHub
+Release, or package publish exists for v0.27.1. No GitHub Release exists yet
+for this placeholder. The matching install query is
+`JTechJapan.IntentSystem.Cli --version 0.27.1`.

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -2993,7 +2993,101 @@ result は literal bytes の削減、追加した reference bytes、record の n
 `shrink-audit.jsonl` に明記します。`.intent-cli/runs/*.provider.jsonl` は別の provider-run state なので
 scope 外です。`--dry-run` なら manifest、JSONL、audit を書き込まずに測定済み plan だけを確認できます。
 
-### 次リリース準備(v0.27.0)
+### 次リリース準備(v0.27.1)
+
+**POST-RELEASE ROLL / PLACEHOLDER ONLY。**
+
+shipped stable line は `intent-cli 0.27.0-f43fbd1-G753`、source revision は
+`f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330` です。tracked な EN/JA
+`release-notes-v0.27.0.md` は shipped evidence であり、この roll では
+byte-identical のままです。この roll 後の policy pair は次のとおりです:
+
+```json
+{
+  "stableVersion": "0.27.0",
+  "nextVersion": "0.27.1"
+}
+```
+
+`0.27.1` は replaceable placeholder だけで、次の real release number を
+決定したものではありません。EN/JA に `release-notes-v0.27.1.md` の DRAFT
+stub を追加します。それぞれの stub 自身が replaceable planning scaffold で
+changelog ではないと明記します。tag、GitHub Release、package publish、
+post-release roll、G725 detector の変更はこの作業に含めません。
+
+version-flow の pair は `stableVersion → 0.27.0` と
+`nextVersion → 0.27.1` です。対応する package artifact 名は
+`JTechJapan.IntentSystem.Cli.0.27.1.nupkg` ですが、placeholder の名前だけです。
+canonical release-prep coordination scope は
+`release-prep:<owner/repo>:0.27.1` です。plain policy の current value は
+stableVersion 0.27.0、nextVersion 0.27.1 です。v0.27.0 GitHub Release は
+shipped evidence の正式な根拠です:
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.27.0。この roll
+では tag、publish、GitHub Release の作成を行いません。
+
+過去の readiness audit との continuity のため、v0.23.0 GitHub Release と
+https://github.com/J-Tech-Japan/intent-system/releases/tag/v0.23.0、
+`release-notes-v0.23.0.md` は自己完結型バイナリを記録します。npm leg は
+registry に到達しなかったため、npm で利用できると扱ってはいけません。
+installed 0.23.2 CLI と `checkout_freshness/provenance` は historical evidence
+として残します。v0.27.0 release-note file は shipped-note evidence ですが、
+prepare-only の wording と authoritative な GitHub Release の間には
+source-note inconsistency があります。この source-note inconsistency はこの
+roll より前から存在し、この scope 外の点は後の explicitly scoped remediation
+で扱います。
+
+### この roll の G725 evidence boundary
+
+提供された pre-roll の host-root observation は target checkout
+`f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330` に対して実行され、`stalled=true` と
+次の actionable item を返しました:
+
+```text
+kind=version-roll-required
+is_informational=false
+released_version=0.27.0
+expected_stable_version=0.27.0
+expected_next_version=0.27.1
+```
+
+この observation に使った host 側 metadata checkout は local revision
+`35c6d96a` が `origin/main` `209b1369` より stale だと warning を出しました。
+この provenance はそのまま記録し、fresh な synced-main measurement とは
+扱いません。この edit 前に同じ target checkout から available child run を
+実行した結果も上記の actionable `version-roll-required` item を返しました。
+同時に informational な stale-claim item と child queue-state file missing の
+warning も返しました。
+
+この child roll 後、checkout
+`f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330` から実行した child run は
+`stalled=true` を返し、informational な G717、G719、G725 の `claim-stale` item
+だけを含み、`version-roll-required` item はなく、child queue state が見つからない
+warning も返しました。policy pair は正しいですが、この silence だけでは evidence ではなく、
+roll の証明にもなりません。valid な answer には、この PR merge 後に
+synced host-main checkout から同じ command を実行し、checkout commit と
+freshness/provenance を記録する必要があります。implementation seat は host
+repository に入りません。**HOST DUTY REQUEST:** merge 後、synced host-main
+target checkout から
+`intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json`
+を実行し、関連する before/after の `items`、checkout commit、freshness/provenance
+を返してください。この child-side silence を proof として扱わないでください。
+
+host worker は #1640 を selected しましたが、issue-preflight は
+`.git/FETCH_HEAD` を読めないため `canonical-unavailable` を返しました。
+fresh child selector は local `execution-unit:G754` が unheld なので
+`next-action=wait` を返しました。これは既知の child/host registry
+contradiction であり、child が ownership を決めたものではありません。提供された
+host claim を正本として使い、この child は execution-unit claim を create、alter、
+release、verify せず、host repository に入りませんでした。
+
+shipped line の real-install evidence は `intent-cli 0.27.0-f43fbd1-G753` です。
+この roll で観測した child verification は、dedicated v0.27.1 guard が 4 passed、
+0 failed、0 skipped、adjacent release guard が 65 passed、0 failed、0 skipped、
+G613 が 6 passed、0 failed、0 skipped、Full Release suite が 5336 passed、0 failed、
+1 skipped (5337 total)、`git diff --check` は clean です。CI は push 後の別の
+check です。
+
+### 以前の v0.27.0 release-prep evidence (provenance)
 
 **RELEASE PREPARED / NOT PUBLISHED。**
 

--- a/docs/ja/09-developer-reference.md
+++ b/docs/ja/09-developer-reference.md
@@ -3072,6 +3072,15 @@ target checkout から
 を実行し、関連する before/after の `items`、checkout commit、freshness/provenance
 を返してください。この child-side silence を proof として扱わないでください。
 
+最終 post-change child run は committed checkout
+`a21c1f2334d0a81412fa1f9b49e0b8320e39de91` で実行しました。同じく
+`stalled=true` ですが、informational な G717、G719、G725 の `claim-stale` item
+だけで、`version-roll-required` item はありませんでした。freshness warning は
+local HEAD `a21c1f2` が `origin/main`
+`f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330` より stale だと示し、child queue-state
+warning も残りました。これは child evidence であり、synced host-root proof では
+ありません。
+
 host worker は #1640 を selected しましたが、issue-preflight は
 `.git/FETCH_HEAD` を読めないため `canonical-unavailable` を返しました。
 fresh child selector は local `execution-unit:G754` が unheld なので

--- a/docs/ja/release-notes-v0.27.1.md
+++ b/docs/ja/release-notes-v0.27.1.md
@@ -1,0 +1,10 @@
+# リリースノート — intent-cli v0.27.1
+
+> **⚠️ DRAFT / 未リリース。** これは replaceable planning scaffold であり、
+> changelog ではありません。次の release-prep パケットが、次の real release number を
+> 測定して決めた後、この placeholder を replace します。この file は changelog
+> として扱ってはいけません。
+
+この placeholder には release entry を記録しません。v0.27.1 の tag、GitHub
+Release、package publish はまだ存在しません (no GitHub Release)。matching install
+query は `JTechJapan.IntentSystem.Cli --version 0.27.1` です。

--- a/eng/version.json
+++ b/eng/version.json
@@ -1,4 +1,4 @@
 {
-  "stableVersion": "0.26.0",
-  "nextVersion": "0.27.0"
+  "stableVersion": "0.27.0",
+  "nextVersion": "0.27.1"
 }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs
@@ -165,12 +165,12 @@ public sealed class ReleaseNotesV0240DocsTests
     }
 
     [Fact]
-    public void ShippedV0240NotesAndReadinessPointAtTheCurrentV0261Line()
+    public void ShippedV0240NotesAndReadinessPointAtTheCurrentV0271Line()
     {
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.26.0", policy.StableVersion);
-        Assert.Equal("0.27.0", policy.NextVersion);
+        Assert.Equal("0.27.0", policy.StableVersion);
+        Assert.Equal("0.27.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -181,18 +181,20 @@ public sealed class ReleaseNotesV0240DocsTests
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.0.md")));
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
 
             var reference = File.ReadAllText(Path.Combine(root, "docs", language, "09-developer-reference.md"));
             Assert.Contains("0.24.0", reference, StringComparison.Ordinal);
             Assert.Contains("release-notes-v0.24.0.md", reference, StringComparison.Ordinal);
             Assert.Contains("0.25.0", reference, StringComparison.Ordinal);
             Assert.Contains("release-notes-v0.27.0.md", reference, StringComparison.Ordinal);
+            Assert.Contains("release-notes-v0.27.1.md", reference, StringComparison.Ordinal);
             Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
             Assert.Contains(
-                language == "en" ? "Next release readiness (v0.27.0)" : "次リリース準備(v0.27.0)",
+                language == "en" ? "Next release readiness (v0.27.1)" : "次リリース準備(v0.27.1)",
                 reference,
                 StringComparison.Ordinal);
-            Assert.Contains("intent-cli 0.26.0-93f07f8-G749", reference, StringComparison.Ordinal);
+            Assert.Contains("intent-cli 0.27.0-f43fbd1-G753", reference, StringComparison.Ordinal);
             Assert.Contains("ReleasePackageMetadataTests", reference, StringComparison.Ordinal);
             Assert.Contains("VersionSourcePolicyGuardTests", reference, StringComparison.Ordinal);
         }

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs
@@ -14,7 +14,7 @@ public sealed class ReleaseNotesV0250DocsTests
         "5c4af5d88ddcfa47335bad4df56ad3e40dae9140";
     private const string BuiltDisplayIdentity = "intent-cli 0.24.1-5c4af5d-G741";
     private const string InstalledDisplayIdentity = "intent-cli 0.24.0-df472fe-G737";
-    private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.26.0-93f07f8-G749";
+    private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.27.0-f43fbd1-G753";
 
     private static readonly (string Unit, string Pr, string Merge)[] Units =
     [
@@ -165,8 +165,8 @@ public sealed class ReleaseNotesV0250DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policy = RepoVersionPolicySource.Read();
 
-        Assert.Equal("0.26.0", policy.StableVersion);
-        Assert.Equal("0.27.0", policy.NextVersion);
+        Assert.Equal("0.27.0", policy.StableVersion);
+        Assert.Equal("0.27.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -176,6 +176,7 @@ public sealed class ReleaseNotesV0250DocsTests
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.0.md")));
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
         }
     }
 
@@ -188,12 +189,13 @@ public sealed class ReleaseNotesV0250DocsTests
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.27.0)" : "次リリース準備(v0.27.0)",
+            language == "en" ? "Next release readiness (v0.27.1)" : "次リリース準備(v0.27.1)",
             reference,
             StringComparison.Ordinal);
         Assert.Contains(CurrentStableInstallDisplayIdentity, reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.26.0.md", reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.27.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.27.1.md", reference, StringComparison.Ordinal);
         Assert.DoesNotContain("release-notes-v0.24.1.md", reference, StringComparison.Ordinal);
         Assert.Contains("ReleaseNotesV0250DocsTests", reference, StringComparison.Ordinal);
         Assert.Contains("JapaneseTerminologyGuardG613Tests", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs
@@ -5,9 +5,9 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G749/G753: the frozen v0.26.0 release-prep notes retain their measured
-/// evidence while the v0.27.0 preparation updates the current readiness
-/// mirrors in both languages.
+/// G749/G753/G754: the frozen v0.26.0 release-prep notes retain their measured
+/// evidence while the v0.27.1 post-release roll updates current readiness in
+/// both languages.
 /// </summary>
 public sealed class ReleaseNotesV0260DocsTests
 {
@@ -16,7 +16,7 @@ public sealed class ReleaseNotesV0260DocsTests
     private const string BuiltDisplayIdentity = "intent-cli 0.25.1-a49ad93-G748";
     private const string FinalBuiltDisplayIdentity = "intent-cli 0.26.0-a49ad93-G748";
     private const string InstalledDisplayIdentity = "intent-cli 0.25.0-74a1c72-G741";
-    private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.26.0-93f07f8-G749";
+    private const string CurrentStableInstallDisplayIdentity = "intent-cli 0.27.0-f43fbd1-G753";
     private const string PreRollTargetCheckout = "bb9754859ac8055adbd504f294145b7494668c1a";
     private const string PrHead = "c73e12e6d08c6e7698f393c47c571f1320bedf90";
     private const string ArchiveUsage =
@@ -214,12 +214,12 @@ public sealed class ReleaseNotesV0260DocsTests
         var root = RepoVersionPolicySource.RepoRoot();
         var policyPath = Path.Combine(root, "eng", "version.json");
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.26.0\",\n  \"nextVersion\": \"0.27.0\"\n}\n",
+            "{\n  \"stableVersion\": \"0.27.0\",\n  \"nextVersion\": \"0.27.1\"\n}\n",
             File.ReadAllText(policyPath));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.26.0", policy.StableVersion);
-        Assert.Equal("0.27.0", policy.NextVersion);
+        Assert.Equal("0.27.0", policy.StableVersion);
+        Assert.Equal("0.27.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -228,6 +228,7 @@ public sealed class ReleaseNotesV0260DocsTests
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.0.md")));
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
         }
     }
 
@@ -252,7 +253,7 @@ public sealed class ReleaseNotesV0260DocsTests
         var readiness = ReadCurrentReadiness(language);
 
         Assert.Contains(
-            language == "en" ? "Next release readiness (v0.27.0)" : "次リリース準備(v0.27.0)",
+            language == "en" ? "Next release readiness (v0.27.1)" : "次リリース準備(v0.27.1)",
             readiness,
             StringComparison.Ordinal);
         Assert.Contains("0.25.0", readiness, StringComparison.Ordinal);
@@ -367,7 +368,7 @@ public sealed class ReleaseNotesV0260DocsTests
     {
         var content = File.ReadAllText(Path.Combine(
             RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
-        var heading = language == "en" ? "### Next release readiness (v0.27.0)" : "### 次リリース準備(v0.27.0)";
+        var heading = language == "en" ? "### Next release readiness (v0.27.1)" : "### 次リリース準備(v0.27.1)";
         var start = content.IndexOf(heading, StringComparison.Ordinal);
         Assert.True(start >= 0, $"Missing current readiness heading in {language}.");
         var end = content.IndexOf("**Previous v0.25.0 preparation evidence", start, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs
@@ -5,9 +5,8 @@ using IntentSystem.Cli.Infrastructure;
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
-/// G753: v0.27.0 release-prep evidence is measured from the functional head,
-/// accounts for the post-release roll, and keeps the EN/JA operator narrative
-/// in lockstep.
+/// G753/G754: frozen v0.27.0 release-prep evidence remains in lockstep while
+/// the v0.27.1 post-release roll updates the current readiness mirrors.
 /// </summary>
 public sealed class ReleaseNotesV0270DocsTests
 {
@@ -170,12 +169,12 @@ public sealed class ReleaseNotesV0270DocsTests
     {
         var root = RepoVersionPolicySource.RepoRoot();
         Assert.Equal(
-            "{\n  \"stableVersion\": \"0.26.0\",\n  \"nextVersion\": \"0.27.0\"\n}\n",
+            "{\n  \"stableVersion\": \"0.27.0\",\n  \"nextVersion\": \"0.27.1\"\n}\n",
             File.ReadAllText(Path.Combine(root, "eng", "version.json")));
 
         var policy = RepoVersionPolicySource.Read();
-        Assert.Equal("0.26.0", policy.StableVersion);
-        Assert.Equal("0.27.0", policy.NextVersion);
+        Assert.Equal("0.27.0", policy.StableVersion);
+        Assert.Equal("0.27.1", policy.NextVersion);
 
         foreach (var language in new[] { "en", "ja" })
         {
@@ -183,6 +182,7 @@ public sealed class ReleaseNotesV0270DocsTests
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.0.md")));
             Assert.False(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.26.1.md")));
             Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
         }
     }
 
@@ -197,8 +197,8 @@ public sealed class ReleaseNotesV0270DocsTests
 
         Assert.Contains(
             language == "en"
-                ? "### Next release readiness (v0.27.0)"
-                : "### 次リリース準備(v0.27.0)",
+                ? "### Next release readiness (v0.27.1)"
+                : "### 次リリース準備(v0.27.1)",
             reference,
             StringComparison.Ordinal);
         Assert.DoesNotContain(
@@ -209,6 +209,8 @@ public sealed class ReleaseNotesV0270DocsTests
             StringComparison.Ordinal);
         Assert.Contains(InstalledDisplayIdentity, reference, StringComparison.Ordinal);
         Assert.Contains("release-notes-v0.27.0.md", reference, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.27.1.md", reference, StringComparison.Ordinal);
+        Assert.Contains("intent-cli 0.27.0-f43fbd1-G753", reference, StringComparison.Ordinal);
         Assert.Contains(PreparedFunctionalHead, reference, StringComparison.Ordinal);
         Assert.Contains("104 usages", reference, StringComparison.Ordinal);
         Assert.Contains("111.5MB", reference, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
@@ -13,6 +13,7 @@ public sealed class ReleaseNotesV0271DocsTests
 {
     private const string ShippedIdentity = "intent-cli 0.27.0-f43fbd1-G753";
     private const string ShippedHead = "f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330";
+    private const string PostRollChildHead = "a21c1f2334d0a81412fa1f9b49e0b8320e39de91";
     private const string StaleHostCheckout = "35c6d96a";
     private const string HostOriginMain = "209b1369";
 
@@ -80,6 +81,7 @@ public sealed class ReleaseNotesV0271DocsTests
         Assert.Contains("stalled=true", readiness, StringComparison.Ordinal);
         Assert.Contains(StaleHostCheckout, readiness, StringComparison.Ordinal);
         Assert.Contains(HostOriginMain, readiness, StringComparison.Ordinal);
+        Assert.Contains(PostRollChildHead, readiness, StringComparison.Ordinal);
         Assert.Contains("next-action=wait", readiness, StringComparison.Ordinal);
         Assert.Contains("execution-unit:G754", readiness, StringComparison.Ordinal);
         Assert.Contains("unheld", readiness, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs
@@ -1,0 +1,134 @@
+using System.Security.Cryptography;
+using System.Text.RegularExpressions;
+using IntentSystem.Cli.Infrastructure;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G754: the post-release roll records the shipped v0.27.0 identity, creates
+/// replaceable v0.27.1 placeholders, and keeps the G725 evidence boundary
+/// explicit without changing the detector.
+/// </summary>
+public sealed class ReleaseNotesV0271DocsTests
+{
+    private const string ShippedIdentity = "intent-cli 0.27.0-f43fbd1-G753";
+    private const string ShippedHead = "f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330";
+    private const string StaleHostCheckout = "35c6d96a";
+    private const string HostOriginMain = "209b1369";
+
+    [Fact]
+    public void VersionPolicyAndPlaceholderNotesAreExact()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var policyPath = Path.Combine(root, "eng", "version.json");
+
+        Assert.Equal(
+            "{\n  \"stableVersion\": \"0.27.0\",\n  \"nextVersion\": \"0.27.1\"\n}\n",
+            File.ReadAllText(policyPath));
+
+        var policy = RepoVersionPolicySource.Read();
+        Assert.Equal("0.27.0", policy.StableVersion);
+        Assert.Equal("0.27.1", policy.NextVersion);
+
+        foreach (var language in new[] { "en", "ja" })
+        {
+            var stub = File.ReadAllText(Path.Combine(
+                root, "docs", language, "release-notes-v0.27.1.md"));
+
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.0.md")));
+            Assert.True(File.Exists(Path.Combine(root, "docs", language, "release-notes-v0.27.1.md")));
+            Assert.DoesNotContain("- G", stub, StringComparison.Ordinal);
+
+            if (language == "en")
+            {
+                Assert.Contains("DRAFT / UNRELEASED", stub, StringComparison.Ordinal);
+                Assert.Contains("replaceable planning scaffold", stub, StringComparison.Ordinal);
+                Assert.Contains("not a changelog", stub, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("release-prep packet will replace", stub, StringComparison.Ordinal);
+            }
+            else
+            {
+                Assert.Contains("DRAFT / 未リリース", stub, StringComparison.Ordinal);
+                Assert.Contains("replaceable planning scaffold", stub, StringComparison.Ordinal);
+                Assert.Contains("changelog ではありません", stub, StringComparison.Ordinal);
+                Assert.Contains("replace", stub, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void ReadinessPinsShippedIdentityAndG725EvidenceBoundary(string language)
+    {
+        var readiness = ReadCurrentReadiness(language);
+        var compact = Regex.Replace(readiness, @"\s+", " ");
+
+        Assert.Contains(ShippedIdentity, readiness, StringComparison.Ordinal);
+        Assert.Contains(ShippedHead, readiness, StringComparison.Ordinal);
+        Assert.Contains("stableVersion", readiness, StringComparison.Ordinal);
+        Assert.Contains("0.27.1", readiness, StringComparison.Ordinal);
+        Assert.Contains("replaceable placeholder", readiness, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("release-notes-v0.27.1.md", readiness, StringComparison.Ordinal);
+        Assert.Contains("release-notes-v0.27.0.md", readiness, StringComparison.Ordinal);
+        Assert.Contains("byte-identical", readiness, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("kind=version-roll-required", readiness, StringComparison.Ordinal);
+        Assert.Contains("is_informational=false", readiness, StringComparison.Ordinal);
+        Assert.Contains("released_version=0.27.0", readiness, StringComparison.Ordinal);
+        Assert.Contains("expected_stable_version=0.27.0", readiness, StringComparison.Ordinal);
+        Assert.Contains("expected_next_version=0.27.1", readiness, StringComparison.Ordinal);
+        Assert.Contains("stalled=true", readiness, StringComparison.Ordinal);
+        Assert.Contains(StaleHostCheckout, readiness, StringComparison.Ordinal);
+        Assert.Contains(HostOriginMain, readiness, StringComparison.Ordinal);
+        Assert.Contains("next-action=wait", readiness, StringComparison.Ordinal);
+        Assert.Contains("execution-unit:G754", readiness, StringComparison.Ordinal);
+        Assert.Contains("unheld", readiness, StringComparison.Ordinal);
+        Assert.Contains("G725", readiness, StringComparison.Ordinal);
+        Assert.Contains("HOST DUTY REQUEST", readiness, StringComparison.Ordinal);
+        Assert.Contains(
+            language == "en" ? "no `version-roll-required` item" : "`version-roll-required` item はなく",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "non-evidence" : "evidence ではなく",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            language == "en" ? "does not prove the roll" : "roll の証明にもなりません",
+            compact,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ShippedV0270NoteBytesRemainPinned()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+
+        Assert.Equal(
+            "1b810139d4775fa4306bc571c150e49c4e882464c8228b82b65ed3a0ad0978cb",
+            Sha256(Path.Combine(root, "docs", "en", "release-notes-v0.27.0.md")));
+        Assert.Equal(
+            "6973f0438bd0bb208fc22e6a6d31596ee455b8284c7edc345687e3f3016e414d",
+            Sha256(Path.Combine(root, "docs", "ja", "release-notes-v0.27.0.md")));
+    }
+
+    private static string ReadCurrentReadiness(string language)
+    {
+        var content = File.ReadAllText(Path.Combine(
+            RepoVersionPolicySource.RepoRoot(), "docs", language, "09-developer-reference.md"));
+        var heading = language == "en"
+            ? "### Next release readiness (v0.27.1)"
+            : "### 次リリース準備(v0.27.1)";
+        var endHeading = language == "en"
+            ? "### Previous v0.27.0 release-prep evidence"
+            : "### 以前の v0.27.0 release-prep evidence";
+        var start = content.IndexOf(heading, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Missing current readiness heading in {language}.");
+        var end = content.IndexOf(endHeading, start, StringComparison.Ordinal);
+        Assert.True(end > start, $"Missing prior-readiness boundary in {language}.");
+        return content[start..end];
+    }
+
+    private static string Sha256(string path) =>
+        Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(path))).ToLowerInvariant();
+}


### PR DESCRIPTION
Closes #1640

## Summary

This PR performs only the v0.27.0 post-release roll:
- `eng/version.json` is exactly stableVersion `0.27.0`, nextVersion `0.27.1`.
- EN/JA `release-notes-v0.27.1.md` are DRAFT, replaceable planning scaffolds and explicitly not changelogs.
- EN/JA readiness mirrors identify shipped `intent-cli 0.27.0-f43fbd1-G753` and describe `0.27.1` only as a replaceable placeholder.
- No shipped v0.27.0 release-note file, source code, tag, GitHub Release, publish, post-roll, next-real-version decision, or G725 behavior was changed.

## Exact changed paths

- `eng/version.json`
- `docs/en/09-developer-reference.md`
- `docs/ja/09-developer-reference.md`
- `docs/en/release-notes-v0.27.1.md`
- `docs/ja/release-notes-v0.27.1.md`
- `tests/IntentSystem.Cli.Tests/ReleaseNotesV0240DocsTests.cs`
- `tests/IntentSystem.Cli.Tests/ReleaseNotesV0250DocsTests.cs`
- `tests/IntentSystem.Cli.Tests/ReleaseNotesV0260DocsTests.cs`
- `tests/IntentSystem.Cli.Tests/ReleaseNotesV0270DocsTests.cs`
- `tests/IntentSystem.Cli.Tests/ReleaseNotesV0271DocsTests.cs`

## G725 evidence boundary

The supplied pre-roll host-root observation on target checkout `f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330` found one actionable `version-roll-required` item: `is_informational=false`, `stalled=true`, released `0.27.0`, expected stable `0.27.0`, expected next `0.27.1`. The host metadata checkout separately warned that local `35c6d96a` was stale versus `origin/main 209b1369`.

The available child before-change run at `f43fbd19f6e0cb7fa284ccd2f89d2932f63ca330` also showed the actionable version-roll-required item. The final post-change child run was observed at committed checkout `a21c1f2334d0a81412fa1f9b49e0b8320e39de91`: `stalled=true`, only informational stale-claim items for G717/G719/G725, no version-roll-required item; it warned that local `a21c1f2` was stale versus child `origin/main f43fbd19` and that child queue state was missing. This child-side silence is non-evidence and does not prove the roll; the final PR head is `cd32f009b0236271672d7ffec6e1ca47fa18df5c`.

HOST DUTY REQUEST: after merge, run `intent-cli automation stalled-work --domain intent-cli --repo J-Tech-Japan/intent-system --format json` from a freshly synced host-main target checkout and return the exact before/after `items`, checkout commit, and freshness/provenance. Do not present child-side silence as the canonical post-merge answer.

The worker next-action selected #1640 but issue-preflight returned wait/canonical-unavailable because child-side canonical claim verification could not open `.git/FETCH_HEAD`; the supplied host origin/main claim for execution-unit:G754 is authoritative. No execution-unit claim was created, modified, released, or verified in the child product repo.

## Verification

- Installed identity: `intent-cli 0.27.0-f43fbd1-G753`.
- `ReleaseNotesV0271DocsTests`: Passed 4, Failed 0, Skipped 0, Total 4.
- Adjacent release/version guards: Passed 65, Failed 0, Skipped 0, Total 65.
- Broad release-note guard filter: Passed 244, Failed 0, Skipped 0, Total 244.
- G613: Passed 6, Failed 0, Skipped 0, Total 6.
- Full Release: Passed 5336, Failed 0, Skipped 1, Total 5337.
- `git diff --check`: clean.
- Shipped EN v0.27.0 note SHA-256 before/after: `1b810139d4775fa4306bc571c150e49c4e882464c8228b82b65ed3a0ad0978cb`.
- Shipped JA v0.27.0 note SHA-256 before/after: `6973f0438bd0bb208fc22e6a6d31596ee455b8284c7edc345687e3f3016e414d`.
- Exact branch head: `cd32f009b0236271672d7ffec6e1ca47fa18df5c`.

CI is expected to run on this non-draft PR.