### PR TITLE
G755: verify claims from canonical default branch

### DIFF
--- a/docs/en/05-implementation-loop.md
+++ b/docs/en/05-implementation-loop.md
@@ -211,12 +211,15 @@ line after broad union rules only through an explicit reviewed commit.
 ### Preview: claim-aware start surfaces (G680)
 
 Packet draft, queue seed/publish-flow, worker next-action, and release-prep use
-the same `claim verify` judgment. In a Git worktree the verifier first fetches
-the current branch and reads the claims tree from the fresh `origin` ref; local
-absence or a stale local record is never proof of ownership or no-store. If
-fresh canonical Git evidence cannot be established it fails closed. A genuine
-canonical no-store host keeps legacy single-team output byte-identical. A
-configured store requires the invoking team to hold the matching scope;
+the same `claim verify` judgment. In a Git worktree the verifier uses the same
+remote-default-branch resolver as claim acquire, fetches the canonical branch
+from origin, and reads the claims tree from its fresh `origin` ref; the reading
+checkout's current branch, local absence, or a stale local record is never
+proof of ownership or no-store. This also gives a detached checkout the same
+canonical answer. If the default branch cannot be resolved or fetched, the
+verifier fails closed with `canonical-unavailable`; a genuine canonical
+no-store host keeps legacy single-team output byte-identical. A configured
+store requires the invoking team to hold the matching scope;
 unheld and other-team refusals name scope, holder, and holder team. Next-slice
 uses that same judgment in recommendation mode: unheld and own-team units
 remain candidates, while claimed-elsewhere units are excluded with holder

--- a/docs/ja/05-implementation-loop.md
+++ b/docs/ja/05-implementation-loop.md
@@ -201,11 +201,13 @@ existing host は自動 migrate しません。最後の specific line は broad
 ### Preview: claim-aware start surface (G680)
 
 packet draft、queue seed/publish-flow、worker next-action、release-prep は同じ
-`claim verify` judgment を使います。Git worktree では verifier が current branch を最初に
-fetch し、fresh な `origin` ref の claims tree を読みます。local absence や stale local record を
-ownership / no-store の証拠にはせず、fresh canonical Git evidence を確立できなければ fail closed
-します。canonical に claims store が存在しない host だけは legacy single-team output を
-byte-identical に維持します。store が設定されている場合、invoking team が matching scope を
+`claim verify` judgment を使います。Git worktree では verifier が claim acquire と同じ
+remote-default-branch resolver を使って origin の canonical branch を解決し、そこを fetch して
+fresh な `origin` ref の claims tree を読みます。読む checkout の current branch、local absence、
+stale local record は ownership / no-store の証拠ではありません。detached checkout でも同じ
+canonical answer を返します。default branch を解決または fetch できなければ
+`canonical-unavailable` で fail closed します。canonical に claims store が存在しない host
+だけは legacy single-team output を byte-identical に維持します。store が設定されている場合、invoking team が matching scope を
 保持している必要があります。unheld / other-team の拒否は scope、holder、holder team を
 名指します。next-slice は同じ judgment を recommendation mode で使い、unheld と own-team
 unit は candidate のまま、claimed-elsewhere unit は holder evidence 付きで除外します。

--- a/src/IntentSystem.Cli/Commands/ClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/ClaimCommand.cs
@@ -114,22 +114,9 @@ internal static class ClaimCommand
         ArgumentNullException.ThrowIfNull(warningWriter);
         deleteDirectory ??= path => Directory.Delete(path, recursive: true);
 
-        var origin = RunGit(repoRoot, ["remote", "get-url", "origin"]);
-        EnsureSuccess(origin, "resolve origin");
-        var defaultBranchResult = RunGit(repoRoot, ["ls-remote", "--symref", "origin", "HEAD"]);
-        EnsureSuccess(defaultBranchResult, "resolve origin default branch");
-        var remote = origin.StandardOutput.Trim();
-        if (remote.Length == 0)
-        {
-            throw new InvalidOperationException("claim requires an origin remote");
-        }
-
-        if (!TryParseRemoteDefaultBranch(defaultBranchResult.StandardOutput, out var defaultBranch))
-        {
-            throw new InvalidOperationException(
-                "Could not resolve origin default branch from its HEAD symref; refusing to "
-                + "fall back to the current branch.");
-        }
+        var canonicalBranch = ResolveRemoteDefaultBranch(repoRoot);
+        var remote = canonicalBranch.Remote;
+        var defaultBranch = canonicalBranch.Name;
         if (!request.Write)
         {
             return new ClaimTransactionResult(
@@ -668,6 +655,33 @@ internal static class ClaimCommand
         return true;
     }
 
+    /// <summary>
+    /// Resolve the one canonical remote branch used by both claim writes and
+    /// claim reads. The caller must fail closed when this metadata is absent
+    /// or unsafe; no caller may substitute its current checkout branch.
+    /// </summary>
+    internal static ClaimRemoteDefaultBranch ResolveRemoteDefaultBranch(string repoRoot)
+    {
+        var origin = RunGit(repoRoot, ["remote", "get-url", "origin"]);
+        EnsureSuccess(origin, "resolve origin");
+        var defaultBranchResult = RunGit(repoRoot, ["ls-remote", "--symref", "origin", "HEAD"]);
+        EnsureSuccess(defaultBranchResult, "resolve origin default branch");
+        var remote = origin.StandardOutput.Trim();
+        if (remote.Length == 0)
+        {
+            throw new InvalidOperationException("claim requires an origin remote");
+        }
+
+        if (!TryParseRemoteDefaultBranch(defaultBranchResult.StandardOutput, out var defaultBranch))
+        {
+            throw new InvalidOperationException(
+                "Could not resolve origin default branch from its HEAD symref; refusing to "
+                + "fall back to the current branch.");
+        }
+
+        return new ClaimRemoteDefaultBranch(remote, defaultBranch);
+    }
+
     private static bool IsSafeRemoteBranch(string value)
     {
         if (value.Length == 0
@@ -968,6 +982,8 @@ internal static class ClaimCommand
         writer.WriteLine($"- detail: {result.Detail}");
     }
 }
+
+internal sealed record ClaimRemoteDefaultBranch(string Remote, string Name);
 
 internal enum ClaimOperation { Acquire, Release, Takeover }
 

--- a/src/IntentSystem.Cli/Commands/ClaimOwnershipVerifier.cs
+++ b/src/IntentSystem.Cli/Commands/ClaimOwnershipVerifier.cs
@@ -184,27 +184,27 @@ internal static class ClaimOwnershipVerifier
             return ReadLocalEvidence(repoRoot, scope);
         }
 
-        var branch = RunGit(repoRoot, ["branch", "--show-current"]);
-        if (branch.ExitCode != 0 || string.IsNullOrWhiteSpace(branch.StandardOutput))
+        ClaimRemoteDefaultBranch canonicalBranch;
+        try
         {
-            return CanonicalClaimEvidence.Unavailable("the current Git checkout has no named branch");
+            canonicalBranch = ClaimCommand.ResolveRemoteDefaultBranch(repoRoot);
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException)
+        {
+            return CanonicalClaimEvidence.Unavailable(
+                string.IsNullOrWhiteSpace(exception.Message)
+                    ? "resolving origin default branch failed"
+                    : exception.Message);
         }
 
-        var origin = RunGit(repoRoot, ["remote", "get-url", "origin"]);
-        if (origin.ExitCode != 0 || string.IsNullOrWhiteSpace(origin.StandardOutput))
-        {
-            return CanonicalClaimEvidence.Unavailable("the current Git checkout has no origin remote");
-        }
-
-        var branchName = branch.StandardOutput.Trim();
-        var remoteRef = $"refs/remotes/origin/{branchName}";
+        var remoteRef = $"refs/remotes/origin/{canonicalBranch.Name}";
         var fetch = RunGit(repoRoot,
-            ["fetch", "--quiet", "origin", $"+refs/heads/{branchName}:{remoteRef}"]);
+            ["fetch", "--quiet", "origin", $"+refs/heads/{canonicalBranch.Name}:{remoteRef}"]);
         if (fetch.ExitCode != 0)
         {
             return CanonicalClaimEvidence.Unavailable(
                 string.IsNullOrWhiteSpace(fetch.StandardError)
-                    ? "fetching the current branch from origin failed"
+                    ? "fetching the canonical default branch from origin failed"
                     : fetch.StandardError.Trim());
         }
 

--- a/src/IntentSystem.Cli/Commands/WorkerClaimCommand.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerClaimCommand.cs
@@ -193,15 +193,15 @@ internal static class WorkerClaimCommand
         }
 
         var store = ClaimOwnershipVerifier.ProbeStore(context.RepoRoot);
-        if (!store.StoreConfigured)
-        {
-            return null;
-        }
         if (!store.Available)
         {
             return ClaimOwnershipVerifier.Unavailable(
                 $"execution-unit:issue-{number}",
                 $"claim verification refused issue #{number}: fresh canonical Git evidence is unavailable ({store.Detail}).");
+        }
+        if (!store.StoreConfigured)
+        {
+            return null;
         }
 
         try

--- a/tests/IntentSystem.Cli.Tests/ClaimOwnershipVerifierG755Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClaimOwnershipVerifierG755Tests.cs
@@ -1,0 +1,220 @@
+using System.Diagnostics;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class ClaimOwnershipVerifierG755Tests
+{
+    [Fact]
+    public void NonDefaultCheckout_ReadsCanonicalClaim_G755()
+    {
+        using var repos = new ClaimRepositories();
+        var scope = PrepareOwnedNonDefaultCheckout(repos);
+
+        var result = ClaimOwnershipVerifier.Verify(repos.FirstClone, scope, "team-a");
+
+        Assert.True(result.Passed);
+        Assert.Equal(ClaimOwnershipVerification.StatusOwned, result.Status);
+        Assert.Equal("alice", result.Holder);
+        Assert.Equal("team-a", result.HolderTeam);
+    }
+
+    [Fact]
+    public void NonDefaultCheckout_WithNoLocalClaimsStore_DoesNotFailOpen_G755()
+    {
+        using var repos = new ClaimRepositories();
+        var scope = PrepareOwnedNonDefaultCheckout(repos);
+
+        var result = ClaimOwnershipVerifier.Verify(repos.FirstClone, scope, "team-a");
+
+        Assert.NotEqual(ClaimOwnershipVerification.StatusNotConfigured, result.Status);
+        Assert.True(result.Passed);
+        Assert.Equal(ClaimOwnershipVerification.StatusOwned, result.Status);
+        Assert.Equal("alice", result.Holder);
+        Assert.Equal("team-a", result.HolderTeam);
+    }
+
+    [Fact]
+    public void CanonicalBranchResolutionFailure_FailsClosed_G755()
+    {
+        using var repos = new ClaimRepositories();
+        var scope = PrepareOwnedNonDefaultCheckout(repos);
+        Run(repos.Bare, "git", "symbolic-ref", "HEAD", "refs/heads/missing");
+
+        var result = ClaimOwnershipVerifier.Verify(repos.FirstClone, scope, "team-a");
+
+        Assert.False(result.Passed);
+        Assert.Equal(ClaimOwnershipVerification.StatusCanonicalUnavailable, result.Status);
+        Assert.NotEqual(ClaimOwnershipVerification.StatusNotConfigured, result.Status);
+        Assert.NotEmpty(result.Detail);
+    }
+
+    [Fact]
+    public void CanonicalNoStore_PreservesLegacyVerificationOutput_G755()
+    {
+        using var repos = new ClaimRepositories();
+        using var localRoot = new TempDirectory("claim-g755-no-store-");
+        const string scope = "execution-unit:G755-no-store";
+
+        var local = Render(localRoot.Path, scope);
+        var canonical = Render(repos.FirstClone, scope);
+
+        Assert.Equal(local, canonical);
+        using var document = JsonDocument.Parse(canonical);
+        Assert.True(document.RootElement.GetProperty("passed").GetBoolean());
+        Assert.Equal(
+            ClaimOwnershipVerification.StatusNotConfigured,
+            document.RootElement.GetProperty("status").GetString());
+        Assert.False(document.RootElement.GetProperty("store_configured").GetBoolean());
+    }
+
+    [Fact]
+    public void DetachedHead_ReadsCanonicalClaim_G755()
+    {
+        using var repos = new ClaimRepositories();
+        var scope = PrepareOwnedNonDefaultCheckout(repos);
+        var canonicalCommit = ReadBareRef(repos.Bare, "main");
+        Run(repos.FirstClone, "git", "checkout", "--quiet", "--detach", canonicalCommit);
+
+        var result = ClaimOwnershipVerifier.Verify(repos.FirstClone, scope, "team-a");
+
+        Assert.True(result.Passed);
+        Assert.Equal(ClaimOwnershipVerification.StatusOwned, result.Status);
+        Assert.Equal("alice", result.Holder);
+        Assert.Equal("team-a", result.HolderTeam);
+    }
+
+    [Fact]
+    public void DocumentationMirrorsDescribeCanonicalRead_G755()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var english = File.ReadAllText(Path.Combine(root, "docs", "en", "05-implementation-loop.md"));
+        var japanese = File.ReadAllText(Path.Combine(root, "docs", "ja", "05-implementation-loop.md"));
+
+        Assert.Contains("remote-default-branch resolver", english, StringComparison.Ordinal);
+        Assert.Contains("canonical-unavailable", english, StringComparison.Ordinal);
+        Assert.DoesNotContain("the verifier first fetches\nthe current branch", english, StringComparison.Ordinal);
+        Assert.Contains("remote-default-branch resolver", japanese, StringComparison.Ordinal);
+        Assert.Contains("canonical-unavailable", japanese, StringComparison.Ordinal);
+        Assert.DoesNotContain("verifier が current branch を最初に\nfetch", japanese, StringComparison.Ordinal);
+    }
+
+    private static string PrepareOwnedNonDefaultCheckout(ClaimRepositories repos)
+    {
+        repos.PrepareNonDefaultCheckout();
+        const string scope = "execution-unit:G755-reader";
+        var acquired = ClaimCommand.RunTransaction(
+            repos.FirstClone,
+            Request(scope, "alice", "team-a"));
+
+        Assert.Equal("acquired", acquired.Status);
+        Assert.True(acquired.PushSucceeded);
+        Assert.Equal("refs/heads/main", acquired.TargetRef);
+        Assert.False(Directory.Exists(
+            Path.Combine(repos.FirstClone, ClaimCommand.ClaimsDirectory)));
+        return scope;
+    }
+
+    private static string Render(string repoRoot, string scope)
+    {
+        using var writer = new StringWriter();
+        var exitCode = ClaimVerificationCommand.Execute(
+            Context(repoRoot),
+            ["--scope", scope, "--team", "team-a", "--format", "json"],
+            writer);
+        Assert.Equal(0, exitCode);
+        return writer.ToString();
+    }
+
+    private static CliContext Context(string root) => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private static ClaimRequest Request(string scope, string actor, string team) =>
+        new(ClaimOperation.Acquire, scope, actor, team, null, null, true, "json", ClaimCommand.DefaultMaxAttempts);
+
+    private static string ReadBareRef(string bare, string branch) =>
+        Run(bare, "git", "rev-parse", $"refs/heads/{branch}").Trim();
+
+    private static string Run(string workdir, string fileName, params string[] arguments)
+    {
+        var info = new ProcessStartInfo(fileName)
+        {
+            WorkingDirectory = workdir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var argument in arguments) info.ArgumentList.Add(argument);
+        using var process = Process.Start(info)!;
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, $"{fileName} {string.Join(' ', arguments)} failed: {error}");
+        return output;
+    }
+
+    private sealed class ClaimRepositories : IDisposable
+    {
+        private readonly TempDirectory temp = new("claim-repos-g755-");
+
+        public ClaimRepositories()
+        {
+            Bare = Path.Combine(temp.Path, "origin.git");
+            var seed = Path.Combine(temp.Path, "seed");
+            FirstClone = Path.Combine(temp.Path, "first");
+            Directory.CreateDirectory(Bare);
+            Run(Bare, "git", "init", "--bare", "--quiet");
+            Directory.CreateDirectory(seed);
+            Run(seed, "git", "init", "--quiet", "--initial-branch=main");
+            Run(seed, "git", "config", "user.name", "seed");
+            Run(seed, "git", "config", "user.email", "seed@example.invalid");
+            File.WriteAllText(Path.Combine(seed, "README.md"), "seed\n");
+            Run(seed, "git", "add", "README.md");
+            Run(seed, "git", "commit", "--quiet", "-m", "seed");
+            Run(seed, "git", "remote", "add", "origin", Bare);
+            Run(seed, "git", "push", "--quiet", "-u", "origin", "main");
+            Run(Bare, "git", "symbolic-ref", "HEAD", "refs/heads/main");
+            Run(temp.Path, "git", "clone", "--quiet", Bare, FirstClone);
+        }
+
+        public string Bare { get; }
+        public string FirstClone { get; }
+
+        public void PrepareNonDefaultCheckout()
+        {
+            Run(FirstClone, "git", "switch", "--quiet", "-c", "design-thread");
+            File.WriteAllText(Path.Combine(FirstClone, "feature.txt"), "feature\n");
+            Run(FirstClone, "git", "add", "feature.txt");
+            Run(FirstClone, "git", "-c", "user.name=feature", "-c", "user.email=feature@example.invalid",
+                "commit", "--quiet", "-m", "feature");
+            Run(FirstClone, "git", "push", "--quiet", "-u", "origin", "design-thread");
+        }
+
+        public void Dispose() => temp.Dispose();
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory(string prefix) => Path = Directory.CreateTempSubdirectory(prefix).FullName;
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/WorkerClaimCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/WorkerClaimCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text.Json;
 using IntentSystem.Cli;
@@ -184,6 +185,42 @@ public sealed class WorkerClaimCommandTests : IDisposable
         Assert.False(result.Proceed);
         Assert.Contains(result.Errors, error =>
             error.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.ClaimRegistryRefused, StringComparison.Ordinal));
+        Assert.Empty(mutator.AppliedTransitions);
+    }
+
+    [Fact]
+    public void Execute_IssueWithCanonicalUnavailable_RefusesBeforeNoStoreBypassWithoutLabelMutation_G755Repair()
+    {
+        using var workspace = new WorkerClaimWorkspace();
+        InitializeBrokenOrigin(workspace.RootPath);
+        var mutator = new FakeMutator
+        {
+            Labels = new[] { "intent-target" },
+        };
+        WorkerClaimCommand.MutatorFactory = () => mutator;
+
+        using var writer = new StringWriter();
+        var exitCode = WorkerClaimCommand.Execute(
+            workspace.Context,
+            new[]
+            {
+                "--repo", "J-Tech-Japan/intent-system",
+                "--kind", "issue",
+                "--number", "1642",
+                "--write",
+                "--format", "json",
+            },
+            writer);
+
+        Assert.Equal(2, exitCode);
+        var result = JsonSerializer.Deserialize<WorkerClaimResult>(writer.ToString())!;
+        Assert.False(result.Proceed);
+        Assert.False(result.Applied);
+        Assert.Empty(result.AddLabels);
+        Assert.Empty(result.RemoveLabels);
+        Assert.Contains(result.Errors, error =>
+            error.StartsWith(WorkerClaimCompleteConstants.ErrorCodes.ClaimRegistryRefused, StringComparison.Ordinal)
+            && error.Contains("canonical Git evidence is unavailable", StringComparison.Ordinal));
         Assert.Empty(mutator.AppliedTransitions);
     }
 
@@ -576,6 +613,34 @@ public sealed class WorkerClaimCommandTests : IDisposable
         }
         throw new FileNotFoundException(
             $"Could not locate source file {fileName} from {directory}");
+    }
+
+    private static void InitializeBrokenOrigin(string repoRoot)
+    {
+        RunGit(repoRoot, "init", "--quiet");
+        RunGit(repoRoot, "remote", "add", "origin", Path.Combine(repoRoot, "missing-origin.git"));
+    }
+
+    private static void RunGit(string workingDirectory, params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "git",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var standardError = process!.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, standardError);
     }
 
     internal sealed class FakeMutator : IGitHubLabelMutator


### PR DESCRIPTION
Closes #1642

## Summary

This PR fixes the G755 claim-reader asymmetry:
- `ClaimCommand.ResolveRemoteDefaultBranch` is the single shared remote-default-branch resolver.
- `ClaimCommand.RunTransaction` and `ClaimOwnershipVerifier.ReadCanonicalEvidence` both call that resolver.
- The reader fetches and reads `refs/remotes/origin/<resolved-default-branch>`, independent of the checkout branch or detached HEAD.
- Resolution or canonical fetch failure returns `canonical-unavailable` and never `not-configured`.
- `not-configured` remains reserved for a canonical branch with no claims store, preserving the legacy output.
- G747 writer behavior and tests are unchanged.

No `branch --show-current` call remains in `ClaimOwnershipVerifier.cs`.

## Required pre-fix reproduction

The new real bare-origin tests were added before the production change and run on parent `6ea81ac85e5fc104d5cd954766c916445f751183`. The actual focused result was:

```
[xUnit.net ...] ClaimOwnershipVerifierG755Tests.NonDefaultCheckout_ReadsCanonicalClaim_G755 [FAIL]
Expected: "owned"
Actual:   "not-configured"

[xUnit.net ...] ClaimOwnershipVerifierG755Tests.DetachedHead_ReadsCanonicalClaim_G755 [FAIL]
Expected: True
Actual:   False

[xUnit.net ...] ClaimOwnershipVerifierG755Tests.NonDefaultCheckout_WithNoLocalClaimsStore_DoesNotFailOpen_G755 [FAIL]
Assert.NotEqual() Failure:
Expected: Not "not-configured"
Actual:       "not-configured"

[xUnit.net ...] ClaimOwnershipVerifierG755Tests.CanonicalBranchResolutionFailure_FailsClosed_G755 [FAIL]
Assert.False() Failure:
Expected: False
Actual:   True

Failed! - Failed: 4, Passed: 1, Skipped: 0, Total: 5
```

The canonical no-store compatibility case was the one parent test that passed.

## Resolver and consumer inventory

There is one resolver implementation, `ResolveRemoteDefaultBranch`, and two production call sites:
1. `ClaimCommand.RunTransaction` (writer).
2. `ClaimOwnershipVerifier.ReadCanonicalEvidence` (reader).

`TryParseRemoteDefaultBranch` remains only the parser used by that resolver; it is not a second branch-resolution path.

The seven named `ClaimOwnershipVerifier.Verify` consumers required no call-site changes:
- `PacketDraftCommand`
- `AutomationQueueSeedFromPacketCommand`
- `WorkerIssuePreflightCommand`
- `IntentNextSliceCommand` (two existing call sites)
- `WorkerClaimCommand`
- `IssuePublishFlowCommand`
- `WorkerNextActionCommand` (two existing call sites)

## Documentation

Both `docs/en/05-implementation-loop.md` and `docs/ja/05-implementation-loop.md` now describe the shared canonical default-branch resolver, canonical fetch, detached-HEAD behavior, fail-closed `canonical-unavailable`, and byte-compatible genuine no-store behavior. The focused documentation mirror test also asserts that the old current-branch wording is absent.

## Verification

Commands used `NUGET_PACKAGES=/private/tmp/g755-nuget NUGET_HTTP_CACHE_PATH=/private/tmp/g755-http-cache`.

- G755 focused real-bare-origin regressions: Passed 6, Failed 0, Skipped 0, Total 6.
- Unmodified `ClaimCommandG747Tests`: Passed 4, Failed 0, Skipped 0, Total 4.
- Unmodified `ClaimCommandG743Tests`: Passed 2, Failed 0, Skipped 0, Total 2.
- Adjacent claim tests (`ClaimCommandG679Tests`, `G680ClaimConsumerTests`, `G717WorkerPathTests`, G743, G747): Passed 29, Failed 0, Skipped 0, Total 29.
- G613 Japanese terminology guard: Passed 6, Failed 0, Skipped 0, Total 6.
- Full Release suite: Passed 5342, Failed 0, Skipped 1, Total 5343.
- `git diff --check`: clean.

The child recorded the supplied host authority for execution-unit:G755. Its child worker selection returned `action=wait`, `source_classification=claim-refused`, because the child registry reported holder none/unheld; issue-preflight was `actionable=true`, `classification=ready-to-implement`, `claim_status=unheld`. This is the known child/host contradiction: orchestration next-action/issue-preflight could not verify the host claim because `.git/FETCH_HEAD` could not be opened, while the supplied host origin/main claim is authoritative. No execution-unit claim was created, modified, verified, or released in the child product repo.