### PR TITLE
G756: report effective external reader topology

### DIFF
--- a/docs/en/05-implementation-loop.md
+++ b/docs/en/05-implementation-loop.md
@@ -154,6 +154,23 @@ existing prohibition is limited to undeclared or ad-hoc routine requests.
 Durable emitted record, validation, and rendered-discovery evidence is in
 [the G736 verification transcript](../g736-topology-host-state-verification.md).
 
+## G756: inspect an external role's effective reader
+
+An `external` resident has a recorded `reader`, but that value can be a
+legacy flat path while domain-scoped event delivery uses another file. The
+read-only `session-layer topology show --domain <domain> --team <team>
+--format json` surface now reports both `reader` (the recorded value) and
+`effective_reader`. The latter comes from the same
+`NotifyEventWriter.TryResolveReadPath` used for event reads, so this surface
+does not invent a second fallback rule. `session-layer topology validate` emits
+the informational `reader-path-divergence` finding when the values differ; it
+names both paths and the path events actually use, while `valid: true` and the
+exit code remain unchanged. A correctly recorded scoped path produces no
+finding. A custom path remains verbatim and produces no finding, and a
+`herdr` resident receives neither reader field nor finding. This is reporting
+only: delivery, legacy upgrade behavior, topology records, and the recorded
+value are not rewritten automatically.
+
 ## G724: worker domain identity on a multi-domain host
 
 The startup marker is display evidence, not a worker binding. In host context,

--- a/docs/ja/05-implementation-loop.md
+++ b/docs/ja/05-implementation-loop.md
@@ -150,6 +150,21 @@ routine request に限られます。
 record、validate、render された discovery の永続的な証拠は
 [G736 verification transcript](../g736-topology-host-state-verification.md) にあります。
 
+## G756: external role の effective reader を確認する
+
+`external` resident には topology に `reader` が記録されますが、legacy の
+flat path が記録され、domain-scoped な event delivery が別の file を使うことがあります。
+read-only の `session-layer topology show --domain <domain> --team <team> --format json` は、
+記録値の `reader` と、実際の読み取り先 `effective_reader` を両方表示します。
+後者は event read と同じ `NotifyEventWriter.TryResolveReadPath` で解決するため、
+この surface が別の fallback rule を推測することはありません。
+`session-layer topology validate` は値が異なると informational な
+`reader-path-divergence` finding を出し、両方の path と event が実際に使う path を示します。
+この差は delivery failure ではないため `valid: true` と exit code は変わりません。
+正しく記録された scoped path では finding はなく、custom path は verbatim のままで finding もありません。
+`herdr` resident には reader field も finding も追加されません。
+これは報告だけの変更であり、delivery、legacy upgrade の動作、topology record、記録値を自動で書き換えません。
+
 ## G724: multi-domain host の worker domain identity
 
 startup marker は display evidence であり、worker binding ではありません。host context の

--- a/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
@@ -148,19 +148,34 @@ internal static class SessionLayerTopologyCommand
             validation = HerdrPaneLabelValidation.Apply(context.RepoRoot, domain!, team!, validation);
         }
 
-        var informationalCount = validation.Findings.Count(finding => finding.IsInformational);
+        var findings = validation.Findings.ToList();
+        if (validation.Valid)
+        {
+            var topologyResolution = NotifyRoleTopologyStore.Resolve(context.RepoRoot, domain!, team!);
+            if (topologyResolution.Resolved)
+            {
+                findings.AddRange(ResolveExternalReaderPaths(
+                    context.RepoRoot,
+                    domain!,
+                    team!,
+                    topologyResolution.Topology!).Findings);
+            }
+        }
+
+        var valid = validation.Valid && findings.All(finding => finding.IsInformational);
+        var informationalCount = findings.Count(finding => finding.IsInformational);
         var result = new SessionLayerTopologyValidationResult
         {
-            Valid = validation.Valid,
-                Team = team!,
-                RecordPath = NotifyRoleTopologyStore.RelativePathFor(domain!, team!),
-                Findings = validation.Findings,
-                RoleDeclarations = validation.RoleDeclarations,
-                HostState = validation.HostState,
-                Summary = (validation.Valid
+            Valid = valid,
+            Team = team!,
+            RecordPath = NotifyRoleTopologyStore.RelativePathFor(domain!, team!),
+            Findings = findings,
+            RoleDeclarations = validation.RoleDeclarations,
+            HostState = validation.HostState,
+            Summary = (valid
                 ? $"Recorded delivery topology for team '{team}' is valid."
                 : $"Recorded delivery topology for team '{team}' is invalid with "
-                    + $"{validation.Findings.Count} finding(s). No topology was changed.")
+                    + $"{findings.Count} finding(s). No topology was changed.")
                 + (informationalCount == 0
                     ? string.Empty
                     : $" {informationalCount} informational finding(s) do not affect valid.")
@@ -240,6 +255,35 @@ internal static class SessionLayerTopologyCommand
         }
 
         var topology = topologyResolution.Topology!;
+        var readerReport = ResolveExternalReaderPaths(context.RepoRoot, domain!, team!, topology);
+        var readerFailure = readerReport.Findings.FirstOrDefault(finding => !finding.IsInformational);
+        if (readerFailure is not null)
+        {
+            var invalid = new SessionLayerTopologyShowResult
+            {
+                Valid = false,
+                Team = team!,
+                WorkspaceId = topology.WorkspaceId,
+                RecordPath = NotifyRoleTopologyStore.RelativePathFor(domain!, team!),
+                Roles = [],
+                EnvelopeProfiles = topology.EnvelopeProfiles.Values
+                    .OrderBy(profile => profile.Name, StringComparer.OrdinalIgnoreCase)
+                    .Select(profile => new SessionLayerTopologyShownProfile
+                    {
+                        Name = profile.Name,
+                        Kind = profile.Kind,
+                        Digest = profile.Digest,
+                        RecordedAt = profile.RecordedAt,
+                    })
+                    .ToArray(),
+                HostState = topology.HostState,
+                Findings = readerReport.Findings,
+                Summary = readerFailure.Message,
+            };
+            EmitShow(writer, format, invalid);
+            return 1;
+        }
+
         var roles = new List<SessionLayerTopologyShownRole>();
         foreach (var (role, record) in topology.Roles.OrderBy(entry => entry.Key, StringComparer.Ordinal))
         {
@@ -290,6 +334,10 @@ internal static class SessionLayerTopologyCommand
                 Frontend = record.Frontend,
                 Model = record.Model,
                 ReasoningEffort = record.ReasoningEffort,
+                Reader = record.Resident == NotifyRecordedRole.ExternalResident ? record.Reader : null,
+                EffectiveReader = readerReport.EffectivePaths.TryGetValue(role, out var effectiveReader)
+                    ? effectiveReader
+                    : null,
             });
         }
 
@@ -311,9 +359,12 @@ internal static class SessionLayerTopologyCommand
                 })
                 .ToArray(),
             HostState = topology.HostState,
-            Findings = [],
+            Findings = readerReport.Findings,
             Summary = $"Resolved {roles.Count} recorded delivery target(s) for team '{team}' without sending."
                 + $" {SessionLayerTopologyDeclaredValueRules.OperatorDeclarationSummary}"
+                + (readerReport.Findings.Count == 0
+                    ? string.Empty
+                    : $" {readerReport.Findings.Count} informational reader-path finding(s) do not affect valid.")
                 + FormatWarnings(topologyResolution.Warnings),
         };
         EmitShow(writer, format, result);
@@ -1187,6 +1238,105 @@ internal static class SessionLayerTopologyCommand
         return 1;
     }
 
+    private static ExternalReaderPathReport ResolveExternalReaderPaths(
+        string routingRoot,
+        string domain,
+        string team,
+        NotifyTeamTopology topology)
+    {
+        var effectivePaths = new Dictionary<string, string>(StringComparer.Ordinal);
+        var findings = new List<SessionLayerTopologyFinding>();
+
+        foreach (var (role, record) in topology.Roles)
+        {
+            if (!string.Equals(record.Resident, NotifyRecordedRole.ExternalResident, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (!NotifyRoleTopologyStore.TryResolveReaderPath(
+                    routingRoot,
+                    record.Reader,
+                    out var recordedReaderPath,
+                    out var recordedReaderError))
+            {
+                findings.Add(new SessionLayerTopologyFinding(
+                    role,
+                    "reader",
+                    "reader-resolution-failed",
+                    $"External role '{role}' could not normalize its recorded reader "
+                    + $"'{record.Reader ?? "<missing>"}': {recordedReaderError}"));
+                continue;
+            }
+
+            if (!NotifyEventWriter.TryResolveReadPath(
+                    routingRoot,
+                    domain,
+                    team,
+                    recordedReaderPath,
+                    out var effectiveReader,
+                    out var readerError))
+            {
+                findings.Add(new SessionLayerTopologyFinding(
+                    role,
+                    "reader",
+                    "reader-resolution-failed",
+                    $"External role '{role}' could not resolve its effective reader from recorded reader "
+                    + $"'{record.Reader ?? "<missing>"}': {readerError}"));
+                continue;
+            }
+
+            effectivePaths[role] = effectiveReader;
+            if (AreEquivalentReaderPaths(routingRoot, record.Reader, effectiveReader))
+            {
+                continue;
+            }
+
+            findings.Add(new SessionLayerTopologyFinding(
+                role,
+                "reader",
+                "reader-path-divergence",
+                $"External role '{role}' records reader '{record.Reader}', but events are delivered to and "
+                + $"read from effective reader '{effectiveReader}'. Update the recorded topology only through "
+                + "an explicit operator decision; this advisory does not change delivery or validity.")
+            {
+                IsInformational = true,
+            });
+        }
+
+        return new ExternalReaderPathReport(effectivePaths, findings);
+    }
+
+    private static bool AreEquivalentReaderPaths(
+        string routingRoot,
+        string? recordedReader,
+        string effectiveReader)
+    {
+        if (recordedReader is null)
+        {
+            return false;
+        }
+
+        // Only NotifyEventWriter.TryResolveReadPath chooses the effective
+        // reader. These full paths normalize the two already-selected values
+        // solely to compare a relative recorded value with an absolute result.
+        var recordedFullPath = NormalizeReaderPath(routingRoot, recordedReader);
+        var effectiveFullPath = NormalizeReaderPath(routingRoot, effectiveReader);
+        return string.Equals(
+            recordedFullPath,
+            effectiveFullPath,
+            OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+    }
+
+    private static string NormalizeReaderPath(string routingRoot, string path) =>
+        Path.GetFullPath(Path.IsPathRooted(path)
+            ? path
+            : Path.Combine(routingRoot, path.Replace('/', Path.DirectorySeparatorChar)));
+
+    private sealed record ExternalReaderPathReport(
+        IReadOnlyDictionary<string, string> EffectivePaths,
+        IReadOnlyList<SessionLayerTopologyFinding> Findings);
+
     private static void EmitValidation(
         TextWriter writer,
         string format,
@@ -1229,9 +1379,12 @@ internal static class SessionLayerTopologyCommand
         writer.WriteLine(result.Summary);
         foreach (var role in result.Roles)
         {
+            var readerDetails = role.Reader is null
+                ? string.Empty
+                : $" reader={role.Reader}; effective_reader={role.EffectiveReader};";
             writer.WriteLine($"- {role.Role}: resident={role.Resident}; delivery_target={role.DeliveryTargetKind}:"
                 + $"{role.DeliveryTarget}; model={role.Model ?? "absent"}; "
-                + $"reasoning_effort={role.ReasoningEffort ?? "absent"};");
+                + $"reasoning_effort={role.ReasoningEffort ?? "absent"};{readerDetails}");
         }
         foreach (var profile in result.EnvelopeProfiles)
         {
@@ -2684,4 +2837,6 @@ internal sealed record SessionLayerTopologyShownRole
     public string? Frontend { get; init; }
     public string? Model { get; init; }
     public string? ReasoningEffort { get; init; }
+    public string? Reader { get; init; }
+    public string? EffectiveReader { get; init; }
 }

--- a/tests/IntentSystem.Cli.Tests/SessionLayerTopologyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerTopologyCommandTests.cs
@@ -12,6 +12,33 @@ public sealed class SessionLayerTopologyCommandTests : IDisposable
     private const string Domain = "intent-cli";
     private const string Team = "g756-team";
     private const string WorkspaceId = "w-g756";
+    // Captured from the parent/pre-change 6ea81ac85e5fc104d5cd954766c916445f751183
+    // with the same healthy external-reader fixture. Keep the complete raw
+    // payload here so compatibility covers ordering, indentation, escaping,
+    // and the trailing newline—not only parsed JSON meaning.
+    private static readonly string ParentHealthyValidationJson = string.Join(
+        Environment.NewLine,
+        [
+            "{",
+            "  \"valid\": true,",
+            "  \"team\": \"g756-team\",",
+            "  \"record_path\": \".intent-cli/topology/intent-cli/g756-team.json\",",
+            "  \"findings\": [],",
+            "  \"role_declarations\": [",
+            "    {",
+            "      \"role\": \"design\"",
+            "    },",
+            "    {",
+            "      \"role\": \"orchestration\"",
+            "    }",
+            "  ],",
+            "  \"host_state\": {",
+            "    \"role\": \"orchestration\",",
+            "    \"envelope\": \"test-owned-host-state\"",
+            "  },",
+            "  \"summary\": \"Recorded delivery topology for team \\u0027g756-team\\u0027 is valid. Model and reasoning effort are operator declarations, not measurements.\"",
+            "}"
+        ]) + Environment.NewLine;
     private readonly string root = Directory.CreateTempSubdirectory("session-layer-topology-g756-").FullName;
 
     [Fact]
@@ -48,17 +75,20 @@ public sealed class SessionLayerTopologyCommandTests : IDisposable
         File.WriteAllText(ScopedEventPath, string.Empty);
         var before = File.ReadAllBytes(TopologyPath);
 
-        var (exitCode, result) = Run(
+        var (exitCode, raw) = RunRaw(
             "session-layer", "topology", "validate",
             "--domain", Domain,
             "--team", Team,
             "--format", "json");
+        using var document = JsonDocument.Parse(raw);
+        var result = document.RootElement.Clone();
 
         Assert.Equal(0, exitCode);
         Assert.True(result.GetProperty("valid").GetBoolean());
         Assert.DoesNotContain(
             result.GetProperty("findings").EnumerateArray(),
             item => item.GetProperty("cause").GetString() == "reader-path-divergence");
+        Assert.Equal(ParentHealthyValidationJson, raw);
         Assert.Equal(before, File.ReadAllBytes(TopologyPath));
     }
 
@@ -221,10 +251,16 @@ public sealed class SessionLayerTopologyCommandTests : IDisposable
 
     private (int ExitCode, JsonElement Result) Run(params string[] args)
     {
+        var (exitCode, raw) = RunRaw(args);
+        using var document = JsonDocument.Parse(raw);
+        return (exitCode, document.RootElement.Clone());
+    }
+
+    private (int ExitCode, string Raw) RunRaw(params string[] args)
+    {
         using var writer = new StringWriter();
         var exitCode = CommandRouter.Execute(args, CreateContext(), writer);
-        using var document = JsonDocument.Parse(writer.ToString());
-        return (exitCode, document.RootElement.Clone());
+        return (exitCode, writer.ToString());
     }
 
     private CliContext CreateContext() => new()

--- a/tests/IntentSystem.Cli.Tests/SessionLayerTopologyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerTopologyCommandTests.cs
@@ -1,0 +1,260 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class SessionLayerTopologyCommandTests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "g756-team";
+    private const string WorkspaceId = "w-g756";
+    private readonly string root = Directory.CreateTempSubdirectory("session-layer-topology-g756-").FullName;
+
+    [Fact]
+    public void Validate_LegacyReaderDivergence_IsAdvisoryAndKeepsExitCode_G756()
+    {
+        const string recordedReader = ".intent-cli/events/g756-team.jsonl";
+        WriteTopology(recordedReader);
+        Directory.CreateDirectory(Path.GetDirectoryName(ScopedEventPath)!);
+        File.WriteAllText(ScopedEventPath, string.Empty);
+
+        var (exitCode, result) = Run(
+            "session-layer", "topology", "validate",
+            "--domain", Domain,
+            "--team", Team,
+            "--format", "json");
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("valid").GetBoolean());
+        var finding = Assert.Single(result.GetProperty("findings").EnumerateArray(), item =>
+            item.GetProperty("cause").GetString() == "reader-path-divergence");
+        Assert.True(finding.GetProperty("is_informational").GetBoolean());
+        var message = finding.GetProperty("message").GetString()!;
+        Assert.Contains(recordedReader, message, StringComparison.Ordinal);
+        Assert.Contains(ScopedEventPath, message, StringComparison.Ordinal);
+        Assert.Contains("delivered", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Validate_SameScopedReader_EmitsNoReaderFinding_G756()
+    {
+        var recordedReader = $".intent-cli/events/{Domain}/{Team}.jsonl";
+        WriteTopology(recordedReader);
+        Directory.CreateDirectory(Path.GetDirectoryName(ScopedEventPath)!);
+        File.WriteAllText(ScopedEventPath, string.Empty);
+        var before = File.ReadAllBytes(TopologyPath);
+
+        var (exitCode, result) = Run(
+            "session-layer", "topology", "validate",
+            "--domain", Domain,
+            "--team", Team,
+            "--format", "json");
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("valid").GetBoolean());
+        Assert.DoesNotContain(
+            result.GetProperty("findings").EnumerateArray(),
+            item => item.GetProperty("cause").GetString() == "reader-path-divergence");
+        Assert.Equal(before, File.ReadAllBytes(TopologyPath));
+    }
+
+    [Fact]
+    public void Show_LegacyReader_ReportsRecordedAndEffectivePaths_G756()
+    {
+        const string recordedReader = ".intent-cli/events/g756-team.jsonl";
+        WriteTopology(recordedReader);
+        Directory.CreateDirectory(Path.GetDirectoryName(ScopedEventPath)!);
+        File.WriteAllText(ScopedEventPath, string.Empty);
+
+        var (exitCode, result) = Run(
+            "session-layer", "topology", "show",
+            "--domain", Domain,
+            "--team", Team,
+            "--format", "json");
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("valid").GetBoolean());
+        var design = Assert.Single(result.GetProperty("roles").EnumerateArray(), item =>
+            item.GetProperty("role").GetString() == "design");
+        Assert.Equal(recordedReader, design.GetProperty("reader").GetString());
+        Assert.Equal(ScopedEventPath, design.GetProperty("effective_reader").GetString());
+        Assert.DoesNotContain(
+            result.GetProperty("roles").EnumerateArray(),
+            item => item.GetProperty("role").GetString() == "orchestration"
+                && item.TryGetProperty("effective_reader", out _));
+    }
+
+    [Fact]
+    public void Show_CustomReader_RemainsVerbatimAndHasNoFinding_G756()
+    {
+        const string customReader = ".intent-cli/events/custom-g756.jsonl";
+        WriteTopology(customReader);
+
+        var (showExit, show) = Run(
+            "session-layer", "topology", "show",
+            "--domain", Domain,
+            "--team", Team,
+            "--format", "json");
+        var (validateExit, validation) = Run(
+            "session-layer", "topology", "validate",
+            "--domain", Domain,
+            "--team", Team,
+            "--format", "json");
+
+        Assert.Equal(0, showExit);
+        Assert.Equal(0, validateExit);
+        var design = Assert.Single(show.GetProperty("roles").EnumerateArray(), item =>
+            item.GetProperty("role").GetString() == "design");
+        Assert.Equal(customReader, design.GetProperty("reader").GetString());
+        Assert.Equal(
+            Path.GetFullPath(Path.Combine(root, customReader.Replace('/', Path.DirectorySeparatorChar))),
+            design.GetProperty("effective_reader").GetString());
+        Assert.DoesNotContain(
+            show.GetProperty("findings").EnumerateArray(),
+            item => item.GetProperty("cause").GetString() == "reader-path-divergence");
+        Assert.DoesNotContain(
+            validation.GetProperty("findings").EnumerateArray(),
+            item => item.GetProperty("cause").GetString() == "reader-path-divergence");
+    }
+
+    [Fact]
+    public void Show_HerdrRole_GainsNoReaderFieldsOrFinding_G756()
+    {
+        WriteHerdrOnlyTopology();
+
+        var (showExit, show) = Run(
+            "session-layer", "topology", "show",
+            "--domain", Domain,
+            "--team", Team,
+            "--format", "json");
+        var (validateExit, validation) = Run(
+            "session-layer", "topology", "validate",
+            "--domain", Domain,
+            "--team", Team,
+            "--format", "json");
+
+        Assert.Equal(0, showExit);
+        Assert.Equal(0, validateExit);
+        var orchestration = Assert.Single(show.GetProperty("roles").EnumerateArray());
+        Assert.Equal("orchestration", orchestration.GetProperty("role").GetString());
+        Assert.False(orchestration.TryGetProperty("reader", out _));
+        Assert.False(orchestration.TryGetProperty("effective_reader", out _));
+        Assert.Empty(show.GetProperty("findings").EnumerateArray());
+        Assert.Empty(validation.GetProperty("findings").EnumerateArray());
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DocumentationMirrors_DescribeEffectiveReaderAndAdvisoryDivergence_G756(string language)
+    {
+        var path = Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, "05-implementation-loop.md");
+        var content = File.ReadAllText(path);
+
+        Assert.Contains("effective_reader", content, StringComparison.Ordinal);
+        Assert.Contains("reader-path-divergence", content, StringComparison.Ordinal);
+        Assert.Contains("legacy", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("custom", content, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void WriteTopology(string recordedReader)
+    {
+        var topology = new JsonObject
+        {
+            ["domain"] = Domain,
+            ["team"] = Team,
+            ["workspace_id"] = WorkspaceId,
+            ["roles"] = new JsonObject
+            {
+                ["design"] = new JsonObject
+                {
+                    ["resident"] = "external",
+                    ["reader"] = recordedReader,
+                    ["frontend"] = "claude-app",
+                },
+                ["orchestration"] = HerdrRole(),
+            },
+            ["host_state"] = new JsonObject
+            {
+                ["role"] = "orchestration",
+                ["envelope"] = "test-owned-host-state",
+            },
+        };
+        WriteTopologyJson(topology);
+    }
+
+    private void WriteHerdrOnlyTopology()
+    {
+        var topology = new JsonObject
+        {
+            ["domain"] = Domain,
+            ["team"] = Team,
+            ["workspace_id"] = WorkspaceId,
+            ["roles"] = new JsonObject { ["orchestration"] = HerdrRole() },
+            ["host_state"] = new JsonObject
+            {
+                ["role"] = "orchestration",
+                ["envelope"] = "test-owned-host-state",
+            },
+        };
+        WriteTopologyJson(topology);
+    }
+
+    private static JsonObject HerdrRole() => new()
+    {
+        ["resident"] = "herdr",
+        ["workspace_id"] = WorkspaceId,
+        ["pane_id"] = $"{WorkspaceId}:p1",
+        ["cwd"] = "/test-owned",
+        ["kind"] = "codex",
+    };
+
+    private void WriteTopologyJson(JsonObject topology)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(TopologyPath)!);
+        File.WriteAllText(TopologyPath, topology.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+    }
+
+    private (int ExitCode, JsonElement Result) Run(params string[] args)
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(args, CreateContext(), writer);
+        using var document = JsonDocument.Parse(writer.ToString());
+        return (exitCode, document.RootElement.Clone());
+    }
+
+    private CliContext CreateContext() => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = Domain,
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+
+    private string TopologyPath => NotifyRoleTopologyStore.ResolvePath(root, Domain, Team);
+
+    private string ScopedEventPath => Path.Combine(
+        root,
+        ".intent-cli",
+        "events",
+        Domain,
+        $"{Team}.jsonl");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1644.

`session-layer topology show --format json` now reports the recorded `reader` and the `effective_reader` for external-resident roles. The effective value is selected by the existing `NotifyEventWriter.TryResolveReadPath` call path after the existing reader safety normalization; no second fallback or delivery resolver was introduced. `topology validate` reports `reader-path-divergence` as informational, naming the recorded and effective paths while preserving `valid: true` and exit code 0. Custom paths stay on their selected path without a finding, and herdr roles receive neither field nor finding.

## Verification

- Parent baseline `6ea81ac85e5fc104d5cd954766c916445f751183`: `git show 6ea81ac85e5fc104d5cd954766c916445f751183:tests/IntentSystem.Cli.Tests/SessionLayerTopologyCommandTests.cs` returned `fatal: path ... exists on disk, but not in ...` (the focused test file was absent).
- G756 focused suite: 7 passed, 0 failed, 0 skipped, 7 total.
- Existing topology suites (G592/G604/G713/G736/G739): 50 passed, 0 failed, 0 skipped, 50 total.
- G613 terminology guard: 6 passed, 0 failed, 0 skipped, 6 total.
- Full Release suite: 5,343 passed, 0 failed, 1 skipped, 5,344 total.
- `git diff --check`: passed.

Delivery, `TryResolveRecordedWritePath`, topology records, legacy upgrade behavior, notify collect, pane resolution, and `delivery_method` are unchanged. The child recorded the known preflight refusal (`.git/FETCH_HEAD` unavailable / canonical-unavailable) and consumed the supplied host claim evidence without creating or mutating a child execution-unit claim.
