### PR TITLE
G757: add role-scoped notify collect

### DIFF
--- a/docs/adr/0012-external-role-cursor-pull.md
+++ b/docs/adr/0012-external-role-cursor-pull.md
@@ -1,0 +1,55 @@
+# ADR 0012: External roles receive by cursor-based pull
+
+- Status: Accepted (preview-through-1.x)
+- Date: 2026-08-29
+- Deciders: Design, orchestration, implementation, and review; recorded by G757
+- Related: G300, G578, G681, G756, G757 / #1645
+
+## Context
+
+An external-resident role has a recorded reader and can already receive a
+durable notification event. It cannot, however, ask what arrived without
+already knowing the task id. Polling a path derived by the role duplicates the
+CLI's reader-resolution rules, while a pushed acknowledgement position would
+add state and a second authority to the receive path.
+
+## Decision
+
+1. `notify collect` gains a role-scoped mode using `--role <role>` instead of
+   `--task-id`. It reads the role's recorded external reader after resolving
+   the effective path through `NotifyEventWriter.TryResolveReadPath`.
+2. The caller may supply an opaque `--since <cursor>`. The result returns a
+   `next_cursor`; the CLI stores no acknowledgement, watermark, or per-reader
+   read position. Resumption therefore remains explicit at the call site and
+   is deterministic without a server-side receive state.
+3. `--wait` is an optional bounded receive operation and requires
+   `--timeout-ms`. A timeout returns the explicit non-error `no-new-events`
+   result. A missing reader is `no-events`, and a cursor that cannot identify
+   an intact position is the explicit `cursor-unhonourable` refusal. Neither
+   case silently resets or skips the caller's position.
+4. The command is a short-lived synchronous read/poll. It creates no daemon,
+   watcher, timer, process, or durable acknowledgement state. Pane-resident
+   wake delivery, transports, supervise, and the existing task-id collection
+   path remain unchanged.
+
+## Consequences
+
+- External roles have a canonical receive surface that can discover work
+  through the durable event stream rather than an out-of-band wake channel.
+- Caller-owned cursors make no-loss/no-duplicate resumption possible while
+  keeping acknowledgement policy outside the CLI.
+- A reader replacement, truncation, or malformed cursor is visible as an
+  explicit refusal instead of causing replay or silent loss.
+- The reader path remains compatible with scoped and legacy event locations
+  because path selection is delegated to the existing shared resolver.
+
+## Rejected alternatives
+
+- Add a second path computation in `notify collect`: rejected because delivery
+  and reading must share `TryResolveReadPath`.
+- Persist a per-role acknowledgement file: rejected because it would create
+  server-side receive state and make caller progress implicit.
+- Reset an invalid cursor to the start or end: rejected because either choice
+  duplicates already-consumed events or silently loses events.
+- Run a background watcher or daemon: rejected because receive is an explicit
+  bounded command and must leave no process or watcher after exit.

--- a/docs/en/05-implementation-loop.md
+++ b/docs/en/05-implementation-loop.md
@@ -53,6 +53,32 @@ copy a long loop body from this document.
 - Select work only via `intent-cli worker next-action`; process at most one action per wake
 - All label transitions go through `intent-cli worker` — never raw `gh ... --add-label`
 
+## G757: external-role cursor-based receive
+
+An external-resident role can receive a durable event without already knowing
+the task id. Use the role-scoped read mode:
+
+```text
+intent-cli notify collect --domain <domain> --team <team> --role <role> \
+  [--since <opaque-cursor>] [--wait --timeout-ms <milliseconds>] --format json
+```
+
+The role must have a recorded external reader. The command resolves that
+reader through `NotifyEventWriter.TryResolveReadPath`, so scoped-versus-legacy
+reader compatibility stays in one place. It performs one immediate read unless
+`--wait` is supplied; `--wait` always requires a bounded `--timeout-ms` and
+returns `cause: "no-new-events"` with a non-error exit when the bound expires.
+A missing reader file is `cause: "no-events"`, not an error.
+
+The cursor is opaque and caller-owned: the CLI stores no acknowledgement or
+read position. Pass the returned `next_cursor` to the next call to resume
+without loss or duplication. If the cursor no longer identifies an intact
+position in the same reader, the command returns the explicit
+`cursor-unhonourable` result and never resets to the beginning or skips to the
+end. The existing `--task-id` collection path and result shape remain
+unchanged. Role collection is a short-lived command; it leaves no watcher,
+timer, process, or other receive state behind.
+
 ## Metadata / label safety
 
 - A child agent never manually applies workflow labels to a PR. For issue-to-PR `pr-created`, canonical `worker complete --kind issue --outcome pr-created --github-only --write` may apply target-repository `intent-target` to the PR; `intent-pr-created` remains an issue-side marker.

--- a/docs/ja/05-implementation-loop.md
+++ b/docs/ja/05-implementation-loop.md
@@ -52,6 +52,32 @@
 - 作業の選択は `intent-cli worker next-action` のみ。1 wake で最大 1 アクション
 - label 遷移はすべて `intent-cli worker` 経由 — raw `gh ... --add-label` は使わない
 
+## G757: external role の cursor-based receive
+
+external-resident の role は、まだ task id を知らなくても durable event を
+受信できます。role-scoped read mode を使います:
+
+```text
+intent-cli notify collect --domain <domain> --team <team> --role <role> \
+  [--since <opaque-cursor>] [--wait --timeout-ms <milliseconds>] --format json
+```
+
+role には記録済みの external reader が必要です。command は reader を
+`NotifyEventWriter.TryResolveReadPath` だけで解決するため、scoped reader と
+legacy reader の互換性は一つの resolver に集約されます。`--wait` がない場合は
+一回だけ即時 read を行い、`--wait` を付ける場合は bounded な
+`--timeout-ms` が必須です。bound 到達時は non-error exit とともに
+`cause: "no-new-events"` を返します。reader file がまだない場合は error ではなく
+`cause: "no-events"` です。
+
+cursor は opaque で caller が所有します。CLI は acknowledgement や read position を
+保存しません。結果の `next_cursor` を次の call に渡すと、event の loss や重複なしに
+再開できます。cursor が同じ reader の intact な位置を指せなくなった場合は
+`cursor-unhonourable` という明示的な result を返し、先頭への reset や末尾への skip
+を行いません。既存の `--task-id` collection の path と result shape は変更しません。
+role collection は短命な command であり、終了後に watcher、timer、process、その他の
+receive state を残しません。
+
 ## metadata / label の安全境界
 
 - child agent は PR に workflow label を手動で付けません。issue-to-PR の `pr-created` では、canonical な `worker complete --kind issue --outcome pr-created --github-only --write` が target repository の PR に `intent-target` を付けることがあります。`intent-pr-created` は issue 側の marker のままです。

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -40,8 +41,12 @@ internal static class NotifyCommand
         + "[--routing-root <host-root>] [--report-root <role-work-root>] [--dry-run|--write] [--format markdown|json]";
 
     private const string CollectUsage =
-        "Usage: intent-cli notify collect --domain <d> --team <t> --task-id <id> "
+        "Usage: intent-cli notify collect --domain <d> --team <t> (--task-id <id> | --role <role> "
+        + "[--since <cursor>] [--wait --timeout-ms <milliseconds>]) "
         + "[--routing-root <host-root>] [--report-root <role-work-root>] [--dry-run|--write] [--format markdown|json]";
+
+    private const int MaximumRoleCollectTimeoutMilliseconds = 300_000;
+    private const int RoleCollectPollMilliseconds = 25;
 
     private const string ReconcileUsage =
         "Usage: intent-cli notify reconcile --domain <d> --team <t> --task-id <id> "
@@ -460,6 +465,11 @@ internal static class NotifyCommand
         string routingRoot,
         string reportRoot)
     {
+        if (options.Role is not null)
+        {
+            return ExecuteRoleCollect(writer, options, routingRoot);
+        }
+
         var pending = NotifyPendingDelegationStore.Find(routingRoot, options.Domain, options.Team, options.TaskId!);
         var outbox = pending.Resolved && pending.Record is not null
             ? NotifyReportOutboxStore.Find(reportRoot, options.Domain!, options.Team!, options.TaskId!, pending.Record.ResultNonce)
@@ -531,6 +541,415 @@ internal static class NotifyCommand
             existingOutbox: outbox.Entry,
             reportRoot: reportRoot);
     }
+
+    private static int ExecuteRoleCollect(
+        TextWriter writer,
+        NotifyOptions options,
+        string routingRoot)
+    {
+        var topology = NotifyRoleTopologyStore.Resolve(routingRoot, options.Domain!, options.Team!);
+        if (!topology.Resolved || topology.Topology is not { } teamTopology)
+        {
+            EmitRoleCollect(writer, options.Format, RoleCollectFailure(
+                options,
+                null,
+                topology.Cause ?? "topology-unavailable",
+                topology.Summary));
+            return 1;
+        }
+
+        var roleResolution = NotifyRoleTopologyStore.ResolveRecordedRole(teamTopology, options.Role!);
+        if (!roleResolution.Resolved || roleResolution.Record is not { } recordedRole)
+        {
+            EmitRoleCollect(writer, options.Format, RoleCollectFailure(
+                options,
+                null,
+                roleResolution.Cause ?? "unknown-role",
+                roleResolution.Summary));
+            return 1;
+        }
+
+        if (!string.Equals(recordedRole.Resident, NotifyRecordedRole.ExternalResident, StringComparison.Ordinal))
+        {
+            EmitRoleCollect(writer, options.Format, RoleCollectFailure(
+                options,
+                null,
+                "role-reader-unavailable",
+                $"Logical role '{options.Role}' is resident in herdr and has no external reader. "
+                + "Role-scoped collect is available only for a role with a recorded external reader."));
+            return 1;
+        }
+
+        if (!NotifyRoleTopologyStore.TryResolveReaderPath(
+                routingRoot,
+                recordedRole.Reader,
+                out var recordedReaderPath,
+                out var recordedReaderError))
+        {
+            EmitRoleCollect(writer, options.Format, RoleCollectFailure(
+                options,
+                null,
+                "reader-unavailable",
+                $"External logical role '{options.Role}' has no usable recorded reader: {recordedReaderError}"));
+            return 1;
+        }
+
+        // The topology record is only the declared input. The effective path,
+        // including scoped-versus-legacy compatibility, belongs to the same
+        // resolver used by the writer and every other reader. Re-resolving on
+        // each bounded wait pass also observes a canonical file appearing
+        // after a previously missing reader.
+        var readerPath = string.Empty;
+        var stopwatch = options.Wait ? System.Diagnostics.Stopwatch.StartNew() : null;
+        while (true)
+        {
+            if (!NotifyEventWriter.TryResolveReadPath(
+                    routingRoot,
+                    options.Domain!,
+                    options.Team!,
+                    recordedReaderPath,
+                    out readerPath,
+                    out var readerError))
+            {
+                EmitRoleCollect(writer, options.Format, RoleCollectFailure(
+                    options,
+                    null,
+                    "reader-unavailable",
+                    $"Could not resolve the effective reader for external logical role '{options.Role}': {readerError}"));
+                return 1;
+            }
+
+            var read = ReadRoleCollectSnapshot(readerPath, recordedReaderPath, options.Since);
+            if (!read.Succeeded)
+            {
+                EmitRoleCollect(writer, options.Format, RoleCollectFailure(
+                    options,
+                    readerPath,
+                    read.Cause!,
+                    read.Summary!));
+                return 1;
+            }
+
+            if (read.Events.Count > 0)
+            {
+                EmitRoleCollect(writer, options.Format, RoleCollectSuccess(
+                    options,
+                    readerPath,
+                    read,
+                    outcome: "events",
+                    cause: null,
+                    timedOut: false,
+                    summary: $"Collected {read.Events.Count} event(s) for external logical role '{options.Role}' from the effective reader."));
+                return 0;
+            }
+
+            if (!options.Wait)
+            {
+                EmitRoleCollect(writer, options.Format, RoleCollectSuccess(
+                    options,
+                    readerPath,
+                    read,
+                    outcome: "no-events",
+                    cause: "no-events",
+                    timedOut: false,
+                    summary: File.Exists(readerPath)
+                        ? $"No events are available for external logical role '{options.Role}' after the supplied cursor; the read was non-blocking."
+                        : $"The effective reader '{readerPath}' does not exist yet; treating it as no-events for external logical role '{options.Role}'."));
+                return 0;
+            }
+
+            var elapsedMilliseconds = stopwatch!.ElapsedMilliseconds;
+            var remainingMilliseconds = options.TimeoutMilliseconds!.Value - elapsedMilliseconds;
+            if (remainingMilliseconds <= 0)
+            {
+                EmitRoleCollect(writer, options.Format, RoleCollectSuccess(
+                    options,
+                    readerPath,
+                    read,
+                    outcome: "no-new-events",
+                    cause: "no-new-events",
+                    timedOut: true,
+                    summary: $"No new events arrived for external logical role '{options.Role}' before the bounded {options.TimeoutMilliseconds.Value}ms wait expired."));
+                return 0;
+            }
+
+            // A synchronous bounded poll keeps the command single-process and
+            // leaves no watcher, timer, or background task after return.
+            Thread.Sleep((int)Math.Min(RoleCollectPollMilliseconds, remainingMilliseconds));
+        }
+    }
+
+    private static NotifyRoleCollectResult RoleCollectSuccess(
+        NotifyOptions options,
+        string readerPath,
+        NotifyRoleCollectReadResult read,
+        string outcome,
+        string? cause,
+        bool timedOut,
+        string summary) => new()
+        {
+            Operation = OperationCollect,
+            RoutingRoot = options.RoutingRoot!,
+            Domain = options.Domain!,
+            Team = options.Team!,
+            Role = options.Role!,
+            ReaderPath = readerPath,
+            CommandMode = options.Write ? "write" : "dry-run",
+            Cursor = options.Since,
+            NextCursor = read.NextCursor,
+            Events = read.Events,
+            Outcome = outcome,
+            Wait = options.Wait,
+            TimedOut = timedOut,
+            Cause = cause,
+            Summary = summary,
+        };
+
+    private static NotifyRoleCollectResult RoleCollectFailure(
+        NotifyOptions options,
+        string? readerPath,
+        string cause,
+        string summary) => new()
+        {
+            Operation = OperationCollect,
+            RoutingRoot = options.RoutingRoot ?? string.Empty,
+            Domain = options.Domain,
+            Team = options.Team,
+            Role = options.Role,
+            ReaderPath = readerPath,
+            CommandMode = options.Write ? "write" : "dry-run",
+            Cursor = options.Since,
+            NextCursor = string.Empty,
+            Events = [],
+            Outcome = "error",
+            Wait = options.Wait,
+            TimedOut = false,
+            Cause = cause,
+            Summary = summary,
+        };
+
+    private static void EmitRoleCollect(TextWriter writer, string format, NotifyRoleCollectResult result)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+            return;
+        }
+
+        writer.WriteLine($"# notify collect — {result.Role ?? "<role>"}");
+        writer.WriteLine();
+        writer.WriteLine($"- command mode: {result.CommandMode}");
+        if (result.ReaderPath is not null)
+        {
+            writer.WriteLine($"- effective reader: `{result.ReaderPath}`");
+        }
+        if (result.Cursor is not null)
+        {
+            writer.WriteLine($"- cursor: `{result.Cursor}`");
+        }
+        writer.WriteLine($"- next cursor: `{result.NextCursor}`");
+        writer.WriteLine($"- outcome: {result.Outcome}");
+        writer.WriteLine($"- wait: {result.Wait.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"- timed out: {result.TimedOut.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"- events: {result.Events.Count}");
+        if (result.Cause is not null)
+        {
+            writer.WriteLine($"- cause: {result.Cause}");
+        }
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+    }
+
+    private static NotifyRoleCollectReadResult ReadRoleCollectSnapshot(
+        string readerPath,
+        string cursorReaderPath,
+        string? suppliedCursor)
+    {
+        byte[] bytes;
+        try
+        {
+            using var stream = new FileStream(
+                readerPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            using var buffer = new MemoryStream();
+            stream.CopyTo(buffer);
+            bytes = buffer.ToArray();
+        }
+        catch (FileNotFoundException)
+        {
+            bytes = [];
+        }
+        catch (DirectoryNotFoundException)
+        {
+            bytes = [];
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            return NotifyRoleCollectReadResult.Failure(
+                "reader-unreadable",
+                $"The effective reader '{readerPath}' could not be read: {exception.Message}");
+        }
+
+        var completeEnd = CompleteLineEnd(bytes);
+        var startOffset = 0;
+        if (suppliedCursor is not null)
+        {
+            if (!TryDecodeRoleCollectCursor(suppliedCursor, out var cursor, out var cursorError)
+                || cursor is null)
+            {
+                return NotifyRoleCollectReadResult.Failure(
+                    "cursor-unhonourable",
+                    $"The supplied --since cursor is unhonourable: {cursorError} refusing to reset or skip events.");
+            }
+
+            if (cursor.Version != 1
+                || !string.Equals(cursor.ReaderDigest, Digest(cursorReaderPath), StringComparison.Ordinal)
+                || cursor.ByteOffset < 0
+                || cursor.ByteOffset > bytes.Length
+                || cursor.ByteOffset > int.MaxValue
+                || cursor.ByteOffset > 0 && bytes[cursor.ByteOffset - 1] != (byte)'\n'
+                || cursor.CompleteLineCount != CountCompleteLines(bytes, (int)cursor.ByteOffset)
+                || !string.Equals(
+                    cursor.PrefixDigest,
+                    Digest(bytes.AsSpan(0, (int)cursor.ByteOffset)),
+                    StringComparison.Ordinal))
+            {
+                return NotifyRoleCollectReadResult.Failure(
+                    "cursor-unhonourable",
+                    "The supplied --since cursor no longer identifies an intact complete-line position in the same effective reader; refusing to reset or skip events.");
+            }
+
+            startOffset = (int)cursor.ByteOffset;
+        }
+
+        var events = new List<NotifyDesignEvent>();
+        var position = startOffset;
+        while (position < completeEnd)
+        {
+            var lineStart = position;
+            while (position < completeEnd && bytes[position] != (byte)'\n')
+            {
+                position++;
+            }
+
+            var lineLength = position - lineStart;
+            if (lineLength > 0 && bytes[lineStart + lineLength - 1] == (byte)'\r')
+            {
+                lineLength--;
+            }
+
+            if (lineLength == 0)
+            {
+                return NotifyRoleCollectReadResult.Failure(
+                    "reader-invalid",
+                    $"The effective reader '{readerPath}' contains an empty JSONL record; refusing to guess its cursor position.");
+            }
+
+            try
+            {
+                var designEvent = JsonSerializer.Deserialize<NotifyDesignEvent>(
+                    bytes.AsSpan(lineStart, lineLength));
+                if (designEvent is null)
+                {
+                    throw new JsonException("record deserialized to null");
+                }
+
+                events.Add(designEvent);
+            }
+            catch (Exception exception) when (exception is JsonException or NotSupportedException)
+            {
+                return NotifyRoleCollectReadResult.Failure(
+                    "reader-invalid",
+                    $"The effective reader '{readerPath}' contains an invalid JSONL record at byte {lineStart}: {exception.Message}");
+            }
+
+            position++;
+        }
+
+        return new NotifyRoleCollectReadResult
+        {
+            Succeeded = true,
+            Events = events,
+            NextCursor = EncodeRoleCollectCursor(cursorReaderPath, bytes, completeEnd),
+        };
+    }
+
+    private static int CompleteLineEnd(byte[] bytes)
+    {
+        if (bytes.Length == 0 || bytes[^1] == (byte)'\n')
+        {
+            return bytes.Length;
+        }
+
+        var lastNewline = Array.LastIndexOf(bytes, (byte)'\n');
+        return lastNewline < 0 ? 0 : lastNewline + 1;
+    }
+
+    private static int CountCompleteLines(byte[] bytes, int end)
+    {
+        var count = 0;
+        for (var index = 0; index < end; index++)
+        {
+            if (bytes[index] == (byte)'\n')
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static string EncodeRoleCollectCursor(string readerPath, byte[] bytes, int byteOffset)
+    {
+        var cursor = new NotifyRoleCollectCursor
+        {
+            Version = 1,
+            ReaderDigest = Digest(readerPath),
+            ByteOffset = byteOffset,
+            CompleteLineCount = CountCompleteLines(bytes, byteOffset),
+            PrefixDigest = Digest(bytes.AsSpan(0, byteOffset)),
+        };
+        var json = JsonSerializer.SerializeToUtf8Bytes(cursor);
+        return Convert.ToBase64String(json)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    private static bool TryDecodeRoleCollectCursor(
+        string value,
+        out NotifyRoleCollectCursor? cursor,
+        out string error)
+    {
+        cursor = null;
+        error = "the cursor is not a valid opaque cursor token.";
+        try
+        {
+            var encoded = value.Replace('-', '+')
+                .Replace('_', '/');
+            encoded = encoded.PadRight(encoded.Length + ((4 - encoded.Length % 4) % 4), '=');
+            var json = Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
+            cursor = JsonSerializer.Deserialize<NotifyRoleCollectCursor>(json);
+            if (cursor is null)
+            {
+                return false;
+            }
+
+            error = string.Empty;
+            return true;
+        }
+        catch (Exception exception) when (exception is FormatException or JsonException or NotSupportedException)
+        {
+            error = exception.Message;
+            return false;
+        }
+    }
+
+    private static string Digest(string value) => Digest(Encoding.UTF8.GetBytes(value));
+
+    private static string Digest(ReadOnlySpan<byte> value) => Convert.ToHexString(SHA256.HashData(value));
 
     private static int ExecuteReconcile(
         TextWriter writer,
@@ -2397,6 +2816,8 @@ internal static class NotifyCommand
         string? toRole = null;
         string? reportToRole = null;
         string? taskId = null;
+        string? role = null;
+        string? since = null;
         string? objective = null;
         string? resultNonce = null;
         string? status = null;
@@ -2422,6 +2843,7 @@ internal static class NotifyCommand
         int? claimedSilentMinutes = null;
         int? backlogIdleMinutes = null;
         int? repairSilentMinutes = null;
+        int? timeoutMilliseconds = null;
         var inputs = new List<string>();
         var expectedArtifacts = new List<string>();
         var preApprovalAcceptRules = new List<NotifyPreApprovalRule>();
@@ -2431,6 +2853,7 @@ internal static class NotifyCommand
         var autoRedispatch = false;
         var once = false;
         var eventMode = false;
+        var wait = false;
         var format = FormatMarkdown;
         error = string.Empty;
 
@@ -2445,6 +2868,8 @@ internal static class NotifyCommand
                 case "--to": if (!ReadValue(args, ref index, argument, out toRole, out error)) return false; break;
                 case "--report-to": if (!ReadValue(args, ref index, argument, out reportToRole, out error)) return false; break;
                 case "--task-id": if (!ReadValue(args, ref index, argument, out taskId, out error)) return false; break;
+                case "--role": if (!ReadValue(args, ref index, argument, out role, out error)) return false; break;
+                case "--since": if (!ReadValue(args, ref index, argument, out since, out error)) return false; break;
                 case "--objective": if (!ReadValue(args, ref index, argument, out objective, out error)) return false; break;
                 case "--result-nonce": if (!ReadValue(args, ref index, argument, out resultNonce, out error)) return false; break;
                 case "--status": if (!ReadValue(args, ref index, argument, out status, out error)) return false; break;
@@ -2547,6 +2972,15 @@ internal static class NotifyCommand
                     }
                     repairSilentMinutes = parsedRepair;
                     break;
+                case "--timeout-ms":
+                    if (!ReadValue(args, ref index, argument, out var timeoutValue, out error)
+                        || !int.TryParse(timeoutValue, NumberStyles.None, CultureInfo.InvariantCulture, out var parsedTimeout))
+                    {
+                        error = "--timeout-ms requires a whole-number milliseconds value.";
+                        return false;
+                    }
+                    timeoutMilliseconds = parsedTimeout;
+                    break;
                 case "--pre-approve":
                     if (!ReadValue(args, ref index, argument, out var acceptRuleValue, out error)
                         || !NotifyPreApprovalPolicyStore.TryParseRule(acceptRuleValue!, out var acceptRule))
@@ -2616,6 +3050,7 @@ internal static class NotifyCommand
                 case "--auto-redispatch": autoRedispatch = true; break;
                 case "--once": once = true; break;
                 case "--event-mode": eventMode = true; break;
+                case "--wait": wait = true; break;
                 case "--format":
                     if (!ReadValue(args, ref index, argument, out format, out error)) return false;
                     if (format is not FormatJson and not FormatMarkdown)
@@ -2638,6 +3073,8 @@ internal static class NotifyCommand
             ToRole = toRole,
             ReportToRole = reportToRole,
             TaskId = taskId,
+            Role = role,
+            Since = since,
             Objective = objective,
             Inputs = inputs,
             ExpectedArtifacts = expectedArtifacts,
@@ -2665,6 +3102,7 @@ internal static class NotifyCommand
             ClaimedSilentMinutes = claimedSilentMinutes,
             BacklogIdleMinutes = backlogIdleMinutes,
             RepairSilentMinutes = repairSilentMinutes,
+            TimeoutMilliseconds = timeoutMilliseconds,
             PreApprovalAcceptRules = preApprovalAcceptRules,
             PreApprovalEscalateRules = preApprovalEscalateRules,
             ScopedPolicies = scopedPolicies,
@@ -2672,6 +3110,7 @@ internal static class NotifyCommand
             AutoRedispatch = autoRedispatch,
             Once = once,
             EventMode = eventMode,
+            Wait = wait,
             Format = format,
         };
 
@@ -2684,7 +3123,9 @@ internal static class NotifyCommand
         var requiredIdentity = string.Equals(operation, OperationStatus, StringComparison.Ordinal)
             ? new[] { ("--task-id", options.TaskId) }
             : string.Equals(operation, OperationCollect, StringComparison.Ordinal)
-                ? new[] { ("--domain", options.Domain), ("--team", options.Team), ("--task-id", options.TaskId) }
+                ? options.Role is not null
+                    ? new[] { ("--domain", options.Domain), ("--team", options.Team), ("--role", options.Role) }
+                    : new[] { ("--domain", options.Domain), ("--team", options.Team), ("--task-id", options.TaskId) }
             : string.Equals(operation, OperationReconcile, StringComparison.Ordinal)
                 ? new[] { ("--domain", options.Domain), ("--team", options.Team), ("--task-id", options.TaskId) }
             : string.Equals(operation, OperationSupervise, StringComparison.Ordinal)
@@ -2712,6 +3153,16 @@ internal static class NotifyCommand
         if (options.Team is not null
             && !NotifyEventWriter.TryValidateTeam(options.Team, out error))
         {
+            return false;
+        }
+
+        if (!string.Equals(operation, OperationCollect, StringComparison.Ordinal)
+            && (options.Role is not null
+                || options.Since is not null
+                || options.Wait
+                || options.TimeoutMilliseconds is not null))
+        {
+            error = "--role, --since, --wait, and --timeout-ms are supported only by notify collect.";
             return false;
         }
 
@@ -2879,10 +3330,54 @@ internal static class NotifyCommand
         }
         else if (string.Equals(operation, OperationCollect, StringComparison.Ordinal))
         {
+            if ((options.TaskId is null) == (options.Role is null))
+            {
+                error = "collect requires exactly one of --task-id or --role.";
+                return false;
+            }
+
             if (options.FromRole is not null || options.ToRole is not null || options.Status is not null
                 || options.Artifact is not null || options.Summary is not null)
             {
-                error = "collect reads the persisted outbox entry; it accepts only domain, team, task-id, routing-root, write/dry-run, and format.";
+                error = options.Role is not null
+                    ? "role-scoped collect accepts only domain, team, role, since, wait, timeout-ms, routing-root, write/dry-run, and format."
+                    : "collect reads the persisted outbox entry; it accepts only domain, team, task-id, routing-root, write/dry-run, and format.";
+                return false;
+            }
+
+            if (options.Role is null
+                && (options.Since is not null || options.Wait || options.TimeoutMilliseconds is not null))
+            {
+                error = "--since, --wait, and --timeout-ms are supported only with role-scoped collect (--role).";
+                return false;
+            }
+
+            if (options.Role is not null)
+            {
+                if (options.Wait && options.TimeoutMilliseconds is null)
+                {
+                    error = "role-scoped collect --wait requires --timeout-ms with a bounded duration.";
+                    return false;
+                }
+
+                if (!options.Wait && options.TimeoutMilliseconds is not null)
+                {
+                    error = "role-scoped collect --timeout-ms requires --wait.";
+                    return false;
+                }
+
+                if (options.TimeoutMilliseconds is not null
+                    && (options.TimeoutMilliseconds < 1
+                        || options.TimeoutMilliseconds > MaximumRoleCollectTimeoutMilliseconds))
+                {
+                    error = $"role-scoped collect --timeout-ms must be between 1 and {MaximumRoleCollectTimeoutMilliseconds} milliseconds.";
+                    return false;
+                }
+            }
+
+            if (options.Role is not null && options.TaskId is not null)
+            {
+                error = "collect requires exactly one of --task-id or --role; do not supply both.";
                 return false;
             }
         }
@@ -2993,6 +3488,8 @@ internal sealed record NotifyOptions
     public string? ToRole { get; init; }
     public string? ReportToRole { get; init; }
     public string? TaskId { get; init; }
+    public string? Role { get; init; }
+    public string? Since { get; init; }
     public string? Objective { get; init; }
     public required IReadOnlyList<string> Inputs { get; init; }
     public required IReadOnlyList<string> ExpectedArtifacts { get; init; }
@@ -3020,12 +3517,14 @@ internal sealed record NotifyOptions
     public int? ClaimedSilentMinutes { get; init; }
     public int? BacklogIdleMinutes { get; init; }
     public int? RepairSilentMinutes { get; init; }
+    public int? TimeoutMilliseconds { get; init; }
     public required IReadOnlyList<NotifyPreApprovalRule> PreApprovalAcceptRules { get; init; }
     public required IReadOnlyList<NotifyPreApprovalRule> PreApprovalEscalateRules { get; init; }
     public required IReadOnlyList<NotifyScopedPromptPolicy> ScopedPolicies { get; init; }
     public bool AutoRedispatch { get; init; }
     public bool Once { get; init; }
     public bool EventMode { get; init; }
+    public bool Wait { get; init; }
     public bool Write { get; init; }
     public required string Format { get; init; }
 }
@@ -3077,6 +3576,51 @@ internal sealed record NotifyResult
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ContinuationChainId => ContinuationChain?.ChainId;
     [JsonPropertyName("summary")] public required string Summary { get; init; }
+}
+
+internal sealed record NotifyRoleCollectResult
+{
+    [JsonPropertyName("operation")] public required string Operation { get; init; }
+    [JsonPropertyName("routing_root")] public required string RoutingRoot { get; init; }
+    [JsonPropertyName("domain")] public string? Domain { get; init; }
+    [JsonPropertyName("team")] public string? Team { get; init; }
+    [JsonPropertyName("role")] public string? Role { get; init; }
+    [JsonPropertyName("reader_path")] public string? ReaderPath { get; init; }
+    [JsonPropertyName("command_mode")] public required string CommandMode { get; init; }
+    [JsonPropertyName("cursor")] public string? Cursor { get; init; }
+    [JsonPropertyName("next_cursor")] public required string NextCursor { get; init; }
+    [JsonPropertyName("events")] public required IReadOnlyList<NotifyDesignEvent> Events { get; init; }
+    [JsonPropertyName("outcome")] public required string Outcome { get; init; }
+    [JsonPropertyName("wait")] public bool Wait { get; init; }
+    [JsonPropertyName("timed_out")] public bool TimedOut { get; init; }
+    [JsonPropertyName("cause")] public string? Cause { get; init; }
+    [JsonPropertyName("summary")] public required string Summary { get; init; }
+}
+
+internal sealed record NotifyRoleCollectReadResult
+{
+    public required bool Succeeded { get; init; }
+    public IReadOnlyList<NotifyDesignEvent> Events { get; init; } = [];
+    public required string NextCursor { get; init; }
+    public string? Cause { get; init; }
+    public string? Summary { get; init; }
+
+    public static NotifyRoleCollectReadResult Failure(string cause, string summary) => new()
+    {
+        Succeeded = false,
+        NextCursor = string.Empty,
+        Cause = cause,
+        Summary = summary,
+    };
+}
+
+internal sealed record NotifyRoleCollectCursor
+{
+    [JsonPropertyName("version")] public int Version { get; init; }
+    [JsonPropertyName("reader_digest")] public string ReaderDigest { get; init; } = string.Empty;
+    [JsonPropertyName("byte_offset")] public long ByteOffset { get; init; }
+    [JsonPropertyName("complete_line_count")] public int CompleteLineCount { get; init; }
+    [JsonPropertyName("prefix_digest")] public string PrefixDigest { get; init; } = string.Empty;
 }
 
 internal sealed record NotifyReconciliationResult

--- a/tests/IntentSystem.Cli.Tests/NotifyCollectCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyCollectCommandTests.cs
@@ -1,0 +1,256 @@
+using System.Diagnostics;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class NotifyCollectCommandTests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 8, 29, 18, 0, 0, TimeSpan.Zero);
+    private readonly Workspace workspace = new();
+
+    public void Dispose() => workspace.Dispose();
+
+    [Fact]
+    public void RoleCollectUsesReturnedCursorWithoutLossOrDuplicate()
+    {
+        workspace.AppendEvent("G757-first", "first");
+        workspace.AppendEvent("G757-second", "second");
+
+        var first = workspace.Run(RoleCollectArgs());
+        Assert.Equal(0, first.ExitCode);
+        Assert.Equal("events", first.Result.GetProperty("outcome").GetString());
+        Assert.Equal(workspace.ScopedEventPath, first.Result.GetProperty("reader_path").GetString());
+        Assert.Equal(
+            ["G757-first", "G757-second"],
+            EventUnits(first.Result));
+        var firstCursor = first.Result.GetProperty("next_cursor").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(firstCursor));
+
+        workspace.AppendEvent("G757-third", "third");
+        var resumed = workspace.Run(RoleCollectArgs("--since", firstCursor!));
+        Assert.Equal(0, resumed.ExitCode);
+        Assert.Equal(["G757-third"], EventUnits(resumed.Result));
+        var resumedCursor = resumed.Result.GetProperty("next_cursor").GetString();
+        Assert.NotEqual(firstCursor, resumedCursor);
+
+        var complete = workspace.Run(RoleCollectArgs("--since", resumedCursor!));
+        Assert.Equal(0, complete.ExitCode);
+        Assert.Empty(EventUnits(complete.Result));
+        Assert.Equal("no-events", complete.Result.GetProperty("cause").GetString());
+    }
+
+    [Fact]
+    public void UnhonourableCursorIsExplicitAndNeverReset()
+    {
+        workspace.AppendEvent("G757-existing", "existing");
+
+        var initial = workspace.Run(RoleCollectArgs());
+        var cursor = initial.Result.GetProperty("next_cursor").GetString()!;
+        File.WriteAllText(workspace.ScopedEventPath, string.Empty);
+
+        var (exitCode, result) = workspace.Run(RoleCollectArgs("--since", cursor));
+
+        Assert.Equal(1, exitCode);
+        Assert.Equal("cursor-unhonourable", result.GetProperty("cause").GetString());
+        Assert.Equal("error", result.GetProperty("outcome").GetString());
+        Assert.Empty(EventUnits(result));
+        Assert.Contains("refusing to reset or skip events", result.GetProperty("summary").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WaitReturnsAfterGenuineSecondWriterAppends()
+    {
+        var appendTask = Task.Run(() =>
+        {
+            Thread.Sleep(100);
+            workspace.AppendEvent("G757-woken", "woken");
+        });
+
+        var stopwatch = Stopwatch.StartNew();
+        var (exitCode, result) = workspace.Run(RoleCollectArgs("--wait", "--timeout-ms", "2000"));
+        stopwatch.Stop();
+        await appendTask;
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("events", result.GetProperty("outcome").GetString());
+        Assert.False(result.GetProperty("timed_out").GetBoolean());
+        Assert.Equal(["G757-woken"], EventUnits(result));
+        Assert.InRange(stopwatch.ElapsedMilliseconds, 50, 1500);
+        Assert.True(appendTask.IsCompleted);
+    }
+
+    [Fact]
+    public void WaitTimeoutIsExplicitNoNewEventsAndNonError()
+    {
+        workspace.CreateEmptyReader();
+        var stopwatch = Stopwatch.StartNew();
+        var (exitCode, result) = workspace.Run(RoleCollectArgs("--wait", "--timeout-ms", "75"));
+        stopwatch.Stop();
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("no-new-events", result.GetProperty("outcome").GetString());
+        Assert.Equal("no-new-events", result.GetProperty("cause").GetString());
+        Assert.True(result.GetProperty("timed_out").GetBoolean());
+        Assert.Empty(EventUnits(result));
+        Assert.InRange(stopwatch.ElapsedMilliseconds, 50, 1000);
+    }
+
+    [Fact]
+    public void NonWaitMissingReaderIsNoEventsAndReturnsImmediately()
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var (exitCode, result) = workspace.Run(RoleCollectArgs());
+        stopwatch.Stop();
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("no-events", result.GetProperty("outcome").GetString());
+        Assert.Equal("no-events", result.GetProperty("cause").GetString());
+        Assert.Empty(EventUnits(result));
+        Assert.False(string.IsNullOrWhiteSpace(result.GetProperty("next_cursor").GetString()));
+        Assert.InRange(stopwatch.ElapsedMilliseconds, 0, 500);
+
+        workspace.AppendEvent("G757-after-missing", "after missing reader");
+        var resumed = workspace.Run(RoleCollectArgs(
+            "--since", result.GetProperty("next_cursor").GetString()!));
+        Assert.Equal(0, resumed.ExitCode);
+        Assert.Equal(["G757-after-missing"], EventUnits(resumed.Result));
+    }
+
+    [Fact]
+    public void WaitRequiresBoundedTimeout()
+    {
+        var raw = workspace.RunRaw(
+            "notify", "collect", "--domain", Workspace.Domain, "--team", Workspace.Team,
+            "--role", Workspace.Role, "--wait", "--format", "json");
+
+        Assert.Equal(1, raw.ExitCode);
+        Assert.Contains("--wait requires --timeout-ms", raw.Output, StringComparison.Ordinal);
+        Assert.Contains("Usage: intent-cli notify collect", raw.Output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TaskIdCollectKeepsLegacyResultShape()
+    {
+        var raw = workspace.RunRaw(
+            "notify", "collect", "--domain", Workspace.Domain, "--team", Workspace.Team,
+            "--task-id", "G757-legacy-shape", "--format", "json");
+
+        Assert.Equal(1, raw.ExitCode);
+        using var document = JsonDocument.Parse(raw.Output);
+        var result = document.RootElement;
+        Assert.Equal("collect", result.GetProperty("operation").GetString());
+        Assert.Equal("G757-legacy-shape", result.GetProperty("task_id").GetString());
+        Assert.Equal("outbox-entry-unavailable", result.GetProperty("cause").GetString());
+        Assert.False(result.TryGetProperty("role", out _));
+        Assert.False(result.TryGetProperty("events", out _));
+    }
+
+    private static string[] EventUnits(JsonElement result) =>
+        result.GetProperty("events")
+            .EnumerateArray()
+            .Select(item => item.GetProperty("unit").GetString()!)
+            .ToArray();
+
+    private static string[] RoleCollectArgs(params string[] extra)
+    {
+        var args = new List<string>
+        {
+            "notify", "collect", "--domain", Workspace.Domain, "--team", Workspace.Team,
+            "--role", Workspace.Role, "--format", "json",
+        };
+        args.AddRange(extra);
+        return args.ToArray();
+    }
+
+    private sealed class Workspace : IDisposable
+    {
+        public const string Domain = "intent-cli";
+        public const string Team = "intent-cli-dev";
+        public const string Role = "external-review";
+
+        public Workspace()
+        {
+            RootPath = Directory.CreateTempSubdirectory("notify-g757-").FullName;
+            Directory.CreateDirectory(Path.Combine(RootPath, ".intent-cli"));
+            var topologyPath = NotifyRoleTopologyStore.ResolvePath(RootPath, Domain, Team);
+            Directory.CreateDirectory(Path.GetDirectoryName(topologyPath)!);
+            File.WriteAllText(topologyPath, JsonSerializer.Serialize(new
+            {
+                domain = Domain,
+                team = Team,
+                workspace_id = "external-workspace",
+                roles = new Dictionary<string, object>
+                {
+                    [Role] = new
+                    {
+                        resident = NotifyRecordedRole.ExternalResident,
+                        reader = NotifyEventWriter.RelativePathFor(Domain, Team),
+                    },
+                },
+            }));
+        }
+
+        public string RootPath { get; }
+
+        public string ScopedEventPath => Path.Combine(
+            RootPath,
+            NotifyEventWriter.RelativePathFor(Domain, Team).Replace('/', Path.DirectorySeparatorChar));
+
+        public void CreateEmptyReader()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(ScopedEventPath)!);
+            File.WriteAllText(ScopedEventPath, string.Empty);
+        }
+
+        public void AppendEvent(string unit, string summary)
+        {
+            NotifyEventWriter.Append(ScopedEventPath, new NotifyDesignEvent
+            {
+                Timestamp = FixedNow,
+                Team = Team,
+                Kind = "question",
+                Unit = unit,
+                Summary = summary,
+                Artifact = "issue #1645",
+            });
+        }
+
+        public (int ExitCode, JsonElement Result) Run(string[] args)
+        {
+            var raw = RunRaw(args);
+            using var document = JsonDocument.Parse(raw.Output);
+            return (raw.ExitCode, document.RootElement.Clone());
+        }
+
+        public (int ExitCode, string Output) RunRaw(params string[] args)
+        {
+            using var writer = new StringWriter();
+            var exitCode = CommandRouter.Execute(args, CreateContext(), writer);
+            return (exitCode, writer.ToString());
+        }
+
+        private CliContext CreateContext() => new()
+        {
+            RepoRoot = RootPath,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = Domain,
+                    ArtifactRoot = ".intent-cli",
+                },
+            },
+        };
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #1645

## Summary

- Adds `notify collect --role` for external-resident roles.
- Adds caller-owned opaque `--since` / `next_cursor` resumption with prefix and complete-line integrity checks.
- Adds bounded synchronous `--wait --timeout-ms`; timeout is an explicit non-error `no-new-events` result.
- Uses `NotifyEventWriter.TryResolveReadPath` for effective scoped/legacy reader resolution, including re-resolution during a bounded wait.
- Leaves the existing `--task-id` collection path and result shape unchanged.
- Adds the cursor-based pull ADR and matching EN/JA implementation-loop guidance.

## Verification

- Parent baseline: `git show HEAD:tests/IntentSystem.Cli.Tests/NotifyCollectCommandTests.cs` returned `fatal: path ... does not exist in 'HEAD'`; installed `intent-cli 0.27.0-f43fbd1-G753` rejected the new invocation with `invalid-notification: Unknown argument '--role'`.
- Focused role-collect tests: 7 passed, 0 failed.
- Adjacent notify/event-stream suites: 37 passed, 0 failed.
- G613 Japanese terminology guard: 6 passed, 0 failed.
- Full Release suite: Failed 0, Passed 5350, Skipped 1, Total 5351.
- `git diff --check`: passed.
- The wait regression uses a genuine second `NotifyEventWriter.Append` while collect is blocked; missing-reader, cursor resumption, cursor refusal, timeout, required-bound, and task-id compatibility are covered.

## Worker boundary

The supplied authoritative host evidence is consumed: origin/main carries execution-unit:G757 for actor=implementation/team=intent-cli-dev at host commit `c8099f0fd2395fc923e9604970db7b229769570c`. The child GitHub-only selector returned `action=wait` because its local execution-unit:G757 registry is unheld, while child issue-preflight returned `actionable=true`, `classification=ready-to-implement`, `claim_status=unheld`, and the same local unheld refusal. This is the known child/host registry contradiction; no child execution-unit claim was created or mutated.
