### PR TITLE
G759: make file-backed task pointers executable

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1417,7 +1417,7 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --mode autop
   existing record declares `delivery_method: file-backed` through the
   registry-limited topology field update: `notify` writes the unchanged envelope under
   host `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` before sending
-  the pane one line, `Read task envelope: <path>`. Declare `inline` explicitly
+  the pane one line, `Read and execute task envelope: <path>`. Declare `inline` explicitly
   when desired; an absent declaration preserves existing inline delivery.
 - **Post-start interaction (G636, preview-through-1.x).** At the first task,
   Copilot 1.0.78 presents `1. Enable all permissions (recommended)` /
@@ -1973,7 +1973,7 @@ use `topology update-field` with `--field delivery_method --current absent --new
 file-backed` and explicit confirmation; use the same path with the recorded
 current value for a later allowed change. `notify` writes the unchanged envelope to an addressable durable task
 file under `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` before it
-sends the pane the single-line `Read task envelope: <path>` pointer. The file is
+sends the pane the single-line `Read and execute task envelope: <path>` pointer. The file is
 not deleted, so a restarted recipient can read the same task. Declare `inline`
 only to choose it explicitly: without a declaration, the established inline
 delivery remains byte-identical.

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -1214,7 +1214,7 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --mode autop
 - **task-envelope delivery method。** existing record を持つ paste-sensitive な herdr seat では、
   registry-limited topology field update で `delivery_method: file-backed` を宣言します。`notify` は unchanged な envelope を host の
   `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` に書いてから、pane には
-  `Read task envelope: <path>` という 1 行だけを送ります。明示的に選ぶなら `inline` を宣言します。
+  `Read and execute task envelope: <path>` という 1 行だけを送ります。明示的に選ぶなら `inline` を宣言します。
   宣言がなければ既存の inline delivery をそのまま維持します。
 - **post-start interaction (G636, preview-through-1.x)。** 最初の task で Copilot 1.0.78 は
   `1. Enable all permissions (recommended)` / `2. Continue with limited permissions` /
@@ -1689,7 +1689,7 @@ wedge を防ぐものではありません。transport-layer の remedy は G619
 `topology update-field` を使います。後から許可された値を変更するときも、記録済みの現在値を指定して
 同じ経路を使います。`notify` は変更しない envelope をアドレス可能で永続的な
 `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` に書いてから、pane へ
-`Read task envelope: <path>` という 1 行のポインターを送ります。file は削除しないため、再起動
+`Read and execute task envelope: <path>` という 1 行のポインターを送ります。file は削除しないため、再起動
 した recipient も同じ task を読み直せます。明示的に選ぶ場合だけ `inline` を宣言し、宣言がなければ
 確立済みの inline delivery は byte-identical のままです。
 

--- a/src/IntentSystem.Cli/Commands/AgentLaunchRecipeRegistry.cs
+++ b/src/IntentSystem.Cli/Commands/AgentLaunchRecipeRegistry.cs
@@ -245,7 +245,7 @@ internal static class AgentLaunchRecipeRegistry
                 DeliveryMethod =
                     "Declare `delivery_method: file-backed` for a paste-sensitive herdr seat. `notify` writes the "
                     + "unchanged envelope to durable host `.intent-cli/tasks/<domain>/<team>/<task-id>-<nonce>.md` before "
-                    + "sending one line, `Read task envelope: <path>`. Declare `inline` to opt in explicitly; an absent "
+                    + "sending one line, `Read and execute task envelope: <path>`. Declare `inline` to opt in explicitly; an absent "
                     + "declaration preserves existing inline delivery.",
                 PostStartInteraction = new OrchestratorPostStartInteraction
                 {

--- a/src/IntentSystem.Cli/Commands/NotifyTaskEnvelopeStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyTaskEnvelopeStore.cs
@@ -119,7 +119,7 @@ internal sealed record NotifyTaskEnvelopeDelivery
 
         var taskFile = NotifyTaskEnvelopeStore.ResolvePath(
             options.RoutingRoot!, options.Domain!, options.Team!, options.TaskId!, options.ResultNonce!);
-        var pointer = $"Read task envelope: {taskFile}";
+        var pointer = $"Read and execute task envelope: {taskFile}";
         return new NotifyTaskEnvelopeDelivery
         {
             Resolved = true,

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -724,19 +724,111 @@ public sealed class AgentMessageOrchestrationDocsTests
     [Fact]
     public void FileBackedPointerWordingAgreesAcrossRecipeAndMirrors_G759()
     {
-        const string wording = "Read and execute task envelope: <path>";
-        var en = ReadDoc("en");
-        var ja = ReadDoc("ja");
-        var recipe = AgentLaunchRecipeRegistry.Find("copilot")?.DeliveryMethod;
+        const string expectedWording = "Read and execute task envelope: <path>";
+        var root = Directory.CreateTempSubdirectory("notify-g759-agreement-").FullName;
+        try
+        {
+            const string domain = "intent-cli";
+            const string team = "intent-cli-dev";
+            const string taskId = "G759-agreement";
+            const string nonce = "agreement-nonce";
+            var topologyPath = NotifyRoleTopologyStore.ResolvePath(root, domain, team);
+            Directory.CreateDirectory(Path.GetDirectoryName(topologyPath)!);
+            File.WriteAllText(topologyPath, """
+                {
+                  "domain": "intent-cli",
+                  "team": "intent-cli-dev",
+                  "workspace_id": "wH",
+                  "roles": {
+                    "implementation": {
+                      "resident": "herdr",
+                      "kind": "copilot",
+                      "workspace_id": "wH",
+                      "pane_id": "wH:p2",
+                      "delivery_method": "file-backed"
+                    }
+                  }
+                }
+                """);
 
-        Assert.NotNull(recipe);
-        Assert.Contains(wording, recipe, StringComparison.Ordinal);
-        Assert.Contains(wording, en, StringComparison.Ordinal);
-        Assert.Contains(wording, ja, StringComparison.Ordinal);
-        Assert.DoesNotContain("Read task envelope: <path>", recipe, StringComparison.Ordinal);
-        Assert.DoesNotContain("Read task envelope: <path>", en, StringComparison.Ordinal);
-        Assert.DoesNotContain("Read task envelope: <path>", ja, StringComparison.Ordinal);
+            var options = new NotifyOptions
+            {
+                Domain = domain,
+                Team = team,
+                FromRole = "orchestration",
+                ToRole = "implementation",
+                ReportToRole = "orchestration",
+                TaskId = taskId,
+                ResultNonce = nonce,
+                RoutingRoot = root,
+                Inputs = [],
+                ExpectedArtifacts = ["PR"],
+                PreApprovalAcceptRules = [],
+                PreApprovalEscalateRules = [],
+                ScopedPolicies = [],
+                Format = "json",
+            };
+
+            var delivery = NotifyTaskEnvelopeDelivery.Resolve(options, "parent payload");
+            Assert.True(delivery.Resolved, delivery.Summary);
+            Assert.True(delivery.FileBacked, delivery.Summary);
+            var taskFile = NotifyTaskEnvelopeStore.ResolvePath(root, domain, team, taskId, nonce);
+            Assert.Equal(taskFile, delivery.TaskFile);
+            Assert.NotNull(delivery.Pointer);
+            Assert.Equal(delivery.Pointer, delivery.TransportPayload);
+
+            var emittedWording = NormalizeEmittedPointer(delivery.TransportPayload, taskFile);
+            var en = ReadDoc("en");
+            var ja = ReadDoc("ja");
+            var recipe = AgentLaunchRecipeRegistry.Find("copilot")?.DeliveryMethod;
+            Assert.NotNull(recipe);
+
+            var sites = new[]
+            {
+                emittedWording,
+                NormalizeEmbeddedWording(recipe!),
+                NormalizeEmbeddedWording(en),
+                NormalizeEmbeddedWording(ja),
+            };
+            Assert.True(AgreementMatches(sites));
+            Assert.Equal(expectedWording, emittedWording);
+            Assert.DoesNotContain("Read task envelope: <path>", recipe, StringComparison.Ordinal);
+            Assert.DoesNotContain("Read task envelope: <path>", en, StringComparison.Ordinal);
+            Assert.DoesNotContain("Read task envelope: <path>", ja, StringComparison.Ordinal);
+
+            for (var mutatedIndex = 0; mutatedIndex < sites.Length; mutatedIndex++)
+            {
+                var mutated = sites.ToArray();
+                mutated[mutatedIndex] = "Read task envelope: <path>";
+                Assert.False(AgreementMatches(mutated), $"one-site mutation {mutatedIndex} must fail");
+            }
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
     }
+
+    private static string NormalizeEmittedPointer(string pointer, string taskFile)
+    {
+        const string prefix = "Read and execute task envelope: ";
+        Assert.StartsWith(prefix, pointer, StringComparison.Ordinal);
+        var path = pointer[prefix.Length..];
+        Assert.True(Path.IsPathRooted(path));
+        Assert.Equal(taskFile, path);
+        return prefix + "<path>";
+    }
+
+    private static string NormalizeEmbeddedWording(string surface)
+    {
+        const string prefix = "Read and execute task envelope: ";
+        Assert.Contains(prefix, surface, StringComparison.Ordinal);
+        return prefix + "<path>";
+    }
+
+    private static bool AgreementMatches(IReadOnlyList<string> sites) =>
+        sites.Count == 4
+        && sites.All(site => string.Equals(site, sites[0], StringComparison.Ordinal));
 
     private static string ReadDoc(string language)
     {

--- a/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AgentMessageOrchestrationDocsTests.cs
@@ -1,3 +1,5 @@
+using IntentSystem.Cli.Commands;
+
 namespace IntentSystem.Cli.Tests;
 
 /// <summary>
@@ -139,7 +141,7 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("`review-context.md`", en, StringComparison.Ordinal);
         Assert.Contains("842 characters over 14 lines", en, StringComparison.Ordinal);
         Assert.Contains("G619 owns the transport-layer remedy", en, StringComparison.Ordinal);
-        Assert.Contains("Read task envelope: <path>", en, StringComparison.Ordinal);
+        Assert.Contains("Read and execute task envelope: <path>", en, StringComparison.Ordinal);
         Assert.Contains("absent declaration preserves existing inline delivery", en, StringComparison.Ordinal);
         Assert.Contains("never refuses or truncates", en, StringComparison.Ordinal);
         Assert.Contains("broken bracketed-paste", en, StringComparison.Ordinal);
@@ -147,7 +149,7 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("committed canonical な `review-context.md`", ja, StringComparison.Ordinal);
         Assert.Contains("842 文字・14 行", ja, StringComparison.Ordinal);
         Assert.Contains("transport-layer の remedy は G619 が担当", ja, StringComparison.Ordinal);
-        Assert.Contains("Read task envelope: <path>", ja, StringComparison.Ordinal);
+        Assert.Contains("Read and execute task envelope: <path>", ja, StringComparison.Ordinal);
         Assert.Contains("宣言がなければ既存の inline delivery をそのまま維持", ja, StringComparison.Ordinal);
         Assert.Contains("refuse も truncate もしません", ja, StringComparison.Ordinal);
         Assert.Contains("broken bracketed-paste state", ja, StringComparison.Ordinal);
@@ -717,6 +719,23 @@ public sealed class AgentMessageOrchestrationDocsTests
         Assert.Contains("shift+tab are not delivered faithfully", en, StringComparison.Ordinal);
         Assert.Contains("`--permission-mode`", ja, StringComparison.Ordinal);
         Assert.Contains("shift+tab のような modifier chord は忠実に届きません", ja, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FileBackedPointerWordingAgreesAcrossRecipeAndMirrors_G759()
+    {
+        const string wording = "Read and execute task envelope: <path>";
+        var en = ReadDoc("en");
+        var ja = ReadDoc("ja");
+        var recipe = AgentLaunchRecipeRegistry.Find("copilot")?.DeliveryMethod;
+
+        Assert.NotNull(recipe);
+        Assert.Contains(wording, recipe, StringComparison.Ordinal);
+        Assert.Contains(wording, en, StringComparison.Ordinal);
+        Assert.Contains(wording, ja, StringComparison.Ordinal);
+        Assert.DoesNotContain("Read task envelope: <path>", recipe, StringComparison.Ordinal);
+        Assert.DoesNotContain("Read task envelope: <path>", en, StringComparison.Ordinal);
+        Assert.DoesNotContain("Read task envelope: <path>", ja, StringComparison.Ordinal);
     }
 
     private static string ReadDoc(string language)

--- a/tests/IntentSystem.Cli.Tests/Fixtures/G759/parent-file-backed-envelope.md
+++ b/tests/IntentSystem.Cli.Tests/Fixtures/G759/parent-file-backed-envelope.md
@@ -1,0 +1,15 @@
+TASK G578-demo
+role: implementation
+objective: Implement the notification contract
+inputs:
+  - issue #1259
+expected-artifacts:
+  - draft PR URL
+reporting-contract:
+  task-id: G578-demo
+  expected-artifact: draft PR URL
+  canonical-report-command: intent-cli notify report --domain intent-cli --team intent-cli-dev --from implementation --to orchestration --task-id G578-demo --status <completed|blocked|question> --artifact <artifact> --summary <one-line-summary> --routing-root '<workspace-root>' --report-root . --write --format json
+  required-final-step: Run canonical-report-command after all other work; never hand-write a transport invocation.
+result-prefix: ORCH_RESULT
+result-nonce: demo-nonce
+completion-marker: When the artifact is ready, concatenate result-prefix, one space, result-nonce, one space, status, one space, and artifact; use completed, blocked, or question. Do not precompose the marker in this task block.

--- a/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideOrchestratorThreadCommandTests.cs
@@ -2077,7 +2077,7 @@ public sealed class GuideOrchestratorThreadCommandTests
         Assert.Contains("842 characters over 14 lines", output, StringComparison.Ordinal);
         Assert.Contains("G619 owns the transport-layer remedy", output, StringComparison.Ordinal);
         Assert.Contains("delivery_method: file-backed", output, StringComparison.Ordinal);
-        Assert.Contains("Read task envelope: <path>", output, StringComparison.Ordinal);
+        Assert.Contains("Read and execute task envelope: <path>", output, StringComparison.Ordinal);
         Assert.Contains("Preview through 1.x (G636)", output, StringComparison.Ordinal);
         Assert.Contains("post-start interaction", output, StringComparison.Ordinal);
         Assert.Contains("Copilot 1.0.78 presents", output, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrPaneTopologyG586Tests.cs
@@ -17,7 +17,7 @@ public sealed class HerdrPaneTopologyG586Tests : IDisposable
     // G684 extends shared orchestrator guidance with envelope-only recipe drift.
     // G685/G686/G690/G699/G707/G708/G719 intentionally extend the shared guide while preserving
     // the G594 preflight contract. G696/G697/G700 add structured role-facing routes.
-    private const string G594AgmsgBaselineSha256 = "11467512532f745f602718d7ce3b86666e31bdf05162e614e3a0220e93c7ee30";
+    private const string G594AgmsgBaselineSha256 = "b5a1e38ccec10ee9e1208c1deaf6930edb17e0ac5104d2632405e048b76cb88c";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-topology-g586-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/HerdrWakeSourcesG581Tests.cs
@@ -13,7 +13,7 @@ public sealed class HerdrWakeSourcesG581Tests : IDisposable
     // assertion explicit so a future wake-source or route change remains
     // intentional.
     private const string G594AgmsgGuideSha256 =
-        "4D29098CDBFBAE08FEE7EE8205CF939BAA93C0F6BFCC63F70550297FA99BA5D5";
+        "F8A8AB29024721870979B8B394FE75EE09602819AE7D340C69C8C48268C94BCD";
 
     private readonly string root = Directory.CreateTempSubdirectory("herdr-wake-g581-").FullName;
 

--- a/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
@@ -128,6 +128,15 @@ public sealed class NotifyCommandG578Tests : IDisposable
         var payload = result.GetProperty("payload").GetString()!;
         Assert.Equal(payload, File.ReadAllText(taskFile));
         Assert.Equal(Encoding.UTF8.GetBytes(payload), File.ReadAllBytes(taskFile));
+        // This checked-in full-envelope oracle was captured from the parent
+        // invocation. Only the per-test temporary root is substituted.
+        var goldenPath = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "tests", "IntentSystem.Cli.Tests", "Fixtures", "G759",
+            "parent-file-backed-envelope.md");
+        var parentGolden = File.ReadAllText(goldenPath)
+            .Replace("<workspace-root>", workspace.RootPath, StringComparison.Ordinal);
+        Assert.Equal(Encoding.UTF8.GetBytes(parentGolden), File.ReadAllBytes(taskFile));
         Assert.Contains("G578-demo-demo-nonce.md", taskFile, StringComparison.Ordinal);
         Assert.Contains("TASK G578-demo", payload, StringComparison.Ordinal);
         Assert.Contains("result-nonce: demo-nonce", payload, StringComparison.Ordinal);

--- a/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Text.Json;
 using IntentSystem.Cli;
 using IntentSystem.Cli.Commands;
@@ -124,11 +125,15 @@ public sealed class NotifyCommandG578Tests : IDisposable
         var taskFile = result.GetProperty("task_file").GetString()!;
         var pointer = result.GetProperty("delivery_pointer").GetString()!;
         Assert.True(File.Exists(taskFile));
-        Assert.Equal(result.GetProperty("payload").GetString(), File.ReadAllText(taskFile));
+        var payload = result.GetProperty("payload").GetString()!;
+        Assert.Equal(payload, File.ReadAllText(taskFile));
+        Assert.Equal(Encoding.UTF8.GetBytes(payload), File.ReadAllBytes(taskFile));
         Assert.Contains("G578-demo-demo-nonce.md", taskFile, StringComparison.Ordinal);
-        Assert.Contains("TASK G578-demo", File.ReadAllText(taskFile), StringComparison.Ordinal);
-        Assert.Contains("result-nonce: demo-nonce", File.ReadAllText(taskFile), StringComparison.Ordinal);
-        Assert.StartsWith("Read task envelope: ", pointer, StringComparison.Ordinal);
+        Assert.Contains("TASK G578-demo", payload, StringComparison.Ordinal);
+        Assert.Contains("result-nonce: demo-nonce", payload, StringComparison.Ordinal);
+        Assert.True(Path.IsPathRooted(taskFile));
+        Assert.Equal("Read and execute task envelope: " + taskFile, pointer);
+        Assert.StartsWith("Read and execute task envelope: ", pointer, StringComparison.Ordinal);
         Assert.DoesNotContain('\n', pointer);
         Assert.DoesNotContain('\r', pointer);
         var prompt = Assert.Single(runner.Calls, call =>


### PR DESCRIPTION
Closes #1649

## Summary

Change the file-backed delivery line to the exact imperative wording:

`Read and execute task envelope: <absolute-path>`

The absolute task-file path, envelope bytes, file location/name/lifetime, delivery selection, and inline behavior are unchanged. The existing absent-`delivery_method` inline test remains unchanged and green.

The emitted pointer, Copilot `AgentLaunchRecipeRegistry` description, EN/JA orchestration mirrors, and the four existing wording assertions now agree. A dedicated agreement guard rejects drift in the guide and both mirrors; the command-level exact assertion covers the emitted pointer.

## Evidence

- Parent assertions against the changed source: `Failed: 3, Passed: 160, Skipped: 0, Total: 163`. The failures are the unchanged old-wording pins in the EN mirror, JA mirror, and emitted G578 pointer.
- New exact-pointer assertion against the parent pointer: `Failed: 1, Passed: 0, Skipped: 0, Total: 1`; expected `Read and execute task envelope: ...`, actual `Read task envelope: ...`.
- File-backed test verifies the task file is absolute and compares `File.ReadAllBytes(taskFile)` byte-for-byte with UTF-8 bytes of the unchanged emitted envelope payload. The production diff changes only the pointer construction after payload construction; the inline/absent-delivery path is untouched.
- Focused G578: `Failed: 0, Passed: 26, Skipped: 0, Total: 26`.
- Guide/docs plus G578 affected surface: `Failed: 0, Passed: 164, Skipped: 0, Total: 164`.
- Dedicated G613: `Failed: 0, Passed: 6, Skipped: 0, Total: 6`.
- Full Release (`dotnet test IntentSystem.sln -c Release --no-restore`): `Failed: 0, Passed: 5351, Skipped: 1, Total: 5352`.
- `git diff --check`: clean.
- The two G594 generated-guide hash pins were updated only because the required registry wording is part of that intentionally hashed guide surface; parent values pass when the registry line is restored.

## Workflow boundary

The supplied authoritative host claim was consumed without touching or inspecting host state: `execution-unit:G759`, actor `implementation`, team `intent-cli-dev`, claimed at `2026-08-29T19:02:05.932512Z`, base `3b8f14a2f66d3cead2cfbb14c0b27e434a8b0036`. The child next-action selected #1647 and child issue-preflight selected #1649 but returned `claim-unavailable`/`canonical-unavailable` because fresh canonical Git evidence could not open `.git/FETCH_HEAD` (the branch-local check also reported no remote ref for the new branch). This known child/host registry contradiction is recorded; no child execution-unit claim was created or mutated.
