### PR TITLE
G758: use containment for checkout freshness

### DIFF
--- a/src/IntentSystem.Cli/Commands/CheckoutFreshnessProbe.cs
+++ b/src/IntentSystem.Cli/Commands/CheckoutFreshnessProbe.cs
@@ -101,7 +101,85 @@ internal static class CheckoutFreshnessProbe
                 "the origin response did not identify a default branch and HEAD");
         }
 
-        if (string.Equals(localHead, remoteHead, StringComparison.OrdinalIgnoreCase))
+        return DetermineContainment(repoRoot, runner, localHead, defaultBranch, remoteHead);
+    }
+
+    private static CheckoutFreshnessObservation DetermineContainment(
+        string repoRoot,
+        IGitRemoteCommandRunner runner,
+        string localHead,
+        string defaultBranch,
+        string remoteHead)
+    {
+        GitRemoteCommandResult remoteTipObject;
+        try
+        {
+            // A remote tip that is not already in the local object store cannot
+            // be reachable from HEAD. Treat that absence as a real stale
+            // result without fetching or otherwise mutating the checkout.
+            remoteTipObject = runner.Run(
+                repoRoot,
+                ["cat-file", "-e", $"{remoteHead}^{{commit}}"]);
+        }
+        catch (Exception exception) when (IsProbeFailure(exception))
+        {
+            return UnknownObservation(
+                localHead,
+                defaultBranch,
+                remoteHead,
+                $"the origin default branch tip could not be checked locally ({exception.Message})");
+        }
+
+        if (remoteTipObject.TimedOut)
+        {
+            return UnknownObservation(
+                localHead,
+                defaultBranch,
+                remoteHead,
+                FirstNonEmpty(
+                    remoteTipObject.StdErr,
+                    $"git cat-file -e {remoteHead}^{{commit}} timed out after {DefaultTimeout.TotalSeconds:0.###} seconds"));
+        }
+
+        if (remoteTipObject.ExitCode != 0)
+        {
+            return new CheckoutFreshnessObservation
+            {
+                Status = Stale,
+                LocalHead = localHead,
+                DefaultBranch = defaultBranch,
+                RemoteHead = remoteHead,
+            };
+        }
+
+        GitRemoteCommandResult ancestry;
+        try
+        {
+            ancestry = runner.Run(
+                repoRoot,
+                ["merge-base", "--is-ancestor", remoteHead, "HEAD"]);
+        }
+        catch (Exception exception) when (IsProbeFailure(exception))
+        {
+            return UnknownObservation(
+                localHead,
+                defaultBranch,
+                remoteHead,
+                $"the origin default branch tip could not be compared locally ({exception.Message})");
+        }
+
+        if (ancestry.TimedOut)
+        {
+            return UnknownObservation(
+                localHead,
+                defaultBranch,
+                remoteHead,
+                FirstNonEmpty(
+                    ancestry.StdErr,
+                    $"git merge-base --is-ancestor {remoteHead} HEAD timed out after {DefaultTimeout.TotalSeconds:0.###} seconds"));
+        }
+
+        if (ancestry.ExitCode == 0)
         {
             return new CheckoutFreshnessObservation
             {
@@ -112,6 +190,17 @@ internal static class CheckoutFreshnessProbe
             };
         }
 
+        if (ancestry.ExitCode != 1)
+        {
+            return UnknownObservation(
+                localHead,
+                defaultBranch,
+                remoteHead,
+                FirstNonEmpty(
+                    ancestry.StdErr,
+                    "the origin default branch tip could not be compared locally"));
+        }
+
         return new CheckoutFreshnessObservation
         {
             Status = Stale,
@@ -120,7 +209,6 @@ internal static class CheckoutFreshnessProbe
             RemoteHead = remoteHead,
         };
     }
-
     private static CheckoutFreshnessObservation UnknownObservation(
         string? localHead,
         string? defaultBranch,

--- a/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/AutomationStalledWorkCommandTests.cs
@@ -337,6 +337,119 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
     }
 
     [Fact]
+    public void Capture_IdenticalRemoteTipRemainsCurrentUsingLocalContainment_G758()
+    {
+        using var fixture = new FreshnessCheckoutFixture();
+        const string localHead = "identical-tip";
+        const string remoteHead = "identical-tip";
+        var runner = CreateContainmentRunner(localHead, remoteHead);
+
+        var observation = CheckoutFreshnessProbe.Capture(fixture.CheckoutPath, runner);
+
+        Assert.NotNull(observation);
+        Assert.Equal(CheckoutFreshnessProbe.Current, observation!.Status);
+        Assert.Equal(string.Empty, observation.Warning);
+        AssertContainmentGitSequence(runner, localHead, remoteHead);
+    }
+
+    [Fact]
+    public void Analyze_AheadContainingRemoteTipRemainsCurrentAndSilent_G758()
+    {
+        using var fixture = new FreshnessCheckoutFixture();
+        const string localHead = "ahead-head";
+        const string remoteHead = "base-head";
+        var runner = CreateContainmentRunner(localHead, remoteHead);
+        AutomationStalledWorkCommand.CandidateListerFactory = () => new FakeLister();
+        AutomationStalledWorkCommand.GitCommandRunnerFactory = () => runner;
+
+        var result = AutomationStalledWorkCommand.Analyze(
+            fixture.Context,
+            "intent-cli",
+            "J-Tech-Japan/intent-system",
+            staleMinutes: 60);
+
+        Assert.Null(result.CheckoutFreshness);
+        Assert.DoesNotContain(result.Warnings, warning =>
+            warning.Contains("checkout freshness", StringComparison.Ordinal));
+        AssertContainmentGitSequence(runner, localHead, remoteHead);
+    }
+
+    [Fact]
+    public void Capture_GenuinelyBehindRemoteTipRemainsStaleWithActionableWarning_G758()
+    {
+        using var fixture = new FreshnessCheckoutFixture();
+        const string localHead = "behind-head";
+        const string remoteHead = "newer-tip";
+        var runner = CreateContainmentRunner(localHead, remoteHead, ancestryExitCode: 1);
+
+        var observation = CheckoutFreshnessProbe.Capture(fixture.CheckoutPath, runner);
+
+        Assert.NotNull(observation);
+        Assert.Equal(CheckoutFreshnessProbe.Stale, observation!.Status);
+        Assert.Equal(
+            "checkout freshness: stale; this answer was computed from local HEAD behind-head "
+            + "but origin/main is newer-tip. Sync the checkout and re-run the report; "
+            + "this command is read-only and does not fetch, pull, reset, or sync.",
+            observation.Warning);
+        AssertContainmentGitSequence(runner, localHead, remoteHead);
+    }
+
+    [Fact]
+    public void Capture_DetachedHeadAtRemoteTipRemainsCurrentAndSilent_G758()
+    {
+        using var fixture = new FreshnessCheckoutFixture();
+        fixture.DetachAtTip();
+        const string localHead = "detached-tip";
+        const string remoteHead = "detached-tip";
+        var runner = CreateContainmentRunner(localHead, remoteHead);
+
+        var observation = CheckoutFreshnessProbe.Capture(fixture.CheckoutPath, runner);
+
+        Assert.NotNull(observation);
+        Assert.Equal(CheckoutFreshnessProbe.Current, observation!.Status);
+        Assert.Equal(string.Empty, observation.Warning);
+        AssertContainmentGitSequence(runner, localHead, remoteHead);
+    }
+
+    [Fact]
+    public void Capture_AbsentRemoteTipObjectIsStaleWithoutAncestryMutation_G758()
+    {
+        using var fixture = new FreshnessCheckoutFixture();
+        const string localHead = "local-head";
+        const string remoteHead = "missing-tip";
+        var runner = CreateContainmentRunner(localHead, remoteHead, objectExitCode: 128);
+
+        var observation = CheckoutFreshnessProbe.Capture(fixture.CheckoutPath, runner);
+
+        Assert.NotNull(observation);
+        Assert.Equal(CheckoutFreshnessProbe.Stale, observation!.Status);
+        Assert.Contains("checkout freshness: stale", observation.Warning, StringComparison.Ordinal);
+        Assert.Equal(
+            [
+                "rev-parse HEAD",
+                "ls-remote --symref origin HEAD",
+                $"cat-file -e {remoteHead}^{{commit}}",
+            ],
+            runner.Calls.Select(call => string.Join(' ', call.Arguments)));
+    }
+
+    [Fact]
+    public void Capture_UsesOnlyTheReadOnlyContainmentGitSequence_G758()
+    {
+        using var fixture = new FreshnessCheckoutFixture();
+        const string localHead = "ahead-head";
+        const string remoteHead = "base-head";
+        var runner = CreateContainmentRunner(localHead, remoteHead);
+
+        _ = CheckoutFreshnessProbe.Capture(fixture.CheckoutPath, runner);
+
+        AssertContainmentGitSequence(runner, localHead, remoteHead);
+        Assert.DoesNotContain(runner.Calls, call =>
+            call.Arguments.Any(argument =>
+                argument is "fetch" or "pull" or "reset" or "sync"));
+    }
+
+    [Fact]
     public void Execute_DispositionSettledDelegationLeavesSupervisionAndStalledWorkOpenPopulation_G671()
     {
         using var workspace = new StalledWorkWorkspace();
@@ -4107,6 +4220,65 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         public IReadOnlyList<GitHubAutomationReleaseCandidate> ListPublishedReleases(string repo) => releases;
     }
 
+    private static RecordingGitRunner CreateContainmentRunner(
+        string localHead,
+        string remoteHead,
+        int objectExitCode = 0,
+        int ancestryExitCode = 0)
+    {
+        var runner = new RecordingGitRunner
+        {
+            Responses = new Dictionary<string, GitRemoteCommandResult>(StringComparer.Ordinal)
+            {
+                ["rev-parse HEAD"] = new GitRemoteCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = $"{localHead}\n",
+                    StdErr = string.Empty,
+                },
+                ["ls-remote --symref origin HEAD"] = new GitRemoteCommandResult
+                {
+                    ExitCode = 0,
+                    StdOut = $"ref: refs/heads/main\tHEAD\n{remoteHead}\tHEAD\n",
+                    StdErr = string.Empty,
+                },
+                [$"cat-file -e {remoteHead}^{{commit}}"] = new GitRemoteCommandResult
+                {
+                    ExitCode = objectExitCode,
+                    StdOut = string.Empty,
+                    StdErr = objectExitCode == 0 ? string.Empty : "missing object\n",
+                },
+            },
+        };
+
+        if (objectExitCode == 0)
+        {
+            runner.Responses[$"merge-base --is-ancestor {remoteHead} HEAD"] = new GitRemoteCommandResult
+            {
+                ExitCode = ancestryExitCode,
+                StdOut = string.Empty,
+                StdErr = ancestryExitCode == 0 ? string.Empty : "not an ancestor\n",
+            };
+        }
+
+        return runner;
+    }
+
+    private static void AssertContainmentGitSequence(
+        RecordingGitRunner runner,
+        string localHead,
+        string remoteHead)
+    {
+        Assert.Equal(
+            [
+                "rev-parse HEAD",
+                "ls-remote --symref origin HEAD",
+                $"cat-file -e {remoteHead}^{{commit}}",
+                $"merge-base --is-ancestor {remoteHead} HEAD",
+            ],
+            runner.Calls.Select(call => string.Join(' ', call.Arguments)));
+    }
+
     private sealed class RecordingGitRunner : IGitRemoteCommandRunner
     {
         public Dictionary<string, GitRemoteCommandResult> Responses { get; init; } = new(StringComparer.Ordinal);
@@ -4189,6 +4361,8 @@ public sealed class AutomationStalledWorkCommandTests : IDisposable
         public string RunGit(params string[] arguments) => RunGit(CheckoutPath, arguments);
 
         public void SetOrigin(string url) => RunGit(CheckoutPath, "remote", "set-url", "origin", url);
+
+        public void DetachAtTip() => RunGit(CheckoutPath, "checkout", "--detach", "HEAD");
 
         public void WritePacketDomain(string executionUnit, string domain)
         {


### PR DESCRIPTION
Closes #1647

## Summary

- Change checkout freshness from SHA equality to local containment.
- Treat an absent local remote-tip object as stale without fetching.
- Keep `git ls-remote --symref origin HEAD`, current/stale/unknown statuses, current silence, warning wording, timeout, runner seam, and all stalled-work behavior unchanged.

## Verification

The new same-class G758 tests cover identical tips, ahead-containing tips, genuinely behind tips, detached-at-tip, an absent remote-tip object, and the exact read-only command sequence. The successful sequence is exactly:

1. `git rev-parse HEAD`
2. `git ls-remote --symref origin HEAD`
3. `git cat-file -e <remote-tip>^{commit}`
4. `git merge-base --is-ancestor <remote-tip> HEAD`

The absent-object path stops after step 3 and reports stale. No fetch, pull, reset, sync, or other mutation is issued.

Parent failure evidence at `ec261ec4c16454d122a3baec0d48393a4245f513` with the six new tests: `Failed: 6, Passed: 0, Skipped: 0, Total: 6`. The parent reported the ahead-containing case as stale and issued only the first two Git calls; all six new tests therefore failed their expected current/sequence assertions.

- G758 focused: `Failed 0, Passed 6, Skipped 0, Total 6`
- Existing G727 freshness/unknown tests: `Failed 0, Passed 3, Skipped 0, Total 3`
- Full `AutomationStalledWorkCommandTests`: `Failed 0, Passed 125, Skipped 0, Total 125`
- Full Release suite: `Failed 0, Passed 5363, Skipped 1, Total 5364`
- `git diff --check`: clean

## Coordination boundary

The supplied host authority is execution-unit:G758 held by implementation/team intent-cli-dev, claimed at `2026-08-29T18:28:41.844237Z`, base `f632f9da13496061a31e05addeb593049edefbbb`, verified on host origin/main. Child next-action selected #1647 but returned `wait`; child issue-preflight returned `claim-unavailable` because fresh canonical Git evidence could not open `.git/FETCH_HEAD` (`Operation not permitted`). This known child/host contradiction is recorded; no child execution-unit claim was created or mutated.
