### PR TITLE
fix: resolve task-envelope report root from recipient cwd

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -484,7 +484,7 @@ intent-cli notify report --domain <domain> --team <team> --from <receiver-role> 
   --to <orchestrator-role> --task-id <task-id> \
   --status completed|blocked|question --artifact <artifact> \
   --summary <one-line-summary> --routing-root <host-routing-root> \
-  --report-root . --write --format json
+  --report-root <role-work-root> --write --format json
 
 # Route a design decision to the existing events.jsonl boundary.
 intent-cli notify escalate --domain <domain> --team <team> --from <sender-role> \
@@ -637,7 +637,7 @@ unrecognised identifier would silence unsolicited reports and answers to
 escalations—the messages whose information the recipient did not know to
 request.
 
-**Sender-local report routing and executability/actionability diagnostics (G719/G731 — preview-through-1.x).** An implementation seat receives exactly one bounded `--add-dir <role-work-root>` and is not granted `--add-dir <host-routing-root>` or host-root write access. Its canonical report carries `--routing-root <host-routing-root> --report-root .`: the host root remains read/transport authority and the role root is the writable sender-local outbox. A report on a seat that genuinely lacks the host routing root must persist its local outbox, identify `report_storage_mode: sender-local-role-work-root`, and identify `host_state_sync: deferred-to-orchestration`; orchestration reconciles host pending/continuation state with `intent-cli notify reconcile --domain <d> --team <t> --task-id <id> --routing-root <host> --report-root <role-work-root> --write --format json`. It must not retry a host write, hand-write transport, or widen the seat.
+**Sender-local report routing and executability/actionability diagnostics (G719/G731/G760 — preview-through-1.x).** An implementation seat receives exactly one bounded `--add-dir <role-work-root>` and is not granted `--add-dir <host-routing-root>` or host-root write access. Its task-envelope canonical report carries `--routing-root <host-routing-root> --report-root <role-work-root>`: at generation time, `<role-work-root>` is replaced with the recipient's recorded absolute topology `cwd` and shell-quoted. If no cwd is recorded, the envelope carries the explicit `<role-work-root>` substitution placeholder; it never emits a bare `.` that depends on the receiver's current directory. The host root remains read/transport authority and the role root is the writable sender-local outbox. A report on a seat that genuinely lacks the host routing root must persist its local outbox, identify `report_storage_mode: sender-local-role-work-root`, and identify `host_state_sync: deferred-to-orchestration`; orchestration reconciles host pending/continuation state with `intent-cli notify reconcile --domain <d> --team <t> --task-id <id> --routing-root <host> --report-root <role-work-root> --write --format json`. It must not retry a host write, hand-write transport, or widen the seat.
 
 G731 makes the delivery decision capability/outcome-based across both
 `notify report` and `notify collect`: differing report and routing roots are
@@ -1396,7 +1396,7 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --mode autop
 - **Role-derived roots.** Give every role one bounded `--add-dir <role-work-root>`
   for its checkout or worktree. A reviewer may additionally need `--add-dir
   <host-routing-root>` for an external-reader surface; an implementation seat
-  uses `--routing-root <host-routing-root> --report-root .` and must not receive
+  uses `--routing-root <host-routing-root> --report-root <role-work-root>` resolved from the recipient's absolute topology `cwd` (or the explicit `<role-work-root>` placeholder when absent) and must not receive
   host-root write access. Do not add unrelated developer-machine roots. Before
   delegation, the orchestrator compares workspace prerequisites with this
   recorded write envelope and prepares anything outside it under orchestrator
@@ -1445,7 +1445,7 @@ herdr agent start <logical-role> --kind codex --pane <pane-id> -- --sandbox work
 - **Role-derived roots.** Use one bounded `--add-dir <role-work-root>` for the
   role checkout/worktree. The implementation seat does not receive
   `--add-dir <host-routing-root>` or MyIntentHost write access: its canonical
-  report uses `--routing-root <host-routing-root> --report-root .`, with the
+  report uses `--routing-root <host-routing-root> --report-root <role-work-root>` resolved from the recipient's absolute topology `cwd` (or the explicit `<role-work-root>` placeholder when absent), with the
   host root as read/transport authority and the role root as the writable
   sender-local handoff. Add a host root only when another role's external
   reader explicitly requires it. The role-work-root is an ordinary-file
@@ -1496,7 +1496,7 @@ herdr agent start <logical-role> --kind codex --pane <pane-id> -- --sandbox work
 three additional facts: an expected action inside the recorded roots succeeds;
 the role reaches its canonical reporting surface; and a deliberately
 out-of-scope action is denied. For implementation, prove the report with
-`--routing-root <host-routing-root> --report-root .` and record the local outbox
+`--routing-root <host-routing-root> --report-root <role-work-root>` from the recipient's absolute topology `cwd` (or the explicit `<role-work-root>` placeholder when absent) and record the local outbox
 plus deferred host-state reconciliation without granting host-root write access.
 Capture that denial for review. A live pane or a successful allowed action alone
 is **not** READY. If a denial probe unexpectedly succeeds, first

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -434,7 +434,7 @@ intent-cli notify report --domain <domain> --team <team> --from <receiver-role> 
   --to <orchestrator-role> --task-id <task-id> \
   --status completed|blocked|question --artifact <artifact> \
   --summary <one-line-summary> --routing-root <host-routing-root> \
-  --report-root . --write --format json
+  --report-root <role-work-root> --write --format json
 
 # design decision を既存 events.jsonl boundary へ送る。
 intent-cli notify escalate --domain <domain> --team <team> --from <sender-role> \
@@ -541,7 +541,7 @@ supervision state と emission-policy JSON shape を保持します。
 **report outbox (G653 — 1.x を通じた preview)。** `notify report --write` は transport を試す前に sender-side outbox entry を保存します。entry は task id、result nonce、status、artifact、summary、delivery timestamp を保持し、delivery failure は完了した作業を失わず `undelivered` として残ります。supervision は entry と `notify collect` の remedy を表示するだけで自動送信しません。recipient-side terminal の `ORCH_RESULT` は人間向けの record のままで、intent-cli は terminal を `parse` しません。visible result に arrived report がないときは、recipient を `re-delegate` したり task を `redo` したりせず persisted outbox entry を `collect` します。collection は同じ task id の original report だけを一度送信し、already-delivered entry は拒否します。entry は dispatch generation（result nonce）単位なので、再委譲された task id も新しい report を運べ、unmatched report も message として継続します。undelivered の current generation に対する二回目の report は fail-closed で拒否し、正確な `notify collect` recovery command を示します。
 新しい委譲を開始する前に、`notify delegate --write` は undelivered report entry がある task を拒否し、supervision finding と同じ `notify collect` command を示します。これにより finding の対象と collect できる entry は一致します。また、report が settled になった task id/result nonce の組も作業開始前に拒否し、fresh `--result-nonce` または新しい task id を要求します。outbox がない open generation は idempotent に再送できます。
 
-**sender-local report routing と executability/actionability 診断 (G719/G731 — preview-through-1.x)。** implementation seat には checkout/worktree 用の境界付き `--add-dir <role-work-root>` を 1 つだけ与え、`--add-dir <host-routing-root>` や MyIntentHost への write access は与えません。canonical report は `--routing-root <host-routing-root> --report-root .` を持ち、host root は read/transport の基準経路、role root は sender-local outbox の write root です。host routing root を実際には書けない seat でも local outbox を保存し、`report_storage_mode: sender-local-role-work-root` と `host_state_sync: deferred-to-orchestration` を示して、orchestration が `intent-cli notify reconcile --domain <d> --team <t> --task-id <id> --routing-root <host> --report-root <role-work-root> --write --format json` で host の pending/continuation state を整合します。host write の retry、hand-write transport、seat boundary の拡大はしません。
+**sender-local report routing と executability/actionability 診断 (G719/G731/G760 — preview-through-1.x)。** implementation seat には checkout/worktree 用の境界付き `--add-dir <role-work-root>` を 1 つだけ与え、`--add-dir <host-routing-root>` や MyIntentHost への write access は与えません。task envelope の canonical report は `--routing-root <host-routing-root> --report-root <role-work-root>` を持ち、生成時に `<role-work-root>` を recipient の topology に記録された absolute `cwd` で置き換え、shell 用の引用符を付けます。cwd が記録されていない場合は明示的な `<role-work-root>` substitution placeholder を残し、receiver の current directory に依存する bare `.` は出しません。host root は read/transport の基準経路、role root は sender-local outbox の write root です。host routing root を実際には書けない seat でも local outbox を保存し、`report_storage_mode: sender-local-role-work-root` と `host_state_sync: deferred-to-orchestration` を示して、orchestration が `intent-cli notify reconcile --domain <d> --team <t> --task-id <id> --routing-root <host> --report-root <role-work-root> --write --format json` で host の pending/continuation state を整合します。host write の retry、hand-write transport、seat boundary の拡大はしません。
 
 G731 では delivery の判断を `notify report` と `notify collect` に共通化し、report root と routing root が異なるという事実だけでは拒否しません。両方の caller が現在の execution context で external-reader への append を試みます。host append が成功すれば root が異なっていても report は delivery 済みとなり、sender-local outbox は `delivered` に更新されます。一方、実際の I/O または access error が発生した場合だけ entry を `undelivered` のまま保持し、`report-routing-root-write-required` は未測定の sandbox 制約を断定せず、観測した失敗を示します。`notify collect --routing-root <host> --report-root <role-work-root>` が名前付きの delivery-level recovery command です。`notify reconcile` は append を再試行せず、undelivered entry には exact collect command を `recovery_command` と summary の両方で返します。
 
@@ -1034,7 +1034,7 @@ bounded readiness/report check を再実行します。再登録、kill、restar
 これは 1.x を通じた preview で、1.0 compatibility promise の対象外です。
 
 `notify delegate` は task id、expected artifact、fresh marker nonce、isolated child
-checkout から必要な transport-neutral `--routing-root` と sender-local `--report-root .` を含む完全な canonical report
+checkout から必要な transport-neutral `--routing-root` と、recipient の topology `cwd` から解決した absolute な sender-local `--report-root <role-work-root>`（cwd がない場合は明示的 placeholder）を含む完全な canonical report
 command を配信 task に埋め込みます。receiver は他のすべての作業後、その report
 command を final step として実行するため、herdr-only の完了が receiver pane に表示される
 だけで終わらず orchestration role を能動的に呼び起こします。herdr-only mode の source of truth は
@@ -1195,7 +1195,7 @@ herdr agent start <logical-role> --kind copilot --pane <pane-id> -- --mode autop
 - **role-derived root。** 各 role には checkout または worktree 用の境界付き
   `--add-dir <role-work-root>` を 1 つ与えます。reviewer には canonical reporting surface
   である `intent-cli notify report` のため、さらに `--add-dir <host-routing-root>` が必要です。
-  implementation seat は `--routing-root <host-routing-root> --report-root .` を使い、host root を
+  implementation seat は recipient の absolute な topology `cwd` に解決した `--routing-root <host-routing-root> --report-root <role-work-root>`（cwd がない場合は明示的 placeholder）を使い、host root を
   read/transport の基準経路として扱い、host root write access や追加の `--add-dir` を受けません。
   developer-machine の無関係な root は追加しません。delegation の前に orchestrator は workspace
   prerequisite をこの記録済み write envelope と比較し、その外側にあるものを orchestrator の権限
@@ -1237,7 +1237,7 @@ herdr agent start <logical-role> --kind codex --pane <pane-id> -- --sandbox work
 ```
 
 - **role-derived root。** role の checkout/worktree には境界付きの
-  `--add-dir <role-work-root>` を 1 つ使います。implementation seat は `--routing-root <host-routing-root> --report-root .`
+  `--add-dir <role-work-root>` を 1 つ使います。implementation seat は recipient の absolute な topology `cwd` に解決した `--routing-root <host-routing-root> --report-root <role-work-root>`（cwd がない場合は明示的 placeholder）
   を使い、host root を read/transport の基準経路、role root を writable sender-local outbox として扱います。
   host root の write access や追加の `--add-dir` は与えません。external reader が明示的に必要な別 role だけが
   host root を追加できます。role-work-root は ordinary file root であり、repository metadata 全体への
@@ -1272,7 +1272,7 @@ herdr agent start <logical-role> --kind codex --pane <pane-id> -- --sandbox work
 
 **unattended READY branch。** 通常の G556 liveness check に加え、次の 3 点を証明します:
 記録済み root 内の期待される action が成功すること、role が canonical reporting surface
-（implementation なら `--routing-root <host-routing-root> --report-root .` の sender-local report、
+（implementation なら recipient の absolute な topology `cwd` に解決した `--routing-root <host-routing-root> --report-root <role-work-root>`（cwd がない場合は明示的 placeholder）の sender-local report、
 review なら host routing root 経由の `intent-cli notify report`）へ到達できること、意図的に
 out-of-scope にした action が拒否されることです。その拒否を review 用に記録します。live pane
 だけ、または許可済み action の成功だけでは **READY ではありません**。denial probe が予想に反して

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -29,6 +29,8 @@ internal static class NotifyCommand
     private const string DispositionKindSuperseded = "superseded";
     private const string DispositionKindAppliedElsewhere = "applied-elsewhere";
 
+    private const string MissingRecipientWorkRootPlaceholder = "<role-work-root>";
+
     private const string DelegateUsage =
         "Usage: intent-cli notify delegate --domain <d> [--team <t>] --from <role> --to <role> --report-to <role> "
         + "--task-id <id> --objective <text> [--input <value>]... --expected-artifact <value> "
@@ -2420,11 +2422,28 @@ internal static class NotifyCommand
         return builder.ToString();
     }
 
-    private static string BuildReportCommand(NotifyOptions options) =>
-        $"intent-cli notify report --domain {options.Domain} --team {options.Team} --from {options.ToRole} "
+    private static string BuildReportCommand(NotifyOptions options)
+    {
+        var reportRoot = ResolveRecipientReportRoot(options);
+        return $"intent-cli notify report --domain {options.Domain} --team {options.Team} --from {options.ToRole} "
         + $"--to {options.ReportToRole} --task-id {options.TaskId} --status <completed|blocked|question> "
-        + $"--artifact <artifact> --summary <one-line-summary> --routing-root {ShellQuote(options.RoutingRoot!)} --report-root . "
+        + $"--artifact <artifact> --summary <one-line-summary> --routing-root {ShellQuote(options.RoutingRoot!)} --report-root {reportRoot} "
         + "--write --format json";
+    }
+
+    private static string ResolveRecipientReportRoot(NotifyOptions options)
+    {
+        var topology = NotifyRoleTopologyStore.Resolve(options.RoutingRoot!, options.Domain!, options.Team!);
+        var roleResolution = topology.Resolved && topology.Topology is { } teamTopology
+            ? NotifyRoleTopologyStore.ResolveRecordedRole(teamTopology, options.ToRole!)
+            : null;
+        var cwd = roleResolution?.Resolved == true
+            ? roleResolution.Record?.Cwd
+            : null;
+        return string.IsNullOrWhiteSpace(cwd)
+            ? MissingRecipientWorkRootPlaceholder
+            : ShellQuote(Path.GetFullPath(cwd));
+    }
 
     private static string? BuildReconciliationCommand(string operation, NotifyOptions options) =>
         (string.Equals(operation, OperationReport, StringComparison.Ordinal)

--- a/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
@@ -130,13 +130,12 @@ public sealed class NotifyCommandG578Tests : IDisposable
         Assert.Equal(Encoding.UTF8.GetBytes(payload), File.ReadAllBytes(taskFile));
         // This checked-in full-envelope oracle was captured from the parent
         // invocation. Only the per-test temporary root is substituted.
-        var goldenPath = Path.Combine(
-            RepoVersionPolicySource.RepoRoot(),
-            "tests", "IntentSystem.Cli.Tests", "Fixtures", "G759",
-            "parent-file-backed-envelope.md");
-        var parentGolden = File.ReadAllText(goldenPath)
-            .Replace("<workspace-root>", workspace.RootPath, StringComparison.Ordinal);
-        Assert.Equal(Encoding.UTF8.GetBytes(parentGolden), File.ReadAllBytes(taskFile));
+        var parentGolden = LoadParentEnvelope(workspace.RootPath);
+        var expectedEnvelope = parentGolden.Replace(
+            "--report-root . --write --format json",
+            "--report-root <role-work-root> --write --format json",
+            StringComparison.Ordinal);
+        Assert.Equal(Encoding.UTF8.GetBytes(expectedEnvelope), File.ReadAllBytes(taskFile));
         Assert.Contains("G578-demo-demo-nonce.md", taskFile, StringComparison.Ordinal);
         Assert.Contains("TASK G578-demo", payload, StringComparison.Ordinal);
         Assert.Contains("result-nonce: demo-nonce", payload, StringComparison.Ordinal);
@@ -239,11 +238,13 @@ public sealed class NotifyCommandG578Tests : IDisposable
         var expectedReportRoot = ShellQuoteForTest(Path.GetFullPath(recipientCwd));
         var expectedCommand = parentCommand
             .Replace("--report-root .", $"--report-root {expectedReportRoot}", StringComparison.Ordinal);
-        var expectedParentEnvelope = ExpectedParentEnvelope(workspace.RootPath);
-        var expectedEnvelope = expectedParentEnvelope
-            .Replace(parentCommand, expectedCommand, StringComparison.Ordinal);
+        var parentEnvelope = LoadParentEnvelope(workspace.RootPath);
+        var expectedEnvelope = parentEnvelope.Replace(
+            "--report-root . --write --format json",
+            $"--report-root {expectedReportRoot} --write --format json",
+            StringComparison.Ordinal);
 
-        Assert.Equal(expectedEnvelope, payload);
+        Assert.Equal(Encoding.UTF8.GetBytes(expectedEnvelope), Encoding.UTF8.GetBytes(payload));
     }
 
     [Fact]
@@ -644,25 +645,12 @@ public sealed class NotifyCommandG578Tests : IDisposable
         + "--artifact <artifact> --summary <one-line-summary> "
         + $"--routing-root {ShellQuoteForTest(routingRoot)} --report-root . --write --format json";
 
-    private static string ExpectedParentEnvelope(string routingRoot) =>
-        string.Join('\n',
-        [
-            "TASK G578-demo",
-            "role: implementation",
-            "objective: Implement the notification contract",
-            "inputs:",
-            "  - issue #1259",
-            "expected-artifacts:",
-            "  - draft PR URL",
-            "reporting-contract:",
-            "  task-id: G578-demo",
-            "  expected-artifact: draft PR URL",
-            $"  canonical-report-command: {ExpectedParentReportCommand(routingRoot)}",
-            "  required-final-step: Run canonical-report-command after all other work; never hand-write a transport invocation.",
-            "result-prefix: ORCH_RESULT",
-            "result-nonce: demo-nonce",
-            "completion-marker: When the artifact is ready, concatenate result-prefix, one space, result-nonce, one space, status, one space, and artifact; use completed, blocked, or question. Do not precompose the marker in this task block.",
-        ]);
+    private static string LoadParentEnvelope(string routingRoot) =>
+        File.ReadAllText(Path.Combine(
+                RepoVersionPolicySource.RepoRoot(),
+                "tests", "IntentSystem.Cli.Tests", "Fixtures", "G759",
+                "parent-file-backed-envelope.md"))
+            .Replace("<workspace-root>", routingRoot, StringComparison.Ordinal);
 
     private static string ShellQuoteForTest(string value) =>
         $"'{value.Replace("'", "'\\''", StringComparison.Ordinal)}'";

--- a/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyCommandG578Tests.cs
@@ -187,6 +187,66 @@ public sealed class NotifyCommandG578Tests : IDisposable
     }
 
     [Fact]
+    public void Delegate_UsesAbsoluteShellQuotedRecipientTopologyCwdForReportRoot_G760()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var recipientCwd = Path.Combine(workspace.RootPath, "recipient's-work-root");
+        workspace.SetImplementationCwd(recipientCwd);
+        NotifyCommand.ProcessRunnerFactory = SuccessfulRunner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(0, exitCode);
+        var command = ExtractReportCommand(result.GetProperty("payload").GetString()!);
+        var expectedReportRoot = ShellQuoteForTest(Path.GetFullPath(recipientCwd));
+        var expected = ExpectedParentReportCommand(workspace.RootPath)
+            .Replace("--report-root .", $"--report-root {expectedReportRoot}", StringComparison.Ordinal);
+
+        Assert.Equal(expected, command);
+        Assert.Contains($"--report-root {expectedReportRoot} --write", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("--report-root .", command, StringComparison.Ordinal);
+        Assert.Contains($"--routing-root {ShellQuoteForTest(workspace.RootPath)}", command, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Delegate_UsesExplicitRoleWorkRootPlaceholderWhenRecipientCwdIsAbsent_G760()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        NotifyCommand.ProcessRunnerFactory = SuccessfulRunner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(0, exitCode);
+        var command = ExtractReportCommand(result.GetProperty("payload").GetString()!);
+
+        Assert.Contains("--report-root <role-work-root> --write", command, StringComparison.Ordinal);
+        Assert.DoesNotContain("--report-root .", command, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Delegate_ChangesOnlyReportRootInParentEnvelope_G760()
+    {
+        workspace.SetMode(SessionLayerMode.HerdrOnly);
+        var recipientCwd = Path.Combine(workspace.RootPath, "recipient-work-root");
+        workspace.SetImplementationCwd(recipientCwd);
+        NotifyCommand.ProcessRunnerFactory = SuccessfulRunner;
+
+        var (exitCode, result) = workspace.Run(DelegateArgs());
+
+        Assert.Equal(0, exitCode);
+        var payload = result.GetProperty("payload").GetString()!;
+        var parentCommand = ExpectedParentReportCommand(workspace.RootPath);
+        var expectedReportRoot = ShellQuoteForTest(Path.GetFullPath(recipientCwd));
+        var expectedCommand = parentCommand
+            .Replace("--report-root .", $"--report-root {expectedReportRoot}", StringComparison.Ordinal);
+        var expectedParentEnvelope = ExpectedParentEnvelope(workspace.RootPath);
+        var expectedEnvelope = expectedParentEnvelope
+            .Replace(parentCommand, expectedCommand, StringComparison.Ordinal);
+
+        Assert.Equal(expectedEnvelope, payload);
+    }
+
+    [Fact]
     public void UnrecordedMode_IsConfigurationIncompleteBeforeDefaultAgmsgTransport_G594()
     {
         var runner = SuccessfulRunner();
@@ -571,6 +631,42 @@ public sealed class NotifyCommandG578Tests : IDisposable
         "--write", "--format", "json",
     ];
 
+    private static string ExtractReportCommand(string payload)
+    {
+        const string prefix = "  canonical-report-command: ";
+        var line = payload.Split('\n').Single(line => line.StartsWith(prefix, StringComparison.Ordinal));
+        return line[prefix.Length..];
+    }
+
+    private static string ExpectedParentReportCommand(string routingRoot) =>
+        "intent-cli notify report --domain intent-cli --team intent-cli-dev --from implementation "
+        + "--to orchestration --task-id G578-demo --status <completed|blocked|question> "
+        + "--artifact <artifact> --summary <one-line-summary> "
+        + $"--routing-root {ShellQuoteForTest(routingRoot)} --report-root . --write --format json";
+
+    private static string ExpectedParentEnvelope(string routingRoot) =>
+        string.Join('\n',
+        [
+            "TASK G578-demo",
+            "role: implementation",
+            "objective: Implement the notification contract",
+            "inputs:",
+            "  - issue #1259",
+            "expected-artifacts:",
+            "  - draft PR URL",
+            "reporting-contract:",
+            "  task-id: G578-demo",
+            "  expected-artifact: draft PR URL",
+            $"  canonical-report-command: {ExpectedParentReportCommand(routingRoot)}",
+            "  required-final-step: Run canonical-report-command after all other work; never hand-write a transport invocation.",
+            "result-prefix: ORCH_RESULT",
+            "result-nonce: demo-nonce",
+            "completion-marker: When the artifact is ready, concatenate result-prefix, one space, result-nonce, one space, status, one space, and artifact; use completed, blocked, or question. Do not precompose the marker in this task block.",
+        ]);
+
+    private static string ShellQuoteForTest(string value) =>
+        $"'{value.Replace("'", "'\\''", StringComparison.Ordinal)}'";
+
     private sealed class FakeNotifyProcessRunner(
         Func<string, IReadOnlyList<string>, NotifyProcessResult> handler) : INotifyProcessRunner
     {
@@ -623,6 +719,7 @@ public sealed class NotifyCommandG578Tests : IDisposable
         public string EventPath => Path.Combine(RootPath, ".intent-cli", "events", Domain, $"{Team}.jsonl");
         public CliContext Context { get; }
         private string? implementationDeliveryMethod;
+        private string? implementationCwd;
 
         private void WriteTopology()
         {
@@ -665,6 +762,12 @@ public sealed class NotifyCommandG578Tests : IDisposable
             WriteTopology();
         }
 
+        public void SetImplementationCwd(string? cwd)
+        {
+            implementationCwd = cwd;
+            WriteTopology();
+        }
+
         public void SeedPending(string taskId = "G578-demo", string recipientRole = "implementation")
         {
             var result = NotifyPendingDelegationStore.WriteDispatch(RootPath, new NotifyPendingDelegation
@@ -696,6 +799,10 @@ public sealed class NotifyCommandG578Tests : IDisposable
             if (implementationDeliveryMethod is not null)
             {
                 role["delivery_method"] = implementationDeliveryMethod;
+            }
+            if (implementationCwd is not null)
+            {
+                role["cwd"] = implementationCwd;
             }
 
             return role;

--- a/tests/IntentSystem.Cli.Tests/NotifyG719Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifyG719Tests.cs
@@ -38,7 +38,7 @@ public sealed class NotifyG719Tests : IDisposable
         Assert.Equal(0, delegateExit);
         var generatedCommand = delegateResult.GetProperty("report_command").GetString()!;
         Assert.Contains(
-            $"--routing-root '{workspace.HostRoot}' --report-root .",
+            $"--routing-root '{workspace.HostRoot}' --report-root '{workspace.SeatRoot}'",
             generatedCommand,
             StringComparison.Ordinal);
 
@@ -47,7 +47,7 @@ public sealed class NotifyG719Tests : IDisposable
             generatedCommand,
             "https://example.test/pr/1560",
             "generated-sandbox-report-verified");
-        Assert.Contains("--report-root .", exactCommand, StringComparison.Ordinal);
+        Assert.Contains($"--report-root '{workspace.SeatRoot}'", exactCommand, StringComparison.Ordinal);
 
         var hostBefore = workspace.HostSnapshot();
         var originalHostRootMode = workspace.HostRootMode();
@@ -561,7 +561,7 @@ public sealed class NotifyG719Tests : IDisposable
                 roles = new Dictionary<string, object>
                 {
                     ["orchestration"] = orchestration,
-                    ["implementation"] = new { resident = NotifyRecordedRole.HerdrResident, workspace_id = "wG719", pane_id = "wG719:p2" },
+                    ["implementation"] = new { resident = NotifyRecordedRole.HerdrResident, workspace_id = "wG719", pane_id = "wG719:p2", cwd = SeatRoot },
                 },
             }));
 


### PR DESCRIPTION
Closes #1651

## Summary
Task-envelope canonical-report-command now resolves --report-root from the recipient role topology cwd, normalizes it to an absolute path, and shell-quotes it. When the recipient has no recorded cwd, the envelope carries the explicit <role-work-root> placeholder. The remaining command and full envelope stay byte-compatible with the parent; routing-root, nonce, completion marker, notify reconcile/collect/outbox behavior, and host permissions are unchanged.

## Evidence
- Parent baseline 145c5a43c031353a5e5ad4d7ea9eb3fb7365304c with the three G760 regressions applied: 26 existing tests passed and 3 new tests failed. The failures were the missing explicit placeholder, the absolute shell-quoted recipient cwd, and the full-envelope report-root-only substitution; parent output still emitted --report-root ..
- Change: NotifyCommandG578Tests 29 passed, 0 failed, 0 skipped.
- Existing G719 compatibility: 4 passed, 0 failed, 0 skipped.
- Orchestration docs: 24 passed, 0 failed, 0 skipped.
- G613: 6 passed, 0 failed, 0 skipped.
- Packaged invocation smoke: 11 passed, 0 failed, 0 skipped.
- Full Release on current main c6e6922e8ca89520465adfa8f69375eefd5d4fa6: 5367 passed, 0 failed, 1 skipped, 5368 total.
- git diff --check: clean.
- GitHub CI run 33275004022: Build and test source contract passed; npm package dry-run passed.

The focused tests cover a topology cwd containing a single quote, no cwd placeholder, and exact UTF-8 byte equality against the checked-in parent envelope after replacing only the report-root segment. The G719 fixture adaptation records its existing seat root as the topology cwd so its shell-executed generated report continues to exercise the same sender-local behavior; no product outbox or transport semantics changed.

## Worker boundary
Child worker next-action returned wait for issue 1651 because local execution-unit G760 was reported holder none/unheld, and issue-preflight returned actionable=true ready-to-implement with the same local claim refusal. Supplied authoritative host evidence is consumed instead: origin/main claim d1ceba84afe2ca6acda45a2ea08a9ef29579bd699089b07e41768b1e7071c325.json records execution-unit:G760 for implementation/team intent-cli-dev at base 34a2540357b4dc0cddc594c7e63027f7d12ba357. No child execution-unit claim or host metadata was accessed or mutated.