### PR TITLE
[eval-localllm] G735: no-think run, Qwen3.8-Flash-Next via llama.cpp GGUF Q3_K_XL

### DIFF
--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -90,7 +90,10 @@ intent-cli notify delegate --domain <domain> --team <team> --from <sender-role> 
 The move requires a complete explicit old-to-new pane map for recorded herdr
 roles, updates the team and role workspace/pane ids in one atomic operation,
 and preserves role membership, cwd, kind, delivery method, readers, profiles,
-and all other fields. It never queries herdr, discovers a workspace, creates
+and all other fields. Several roles that share one recorded old pane travel
+together under a single mapping for that old pane; only mapping two *different*
+recorded old panes to one new pane is refused as a genuinely ambiguous move.
+It never queries herdr, discovers a workspace, creates
 panes, or repairs a per-role refusal. The writer holds a CAS lock and compares
 the topology digest before replacement; a stale `--current-digest` is refused.
 The existing per-role mismatch message points to this command as the

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -84,8 +84,11 @@ intent-cli notify delegate --domain <domain> --team <team> --from <sender-role> 
 
 move は、記録済み herdr role ごとに完全な old-to-new pane map を明示的に必要とし、team と role の
 workspace/pane id を一つの atomic operation で更新します。role membership、cwd、kind、delivery method、
-reader、profile、その他すべての field は維持します。herdr query、workspace の discover、pane の作成、
-per-role refusal の repair は行いません。writer は CAS lock を保持し、置換前に topology digest を比較します。
+reader、profile、その他すべての field は維持します。一つの記録済み old pane を共有する複数の role は、
+その old pane に対する単一の mapping で共に移動します。*異なる* 2 つの記録済み old pane を 1 つの
+new pane へ写す mapping のみ genuinely ambiguous な move として拒否されます。herdr query、workspace の
+discover、pane の作成、per-role refusal の repair は行いません。writer は CAS lock を保持し、置換前に
+topology digest を比較します。
 stale な `--current-digest` は拒否されます。既存の per-role mismatch message は sanctioned な whole-team
 transition としてこの command を示します。
 

--- a/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
@@ -1184,7 +1184,8 @@ internal static class SessionLayerTopologyWriter
                     + $"'{request.Role}' requested '{request.WorkspaceId}'. Refusing to repair the conflict. "
                     + "For an operator-approved whole-team rebuild, use `intent-cli session-layer topology move "
                     + "--domain <domain> --team <team> --workspace-id <new-workspace-id> --pane-map "
-                    + "<old-pane>=<new-pane> --write`.");
+                    + "<old-pane>=<new-pane> --write`. Pass one --pane-map per recorded old pane: several roles "
+                    + "that share one recorded old pane travel together under that single mapping.");
             }
 
             if (string.IsNullOrWhiteSpace(recordedWorkspace))
@@ -1339,7 +1340,7 @@ internal static class SessionLayerTopologyWriter
             }
 
             var recordedPanes = new HashSet<string>(StringComparer.Ordinal);
-            var mappedPanes = new HashSet<string>(StringComparer.Ordinal);
+            var mappedPanes = new Dictionary<string, string>(StringComparer.Ordinal);
             foreach (var (roleName, roleNode) in roles!.OrderBy(entry => entry.Key, StringComparer.Ordinal))
             {
                 if (roleNode is not JsonObject role)
@@ -1377,14 +1378,18 @@ internal static class SessionLayerTopologyWriter
                         + "refusing a partial workspace move.");
                 }
 
-                if (!mappedPanes.Add(newPane))
+                if (!mappedPanes.TryGetValue(newPane, out var mappedFromOldPane))
+                {
+                    mappedPanes[newPane] = oldPane;
+                }
+                else if (!string.Equals(mappedFromOldPane, oldPane, StringComparison.Ordinal))
                 {
                     return MoveConflict(
                         request,
                         path,
                         currentDigest,
-                        $"--pane-map maps more than one recorded role to new pane '{newPane}'; refusing an "
-                        + "ambiguous workspace move.");
+                        $"--pane-map maps two different recorded old panes ('{mappedFromOldPane}' and '{oldPane}') "
+                        + $"to new pane '{newPane}'; refusing an ambiguous workspace move.");
                 }
 
                 var paneWorkspace = WorkspaceFromPane(newPane);

--- a/tests/IntentSystem.Cli.Tests/TopologyWorkspaceMoveSharedPaneG735Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/TopologyWorkspaceMoveSharedPaneG735Tests.cs
@@ -1,0 +1,192 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G735: a pane map that moves several roles sharing one recorded old pane
+/// onto one new pane is unambiguous — the roles travel with their pane — and
+/// must be accepted. Only two different old panes mapping to one new pane is
+/// genuinely ambiguous and keeps its refusal. The record-side whole-team
+/// refusal must point at a move that actually performs the rebuild.
+/// Fixtures are intentionally left for the host environment; these tests never
+/// delete a temporary path.
+/// </summary>
+public sealed class TopologyWorkspaceMoveSharedPaneG735Tests
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+
+    [Fact]
+    public void Move_SharedOldPaneRolesTravelTogether_G735()
+    {
+        var context = CreateFixture();
+        SetHerdrOnly(context);
+        RecordHerdr(context, "orchestrator", "wS:p1", "/orchestrator", "codex", "inline");
+        RecordHerdr(context, "orchestration", "wS:p1", "/orchestration", "claude", "inline");
+        RecordHerdr(context, "implementation", "wS:p2", "/implementation", "claude", "file-backed");
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(context.RepoRoot, Domain, Team);
+
+        var preview = Run(context, [
+            "session-layer", "topology", "move", "--domain", Domain, "--team", Team,
+            "--workspace-id", "w44",
+            "--pane-map", "wS:p1=w44:p1", "--pane-map", "wS:p2=w44:p2",
+            "--dry-run", "--format", "json",
+        ]);
+        Assert.Equal("dry-run", preview.GetProperty("mode").GetString());
+        Assert.True(preview.GetProperty("changed").GetBoolean());
+        Assert.False(preview.GetProperty("conflict").GetBoolean());
+
+        var write = Run(context, [
+            "session-layer", "topology", "move", "--domain", Domain, "--team", Team,
+            "--workspace-id", "w44",
+            "--pane-map", "wS:p1=w44:p1", "--pane-map", "wS:p2=w44:p2",
+            "--current-digest", preview.GetProperty("current_digest").GetString()!,
+            "--write", "--format", "json",
+        ]);
+        Assert.True(write.GetProperty("applied").GetBoolean());
+        Assert.False(write.GetProperty("conflict").GetBoolean());
+
+        var moved = JsonNode.Parse(File.ReadAllText(topologyPath))!.AsObject();
+        Assert.Equal("w44", moved["workspace_id"]!.GetValue<string>());
+        var movedRoles = moved["roles"]!.AsObject();
+        Assert.Equal("w44:p1", movedRoles["orchestrator"]!["pane_id"]!.GetValue<string>());
+        Assert.Equal("w44:p1", movedRoles["orchestration"]!["pane_id"]!.GetValue<string>());
+        Assert.Equal("w44:p2", movedRoles["implementation"]!["pane_id"]!.GetValue<string>());
+        Assert.Equal("/orchestrator", movedRoles["orchestrator"]!["cwd"]!.GetValue<string>());
+        Assert.Equal("codex", movedRoles["orchestrator"]!["kind"]!.GetValue<string>());
+        Assert.Equal("claude", movedRoles["orchestration"]!["kind"]!.GetValue<string>());
+
+        var validation = Run(context, [
+            "session-layer", "topology", "validate", "--domain", Domain, "--team", Team, "--format", "json",
+        ]);
+        Assert.True(validation.GetProperty("valid").GetBoolean());
+    }
+
+    [Fact]
+    public void Move_TwoDifferentOldPanesToOneNewPaneStillRefused_G735()
+    {
+        var context = CreateFixture();
+        SetHerdrOnly(context);
+        RecordHerdr(context, "orchestrator", "wS:p1", "/orchestrator", "codex", "inline");
+        RecordHerdr(context, "implementation", "wS:p2", "/implementation", "claude", "inline");
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(context.RepoRoot, Domain, Team);
+        var before = File.ReadAllText(topologyPath);
+
+        var refused = Run(context, [
+            "session-layer", "topology", "move", "--domain", Domain, "--team", Team,
+            "--workspace-id", "w44",
+            "--pane-map", "wS:p1=w44:p1", "--pane-map", "wS:p2=w44:p1",
+            "--dry-run", "--format", "json",
+        ], expectedExitCode: 1);
+
+        Assert.True(refused.GetProperty("conflict").GetBoolean());
+        var summary = refused.GetProperty("summary").GetString();
+        Assert.Contains("wS:p1", summary, StringComparison.Ordinal);
+        Assert.Contains("wS:p2", summary, StringComparison.Ordinal);
+        Assert.Contains("ambiguous", summary, StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllText(topologyPath));
+    }
+
+    [Fact]
+    public void Record_WholeTeamRefusalPointsAtMoveThatPerformsSharedPaneRebuild_G735()
+    {
+        var context = CreateFixture();
+        SetHerdrOnly(context);
+        RecordHerdr(context, "orchestrator", "wS:p1", "/orchestrator", "codex", "inline");
+        RecordHerdr(context, "orchestration", "wS:p1", "/orchestration", "claude", "inline");
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(context.RepoRoot, Domain, Team);
+        var before = File.ReadAllText(topologyPath);
+
+        var refusal = RunWithResult(context, [
+            "session-layer", "topology", "record", "--domain", Domain, "--team", Team, "--role", "implementation",
+            "--resident", "herdr", "--workspace-id", "w44", "--pane-id", "w44:p2",
+            "--cwd", "/implementation", "--kind", "claude", "--delivery-method", "inline",
+            "--write", "--format", "json",
+        ]);
+        Assert.Equal(1, refusal.ExitCode);
+        var refusalSummary = refusal.Result.GetProperty("summary").GetString();
+        Assert.Contains("already records workspace_id", refusalSummary, StringComparison.Ordinal);
+        Assert.Contains("topology move", refusalSummary, StringComparison.Ordinal);
+
+        var rebuild = Run(context, [
+            "session-layer", "topology", "move", "--domain", Domain, "--team", Team,
+            "--workspace-id", "w44",
+            "--pane-map", "wS:p1=w44:p1",
+            "--write", "--format", "json",
+        ]);
+        Assert.True(rebuild.GetProperty("applied").GetBoolean());
+        Assert.NotEqual(before, File.ReadAllText(topologyPath));
+
+        var moved = JsonNode.Parse(File.ReadAllText(topologyPath))!.AsObject();
+        Assert.Equal("w44", moved["workspace_id"]!.GetValue<string>());
+        Assert.Equal("w44:p1", moved["roles"]!["orchestrator"]!["pane_id"]!.GetValue<string>());
+        Assert.Equal("w44:p1", moved["roles"]!["orchestration"]!["pane_id"]!.GetValue<string>());
+    }
+
+    private static CliContext CreateFixture()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"intent-g735-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        return new CliContext
+        {
+            RepoRoot = root,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = Domain,
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                },
+            },
+        };
+    }
+
+    private static void SetHerdrOnly(CliContext context)
+    {
+        using var writer = new StringWriter();
+        var exitCode = SessionLayerCommand.ExecuteSet(
+            context,
+            ["--domain", Domain, "--team", Team, "--mode", SessionLayerMode.HerdrOnly, "--write", "--format", "json"],
+            writer);
+        Assert.Equal(0, exitCode);
+    }
+
+    private static void RecordHerdr(
+        CliContext context,
+        string role,
+        string pane,
+        string cwd,
+        string kind,
+        string deliveryMethod)
+    {
+        var result = RunWithResult(context, [
+            "session-layer", "topology", "record", "--domain", Domain, "--team", Team, "--role", role,
+            "--resident", "herdr", "--workspace-id", pane[..pane.IndexOf(':')], "--pane-id", pane,
+            "--cwd", cwd, "--kind", kind, "--delivery-method", deliveryMethod, "--write", "--format", "json",
+        ]);
+        Assert.Equal(0, result.ExitCode);
+        Assert.False(result.Result.GetProperty("conflict").GetBoolean());
+    }
+
+    private static JsonElement Run(CliContext context, IReadOnlyList<string> args, int expectedExitCode = 0)
+    {
+        var result = RunWithResult(context, args);
+        Assert.Equal(expectedExitCode, result.ExitCode);
+        return result.Result;
+    }
+
+    private static (int ExitCode, JsonElement Result) RunWithResult(
+        CliContext context,
+        IReadOnlyList<string> args)
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(args.ToArray(), context, writer);
+        using var document = JsonDocument.Parse(writer.ToString());
+        return (exitCode, document.RootElement.Clone());
+    }
+}


### PR DESCRIPTION
# G735: topology move accepts shared-pane roles; record's pointer now leads somewhere that works

Fixes #1593.

## What I did

**1. Corrected the pane-map guard (was keyed on the wrong side of the mapping).**
`SessionLayerTopologyCommand.cs` tracked seen *new* panes in a `HashSet`, so any repeat of a new pane was refused — including the unambiguous case where several roles share one old pane. The check is now keyed on old-pane identity: a new pane may be reused only when every mapping into it comes from the *same* old pane. Two *different* old panes mapping to one new pane remains a refusal, and the refusal now names both old panes.

- `mappedPanes` became a `Dictionary<newPane, oldPane>`; a repeat new pane is accepted only if it maps from the same recorded old pane.
- New refusal wording: `--pane-map maps two different recorded old panes ('w44:p2' and 'w44:p1') to new pane 'w55:p1'; refusing an ambiguous workspace move.`

**2. Resolved the mutual redirection.** The record-side refusal still refuses (unchanged in principle — whole-team moves are not done role by role) and still points to `topology move`, but now also states the rule that makes the pointed-to command actually work for the shared-pane shape: "Pass one --pane-map per recorded old pane: several roles that share one recorded old pane travel together under that single mapping." A reader arriving at `record` now reaches a `move` invocation that succeeds.

**3. Tests** (`TopologyWorkspaceMoveSharedPaneG735Tests.cs`, 3 new tests — the failing shape was *constructed*, since no local team has two roles on one pane):
- shared old pane (`orchestrator` + `orchestration` both at `wS:p1`) moves and validates;
- two different old panes → one new pane is still refused and the record is untouched;
- the record-side refusal text points at a move that then performs the shared-pane rebuild.

**4. Docs:** updated the `topology workspace move` section in `docs/en/08-command-reference.md` and `docs/ja/08-command-reference.md` to state the shared-pane rule and the still-refused ambiguous case.

## What I verified

Build: `dotnet build src/IntentSystem.Cli/IntentSystem.Cli.csproj -c Release` — succeeded, 0 warnings.
Full suite: `dotnet test tests/IntentSystem.Cli.Tests/IntentSystem.Cli.Tests.csproj -c Release` — **5211 passed, 0 failed, 1 skipped** (pre-existing skip). No test files were modified.

End-to-end with the built CLI against a constructed fixture (`remote-herdr` team, `orchestrator` + `orchestration` both recorded at `wS:p1`, `implementation` at `wS:p2`):

Shared-pane move succeeding:
```
$ session-layer topology move --domain remote-herdr --team remote-herdr --workspace-id w44 \
    --pane-map wS:p1=w44:p1 --pane-map wS:p2=w44:p2 --write
applied: True | conflict: False
Moved recorded topology for team 'remote-herdr' from workspace 'wS' to 'w44' with 2 pane mapping(s).

$ session-layer topology validate ...
valid: True
```

Ambiguous mapping still refused (after the move, so the recorded panes are w44:p1/w44:p2):
```
$ session-layer topology move --workspace-id w55 --pane-map w44:p1=w55:p1 --pane-map w44:p2=w55:p1 --write
conflict: True
--pane-map maps two different recorded old panes ('w44:p2' and 'w44:p1') to new pane 'w55:p1'; refusing an ambiguous workspace move.
```

What `record` says when the team already records a workspace:
```
conflict: True
Team 'remote-herdr' already records workspace_id 'wS', but role 'review' requested 'w44'. Refusing
to repair the conflict. For an operator-approved whole-team rebuild, use `intent-cli session-layer
topology move --domain <domain> --team <team> --workspace-id <new-workspace-id> --pane-map
<old-pane>=<new-pane> --write`. Pass one --pane-map per recorded old pane: several roles that share
one recorded old pane travel together under that single mapping.
```

## For the reporter: does your hand-edited topology match what the fixed command produces?

**Yes — leave it alone, with one field to check.** The fixed move writes exactly: the team-level `workspace_id` set to the new workspace, and for every herdr role `workspace_id` = the new workspace id and `pane_id` = the mapped new pane. Nothing else (cwd, kind, delivery method, readers, custom fields) is touched.

One nuance the packet didn't name: the move writes role `workspace_id` as the `--workspace-id` argument verbatim — it does not derive it from the pane prefix. If your hand edit set role `workspace_id` to the bare new workspace (e.g. `w44`), it matches the command's output exactly. If you wrote a prefixed value (e.g. `w44:w44`), that field differs from what the command would produce; fix just that field or redo the move — `topology validate` may still pass on the prefixed form, so check it explicitly.

## What I could not do

- Nothing was left unverified that the packet asked for. Both directions (shared-pane success, ambiguous refusal), post-move validation, and the record-side message are shown above from real runs.
- The fix was validated on a constructed fixture, not a local reproduction — no domain on this host records two roles on one pane, as the packet states.

Out of scope untouched: role topology semantics, the record-side refusal in principle, workspace auto-detection.
