### PR TITLE
docs: expose external design receive guidance

### DIFF
--- a/src/IntentSystem.Cli/Commands/GuideBootstrapCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideBootstrapCommand.cs
@@ -163,7 +163,7 @@ internal static class GuideBootstrapCommand
                 {
                     Number = 5,
                     Id = "ask-app-kind-and-place-design",
-                    Instruction = "Ask the human which agent kind this application conversation uses and whether that kind has an inbound application monitor. Never infer or default either answer. With a monitor, design may be the recorded external reader; without one, design must be a recorded herdr seat at the routing-root cwd. This placement rule does not move recovery authority from orchestration.",
+                    Instruction = $"Ask the human which agent kind this application conversation uses and whether that kind has an inbound application monitor. Never infer or default either answer. With a monitor, design may be the recorded external reader; at the human-selected external branch, follow the rendered `intent-cli guide design-thread --domain {domainArg} --team {teamArg} --routing-root {routingRoot} --format markdown` guidance for its canonical role-scoped `intent-cli notify collect --role design` receive, caller-held cursor, and bounded wait. Without one, design must be a recorded herdr seat at the routing-root cwd. This placement rule does not move recovery authority from orchestration.",
                     EmittedCommands =
                     [
                         $"intent-cli session-layer topology record --domain {domainArg} --team {teamArg} --role design --resident <external-or-herdr-from-human-answer> <reader-or-workspace-pane-and-cwd-fields> --write --format json",

--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -79,6 +79,8 @@ internal static class GuideDesignThreadCommand
     internal static DesignThreadGuideResult BuildResult(string? domain, string? team, string? routingRoot)
     {
         var root = string.IsNullOrWhiteSpace(routingRoot) ? "<routing-root>" : routingRoot!;
+        var domainArg = string.IsNullOrWhiteSpace(domain) ? "<domain>" : domain.Trim();
+        var teamArg = string.IsNullOrWhiteSpace(team) ? "<team>" : team.Trim();
         return new DesignThreadGuideResult
         {
             Process = "design-thread-operating-contract",
@@ -93,6 +95,12 @@ internal static class GuideDesignThreadCommand
                 Command = CommandName,
                 Catalog = "intent-cli guide commands list --format json",
                 Advisor = "intent-cli guide next --format json",
+                ExternalReader = new DesignThreadExternalReader
+                {
+                    Command = $"intent-cli notify collect --domain {domainArg} --team {teamArg} --role design --since <cursor> --wait --timeout-ms <timeout-ms> --format json",
+                    CursorRule = "The caller holds the opaque cursor: omit `--since` for the first receive; the next cursor is returned in each result, and the caller supplies that returned cursor in the next call.",
+                    WaitRule = "A bounded wait is required: use `--wait` with a finite `--timeout-ms <timeout-ms>`; never use an unbounded wait.",
+                },
             },
             WakeRule = new DesignThreadWakeRule { ValidOutcomes = ValidWakeOutcomes, NotOutcomes = InvalidWakeOutcomes },
             Provenance = new DesignThreadProvenance
@@ -190,6 +198,11 @@ internal static class GuideDesignThreadCommand
         writer.WriteLine($"- command: `{result.Reachability.Command}`");
         writer.WriteLine($"- catalog: `{result.Reachability.Catalog}`");
         writer.WriteLine($"- design-role advisor: `{result.Reachability.Advisor}` names this guide.");
+        writer.WriteLine();
+        writer.WriteLine("## External-resident design receive");
+        writer.WriteLine($"- canonical receive: `{result.Reachability.ExternalReader.Command}`");
+        writer.WriteLine($"- cursor: {result.Reachability.ExternalReader.CursorRule}");
+        writer.WriteLine($"- wait: {result.Reachability.ExternalReader.WaitRule}");
         WriteList(writer, "## 1. Four-outcome wake rule", result.WakeRule.ValidOutcomes);
         WriteList(writer, "### Not outcomes", result.WakeRule.NotOutcomes);
         writer.WriteLine("## 2. Provenance vocabulary");
@@ -320,7 +333,19 @@ internal sealed record DesignThreadGuideResult
     public required IReadOnlyList<string> NegativeInvariants { get; init; }
 }
 
-internal sealed record DesignThreadReachability { public required string Command { get; init; } public required string Catalog { get; init; } public required string Advisor { get; init; } }
+internal sealed record DesignThreadReachability
+{
+    public required string Command { get; init; }
+    public required string Catalog { get; init; }
+    public required string Advisor { get; init; }
+    public required DesignThreadExternalReader ExternalReader { get; init; }
+}
+internal sealed record DesignThreadExternalReader
+{
+    public required string Command { get; init; }
+    public required string CursorRule { get; init; }
+    public required string WaitRule { get; init; }
+}
 internal sealed record DesignThreadWakeRule { public required IReadOnlyList<string> ValidOutcomes { get; init; } public required IReadOnlyList<string> NotOutcomes { get; init; } }
 internal sealed record DesignThreadProvenance { public required IReadOnlyList<string> Vocabulary { get; init; } public required string ExecutionUnitRule { get; init; } public required IReadOnlyList<string> ExternalOriginFields { get; init; } }
 internal sealed record DesignThreadApproval { public required string ReadOnlyRule { get; init; } public required string MergeRule { get; init; } public required IReadOnlyList<string> MergeTransaction { get; init; } public required IReadOnlyList<string> ExplicitAcceptanceStillRequired { get; init; } }

--- a/tests/IntentSystem.Cli.Tests/GuideDesignThreadCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/GuideDesignThreadCommandTests.cs
@@ -1,0 +1,143 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+public sealed class GuideDesignThreadCommandTests
+{
+    [Fact]
+    public void DesignThread_RenderedGuideNamesExternalRoleScopedReceiveWithCallerCursorAndBoundedWait()
+    {
+        var output = RenderDesignMarkdown();
+        var section = SectionFrom(output, "## External-resident design receive");
+
+        Assert.Contains(
+            "intent-cli notify collect --domain <domain> --team <team> --role design --since <cursor> --wait --timeout-ms <timeout-ms> --format json",
+            section,
+            StringComparison.Ordinal);
+        Assert.Contains("caller", section, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("opaque cursor", section, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("returned in each result", section, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("bounded", section, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("required", section, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("--task-id", section, StringComparison.Ordinal);
+        Assert.DoesNotContain("claude", section, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("codex", section, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("copilot", section, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Bootstrap_RenderedExternalBranchPointsToDesignThreadReceiveGuidance()
+    {
+        var root = Directory.CreateTempSubdirectory("g762-bootstrap-").FullName;
+        try
+        {
+            using var writer = new StringWriter();
+            Assert.Equal(
+                0,
+                GuideBootstrapCommand.Execute(
+                    CreateContext(root),
+                    [
+                        "--domain", "intent-cli", "--team", "intent-cli-dev", "--target-repo", "owner/repo",
+                        "--routing-root", root, "--format", "json",
+                    ],
+                    writer));
+
+            using var document = JsonDocument.Parse(writer.ToString());
+            var externalBranch = document.RootElement.GetProperty("steps")[4];
+            var instruction = externalBranch.GetProperty("instruction").GetString()!;
+            Assert.Contains("human-selected external branch", instruction, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("intent-cli guide design-thread", instruction, StringComparison.Ordinal);
+            Assert.Contains("notify collect", instruction, StringComparison.Ordinal);
+            Assert.Contains("role-scoped", instruction, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("bounded", instruction, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void DesignThread_RenderedDeploymentRuleRemainsByteIdentical()
+    {
+        using var document = JsonDocument.Parse(RenderDesignJson("/routing-root"));
+        Assert.Equal(
+            "A design seat whose agent kind has no inbound app monitor must be a recorded resident herdr seat with cwd `/routing-root`, where persistent AGENTS rules apply. A kind with an inbound app monitor may use that external reader. This is a deployment rule, not a recommendation.",
+            document.RootElement.GetProperty("monitoring").GetProperty("deployment_rule").GetString());
+    }
+
+    [Fact]
+    public void OrchestratorThread_RenderedOutputRemainsByteIdentical()
+    {
+        var root = Directory.CreateTempSubdirectory("g762-orchestrator-").FullName;
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, ".intent-cli"));
+            var context = CreateContext(root);
+            using var writer = new StringWriter();
+            Assert.Equal(
+                0,
+                CommandRouter.Execute(
+                    [
+                        "guide", "orchestrator-thread", "--domain", "intent-cli",
+                        "--target-repo", "J-Tech-Japan/intent-system", "--agent", "codex",
+                        "--team", "intent-cli-dev", "--format", "markdown",
+                    ],
+                    context,
+                    writer));
+
+            var hash = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(writer.ToString())));
+            Assert.Equal("b5a1e38ccec10ee9e1208c1deaf6930edb17e0ac5104d2632405e048b76cb88c", hash);
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static string RenderDesignMarkdown()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(CreateContext(Path.GetTempPath()), [], writer));
+        return writer.ToString();
+    }
+
+    private static string RenderDesignJson(string routingRoot)
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(
+            0,
+            GuideDesignThreadCommand.Execute(
+                CreateContext(routingRoot),
+                ["--routing-root", routingRoot, "--format", "json"],
+                writer));
+        return writer.ToString();
+    }
+
+    private static string SectionFrom(string output, string heading)
+    {
+        var start = output.IndexOf(heading, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"missing section heading: {heading}");
+        var next = output.IndexOf("\n## ", start + heading.Length, StringComparison.Ordinal);
+        return next < 0 ? output[start..] : output[start..next];
+    }
+
+    private static CliContext CreateContext(string root) => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+        },
+    };
+}


### PR DESCRIPTION
Closes #1657

## Summary
- Add rendered `guide design-thread` guidance for an external-resident design seat using role-scoped `intent-cli notify collect --role design` with a caller-held opaque cursor and required bounded `--wait`/`--timeout-ms`.
- Make bootstrap step 5 point to that rendered guidance at the human-selected external branch.
- Keep notify collect behavior, the design deployment rule, and the orchestrator-thread guide unchanged.

## Verification
- Parent baseline `5d553b7a`: the new rendered design receive and bootstrap pointer tests failed (missing section / missing pointer); the deployment and existing orchestrator hash guards passed.
- Focused G762 rendered-guide tests: 4 passed, 0 failed.
- Existing guide compatibility set (G654/G706/G664/G586): 27 passed, 0 failed.
- Full Release: Failed 0, Passed 5371, Skipped 1, Total 5372.
- `git diff --check`: clean.

The child selector/preflight reported `next-action=wait` on unrelated issue #1655 and issue-preflight `classification=claim-unavailable` because `.git/FETCH_HEAD` could not be opened. The supplied authoritative host claim for `execution-unit:G762` on host origin/main was consumed; no child execution-unit claim was created or mutated.