### PR TITLE
G761: add guarded topology residence transition

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1795,7 +1795,7 @@ form a recovery dead end.
 Agent kind is whatever herdr can start: Claude, Codex, Copilot, Cursor, OpenCode,
 and others are examples, not a supported-set restriction. Logical role defaults
 are `implementation`, `review`, `interview`, and `clarify`; existing explicit
-role mappings, including legacy product-named mappings, remain valid. The three
+role mappings, including legacy product-named mappings, remain valid. The four
 update/retire mutation commands emit JSON and support only `--format json`. For `update-kind`,
 an explicit `--dry-run` takes precedence over `--write` in either flag order and
 never writes.
@@ -1840,6 +1840,32 @@ The registry initially permits only `delivery_method`, so an unknown or dotted
 name is refused rather than becoming an arbitrary JSON-path editor. The command
 changes only that field. It does not relax `record`: re-recording a different
 shape still refuses its conflict and has no force flag.
+
+#### Guarded residence transition (G761)
+
+When the human answer from `guide bootstrap` changes whether a role has an
+inbound application monitor, use the explicit residence transition instead of
+editing the topology file:
+
+```text
+intent-cli session-layer topology update-residence --domain <domain> --team <team> --role <role> --current-resident <herdr|external> --new-resident <herdr|external> [destination fields] --confirm-update-residence --write --format json
+```
+
+The human answer from `guide bootstrap` controls residence. intent-cli never
+infers it or supplies a default. The command asserts the recorded current
+resident, requires the new resident and explicit confirmation, and uses the
+same guarded compare-and-swap shape as the other topology writers. Use
+`--dry-run` for the guarded preview; it does not write the record.
+
+The destination has the same shape as `topology record`: `herdr` requires
+`--workspace-id`, `--pane-id`, and `--cwd`, and rejects `--reader` and
+`--frontend`; `external` requires `--reader` and rejects workspace, pane, cwd,
+kind, and delivery-method fields. Fields owned only by the old residence are
+removed, so a transitioned role has no stranded reader or pane fields. The
+existing `record` conflict refusal remains fail-closed and has no
+`--force`/`--replace` bypass. Delivery resolution is unchanged: herdr still
+resolves to its recorded pane and external still resolves to its recorded
+reader.
 
 #### Visible, generated mode markers
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -1542,7 +1542,7 @@ refusal は動作する whole-team move command を示すため、二つの surf
 agent kind は herdr が起動できる任意の kind です。Claude、Codex、Copilot、Cursor、OpenCode などは
 例であり、supported-set の制約ではありません。logical role の既定値は `implementation`、`review`、
 `interview`、`clarify` です。legacy の product 名を含め、既存の明示的な role mapping はそのまま
-有効です。3 つの update/retire mutation command は JSON を出力し、`--format json` だけをサポートします。
+有効です。4 つの update/retire mutation command は JSON を出力し、`--format json` だけをサポートします。
 `update-kind` では明示した `--dry-run` が flag の順序にかかわらず `--write` より優先され、決して
 書き込みません。
 
@@ -1575,6 +1575,27 @@ herdr query を行いません。mapping が存在するか herdr-only が必要
 unknown または dotted name は任意の JSON path を編集できないよう拒否されます。この command が
 変更するのはその field だけです。`record` の conflict refusal は緩和されず、異なる shape の re-record は
 引き続き拒否され、force flag もありません。
+
+#### Guarded residence transition (G761)
+
+`guide bootstrap` の human answer が role の inbound application monitor の有無を変える場合は、topology file を
+直接編集せず、明示的な residence transition を使います。
+
+```text
+intent-cli session-layer topology update-residence --domain <domain> --team <team> --role <role> --current-resident <herdr|external> --new-resident <herdr|external> [destination fields] --confirm-update-residence --write --format json
+```
+
+`guide bootstrap` の human answer が residence を決めます。intent-cli は residence を推測せず、default も
+補いません。command は記録済みの current resident を確認し、新しい resident と explicit confirmation を
+要求し、他の topology writer と同じ guarded compare-and-swap の形を使います。guarded preview には
+`--dry-run` を指定し、record は書き換えません。
+
+destination の形は `topology record` と同じです。`herdr` は `--workspace-id`、`--pane-id`、`--cwd` が必要で、
+`--reader` と `--frontend` を拒否します。`external` は `--reader` が必要で、workspace、pane、cwd、kind、
+delivery-method field を拒否します。旧 residence だけに属する field は削除するため、transition 後に reader や
+pane field が stranded になることはありません。既存の `record` conflict refusal は fail-closed のままで、
+`--force`/`--replace` の bypass はありません。delivery resolution も変わらず、herdr は記録済み pane、external は
+記録済み reader に解決されます。
 
 #### 可視な生成済み mode marker
 

--- a/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
@@ -46,6 +46,13 @@ internal static class SessionLayerTopologyCommand
         "Usage: intent-cli session-layer topology update-field --domain <name> --team <name> --role <name> "
         + "--field delivery_method --current <value|absent> --new <value> --confirm-update-field "
         + "[--dry-run|--write] [--format json]";
+    private const string UpdateResidenceUsage =
+        "Usage: intent-cli session-layer topology update-residence --domain <name> --team <name> --role <name> "
+        + "--current-resident herdr|external --new-resident herdr|external "
+        + "[--workspace-id <id> --pane-id <id> --cwd <path> | --reader <routing-root-relative-path>] "
+        + "[--frontend <name>] [--kind <kind>] [--delivery-method inline|file-backed] "
+        + "[--model <text>] [--reasoning-effort <text>] --confirm-update-residence "
+        + "[--dry-run|--write] --format json";
     private const string RetireLegacyUsage =
         "Usage: intent-cli session-layer topology retire-legacy --domain <name> --team <name> "
         + "--evidence <named-fleet-migration-evidence> --confirm-retire-legacy --write [--format json]";
@@ -80,6 +87,7 @@ internal static class SessionLayerTopologyCommand
             writer.WriteLine(MoveUsage);
             writer.WriteLine(UpdateKindUsage);
             writer.WriteLine(UpdateFieldUsage);
+            writer.WriteLine(UpdateResidenceUsage);
             writer.WriteLine(RetireLegacyUsage);
             writer.WriteLine(RecordProfileUsage);
             return args.Length == 0 ? 1 : 0;
@@ -115,6 +123,7 @@ internal static class SessionLayerTopologyCommand
             "move" => ExecuteMove(context, args[1..], writer),
             "update-kind" => ExecuteUpdateKind(context, args[1..], writer),
             "update-field" => ExecuteUpdateField(context, args[1..], writer),
+            "update-residence" => ExecuteUpdateResidence(context, args[1..], writer),
             "retire-legacy" => ExecuteRetireLegacy(context, args[1..], writer),
             _ => UnknownSubcommand(args[0], writer),
         };
@@ -498,6 +507,26 @@ internal static class SessionLayerTopologyCommand
         return result.Conflict ? 1 : 0;
     }
 
+    internal static int ExecuteUpdateResidence(CliContext context, string[] args, TextWriter writer)
+    {
+        if (IsHelp(args))
+        {
+            writer.WriteLine(UpdateResidenceUsage);
+            return 0;
+        }
+
+        if (!TryParseUpdateResidenceArguments(args, out var request, out var error))
+        {
+            writer.WriteLine(error);
+            writer.WriteLine(UpdateResidenceUsage);
+            return 1;
+        }
+
+        var result = SessionLayerTopologyWriter.UpdateResidence(context.RepoRoot, request!);
+        WriteJson(writer, result);
+        return result.Conflict ? 1 : 0;
+    }
+
     internal static int ExecuteRetireLegacy(CliContext context, string[] args, TextWriter writer)
     {
         if (IsHelp(args))
@@ -695,6 +724,165 @@ internal static class SessionLayerTopologyCommand
         // A dry-run is an explicit non-mutating request, irrespective of flag order.
         var write = requestedWrite && !requestedDryRun;
         request = new(values["--domain"], values["--team"], values["--role"], values["--field"], values["--current"], values["--new"], write);
+        return true;
+    }
+
+    private static bool TryParseUpdateResidenceArguments(
+        string[] args,
+        out SessionLayerTopologyResidenceUpdateRequest? request,
+        out string error)
+    {
+        request = null;
+        error = string.Empty;
+        var values = new Dictionary<string, string>(StringComparer.Ordinal);
+        var confirm = false;
+        var requestedWrite = false;
+        var requestedDryRun = false;
+        var format = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            var option = args[index];
+            switch (option)
+            {
+                case "--confirm-update-residence":
+                    confirm = true;
+                    break;
+                case "--write":
+                    requestedWrite = true;
+                    break;
+                case "--dry-run":
+                    requestedDryRun = true;
+                    break;
+                case "--format":
+                    if (!TryReadValue(args, ref index, option, out var requestedFormat, out error)
+                        || !string.Equals(requestedFormat, FormatJson, StringComparison.Ordinal))
+                    {
+                        error = string.IsNullOrEmpty(error)
+                            ? "update-residence supports only '--format json'."
+                            : error;
+                        return false;
+                    }
+                    format = requestedFormat!;
+                    break;
+                case "--domain" or "--team" or "--role" or "--current-resident" or "--new-resident"
+                    or "--workspace-id" or "--pane-id" or "--cwd" or "--kind" or "--delivery-method"
+                    or "--reader" or "--frontend" or "--model" or "--reasoning-effort":
+                    if (!TryReadValue(args, ref index, option, out var value, out error))
+                    {
+                        return false;
+                    }
+                    values[option] = value!;
+                    break;
+                default:
+                    error = $"Unknown argument '{option}'.";
+                    return false;
+            }
+        }
+
+        var required = new[] { "--domain", "--team", "--role", "--current-resident", "--new-resident" };
+        if (!confirm || (!requestedWrite && !requestedDryRun)
+            || !string.Equals(format, FormatJson, StringComparison.Ordinal)
+            || required.Any(name => !values.TryGetValue(name, out var value) || string.IsNullOrWhiteSpace(value)))
+        {
+            error = "--domain, --team, --role, --current-resident, --new-resident, "
+                + "--confirm-update-residence, --format json, and either --write or --dry-run are required.";
+            return false;
+        }
+
+        var currentResidence = values["--current-resident"];
+        var newResidence = values["--new-resident"];
+        if (currentResidence is not (NotifyRecordedRole.HerdrResident or NotifyRecordedRole.ExternalResident)
+            || newResidence is not (NotifyRecordedRole.HerdrResident or NotifyRecordedRole.ExternalResident))
+        {
+            error = "--current-resident and --new-resident must each be 'herdr' or 'external'.";
+            return false;
+        }
+
+        if (string.Equals(currentResidence, newResidence, StringComparison.Ordinal))
+        {
+            error = "--current-resident and --new-resident must name different residences.";
+            return false;
+        }
+
+        if (!SessionLayerTopologyDeclaredValueRules.TryValidate(
+                values.GetValueOrDefault("--model"),
+                "--model",
+                out error)
+            || !SessionLayerTopologyDeclaredValueRules.TryValidate(
+                values.GetValueOrDefault("--reasoning-effort"),
+                "--reasoning-effort",
+                out error))
+        {
+            return false;
+        }
+
+        if (string.Equals(newResidence, NotifyRecordedRole.HerdrResident, StringComparison.Ordinal))
+        {
+            if (!values.TryGetValue("--workspace-id", out var workspaceId) || string.IsNullOrWhiteSpace(workspaceId)
+                || !values.TryGetValue("--pane-id", out var paneId) || string.IsNullOrWhiteSpace(paneId)
+                || !values.TryGetValue("--cwd", out var cwd) || string.IsNullOrWhiteSpace(cwd))
+            {
+                error = "A herdr destination requires --workspace-id, --pane-id, and --cwd.";
+                return false;
+            }
+
+            if (values.ContainsKey("--reader") || values.ContainsKey("--frontend"))
+            {
+                error = "A herdr destination does not accept --reader or --frontend.";
+                return false;
+            }
+
+            if (values.TryGetValue("--delivery-method", out var deliveryMethod)
+                && deliveryMethod is not ("inline" or "file-backed"))
+            {
+                error = "--delivery-method must be inline or file-backed when supplied.";
+                return false;
+            }
+
+            var paneWorkspace = WorkspaceFromPane(paneId!);
+            if (paneWorkspace is not null
+                && !string.Equals(paneWorkspace, workspaceId, StringComparison.Ordinal))
+            {
+                error = $"--pane-id '{paneId}' belongs to workspace '{paneWorkspace}', not --workspace-id "
+                    + $"'{workspaceId}'. Refusing a cross-workspace mapping.";
+                return false;
+            }
+        }
+        else
+        {
+            if (!values.TryGetValue("--reader", out var reader) || string.IsNullOrWhiteSpace(reader))
+            {
+                error = "An external destination requires --reader.";
+                return false;
+            }
+
+            if (values.ContainsKey("--workspace-id") || values.ContainsKey("--pane-id")
+                || values.ContainsKey("--cwd") || values.ContainsKey("--kind")
+                || values.ContainsKey("--delivery-method"))
+            {
+                error = "An external destination does not accept --workspace-id, --pane-id, --cwd, --kind, "
+                    + "or --delivery-method.";
+                return false;
+            }
+        }
+
+        request = new SessionLayerTopologyResidenceUpdateRequest(
+            values["--domain"],
+            values["--team"],
+            values["--role"],
+            currentResidence,
+            newResidence,
+            values.GetValueOrDefault("--workspace-id"),
+            values.GetValueOrDefault("--pane-id"),
+            values.GetValueOrDefault("--cwd"),
+            values.GetValueOrDefault("--kind"),
+            values.GetValueOrDefault("--delivery-method"),
+            values.GetValueOrDefault("--reader"),
+            values.GetValueOrDefault("--frontend"),
+            values.GetValueOrDefault("--model"),
+            values.GetValueOrDefault("--reasoning-effort"),
+            requestedWrite && !requestedDryRun);
         return true;
     }
 
@@ -2266,6 +2454,183 @@ internal static class SessionLayerTopologyWriter
         }
     }
 
+    public static SessionLayerTopologyResidenceUpdateResult UpdateResidence(
+        string routingRoot,
+        SessionLayerTopologyResidenceUpdateRequest request)
+    {
+        var mode = request.Write ? "write" : "dry-run";
+        var path = NotifyRoleTopologyStore.ResolvePath(routingRoot, request.Domain, request.Team);
+        FileStream? casLock = null;
+        string? currentDigest = null;
+        try
+        {
+            if (request.Write)
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+                casLock = AcquireCasLock(path);
+                EnsureLocalIgnore(routingRoot);
+            }
+
+            if (!File.Exists(path))
+            {
+                return ResidenceConflict(request,
+                    $"Topology record '{path}' is absent; refusing to update an unrecorded role.");
+            }
+
+            var originalBytes = File.ReadAllBytes(path);
+            currentDigest = ComputeTopologyDigest(originalBytes);
+            var validation = NotifyRoleTopologyStore.Validate(routingRoot, request.Domain, request.Team);
+            if (!validation.Valid)
+            {
+                return ResidenceConflict(request,
+                    "Topology record is invalid; refusing update-residence. "
+                    + string.Join(" ", validation.Findings.Select(finding => finding.Message)));
+            }
+
+            var root = JsonNode.Parse(originalBytes) as JsonObject
+                ?? throw new JsonException("the root is not an object");
+            var teamError = string.Empty;
+            var rolesError = string.Empty;
+            if (!TrySelectTeamForWrite(root, request.Team, out var team, out teamError)
+                || !TrySelectRolesForWrite(team!, out var roles, out rolesError)
+                || !roles!.TryGetPropertyValue(request.Role, out var roleNode)
+                || roleNode is not JsonObject role)
+            {
+                return ResidenceConflict(request,
+                    teamError.Length == 0 ? rolesError : teamError);
+            }
+
+            var actualResidence = ReadString(role, "resident");
+            if (!string.Equals(actualResidence, request.CurrentResidence, StringComparison.Ordinal))
+            {
+                return ResidenceConflict(request,
+                    $"Role '{request.Role}' records residence '{actualResidence ?? "missing"}', not stated current "
+                    + $"residence '{request.CurrentResidence}'. Refusing update-residence.");
+            }
+
+            if (request.NewResidence is not (NotifyRecordedRole.HerdrResident or NotifyRecordedRole.ExternalResident))
+            {
+                return ResidenceConflict(request,
+                    $"New residence '{request.NewResidence}' is unsupported; refusing update-residence.");
+            }
+
+            if (!SessionLayerTopologyDeclaredValueRules.TryValidate(request.Model, "--model", out var declaredError)
+                || !SessionLayerTopologyDeclaredValueRules.TryValidate(
+                    request.ReasoningEffort,
+                    "--reasoning-effort",
+                    out declaredError))
+            {
+                return ResidenceConflict(request, declaredError);
+            }
+
+            if (string.Equals(request.NewResidence, NotifyRecordedRole.ExternalResident, StringComparison.Ordinal)
+                && !NotifyRoleTopologyStore.TryResolveReaderPath(
+                    routingRoot,
+                    request.Reader,
+                    out _,
+                    out var readerError))
+            {
+                return ResidenceConflict(request,
+                    $"External role '{request.Role}' field 'reader' is unsafe: {readerError}");
+            }
+
+            var before = root.DeepClone();
+            role["resident"] = request.NewResidence;
+            if (string.Equals(request.NewResidence, NotifyRecordedRole.HerdrResident, StringComparison.Ordinal))
+            {
+                role.Remove("reader");
+                role.Remove("frontend");
+                role["workspace_id"] = request.WorkspaceId;
+                role["pane_id"] = request.PaneId;
+                role["cwd"] = request.Cwd;
+                if (request.Kind is not null)
+                {
+                    role["kind"] = request.Kind;
+                }
+                if (request.DeliveryMethod is not null)
+                {
+                    role["delivery_method"] = request.DeliveryMethod;
+                }
+                SetTeamWorkspace(team!, request.WorkspaceId!);
+            }
+            else
+            {
+                role.Remove("workspace_id");
+                role.Remove("pane_id");
+                role.Remove("cwd");
+                role.Remove("kind");
+                role.Remove("delivery_method");
+                role["reader"] = request.Reader;
+                if (request.Frontend is not null)
+                {
+                    role["frontend"] = request.Frontend;
+                }
+                else
+                {
+                    role.Remove("frontend");
+                }
+            }
+
+            if (request.Model is not null)
+            {
+                role["model"] = request.Model;
+            }
+            if (request.ReasoningEffort is not null)
+            {
+                role["reasoning_effort"] = request.ReasoningEffort;
+            }
+
+            var after = root.DeepClone();
+            var changed = !JsonNode.DeepEquals(before, after);
+            if (request.Write && changed)
+            {
+                // The lock serializes canonical writers. The second digest
+                // read is the compare step for edits made by non-cooperating
+                // writers while this transition was being prepared.
+                var beforeWriteDigest = ComputeTopologyDigest(File.ReadAllBytes(path));
+                if (!string.Equals(beforeWriteDigest, currentDigest, StringComparison.OrdinalIgnoreCase))
+                {
+                    return ResidenceConflict(request,
+                        $"Topology update-residence lost its CAS: current digest is '{beforeWriteDigest}', "
+                        + $"not the snapshot digest '{currentDigest}'. Refusing to overwrite a concurrently changed record.");
+                }
+
+                WriteAtomically(path, root.ToJsonString(FileJsonOptions) + Environment.NewLine);
+            }
+
+            return new SessionLayerTopologyResidenceUpdateResult
+            {
+                Team = request.Team,
+                Role = request.Role,
+                CurrentResident = request.CurrentResidence,
+                NewResident = request.NewResidence,
+                Mode = mode,
+                Applied = request.Write && changed,
+                Changed = changed,
+                Conflict = false,
+                Summary = request.Write
+                    ? $"Updated recorded role '{request.Role}' in team '{request.Team}' from residence "
+                        + $"'{request.CurrentResidence}' to '{request.NewResidence}'."
+                    : $"Dry-run: would update recorded role '{request.Role}' in team '{request.Team}' from residence "
+                        + $"'{request.CurrentResidence}' to '{request.NewResidence}'.",
+            };
+        }
+        catch (IOException exception)
+        {
+            return ResidenceConflict(request,
+                $"Topology update-residence could not acquire its CAS lock or read/write the record: {exception.Message}");
+        }
+        catch (Exception exception) when (exception is UnauthorizedAccessException or JsonException)
+        {
+            return ResidenceConflict(request,
+                $"Topology update-residence could not read the record: {exception.Message}");
+        }
+        finally
+        {
+            casLock?.Dispose();
+        }
+    }
+
     public static SessionLayerTopologyLegacyRetireResult RetireLegacy(string routingRoot, SessionLayerTopologyLegacyRetireRequest request)
     {
         var legacyPath = NotifyRoleTopologyStore.ResolvePath(routingRoot);
@@ -2564,6 +2929,21 @@ internal static class SessionLayerTopologyWriter
         WriteAtomically(path, content);
     }
 
+    private static SessionLayerTopologyResidenceUpdateResult ResidenceConflict(
+        SessionLayerTopologyResidenceUpdateRequest request,
+        string summary) => new()
+        {
+            Team = request.Team,
+            Role = request.Role,
+            CurrentResident = request.CurrentResidence,
+            NewResident = request.NewResidence,
+            Mode = request.Write ? "write" : "dry-run",
+            Applied = false,
+            Changed = false,
+            Conflict = true,
+            Summary = summary,
+        };
+
     private static SessionLayerTopologyMoveResult MoveConflict(
         SessionLayerTopologyMoveRequest request,
         string path,
@@ -2773,6 +3153,36 @@ internal sealed record SessionLayerTopologyProfileRecordResult
     public required bool AlreadyRecorded { get; init; }
     public required bool Conflict { get; init; }
     public required string Digest { get; init; }
+    public required string Summary { get; init; }
+}
+
+internal sealed record SessionLayerTopologyResidenceUpdateRequest(
+    string Domain,
+    string Team,
+    string Role,
+    string CurrentResidence,
+    string NewResidence,
+    string? WorkspaceId,
+    string? PaneId,
+    string? Cwd,
+    string? Kind,
+    string? DeliveryMethod,
+    string? Reader,
+    string? Frontend,
+    string? Model,
+    string? ReasoningEffort,
+    bool Write);
+
+internal sealed record SessionLayerTopologyResidenceUpdateResult
+{
+    public required string Team { get; init; }
+    public required string Role { get; init; }
+    public required string CurrentResident { get; init; }
+    public required string NewResident { get; init; }
+    public required string Mode { get; init; }
+    public required bool Applied { get; init; }
+    public required bool Changed { get; init; }
+    public required bool Conflict { get; init; }
     public required string Summary { get; init; }
 }
 

--- a/tests/IntentSystem.Cli.Tests/SessionLayerTopologyCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/SessionLayerTopologyCommandTests.cs
@@ -191,6 +191,272 @@ public sealed class SessionLayerTopologyCommandTests : IDisposable
         Assert.Contains("custom", content, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void UpdateResidence_ExternalToHerdr_RemovesExternalOnlyFields_G761()
+    {
+        WriteTopology(".intent-cli/events/g756-team.jsonl");
+
+        var (exitCode, result) = Run(
+            "session-layer", "topology", "update-residence",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--current-resident", "external",
+            "--new-resident", "herdr",
+            "--workspace-id", WorkspaceId,
+            "--pane-id", $"{WorkspaceId}:p2",
+            "--cwd", "/new-design",
+            "--kind", "codex",
+            "--delivery-method", "inline",
+            "--confirm-update-residence",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("external", result.GetProperty("current_resident").GetString());
+        Assert.Equal("herdr", result.GetProperty("new_resident").GetString());
+        Assert.True(result.GetProperty("applied").GetBoolean());
+
+        var role = ReadRole("design");
+        Assert.Equal("herdr", role.GetProperty("resident").GetString());
+        Assert.Equal(WorkspaceId, role.GetProperty("workspace_id").GetString());
+        Assert.Equal($"{WorkspaceId}:p2", role.GetProperty("pane_id").GetString());
+        Assert.Equal("/new-design", role.GetProperty("cwd").GetString());
+        Assert.False(role.TryGetProperty("reader", out _));
+        Assert.False(role.TryGetProperty("frontend", out _));
+    }
+
+    [Fact]
+    public void UpdateResidence_HerdrToExternal_RemovesHerdrOnlyFields_G761()
+    {
+        WriteHerdrDesignTopology();
+
+        var (exitCode, result) = Run(
+            "session-layer", "topology", "update-residence",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--current-resident", "herdr",
+            "--new-resident", "external",
+            "--reader", ".intent-cli/events/new-design.jsonl",
+            "--frontend", "design-web",
+            "--confirm-update-residence",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(0, exitCode);
+        Assert.True(result.GetProperty("applied").GetBoolean());
+
+        var role = ReadRole("design");
+        Assert.Equal("external", role.GetProperty("resident").GetString());
+        Assert.Equal(".intent-cli/events/new-design.jsonl", role.GetProperty("reader").GetString());
+        Assert.Equal("design-web", role.GetProperty("frontend").GetString());
+        Assert.False(role.TryGetProperty("workspace_id", out _));
+        Assert.False(role.TryGetProperty("pane_id", out _));
+        Assert.False(role.TryGetProperty("cwd", out _));
+        Assert.False(role.TryGetProperty("kind", out _));
+        Assert.False(role.TryGetProperty("delivery_method", out _));
+    }
+
+    [Fact]
+    public void UpdateResidence_DryRun_IsByteIdentical_G761()
+    {
+        WriteTopology(".intent-cli/events/g756-team.jsonl");
+        var before = File.ReadAllBytes(TopologyPath);
+
+        var (exitCode, result) = Run(
+            "session-layer", "topology", "update-residence",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--current-resident", "external",
+            "--new-resident", "herdr",
+            "--workspace-id", WorkspaceId,
+            "--pane-id", $"{WorkspaceId}:p2",
+            "--cwd", "/new-design",
+            "--confirm-update-residence",
+            "--dry-run",
+            "--format", "json");
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal("dry-run", result.GetProperty("mode").GetString());
+        Assert.False(result.GetProperty("applied").GetBoolean());
+        Assert.True(result.GetProperty("changed").GetBoolean());
+        Assert.Equal(before, File.ReadAllBytes(TopologyPath));
+    }
+
+    [Fact]
+    public void UpdateResidence_WrongCurrent_RefusesWithoutMutation_G761()
+    {
+        WriteTopology(".intent-cli/events/g756-team.jsonl");
+        var before = File.ReadAllBytes(TopologyPath);
+
+        var (exitCode, raw) = RunRaw(
+            "session-layer", "topology", "update-residence",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--current-resident", "herdr",
+            "--new-resident", "external",
+            "--reader", ".intent-cli/events/new-design.jsonl",
+            "--confirm-update-residence",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(raw);
+        Assert.True(document.RootElement.GetProperty("conflict").GetBoolean());
+        Assert.Contains("not stated current residence", raw, StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllBytes(TopologyPath));
+    }
+
+    [Fact]
+    public void UpdateResidence_MissingConfirmation_RefusesWithoutMutation_G761()
+    {
+        WriteTopology(".intent-cli/events/g756-team.jsonl");
+        var before = File.ReadAllBytes(TopologyPath);
+
+        var (exitCode, raw) = RunRaw(
+            "session-layer", "topology", "update-residence",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--current-resident", "external",
+            "--new-resident", "herdr",
+            "--workspace-id", WorkspaceId,
+            "--pane-id", $"{WorkspaceId}:p2",
+            "--cwd", "/new-design",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("--confirm-update-residence", raw, StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllBytes(TopologyPath));
+    }
+
+    [Fact]
+    public void UpdateResidence_EnforcesDestinationRequiredFields_G761()
+    {
+        WriteTopology(".intent-cli/events/g756-team.jsonl");
+        var beforeExternal = File.ReadAllBytes(TopologyPath);
+
+        var (herdrExit, herdrRaw) = RunRaw(
+            "session-layer", "topology", "update-residence",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--current-resident", "external",
+            "--new-resident", "herdr",
+            "--workspace-id", WorkspaceId,
+            "--pane-id", $"{WorkspaceId}:p2",
+            "--confirm-update-residence",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(1, herdrExit);
+        Assert.Contains("requires --workspace-id, --pane-id, and --cwd", herdrRaw, StringComparison.Ordinal);
+        Assert.Equal(beforeExternal, File.ReadAllBytes(TopologyPath));
+
+        WriteHerdrDesignTopology();
+        var beforeHerdr = File.ReadAllBytes(TopologyPath);
+        var (externalExit, externalRaw) = RunRaw(
+            "session-layer", "topology", "update-residence",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--current-resident", "herdr",
+            "--new-resident", "external",
+            "--confirm-update-residence",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(1, externalExit);
+        Assert.Contains("requires --reader", externalRaw, StringComparison.Ordinal);
+        Assert.Equal(beforeHerdr, File.ReadAllBytes(TopologyPath));
+    }
+
+    [Fact]
+    public void UpdateResidence_RejectsDestinationForbiddenFields_G761()
+    {
+        WriteTopology(".intent-cli/events/g756-team.jsonl");
+        var beforeExternal = File.ReadAllBytes(TopologyPath);
+        var (herdrExit, herdrRaw) = RunRaw(
+            "session-layer", "topology", "update-residence",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--current-resident", "external",
+            "--new-resident", "herdr",
+            "--workspace-id", WorkspaceId,
+            "--pane-id", $"{WorkspaceId}:p2",
+            "--cwd", "/new-design",
+            "--reader", ".intent-cli/events/old.jsonl",
+            "--confirm-update-residence",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(1, herdrExit);
+        Assert.Contains("does not accept --reader or --frontend", herdrRaw, StringComparison.Ordinal);
+        Assert.Equal(beforeExternal, File.ReadAllBytes(TopologyPath));
+
+        WriteHerdrDesignTopology();
+        var beforeHerdr = File.ReadAllBytes(TopologyPath);
+        var (externalExit, externalRaw) = RunRaw(
+            "session-layer", "topology", "update-residence",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--current-resident", "herdr",
+            "--new-resident", "external",
+            "--reader", ".intent-cli/events/new-design.jsonl",
+            "--workspace-id", WorkspaceId,
+            "--confirm-update-residence",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(1, externalExit);
+        Assert.Contains("does not accept --workspace-id, --pane-id, --cwd", externalRaw, StringComparison.Ordinal);
+        Assert.Equal(beforeHerdr, File.ReadAllBytes(TopologyPath));
+    }
+
+    [Theory]
+    [InlineData("en", "the human answer from `guide bootstrap`")]
+    [InlineData("ja", "`guide bootstrap` の human answer")]
+    public void DocumentationMirrors_DescribeHumanControlledResidenceTransition_G761(string language, string wording)
+    {
+        var path = Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, "12-agent-message-orchestration.md");
+        var content = File.ReadAllText(path);
+
+        Assert.Contains("topology update-residence", content, StringComparison.Ordinal);
+        Assert.Contains("--current-resident", content, StringComparison.Ordinal);
+        Assert.Contains("--new-resident", content, StringComparison.Ordinal);
+        Assert.Contains("--confirm-update-residence", content, StringComparison.Ordinal);
+        Assert.Contains(wording, content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Record_StillRefusesConflictingShapeWithoutBypass_G761()
+    {
+        WriteTopology(".intent-cli/events/g756-team.jsonl");
+        var before = File.ReadAllBytes(TopologyPath);
+
+        var (exitCode, raw) = RunRaw(
+            "session-layer", "topology", "record",
+            "--domain", Domain,
+            "--team", Team,
+            "--role", "design",
+            "--resident", "external",
+            "--reader", ".intent-cli/events/new-design.jsonl",
+            "--write",
+            "--format", "json");
+
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Refusing to silently repair or replace it", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("--force", raw, StringComparison.Ordinal);
+        Assert.DoesNotContain("--replace", raw, StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllBytes(TopologyPath));
+    }
+
     private void WriteTopology(string recordedReader)
     {
         var topology = new JsonObject
@@ -232,6 +498,43 @@ public sealed class SessionLayerTopologyCommandTests : IDisposable
             },
         };
         WriteTopologyJson(topology);
+    }
+
+    private void WriteHerdrDesignTopology()
+    {
+        var topology = new JsonObject
+        {
+            ["domain"] = Domain,
+            ["team"] = Team,
+            ["workspace_id"] = WorkspaceId,
+            ["roles"] = new JsonObject
+            {
+                ["design"] = new JsonObject
+                {
+                    ["resident"] = "herdr",
+                    ["workspace_id"] = WorkspaceId,
+                    ["pane_id"] = $"{WorkspaceId}:p1",
+                    ["cwd"] = "/old-design",
+                    ["kind"] = "codex",
+                    ["delivery_method"] = "inline",
+                    ["model"] = "declared-model",
+                    ["reasoning_effort"] = "high",
+                },
+                ["orchestration"] = HerdrRole(),
+            },
+            ["host_state"] = new JsonObject
+            {
+                ["role"] = "orchestration",
+                ["envelope"] = "test-owned-host-state",
+            },
+        };
+        WriteTopologyJson(topology);
+    }
+
+    private JsonElement ReadRole(string role)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(TopologyPath));
+        return document.RootElement.GetProperty("roles").GetProperty(role).Clone();
     }
 
     private static JsonObject HerdrRole() => new()


### PR DESCRIPTION
## Summary

Closes #1655

- Add `session-layer topology update-residence` for explicit `external` <-> `herdr` transitions.
- Require the asserted current resident, a different new resident, explicit confirmation, and `--write` or `--dry-run --format json`.
- Validate destination fields like `topology record`, remove residence-exclusive fields from the old shape, and use a topology CAS lock plus a second digest comparison before writing.
- Keep `record` conflict refusal, delivery resolution, and all existing topology mutation surfaces unchanged.
- Document that `guide bootstrap`'s human answer controls residence in both EN/JA orchestration mirrors.

## Verification

Exact checkout head: `39ade693e191d87f1d8def113ca80e7aad0404ec`

Changed paths:

- `src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs`
- `tests/IntentSystem.Cli.Tests/SessionLayerTopologyCommandTests.cs`
- `docs/en/12-agent-message-orchestration.md`
- `docs/ja/12-agent-message-orchestration.md`

Parent evidence was collected in an isolated worktree at parent `ff11a355377fe2b1698cce1e14f39d8c79c20bd5` with an ephemeral `G761ParentAbsenceTests` probe. The parent had no `update-residence` route:

```text
Failed!  - Failed:     1, Passed:     0, Skipped:     0, Total:     1
Error Message:
Assert.Equal() Failure: Values differ
Expected: 0
Actual:   1
```

Post-change evidence (SDK 10.0.100, Release):

- New/affected `SessionLayerTopologyCommandTests`: `Failed: 0, Passed: 17, Skipped: 0, Total: 17`.
- Topology plus orchestration documentation tests: `Failed: 0, Passed: 41, Skipped: 0, Total: 41`.
- Adjacent topology, delivery-resolution, notify, and G613 tests: `Failed: 0, Passed: 87, Skipped: 0, Total: 87`.
- Full Release suite: `Failed: 0, Passed: 5381, Skipped: 1, Total: 5382`.
- `git diff --check`: passed.

The focused tests cover both directions, wrong current value, missing confirmation, required and forbidden destination fields, dry-run byte identity, absence of old-residence fields, and unchanged `record` conflict refusal. The adjacent delivery suites remain green; no delivery-resolution source was changed.

## Coordination boundary

The supplied host claim for `execution-unit:G761` is authoritative. The child worker next-action/preflight contradiction was recorded: next-action waits on issue `#1655`, and issue-preflight is `actionable=false`, `classification=claim-unavailable`, `claim_status=canonical-unavailable` because child `.git/FETCH_HEAD` cannot be opened (`Operation not permitted`). No child product-repo execution-unit claim was created, verified, released, or mutated. The canonical GitHub issue claim was performed through the worker command as required.
