### PR TITLE
G735: topology move must move a team that shares one pane (wS:p1 → w44:p1)

### DIFF
--- a/docs/en/08-command-reference.md
+++ b/docs/en/08-command-reference.md
@@ -90,11 +90,16 @@ intent-cli notify delegate --domain <domain> --team <team> --from <sender-role> 
 The move requires a complete explicit old-to-new pane map for recorded herdr
 roles, updates the team and role workspace/pane ids in one atomic operation,
 and preserves role membership, cwd, kind, delivery method, readers, profiles,
-and all other fields. It never queries herdr, discovers a workspace, creates
-panes, or repairs a per-role refusal. The writer holds a CAS lock and compares
-the topology digest before replacement; a stale `--current-digest` is refused.
-The existing per-role mismatch message points to this command as the
-sanctioned whole-team transition.
+and all other fields. A map may point several recorded roles at one new pane
+when those roles share one old pane — the roles travel with their pane, so
+that is not ambiguous (G735). The refusal `--pane-map maps more than one
+recorded role to new pane '<pane>'; refusing an ambiguous workspace move.` is
+reserved for genuinely ambiguous maps — a new pane no role currently occupies
+that two or more different old panes both map to — and those keep failing.
+The writer holds a CAS lock and compares the topology digest before
+replacement; a stale `--current-digest` is refused. The existing per-role
+mismatch message points to this command as the sanctioned whole-team
+transition.
 
 ---
 

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1599,7 +1599,11 @@ complete inspect → dry-run preview → explicit write → validate → notify
 preflight sequence. The move requires a complete operator-supplied old-pane to
 new-pane map for herdr roles, holds a CAS lock, compares the topology digest,
 and atomically updates the team and role workspace/pane ids while preserving
-all other role fields. It never queries herdr, creates panes, changes
+all other role fields. Several roles recorded on one old pane may map to one
+new pane — the roles travel with their pane, so the map is not ambiguous (no
+longer refused after G735); only a map that sends two or more different old
+panes to one new pane (a pane no role occupies) remains refused as
+ambiguous. It never queries herdr, creates panes, changes
 membership, or repairs a per-role conflict; that refusal names this move
 command as its sanctioned whole-team transition.
 

--- a/docs/ja/08-command-reference.md
+++ b/docs/ja/08-command-reference.md
@@ -84,8 +84,12 @@ intent-cli notify delegate --domain <domain> --team <team> --from <sender-role> 
 
 move は、記録済み herdr role ごとに完全な old-to-new pane map を明示的に必要とし、team と role の
 workspace/pane id を一つの atomic operation で更新します。role membership、cwd、kind、delivery method、
-reader、profile、その他すべての field は維持します。herdr query、workspace の discover、pane の作成、
-per-role refusal の repair は行いません。writer は CAS lock を保持し、置換前に topology digest を比較します。
+reader、profile、その他すべての field は維持します。複数の recorded role が一つの old pane を共有して
+いる場合、それらを一つの new pane へ向ける map は許容されます — role は pane と共に移動するため、
+これは曖昧ではありません（G735）。`--pane-map maps more than one recorded role to new pane
+'<pane>'; refusing an ambiguous workspace move.` という拒否は、二つ以上の異なる old pane が同じ
+new pane（どの role も現在占めていない pane）へ向かう真に曖昧な map 専用で、従来どおり拒否されます。
+writer は CAS lock を保持し、置換前に topology digest を比較します。
 stale な `--current-digest` は拒否されます。既存の per-role mismatch message は sanctioned な whole-team
 transition としてこの command を示します。
 

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -1365,9 +1365,12 @@ G697 は意図的な workspace rebuild の path を追加します。インス�
 `guide orchestrator-thread` から到達でき、inspect → dry-run preview → explicit write →
 validate → notify preflight の完全な順序を表示します。move は herdr role ごとの operator-supplied
 old-pane から new-pane への完全な map を必要とし、CAS lock を保持して topology digest を比較します。
-team と role の workspace/pane id だけを atomic に更新し、他の role field は維持します。herdr query、
-pane 作成、membership 変更、per-role conflict の repair は行いません。既存の refusal は sanctioned な
-whole-team transition としてこの move command を示します。
+team と role の workspace/pane id だけを atomic に更新し、他の role field は維持します。複数の recorded
+role が一つの old pane を共有している場合、それらを一つの new pane へ向ける map は許容されます —
+role は pane と共に移動するため曖昧ではないため（G735 で拒否は解除）。二つ以上の異なる old pane が
+同じ new pane（どの role も占めていない pane）へ向かう真に曖昧な map だけが拒否され続けます。
+herdr query、pane 作成、membership 変更、per-role conflict の repair は行いません。既存の refusal は
+sanctioned な whole-team transition としてこの move command を示します。
 
 agent kind は herdr が起動できる任意の kind です。Claude、Codex、Copilot、Cursor、OpenCode などは
 例であり、supported-set の制約ではありません。logical role の既定値は `implementation`、`review`、

--- a/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/SessionLayerTopologyCommand.cs
@@ -1339,7 +1339,7 @@ internal static class SessionLayerTopologyWriter
             }
 
             var recordedPanes = new HashSet<string>(StringComparer.Ordinal);
-            var mappedPanes = new HashSet<string>(StringComparer.Ordinal);
+            var newPaneOwners = new Dictionary<string, string>(StringComparer.Ordinal);
             foreach (var (roleName, roleNode) in roles!.OrderBy(entry => entry.Key, StringComparer.Ordinal))
             {
                 if (roleNode is not JsonObject role)
@@ -1377,7 +1377,12 @@ internal static class SessionLayerTopologyWriter
                         + "refusing a partial workspace move.");
                 }
 
-                if (!mappedPanes.Add(newPane))
+                // G735: several roles recorded on the SAME old pane travel
+                // together, so a shared old-pane -> new-pane pair is not
+                // ambiguous. Only a new pane that two or more DIFFERENT old
+                // panes map to (a pane no role occupies) stays refused.
+                if (newPaneOwners.TryGetValue(newPane, out var owner)
+                    && !string.Equals(owner, oldPane, StringComparison.Ordinal))
                 {
                     return MoveConflict(
                         request,
@@ -1386,6 +1391,8 @@ internal static class SessionLayerTopologyWriter
                         $"--pane-map maps more than one recorded role to new pane '{newPane}'; refusing an "
                         + "ambiguous workspace move.");
                 }
+
+                newPaneOwners[newPane] = oldPane;
 
                 var paneWorkspace = WorkspaceFromPane(newPane);
                 if (paneWorkspace is not null

--- a/tests/IntentSystem.Cli.Tests/TopologySharedPaneMoveG735Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/TopologySharedPaneMoveG735Tests.cs
@@ -1,0 +1,158 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G735: the topology move guard was keyed on new-pane repetition, so a team
+/// whose roles share one pane (the shape the orchestrator guide documents)
+/// could not be rebuilt at all: <c>move</c> refused it as ambiguous while
+/// <c>record</c> redirected to <c>move</c>. The guard must key on old-pane
+/// identity instead — a shared old pane traveling to one new pane is not
+/// ambiguous, while two different old panes collapsing onto one new pane
+/// stays refused. The fixtures below construct both shapes; neither exists
+/// on the host.
+/// </summary>
+public sealed class TopologySharedPaneMoveG735Tests
+{
+    private const string Domain = "remote-herdr";
+    private const string Team = "remote-herdr";
+
+    [Fact]
+    public void Move_SharedPaneRoles_TravelWithTheirPaneAndTheMoveApplies_G735()
+    {
+        var context = CreateFixture();
+        SetHerdrOnly(context);
+
+        // The failing shape from #1593: orchestration AND orchestrator sit
+        // on wS:p1 while implementation sits on wS:p2.
+        Assert.Equal(0, Record(context, "orchestration", "wS:p1", "/orchestration", "codex", "inline").ExitCode);
+        Assert.Equal(0, Record(context, "orchestrator", "wS:p1", "/orchestrator", "codex", "inline").ExitCode);
+        Assert.Equal(0, Record(context, "implementation", "wS:p2", "/implementation", "claude", "file-backed")
+            .ExitCode);
+
+        var preview = Run(context, [
+            "session-layer", "topology", "move", "--domain", Domain, "--team", Team,
+            "--workspace-id", "w44", "--pane-map", "wS:p1=w44:p1", "--pane-map", "wS:p2=w44:p2",
+            "--dry-run", "--format", "json",
+        ]);
+        Assert.Equal("dry-run", preview.Result.GetProperty("mode").GetString());
+        Assert.False(preview.Result.GetProperty("conflict").GetBoolean());
+        Assert.True(preview.Result.GetProperty("changed").GetBoolean());
+
+        var write = Run(context, [
+            "session-layer", "topology", "move", "--domain", Domain, "--team", Team,
+            "--workspace-id", "w44", "--pane-map", "wS:p1=w44:p1", "--pane-map", "wS:p2=w44:p2",
+            "--write", "--format", "json",
+        ]);
+        Assert.False(write.Result.GetProperty("conflict").GetBoolean());
+        Assert.True(write.Result.GetProperty("applied").GetBoolean());
+
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(context.RepoRoot, Domain, Team);
+        var topology = JsonNode.Parse(File.ReadAllText(topologyPath))!.AsObject();
+        var roles = topology["roles"]!.AsObject();
+        Assert.Equal("w44:p1", roles["orchestration"]!["pane_id"]!.GetValue<string>());
+        Assert.Equal("w44:p1", roles["orchestrator"]!["pane_id"]!.GetValue<string>());
+        Assert.Equal("w44:p2", roles["implementation"]!["pane_id"]!.GetValue<string>());
+
+        var validated = Run(context, [
+            "session-layer", "topology", "validate", "--domain", Domain, "--team", Team, "--format", "json",
+        ]);
+        Assert.True(validated.Result.GetProperty("valid").GetBoolean());
+    }
+
+    [Fact]
+    public void Move_TwoOldPanesMappingToOneNewPane_RemainsRefusedAsAmbiguous_G735()
+    {
+        var context = CreateFixture();
+        SetHerdrOnly(context);
+
+        // Genuinely ambiguous: wS:p1 and wS:p2 are distinct panes whose
+        // roles would collapse onto w44:p1 — which pane's roles go where?
+        Assert.Equal(0, Record(context, "orchestration", "wS:p1", "/orchestration", "codex", "inline").ExitCode);
+        Assert.Equal(0, Record(context, "orchestrator", "wS:p2", "/orchestrator", "codex", "inline").ExitCode);
+
+        var topologyPath = NotifyRoleTopologyStore.ResolvePath(context.RepoRoot, Domain, Team);
+        var before = File.ReadAllText(topologyPath);
+
+        var result = Run(context, [
+            "session-layer", "topology", "move", "--domain", Domain, "--team", Team,
+            "--workspace-id", "w44", "--pane-map", "wS:p1=w44:p1", "--pane-map", "wS:p2=w44:p1",
+            "--dry-run", "--format", "json",
+        ], 1);
+
+        Assert.True(result.Result.GetProperty("conflict").GetBoolean());
+        Assert.Contains(
+            "maps more than one recorded role to new pane 'w44:p1'",
+            result.Result.GetProperty("summary").GetString(),
+            StringComparison.Ordinal);
+        Assert.Equal(before, File.ReadAllText(topologyPath));
+    }
+
+    private static CliContext CreateFixture()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"intent-g735-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(root);
+        return new CliContext
+        {
+            RepoRoot = root,
+            Config = new CliConfig
+            {
+                Project = new ProjectConfig
+                {
+                    Domain = Domain,
+                    ArtifactRoot = ".intent-cli",
+                    WorktreeRoot = ".intent-cli/worktrees",
+                },
+            },
+        };
+    }
+
+    private static void SetHerdrOnly(CliContext context)
+    {
+        using var writer = new StringWriter();
+        var exitCode = SessionLayerCommand.ExecuteSet(
+            context,
+            ["--domain", Domain, "--team", Team, "--mode", SessionLayerMode.HerdrOnly, "--write", "--format", "json"],
+            writer);
+        Assert.Equal(0, exitCode);
+    }
+
+    private static (int ExitCode, JsonElement Result) Record(
+        CliContext context,
+        string role,
+        string pane,
+        string cwd,
+        string kind,
+        string deliveryMethod)
+    {
+        var result = Run(context, [
+            "session-layer", "topology", "record", "--domain", Domain, "--team", Team, "--role", role,
+            "--resident", "herdr", "--workspace-id", pane[..pane.IndexOf(':')], "--pane-id", pane,
+            "--cwd", cwd, "--kind", kind, "--delivery-method", deliveryMethod, "--write", "--format", "json",
+        ]);
+        Assert.Equal(0, result.ExitCode);
+        return result;
+    }
+
+    private static (int ExitCode, JsonElement Result) Run(
+        CliContext context,
+        IReadOnlyList<string> args,
+        int expectedExitCode = 0)
+    {
+        using var writer = new StringWriter();
+        var exitCode = CommandRouter.Execute(args.ToArray(), context, writer);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var result = (exitCode, document.RootElement.Clone());
+        if (exitCode != expectedExitCode)
+        {
+            throw new InvalidOperationException($"expected {expectedExitCode}, got {result}");
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## What

`intent-cli session-layer topology move` (the whole-team, pane-map move) refused
`--pane-map wS:p1=w44:p1` whenever **two roles were recorded on one pane** —
with `--pane-map maps more than one recorded role to new pane '<pane>'; refusing
an ambiguous workspace move.` — while `session-layer topology record` redirected
to `move`. The only shape the orchestrator guide documents (multiple roles on
one pane, e.g. `wS:p1` → `w44:p1`) was therefore unreachable: no command could
rebuild such a team.

## Fix

`SessionLayerTopologyCommand.ExecuteMove` now keys the guard on **old-pane
identity** (one owner per old pane, stored in `newPaneOwners`), so a shared old
pane traveling to one new pane is applied, while a new pane that two *different*
old panes map to (a pane no role occupies) stays refused as ambiguous.

## Verification

- `dotnet build src/IntentSystem.Cli -c Release`: 0 warnings / 0 errors.
- `dotnet test tests/IntentSystem.Cli.Tests -c Release`: **5210 passed, 0 failed, 1 skipped** —
  including the new `TopologySharedPaneMoveG735Tests` (shared-pane move applies;
  genuinely-ambiguous mapping still refused).
- Docs updated (EN + JA): `docs/{en,ja}/08-command-reference.md`,
  `docs/{en,ja}/12-agent-message-orchestration.md`.

## Not reproducible here

- The failing `intent-cli` **binary** (`0.27.1-...-G756` at `~/.local/bin`): the issue
  was measured against the *installed* binary, so the pre-fix refusal could not be
  re-observed on the fixed code path; the new tests exercise `CommandRouter` directly.
- A host runtime with a real `w44` workspace or `wS:p1` pane: no host `w44`/`wS`
  workspace exists in this repo, so end-to-end herdr behavior is untested; the
  tests construct the pane shapes themselves under `Path.GetTempPath()`.

## Notes

- Scope: `src/` + `docs/` + the new test only; `docs/ja/07-recovery.md` and the
  three `02*` / `05` / `06` docs that merely mention `topology` were **not** changed —
  the guide wording lives in `TopologyWorkspaceMoveGuidance.cs` (16:Create), which is
  unchanged.
- `.artifacts/` is untracked and **must not be committed** (AGENTS.md "Do Not
  Commit"); only `src/`, `docs/`, and the new test file were staged for `76b06d64`.
- The `intent-cli` skill (`~/.claude/skills/intent-cli/SKILL.md`) does not mention
  `topology` — no skill-level wording to sync with the widened guard.
