### PR TITLE
G765: declare supervision persistence and independent liveness

### DIFF
--- a/docs/adr/0013-supervision-persistence-declaration.md
+++ b/docs/adr/0013-supervision-persistence-declaration.md
@@ -1,0 +1,52 @@
+# ADR 0013: supervision persistence is declared by the operator
+
+- Status: Accepted for the preview-through-1.x supervision surface
+- Date: 2026-08-30
+- Scope: `notify supervise install`, reconciliation, and read-only liveness
+
+## Decision
+
+The operator must explicitly declare a supervision scheduler artifact's
+cross-login persistence intent at install time with
+`--persistence persistent`. intent-cli records that choice in the emitted
+artifact metadata. It does not infer persistence from a path, from a loaded
+process, or from a previous cycle.
+
+`notify supervise reconcile --write` keeps artifacts carrying the declaration
+and reports them as declared persistent. An undeclared login-persistent
+artifact remains legacy and is removable. This distinction prevents a normal
+session-only artifact from silently acquiring a new lifecycle contract while
+giving an operator-declared artifact a recoverable, auditable disposition.
+
+Install remains authoring-only: it does not execute `launchctl`, `systemctl`,
+Task Scheduler, or any other lifecycle command. Registration stays an explicit
+operator action using the command printed by the artifact. The liveness surface
+therefore reports durable installation evidence rather than claiming that the
+CLI registered or loaded a scheduler job.
+
+`notify supervise liveness --domain <domain> --team <team> --format json` is a
+separate read-only observer. It reads the persisted last completed cycle,
+declared bound, elapsed age, and artifact/installation evidence without
+starting or depending on the supervisor process. This gives a design or
+orchestration thread an independent answer when the supervisor is absent.
+
+## Consequences
+
+- Omitting `--persistence` preserves the pre-G765 artifact bytes and the
+  session-only cleanup behavior.
+- Reconciliation can explain and test keep-versus-remove decisions instead of
+  treating every scheduler artifact as one indistinguishable class.
+- A persistent declaration is intent and evidence, not automatic OS
+  registration or an entitlement to execute lifecycle operations.
+- A stale or missing cycle is observable without staffing supervision with a
+  language-model seat or adding a second supervisor.
+
+## Rejected alternatives
+
+- Inferring persistence from `~/Library/LaunchAgents` or another path would
+  make legacy operator workarounds indistinguishable from explicit intent and
+  would preserve the accidental lifecycle contract G712 rejected.
+- Having liveness invoke or restart the supervisor would make the detector
+  depend on the thing it detects and would violate the no-execution boundary.
+- Changing cycle format, interval/bound semantics, archive, shrink, or repair
+  behavior would broaden this persistence/liveness slice.

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -979,6 +979,49 @@ G676 writer identity that differs from the installed identity is emitted as
 `duplicate-supervisor` through G699's recorded repeat-backoff and parked state.
 The finding uses cycle writer identity only: it reads no terminal content and
 never kills, stops, elects, or ranks a supervisor.
+
+### Declared persistence and independent supervision liveness (G765 — preview-through-1.x)
+
+The operator may declare that an emitted scheduler artifact is intended to
+persist across login with `--persistence persistent`:
+
+```bash
+intent-cli notify supervise install --domain <domain> --team <team> \
+  --repo <owner/repo> --owner-role <logical-role> --bound <seconds> \
+  --interval <seconds> --persistence persistent --write --format json
+```
+
+The declaration is written as artifact metadata. It is intent, not a hidden
+registration: install still only authors the artifact and proves its first
+cycle; the operator owns the printed platform registration command. During
+reconciliation, an artifact with that metadata is reported as **declared
+persistent and kept**, while an undeclared login-persistent artifact is
+reported as **legacy and removable**. `reconcile --write` removes only the
+latter. Omitting `--persistence` preserves the existing session-only artifact
+bytes and cleanup behavior.
+
+Absence is observable independently of the supervisor through the read-only
+surface:
+
+```bash
+intent-cli notify supervise liveness --domain <domain> --team <team> --format json
+```
+
+It reports the last completed cycle, declared bound, elapsed age, and whether
+durable installation evidence says the scheduler job is loaded. The command
+reads persisted state and artifact metadata only: it does not run the
+supervisor and executes no `launchctl`, `systemctl`, or other OS lifecycle
+command. This allows a design or orchestration thread to report a missing or
+over-bound supervisor even when no supervisor process is alive. The scheduler
+load answer is explicitly durable installation evidence, not a claim that the
+CLI performed registration.
+
+> **Preview through 1.x (G765).** Persistence is operator-declared and
+> recorded, reconciliation names the keep/remove distinction, and liveness is
+> a read-only observer. No lifecycle execution, automatic re-arming, or
+> change to interval, bound, cycle, shrink, archive, or repair semantics is
+> introduced.
+
 ### Event-driven supervision (G659 — preview-through-1.x)
 
 Add `--event-mode` to the one standing `notify supervise` invocation to opt in.

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1007,14 +1007,17 @@ surface:
 intent-cli notify supervise liveness --domain <domain> --team <team> --format json
 ```
 
-It reports the last completed cycle, declared bound, elapsed age, and whether
-durable installation evidence says the scheduler job is loaded. The command
-reads persisted state and artifact metadata only: it does not run the
+It reports the last completed cycle, declared bound, elapsed age, and an
+explicitly non-live installation-evidence state. The JSON field
+`scheduler_installation_evidence` is `installation-artifact-present` when the
+installed first-cycle record and its artifact path are present, otherwise it
+is `unknown`; `scheduler_live_state` is always `unknown` on this path. The
+command reads persisted state and artifact metadata only: it does not run the
 supervisor and executes no `launchctl`, `systemctl`, or other OS lifecycle
 command. This allows a design or orchestration thread to report a missing or
-over-bound supervisor even when no supervisor process is alive. The scheduler
-load answer is explicitly durable installation evidence, not a claim that the
-CLI performed registration.
+over-bound supervisor even when no supervisor process is alive. The evidence
+state is not a claim that a scheduler job is loaded or that the CLI performed
+registration; registration remains the operator's explicit action.
 
 > **Preview through 1.x (G765).** Persistence is operator-declared and
 > recorded, reconciliation names the keep/remove distinction, and liveness is

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -845,14 +845,17 @@ absence は supervisor 自身から独立した read-only surface で確認で�
 intent-cli notify supervise liveness --domain <domain> --team <team> --format json
 ```
 
-これは last completed cycle、declared bound、elapsed age、そして永続的な
-installation evidence が scheduler job を loaded と示すかを報告します。command
-は persisted state と artifact metadata だけを読み、supervisor を実行せず、
-`launchctl`、`systemctl`、その他の OS lifecycle command を実行しません。そのため
-supervisor process が存在しない場合でも、design または orchestration thread が
-missing / bound 超過の supervisor を報告できます。scheduler load の答えは明示的に
-永続インストールの記録であり、CLI が registration を実行したという意味では
-ありません。
+これは last completed cycle、declared bound、elapsed age、そして明示的に
+non-live な installation evidence の状態を報告します。JSON の
+`scheduler_installation_evidence` は installed first-cycle record と artifact path
+が存在するとき `installation-artifact-present`、それ以外は `unknown` です。この path の
+`scheduler_live_state` は常に `unknown` で、scheduler job が現在 loaded かを示す
+boolean ではありません。command は persisted state と artifact metadata だけを読み、
+supervisor を実行せず、`launchctl`、`systemctl`、その他の OS lifecycle command を
+実行しません。そのため supervisor process が存在しない場合でも、design または
+orchestration thread が missing / bound 超過の supervisor を報告できます。これは
+CLI が registration を実行したという意味ではなく、registration は operator の明示的な
+action のままです。
 
 > **1.x を通じた preview (G765)。** persistence は operator が宣言して記録し、
 > reconcile は keep/remove の違いを明示し、liveness は read-only observer です。

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -819,6 +819,46 @@ G699 の記録済み repeat-backoff と parked state を通じて
 terminal content を読みません。また supervisor の kill、stop、elect、rank は
 自動実行しません。
 
+### operator が宣言する persistence と supervision から独立した liveness (G765 — preview-through-1.x)
+
+operator は、login をまたいで保持する意図を scheduler artifact に
+`--persistence persistent` で宣言できます。
+
+```bash
+intent-cli notify supervise install --domain <domain> --team <team> \
+  --repo <owner/repo> --owner-role <logical-role> --bound <seconds> \
+  --interval <seconds> --persistence persistent --write --format json
+```
+
+この declaration は artifact metadata として記録されます。これは隠れた
+registration ではありません。install は引き続き artifact の authoring と
+first cycle の proof だけを行い、表示された platform registration command の
+実行は operator が担当します。reconcile は metadata がある artifact を
+**declared persistent として保持**し、宣言のない login-persistent artifact を
+**legacy として削除可能**と明示します。`reconcile --write` が削除するのは後者だけです。
+`--persistence` を省略すれば、従来の session-only artifact の bytes と cleanup
+behavior は変わりません。
+
+absence は supervisor 自身から独立した read-only surface で確認できます。
+
+```bash
+intent-cli notify supervise liveness --domain <domain> --team <team> --format json
+```
+
+これは last completed cycle、declared bound、elapsed age、そして永続的な
+installation evidence が scheduler job を loaded と示すかを報告します。command
+は persisted state と artifact metadata だけを読み、supervisor を実行せず、
+`launchctl`、`systemctl`、その他の OS lifecycle command を実行しません。そのため
+supervisor process が存在しない場合でも、design または orchestration thread が
+missing / bound 超過の supervisor を報告できます。scheduler load の答えは明示的に
+永続インストールの記録であり、CLI が registration を実行したという意味では
+ありません。
+
+> **1.x を通じた preview (G765)。** persistence は operator が宣言して記録し、
+> reconcile は keep/remove の違いを明示し、liveness は read-only observer です。
+> lifecycle の実行、automatic re-arming、interval / bound / cycle / shrink / archive /
+> repair semantics の変更はありません。
+
 ### event-driven supervision (G659 — preview-through-1.x)
 
 1 つの standing `notify supervise` invocation に `--event-mode` を追加して有効化します。

--- a/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
+++ b/src/IntentSystem.Cli/Commands/GuideDesignThreadCommand.cs
@@ -160,7 +160,7 @@ internal static class GuideDesignThreadCommand
             Monitoring = new DesignThreadMonitoring
             {
                 Separation = "Supervision runs outside the design conversation and is consulted at most once per design wake.",
-                ResidualDesignCheck = "At low frequency, design checks the last completed supervision-cycle record. Compare its age with the declared supervision-liveness bound; do not use a conversational heartbeat.",
+                ResidualDesignCheck = "At low frequency, design runs the read-only `intent-cli notify supervise liveness --domain <domain> --team <team> --format json` surface. It reports the last completed supervision cycle, declared bound, elapsed age, and scheduler-load evidence without running or depending on the supervisor; compare the age with the declared supervision-liveness bound and do not use a conversational heartbeat.",
                 BoundRule = "The declared detection bound must be greater than the configured wake interval plus scheduling jitter.",
                 GuideRefreshRule = "Re-read installed guides after a CLI version change or session-layer configuration change, not on every wake.",
                 DeploymentRule = $"A design seat whose agent kind has no inbound app monitor must be a recorded resident herdr seat with cwd `{root}`, where persistent AGENTS rules apply. A kind with an inbound app monitor may use that external reader. This is a deployment rule, not a recommendation.",

--- a/src/IntentSystem.Cli/Commands/NotifyCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifyCommand.cs
@@ -80,6 +80,7 @@ internal static class NotifyCommand
         + "[--pre-approve <agent-kind>:<prompt-class>]... [--pre-escalate <agent-kind>:<prompt-class>]... "
         + "[--shell-policy <json>]... "
         + "[--format markdown|json]\n"
+        + NotifySuperviseLivenessCommand.Usage + "\n"
         + "Event mode: --event-mode keeps the blocking per-seat herdr wait inside this supervisor process and re-arms it after failure. It is the implementation of the normative SECOND wake source from herdr pane.agent_status_changed, alongside the independent interval safety floor; it does not change outcome or label behavior.\n"
         + NotifySuperviseShrinkCommand.Usage + "\n"
         + NotifySuperviseArchiveCommand.Usage + "\n"
@@ -143,6 +144,8 @@ internal static class NotifyCommand
 
         return args[0] switch
         {
+            NotifySuperviseLivenessCommand.Operation =>
+                NotifySuperviseLivenessCommand.Execute(context, args[1..], writer),
             NotifySuperviseArchiveCommand.Operation =>
                 NotifySuperviseArchiveCommand.Execute(context, args[1..], writer),
             NotifySuperviseShrinkCommand.Operation =>

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseInstallCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseInstallCommand.cs
@@ -21,6 +21,7 @@ internal static class NotifySuperviseInstallCommand
         "Usage: intent-cli notify supervise install --domain <d> --team <t> --repo <owner/repo> "
         + "--owner-role <role> --bound <seconds> --interval <seconds> "
         + "[--startup-bound <seconds>; default 30] "
+        + "[--persistence persistent] "
         + "[--event-mode] [--platform macos|windows|linux] [--output <path>] [--routing-root <host-root>] "
         + "[--dry-run|--write] [--format markdown|json]";
 
@@ -130,7 +131,8 @@ internal static class NotifySuperviseInstallCommand
             runtime.RecordedPath,
             routingRoot,
             standardOutPath,
-            standardErrorPath);
+            standardErrorPath,
+            options.PersistenceIntent);
         var (registrationCommand, unregistrationCommand) = BuildOperatorCommands(options.Platform, label, artifactPath);
         var crossAuthored = !string.Equals(options.Platform, CurrentPlatform(), StringComparison.Ordinal);
         var unresolvedBinaries = runtime.Binaries
@@ -241,7 +243,10 @@ internal static class NotifySuperviseInstallCommand
             Label = label,
             ArtifactPath = artifactPath,
             ArtifactWritten = options.Write,
-            Lifetime = "current GUI session only; no LaunchAgents login auto-load and no reboot persistence",
+            Lifetime = options.PersistenceIntent is null
+                ? "current GUI session only; no LaunchAgents login auto-load and no reboot persistence"
+                : "operator-declared persistent intent; registration remains an explicit operator action and intent-cli executes no OS lifecycle command",
+            PersistenceIntent = options.PersistenceIntent,
             LegacyArtifactsRemoved = legacyArtifactsRemoved,
             VerificationStatus = verificationStatus,
             StartupBoundSeconds = options.StartupBoundSeconds,
@@ -264,8 +269,8 @@ internal static class NotifySuperviseInstallCommand
             RuntimeBinaries = runtime.Binaries,
             UnresolvedBinaries = unresolvedBinaries,
             Summary = options.Write
-                ? $"Emitted and first-cycle-verified the {options.Platform} supervisor artifact with event mode {(options.EventMode ? "enabled" : "disabled")} for the current GUI session only; no LaunchAgents login auto-load or reboot persistence is configured. Runtime transport binaries are resolved absolutely when available; unresolved binaries: {(unresolvedBinaries.Length == 0 ? "none" : string.Join(", ", unresolvedBinaries))}; the recorded PATH covers any remaining command name. First-cycle evidence is recorded at '{NotifySupervisionStore.ResolveInstalledSupervisorPath(context.ResolveSupervisionArtifactRootPath(), options.Domain, options.Team)}'. Legacy login-persistent artifacts removed: {legacyArtifactsRemoved.Length}. Install emitted the artifact but did not execute lifecycle registration; use 'intent-cli notify supervise reconcile --write' for explicit unload/removal."
-                : $"Previewed the {options.Platform} supervisor artifact path and operator lifecycle commands without writing, probing, or executing anything. Lifetime is current GUI session only; no LaunchAgents login auto-load or reboot persistence is configured. Runtime transport binaries are resolved absolutely when available; unresolved binaries: {(unresolvedBinaries.Length == 0 ? "none" : string.Join(", ", unresolvedBinaries))}; the recorded PATH covers any remaining command name. A write requires bounded first-cycle proof and records failure log paths.",
+                ? $"Emitted and first-cycle-verified the {options.Platform} supervisor artifact with event mode {(options.EventMode ? "enabled" : "disabled")} for {(options.PersistenceIntent is null ? "the current GUI session only; no LaunchAgents login auto-load or reboot persistence is configured" : "operator-declared persistent intent; the operator still owns explicit registration and intent-cli executes no OS lifecycle command")}. Runtime transport binaries are resolved absolutely when available; unresolved binaries: {(unresolvedBinaries.Length == 0 ? "none" : string.Join(", ", unresolvedBinaries))}; the recorded PATH covers any remaining command name. First-cycle evidence is recorded at '{NotifySupervisionStore.ResolveInstalledSupervisorPath(context.ResolveSupervisionArtifactRootPath(), options.Domain, options.Team)}'. Legacy login-persistent artifacts removed: {legacyArtifactsRemoved.Length}. Install emitted the artifact but did not execute lifecycle registration; use 'intent-cli notify supervise reconcile --write' for explicit unload/removal."
+                : $"Previewed the {options.Platform} supervisor artifact path and operator lifecycle commands without writing, probing, or executing anything. Lifetime is {(options.PersistenceIntent is null ? "current GUI session only; no LaunchAgents login auto-load or reboot persistence is configured" : "operator-declared persistent intent; registration remains an explicit operator action")}. Runtime transport binaries are resolved absolutely when available; unresolved binaries: {(unresolvedBinaries.Length == 0 ? "none" : string.Join(", ", unresolvedBinaries))}; the recorded PATH covers any remaining command name. A write requires bounded first-cycle proof and records failure log paths.",
         };
         Emit(writer, options.Format, result);
         return 0;
@@ -391,19 +396,46 @@ internal static class NotifySuperviseInstallCommand
         string recordedPath,
         string routingRoot,
         string standardOutPath,
-        string standardErrorPath) => platform switch
+        string standardErrorPath,
+        string? persistenceIntent)
     {
-        MacOs => BuildLaunchdArtifact(
-            label,
-            intentCliExecutable,
-            arguments,
-            recordedPath,
-            routingRoot,
-            standardOutPath,
-            standardErrorPath),
-        Windows => BuildTaskSchedulerArtifact(label, intentCliExecutable, arguments, recordedPath),
-        _ => BuildSystemdArtifact(label, intentCliExecutable, arguments, recordedPath),
-    };
+        var artifact = platform switch
+        {
+            MacOs => BuildLaunchdArtifact(
+                label,
+                intentCliExecutable,
+                arguments,
+                recordedPath,
+                routingRoot,
+                standardOutPath,
+                standardErrorPath),
+            Windows => BuildTaskSchedulerArtifact(label, intentCliExecutable, arguments, recordedPath),
+            _ => BuildSystemdArtifact(label, intentCliExecutable, arguments, recordedPath),
+        };
+
+        if (persistenceIntent is null)
+        {
+            return artifact;
+        }
+
+        if (platform == Linux)
+        {
+            return "# " + NotifySuperviseArtifactInventory.PersistenceMarker + Environment.NewLine + artifact;
+        }
+
+        // Keep the XML declaration first so the Windows task and macOS plist
+        // remain valid documents while carrying the same declaration marker.
+        var firstLineBreak = artifact.IndexOf('\n');
+        if (firstLineBreak < 0)
+        {
+            return "<!-- " + NotifySuperviseArtifactInventory.PersistenceMarker + " -->" + Environment.NewLine + artifact;
+        }
+
+        var lineEnding = firstLineBreak > 0 && artifact[firstLineBreak - 1] == '\r' ? "\r\n" : "\n";
+        return artifact.Insert(
+            firstLineBreak + 1,
+            "<!-- " + NotifySuperviseArtifactInventory.PersistenceMarker + " -->" + lineEnding);
+    }
 
     private static string BuildLaunchdArtifact(
         string label,
@@ -560,6 +592,7 @@ RestartSec=30
         string? routingRoot = null;
         string? output = null;
         string? platform = null;
+        string? persistenceIntent = null;
         int? bound = null;
         int? interval = null;
         int? startupBound = null;
@@ -580,6 +613,15 @@ RestartSec=30
                 case "--routing-root": if (!ReadValue(args, ref index, argument, out routingRoot, out error)) return Fail(out options); break;
                 case "--output": if (!ReadValue(args, ref index, argument, out output, out error)) return Fail(out options); break;
                 case "--platform": if (!ReadValue(args, ref index, argument, out platform, out error)) return Fail(out options); break;
+                case "--persistence":
+                    if (!ReadValue(args, ref index, argument, out var persistence, out error)) return Fail(out options);
+                    if (!string.Equals(persistence, "persistent", StringComparison.Ordinal))
+                    {
+                        error = "--persistence accepts only 'persistent'; omit it for the legacy session-only behavior.";
+                        return Fail(out options);
+                    }
+                    persistenceIntent = "persistent";
+                    break;
                 case "--bound":
                     if (!ReadPositiveInt(args, ref index, argument, 86_400, out bound, out error)) return Fail(out options);
                     break;
@@ -637,6 +679,7 @@ RestartSec=30
             RoutingRoot = routingRoot, Output = output, Platform = platform,
             Write = write, Format = format!,
             EventMode = eventMode,
+            PersistenceIntent = persistenceIntent,
         };
         return true;
     }
@@ -766,6 +809,7 @@ RestartSec=30
         public string? Output { get; init; }
         public required bool Write { get; init; }
         public bool EventMode { get; init; }
+        public string? PersistenceIntent { get; init; }
         public required string Format { get; init; }
     }
 
@@ -793,6 +837,9 @@ RestartSec=30
         [JsonPropertyName("artifact_path")] public required string ArtifactPath { get; init; }
         [JsonPropertyName("artifact_written")] public required bool ArtifactWritten { get; init; }
         [JsonPropertyName("lifetime")] public required string Lifetime { get; init; }
+        [JsonPropertyName("persistence_intent")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? PersistenceIntent { get; init; }
         [JsonPropertyName("legacy_artifacts_removed")] public required IReadOnlyList<string> LegacyArtifactsRemoved { get; init; }
         [JsonPropertyName("verification_status")] public required string VerificationStatus { get; init; }
         [JsonPropertyName("startup_bound_seconds")] public required int StartupBoundSeconds { get; init; }

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
@@ -79,10 +79,15 @@ internal static class NotifySuperviseLivenessCommand
             NotifySuperviseArtifactInventory.UserProfileDirectoryFactory());
         var installedArtifactPresent = state.InstalledSupervisor is { ArtifactPath: { } path }
             && File.Exists(path);
-        var schedulerJobLoaded = state.InstalledSupervisor is not null && installedArtifactPresent;
-        var schedulerEvidence = schedulerJobLoaded
-            ? "installed first-cycle record and scheduler artifact are both present; no OS lifecycle query was executed"
-            : "no installed first-cycle record with a present scheduler artifact; no OS lifecycle query was executed";
+        // A first-cycle record plus an artifact proves only durable installation
+        // evidence. Registration is an explicit operator action outside this
+        // read-only command, so the live scheduler state is never inferred.
+        var schedulerInstallationEvidence = installedArtifactPresent
+            ? "installation-artifact-present"
+            : "unknown";
+        var schedulerEvidenceDetail = installedArtifactPresent
+            ? "installed first-cycle record and scheduler artifact are both present; this is non-live durable installation evidence only; scheduler live state is unknown because no OS lifecycle query was executed"
+            : "durable installation evidence is unavailable; scheduler live state is unknown because no OS lifecycle query was executed";
 
         var result = new NotifySuperviseLivenessResult
         {
@@ -95,11 +100,12 @@ internal static class NotifySuperviseLivenessCommand
             DeclaredBoundSeconds = boundSeconds,
             ElapsedSeconds = elapsedSeconds,
             AbsentSinceLastCycle = absentSinceLastCycle,
-            SchedulerJobLoaded = schedulerJobLoaded,
-            SchedulerJobEvidence = schedulerEvidence,
+            SchedulerInstallationEvidence = schedulerInstallationEvidence,
+            SchedulerLiveState = "unknown",
+            SchedulerEvidenceDetail = schedulerEvidenceDetail,
             SchedulerArtifactPaths = artifacts,
             CommandsExecuted = "none (persisted supervision state and artifact metadata only)",
-            Summary = BuildSummary(lastCycle, boundSeconds, elapsedSeconds, schedulerJobLoaded),
+            Summary = BuildSummary(lastCycle, boundSeconds, elapsedSeconds, schedulerInstallationEvidence),
         };
 
         Emit(writer, result, options.Format);
@@ -110,7 +116,7 @@ internal static class NotifySuperviseLivenessCommand
         NotifySupervisionCycle? lastCycle,
         int? boundSeconds,
         long? elapsedSeconds,
-        bool schedulerJobLoaded)
+        string schedulerInstallationEvidence)
     {
         var cycleSummary = lastCycle is null
             ? "No completed supervision cycle is recorded; no supervisor process is required to produce this answer."
@@ -121,7 +127,7 @@ internal static class NotifySuperviseLivenessCommand
         var absenceSummary = lastCycle is null || boundSeconds is { } declared && elapsedSeconds is { } elapsed && elapsed > declared
             ? " Supervision is absent or beyond its declared bound."
             : " Supervision liveness is within the available evidence.";
-        return $"Read-only liveness: {cycleSummary}{absenceSummary} Scheduler job loaded={schedulerJobLoaded.ToString().ToLowerInvariant()} based on durable installation evidence; the supervisor was not run.";
+        return $"Read-only liveness: {cycleSummary}{absenceSummary} Scheduler live state=unknown; durable installation evidence={schedulerInstallationEvidence}; the supervisor was not run.";
     }
 
     private static void EmitFailure(TextWriter writer, string error, string format)
@@ -158,8 +164,9 @@ internal static class NotifySuperviseLivenessCommand
         writer.WriteLine($"- declared bound: {result.DeclaredBoundSeconds?.ToString(CultureInfo.InvariantCulture) ?? "<unrecorded>"}s");
         writer.WriteLine($"- elapsed: {result.ElapsedSeconds?.ToString(CultureInfo.InvariantCulture) ?? "<unknown>"}s");
         writer.WriteLine($"- absent since last cycle: {result.AbsentSinceLastCycle.ToString().ToLowerInvariant()}");
-        writer.WriteLine($"- scheduler job loaded: {result.SchedulerJobLoaded.ToString().ToLowerInvariant()}");
-        writer.WriteLine($"- scheduler evidence: {result.SchedulerJobEvidence}");
+        writer.WriteLine($"- scheduler live state: {result.SchedulerLiveState}");
+        writer.WriteLine($"- scheduler installation evidence: {result.SchedulerInstallationEvidence}");
+        writer.WriteLine($"- scheduler evidence detail: {result.SchedulerEvidenceDetail}");
         writer.WriteLine($"- commands executed: {result.CommandsExecuted}");
         writer.WriteLine();
         writer.WriteLine(result.Summary);
@@ -265,8 +272,9 @@ internal sealed record NotifySuperviseLivenessResult
     [JsonPropertyName("declared_bound_seconds")] public int? DeclaredBoundSeconds { get; init; }
     [JsonPropertyName("elapsed_seconds")] public long? ElapsedSeconds { get; init; }
     [JsonPropertyName("absent_since_last_cycle")] public required bool AbsentSinceLastCycle { get; init; }
-    [JsonPropertyName("scheduler_job_loaded")] public required bool SchedulerJobLoaded { get; init; }
-    [JsonPropertyName("scheduler_job_evidence")] public required string SchedulerJobEvidence { get; init; }
+    [JsonPropertyName("scheduler_installation_evidence")] public required string SchedulerInstallationEvidence { get; init; }
+    [JsonPropertyName("scheduler_live_state")] public required string SchedulerLiveState { get; init; }
+    [JsonPropertyName("scheduler_evidence_detail")] public required string SchedulerEvidenceDetail { get; init; }
     [JsonPropertyName("scheduler_artifact_paths")] public required IReadOnlyList<string> SchedulerArtifactPaths { get; init; }
     [JsonPropertyName("commands_executed")] public required string CommandsExecuted { get; init; }
     [JsonPropertyName("summary")] public required string Summary { get; init; }

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
@@ -1,0 +1,273 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace IntentSystem.Cli.Commands;
+
+/// <summary>
+/// G765: a read-only observer of the persisted supervision state. This is
+/// intentionally separate from <see cref="NotifyMeasuredSupervisor"/> so an
+/// absent supervisor can still be diagnosed by another operator-facing
+/// command.
+/// </summary>
+internal static class NotifySuperviseLivenessCommand
+{
+    public const string Operation = "liveness";
+    public const string Usage =
+        "Usage: intent-cli notify supervise liveness --domain <d> --team <t> "
+        + "[--routing-root <host-root>] [--format markdown|json]";
+
+    private const string FormatJson = "json";
+    private const string FormatMarkdown = "markdown";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public static int Execute(CliContext context, string[] args, TextWriter writer)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(args);
+        ArgumentNullException.ThrowIfNull(writer);
+
+        if (args.Length == 1 && string.Equals(args[0], "--help", StringComparison.Ordinal))
+        {
+            writer.WriteLine(Usage);
+            return 0;
+        }
+
+        if (!TryParse(args, out var options, out var error))
+        {
+            EmitFailure(writer, error, options?.Format ?? FormatMarkdown);
+            return 1;
+        }
+
+        string artifactRoot;
+        try
+        {
+            _ = Path.GetFullPath(options.RoutingRoot ?? context.RepoRoot);
+            artifactRoot = context.ResolveSupervisionArtifactRootPath();
+        }
+        catch (Exception exception) when (exception is ArgumentException or NotSupportedException)
+        {
+            EmitFailure(writer, $"invalid-routing-root: {exception.Message}", options.Format);
+            return 1;
+        }
+
+        var state = NotifySupervisionStore.Read(artifactRoot, options.Domain, options.Team);
+        if (!state.Resolved)
+        {
+            EmitFailure(writer, state.Error ?? "supervision-state-unreadable", options.Format);
+            return 1;
+        }
+
+        var now = (NotifyCommand.UtcNowFactory?.Invoke() ?? DateTimeOffset.UtcNow).ToUniversalTime();
+        var lastCycle = state.LastIntervalCycle ?? state.LastCycle;
+        var elapsedSeconds = lastCycle is { } cycle
+            ? (long?)Math.Max(0, (long)(now - cycle.CompletedAt).TotalSeconds)
+            : null;
+        var boundSeconds = state.Bound?.BoundSeconds;
+        var absentSinceLastCycle = lastCycle is null
+            || boundSeconds is { } bound && elapsedSeconds is { } elapsed && elapsed > bound;
+
+        var schedulerLabel = $"intent-cli.supervise.{options.Domain}.{options.Team}";
+        var artifacts = NotifySuperviseArtifactInventory.FindManagedArtifacts(
+            artifactRoot,
+            schedulerLabel,
+            NotifySuperviseArtifactInventory.UserProfileDirectoryFactory());
+        var installedArtifactPresent = state.InstalledSupervisor is { ArtifactPath: { } path }
+            && File.Exists(path);
+        var schedulerJobLoaded = state.InstalledSupervisor is not null && installedArtifactPresent;
+        var schedulerEvidence = schedulerJobLoaded
+            ? "installed first-cycle record and scheduler artifact are both present; no OS lifecycle query was executed"
+            : "no installed first-cycle record with a present scheduler artifact; no OS lifecycle query was executed";
+
+        var result = new NotifySuperviseLivenessResult
+        {
+            Operation = "supervise-liveness",
+            RoutingRoot = Path.GetFullPath(options.RoutingRoot ?? context.RepoRoot),
+            Domain = options.Domain,
+            Team = options.Team,
+            CommandMode = "read-only",
+            LastCompletedCycleAt = lastCycle?.CompletedAt,
+            DeclaredBoundSeconds = boundSeconds,
+            ElapsedSeconds = elapsedSeconds,
+            AbsentSinceLastCycle = absentSinceLastCycle,
+            SchedulerJobLoaded = schedulerJobLoaded,
+            SchedulerJobEvidence = schedulerEvidence,
+            SchedulerArtifactPaths = artifacts,
+            CommandsExecuted = "none (persisted supervision state and artifact metadata only)",
+            Summary = BuildSummary(lastCycle, boundSeconds, elapsedSeconds, schedulerJobLoaded),
+        };
+
+        Emit(writer, result, options.Format);
+        return 0;
+    }
+
+    private static string BuildSummary(
+        NotifySupervisionCycle? lastCycle,
+        int? boundSeconds,
+        long? elapsedSeconds,
+        bool schedulerJobLoaded)
+    {
+        var cycleSummary = lastCycle is null
+            ? "No completed supervision cycle is recorded; no supervisor process is required to produce this answer."
+            : $"The last completed supervision cycle was {elapsedSeconds}s ago."
+                + (boundSeconds is { } bound
+                    ? $" The declared detection bound is {bound}s."
+                    : " No detection bound was declared.");
+        var absenceSummary = lastCycle is null || boundSeconds is { } declared && elapsedSeconds is { } elapsed && elapsed > declared
+            ? " Supervision is absent or beyond its declared bound."
+            : " Supervision liveness is within the available evidence.";
+        return $"Read-only liveness: {cycleSummary}{absenceSummary} Scheduler job loaded={schedulerJobLoaded.ToString().ToLowerInvariant()} based on durable installation evidence; the supervisor was not run.";
+    }
+
+    private static void EmitFailure(TextWriter writer, string error, string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(new
+            {
+                operation = "supervise-liveness",
+                command_mode = "read-only",
+                success = false,
+                error,
+                commands_executed = "none",
+            }, JsonOptions));
+            return;
+        }
+
+        writer.WriteLine($"supervise-liveness-failed: {error}");
+    }
+
+    private static void Emit(TextWriter writer, NotifySuperviseLivenessResult result, string format)
+    {
+        if (string.Equals(format, FormatJson, StringComparison.Ordinal))
+        {
+            writer.WriteLine(JsonSerializer.Serialize(result, JsonOptions));
+            return;
+        }
+
+        writer.WriteLine("# notify supervise liveness");
+        writer.WriteLine();
+        writer.WriteLine($"- domain/team: {result.Domain}/{result.Team}");
+        writer.WriteLine($"- command mode: {result.CommandMode}");
+        writer.WriteLine($"- last completed cycle: {result.LastCompletedCycleAt?.ToString("O") ?? "<none>"}");
+        writer.WriteLine($"- declared bound: {result.DeclaredBoundSeconds?.ToString(CultureInfo.InvariantCulture) ?? "<unrecorded>"}s");
+        writer.WriteLine($"- elapsed: {result.ElapsedSeconds?.ToString(CultureInfo.InvariantCulture) ?? "<unknown>"}s");
+        writer.WriteLine($"- absent since last cycle: {result.AbsentSinceLastCycle.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"- scheduler job loaded: {result.SchedulerJobLoaded.ToString().ToLowerInvariant()}");
+        writer.WriteLine($"- scheduler evidence: {result.SchedulerJobEvidence}");
+        writer.WriteLine($"- commands executed: {result.CommandsExecuted}");
+        writer.WriteLine();
+        writer.WriteLine(result.Summary);
+    }
+
+    private static bool TryParse(string[] args, out LivenessOptions options, out string error)
+    {
+        string? domain = null;
+        string? team = null;
+        string? routingRoot = null;
+        var format = FormatMarkdown;
+        error = string.Empty;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--domain":
+                    if (!ReadValue(args, ref index, "--domain", out domain, out error)) return Fail(out options);
+                    break;
+                case "--team":
+                    if (!ReadValue(args, ref index, "--team", out team, out error)) return Fail(out options);
+                    break;
+                case "--routing-root":
+                    if (!ReadValue(args, ref index, "--routing-root", out routingRoot, out error)) return Fail(out options);
+                    break;
+                case "--format":
+                    if (!ReadValue(args, ref index, "--format", out format, out error)) return Fail(out options);
+                    if (format is not FormatJson and not FormatMarkdown)
+                    {
+                        error = "--format must be markdown or json.";
+                        return Fail(out options);
+                    }
+                    break;
+                default:
+                    error = $"Unknown argument '{args[index]}'.";
+                    return Fail(out options);
+            }
+        }
+
+        if (!IsSafeIdentity(domain) || !IsSafeIdentity(team))
+        {
+            error = "--domain and --team are required safe identity values.";
+            return Fail(out options);
+        }
+
+        options = new LivenessOptions
+        {
+            Domain = domain!,
+            Team = team!,
+            RoutingRoot = routingRoot,
+            Format = format!,
+        };
+        return true;
+    }
+
+    private static bool ReadValue(
+        string[] args,
+        ref int index,
+        string option,
+        out string? value,
+        out string error)
+    {
+        if (index + 1 >= args.Length || string.IsNullOrWhiteSpace(args[index + 1]))
+        {
+            value = null;
+            error = $"{option} requires a value.";
+            return false;
+        }
+
+        value = args[++index];
+        error = string.Empty;
+        return true;
+    }
+
+    private static bool IsSafeIdentity(string? value) =>
+        !string.IsNullOrWhiteSpace(value)
+        && value.All(character => char.IsAsciiLetterOrDigit(character) || character is '.' or '_' or ':' or '-');
+
+    private static bool Fail(out LivenessOptions options)
+    {
+        options = null!;
+        return false;
+    }
+
+    private sealed record LivenessOptions
+    {
+        public required string Domain { get; init; }
+        public required string Team { get; init; }
+        public string? RoutingRoot { get; init; }
+        public required string Format { get; init; }
+    }
+}
+
+internal sealed record NotifySuperviseLivenessResult
+{
+    [JsonPropertyName("operation")] public required string Operation { get; init; }
+    [JsonPropertyName("routing_root")] public required string RoutingRoot { get; init; }
+    [JsonPropertyName("domain")] public required string Domain { get; init; }
+    [JsonPropertyName("team")] public required string Team { get; init; }
+    [JsonPropertyName("command_mode")] public required string CommandMode { get; init; }
+    [JsonPropertyName("last_completed_cycle_at")] public DateTimeOffset? LastCompletedCycleAt { get; init; }
+    [JsonPropertyName("declared_bound_seconds")] public int? DeclaredBoundSeconds { get; init; }
+    [JsonPropertyName("elapsed_seconds")] public long? ElapsedSeconds { get; init; }
+    [JsonPropertyName("absent_since_last_cycle")] public required bool AbsentSinceLastCycle { get; init; }
+    [JsonPropertyName("scheduler_job_loaded")] public required bool SchedulerJobLoaded { get; init; }
+    [JsonPropertyName("scheduler_job_evidence")] public required string SchedulerJobEvidence { get; init; }
+    [JsonPropertyName("scheduler_artifact_paths")] public required IReadOnlyList<string> SchedulerArtifactPaths { get; init; }
+    [JsonPropertyName("commands_executed")] public required string CommandsExecuted { get; init; }
+    [JsonPropertyName("summary")] public required string Summary { get; init; }
+}

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseReconcileCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseReconcileCommand.cs
@@ -76,6 +76,12 @@ internal static class NotifySuperviseReconcileCommand
             artifactRoot,
             scope,
             NotifySuperviseArtifactInventory.UserProfileDirectoryFactory());
+        var persistentArtifacts = artifactsBefore
+            .Where(NotifySuperviseArtifactInventory.HasDeclaredPersistence)
+            .ToArray();
+        var removableArtifacts = artifactsBefore
+            .Where(path => !NotifySuperviseArtifactInventory.HasDeclaredPersistence(path))
+            .ToArray();
 
         if (!string.Equals(options.Platform, MacOs, StringComparison.Ordinal)
             || !MacOsDetector())
@@ -137,7 +143,7 @@ internal static class NotifySuperviseReconcileCommand
                 }
             }
 
-            foreach (var artifact in artifactsBefore)
+            foreach (var artifact in removableArtifacts)
             {
                 try
                 {
@@ -163,8 +169,11 @@ internal static class NotifySuperviseReconcileCommand
             artifactRoot,
             scope,
             NotifySuperviseArtifactInventory.UserProfileDirectoryFactory());
+        var remainingRemovableArtifacts = artifactsAfter
+            .Where(path => !NotifySuperviseArtifactInventory.HasDeclaredPersistence(path))
+            .ToArray();
         var success = errors.Count == 0
-            && (!options.Write || (loadedAfter.Count == 0 && artifactsAfter.Count == 0));
+            && (!options.Write || (loadedAfter.Count == 0 && remainingRemovableArtifacts.Length == 0));
         var result = new ReconcileResult
         {
             Operation = "supervise-" + operation,
@@ -179,12 +188,13 @@ internal static class NotifySuperviseReconcileCommand
             Unloaded = unloaded,
             WouldUnload = options.Write ? [] : loadedBefore,
             ArtifactsBefore = artifactsBefore,
-            RemovedArtifacts = options.Write ? artifactsBefore.Where(path => !File.Exists(path)).ToArray() : [],
-            WouldRemoveArtifacts = options.Write ? [] : artifactsBefore,
+            RemovedArtifacts = options.Write ? removableArtifacts.Where(path => !File.Exists(path)).ToArray() : [],
+            WouldRemoveArtifacts = options.Write ? [] : removableArtifacts,
             LoadedAfter = loadedAfter,
             ArtifactsAfter = artifactsAfter,
+            KeptPersistentArtifacts = persistentArtifacts.Length == 0 ? null : persistentArtifacts,
             Errors = errors,
-            Summary = BuildSummary(operation, options.Write, loadedBefore, unloaded, artifactsBefore, artifactsAfter, errors),
+            Summary = BuildSummary(operation, options.Write, loadedBefore, unloaded, removableArtifacts, artifactsAfter, persistentArtifacts, errors),
         };
         Emit(writer, result, options.Format);
         return success ? 0 : 1;
@@ -256,8 +266,9 @@ internal static class NotifySuperviseReconcileCommand
         bool write,
         IReadOnlyList<string> loadedBefore,
         IReadOnlyList<string> unloaded,
-        IReadOnlyList<string> artifactsBefore,
+        IReadOnlyList<string> removableArtifactsBefore,
         IReadOnlyList<string> artifactsAfter,
+        IReadOnlyList<string> persistentArtifacts,
         IReadOnlyList<string> errors)
     {
         if (errors.Count > 0)
@@ -267,10 +278,15 @@ internal static class NotifySuperviseReconcileCommand
 
         if (!write)
         {
-            return $"Dry-run found {loadedBefore.Count} loaded supervise job(s) and {artifactsBefore.Count} artifact(s); no launchctl or filesystem mutation was performed. Use --write to unload and remove them.";
+            return persistentArtifacts.Count == 0
+                ? $"Dry-run found {loadedBefore.Count} loaded supervise job(s) and {removableArtifactsBefore.Count} artifact(s); no launchctl or filesystem mutation was performed. Use --write to unload and remove them."
+                : $"Dry-run found {loadedBefore.Count} loaded supervise job(s); kept declared persistent artifact(s): {string.Join(", ", persistentArtifacts)}; legacy artifact(s) eligible for removal: {removableArtifactsBefore.Count}. No launchctl or filesystem mutation was performed. Use --write to unload and remove only legacy artifacts.";
         }
 
-        return $"{operation} unloaded {unloaded.Count} supervise job(s) and removed {artifactsBefore.Count - artifactsAfter.Count} artifact(s). Remaining loaded jobs: {loadedBefore.Count - unloaded.Count}; remaining artifacts: {artifactsAfter.Count}.";
+        var removedCount = removableArtifactsBefore.Count - artifactsAfter.Count(path => !persistentArtifacts.Contains(path, StringComparer.Ordinal));
+        return persistentArtifacts.Count == 0
+            ? $"{operation} unloaded {unloaded.Count} supervise job(s) and removed {removedCount} artifact(s). Remaining loaded jobs: {loadedBefore.Count - unloaded.Count}; remaining artifacts: {artifactsAfter.Count}."
+            : $"{operation} unloaded {unloaded.Count} supervise job(s), removed {removedCount} legacy artifact(s), and kept declared persistent artifact(s): {string.Join(", ", persistentArtifacts)}. Remaining loaded jobs: {loadedBefore.Count - unloaded.Count}; remaining artifacts: {artifactsAfter.Count}.";
     }
 
     private static string CurrentPlatform() =>
@@ -414,6 +430,10 @@ internal static class NotifySuperviseReconcileCommand
         writer.WriteLine($"- loaded before: {string.Join(", ", result.LoadedBefore.DefaultIfEmpty("none"))}");
         writer.WriteLine($"- unloaded: {string.Join(", ", result.Unloaded.DefaultIfEmpty("none"))}");
         writer.WriteLine($"- removed artifacts: {string.Join(", ", result.RemovedArtifacts.DefaultIfEmpty("none"))}");
+        if (result.KeptPersistentArtifacts is { Count: > 0 })
+        {
+            writer.WriteLine($"- kept declared persistent artifacts: {string.Join(", ", result.KeptPersistentArtifacts)}");
+        }
         writer.WriteLine($"- loaded after: {string.Join(", ", result.LoadedAfter.DefaultIfEmpty("none"))}");
         writer.WriteLine($"- artifacts after: {string.Join(", ", result.ArtifactsAfter.DefaultIfEmpty("none"))}");
         if (result.Errors.Count > 0)
@@ -454,6 +474,9 @@ internal static class NotifySuperviseReconcileCommand
         [JsonPropertyName("would_remove_artifacts")] public required IReadOnlyList<string> WouldRemoveArtifacts { get; init; }
         [JsonPropertyName("artifacts_after")] public required IReadOnlyList<string> ArtifactsAfter { get; init; }
         [JsonPropertyName("loaded_after")] public required IReadOnlyList<string> LoadedAfter { get; init; }
+        [JsonPropertyName("kept_persistent_artifacts")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public IReadOnlyList<string>? KeptPersistentArtifacts { get; init; }
         [JsonPropertyName("errors")] public required IReadOnlyList<string> Errors { get; init; }
         [JsonPropertyName("summary")] public required string Summary { get; init; }
     }
@@ -462,6 +485,7 @@ internal static class NotifySuperviseReconcileCommand
 internal static class NotifySuperviseArtifactInventory
 {
     private const string LabelPrefix = "intent-cli.supervise.";
+    internal const string PersistenceMarker = "intent-cli persistence-intent: persistent";
 
     internal static Func<string> UserProfileDirectoryFactory { get; set; } =
         () => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -526,6 +550,7 @@ internal static class NotifySuperviseArtifactInventory
                     "intent-cli.supervise.*.plist",
                     SearchOption.TopDirectoryOnly)
                 .Where(path => IsManagedArtifact(path, label))
+                .Where(path => !HasDeclaredPersistence(path))
                 .Distinct(StringComparer.Ordinal)
                 .Order(StringComparer.Ordinal)
                 .ToArray();
@@ -554,6 +579,21 @@ internal static class NotifySuperviseArtifactInventory
         }
 
         return removed;
+    }
+
+    public static bool HasDeclaredPersistence(string path)
+    {
+        try
+        {
+            return File.Exists(path)
+                && File.ReadAllText(path).Contains(PersistenceMarker, StringComparison.Ordinal);
+        }
+        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+        {
+            // An unreadable declaration is not evidence of persistence. The
+            // existing fail-closed cleanup behavior remains authoritative.
+            return false;
+        }
     }
 
     private static bool IsManagedArtifact(string path, string? label)

--- a/tests/IntentSystem.Cli.Tests/NotifySuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySuperviseCommandTests.cs
@@ -1,0 +1,270 @@
+using System.Text.Json;
+using System.Xml.Linq;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G765: declared supervision persistence, explicit reconciliation ownership,
+/// and read-only liveness independent of the supervisor process.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifySuperviseCommandTests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+    private const string Label = "intent-cli.supervise.intent-cli.intent-cli-dev";
+    private const string PersistenceMarker = "intent-cli persistence-intent: persistent";
+    private readonly string root = Path.Combine(
+        RepoVersionPolicySource.RepoRoot(),
+        ".artifacts",
+        "g765-supervision-" + Guid.NewGuid().ToString("N"));
+    private readonly string home;
+    private readonly DateTimeOffset now = new(2026, 8, 30, 12, 0, 0, TimeSpan.Zero);
+
+    public NotifySuperviseCommandTests()
+    {
+        Directory.CreateDirectory(root);
+        home = Path.Combine(root, "home");
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifyCommand.UtcNowFactory = () => now;
+        NotifySuperviseReconcileCommand.MacOsDetector = () => true;
+        NotifySuperviseArtifactInventory.UserProfileDirectoryFactory = () => home;
+        NotifySuperviseInstallCommand.FirstCycleProbeFactory = _ => VerifiedFirstCycle();
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.ProcessRunnerFactory = null;
+        NotifyCommand.UtcNowFactory = null;
+        NotifySuperviseReconcileCommand.MacOsDetector = OperatingSystem.IsMacOS;
+        NotifySuperviseArtifactInventory.UserProfileDirectoryFactory =
+            () => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        NotifySuperviseInstallCommand.FirstCycleProbeFactory = null;
+    }
+
+    [Fact]
+    public void InstallPersistent_RecordsIntentInArtifactMetadata()
+    {
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(),
+            [
+                "install", "--domain", Domain, "--team", Team,
+                "--repo", "J-Tech-Japan/intent-system", "--owner-role", "orchestration",
+                "--bound", "900", "--interval", "300", "--platform", "macos",
+                "--output", Path.Combine(root, "install", Label + ".plist"),
+                "--persistence", "persistent", "--write", "--format", "json",
+            ],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var result = document.RootElement;
+        Assert.Equal("persistent", result.GetProperty("persistence_intent").GetString());
+        var artifact = File.ReadAllText(result.GetProperty("artifact_path").GetString()!);
+        Assert.Contains(PersistenceMarker, artifact, StringComparison.Ordinal);
+        Assert.NotNull(XDocument.Parse(artifact));
+    }
+
+    [Fact]
+    public void ReconcileWrite_KeepsDeclaredPersistentAndRemovesLegacyArtifacts()
+    {
+        var persistent = CreateArtifact("persistent", PersistenceMarker);
+        var legacy = CreateLegacyArtifact("legacy artifact");
+        NotifyCommand.ProcessRunnerFactory = () => new EmptyLaunchctlRunner();
+
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(),
+            ["reconcile", "--platform", "macos", "--write", "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var result = document.RootElement;
+        Assert.Contains(
+            persistent,
+            result.GetProperty("kept_persistent_artifacts").EnumerateArray().Select(value => value.GetString()),
+            StringComparer.Ordinal);
+        Assert.Equal(
+            legacy,
+            result.GetProperty("removed_artifacts").EnumerateArray().Single().GetString());
+        Assert.True(File.Exists(persistent));
+        Assert.False(File.Exists(legacy));
+        Assert.Contains(
+            persistent,
+            result.GetProperty("artifacts_after").EnumerateArray().Select(value => value.GetString()),
+            StringComparer.Ordinal);
+        Assert.Contains("declared persistent", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Liveness_IsReadOnlyAndReportsAbsentSupervisorAgainstOldCycle()
+    {
+        Assert.True(NotifySupervisionStore.RecordBound(
+            NotifySupervisionArtifactRoot(),
+            new NotifySupervisionBound
+            {
+                Domain = Domain,
+                Team = Team,
+                BoundSeconds = 900,
+                RecordedAt = now.AddHours(-3),
+            },
+            write: true).Applied);
+        Assert.True(NotifySupervisionStore.RecordCycle(
+            NotifySupervisionStore.ResolveCyclePath(NotifySupervisionArtifactRoot(), Domain, Team),
+            new NotifySupervisionCycle
+            {
+                CycleId = "g765-old-cycle",
+                StartedAt = now.AddHours(-3).AddSeconds(-4),
+                CompletedAt = now.AddHours(-3),
+                IntervalSeconds = 300,
+            },
+            write: true).Applied);
+        NotifyCommand.ProcessRunnerFactory = () =>
+            throw new InvalidOperationException("read-only liveness must not invoke an OS process");
+
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(),
+            ["liveness", "--domain", Domain, "--team", Team, "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var result = document.RootElement;
+        Assert.Equal("supervise-liveness", result.GetProperty("operation").GetString());
+        Assert.Equal(900, result.GetProperty("declared_bound_seconds").GetInt32());
+        Assert.Equal(10_800, result.GetProperty("elapsed_seconds").GetInt64());
+        Assert.True(result.GetProperty("absent_since_last_cycle").GetBoolean());
+        Assert.False(result.GetProperty("scheduler_job_loaded").GetBoolean());
+        Assert.Equal("read-only", result.GetProperty("command_mode").GetString());
+    }
+
+    [Fact]
+    public void Liveness_DoesNotRequireSupervisorProcessOrSchedulerLifecycle()
+    {
+        NotifyCommand.ProcessRunnerFactory = () =>
+            throw new InvalidOperationException("liveness must not run launchctl, systemctl, or a supervisor");
+
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(),
+            ["liveness", "--domain", Domain, "--team", Team, "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var result = document.RootElement;
+        Assert.False(result.GetProperty("scheduler_job_loaded").GetBoolean());
+        Assert.Contains("no supervisor process", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("launchctl", result.GetProperty("commands_executed").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("systemctl", result.GetProperty("commands_executed").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DocumentationNamesDeclaredPersistenceAndIndependentLiveness(string language)
+    {
+        var path = Path.Combine(RepoVersionPolicySource.RepoRoot(), "docs", language, "12-agent-message-orchestration.md");
+        var document = File.ReadAllText(path);
+        Assert.Contains("G765", document, StringComparison.Ordinal);
+        Assert.Contains("--persistence persistent", document, StringComparison.Ordinal);
+        Assert.Contains("notify supervise liveness", document, StringComparison.Ordinal);
+        Assert.Contains("launchctl", document, StringComparison.Ordinal);
+        if (language == "en")
+        {
+            Assert.Contains("does not execute", document, StringComparison.OrdinalIgnoreCase);
+        }
+        else
+        {
+            Assert.Contains("実行しません", document, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void DesignGuidePointsToReadOnlySupervisionLiveness()
+    {
+        using var writer = new StringWriter();
+        Assert.Equal(0, GuideDesignThreadCommand.Execute(CreateContext(), ["--format", "json"], writer));
+        using var document = JsonDocument.Parse(writer.ToString());
+        var residual = document.RootElement.GetProperty("monitoring").GetProperty("residual_design_check").GetString();
+        Assert.Contains("notify supervise liveness", residual, StringComparison.Ordinal);
+        Assert.Contains("read-only", residual, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string NotifySupervisionArtifactRoot() => Path.Combine(root, ".intent-cli", "supervision");
+
+    private string CreateArtifact(string suffix, string content)
+    {
+        var path = Path.Combine(
+            NotifySupervisionArtifactRoot(),
+            Domain,
+            Team,
+            "install",
+            suffix,
+            Label + ".plist");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private string CreateLegacyArtifact(string content)
+    {
+        var path = Path.Combine(home, "Library", "LaunchAgents", Label + ".plist");
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private NotifySuperviseFirstCycleResult VerifiedFirstCycle() => new()
+    {
+        Verified = true,
+        Status = "first-cycle-verified",
+        CycleId = "g765-first-cycle",
+        Writer = new NotifySupervisionWriterIdentity
+        {
+            Pid = 7650,
+            ProcessStartTime = now,
+            Host = "g765-fixture",
+        },
+        ObservedAt = now.AddSeconds(1),
+    };
+
+    private CliContext CreateContext() => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = Domain,
+                ArtifactRoot = ".intent-cli",
+                WorktreeRoot = ".intent-cli/worktrees",
+            },
+            Supervision = new SupervisionConfig { ArtifactRoot = ".intent-cli/supervision" },
+        },
+    };
+
+    private sealed class EmptyLaunchctlRunner : INotifyProcessRunner
+    {
+        public NotifyProcessResult Run(string fileName, IReadOnlyList<string> arguments)
+        {
+            if (fileName == "id")
+            {
+                return new NotifyProcessResult(0, "501\n", string.Empty);
+            }
+
+            if (fileName == "launchctl" && arguments.Count == 1 && arguments[0] == "list")
+            {
+                return new NotifyProcessResult(0, string.Empty, string.Empty);
+            }
+
+            throw new InvalidOperationException($"unexpected process: {fileName} {string.Join(' ', arguments)}");
+        }
+    }
+}

--- a/tests/IntentSystem.Cli.Tests/NotifySuperviseCommandTests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySuperviseCommandTests.cs
@@ -140,7 +140,8 @@ public sealed class NotifySuperviseCommandTests : IDisposable
         Assert.Equal(900, result.GetProperty("declared_bound_seconds").GetInt32());
         Assert.Equal(10_800, result.GetProperty("elapsed_seconds").GetInt64());
         Assert.True(result.GetProperty("absent_since_last_cycle").GetBoolean());
-        Assert.False(result.GetProperty("scheduler_job_loaded").GetBoolean());
+        Assert.Equal("unknown", result.GetProperty("scheduler_installation_evidence").GetString());
+        Assert.Equal("unknown", result.GetProperty("scheduler_live_state").GetString());
         Assert.Equal("read-only", result.GetProperty("command_mode").GetString());
     }
 
@@ -159,10 +160,53 @@ public sealed class NotifySuperviseCommandTests : IDisposable
         Assert.Equal(0, exitCode);
         using var document = JsonDocument.Parse(writer.ToString());
         var result = document.RootElement;
-        Assert.False(result.GetProperty("scheduler_job_loaded").GetBoolean());
+        Assert.Equal("unknown", result.GetProperty("scheduler_installation_evidence").GetString());
+        Assert.Equal("unknown", result.GetProperty("scheduler_live_state").GetString());
         Assert.Contains("no supervisor process", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("launchctl", result.GetProperty("commands_executed").GetString(), StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("systemctl", result.GetProperty("commands_executed").GetString(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Liveness_DoesNotClaimAnUnregisteredArtifactIsLoaded()
+    {
+        var artifact = CreateArtifact("authored-but-unregistered", "authored but never registered");
+        var installedRecord = NotifySupervisionStore.RecordInstalledSupervisor(
+            NotifySupervisionArtifactRoot(),
+            new NotifySupervisionInstalledSupervisor
+            {
+                Domain = Domain,
+                Team = Team,
+                Label = Label,
+                ArtifactPath = artifact,
+                Writer = VerifiedFirstCycle().Writer!,
+                StartupBoundSeconds = 900,
+                RecordedAt = now,
+            },
+            write: true);
+        Assert.True(installedRecord.Applied);
+
+        var processRunnerInvoked = false;
+        NotifyCommand.ProcessRunnerFactory = () =>
+        {
+            processRunnerInvoked = true;
+            throw new InvalidOperationException("unregistered-artifact regression must not query a scheduler");
+        };
+
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(),
+            ["liveness", "--domain", Domain, "--team", Team, "--format", "json"],
+            writer);
+
+        Assert.Equal(0, exitCode);
+        Assert.False(processRunnerInvoked);
+        using var document = JsonDocument.Parse(writer.ToString());
+        var result = document.RootElement;
+        Assert.Equal("installation-artifact-present", result.GetProperty("scheduler_installation_evidence").GetString());
+        Assert.Equal("unknown", result.GetProperty("scheduler_live_state").GetString());
+        Assert.DoesNotContain("scheduler_job_loaded", writer.ToString(), StringComparison.Ordinal);
+        Assert.Contains("scheduler live state=unknown", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]
@@ -176,6 +220,8 @@ public sealed class NotifySuperviseCommandTests : IDisposable
         Assert.Contains("--persistence persistent", document, StringComparison.Ordinal);
         Assert.Contains("notify supervise liveness", document, StringComparison.Ordinal);
         Assert.Contains("launchctl", document, StringComparison.Ordinal);
+        Assert.Contains("scheduler_installation_evidence", document, StringComparison.Ordinal);
+        Assert.Contains("scheduler_live_state", document, StringComparison.Ordinal);
         if (language == "en")
         {
             Assert.Contains("does not execute", document, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
Closes #1665

## Summary

- Add an explicit `--persistence persistent` install declaration recorded in scheduler artifact metadata.
- Make reconcile report declared-persistent artifacts as kept and remove only undeclared legacy login-persistent artifacts.
- Add `notify supervise liveness` as an independent, read-only persisted-state/artifact evidence surface.
- Update the design guide, EN/JA orchestration mirrors, and add ADR 0013.

Install remains authoring-only. No command in the new liveness path invokes a process manager, starts the supervisor, registers a scheduler, or runs `launchctl`, `systemctl`, Task Scheduler, or another OS lifecycle command. The liveness result explicitly says whether durable installation evidence is present; it does not claim that intent-cli performed registration. Omitting `--persistence` returns the existing artifact bytes and legacy session-only output shape.

## Parent evidence

On parent `6cc2b05127f7dc8c9080e425eb5af8e0e099ace7`, the new G765 test class was absent from production behavior and the pre-fix run failed all seven new cases:

```
Failed! - Failed: 7, Passed: 0, Skipped: 0, Total: 7
```

The observed failures were `InstallPersistent_RecordsIntentInArtifactMetadata`, `ReconcileDryRun_KeepsDeclaredPersistentAndNamesLegacyArtifacts`, `Liveness_IsReadOnlyAndReportsAbsentSupervisorAgainstOldCycle`, `Liveness_DoesNotRequireSupervisorProcessOrSchedulerLifecycle`, both EN/JA cases of `DocumentationNamesDeclaredPersistenceAndIndependentLiveness`, and `DesignGuidePointsToReadOnlySupervisionLiveness`.

## Verification

- Focused G765: `NotifySuperviseCommandTests` — 7 passed, 0 failed, 0 skipped, 7 total.
- Established supervision plus G765 adjacent set (G658/G704/G712/G641/G659/G675/G676/G699/G741/G748/G750/G751): 90 passed, 0 failed, 0 skipped, 90 total.
- G613: 6 passed, 0 failed, 0 skipped, 6 total.
- Full Release CLI suite: 5399 passed, 0 failed, 1 skipped, 5400 total.
- `git diff --check`: clean.

The focused liveness tests install no supervisor and set the process-runner seam to throw, proving the answer is produced without a supervisor process or lifecycle command. The reconciliation test writes a declared artifact and a legacy LaunchAgents artifact, verifies the declared artifact remains, and verifies the legacy artifact is removed and named in the result. The install test also parses the persistent macOS plist to keep the metadata valid.

## Lifecycle boundary

This is the resumed original G765 implementation branch, not a duplicate scope or PR. The child GitHub issue claim proceeded with the existing stale `intent-issue-in-progress` label and returned `proceed=true`; its exact warning was that the claim registry is authoritative for `execution-unit:G765` and the label is stale shadow state. Child issue-preflight reported `classification=ready-to-implement`, `actionable=true`, and local `claim_status=unheld` because its child-local registry is distinct. The supplied authoritative host evidence says `execution-unit:G765` remains held by implementation/team `intent-cli-dev`; that host authority was consumed without creating, verifying, releasing, or mutating any child execution-unit claim. G763 was not changed.
