### PR TITLE
G766: fail closed for metadata-branch claim stores

### DIFF
--- a/docs/en/05-implementation-loop.md
+++ b/docs/en/05-implementation-loop.md
@@ -268,6 +268,21 @@ uses that same judgment in recommendation mode: unheld and own-team units
 remain candidates, while claimed-elsewhere units are excluded with holder
 evidence, so it never urges what start will refuse.
 
+### Preview: canonical-empty hosts with metadata-branch claims (G766)
+
+`not-configured` is reserved for a host with no claims store anywhere. A configured
+metadata branch that still carries active claim records proves that the host has
+adopted claims, even when the canonical branch currently has no claim tree. In that
+state the verifier returns `metadata-branch-only` and fails closed for every scope,
+including a scope that never existed. It does not read ownership from the metadata
+branch: the result has no holder or holder team, and a stranded record remains
+unheld until the explicit G763 migration path is used.
+
+This keeps the genuinely unadopted host byte-compatible while preventing the empty
+canonical branch from making every claims-gated command pass. A configured metadata
+branch with no active records does not by itself create a claims store; the reader
+only changes the legacy answer when it can verify active records there.
+
 Numbering is claim-then-draft. Claim `execution-unit:<N>` before scaffolding;
 after losing N, fast-forward, recompute, and retry the next number exactly once.
 The GitHub lifecycle label remains visible defence in depth but is not the

--- a/docs/ja/05-implementation-loop.md
+++ b/docs/ja/05-implementation-loop.md
@@ -254,6 +254,21 @@ canonical answer を返します。default branch を解決または fetch で�
 unit は candidate のまま、claimed-elsewhere unit は holder evidence 付きで除外します。
 これにより start が拒否する作業を recommendation が促しません。
 
+### Preview: canonical branch が空で metadata branch のみに claim がある場合 (G766)
+
+`not-configured` は、どの branch にも claims store がない host のために予約します。
+設定済み metadata branch に active claim record が残っていれば、canonical branch に
+現在 claim tree がなくても、その host が claims を導入済みである証拠です。この場合
+verifier は `metadata-branch-only` を返して、まだ存在しない scope を含む全ての scope を
+fail closed にします。metadata branch の record から ownership は読みません。result に
+holder / holder team はなく、stranded record は明示的な G763 migration path を使うまで
+unheld のままです。
+
+これにより、claims をまだ導入していない host の byte-compatible な挙動を保ちながら、
+canonical branch が空であることだけを理由に claims-gated command が全て pass することを
+防ぎます。設定済み metadata branch に active record がないだけなら claims store とは判定せず、
+そこに active record があることを確認できた場合だけ legacy answer を変更します。
+
 番号は claim-then-draft です。scaffold 前に `execution-unit:<N>` を claim し、N に負けたら
 fast-forward、次番号を再計算し、その番号を exactly once retry します。GitHub lifecycle label
 は visible な defence in depth のままで acquisition fact ではありません。review/closeout gate と

--- a/src/IntentSystem.Cli/Commands/ClaimOwnershipVerifier.cs
+++ b/src/IntentSystem.Cli/Commands/ClaimOwnershipVerifier.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using IntentSystem.Cli.Infrastructure;
 
 namespace IntentSystem.Cli.Commands;
 
@@ -63,6 +64,17 @@ internal static class ClaimOwnershipVerifier
                 Holder: null,
                 HolderTeam: null,
                 Detail: "No claims store is configured; legacy single-team behavior applies unchanged.");
+        }
+
+        if (evidence.MetadataBranchOnly)
+        {
+            return Refused(
+                ClaimOwnershipVerification.StatusMetadataBranchOnly,
+                scope,
+                invokingTeam,
+                null,
+                null,
+                evidence.Detail);
         }
 
         if (evidence.RecordJson is null)
@@ -228,6 +240,23 @@ internal static class ClaimOwnershipVerifier
         var storeConfigured = claimPaths.Length > 0;
         if (!storeConfigured)
         {
+            // G766: an empty canonical claims tree is not enough to infer that
+            // the host never adopted claims. A configured metadata branch is
+            // an additional read-only adoption signal, but it never supplies
+            // ownership for ordinary verification.
+            var metadataConfiguration = ReadConfiguredMetadataBranch(repoRoot);
+            if (metadataConfiguration.Error is not null)
+            {
+                return CanonicalClaimEvidence.Unavailable(metadataConfiguration.Error);
+            }
+
+            var metadataBranch = metadataConfiguration.Branch;
+            if (metadataBranch is not null
+                && !string.Equals(metadataBranch, canonicalBranch.Name, StringComparison.Ordinal))
+            {
+                return ReadMetadataBranchEvidence(repoRoot, metadataBranch);
+            }
+
             return CanonicalClaimEvidence.NoStore;
         }
 
@@ -246,8 +275,102 @@ internal static class ClaimOwnershipVerifier
                     : show.StandardError.Trim());
         }
 
-        return new CanonicalClaimEvidence(true, true, show.StandardOutput, "fresh origin record");
+        return new CanonicalClaimEvidence(true, true, false, show.StandardOutput, "fresh origin record");
     }
+
+    private static CanonicalClaimEvidence ReadMetadataBranchEvidence(
+        string repoRoot,
+        string metadataBranch)
+    {
+        if (!IsSafeRemoteBranch(metadataBranch))
+        {
+            return CanonicalClaimEvidence.Unavailable(
+                $"configured metadata branch '{metadataBranch}' is not a safe remote branch name");
+        }
+
+        var remoteRef = $"refs/remotes/origin/{metadataBranch}";
+        var fetch = RunGit(repoRoot,
+            ["fetch", "--quiet", "origin", $"+refs/heads/{metadataBranch}:{remoteRef}"]);
+        if (fetch.ExitCode != 0)
+        {
+            return CanonicalClaimEvidence.Unavailable(
+                string.IsNullOrWhiteSpace(fetch.StandardError)
+                    ? $"fetching configured metadata branch '{metadataBranch}' failed"
+                    : fetch.StandardError.Trim());
+        }
+
+        var tree = RunGit(repoRoot,
+            ["ls-tree", "-r", "--name-only", remoteRef, "--", ClaimCommand.ClaimsDirectory]);
+        if (tree.ExitCode != 0)
+        {
+            return CanonicalClaimEvidence.Unavailable(
+                string.IsNullOrWhiteSpace(tree.StandardError)
+                    ? $"reading configured metadata branch '{metadataBranch}' claims tree failed"
+                    : tree.StandardError.Trim());
+        }
+
+        var claimCount = tree.StandardOutput
+            .Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Count(IsActiveClaimPath);
+        return claimCount == 0
+            ? CanonicalClaimEvidence.NoStore
+            : CanonicalClaimEvidence.MetadataOnly(
+                metadataBranch,
+                claimCount);
+    }
+
+    private static (string? Branch, string? Error) ReadConfiguredMetadataBranch(string repoRoot)
+    {
+        var configPath = CliRuntimeContracts.GetConfigPath(repoRoot);
+        if (!File.Exists(configPath)) return (null, null);
+
+        try
+        {
+            var project = CliConfigLoader.LoadFromFile(configPath).Project;
+            foreach (var candidate in new[]
+            {
+                project.MetadataSourceBranch,
+                project.MetadataBranch,
+                project.MetadataWriteBranch,
+            })
+            {
+                if (!string.IsNullOrWhiteSpace(candidate)) return (candidate.Trim(), null);
+            }
+        }
+        catch (Exception exception) when (
+            exception is IOException or UnauthorizedAccessException or InvalidOperationException or FormatException)
+        {
+            return (
+                null,
+                string.IsNullOrWhiteSpace(exception.Message)
+                    ? "reading configured metadata-branch settings failed"
+                    : $"reading configured metadata-branch settings failed: {exception.Message}");
+        }
+
+        return (null, null);
+    }
+
+    private static bool IsActiveClaimPath(string path)
+    {
+        var prefix = ClaimCommand.ClaimsDirectory + "/";
+        if (!path.StartsWith(prefix, StringComparison.Ordinal)) return false;
+        var file = path[prefix.Length..];
+        return file.EndsWith(".json", StringComparison.Ordinal)
+            && !file.Contains('/', StringComparison.Ordinal);
+    }
+
+    private static bool IsSafeRemoteBranch(string value) =>
+        value.Length > 0
+        && !value.StartsWith("-", StringComparison.Ordinal)
+        && !value.StartsWith("/", StringComparison.Ordinal)
+        && !value.EndsWith("/", StringComparison.Ordinal)
+        && !value.EndsWith(".", StringComparison.Ordinal)
+        && !value.Contains("..", StringComparison.Ordinal)
+        && !value.Contains("//", StringComparison.Ordinal)
+        && !value.Contains("@{", StringComparison.Ordinal)
+        && !value.Any(c => char.IsControl(c) || char.IsWhiteSpace(c)
+            || c is '~' or '^' or ':' or '?' or '*' or '[' or '\\')
+        && value.Split('/').All(segment => segment is not ("" or "." or ".."));
 
     private static CanonicalClaimEvidence ReadLocalEvidence(string repoRoot, string scope)
     {
@@ -260,7 +383,7 @@ internal static class ClaimOwnershipVerifier
         if (!File.Exists(claimPath)) return CanonicalClaimEvidence.Unheld;
         try
         {
-            return new CanonicalClaimEvidence(true, true, File.ReadAllText(claimPath), "local fixture record");
+            return new CanonicalClaimEvidence(true, true, false, File.ReadAllText(claimPath), "local fixture record");
         }
         catch (IOException exception)
         {
@@ -317,15 +440,23 @@ internal static class ClaimOwnershipVerifier
     private sealed record CanonicalClaimEvidence(
         bool Available,
         bool StoreConfigured,
+        bool MetadataBranchOnly,
         string? RecordJson,
         string Detail)
     {
         public static CanonicalClaimEvidence NoStore { get; } =
-            new(true, false, null, "canonical claims store absent");
+            new(true, false, false, null, "canonical claims store absent");
         public static CanonicalClaimEvidence Unheld { get; } =
-            new(true, true, null, "canonical scope unheld");
+            new(true, true, false, null, "canonical scope unheld");
         public static CanonicalClaimEvidence Unavailable(string detail) =>
-            new(false, false, null, detail);
+            new(false, false, false, null, detail);
+        public static CanonicalClaimEvidence MetadataOnly(string metadataBranch, int claimCount) =>
+            new(
+                true,
+                true,
+                true,
+                null,
+                $"Claims store is configured on metadata branch '{metadataBranch}' with {claimCount} active record(s), but the canonical branch has no claim records; refusing to treat every scope as unconfigured.");
     }
 
     private sealed record GitResult(int ExitCode, string StandardOutput, string StandardError);
@@ -439,4 +570,5 @@ internal sealed record ClaimOwnershipVerification(
     public const string StatusTeamRequired = "team-required";
     public const string StatusInvalid = "invalid";
     public const string StatusCanonicalUnavailable = "canonical-unavailable";
+    public const string StatusMetadataBranchOnly = "metadata-branch-only";
 }

--- a/src/IntentSystem.Cli/Commands/WorkerClaimAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerClaimAnalyzer.cs
@@ -183,6 +183,7 @@ internal static class WorkerClaimAnalyzer
             || claim.Status == ClaimOwnershipVerification.StatusHeldByOtherTeam
             || claim.Status == ClaimOwnershipVerification.StatusTeamRequired
             || claim.Status == ClaimOwnershipVerification.StatusCanonicalUnavailable
+            || claim.Status == ClaimOwnershipVerification.StatusMetadataBranchOnly
             || claim.Status == ClaimOwnershipVerification.StatusInvalid);
 
     /// <summary>

--- a/src/IntentSystem.Cli/Commands/WorkerIssuePreflightAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerIssuePreflightAnalyzer.cs
@@ -57,6 +57,7 @@ internal static class WorkerIssuePreflightAnalyzer
         {
             StoreConfigured: true,
             Status: ClaimOwnershipVerification.StatusCanonicalUnavailable
+                or ClaimOwnershipVerification.StatusMetadataBranchOnly
                 or ClaimOwnershipVerification.StatusInvalid
         };
         var claimDisagreement = hasInProgressLabel && claimIsUnheld;

--- a/src/IntentSystem.Cli/Commands/WorkerNextActionAnalyzer.cs
+++ b/src/IntentSystem.Cli/Commands/WorkerNextActionAnalyzer.cs
@@ -305,5 +305,6 @@ internal static class WorkerNextActionAnalyzer
             || claim.Status == ClaimOwnershipVerification.StatusHeldByOtherTeam
             || claim.Status == ClaimOwnershipVerification.StatusTeamRequired
             || claim.Status == ClaimOwnershipVerification.StatusCanonicalUnavailable
+            || claim.Status == ClaimOwnershipVerification.StatusMetadataBranchOnly
             || claim.Status == ClaimOwnershipVerification.StatusInvalid);
 }

--- a/tests/IntentSystem.Cli.Tests/ClaimCommandG766Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/ClaimCommandG766Tests.cs
@@ -1,0 +1,307 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+[Collection("WorkerNextActionSharedState")]
+public sealed class ClaimCommandG766Tests
+{
+    [Fact]
+    public void MetadataBranchClaimsWithEmptyCanonicalFailClosedForEveryScope_G766()
+    {
+        using var repos = new ClaimRepositories(
+            [Record("execution-unit:G766-known", "alice", "implementation")],
+            configureMetadataBranch: true);
+
+        var known = ClaimOwnershipVerifier.Verify(
+            repos.FirstClone,
+            "execution-unit:G766-known",
+            "implementation");
+        var neverExisted = ClaimOwnershipVerifier.Verify(
+            repos.FirstClone,
+            "execution-unit:G766-never-existed",
+            "implementation");
+
+        Assert.False(known.Passed);
+        Assert.Equal("metadata-branch-only", known.Status);
+        Assert.False(neverExisted.Passed);
+        Assert.Equal("metadata-branch-only", neverExisted.Status);
+        Assert.Null(known.Holder);
+        Assert.Null(known.HolderTeam);
+        Assert.Contains("metadata", known.Detail, StringComparison.OrdinalIgnoreCase);
+
+        using var commandOutput = new StringWriter();
+        var commandExit = ClaimVerificationCommand.Execute(
+            Context(repos.FirstClone),
+            ["--scope", "execution-unit:G766-known", "--team", "implementation", "--format", "json"],
+            commandOutput);
+
+        Assert.Equal(1, commandExit);
+        using var commandResult = JsonDocument.Parse(commandOutput.ToString());
+        Assert.False(commandResult.RootElement.GetProperty("passed").GetBoolean());
+        Assert.Equal(
+            "metadata-branch-only",
+            commandResult.RootElement.GetProperty("status").GetString());
+        Assert.False(commandResult.RootElement.TryGetProperty("holder", out _));
+        Assert.False(commandResult.RootElement.TryGetProperty("holder_team", out _));
+    }
+
+    [Fact]
+    public void NoClaimsAnywherePreservesTheParentNotConfiguredPayload_G766()
+    {
+        using var repos = new ClaimRepositories(
+            [],
+            configureMetadataBranch: false,
+            writeConfigWithoutMetadataBranch: true);
+        const string scope = "execution-unit:G766-no-store";
+
+        using var output = new StringWriter();
+        var exitCode = ClaimVerificationCommand.Execute(
+            Context(repos.FirstClone),
+            ["--scope", scope, "--team", "implementation", "--format", "json"],
+            output);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(
+            "{\n"
+            + "  \"passed\": true,\n"
+            + "  \"status\": \"not-configured\",\n"
+            + "  \"scope\": \"execution-unit:G766-no-store\",\n"
+            + "  \"store_configured\": false,\n"
+            + "  \"invoking_team\": \"implementation\",\n"
+            + "  \"detail\": \"No claims store is configured; legacy single-team behavior applies unchanged.\"\n"
+            + "}\n",
+            output.ToString());
+    }
+
+    [Fact]
+    public void MetadataBranchOnlyIsAnOwnershipStopForAdjacentClaimConsumers_G766()
+    {
+        using var repos = new ClaimRepositories(
+            [Record("execution-unit:G766-consumer", "alice", "implementation")],
+            configureMetadataBranch: true);
+        var claim = ClaimOwnershipVerifier.Verify(
+            repos.FirstClone,
+            "execution-unit:G766-consumer",
+            "implementation");
+        var issue = new GitHubAutomationIssueCandidate
+        {
+            Number = 1669,
+            Title = "G766 claim-store state",
+            Url = "https://github.com/J-Tech-Japan/intent-system/issues/1669",
+            CreatedAt = "2026-08-31T00:00:00Z",
+            Labels =
+            [
+                new GitHubAutomationLabel { Name = "intent-target" },
+                new GitHubAutomationLabel { Name = "intent-issue-in-progress" },
+            ],
+        };
+
+        var workerClaim = WorkerClaimAnalyzer.Analyze(
+            "issue",
+            ["intent-target"],
+            claim);
+        var nextAction = WorkerNextActionAnalyzer.Analyze(
+            "J-Tech-Japan/intent-system",
+            [],
+            [issue],
+            new Dictionary<int, ClaimOwnershipVerification> { [1669] = claim });
+        var issuePreflight = WorkerIssuePreflightAnalyzer.Analyze(
+            new GitHubIssueLookupResult
+            {
+                Number = 1669,
+                State = "OPEN",
+                Title = "G766 claim-store state",
+                Labels = [new GitHubIssueLabel { Name = "intent-target" }],
+            },
+            "J-Tech-Japan/intent-system",
+            1669,
+            repos.FirstClone,
+            claim);
+
+        Assert.False(workerClaim.Proceed);
+        Assert.Contains(workerClaim.Errors, error => error.Contains("Claims store is configured", StringComparison.Ordinal));
+        Assert.Equal(WorkerNextActionConstants.Actions.Wait, nextAction.Action);
+        Assert.Equal(WorkerNextActionConstants.SourceClassifications.ClaimRefused, nextAction.SourceClassification);
+        Assert.Equal(WorkerIssuePreflightConstants.Classifications.ClaimUnavailable, issuePreflight.Classification);
+        Assert.False(issuePreflight.Actionable);
+        Assert.Equal("metadata-branch-only", issuePreflight.ClaimStatus);
+    }
+
+    [Fact]
+    public void MetadataBranchRecordNeverBecomesCanonicalOwnership_G766()
+    {
+        using var repos = new ClaimRepositories(
+            [Record("execution-unit:G766-canonical", "canonical", "implementation")],
+            [Record("execution-unit:G766-metadata-only", "metadata", "review")],
+            configureMetadataBranch: true);
+
+        var canonical = ClaimOwnershipVerifier.Verify(
+            repos.FirstClone,
+            "execution-unit:G766-canonical",
+            "implementation");
+        var metadataOnly = ClaimOwnershipVerifier.Verify(
+            repos.FirstClone,
+            "execution-unit:G766-metadata-only",
+            "review");
+
+        Assert.Equal(ClaimOwnershipVerification.StatusOwned, canonical.Status);
+        Assert.Equal("canonical", canonical.Holder);
+        Assert.Equal(ClaimOwnershipVerification.StatusUnheld, metadataOnly.Status);
+        Assert.Null(metadataOnly.Holder);
+        Assert.Null(metadataOnly.HolderTeam);
+    }
+
+    [Fact]
+    public void DocumentationMirrorsDescribeMetadataOnlyFailClosedState_G766()
+    {
+        var root = RepoVersionPolicySource.RepoRoot();
+        var english = File.ReadAllText(Path.Combine(root, "docs", "en", "05-implementation-loop.md"));
+        var japanese = File.ReadAllText(Path.Combine(root, "docs", "ja", "05-implementation-loop.md"));
+
+        foreach (var document in new[] { english, japanese })
+        {
+            Assert.Contains("metadata-branch-only", document, StringComparison.Ordinal);
+            Assert.Contains("not-configured", document, StringComparison.Ordinal);
+            Assert.Contains("G763", document, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("every scope", english, StringComparison.Ordinal);
+        Assert.Contains("全ての scope", japanese, StringComparison.Ordinal);
+    }
+
+    private static CliContext Context(string root) => new()
+    {
+        RepoRoot = root,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = "intent-cli",
+                ArtifactRoot = ".intent-cli",
+                MetadataSourceBranch = "main-metadata",
+            },
+        },
+    };
+
+    private static ClaimRecord Record(string scope, string actor, string team) =>
+        new("1", scope, actor, team, DateTimeOffset.Parse("2026-08-31T00:00:00Z"), "base-commit");
+
+    private static string Serialize(ClaimRecord record) =>
+        JsonSerializer.Serialize(record, new JsonSerializerOptions { WriteIndented = true }) + Environment.NewLine;
+
+    private static void WriteRecords(string repo, IEnumerable<ClaimRecord> records)
+    {
+        foreach (var record in records)
+        {
+            var relative = ClaimCommand.ClaimPath(record.Scope);
+            var absolute = Path.Combine(repo, relative.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(absolute)!);
+            File.WriteAllText(absolute, Serialize(record), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        }
+    }
+
+    private static string Run(string workdir, string fileName, params string[] arguments)
+    {
+        var info = new ProcessStartInfo(fileName)
+        {
+            WorkingDirectory = workdir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        foreach (var argument in arguments) info.ArgumentList.Add(argument);
+        using var process = Process.Start(info)!;
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        Assert.True(process.ExitCode == 0, $"{fileName} {string.Join(' ', arguments)} failed: {error}");
+        return output;
+    }
+
+    private sealed class ClaimRepositories : IDisposable
+    {
+        private readonly TempDirectory temp = new("claim-g766-repos-");
+
+        public ClaimRepositories(
+            IReadOnlyList<ClaimRecord> metadata,
+            bool configureMetadataBranch,
+            bool writeConfigWithoutMetadataBranch = false)
+            : this([], metadata, configureMetadataBranch, writeConfigWithoutMetadataBranch)
+        {
+        }
+
+        public ClaimRepositories(
+            IReadOnlyList<ClaimRecord> canonical,
+            IReadOnlyList<ClaimRecord> metadata,
+            bool configureMetadataBranch,
+            bool writeConfigWithoutMetadataBranch = false)
+        {
+            Bare = Path.Combine(temp.Path, "origin.git");
+            var seed = Path.Combine(temp.Path, "seed");
+            FirstClone = Path.Combine(temp.Path, "first");
+            Directory.CreateDirectory(Bare);
+            Run(Bare, "git", "init", "--bare", "--quiet");
+            Directory.CreateDirectory(seed);
+            Run(seed, "git", "init", "--quiet", "--initial-branch=main");
+            Run(seed, "git", "config", "user.name", "g766-fixture");
+            Run(seed, "git", "config", "user.email", "g766-fixture@example.invalid");
+            File.WriteAllText(Path.Combine(seed, "README.md"), "g766 fixture\n");
+            Run(seed, "git", "add", "README.md");
+            Run(seed, "git", "commit", "--quiet", "-m", "seed");
+            Run(seed, "git", "remote", "add", "origin", Bare);
+            Run(seed, "git", "push", "--quiet", "-u", "origin", "main");
+
+            WriteRecords(seed, canonical);
+            if (canonical.Count > 0)
+            {
+                Run(seed, "git", "add", "--", ClaimCommand.ClaimsDirectory);
+                Run(seed, "git", "commit", "--quiet", "-m", "canonical claims");
+                Run(seed, "git", "push", "--quiet", "origin", "main");
+            }
+            Run(seed, "git", "switch", "--quiet", "-c", "main-metadata");
+            WriteRecords(seed, metadata);
+            if (metadata.Count > 0)
+            {
+                Run(seed, "git", "add", "--", ClaimCommand.ClaimsDirectory);
+                Run(seed, "git", "commit", "--quiet", "-m", "metadata claims");
+            }
+            Run(seed, "git", "push", "--quiet", "-u", "origin", "main-metadata");
+            Run(Bare, "git", "symbolic-ref", "HEAD", "refs/heads/main");
+            Run(temp.Path, "git", "clone", "--quiet", Bare, FirstClone);
+            if (configureMetadataBranch || writeConfigWithoutMetadataBranch)
+            {
+                var configDirectory = Path.Combine(FirstClone, ".intent-cli");
+                Directory.CreateDirectory(configDirectory);
+                File.WriteAllText(
+                    Path.Combine(configDirectory, "config.toml"),
+                    "[project]\n"
+                    + "domain = \"intent-cli\"\n"
+                    + "artifact_root = \".intent-cli\"\n"
+                    + (configureMetadataBranch
+                        ? "metadata_source_branch = \"main-metadata\"\n"
+                        : string.Empty));
+            }
+        }
+
+        public string Bare { get; }
+        public string FirstClone { get; }
+
+        public void Dispose() => temp.Dispose();
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory(string prefix) => Path = Directory.CreateTempSubdirectory(prefix).FullName;
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path)) Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1669

## Summary

When origin/default is empty but a configured metadata branch still carries active claim records, canonical claim verification now returns the distinct `metadata-branch-only` refusal for both existing and never-existed scopes. It never reads a metadata record as ownership. A genuinely unadopted host, including a valid config with no metadata branch, retains the parent `not-configured` JSON and exit behavior. The worker claim, next-action, and issue-preflight consumers treat the new status as an ownership stop.

## Evidence

- Parent oracle: `6cc2b05127f7dc8c9080e425eb5af8e0e099ace7`. Before the implementation, the G766 focused tests reported `Test Run Failed`, `Total tests: 5`, `Passed: 2`, `Failed: 3`: the metadata-branch fail-open, adjacent-consumer bypass, and documentation guard each failed. The two compatibility tests (no-store payload and canonical-only ownership) passed on the parent as expected.
- Child focused G766: `Total tests: 5`, `Passed: 5`, `Failed: 0`.
- Claim-focused suite, including G743/G747/G755/G763 and adjacent worker/claim consumers: `Total tests: 121`, `Passed: 121`, `Failed: 0`.
- G613: `Total tests: 6`, `Passed: 6`, `Failed: 0`.
- Full Release: `Total: 5398`, `Passed: 5397`, `Failed: 0`, `Skipped: 1`; exit 0.
- `git diff --check`: clean.

## Scope and ownership boundary

The child next-action result was `action=wait`, issue `#1669`, with local claim holder `none`/unheld; supported child issue-preflight was `actionable=true`, `classification=ready-to-implement`, `claim_status=unheld`. This is the known child/local registry contradiction. The supplied authoritative host evidence remains: execution-unit:G766 held by actor `implementation`, team `intent-cli-dev`, claim file `4f246379560b484f0ba64801a6ff9aa6e0a34f1aa9c8fce3ca260264759af3be.json`, claimed at `2026-08-31T01:22:02.894245+00:00`, base `91903554f4d31d902899c858550ed538cab0d653`; the host preflight refusal was the unreadable `.git/FETCH_HEAD` boundary. No child execution-unit claim was created or mutated, and no host repository/state was entered.

Only claim verification, the three worker-consumer status gates, focused tests, and the two EN/JA implementation-loop mirrors changed. G763/G755 writer, migration, canonical branch, and claim transaction behavior remain untouched.