### PR TITLE
G767: degrade supervision history reads per record

### DIFF
--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1025,6 +1025,34 @@ registration; registration remains the operator's explicit action.
 > change to interval, bound, cycle, shrink, archive, or repair semantics is
 > introduced.
 
+### Record-by-record supervision history reads (G767 — preview-through-1.x)
+
+Supervision history is read one non-blank JSONL record at a time. A malformed
+line in `cycles.jsonl`, `stalls.jsonl`, or the prompt-audit records does not
+make the whole team directory unreadable: valid records remain available and
+the read result carries deterministic corruption evidence with the component,
+relative file, one-based line number, and reason. The liveness JSON always
+includes `unreadable_record_count`; a non-zero count also includes
+`unreadable_records`, and its human-readable summary says that the reading is
+partial. A successful command reports `success: true`; a clean directory
+therefore reports zero without a partial-reading statement.
+
+If every cycle line is malformed, liveness has no readable cycle and does not
+report supervision as healthy. Its non-zero unreadable count and file/line
+evidence still distinguish that state from a genuinely empty history. This is
+the same degrade-and-report shape used by the sanctioned shrink reader: the
+reader preserves evidence and names the damaged input rather than silently
+turning corruption into absence. The measured incident was 9 malformed lines
+from 5 incidents in 663,959 lines (0.0014%); this slice changes how readers
+report that evidence, not how fragments were written or how appends are
+ordered. It does not repair existing files or claim to prevent future
+corruption.
+
+The reader remains read-only and does not run a supervisor or an OS lifecycle
+command. `stalls.jsonl` and prompt-audit records receive the same per-record
+treatment as cycles, so a damaged secondary history cannot silently erase the
+rest of the team's supervision answer.
+
 ### Event-driven supervision (G659 — preview-through-1.x)
 
 Add `--event-mode` to the one standing `notify supervise` invocation to opt in.

--- a/docs/en/12-agent-message-orchestration.md
+++ b/docs/en/12-agent-message-orchestration.md
@@ -1034,8 +1034,9 @@ the read result carries deterministic corruption evidence with the component,
 relative file, one-based line number, and reason. The liveness JSON always
 includes `unreadable_record_count`; a non-zero count also includes
 `unreadable_records`, and its human-readable summary says that the reading is
-partial. A successful command reports `success: true`; a clean directory
-therefore reports zero without a partial-reading statement.
+partial. A successful command returns exit code 0 and omits the failure-only
+`success` field; a clean directory therefore reports zero without a
+partial-reading statement.
 
 If every cycle line is malformed, liveness has no readable cycle and does not
 report supervision as healthy. Its non-zero unreadable count and file/line

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -862,6 +862,31 @@ action のままです。
 > lifecycle の実行、automatic re-arming、interval / bound / cycle / shrink / archive /
 > repair semantics の変更はありません。
 
+### supervision history の record 単位 read と corruption evidence (G767 — preview-through-1.x)
+
+supervision history は、空白でない JSONL record を 1 行ずつ読み取ります。
+`cycles.jsonl`、`stalls.jsonl`、prompt-audit record のどれかに malformed な
+line があっても team directory 全体を unreadable にはしません。読める record は
+残し、読み取り結果には component、relative file、1-based line number、reason を持つ
+deterministic な corruption evidence を出します。liveness JSON には常に
+`unreadable_record_count` を含め、0 より大きい場合は `unreadable_records` も含めます。
+human-readable summary には reading が partial であることを明示します。成功した
+command は `success: true` を返します。したがって clean な directory は count=0 で、
+partial-reading statement を出しません。
+
+cycle line がすべて malformed の場合は readable cycle がないため、supervision を
+healthy とは報告しません。それでも non-zero の unreadable count と file/line evidence
+によって、本当に empty な history と区別できます。これは sanctioned な shrink reader
+と同じ degrade-and-report の形です。corruption を absence に黙って変換せず、読める
+evidence を保持して damaged input を示します。測定された incident は 663,959 行中
+5 incident、9 malformed line（0.0014%）でした。この unit が変えるのは reader の
+evidence の示し方だけであり、fragment がどう書かれたかや append order は調査・修正
+しません。既存 file を修復せず、将来の corruption を防ぐとも主張しません。
+
+reader は read-only のままで、supervisor や OS lifecycle command を実行しません。
+`stalls.jsonl` と prompt-audit record にも cycles と同じ record 単位の扱いを適用するため、
+secondary history の damage が team の supervision answer の残りを黙って消すことはありません。
+
 ### event-driven supervision (G659 — preview-through-1.x)
 
 1 つの standing `notify supervise` invocation に `--event-mode` を追加して有効化します。

--- a/docs/ja/12-agent-message-orchestration.md
+++ b/docs/ja/12-agent-message-orchestration.md
@@ -871,8 +871,8 @@ line があっても team directory 全体を unreadable にはしません。�
 deterministic な corruption evidence を出します。liveness JSON には常に
 `unreadable_record_count` を含め、0 より大きい場合は `unreadable_records` も含めます。
 human-readable summary には reading が partial であることを明示します。成功した
-command は `success: true` を返します。したがって clean な directory は count=0 で、
-partial-reading statement を出しません。
+command は終了コード 0 を返し、失敗応答専用の `success` field は含めません。したがって
+clean な directory は count=0 で、partial-reading statement を出しません。
 
 cycle line がすべて malformed の場合は readable cycle がないため、supervision を
 healthy とは報告しません。それでも non-zero の unreadable count と file/line evidence

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
@@ -96,7 +96,6 @@ internal static class NotifySuperviseLivenessCommand
             Domain = options.Domain,
             Team = options.Team,
             CommandMode = "read-only",
-            Success = true,
             LastCompletedCycleAt = lastCycle?.CompletedAt,
             DeclaredBoundSeconds = boundSeconds,
             ElapsedSeconds = elapsedSeconds,
@@ -294,7 +293,6 @@ internal sealed record NotifySuperviseLivenessResult
     [JsonPropertyName("domain")] public required string Domain { get; init; }
     [JsonPropertyName("team")] public required string Team { get; init; }
     [JsonPropertyName("command_mode")] public required string CommandMode { get; init; }
-    [JsonPropertyName("success")] public required bool Success { get; init; }
     [JsonPropertyName("last_completed_cycle_at")] public DateTimeOffset? LastCompletedCycleAt { get; init; }
     [JsonPropertyName("declared_bound_seconds")] public int? DeclaredBoundSeconds { get; init; }
     [JsonPropertyName("elapsed_seconds")] public long? ElapsedSeconds { get; init; }

--- a/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySuperviseLivenessCommand.cs
@@ -96,6 +96,7 @@ internal static class NotifySuperviseLivenessCommand
             Domain = options.Domain,
             Team = options.Team,
             CommandMode = "read-only",
+            Success = true,
             LastCompletedCycleAt = lastCycle?.CompletedAt,
             DeclaredBoundSeconds = boundSeconds,
             ElapsedSeconds = elapsedSeconds,
@@ -105,7 +106,16 @@ internal static class NotifySuperviseLivenessCommand
             SchedulerEvidenceDetail = schedulerEvidenceDetail,
             SchedulerArtifactPaths = artifacts,
             CommandsExecuted = "none (persisted supervision state and artifact metadata only)",
-            Summary = BuildSummary(lastCycle, boundSeconds, elapsedSeconds, schedulerInstallationEvidence),
+            UnreadableRecordCount = state.UnreadableRecords.Count,
+            UnreadableRecords = state.UnreadableRecords.Count == 0
+                ? null
+                : state.UnreadableRecords,
+            Summary = BuildSummary(
+                lastCycle,
+                boundSeconds,
+                elapsedSeconds,
+                schedulerInstallationEvidence,
+                state.UnreadableRecords),
         };
 
         Emit(writer, result, options.Format);
@@ -116,7 +126,8 @@ internal static class NotifySuperviseLivenessCommand
         NotifySupervisionCycle? lastCycle,
         int? boundSeconds,
         long? elapsedSeconds,
-        string schedulerInstallationEvidence)
+        string schedulerInstallationEvidence,
+        IReadOnlyList<NotifySupervisionUnreadableRecord> unreadableRecords)
     {
         var cycleSummary = lastCycle is null
             ? "No completed supervision cycle is recorded; no supervisor process is required to produce this answer."
@@ -127,7 +138,14 @@ internal static class NotifySuperviseLivenessCommand
         var absenceSummary = lastCycle is null || boundSeconds is { } declared && elapsedSeconds is { } elapsed && elapsed > declared
             ? " Supervision is absent or beyond its declared bound."
             : " Supervision liveness is within the available evidence.";
-        return $"Read-only liveness: {cycleSummary}{absenceSummary} Scheduler live state=unknown; durable installation evidence={schedulerInstallationEvidence}; the supervisor was not run.";
+        var corruptionSummary = unreadableRecords.Count == 0
+            ? string.Empty
+            : $" Partial reading: {unreadableRecords.Count} unreadable supervision record(s) were skipped and surfaced as corruption evidence in {string.Join(", ", unreadableRecords.Select(item => $"{item.File} line {item.Line}"))}.";
+        var noReadableCycleSummary = lastCycle is null
+            && unreadableRecords.Any(item => item.Component is "cycles" or "prompt-audits")
+            ? " No readable cycle is available, so liveness is not reported as healthy."
+            : string.Empty;
+        return $"Read-only liveness: {cycleSummary}{absenceSummary}{noReadableCycleSummary}{corruptionSummary} Scheduler live state=unknown; durable installation evidence={schedulerInstallationEvidence}; the supervisor was not run.";
     }
 
     private static void EmitFailure(TextWriter writer, string error, string format)
@@ -167,6 +185,14 @@ internal static class NotifySuperviseLivenessCommand
         writer.WriteLine($"- scheduler live state: {result.SchedulerLiveState}");
         writer.WriteLine($"- scheduler installation evidence: {result.SchedulerInstallationEvidence}");
         writer.WriteLine($"- scheduler evidence detail: {result.SchedulerEvidenceDetail}");
+        writer.WriteLine($"- unreadable record count: {result.UnreadableRecordCount}");
+        if (result.UnreadableRecords is { } unreadableRecords)
+        {
+            foreach (var unreadable in unreadableRecords)
+            {
+                writer.WriteLine($"- unreadable record: {unreadable.File} line {unreadable.Line} ({unreadable.Reason})");
+            }
+        }
         writer.WriteLine($"- commands executed: {result.CommandsExecuted}");
         writer.WriteLine();
         writer.WriteLine(result.Summary);
@@ -268,6 +294,7 @@ internal sealed record NotifySuperviseLivenessResult
     [JsonPropertyName("domain")] public required string Domain { get; init; }
     [JsonPropertyName("team")] public required string Team { get; init; }
     [JsonPropertyName("command_mode")] public required string CommandMode { get; init; }
+    [JsonPropertyName("success")] public required bool Success { get; init; }
     [JsonPropertyName("last_completed_cycle_at")] public DateTimeOffset? LastCompletedCycleAt { get; init; }
     [JsonPropertyName("declared_bound_seconds")] public int? DeclaredBoundSeconds { get; init; }
     [JsonPropertyName("elapsed_seconds")] public long? ElapsedSeconds { get; init; }
@@ -277,5 +304,7 @@ internal sealed record NotifySuperviseLivenessResult
     [JsonPropertyName("scheduler_evidence_detail")] public required string SchedulerEvidenceDetail { get; init; }
     [JsonPropertyName("scheduler_artifact_paths")] public required IReadOnlyList<string> SchedulerArtifactPaths { get; init; }
     [JsonPropertyName("commands_executed")] public required string CommandsExecuted { get; init; }
+    [JsonPropertyName("unreadable_record_count")] public required int UnreadableRecordCount { get; init; }
+    [JsonPropertyName("unreadable_records")] public IReadOnlyList<NotifySupervisionUnreadableRecord>? UnreadableRecords { get; init; }
     [JsonPropertyName("summary")] public required string Summary { get; init; }
 }

--- a/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
+++ b/src/IntentSystem.Cli/Commands/NotifySupervisionStore.cs
@@ -134,9 +134,14 @@ internal static class NotifySupervisionStore
                 var emissionPolicy = ReadEmissionPolicy(Path.Combine(directory, EmissionPolicyFileName));
                 var installedSupervisor = ReadInstalledSupervisor(Path.Combine(directory, InstalledSupervisorFileName));
                 var cyclePaths = ResolveCycleHistoryPaths(directory);
-                var cycles = ReadCycles(cyclePaths);
-                var promptAudits = ReadPromptAudits(cyclePaths);
-                var stalls = ReadStalls(Path.Combine(directory, StallFileName), definitions);
+                var unreadableRecords = new List<NotifySupervisionUnreadableRecord>();
+                var cycles = ReadCycles(cyclePaths, directory, unreadableRecords);
+                var promptAudits = ReadPromptAudits(cyclePaths, directory, unreadableRecords);
+                var stalls = ReadStalls(
+                    Path.Combine(directory, StallFileName),
+                    directory,
+                    definitions,
+                    unreadableRecords);
                 return new NotifySupervisionReadResult
                 {
                     Resolved = true,
@@ -153,6 +158,10 @@ internal static class NotifySupervisionStore
                         .ToDictionary(item => item.Key, StringComparer.Ordinal),
                     StallHistory = stalls,
                     PromptAudits = promptAudits,
+                    UnreadableRecords = unreadableRecords
+                        .OrderBy(item => item.File, StringComparer.Ordinal)
+                        .ThenBy(item => item.Line)
+                        .ToArray(),
                 };
             }
             catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or JsonException or InvalidDataException)
@@ -528,7 +537,10 @@ internal static class NotifySupervisionStore
             ?? throw new InvalidDataException("The installed supervisor record was empty.");
     }
 
-    private static IReadOnlyList<NotifySupervisionCycle> ReadCycles(IEnumerable<string> paths)
+    private static IReadOnlyList<NotifySupervisionCycle> ReadCycles(
+        IEnumerable<string> paths,
+        string directory,
+        ICollection<NotifySupervisionUnreadableRecord> unreadableRecords)
     {
         var cycles = new List<NotifySupervisionCycle>();
         foreach (var path in paths)
@@ -538,17 +550,41 @@ internal static class NotifySupervisionStore
                 continue;
             }
 
+            var lineNumber = 0;
             foreach (var line in File.ReadLines(path))
             {
+                lineNumber++;
                 if (string.IsNullOrWhiteSpace(line))
                 {
                     continue;
                 }
 
-                var entry = JsonSerializer.Deserialize<NotifySupervisionEvent>(line, JsonOptions)
-                    ?? throw new InvalidDataException("A supervision cycle event was empty.");
-                if (!string.Equals(entry.Kind, "cycle", StringComparison.Ordinal) || entry.Cycle is null)
+                if (!TryReadEvent(
+                        path,
+                        directory,
+                        lineNumber,
+                        "cycles",
+                        line,
+                        unreadableRecords,
+                        out var entry))
                 {
+                    continue;
+                }
+
+                if (!string.Equals(entry!.Kind, "cycle", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (entry.Cycle is null)
+                {
+                    AddUnreadableRecord(
+                        path,
+                        directory,
+                        lineNumber,
+                        "cycles",
+                        "missing-cycle-payload",
+                        unreadableRecords);
                     continue;
                 }
 
@@ -559,7 +595,10 @@ internal static class NotifySupervisionStore
         return cycles.OrderBy(item => item.CompletedAt).ToArray();
     }
 
-    private static IReadOnlyList<NotifyPromptAudit> ReadPromptAudits(IEnumerable<string> paths)
+    private static IReadOnlyList<NotifyPromptAudit> ReadPromptAudits(
+        IEnumerable<string> paths,
+        string directory,
+        ICollection<NotifySupervisionUnreadableRecord> unreadableRecords)
     {
         var audits = new List<NotifyPromptAudit>();
         foreach (var path in paths)
@@ -569,20 +608,45 @@ internal static class NotifySupervisionStore
                 continue;
             }
 
+            var lineNumber = 0;
             foreach (var line in File.ReadLines(path))
             {
+                lineNumber++;
                 if (string.IsNullOrWhiteSpace(line))
                 {
                     continue;
                 }
 
-                var entry = JsonSerializer.Deserialize<NotifySupervisionEvent>(line, JsonOptions)
-                    ?? throw new InvalidDataException("A supervision prompt-audit event was empty.");
-                if (string.Equals(entry.Kind, "prompt-audit", StringComparison.Ordinal)
-                    && entry.PromptAudit is not null)
+                if (!TryReadEvent(
+                        path,
+                        directory,
+                        lineNumber,
+                        "prompt-audits",
+                        line,
+                        unreadableRecords,
+                        out var entry))
                 {
-                    audits.Add(entry.PromptAudit);
+                    continue;
                 }
+
+                if (!string.Equals(entry!.Kind, "prompt-audit", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (entry.PromptAudit is null)
+                {
+                    AddUnreadableRecord(
+                        path,
+                        directory,
+                        lineNumber,
+                        "prompt-audits",
+                        "missing-prompt-audit-payload",
+                        unreadableRecords);
+                    continue;
+                }
+
+                audits.Add(entry.PromptAudit);
             }
         }
         return audits.OrderBy(item => item.Timestamp).ToArray();
@@ -610,7 +674,9 @@ internal static class NotifySupervisionStore
 
     private static IReadOnlyList<NotifySupervisionStallRecord> ReadStalls(
         string path,
-        IReadOnlyDictionary<string, string> definitions)
+        string directory,
+        IReadOnlyDictionary<string, string> definitions,
+        ICollection<NotifySupervisionUnreadableRecord> unreadableRecords)
     {
         if (!File.Exists(path))
         {
@@ -619,25 +685,64 @@ internal static class NotifySupervisionStore
 
         var current = new Dictionary<string, NotifySupervisionStallRecord>(StringComparer.Ordinal);
         var history = new List<NotifySupervisionStallRecord>();
+        var lineNumber = 0;
         foreach (var line in File.ReadLines(path))
         {
+            lineNumber++;
             if (string.IsNullOrWhiteSpace(line))
             {
                 continue;
             }
 
-            var entry = JsonSerializer.Deserialize<NotifySupervisionEvent>(line, JsonOptions)
-                ?? throw new InvalidDataException("A supervision stall event was empty.");
-            if (string.Equals(entry.Kind, "open", StringComparison.Ordinal) && entry.Stall is not null)
+            if (!TryReadEvent(
+                    path,
+                    directory,
+                    lineNumber,
+                    "stalls",
+                    line,
+                    unreadableRecords,
+                    out var entry))
             {
+                continue;
+            }
+
+            if (string.Equals(entry!.Kind, "open", StringComparison.Ordinal))
+            {
+                if (entry.Stall is null)
+                {
+                    AddUnreadableRecord(
+                        path,
+                        directory,
+                        lineNumber,
+                        "stalls",
+                        "missing-stall-payload",
+                        unreadableRecords);
+                    continue;
+                }
+
                 current[entry.Stall.Key] = ResolveStoredStall(entry.Stall, definitions);
                 continue;
             }
 
-            if (string.Equals(entry.Kind, "clear", StringComparison.Ordinal)
-                && entry.Key is not null
-                && current.Remove(entry.Key, out var open))
+            if (string.Equals(entry.Kind, "clear", StringComparison.Ordinal))
             {
+                if (entry.Key is null)
+                {
+                    AddUnreadableRecord(
+                        path,
+                        directory,
+                        lineNumber,
+                        "stalls",
+                        "missing-stall-key",
+                        unreadableRecords);
+                    continue;
+                }
+
+                if (!current.Remove(entry.Key, out var open))
+                {
+                    continue;
+                }
+
                 var cleared = open with
                 {
                     ClearedAt = entry.ClearedAt,
@@ -654,6 +759,88 @@ internal static class NotifySupervisionStore
             .OrderBy(item => item.SurfacedAt)
             .ThenBy(item => item.Key, StringComparer.Ordinal)
             .ToArray();
+    }
+
+    private static bool TryReadEvent(
+        string path,
+        string directory,
+        int lineNumber,
+        string component,
+        string line,
+        ICollection<NotifySupervisionUnreadableRecord> unreadableRecords,
+        out NotifySupervisionEvent? entry)
+    {
+        try
+        {
+            entry = JsonSerializer.Deserialize<NotifySupervisionEvent>(line, JsonOptions);
+            if (entry is null)
+            {
+                AddUnreadableRecord(
+                    path,
+                    directory,
+                    lineNumber,
+                    component,
+                    "empty-event",
+                    unreadableRecords);
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.Kind))
+            {
+                AddUnreadableRecord(
+                    path,
+                    directory,
+                    lineNumber,
+                    component,
+                    "missing-event-kind",
+                    unreadableRecords);
+                entry = null;
+                return false;
+            }
+
+            return true;
+        }
+        catch (JsonException)
+        {
+            // Match shrink's degrade-and-report shape: preserve the rest of
+            // the append-only file and expose the exact unreadable line.
+            entry = null;
+            AddUnreadableRecord(
+                path,
+                directory,
+                lineNumber,
+                component,
+                "invalid-json",
+                unreadableRecords);
+            return false;
+        }
+    }
+
+    private static void AddUnreadableRecord(
+        string path,
+        string directory,
+        int lineNumber,
+        string component,
+        string reason,
+        ICollection<NotifySupervisionUnreadableRecord> unreadableRecords)
+    {
+        var file = Path.GetRelativePath(directory, path)
+            .Replace(Path.DirectorySeparatorChar, '/')
+            .Replace(Path.AltDirectorySeparatorChar, '/');
+        if (unreadableRecords.Any(item =>
+                item.File == file
+                && item.Line == lineNumber))
+        {
+            return;
+        }
+
+        unreadableRecords.Add(new NotifySupervisionUnreadableRecord
+        {
+            Component = component,
+            File = file,
+            Line = lineNumber,
+            Reason = reason,
+        });
     }
 
     private static IReadOnlyDictionary<string, string> ReadEvidenceDefinitions(string path)
@@ -2611,7 +2798,16 @@ internal sealed record NotifySupervisionReadResult
     public required IReadOnlyDictionary<string, NotifySupervisionStallRecord> ActiveStalls { get; init; }
     public required IReadOnlyList<NotifySupervisionStallRecord> StallHistory { get; init; }
     public required IReadOnlyList<NotifyPromptAudit> PromptAudits { get; init; }
+    public IReadOnlyList<NotifySupervisionUnreadableRecord> UnreadableRecords { get; init; } = [];
     public string? Error { get; init; }
+}
+
+internal sealed record NotifySupervisionUnreadableRecord
+{
+    [JsonPropertyName("component")] public required string Component { get; init; }
+    [JsonPropertyName("file")] public required string File { get; init; }
+    [JsonPropertyName("line")] public required int Line { get; init; }
+    [JsonPropertyName("reason")] public required string Reason { get; init; }
 }
 
 internal sealed record NotifySupervisionWriteResult(

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionReaderCorruptionG767Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionReaderCorruptionG767Tests.cs
@@ -56,7 +56,7 @@ public sealed class NotifySupervisionReaderCorruptionG767Tests : IDisposable
         Assert.Equal(0, exitCode);
         using var document = JsonDocument.Parse(payload);
         var result = document.RootElement;
-        Assert.True(result.GetProperty("success").GetBoolean());
+        Assert.False(result.TryGetProperty("success", out _));
         Assert.Equal(1, result.GetProperty("unreadable_record_count").GetInt32());
         var evidence = Assert.Single(result.GetProperty("unreadable_records").EnumerateArray());
         Assert.Equal("cycles.jsonl", evidence.GetProperty("file").GetString());
@@ -94,6 +94,7 @@ public sealed class NotifySupervisionReaderCorruptionG767Tests : IDisposable
         Assert.Equal(1, corrupt.GetProperty("unreadable_record_count").GetInt32());
         Assert.True(corrupt.TryGetProperty("unreadable_records", out _));
         Assert.Contains("partial reading", corrupt.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.False(corrupt.TryGetProperty("success", out _));
         Assert.NotEqual(
             clean.GetProperty("unreadable_record_count").GetInt32(),
             corrupt.GetProperty("unreadable_record_count").GetInt32());
@@ -117,11 +118,14 @@ public sealed class NotifySupervisionReaderCorruptionG767Tests : IDisposable
         using var corruptDocument = JsonDocument.Parse(corruptPayload);
         var empty = emptyDocument.RootElement;
         var corrupt = corruptDocument.RootElement;
+        AssertCleanPayloadMatchesParentOracle(emptyPayload, emptyRoot);
         Assert.True(empty.GetProperty("absent_since_last_cycle").GetBoolean());
         Assert.True(corrupt.GetProperty("absent_since_last_cycle").GetBoolean());
         Assert.Contains("No completed supervision cycle", empty.GetProperty("summary").GetString(), StringComparison.Ordinal);
         Assert.Contains("No completed supervision cycle", corrupt.GetProperty("summary").GetString(), StringComparison.Ordinal);
         Assert.Contains("No readable cycle", corrupt.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.False(empty.TryGetProperty("success", out _));
+        Assert.False(corrupt.TryGetProperty("success", out _));
         Assert.Equal(0, empty.GetProperty("unreadable_record_count").GetInt32());
         Assert.Equal(1, corrupt.GetProperty("unreadable_record_count").GetInt32());
         Assert.NotEqual(
@@ -205,6 +209,32 @@ public sealed class NotifySupervisionReaderCorruptionG767Tests : IDisposable
         Assert.Contains("663,959", document, StringComparison.Ordinal);
         Assert.Contains("0.0014%", document, StringComparison.Ordinal);
         Assert.Contains("fragment", document, StringComparison.OrdinalIgnoreCase);
+        if (language == "en")
+        {
+            Assert.Contains("omits the failure-only", document, StringComparison.Ordinal);
+            Assert.Contains("`success` field", document, StringComparison.Ordinal);
+        }
+        else
+        {
+            Assert.Contains("失敗応答専用の `success` field は含めません", document, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void FailedResponseRetainsFailureOnlySuccessFalse_G767()
+    {
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(root),
+            [
+                "liveness", "--domain", Domain, "--team", Team,
+                "--routing-root", "\0", "--format", "json",
+            ],
+            writer);
+
+        Assert.Equal(1, exitCode);
+        using var document = JsonDocument.Parse(writer.ToString());
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
     }
 
     private (int ExitCode, string Payload) RunLiveness(string repoRoot)
@@ -250,4 +280,37 @@ public sealed class NotifySupervisionReaderCorruptionG767Tests : IDisposable
             },
         },
     };
+
+    private static void AssertCleanPayloadMatchesParentOracle(string payload, string repoRoot)
+    {
+        using var document = JsonDocument.Parse(payload);
+        var actual = document.RootElement
+            .EnumerateObject()
+            .Select(property => (property.Name, RawValue: property.Value.GetRawText()))
+            .ToArray();
+        var expected = new[]
+        {
+            ("operation", JsonSerializer.Serialize("supervise-liveness")),
+            ("routing_root", JsonSerializer.Serialize(Path.GetFullPath(repoRoot))),
+            ("domain", JsonSerializer.Serialize(Domain)),
+            ("team", JsonSerializer.Serialize(Team)),
+            ("command_mode", JsonSerializer.Serialize("read-only")),
+            ("absent_since_last_cycle", "true"),
+            ("scheduler_installation_evidence", JsonSerializer.Serialize("unknown")),
+            ("scheduler_live_state", JsonSerializer.Serialize("unknown")),
+            ("scheduler_evidence_detail", JsonSerializer.Serialize(
+                "durable installation evidence is unavailable; scheduler live state is unknown because no OS lifecycle query was executed")),
+            ("scheduler_artifact_paths", "[]"),
+            ("commands_executed", JsonSerializer.Serialize(
+                "none (persisted supervision state and artifact metadata only)")),
+            // The only authorized delta from the parent clean payload is this
+            // corruption counter, which must remain zero for a clean store.
+            ("unreadable_record_count", "0"),
+            ("summary", JsonSerializer.Serialize(
+                "Read-only liveness: No completed supervision cycle is recorded; no supervisor process is required to produce this answer. Supervision is absent or beyond its declared bound. Scheduler live state=unknown; durable installation evidence=unknown; the supervisor was not run.")),
+        };
+
+        Assert.Equal(expected, actual);
+        Assert.False(document.RootElement.TryGetProperty("success", out _));
+    }
 }

--- a/tests/IntentSystem.Cli.Tests/NotifySupervisionReaderCorruptionG767Tests.cs
+++ b/tests/IntentSystem.Cli.Tests/NotifySupervisionReaderCorruptionG767Tests.cs
@@ -1,0 +1,253 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using IntentSystem.Cli;
+using IntentSystem.Cli.Commands;
+using IntentSystem.Cli.Models;
+
+namespace IntentSystem.Cli.Tests;
+
+/// <summary>
+/// G767: supervision history is read record-by-record. Corruption remains
+/// visible evidence rather than becoming either a fatal whole-store read or a
+/// clean absence.
+/// </summary>
+[Collection("WorkerNextActionSharedState")]
+public sealed class NotifySupervisionReaderCorruptionG767Tests : IDisposable
+{
+    private const string Domain = "intent-cli";
+    private const string Team = "intent-cli-dev";
+    private readonly string root = Path.Combine(
+        Path.GetTempPath(),
+        "intent-g767-" + Guid.NewGuid().ToString("N"));
+    private readonly DateTimeOffset now = new(2026, 8, 31, 12, 0, 0, TimeSpan.Zero);
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public NotifySupervisionReaderCorruptionG767Tests()
+    {
+        Directory.CreateDirectory(root);
+        NotifyCommand.UtcNowFactory = () => now;
+        NotifyCommand.ProcessRunnerFactory = null;
+    }
+
+    public void Dispose()
+    {
+        NotifyCommand.UtcNowFactory = null;
+        NotifyCommand.ProcessRunnerFactory = null;
+        if (Directory.Exists(root))
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void OneMalformedCycleLine_PreservesReadableCycleAndReportsPartialEvidence_G767()
+    {
+        var artifactRoot = ArtifactRoot(root);
+        var cyclePath = NotifySupervisionStore.ResolveCyclePath(artifactRoot, Domain, Team);
+        WriteCycle(cyclePath, "readable-cycle", now.AddMinutes(-1));
+        File.AppendAllText(cyclePath, "{\"kind\":\"cycle\",\"cycle\":\n");
+
+        var (exitCode, payload) = RunLiveness(root);
+
+        Assert.Equal(0, exitCode);
+        using var document = JsonDocument.Parse(payload);
+        var result = document.RootElement;
+        Assert.True(result.GetProperty("success").GetBoolean());
+        Assert.Equal(1, result.GetProperty("unreadable_record_count").GetInt32());
+        var evidence = Assert.Single(result.GetProperty("unreadable_records").EnumerateArray());
+        Assert.Equal("cycles.jsonl", evidence.GetProperty("file").GetString());
+        Assert.Equal(2, evidence.GetProperty("line").GetInt32());
+        Assert.Contains("partial reading", result.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+
+        var state = NotifySupervisionStore.Read(artifactRoot, Domain, Team);
+        Assert.True(state.Resolved, state.Error);
+        Assert.Equal("readable-cycle", Assert.Single(state.CycleHistory).CycleId);
+    }
+
+    [Fact]
+    public void CleanAndOneMalformedDiscriminatingPair_ProducesDifferentAnswers_G767()
+    {
+        var cleanRoot = Path.Combine(root, "clean");
+        var corruptRoot = Path.Combine(root, "corrupt");
+        var cleanPath = NotifySupervisionStore.ResolveCyclePath(ArtifactRoot(cleanRoot), Domain, Team);
+        var corruptPath = NotifySupervisionStore.ResolveCyclePath(ArtifactRoot(corruptRoot), Domain, Team);
+        WriteCycle(cleanPath, "same-readable-cycle", now.AddMinutes(-1));
+        WriteCycle(corruptPath, "same-readable-cycle", now.AddMinutes(-1));
+        File.AppendAllText(corruptPath, "not-json\n");
+
+        var (cleanExit, cleanPayload) = RunLiveness(cleanRoot);
+        var (corruptExit, corruptPayload) = RunLiveness(corruptRoot);
+
+        Assert.Equal(0, cleanExit);
+        Assert.Equal(0, corruptExit);
+        using var cleanDocument = JsonDocument.Parse(cleanPayload);
+        using var corruptDocument = JsonDocument.Parse(corruptPayload);
+        var clean = cleanDocument.RootElement;
+        var corrupt = corruptDocument.RootElement;
+        Assert.Equal(0, clean.GetProperty("unreadable_record_count").GetInt32());
+        Assert.False(clean.TryGetProperty("unreadable_records", out _));
+        Assert.DoesNotContain("partial reading", clean.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, corrupt.GetProperty("unreadable_record_count").GetInt32());
+        Assert.True(corrupt.TryGetProperty("unreadable_records", out _));
+        Assert.Contains("partial reading", corrupt.GetProperty("summary").GetString(), StringComparison.OrdinalIgnoreCase);
+        Assert.NotEqual(
+            clean.GetProperty("unreadable_record_count").GetInt32(),
+            corrupt.GetProperty("unreadable_record_count").GetInt32());
+    }
+
+    [Fact]
+    public void AllCorruptAndEmptyDiscriminatingPair_NeverLooksLikeCleanAbsence_G767()
+    {
+        var emptyRoot = Path.Combine(root, "empty");
+        var corruptRoot = Path.Combine(root, "all-corrupt");
+        var corruptPath = NotifySupervisionStore.ResolveCyclePath(ArtifactRoot(corruptRoot), Domain, Team);
+        Directory.CreateDirectory(Path.GetDirectoryName(corruptPath)!);
+        File.WriteAllText(corruptPath, "not-json\n");
+
+        var (emptyExit, emptyPayload) = RunLiveness(emptyRoot);
+        var (corruptExit, corruptPayload) = RunLiveness(corruptRoot);
+
+        Assert.Equal(0, emptyExit);
+        Assert.Equal(0, corruptExit);
+        using var emptyDocument = JsonDocument.Parse(emptyPayload);
+        using var corruptDocument = JsonDocument.Parse(corruptPayload);
+        var empty = emptyDocument.RootElement;
+        var corrupt = corruptDocument.RootElement;
+        Assert.True(empty.GetProperty("absent_since_last_cycle").GetBoolean());
+        Assert.True(corrupt.GetProperty("absent_since_last_cycle").GetBoolean());
+        Assert.Contains("No completed supervision cycle", empty.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Contains("No completed supervision cycle", corrupt.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Contains("No readable cycle", corrupt.GetProperty("summary").GetString(), StringComparison.Ordinal);
+        Assert.Equal(0, empty.GetProperty("unreadable_record_count").GetInt32());
+        Assert.Equal(1, corrupt.GetProperty("unreadable_record_count").GetInt32());
+        Assert.NotEqual(
+            empty.GetProperty("unreadable_record_count").GetInt32(),
+            corrupt.GetProperty("unreadable_record_count").GetInt32());
+    }
+
+    [Fact]
+    public void StallsAndPromptAudits_PreserveValidRecordsAndReportMalformedLines_G767()
+    {
+        var artifactRoot = ArtifactRoot(root);
+        var stallsPath = NotifySupervisionStore.ResolveStallPath(artifactRoot, Domain, Team);
+        var cyclePath = NotifySupervisionStore.ResolveCyclePath(artifactRoot, Domain, Team);
+        Assert.True(NotifySupervisionStore.OpenStall(
+            stallsPath,
+            new NotifySupervisionStallRecord
+            {
+                Key = "g767-valid-stall",
+                Kind = "g767-test-stall",
+                OwnerRole = "orchestration",
+                Source = "g767-test",
+                Summary = "valid stall",
+                SurfacedAt = now.AddMinutes(-2),
+            },
+            write: true).Applied);
+        File.AppendAllText(stallsPath, "not-json-stall\n");
+        Assert.True(NotifySupervisionStore.RecordPromptAudit(
+            cyclePath,
+            new NotifyPromptAudit
+            {
+                PromptKey = "g767-prompt",
+                Seat = "implementation",
+                Pane = "g767:p1",
+                AgentKind = "fixture",
+                PromptClass = "test",
+                Rule = "test",
+                Actor = "g767",
+                Timestamp = now.AddMinutes(-1),
+                Outcome = "observed",
+            },
+            write: true).Applied);
+        File.AppendAllText(cyclePath, "not-json-prompt\n");
+
+        var state = NotifySupervisionStore.Read(artifactRoot, Domain, Team);
+
+        Assert.True(state.Resolved, state.Error);
+        Assert.Contains(state.StallHistory, item => item.Key == "g767-valid-stall");
+        Assert.Contains(state.PromptAudits, item => item.PromptKey == "g767-prompt");
+        using var evidence = JsonDocument.Parse(JsonSerializer.Serialize(
+            typeof(NotifySupervisionReadResult)
+                .GetProperty("UnreadableRecords")!
+                .GetValue(state),
+            JsonOptions));
+        var records = evidence.RootElement.EnumerateArray().ToArray();
+        Assert.Equal(2, records.Length);
+        Assert.Contains(records, item =>
+            item.GetProperty("file").GetString() == "stalls.jsonl"
+            && item.GetProperty("line").GetInt32() == 2);
+        Assert.Contains(records, item =>
+            item.GetProperty("file").GetString() == "cycles.jsonl"
+            && item.GetProperty("line").GetInt32() == 2);
+    }
+
+    [Theory]
+    [InlineData("en")]
+    [InlineData("ja")]
+    public void DocumentationDescribesRecordLevelCorruptionEvidence_G767(string language)
+    {
+        var path = Path.Combine(
+            RepoVersionPolicySource.RepoRoot(),
+            "docs",
+            language,
+            "12-agent-message-orchestration.md");
+        var document = File.ReadAllText(path);
+
+        Assert.Contains("G767", document, StringComparison.Ordinal);
+        Assert.Contains("unreadable_record_count", document, StringComparison.Ordinal);
+        Assert.Contains("unreadable_records", document, StringComparison.Ordinal);
+        Assert.Contains("cycles.jsonl", document, StringComparison.Ordinal);
+        Assert.Contains("stalls.jsonl", document, StringComparison.Ordinal);
+        Assert.Contains("663,959", document, StringComparison.Ordinal);
+        Assert.Contains("0.0014%", document, StringComparison.Ordinal);
+        Assert.Contains("fragment", document, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private (int ExitCode, string Payload) RunLiveness(string repoRoot)
+    {
+        using var writer = new StringWriter();
+        var exitCode = NotifyCommand.ExecuteSupervise(
+            CreateContext(repoRoot),
+            ["liveness", "--domain", Domain, "--team", Team, "--format", "json"],
+            writer);
+        return (exitCode, writer.ToString());
+    }
+
+    private void WriteCycle(string path, string cycleId, DateTimeOffset completedAt)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        Assert.True(NotifySupervisionStore.RecordCycle(
+            path,
+            new NotifySupervisionCycle
+            {
+                CycleId = cycleId,
+                StartedAt = completedAt.AddSeconds(-1),
+                CompletedAt = completedAt,
+                IntervalSeconds = 300,
+            },
+            write: true).Applied);
+    }
+
+    private static string ArtifactRoot(string repoRoot) => Path.Combine(repoRoot, ".intent-cli", "supervision");
+
+    private static CliContext CreateContext(string repoRoot) => new()
+    {
+        RepoRoot = repoRoot,
+        Config = new CliConfig
+        {
+            Project = new ProjectConfig
+            {
+                Domain = Domain,
+                ArtifactRoot = ".intent-cli",
+            },
+            Supervision = new SupervisionConfig
+            {
+                ArtifactRoot = ".intent-cli/supervision",
+            },
+        },
+    };
+}


### PR DESCRIPTION
Closes #1672

## Summary

- Read cycles, stalls, and prompt-audit JSONL records independently; valid records remain readable while malformed lines produce deterministic component/file/line/reason evidence.
- `notify supervise liveness --format json` now reports `success`, an always-present `unreadable_record_count`, optional `unreadable_records`, and a partial-reading summary. All-corrupt cycle history remains absent/unhealthy and is distinct from empty history.
- This is reader/reporting behavior only. It does not repair files, prevent fragments, or change append ordering.

## Parent reproduction

On parent `7adb2b5cac8090865d19c864842dbed48ffab7d2`, the four behavior fixtures failed: `Failed: 4, Passed: 0, Skipped: 0, Total: 4`. The parent failures were whole-store read errors for malformed cycle/stall/prompt lines and exit code 1 for the liveness cases. The parent documentation probe also failed: `Failed: 2, Passed: 0, Skipped: 0, Total: 2` because neither mirror contained G767 corruption evidence.

## Verification

- G767 focused: `Failed: 0, Passed: 6, Skipped: 0, Total: 6`.
- Existing supervision/archival/liveness adjacency: `Failed: 0, Passed: 35, Skipped: 0, Total: 35`.
- G613: `Failed: 0, Passed: 6, Skipped: 0, Total: 6`.
- Full Release: `Failed: 0, Passed: 5411, Skipped: 1, Total: 5412`.
- `git diff --check`: clean.
- Head: `6deeef6e911a6bed8646b73d8325e8a2f7349aa0`.

The child issue preflight/next-action refused only because `.git/FETCH_HEAD` was unreadable (`claim-unavailable` / `canonical-unavailable`); the supplied authoritative host claim for `execution-unit:G767` was consumed. No child execution-unit claim or host state was created, modified, verified, or released.